### PR TITLE
Add reader view for saved articles with content extraction

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
 
   projects/hutch:
     dependencies:
+      '@mozilla/readability':
+        specifier: 0.6.0
+        version: 0.6.0
       compression:
         specifier: 1.8.1
         version: 1.8.1
@@ -80,6 +83,9 @@ importers:
       helmet:
         specifier: 8.1.0
         version: 8.1.0
+      linkedom:
+        specifier: 0.18.12
+        version: 0.18.12
       serverless-http:
         specifier: 4.0.0
         version: 4.0.0
@@ -860,6 +866,10 @@ packages:
     resolution: {integrity: sha512-XGSsWDweP80Fks16lwkAUIr54ICyBs6PsI4mpfTLQaWgEJRtY9xEV+PeyDpJ+sJEGZxqINlpmAwe/6tS1pP8Ng==}
     engines: {node: '>=10.3.0'}
 
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
+
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
@@ -1567,6 +1577,9 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1778,10 +1791,20 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
@@ -1865,6 +1888,19 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -1911,8 +1947,16 @@ packages:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -2206,6 +2250,12 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -2593,6 +2643,15 @@ packages:
     resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   livereload-js@4.0.2:
     resolution: {integrity: sha512-Fy7VwgQNiOkynYyNBTo3v9hQUhcW5pFAheJN148+DTgpShjsy/22pLHKKwDK5v0kOsZsJBK+6q1PMgLvRmrwFQ==}
 
@@ -2851,6 +2910,9 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -3485,6 +3547,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4356,6 +4421,8 @@ snapshots:
 
   '@logdna/tail-file@2.2.0': {}
 
+  '@mozilla/readability@0.6.0': {}
+
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -5162,6 +5229,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -5404,7 +5473,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
+
+  cssom@0.5.0: {}
 
   cssstyle@4.6.0:
     dependencies:
@@ -5460,6 +5541,24 @@ snapshots:
   diff@4.0.4:
     optional: true
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.4.7
@@ -5496,7 +5595,11 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -5880,6 +5983,15 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-escaper@3.0.3: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-cache-semantics@4.2.0: {}
 
@@ -6539,6 +6651,14 @@ snapshots:
 
   lines-and-columns@2.0.3: {}
 
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   livereload-js@4.0.2: {}
 
   livereload@0.10.3:
@@ -6792,6 +6912,10 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   nwsapi@2.2.23: {}
 
@@ -7538,6 +7662,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uhyphen@0.2.0: {}
 
   undici-types@6.21.0: {}
 

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -20,12 +20,14 @@
     "deploy": "PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack prod"
   },
   "dependencies": {
+    "@mozilla/readability": "0.6.0",
     "compression": "1.8.1",
     "cookie-parser": "1.4.7",
     "dotenv": "17.2.3",
     "express": "4.22.1",
     "handlebars": "4.7.8",
     "helmet": "8.1.0",
+    "linkedom": "0.18.12",
     "serverless-http": "4.0.0",
     "zod": "4.1.13"
   },

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -2,8 +2,8 @@ import type { Express } from "express";
 import type { Logger } from "../infra/logger";
 import { initInMemoryAuth } from "./providers/auth/in-memory-auth";
 import { initInMemoryArticleStore } from "./providers/article-store/in-memory-article-store";
-import { initStaticParser } from "./providers/article-parser/static-parser";
-import type { FetchHtml } from "./providers/article-parser/static-parser";
+import { initReadabilityParser } from "./providers/article-parser/readability-parser";
+import type { FetchHtml } from "./providers/article-parser/readability-parser";
 import { createApp } from "./server";
 import { getEnv } from "./require-env";
 
