### PR TITLE
feat(firefox-extension): add right-click context menu to save pages and links

### DIFF
--- a/projects/firefox-extension/src/runtime/background/background.ts
+++ b/projects/firefox-extension/src/runtime/background/background.ts
@@ -5,6 +5,11 @@ import type { PopupMessage } from "./messages.types";
 import { initSaveCurrentTab } from "./save-current-tab";
 import { initIconStatus } from "./icon-status";
 import { createBrowserSetIcon } from "./tinted-icon.browser";
+import {
+	MENU_ITEM_SAVE_LINK,
+	MENU_ITEM_SAVE_PAGE,
+	initSaveFromContextMenu,
+} from "./save-from-context-menu";
 
 const auth = initInMemoryAuth();
 const readingList = initInMemoryReadingList();
@@ -13,6 +18,32 @@ const { updateIconForTab } = initIconStatus({
 	findByUrl: readingList.findByUrl,
 	whenLoggedIn: auth.whenLoggedIn,
 	setIcon: createBrowserSetIcon(),
+});
+const saveFromContextMenu = initSaveFromContextMenu({
+	saveUrl: readingList.saveUrl,
+});
+
+browser.menus.create({
+	id: MENU_ITEM_SAVE_PAGE,
+	title: "Save Page to Hutch",
+	contexts: ["page"],
+});
+
+browser.menus.create({
+	id: MENU_ITEM_SAVE_LINK,
+	title: "Save Link to Hutch",
+	contexts: ["link"],
+});
+
+browser.menus.onClicked.addListener((info, tab) => {
+	const guarded = auth.whenLoggedIn(() => saveFromContextMenu(info, tab));
+	if (guarded.ok) {
+		guarded.value.then(async () => {
+			if (tab?.id && tab.url) {
+				await updateIconForTab(tab.id, tab.url);
+			}
+		});
+	}
 });
 
 async function updateActiveTabIcon() {

--- a/projects/firefox-extension/src/runtime/background/save-from-context-menu.test.ts
+++ b/projects/firefox-extension/src/runtime/background/save-from-context-menu.test.ts
@@ -1,0 +1,136 @@
+import { initInMemoryReadingList } from "../providers/reading-list/in-memory-reading-list";
+import {
+	MENU_ITEM_SAVE_LINK,
+	MENU_ITEM_SAVE_PAGE,
+	initSaveFromContextMenu,
+} from "./save-from-context-menu";
+
+describe("initSaveFromContextMenu", () => {
+	describe("save page", () => {
+		it("should save the page URL and title from the tab", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_PAGE, pageUrl: "https://example.com/article" },
+				{ url: "https://example.com/article", title: "Example Article" },
+			);
+
+			expect(result).toEqual(
+				expect.objectContaining({ ok: true, item: expect.objectContaining({ url: "https://example.com/article", title: "Example Article" }) }),
+			);
+		});
+
+		it("should fall back to pageUrl when tab has no URL", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_PAGE, pageUrl: "https://example.com/page" },
+				{ title: "Some Title" },
+			);
+
+			expect(result).toEqual(
+				expect.objectContaining({ ok: true, item: expect.objectContaining({ url: "https://example.com/page" }) }),
+			);
+		});
+
+		it("should use URL as title when tab has no title", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_PAGE, pageUrl: "https://example.com/no-title" },
+			);
+
+			expect(result).toEqual(
+				expect.objectContaining({ ok: true, item: expect.objectContaining({ url: "https://example.com/no-title", title: "https://example.com/no-title" }) }),
+			);
+		});
+
+		it("should return null when page has no URL", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_PAGE },
+				{ title: "No URL Page" },
+			);
+
+			expect(result).toBeNull();
+		});
+
+		it("should return already-saved for a duplicate page URL", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			await save(
+				{ menuItemId: MENU_ITEM_SAVE_PAGE, pageUrl: "https://example.com/dup" },
+				{ url: "https://example.com/dup", title: "First" },
+			);
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_PAGE, pageUrl: "https://example.com/dup" },
+				{ url: "https://example.com/dup", title: "Second" },
+			);
+
+			expect(result).toEqual({ ok: false, reason: "already-saved" });
+		});
+	});
+
+	describe("save link", () => {
+		it("should save the link URL using linkUrl as both url and title", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_LINK, linkUrl: "https://example.com/linked" },
+				{ url: "https://example.com/page", title: "Page Title" },
+			);
+
+			expect(result).toEqual(
+				expect.objectContaining({ ok: true, item: expect.objectContaining({ url: "https://example.com/linked", title: "https://example.com/linked" }) }),
+			);
+		});
+
+		it("should return already-saved for a duplicate link URL", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			await save(
+				{ menuItemId: MENU_ITEM_SAVE_LINK, linkUrl: "https://example.com/linked" },
+			);
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_LINK, linkUrl: "https://example.com/linked" },
+			);
+
+			expect(result).toEqual({ ok: false, reason: "already-saved" });
+		});
+
+		it("should return null when link menu clicked without linkUrl", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: MENU_ITEM_SAVE_LINK },
+			);
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("unknown menu item", () => {
+		it("should return null for an unrecognized menu item ID", async () => {
+			const list = initInMemoryReadingList();
+			const save = initSaveFromContextMenu({ saveUrl: list.saveUrl });
+
+			const result = await save(
+				{ menuItemId: "unknown-item", pageUrl: "https://example.com" },
+				{ url: "https://example.com", title: "Example" },
+			);
+
+			expect(result).toBeNull();
+		});
+	});
+});

