### PR TITLE
Add data-test-filter attributes to queue filter links

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/queue-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/queue-actions.ts
@@ -203,7 +203,7 @@ export function createQueueActions(authProgress: AuthProgress, progress: QueuePr
       return isOnPage(page, 'page-queue')
     },
     execute: async (page) => {
-      await clickAndWaitForPageReload(page, page.locator('[data-test-filters] a:text-is("Read")'))
+      await clickAndWaitForPageReload(page, page.locator('[data-test-filter="read"]'))
 
       const count = await getArticleCount(page)
       expect(count).toBe(1)
@@ -222,7 +222,7 @@ export function createQueueActions(authProgress: AuthProgress, progress: QueuePr
       return isOnPage(page, 'page-queue')
     },
     execute: async (page) => {
-      await clickAndWaitForPageReload(page, page.locator('[data-test-filters] a:has-text("Unread")'))
+      await clickAndWaitForPageReload(page, page.locator('[data-test-filter="unread"]'))
 
       const count = await getArticleCount(page)
       expect(count).toBe(1)
@@ -241,7 +241,7 @@ export function createQueueActions(authProgress: AuthProgress, progress: QueuePr
       return isOnPage(page, 'page-queue')
     },
     execute: async (page) => {
-      await clickAndWaitForPageReload(page, page.locator('[data-test-filters] a:has-text("Archived")'))
+      await clickAndWaitForPageReload(page, page.locator('[data-test-filter="archived"]'))
 
       const count = await getArticleCount(page)
       expect(count).toBe(1)

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -9,10 +9,10 @@
       </form>
       {{#if saveError}}<p class="queue__save-error" data-test-save-error>{{saveError}}</p>{{/if}}
       <nav class="queue__filters" data-test-filters>
-        <a class="{{filterAllClass}}" href="{{filterAllUrl}}">All</a>
-        <a class="{{filterUnreadClass}}" href="{{filterUnreadUrl}}">Unread</a>
-        <a class="{{filterReadClass}}" href="{{filterReadUrl}}">Read</a>
-        <a class="{{filterArchivedClass}}" href="{{filterArchivedUrl}}">Archived</a>
+        <a class="{{filterAllClass}}" href="{{filterAllUrl}}" data-test-filter="all">All</a>
+        <a class="{{filterUnreadClass}}" href="{{filterUnreadUrl}}" data-test-filter="unread">Unread</a>
+        <a class="{{filterReadClass}}" href="{{filterReadUrl}}" data-test-filter="read">Read</a>
+        <a class="{{filterArchivedClass}}" href="{{filterArchivedUrl}}" data-test-filter="archived">Archived</a>
       </nav>
       <div class="queue__sort">
         <a class="queue__sort-link" href="{{showUrlToggleUrl}}" data-test-show-url>{{showUrlToggleLabel}}</a>


### PR DESCRIPTION
## Summary
This PR improves test reliability by adding explicit `data-test-filter` attributes to the queue filter navigation links and updating the corresponding e2e test selectors to use these attributes instead of text-based locators.

## Key Changes
- Added `data-test-filter` attributes to each filter link in the queue template (`all`, `unread`, `read`, `archived`)
- Updated e2e test selectors in `queue-actions.ts` to use the new `data-test-filter` attributes instead of text-based selectors:
  - Replaced `[data-test-filters] a:text-is("Read")` with `[data-test-filter="read"]`
  - Replaced `[data-test-filters] a:has-text("Unread")` with `[data-test-filter="unread"]`
  - Replaced `[data-test-filters] a:has-text("Archived")` with `[data-test-filter="archived"]`

## Implementation Details
This change follows testing best practices by using dedicated test attributes rather than relying on text content or complex CSS selectors. This makes the tests more maintainable and less brittle to UI text changes, while also improving selector performance and clarity.

https://claude.ai/code/session_01ABu6APiTYnwSY6wuzhJwWQ