@@ -27,7 +27,7 @@ const fetchHtml: FetchHtml = async (url) => {
 export const app = createApp({
 	...initInMemoryAuth(),
 	...initInMemoryArticleStore(),
-	...initStaticParser({ fetchHtml }),
+	...initReadabilityParser({ fetchHtml }),
 });
 
 export const localServer = (expressApp: Express, logger: Logger): void => {

--- a/projects/hutch/src/runtime/domain/article/article.types.ts
+++ b/projects/hutch/src/runtime/domain/article/article.types.ts
@@ -18,6 +18,7 @@ export interface SavedArticle {
 	userId: UserId;
 	url: string;
 	metadata: ArticleMetadata;
+	content?: string;
 	estimatedReadTime: Minutes;
 	status: ArticleStatus;
 	savedAt: Date;

--- a/projects/hutch/src/runtime/providers/article-parser/readability-parser.test.ts
+++ b/projects/hutch/src/runtime/providers/article-parser/readability-parser.test.ts
@@ -1,0 +1,124 @@
+import { initReadabilityParser } from "./readability-parser";
+
+const ARTICLE_HTML = `
+<html>
+<head>
+  <title>Test Article Title</title>
+  <meta property="og:site_name" content="Test Blog">
+  <meta property="og:image" content="https://example.com/image.jpg">
+</head>
+<body>
+  <article>
+    <h1>Test Article Title</h1>
+    <p>This is the first paragraph of the article with enough text to be meaningful content for readability extraction.</p>
+    <p>This is the second paragraph with additional content that helps readability determine this is a real article worth parsing.</p>
+    <p>And a third paragraph to ensure there is enough content for the word count calculation to work properly.</p>
+  </article>
+</body>
+</html>`;
+
+describe("initReadabilityParser", () => {
+	it("should extract article title from HTML", async () => {
+		const fetchHtml = async (_url: string) => ARTICLE_HTML;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://example.com/article");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.title).toBe("Test Article Title");
+		}
+	});
+
+	it("should extract article content as HTML", async () => {
+		const fetchHtml = async (_url: string) => ARTICLE_HTML;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://example.com/article");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.content).toContain("first paragraph");
+		}
+	});
+
+	it("should calculate word count from extracted text", async () => {
+		const fetchHtml = async (_url: string) => ARTICLE_HTML;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://example.com/article");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.wordCount).toBeGreaterThan(0);
+		}
+	});
+
+	it("should extract thumbnail from og:image", async () => {
+		const fetchHtml = async (_url: string) => ARTICLE_HTML;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://example.com/article");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.imageUrl).toBe("https://example.com/image.jpg");
+		}
+	});
+
+	it("should return error for invalid URL", async () => {
+		const fetchHtml = async (_url: string) => ARTICLE_HTML;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("not-a-url");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toBe("Invalid URL");
+		}
+	});
+
+	it("should return error when fetch fails", async () => {
+		const fetchHtml = async (_url: string) => undefined;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://example.com/article");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toBe("Could not fetch article");
+		}
+	});
+
+	it("should fall back to hostname when readability cannot parse", async () => {
+		const fetchHtml = async (_url: string) => "<html><body></body></html>";
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://example.com/article");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.title).toContain("example.com");
+			expect(result.article.siteName).toBe("example.com");
+		}
+	});
+
+	it("should use hostname as siteName when og:site_name is absent", async () => {
+		const htmlWithoutSiteName = `
+		<html><head><title>Post</title></head>
+		<body><article>
+			<h1>Post</h1>
+			<p>Enough content to be parsed by readability as a real article with several words in this paragraph.</p>
+			<p>Another paragraph for good measure with additional text.</p>
+		</article></body></html>`;
+		const fetchHtml = async (_url: string) => htmlWithoutSiteName;
+		const { parseArticle } = initReadabilityParser({ fetchHtml });
+
+		const result = await parseArticle("https://blog.example.com/post");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.siteName).toBe("blog.example.com");
+		}
+	});
+});

--- a/projects/hutch/src/runtime/providers/article-parser/readability-parser.ts
+++ b/projects/hutch/src/runtime/providers/article-parser/readability-parser.ts
@@ -1,0 +1,60 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import type { ParseArticle } from "./article-parser.types";
+import { extractThumbnail } from "./extract-thumbnail";
+
+export type FetchHtml = (url: string) => Promise<string | undefined>;
+
+export function initReadabilityParser(deps: {
+	fetchHtml: FetchHtml;
+}): { parseArticle: ParseArticle } {
+	const parseArticle: ParseArticle = async (url) => {
+		let hostname: string;
+		try {
+			hostname = new URL(url).hostname;
+		} catch {
+			return { ok: false, reason: "Invalid URL" };
+		}
+
+		const html = await deps.fetchHtml(url);
+		if (!html) {
+			return { ok: false, reason: "Could not fetch article" };
+		}
+
+		const imageUrl = extractThumbnail(html);
+		const { document } = parseHTML(html);
+		const reader = new Readability(document);
+		const parsed = reader.parse();
+
+		if (!parsed) {
+			return {
+				ok: true,
+				article: {
+					title: `Article from ${hostname}`,
+					siteName: hostname,
+					excerpt: `Content saved from ${hostname}.`,
+					wordCount: 0,
+					content: "",
+					imageUrl,
+				},
+			};
+		}
+
+		const textContent = parsed.textContent ?? "";
+		const wordCount = textContent.split(/\s+/).filter(Boolean).length;
+
+		return {
+			ok: true,
+			article: {
+				title: parsed.title || `Article from ${hostname}`,
+				siteName: parsed.siteName || hostname,
+				excerpt: parsed.excerpt || `Content saved from ${hostname}.`,
+				wordCount,
+				content: parsed.content ?? "",
+				imageUrl,
+			},
+		};
+	};
+
+	return { parseArticle };
+}

