### PR TITLE
Extract context menu IDs to constants

### DIFF
--- a/projects/browser-extension-core/src/index.ts
+++ b/projects/browser-extension-core/src/index.ts
@@ -17,3 +17,7 @@ export type {
 export type { PopupMessage } from "./popup-message.types";
 export { filterByUrl } from "./popup/filter-by-url";
 export { paginateItems } from "./popup/paginate-items";
+export {
+	MENU_ITEM_SAVE_PAGE,
+	MENU_ITEM_SAVE_LINK,
+} from "./save-from-context-menu";

--- a/projects/firefox-extension/src/runtime/background/background.ts
+++ b/projects/firefox-extension/src/runtime/background/background.ts
@@ -1,5 +1,7 @@
 import {
 	BrowserExtensionCore,
+	MENU_ITEM_SAVE_PAGE,
+	MENU_ITEM_SAVE_LINK,
 	type BrowserShell,
 	type PopupMessage,
 	type ReadingListItem,
@@ -66,12 +68,12 @@ const shell: BrowserShell = {
 
 	createContextMenus() {
 		browser.menus.create({
-			id: "save-page-to-hutch",
+			id: MENU_ITEM_SAVE_PAGE,
 			title: "Save Page to Hutch",
 			contexts: ["page"],
 		});
 		browser.menus.create({
-			id: "save-link-to-hutch",
+			id: MENU_ITEM_SAVE_LINK,
 			title: "Save Link to Hutch",
 			contexts: ["link"],
 		});


### PR DESCRIPTION
## Summary
Refactored context menu ID strings into named constants to improve maintainability and reduce duplication across the codebase.

## Key Changes
- Created `MENU_ITEM_SAVE_PAGE` and `MENU_ITEM_SAVE_LINK` constants in the browser-extension-core package
- Replaced hardcoded menu ID strings (`"save-page-to-hutch"` and `"save-link-to-hutch"`) with the new constants in the Firefox extension background script
- Exported the new constants from `browser-extension-core` for use across the extension

## Implementation Details
- Constants are defined in a new `save-from-context-menu` module within browser-extension-core
- This change centralizes menu ID definitions, making it easier to maintain consistency if these values need to be updated in the future
- The constants are now available for reuse in other parts of the codebase that may need to reference these menu items

https://claude.ai/code/session_017inXhA9ZonPPGEEbDRzSxQ