### PR TITLE
Skip infrastructure checks in Claude Code environment

### DIFF
--- a/projects/firefox-extension/package.json
+++ b/projects/firefox-extension/package.json
@@ -17,7 +17,7 @@
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test:sequential": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000 --runInBand",
     "test-with-coverage": "tsc && c8 node scripts/run-tests-with-coverage.js && node enforce-coverage.config.js",
-    "check-infra": "PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack prod",
+    "check-infra": "if [ \"$CLAUDECODE\" = 1 ]; then echo 'Skipping check-infra in Claude Code environment'; else PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack prod; fi",
     "check": "pnpm compile && pnpm lint && pnpm test-with-coverage && pnpm check-infra",
     "ext:run": "web-ext run --source-dir dist-extension"
   },

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -15,7 +15,7 @@
     "compile": "rm -rf dist && tsc && node scripts/copy-static-assets.js",
     "check-unused-css": "node scripts/check-unused-css.js",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\" \"pnpm check-unused-css\"",
-    "check-infra": "PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack prod",
+    "check-infra": "if [ \"$CLAUDECODE\" = 1 ]; then echo 'Skipping check-infra in Claude Code environment'; else PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack prod; fi",
     "check": "pnpm compile && pnpm lint && pnpm test-with-coverage && pnpm check-infra",
     "deploy": "PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack prod"
   },


### PR DESCRIPTION
## Summary
Modified the `check-infra` npm scripts to skip Pulumi infrastructure preview checks when running in the Claude Code environment, preventing potential authentication or configuration issues in that context.

## Changes
- Updated `check-infra` script in `projects/firefox-extension/package.json` to conditionally skip the Pulumi preview command when the `CLAUDECODE` environment variable is set to `1`
- Updated `check-infra` script in `projects/hutch/package.json` with the same conditional logic
- When skipped, the script outputs an informational message instead of attempting to run the Pulumi command

## Implementation Details
The scripts now use a shell conditional (`if [ "$CLAUDECODE" = 1 ]`) to detect the Claude Code environment and either:
- Echo a skip message and exit successfully, or
- Execute the original Pulumi infrastructure preview command

This allows the `check` command (which depends on `check-infra`) to complete successfully in Claude Code environments without requiring Pulumi credentials or configuration.

https://claude.ai/code/session_01AGutnRQy5d5SZUK9irj6p3