--- a/projects/hutch/src/runtime/providers/article-parser/static-parser.ts
+++ b/projects/hutch/src/runtime/providers/article-parser/static-parser.ts
@@ -1,7 +1,7 @@
 import type { ParseArticle } from "./article-parser.types";
 import { extractThumbnail } from "./extract-thumbnail";
 
-export type FetchHtml = (url: string) => Promise<string | undefined>;
+type FetchHtml = (url: string) => Promise<string | undefined>;
 
 export function initStaticParser(deps?: {
 	fetchHtml?: FetchHtml;

--- a/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
+++ b/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
@@ -9,6 +9,7 @@ export interface SaveArticleParams {
 	userId: UserId;
 	url: string;
 	metadata: SavedArticle["metadata"];
+	content?: string;
 	estimatedReadTime: SavedArticle["estimatedReadTime"];
 }
 

--- a/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.ts
@@ -27,6 +27,7 @@ export function initInMemoryArticleStore(): {
 			userId: params.userId,
 			url: params.url,
 			metadata: params.metadata,
+			content: params.content,
 			estimatedReadTime: params.estimatedReadTime,
 			status: "unread",
 			savedAt: new Date(),

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -13,6 +13,7 @@ import type {
 import type { ParseArticle } from "./providers/article-parser/article-parser.types";
 import type {
 	DeleteArticle,
+	FindArticleById,
 	FindArticlesByUser,
 	SaveArticle,
 	UpdateArticleStatus,
@@ -42,6 +43,7 @@ interface AppDependencies {
 	getSessionUserId: GetSessionUserId;
 	destroySession: DestroySession;
 	parseArticle: ParseArticle;
+	findArticleById: FindArticleById;
 	findArticlesByUser: FindArticlesByUser;
 	saveArticle: SaveArticle;
 	deleteArticle: DeleteArticle;
@@ -111,6 +113,7 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	const queueRouter = initQueueRoutes({
 		findArticlesByUser: deps.findArticlesByUser,
+		findArticleById: deps.findArticleById,
 		saveArticle: deps.saveArticle,
 		parseArticle: deps.parseArticle,
 		deleteArticle: deps.deleteArticle,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -1,13 +1,18 @@
 import { initInMemoryAuth } from "./providers/auth/in-memory-auth";
 import { initInMemoryArticleStore } from "./providers/article-store/in-memory-article-store";
-import { initStaticParser } from "./providers/article-parser/static-parser";
-import type { FetchHtml } from "./providers/article-parser/static-parser";
+import { initReadabilityParser } from "./providers/article-parser/readability-parser";
+import type { FetchHtml } from "./providers/article-parser/readability-parser";
 import { createApp } from "./server";
+
+const stubFetchHtml: FetchHtml = async (url) => {
+	const hostname = new URL(url).hostname;
+	return `<html><head><title>Article from ${hostname}</title></head><body><article><p>Content saved from ${hostname}.</p></article></body></html>`;
+};
 
 export function createTestApp() {
 	const auth = initInMemoryAuth();
 	const articleStore = initInMemoryArticleStore();
-	const parser = initStaticParser();
+	const parser = initReadabilityParser({ fetchHtml: stubFetchHtml });
 
 	const app = createApp({
 		...auth,
@@ -21,7 +26,7 @@ export function createTestApp() {
 export function createTestAppWithFetchHtml(fetchHtml: FetchHtml) {
 	const auth = initInMemoryAuth();
 	const articleStore = initInMemoryArticleStore();
-	const parser = initStaticParser({ fetchHtml });
+	const parser = initReadabilityParser({ fetchHtml });
 
 	const app = createApp({
 		...auth,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -6,6 +6,7 @@ import { calculateReadTime } from "../../../domain/article/estimated-read-time";
 import type { ParseArticle } from "../../../providers/article-parser/article-parser.types";
 import type {
 	DeleteArticle,
+	FindArticleById,
 	FindArticlesByUser,
 	SaveArticle,
 	UpdateArticleStatus,
@@ -15,9 +16,11 @@ import { Base } from "../../base.component";
 import { parseQueueUrl } from "./queue.url";
 import { toQueueViewModel } from "./queue.viewmodel";
 import { createQueuePageContent } from "./queue.template";
+import { createReaderPageContent } from "../reader/reader.template";
 
 interface QueueDependencies {
 	findArticlesByUser: FindArticlesByUser;
+	findArticleById: FindArticleById;
 	saveArticle: SaveArticle;
 	parseArticle: ParseArticle;
 	deleteArticle: DeleteArticle;
@@ -88,10 +91,28 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				wordCount: article.wordCount,
 				imageUrl: article.imageUrl,
 			},
+			content: article.content || undefined,
 			estimatedReadTime: calculateReadTime(article.wordCount),
 		});
 
 		res.redirect(303, "/queue");
+	});
+
+	router.get("/:id/read", async (req: Request, res: Response) => {
+		const userId = req.userId as UserId;
+		const articleId = req.params.id as unknown as import("../../../domain/article/article.types").ArticleId;
+
+		const article = await deps.findArticleById(articleId);
+
+		if (!article || article.userId !== userId) {
+			res.redirect(303, "/queue");
+			return;
+		}
+
+		const pageContent = createReaderPageContent(article);
+		const component = Base(pageContent);
+		const html = component.to("text/html");
+		res.status(html.statusCode).type("html").send(html.body);
 	});
 
 	router.post("/:id/status", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -327,6 +327,106 @@ describe("Queue routes", () => {
 		});
 	});
 
+	describe("Reader view", () => {
+		it("should render saved article content", async () => {
+			const articleHtml = `
+			<html><head><title>Saved Post</title></head>
+			<body><article>
+				<h1>Saved Post</h1>
+				<p>This is archived content that should survive the original site going down. Enough text for readability.</p>
+				<p>A second paragraph with more words for the parser to work with properly.</p>
+			</article></body></html>`;
+
+			const fetchHtml = async (_url: string) => articleHtml;
+			const { app, auth } = createTestAppWithFetchHtml(fetchHtml);
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/saved-post" });
+
+			const queueResponse = await agent.get("/queue");
+			const queueDoc = new JSDOM(queueResponse.text).window.document;
+			const articleId = queueDoc
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+
+			const readerResponse = await agent.get(`/queue/${articleId}/read`);
+
+			expect(readerResponse.status).toBe(200);
+			const doc = new JSDOM(readerResponse.text).window.document;
+			expect(doc.querySelector("[data-test-reader-content]")?.textContent).toContain("archived content");
+			expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe("Saved Post");
+			expect(doc.querySelector("[data-test-back-link]")?.getAttribute("href")).toBe("/queue");
+			expect(doc.querySelector("[data-test-original-link]")?.getAttribute("href")).toBe("https://example.com/saved-post");
+		});
+
+		it("should redirect to queue for non-existent article", async () => {
+			const { app, auth } = createTestApp();
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/queue/nonexistent/read");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+		});
+
+		it("should redirect unauthenticated users to login", async () => {
+			const { app } = createTestApp();
+
+			const response = await request(app).get("/queue/someid/read");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/login");
+		});
+
+		it("should link article title to reader view in queue when content exists", async () => {
+			const articleHtml = `
+			<html><head><title>Content Article</title></head>
+			<body><article>
+				<h1>Content Article</h1>
+				<p>An article with enough content for readability to parse successfully.</p>
+				<p>Additional paragraph with more text to exceed the minimum threshold.</p>
+			</article></body></html>`;
+
+			const fetchHtml = async (_url: string) => articleHtml;
+			const { app, auth } = createTestAppWithFetchHtml(fetchHtml);
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/content-article" });
+
+			const queueResponse = await agent.get("/queue");
+			const doc = new JSDOM(queueResponse.text).window.document;
+			const titleLink = doc.querySelector("[data-test-article-title]");
+			expect(titleLink?.getAttribute("href")).toContain("/read");
+		});
+
+		it("should show no-content fallback when article has no extracted content", async () => {
+			const fetchHtml = async (_url: string) => "<html><body></body></html>";
+			const { app, auth } = createTestAppWithFetchHtml(fetchHtml);
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/empty-page" });
+
+			const queueResponse = await agent.get("/queue");
+			const queueDoc = new JSDOM(queueResponse.text).window.document;
+			const articleId = queueDoc
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+
+			const readerResponse = await agent.get(`/queue/${articleId}/read`);
+			const doc = new JSDOM(readerResponse.text).window.document;
+			expect(doc.querySelector("[data-test-no-content]")?.textContent).toContain("not available");
+		});
+	});
+
 	describe("Filter and sort", () => {
 		it("should filter by status", async () => {
 			const { app, auth } = createTestApp();

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.ts
@@ -44,7 +44,7 @@ function renderArticle(
       <div class="queue-article__content">
         <div class="queue-article__title-row">
           ${unreadDot}
-          <a class="queue-article__title" href="${article.url}" target="_blank" rel="noopener">${article.title}</a>
+          <a class="queue-article__title" href="${article.hasContent ? `/queue/${article.id}/read` : article.url}"${article.hasContent ? "" : ' target="_blank" rel="noopener"'} data-test-article-title>${article.title}</a>
         </div>
         ${options.showUrl ? `<span class="queue-article__url" data-test-article-url>${article.url}</span>` : ""}
         <div class="queue-article__meta">

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -14,6 +14,7 @@ export interface QueueArticleViewModel {
 	isUnread: boolean;
 	savedAgo: string;
 	imageUrl?: string;
+	hasContent: boolean;
 }
 
 export interface QueueViewModel {
@@ -73,6 +74,7 @@ function toArticleViewModel(
 		isUnread: article.status === "unread",
 		savedAgo: formatRelativeDate(article.savedAt, now),
 		imageUrl: article.metadata.imageUrl,
+		hasContent: Boolean(article.content),
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/reader/reader.styles.css
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.styles.css
@@ -1,0 +1,181 @@
+.reader {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+}
+
+.reader__header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-border, #e0e0e0);
+}
+
+.reader__title {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0 0 0.75rem;
+  color: var(--color-text, #1a1a1a);
+}
+
+.reader__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+}
+
+.reader__back {
+  display: inline-block;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  color: var(--color-link, #2B3A55);
+  text-decoration: none;
+}
+
+.reader__back:hover {
+  text-decoration: underline;
+}
+
+.reader__original-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-link, #2B3A55);
+  text-decoration: none;
+}
+
+.reader__original-link:hover {
+  text-decoration: underline;
+}
+
+.reader__content {
+  font-size: 1.125rem;
+  line-height: 1.8;
+  color: var(--color-text, #1a1a1a);
+}
+
+.reader__content p {
+  margin: 0 0 1.25rem;
+}
+
+.reader__content h1,
+.reader__content h2,
+.reader__content h3,
+.reader__content h4 {
+  margin: 2rem 0 1rem;
+  line-height: 1.3;
+}
+
+.reader__content h2 {
+  font-size: 1.5rem;
+}
+
+.reader__content h3 {
+  font-size: 1.25rem;
+}
+
+.reader__content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin: 1rem 0;
+}
+
+.reader__content a {
+  color: var(--color-link, #2B3A55);
+}
+
+.reader__content blockquote {
+  margin: 1.5rem 0;
+  padding: 0.5rem 0 0.5rem 1.25rem;
+  border-left: 3px solid var(--color-border, #e0e0e0);
+  color: var(--color-text-secondary, #666);
+}
+
+.reader__content pre {
+  overflow-x: auto;
+  padding: 1rem;
+  background: var(--color-surface, #f5f5f5);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 1.25rem 0;
+}
+
+.reader__content code {
+  font-size: 0.875em;
+  padding: 0.15em 0.3em;
+  background: var(--color-surface, #f5f5f5);
+  border-radius: 3px;
+}
+
+.reader__content pre code {
+  padding: 0;
+  background: none;
+}
+
+.reader__content ul,
+.reader__content ol {
+  margin: 1rem 0;
+  padding-left: 1.5rem;
+}
+
+.reader__content li {
+  margin-bottom: 0.5rem;
+}
+
+.reader__content figure {
+  margin: 1.5rem 0;
+}
+
+.reader__content figcaption {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+.reader__no-content {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--color-text-secondary, #666);
+}
+
+.reader__no-content-title {
+  font-size: 1.25rem;
+  margin: 0 0 0.75rem;
+}
+
+.reader__no-content-text {
+  margin: 0 0 1rem;
+}
+
+.reader__no-content-link {
+  color: var(--color-link, #2B3A55);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.reader__no-content-link:hover {
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme: dark) {
+  .reader__title {
+    color: var(--color-text, #e0e0e0);
+  }
+
+  .reader__content {
+    color: var(--color-text, #e0e0e0);
+  }
+
+  .reader__content pre {
+    background: var(--color-surface, #2a2a2a);
+  }
+
+  .reader__content code {
+    background: var(--color-surface, #2a2a2a);
+  }
+}

--- a/projects/hutch/src/runtime/web/pages/reader/reader.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.styles.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const stylesPath = join(__dirname, "reader.styles.css");
+export const READER_STYLES = readFileSync(stylesPath, "utf-8");

--- a/projects/hutch/src/runtime/web/pages/reader/reader.template.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.template.ts
@@ -1,0 +1,48 @@
+import type { SavedArticle } from "../../../domain/article/article.types";
+import type { PageContent } from "../../base.component";
+import { READER_STYLES } from "./reader.styles";
+
+function renderReaderContent(article: SavedArticle): string {
+	if (!article.content) {
+		return `
+    <div class="reader__no-content" data-test-no-content>
+      <h2 class="reader__no-content-title">Content not available</h2>
+      <p class="reader__no-content-text">The article content could not be extracted when it was saved.</p>
+      <a class="reader__no-content-link" href="${article.url}" target="_blank" rel="noopener">View original article</a>
+    </div>`;
+	}
+
+	return `
+    <div class="reader__header">
+      <a class="reader__back" href="/queue" data-test-back-link>← Back to queue</a>
+      <h1 class="reader__title" data-test-reader-title>${article.metadata.title}</h1>
+      <div class="reader__meta">
+        <span data-test-reader-site>${article.metadata.siteName}</span>
+        <span>${article.estimatedReadTime} min read</span>
+      </div>
+      <a class="reader__original-link" href="${article.url}" target="_blank" rel="noopener" data-test-original-link>View original</a>
+    </div>
+    <div class="reader__content" data-test-reader-content>
+      ${article.content}
+    </div>`;
+}
+
+export function createReaderPageContent(article: SavedArticle): PageContent {
+	const content = `
+    <main class="reader">
+      ${renderReaderContent(article)}
+    </main>`;
+
+	return {
+		seo: {
+			title: `${article.metadata.title} — Hutch Reader`,
+			description: article.metadata.excerpt,
+			canonicalUrl: `/queue/${article.id}/read`,
+			robots: "noindex, nofollow",
+		},
+		styles: READER_STYLES,
+		bodyClass: "page-reader",
+		content,
+		isAuthenticated: true,
+	};
+}


### PR DESCRIPTION
## Summary
This PR adds a dedicated reader view for saved articles, allowing users to read extracted article content in a distraction-free interface. The implementation replaces the static parser with Mozilla's Readability library for more robust content extraction and adds a new `/queue/:id/read` route to display articles.

## Key Changes
- **Reader View Page**: Added new reader page component (`reader.template.ts`) with dedicated styling (`reader.styles.css`) that displays article content in a clean, readable format with support for various content types (headings, images, code blocks, blockquotes, etc.)
- **Content Extraction**: Replaced static parser with `readabilityParser` using Mozilla's Readability library for intelligent HTML content extraction, including title, excerpt, site name, and word count calculation
- **Article Storage**: Extended `SavedArticle` type to include optional `content` field for storing extracted HTML content
- **Queue Integration**: Updated queue page to link article titles to reader view when content is available, with fallback to original URL when content extraction fails
- **Reader Route**: Added `GET /queue/:id/read` endpoint that displays saved article content with back navigation and original article link
- **Comprehensive Tests**: Added 124 lines of tests for readability parser covering success cases, error handling, and fallback behavior; added 100+ lines of integration tests for reader view functionality

## Implementation Details
- Reader view includes metadata display (site name, estimated read time) and navigation controls
- No-content fallback state gracefully handles articles where content extraction failed
- Dark mode support via CSS custom properties and `prefers-color-scheme` media query
- Content styling handles common HTML elements: paragraphs, headings, images with captions, code blocks, lists, blockquotes, and figures
- Article content is sanitized through Readability's parsing before storage and display
- Test app updated to use Readability parser with stub fetch for consistent test behavior

https://claude.ai/code/session_01G3pLY8nELRCnrxyP3E6FSq