### PR TITLE
Remove article starring feature

### DIFF
--- a/projects/hutch/src/runtime/domain/article/article.types.ts
+++ b/projects/hutch/src/runtime/domain/article/article.types.ts
@@ -20,7 +20,6 @@ export interface SavedArticle {
 	metadata: ArticleMetadata;
 	estimatedReadTime: Minutes;
 	status: ArticleStatus;
-	isStarred: boolean;
 	savedAt: Date;
 	readAt?: Date;
 }

--- a/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
+++ b/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
@@ -18,7 +18,6 @@ export type SortOrder = "asc" | "desc";
 export interface FindArticlesQuery {
 	userId: UserId;
 	status?: ArticleStatus;
-	isStarred?: boolean;
 	sort?: SortField;
 	order?: SortOrder;
 	page?: number;
@@ -53,7 +52,3 @@ export type UpdateArticleStatus = (
 	status: ArticleStatus,
 ) => Promise<boolean>;
 
-export type ToggleArticleStar = (
-	id: ArticleId,
-	userId: UserId,
-) => Promise<boolean>;

--- a/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.test.ts
+++ b/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.test.ts
@@ -33,7 +33,6 @@ describe("initInMemoryArticleStore", () => {
 
 			expect(found?.url).toBe("https://example.com/article");
 			expect(found?.status).toBe("unread");
-			expect(found?.isStarred).toBe(false);
 		});
 	});
 
@@ -173,18 +172,4 @@ describe("initInMemoryArticleStore", () => {
 		});
 	});
 
-	describe("toggleArticleStar", () => {
-		it("should toggle star on and off", async () => {
-			const store = initInMemoryArticleStore();
-			const saved = await store.saveArticle(makeArticleParams());
-
-			await store.toggleArticleStar(saved.id, USER_A);
-			let found = await store.findArticleById(saved.id);
-			expect(found?.isStarred).toBe(true);
-
-			await store.toggleArticleStar(saved.id, USER_A);
-			found = await store.findArticleById(saved.id);
-			expect(found?.isStarred).toBe(false);
-		});
-	});
 });

--- a/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.ts
@@ -8,7 +8,6 @@ import type {
 	FindArticleById,
 	FindArticlesByUser,
 	SaveArticle,
-	ToggleArticleStar,
 	UpdateArticleStatus,
 } from "./article-store.types";
 
