### PR TITLE
Improve reading list item display with title and domain 👀

### DIFF
--- a/projects/firefox-extension/src/runtime/popup/popup.styles.css
+++ b/projects/firefox-extension/src/runtime/popup/popup.styles.css
@@ -259,19 +259,37 @@ h2 {
   border-bottom: none;
 }
 
-.list-view__url {
-  color: #996d1f;
-  font-size: 13px;
-  text-decoration: none;
-  word-break: break-all;
-  line-height: 1.5;
+.list-view__text {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.list-view__url:hover {
+.list-view__item-title {
+  color: #1a202c;
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.list-view__item-title:hover {
   text-decoration: underline;
-  color: #7a5818;
+  color: #996d1f;
+}
+
+.list-view__domain {
+  color: #8c919d;
+  font-size: 11px;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /**

--- a/projects/firefox-extension/src/runtime/popup/popup.ts
+++ b/projects/firefox-extension/src/runtime/popup/popup.ts
@@ -56,12 +56,26 @@ function renderLinks(items: ReadingListItem[]) {
 		const div = document.createElement("div");
 		div.className = "list-view__item";
 
+		const textContainer = document.createElement("div");
+		textContainer.className = "list-view__text";
+
 		const link = document.createElement("a");
-		link.className = "list-view__url";
+		link.className = "list-view__item-title";
 		link.href = item.url;
-		link.textContent = item.url;
+		link.textContent = item.title;
 		link.target = "_blank";
 		link.rel = "noopener noreferrer";
+
+		const domain = document.createElement("span");
+		domain.className = "list-view__domain";
+		try {
+			domain.textContent = new URL(item.url).hostname;
+		} catch {
+			domain.textContent = item.url;
+		}
+
+		textContainer.appendChild(link);
+		textContainer.appendChild(domain);
 
 		const deleteButton = document.createElement("button");
 		deleteButton.className = "list-view__delete";
@@ -79,7 +93,7 @@ function renderLinks(items: ReadingListItem[]) {
 			}
 		});
 
-		div.appendChild(link);
+		div.appendChild(textContainer);
 		div.appendChild(deleteButton);
 		linkList.appendChild(div);
 	}


### PR DESCRIPTION
## Summary
Enhanced the reading list item UI to display both the item title and domain separately, providing better readability and visual hierarchy compared to showing the full URL.

## Key Changes
- **Restructured list item layout**: Created a new `.list-view__text` container that uses flexbox to stack title and domain vertically with consistent spacing
- **Updated link display**: Changed from displaying the full URL to showing the item title with improved styling (darker color, medium font weight, ellipsis overflow handling)
- **Added domain display**: Introduced a new `.list-view__domain` element that extracts and displays the hostname from the URL in a smaller, muted font
- **Improved styling**: 
  - Title link now uses dark color (#1a202c) with hover state changing to the original brown (#996d1f)
  - Domain uses a subtle gray color (#8c919d) at 11px font size
  - Both title and domain have text overflow handling with ellipsis for long content
- **Enhanced error handling**: Added try-catch block when parsing URLs to gracefully fall back to the full URL if hostname extraction fails

## Implementation Details
The changes maintain the existing flex layout of list items while introducing a nested flex container for the text content. This allows the delete button to remain aligned to the right while the title and domain stack vertically on the left.

https://claude.ai/code/session_011Kh7oSs9gZxv2qN9HDkEeK