### PR TITLE
Update default server URL to production endpoint

### DIFF
--- a/projects/firefox-extension/src/runtime/background/background.ts
+++ b/projects/firefox-extension/src/runtime/background/background.ts
@@ -15,7 +15,7 @@ import { createBrowserSetIcon } from "./tinted-icon.browser";
 
 const STORAGE_KEY = "hutch_oauth_tokens";
 const SERVER_URL_KEY = "hutch_server_url";
-const DEFAULT_SERVER_URL = "http://127.0.0.1:3000";
+const DEFAULT_SERVER_URL = "https://hutch-app.com";
 const CLIENT_ID = "hutch-firefox-extension";
 
 const tokenStorage: TokenStorage = {


### PR DESCRIPTION
## Summary
Updated the default server URL configuration for the Firefox extension from a local development endpoint to the production Hutch application URL.

## Changes
- Changed `DEFAULT_SERVER_URL` from `http://127.0.0.1:3000` (local development server) to `https://hutch-app.com` (production endpoint)

## Details
This change ensures that the Firefox extension connects to the production Hutch application by default, rather than requiring users to configure a local development server. The extension will now work out-of-the-box for end users without additional setup.

https://claude.ai/code/session_01RnHDNUxjqe2gUfQmmaj8rL