@@ -18,7 +17,6 @@ export function initInMemoryArticleStore(): {
 	findArticlesByUser: FindArticlesByUser;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
-	toggleArticleStar: ToggleArticleStar;
 } {
 	const articles = new Map<ArticleId, SavedArticle>();
 
@@ -31,7 +29,6 @@ export function initInMemoryArticleStore(): {
 			metadata: params.metadata,
 			estimatedReadTime: params.estimatedReadTime,
 			status: "unread",
-			isStarred: false,
 			savedAt: new Date(),
 		};
 		articles.set(id, article);
@@ -53,10 +50,6 @@ export function initInMemoryArticleStore(): {
 
 		if (query.status) {
 			filtered = filtered.filter((a) => a.status === query.status);
-		}
-
-		if (query.isStarred !== undefined) {
-			filtered = filtered.filter((a) => a.isStarred === query.isStarred);
 		}
 
 		filtered.sort((a, b) => {
@@ -95,22 +88,11 @@ export function initInMemoryArticleStore(): {
 		return true;
 	};
 
-	const toggleArticleStar: ToggleArticleStar = async (id, userId) => {
-		const article = articles.get(id);
-		if (!article || article.userId !== userId) {
-			return false;
-		}
-		article.isStarred = !article.isStarred;
-		articles.set(id, article);
-		return true;
-	};
-
 	return {
 		saveArticle,
 		findArticleById,
 		findArticlesByUser,
 		deleteArticle,
 		updateArticleStatus,
-		toggleArticleStar,
 	};
 }

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -15,7 +15,6 @@ import type {
 	DeleteArticle,
 	FindArticlesByUser,
 	SaveArticle,
-	ToggleArticleStar,
 	UpdateArticleStatus,
 } from "./providers/article-store/article-store.types";
 import { Base } from "./web/base.component";
@@ -44,7 +43,6 @@ interface AppDependencies {
 	saveArticle: SaveArticle;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
-	toggleArticleStar: ToggleArticleStar;
 }
 
 function requireAuth(req: Request, res: Response, next: NextFunction): void {
@@ -100,7 +98,6 @@ export function createApp(dependencies: AppDependencies): Express {
 		parseArticle: deps.parseArticle,
 		deleteArticle: deps.deleteArticle,
 		updateArticleStatus: deps.updateArticleStatus,
-		toggleArticleStar: deps.toggleArticleStar,
 	});
 	app.use("/queue", requireAuth, queueRouter);
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -8,7 +8,6 @@ import type {
 	DeleteArticle,
 	FindArticlesByUser,
 	SaveArticle,
-	ToggleArticleStar,
 	UpdateArticleStatus,
 } from "../../../providers/article-store/article-store.types";
 import type { UserId } from "../../../domain/user/user.types";
@@ -23,7 +22,6 @@ interface QueueDependencies {
 	parseArticle: ParseArticle;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
-	toggleArticleStar: ToggleArticleStar;
 }
 
 export function initQueueRoutes(deps: QueueDependencies): Router {
@@ -36,7 +34,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const result = await deps.findArticlesByUser({
 			userId,
 			status: urlState.status,
-			isStarred: urlState.starred,
 			order: urlState.order,
 			page: urlState.page,
 		});
@@ -103,14 +100,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const status = req.body.status as ArticleStatus;
 
 		await deps.updateArticleStatus(articleId, userId, status);
-		res.redirect(303, req.get("Referer") || "/queue");
-	});
-
-	router.post("/:id/star", async (req: Request, res: Response) => {
-		const userId = req.userId as UserId;
-		const articleId = req.params.id as unknown as import("../../../domain/article/article.types").ArticleId;
-
-		await deps.toggleArticleStar(articleId, userId);
 		res.redirect(303, req.get("Referer") || "/queue");
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -109,31 +109,6 @@ describe("Queue routes", () => {
 		});
 	});
 
-	describe("POST /queue/:id/star", () => {
-		it("should toggle star on article", async () => {
-			const { app, auth } = createTestApp();
-			const agent = await loginAgent(app, auth);
-
-			await agent
-				.post("/queue/save")
-				.type("form")
-				.send({ url: "https://example.com/article" });
-
-			const queueResponse = await agent.get("/queue");
-			const doc = new JSDOM(queueResponse.text).window.document;
-			const articleEl = doc.querySelector("[data-test-article-list] .queue-article");
-			const articleId = articleEl?.getAttribute("data-test-article");
-
-			const starResponse = await agent.post(`/queue/${articleId}/star`);
-
-			expect(starResponse.status).toBe(303);
-
-			const starredResponse = await agent.get("/queue?starred=true");
-			const starredDoc = new JSDOM(starredResponse.text).window.document;
-			expect(starredDoc.querySelectorAll(".queue-article").length).toBe(1);
-		});
-	});
-
 	describe("POST /queue/:id/delete", () => {
 		it("should delete article", async () => {
 			const { app, auth } = createTestApp();

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -214,11 +214,6 @@
   color: var(--foreground);
 }
 
-.queue-article__action-btn--starred {
-  color: var(--color-warning);
-  border-color: var(--color-warning);
-}
-
 .queue-article__action-btn--delete:hover {
   background: hsl(0 84% 60% / 0.1);
   color: var(--error);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.ts
@@ -6,11 +6,6 @@ function renderArticle(
 	article: QueueArticleViewModel,
 	options: { showUrl: boolean },
 ): string {
-	const starClass = article.isStarred
-		? " queue-article__action-btn--starred"
-		: "";
-	const starLabel = article.isStarred ? "Unstar" : "Star";
-
 	const statusActions: string[] = [];
 	if (article.status !== "read") {
 		statusActions.push(`
@@ -52,9 +47,6 @@ function renderArticle(
         <p class="queue-article__excerpt">${article.excerpt}</p>
       </div>
       <div class="queue-article__actions">
-        <form method="POST" action="/queue/${article.id}/star" style="display:inline">
-          <button class="queue-article__action-btn${starClass}" type="submit" title="${starLabel}" data-test-action="star">${article.isStarred ? "★" : "☆"}</button>
-        </form>
         ${statusActions.join("")}
         <form method="POST" action="/queue/${article.id}/delete" style="display:inline">
           <button class="queue-article__action-btn queue-article__action-btn--delete" type="submit" title="Delete" data-test-action="delete">×</button>
@@ -65,7 +57,6 @@ function renderArticle(
 
 function renderFilters(vm: QueueViewModel): string {
 	const activeStatus = vm.filters.status;
-	const isStarred = vm.filters.starred;
 
 	function cls(isActive: boolean): string {
 		return `queue__filter-link${isActive ? " queue__filter-link--active" : ""}`;
@@ -73,11 +64,10 @@ function renderFilters(vm: QueueViewModel): string {
 
 	return `
     <nav class="queue__filters" data-test-filters>
-      <a class="${cls(!activeStatus && !isStarred)}" href="${vm.filterUrls.all}">All</a>
+      <a class="${cls(!activeStatus)}" href="${vm.filterUrls.all}">All</a>
       <a class="${cls(activeStatus === "unread")}" href="${vm.filterUrls.unread}">Unread</a>
       <a class="${cls(activeStatus === "read")}" href="${vm.filterUrls.read}">Read</a>
       <a class="${cls(activeStatus === "archived")}" href="${vm.filterUrls.archived}">Archived</a>
-      <a class="${cls(isStarred === true)}" href="${vm.filterUrls.starred}">Starred</a>
     </nav>`;
 }
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
@@ -3,7 +3,7 @@ import { buildQueueUrl, parseQueueUrl } from "./queue.url";
 describe("parseQueueUrl", () => {
 	it("should return defaults for empty query", () => {
 		const state = parseQueueUrl({});
-		expect(state).toEqual({ status: undefined, starred: undefined, order: "desc", page: 1, showUrl: undefined });
+		expect(state).toEqual({ status: undefined, order: "desc", page: 1, showUrl: undefined });
 	});
 
 	it("should parse valid status", () => {
@@ -14,11 +14,6 @@ describe("parseQueueUrl", () => {
 
 	it("should ignore invalid status", () => {
 		expect(parseQueueUrl({ status: "invalid" }).status).toBeUndefined();
-	});
-
-	it("should parse starred filter", () => {
-		expect(parseQueueUrl({ starred: "true" }).starred).toBe(true);
-		expect(parseQueueUrl({ starred: "false" }).starred).toBe(false);
 	});
 
 	it("should parse order", () => {
@@ -61,10 +56,6 @@ describe("buildQueueUrl", () => {
 
 	it("should include status", () => {
 		expect(buildQueueUrl({ status: "read" })).toBe("/queue?status=read");
-	});
-
-	it("should include starred", () => {
-		expect(buildQueueUrl({ starred: true })).toBe("/queue?starred=true");
 	});
 
 	it("should omit default order (desc)", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -3,7 +3,6 @@ import type { SortOrder } from "../../../providers/article-store/article-store.t
 
 export interface QueueUrlState {
 	status?: ArticleStatus;
-	starred?: boolean;
 	order: SortOrder;
 	page: number;
 	showUrl?: boolean;
@@ -17,9 +16,6 @@ export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 		? (query.status as ArticleStatus)
 		: undefined;
 
-	const starred =
-		query.starred === "true" ? true : query.starred === "false" ? false : undefined;
-
 	const order = VALID_ORDERS.includes(query.order as SortOrder)
 		? (query.order as SortOrder)
 		: "desc";
@@ -29,7 +25,7 @@ export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 
 	const showUrl = query.showUrl === "true" ? true : undefined;
 
-	return { status, starred, order, page, showUrl };
+	return { status, order, page, showUrl };
 }
 
 export function buildQueueUrl(state: Partial<QueueUrlState>): string {
@@ -37,9 +33,6 @@ export function buildQueueUrl(state: Partial<QueueUrlState>): string {
 
 	if (state.status) {
 		params.set("status", state.status);
-	}
-	if (state.starred !== undefined) {
-		params.set("starred", String(state.starred));
 	}
 	if (state.order && state.order !== "desc") {
 		params.set("order", state.order);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -20,7 +20,6 @@ function makeArticle(overrides?: Partial<SavedArticle>): SavedArticle {
 		},
 		estimatedReadTime: 3 as Minutes,
 		status: "unread",
-		isStarred: false,
 		savedAt: new Date("2025-06-01T12:00:00Z"),
 		...overrides,
 	};

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -11,7 +11,6 @@ export interface QueueArticleViewModel {
 	url: string;
 	readTimeLabel: string;
 	status: string;
-	isStarred: boolean;
 	savedAgo: string;
 	imageUrl?: string;
 }
@@ -28,7 +27,6 @@ export interface QueueViewModel {
 		unread: string;
 		read: string;
 		archived: string;
-		starred: string;
 	};
 	paginationUrls: {
 		prev?: string;
@@ -71,7 +69,6 @@ function toArticleViewModel(
 		url: article.url,
 		readTimeLabel: `${readTime} min read`,
 		status: article.status,
-		isStarred: article.isStarred,
 		savedAgo: formatRelativeDate(article.savedAt, now),
 		imageUrl: article.metadata.imageUrl,
 	};
@@ -98,7 +95,6 @@ export function toQueueViewModel(
 			unread: buildQueueUrl({ ...baseFilters, status: "unread" }),
 			read: buildQueueUrl({ ...baseFilters, status: "read" }),
 			archived: buildQueueUrl({ ...baseFilters, status: "archived" }),
-			starred: buildQueueUrl({ ...baseFilters, starred: true }),
 		},
 		paginationUrls: {
 			prev:


### PR DESCRIPTION
## Summary
This PR removes the article starring/favoriting feature from the queue page. The feature allowed users to toggle a star on articles and filter by starred articles, but it is being removed entirely.

## Key Changes
- **Removed star toggle functionality**: Deleted the `POST /queue/:id/star` route and `toggleArticleStar` method from the article store
- **Removed starred filter**: Eliminated the `starred` query parameter and filter UI from the queue page
- **Cleaned up data model**: Removed `isStarred` property from `SavedArticle` interface and all related logic
- **Updated UI**: Removed the star button from article action buttons and the "Starred" filter link from the navigation
- **Removed styling**: Deleted CSS rules for starred article styling (`.queue-article__action-btn--starred`)
- **Updated view models and URL parsing**: Removed `starred` from `QueueUrlState`, `QueueViewModel`, and `QueueArticleViewModel`
- **Removed tests**: Deleted test cases for the star toggle functionality

## Implementation Details
- The removal is comprehensive, touching the data layer (article store), domain models, routing, UI templates, styling, and all related tests
- No database migrations are needed as this only affects in-memory article store implementation
- The filter UI now only shows status-based filters (All, Unread, Read, Archived)

https://claude.ai/code/session_019gjp8efN35PxgwQBMYMc7C