--- a/projects/firefox-extension/src/runtime/background/save-from-context-menu.ts
+++ b/projects/firefox-extension/src/runtime/background/save-from-context-menu.ts
@@ -1,0 +1,33 @@
+import type { SaveUrl, SaveUrlResult } from "../providers/reading-list/reading-list.types";
+
+export const MENU_ITEM_SAVE_PAGE = "save-page-to-hutch";
+export const MENU_ITEM_SAVE_LINK = "save-link-to-hutch";
+
+interface ClickInfo {
+	menuItemId: string;
+	linkUrl?: string;
+	pageUrl?: string;
+}
+
+interface TabInfo {
+	url?: string;
+	title?: string;
+}
+
+export function initSaveFromContextMenu(deps: {
+	saveUrl: SaveUrl;
+}): (info: ClickInfo, tab?: TabInfo) => Promise<SaveUrlResult | null> {
+	return async (info, tab) => {
+		if (info.menuItemId === MENU_ITEM_SAVE_LINK && info.linkUrl) {
+			return deps.saveUrl({ url: info.linkUrl, title: info.linkUrl });
+		}
+
+		if (info.menuItemId === MENU_ITEM_SAVE_PAGE) {
+			const url = info.pageUrl ?? tab?.url;
+			if (!url) return null;
+			return deps.saveUrl({ url, title: tab?.title ?? url });
+		}
+
+		return null;
+	};
+}

--- a/projects/firefox-extension/src/runtime/browser.d.ts
+++ b/projects/firefox-extension/src/runtime/browser.d.ts
@@ -60,4 +60,28 @@ declare namespace browser {
 			addListener(callback: (command: string) => void): void;
 		};
 	}
+
+	namespace menus {
+		type ContextType = "page" | "link";
+
+		interface CreateProperties {
+			id: string;
+			title: string;
+			contexts: ContextType[];
+		}
+
+		interface OnClickData {
+			menuItemId: string;
+			linkUrl?: string;
+			pageUrl?: string;
+		}
+
+		function create(createProperties: CreateProperties): void;
+
+		const onClicked: {
+			addListener(
+				callback: (info: OnClickData, tab?: tabs.Tab) => void,
+			): void;
+		};
+	}
 }

--- a/projects/firefox-extension/src/runtime/manifest.json
+++ b/projects/firefox-extension/src/runtime/manifest.json
@@ -3,7 +3,7 @@
   "name": "Hutch",
   "version": "1.0.0",
   "description": "Save URLs to your reading list",
-  "permissions": ["activeTab", "tabs"],
+  "permissions": ["activeTab", "tabs", "menus"],
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",


### PR DESCRIPTION
Register "Save Page to Hutch" and "Save Link to Hutch" context menu
items so users can save without opening the popup. The handler extracts
the appropriate URL depending on whether a link or page was
right-clicked, and delegates to the existing saveUrl provider behind
the auth guard.

https://claude.ai/code/session_01P9kRDJEjNW6h917ZDXVu34