### PR TITLE
Refactor OAuth and 404 pages to use Base component

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -29,7 +29,7 @@ import { LandingPage } from "./web/pages/landing";
 import { PrivacyPage } from "./web/pages/privacy";
 import { TermsPage } from "./web/pages/terms";
 import { InstallPage } from "./web/pages/install";
-import { render } from "./web/render";
+import { NotFoundPage } from "./web/pages/not-found";
 import { requireEnv } from "./require-env";
 import "./web/session.types";
 
@@ -153,19 +153,9 @@ export function createApp(dependencies: AppDependencies): Express {
 	});
 	app.use("/oauth", oauthRouter);
 
-	const NOT_FOUND_TEMPLATE = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>404 - Not Found</title>
-</head>
-<body>
-  <h1>404 - Page Not Found</h1>
-</body>
-</html>`;
-
 	app.use((_req: Request, res: Response) => {
-		res.status(404).type("html").send(render(NOT_FOUND_TEMPLATE, {}));
+		const result = NotFoundPage().to("text/html");
+		res.status(404).type("html").send(result.body);
 	});
 
 	return app;

--- a/projects/hutch/src/runtime/web/oauth/oauth.template.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.template.ts
@@ -1,6 +1,6 @@
 import Handlebars from "handlebars";
+import { Base } from "../base.component";
 import type { Component } from "../component.types";
-import { HtmlPage } from "../html-page";
 
 interface AuthorizePageParams {
 	clientName: string;
@@ -12,67 +12,131 @@ interface AuthorizePageParams {
 
 const escapeHtml = Handlebars.Utils.escapeExpression;
 
+const OAUTH_AUTHORIZE_STYLES = `
+.oauth-authorize {
+  padding: 80px 20px;
+}
+
+.oauth-authorize__container {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.oauth-authorize__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: var(--foreground);
+}
+
+.oauth-authorize__text {
+  color: var(--muted-foreground);
+  margin-bottom: 24px;
+  line-height: 1.6;
+}
+
+.oauth-authorize__buttons {
+  display: flex;
+  gap: 1rem;
+}
+
+.oauth-authorize__btn {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.oauth-authorize__btn--approve {
+  background: var(--primary);
+  color: white;
+  border: none;
+}
+
+.oauth-authorize__btn--deny {
+  background: var(--background);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+}
+`;
+
+const OAUTH_CALLBACK_STYLES = `
+.oauth-callback {
+  padding: 120px 20px;
+  text-align: center;
+}
+
+.oauth-callback__container {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.oauth-callback__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: var(--foreground);
+}
+
+.oauth-callback__text {
+  color: var(--muted-foreground);
+}
+`;
+
 export function OAuthAuthorizePage(params: AuthorizePageParams): Component {
 	const { clientName, clientId, redirectUri, codeChallenge, state } = params;
 
-	const body = `<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Authorize ${escapeHtml(clientName)}</title>
-	<style>
-		body { font-family: system-ui, sans-serif; max-width: 400px; margin: 40px auto; padding: 20px; }
-		h1 { font-size: 1.5rem; margin-bottom: 1rem; }
-		p { color: #666; margin-bottom: 1.5rem; }
-		.buttons { display: flex; gap: 1rem; }
-		button { padding: 0.75rem 1.5rem; font-size: 1rem; border-radius: 4px; cursor: pointer; }
-		.approve { background: #2563eb; color: white; border: none; }
-		.deny { background: white; border: 1px solid #ccc; }
-	</style>
-</head>
-<body>
-	<h1>Authorize ${escapeHtml(clientName)}</h1>
-	<p><strong>${escapeHtml(clientName)}</strong> wants to access your Hutch account.</p>
-	<form method="POST" action="/oauth/authorize">
-		<input type="hidden" name="client_id" value="${escapeHtml(clientId)}">
-		<input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri)}">
-		<input type="hidden" name="response_type" value="code">
-		<input type="hidden" name="code_challenge" value="${escapeHtml(codeChallenge)}">
-		<input type="hidden" name="code_challenge_method" value="S256">
-		${state ? `<input type="hidden" name="state" value="${escapeHtml(state)}">` : ""}
-		<div class="buttons">
-			<button type="submit" name="action" value="approve" class="approve">Approve</button>
-			<button type="submit" name="action" value="deny" class="deny">Deny</button>
-		</div>
-	</form>
-</body>
-</html>`;
+	const content = `
+    <main class="oauth-authorize">
+      <div class="oauth-authorize__container">
+        <h1 class="oauth-authorize__title">Authorize ${escapeHtml(clientName)}</h1>
+        <p class="oauth-authorize__text"><strong>${escapeHtml(clientName)}</strong> wants to access your Hutch account.</p>
+        <form method="POST" action="/oauth/authorize">
+          <input type="hidden" name="client_id" value="${escapeHtml(clientId)}">
+          <input type="hidden" name="redirect_uri" value="${escapeHtml(redirectUri)}">
+          <input type="hidden" name="response_type" value="code">
+          <input type="hidden" name="code_challenge" value="${escapeHtml(codeChallenge)}">
+          <input type="hidden" name="code_challenge_method" value="S256">
+          ${state ? `<input type="hidden" name="state" value="${escapeHtml(state)}">` : ""}
+          <div class="oauth-authorize__buttons">
+            <button type="submit" name="action" value="approve" class="oauth-authorize__btn oauth-authorize__btn--approve">Approve</button>
+            <button type="submit" name="action" value="deny" class="oauth-authorize__btn oauth-authorize__btn--deny">Deny</button>
+          </div>
+        </form>
+      </div>
+    </main>`;
 
-	return HtmlPage(body);
+	return Base({
+		seo: {
+			title: `Authorize ${clientName} — Hutch`,
+			description: `${clientName} is requesting access to your Hutch account.`,
+			canonicalUrl: "/oauth/authorize",
+			robots: "noindex, nofollow",
+		},
+		styles: OAUTH_AUTHORIZE_STYLES,
+		bodyClass: "page-oauth-authorize",
+		content,
+		isAuthenticated: true,
+	});
 }
 
 export function OAuthCallbackPage(): Component {
-	const body = `<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Authorization Complete</title>
-	<style>
-		body { font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
-		.message { text-align: center; padding: 2rem; background: white; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-		h1 { color: #333; margin: 0 0 1rem 0; font-size: 1.5rem; }
-		p { color: #666; margin: 0; }
-	</style>
-</head>
-<body>
-	<div class="message">
-		<h1>Authorization Complete</h1>
-		<p>You may close this window.</p>
-	</div>
-</body>
-</html>`;
-
-	return HtmlPage(body);
+	return Base({
+		seo: {
+			title: "Authorization Complete — Hutch",
+			description: "OAuth authorization is complete.",
+			canonicalUrl: "/oauth/callback",
+			robots: "noindex, nofollow",
+		},
+		styles: OAUTH_CALLBACK_STYLES,
+		bodyClass: "page-oauth-callback",
+		content: `
+    <main class="oauth-callback">
+      <div class="oauth-callback__container">
+        <h1 class="oauth-callback__title">Authorization Complete</h1>
+        <p class="oauth-callback__text">You may close this window.</p>
+      </div>
+    </main>`,
+		isAuthenticated: true,
+	});
 }

--- a/projects/hutch/src/runtime/web/pages/not-found/index.ts
+++ b/projects/hutch/src/runtime/web/pages/not-found/index.ts
@@ -1,0 +1,1 @@
+export { NotFoundPage } from "./not-found.page";

--- a/projects/hutch/src/runtime/web/pages/not-found/not-found.page.ts
+++ b/projects/hutch/src/runtime/web/pages/not-found/not-found.page.ts
@@ -1,0 +1,24 @@
+import { Base } from "../../base.component";
+import type { Component } from "../../component.types";
+import { NOT_FOUND_STYLES } from "./not-found.styles";
+
+export function NotFoundPage(): Component {
+	return Base({
+		seo: {
+			title: "Page Not Found — Hutch",
+			description: "The page you are looking for does not exist.",
+			canonicalUrl: "https://hutch-app.com",
+			robots: "noindex, nofollow",
+		},
+		styles: NOT_FOUND_STYLES,
+		bodyClass: "page-not-found",
+		content: `
+    <main class="not-found">
+      <div class="not-found__container">
+        <h1 class="not-found__title">Page not found</h1>
+        <p class="not-found__text">The page you are looking for does not exist or has been moved.</p>
+        <a href="/" class="not-found__link">Go to homepage</a>
+      </div>
+    </main>`,
+	});
+}

--- a/projects/hutch/src/runtime/web/pages/not-found/not-found.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/not-found/not-found.styles.ts
@@ -1,0 +1,30 @@
+export const NOT_FOUND_STYLES = `
+.not-found {
+  padding: 120px 20px;
+  text-align: center;
+}
+
+.not-found__container {
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.not-found__title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: var(--foreground);
+}
+
+.not-found__text {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--muted-foreground);
+  margin-bottom: 24px;
+}
+
+.not-found__link {
+  color: var(--primary);
+  text-decoration: underline;
+}
+`;


### PR DESCRIPTION
## Summary
Refactored OAuth authorization/callback pages and the 404 not found page to use the new `Base` component instead of inline HTML templates. This improves consistency, maintainability, and enables proper SEO metadata handling across these pages.

## Key Changes
- **OAuth pages**: Migrated `OAuthAuthorizePage` and `OAuthCallbackPage` from `HtmlPage` wrapper to `Base` component with:
  - Extracted styles into `OAUTH_AUTHORIZE_STYLES` and `OAUTH_CALLBACK_STYLES` constants
  - Added proper SEO metadata (title, description, canonical URL, robots directives)
  - Refactored HTML structure to use semantic content sections
  - Applied BEM-style CSS class naming for better maintainability

- **404 Not Found page**: Created new dedicated page component with:
  - New file structure: `not-found.page.ts`, `not-found.styles.ts`, and `index.ts`
  - Extracted styles into `NOT_FOUND_STYLES` constant
  - Proper SEO configuration with noindex/nofollow directives
  - Consistent styling with other pages using CSS custom properties

- **Server routing**: Updated 404 fallback handler to use `NotFoundPage()` component instead of inline template

## Implementation Details
- All pages now use the `Base` component for consistent layout and styling
- Styles use CSS custom properties (`--foreground`, `--muted-foreground`, `--primary`, `--background`, `--border`) for theme consistency
- BEM naming convention applied to all CSS classes for better organization
- SEO metadata properly configured for all pages with appropriate robots directives

https://claude.ai/code/session_01Fj6zKcBxk5rDLZ9oGzcXaT