### PR TITLE
Replace custom base64url encoding with js-base64 library

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   projects/browser-extension-core:
     dependencies:
+      js-base64:
+        specifier: 3.7.8
+        version: 3.7.8
       zod:
         specifier: 4.1.13
         version: 4.1.13
@@ -3490,6 +3493,9 @@ packages:
 
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -9137,6 +9143,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@5.9.6: {}
+
+  js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
 

--- a/projects/browser-extension-core/package.json
+++ b/projects/browser-extension-core/package.json
@@ -14,6 +14,7 @@
     "check": "pnpm compile && pnpm lint && pnpm test-with-coverage"
   },
   "dependencies": {
+    "js-base64": "3.7.8",
     "zod": "4.1.13"
   },
   "devDependencies": {

--- a/projects/browser-extension-core/src/auth/pkce.ts
+++ b/projects/browser-extension-core/src/auth/pkce.ts
@@ -1,21 +1,14 @@
-function base64UrlEncode(buffer: ArrayBuffer): string {
-	const bytes = new Uint8Array(buffer);
-	let binary = "";
-	for (const byte of bytes) {
-		binary += String.fromCharCode(byte);
-	}
-	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
+import { fromUint8Array } from "js-base64";
 
 export function generateCodeVerifier(): string {
 	const array = new Uint8Array(32);
 	crypto.getRandomValues(array);
-	return base64UrlEncode(array.buffer);
+	return fromUint8Array(array, true);
 }
 
 export async function generateCodeChallenge(verifier: string): Promise<string> {
 	const encoder = new TextEncoder();
 	const data = encoder.encode(verifier);
 	const digest = await crypto.subtle.digest("SHA-256", data);
-	return base64UrlEncode(digest);
+	return fromUint8Array(new Uint8Array(digest), true);
 }


### PR DESCRIPTION
## Summary
Refactored PKCE authentication utilities to use the `js-base64` library instead of a custom base64url encoding implementation.

## Key Changes
- Removed custom `base64UrlEncode()` function from `pkce.ts`
- Added `js-base64` dependency (v3.7.8) to project dependencies
- Updated `generateCodeVerifier()` to use `fromUint8Array(array, true)` for base64url encoding
- Updated `generateCodeChallenge()` to use `fromUint8Array(new Uint8Array(digest), true)` for base64url encoding

## Implementation Details
The `js-base64` library's `fromUint8Array()` function with the second parameter set to `true` provides URL-safe base64 encoding (replacing `+` with `-` and `/` with `_`, and removing padding), which is the standard requirement for PKCE code verifiers and challenges. This eliminates the need to maintain custom encoding logic and leverages a well-tested, maintained library.

https://claude.ai/code/session_01DzzeAWXJQTakdKfgxob8NT