### PR TITLE
Sign Firefox extension via AMO and simplify installation

### DIFF
--- a/projects/firefox-extension/src/infra/index.ts
+++ b/projects/firefox-extension/src/infra/index.ts
@@ -39,7 +39,9 @@ const bucketPolicy = new aws.s3.BucketPolicy("hutch-extension-policy", {
 	),
 });
 
-const distFilesDir = join(__dirname, "..", "..", "dist-extension-files");
+const signedDir = join(__dirname, "..", "..", "dist-extension-signed");
+const unsignedDir = join(__dirname, "..", "..", "dist-extension-files");
+const distFilesDir = fs.existsSync(signedDir) ? signedDir : unsignedDir;
 const xpiFiles = fs
 	.readdirSync(distFilesDir)
 	.filter((f) => f.endsWith(".xpi"));

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -39,7 +39,7 @@ describe("GET /install", () => {
 			'[data-test-cta="download-extension"]',
 		) as HTMLAnchorElement;
 		expect(cta.getAttribute("href")).toBe(getExtensionDownloadUrl("prod", TEST_XPI_FILENAME));
-		expect(cta.textContent).toBe("Download Hutch for Firefox (test mode)");
+		expect(cta.textContent).toBe("Download Hutch for Firefox");
 	});
 
 	it("should render installation steps", async () => {

--- a/projects/hutch/src/runtime/web/pages/install/install.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.styles.ts
@@ -68,11 +68,4 @@ export const INSTALL_PAGE_STYLES = `
   border-radius: 4px;
   font-size: 0.875rem;
 }
-
-.install-page__footnote {
-  font-size: 0.875rem;
-  line-height: 1.6;
-  color: var(--muted-foreground);
-  margin-top: 16px;
-}
 `;

--- a/projects/hutch/src/runtime/web/pages/install/install.template.html
+++ b/projects/hutch/src/runtime/web/pages/install/install.template.html
@@ -3,7 +3,7 @@
       <h1 class="install-page__title">Install Hutch for Firefox</h1>
       <p class="install-page__subtitle">Save articles to your reading list with a single click or keyboard shortcut.</p>
 
-      <a href="{{extensionDownloadUrl}}" class="install-page__download" data-test-cta="download-extension">Download Hutch for Firefox (test mode)</a>
+      <a href="{{extensionDownloadUrl}}" class="install-page__download" data-test-cta="download-extension">Download Hutch for Firefox</a>
 
       <section class="install-page__steps" data-test-section="install-steps">
         <h2>Installation steps</h2>
@@ -13,7 +13,5 @@
           <li>Click "Add" to install the extension</li>
         </ol>
       </section>
-
-      <p class="install-page__footnote" data-test-section="install-footnote">Login uses your real hutch-app.com account via OAuth, but saved links are stored in memory only and will be lost when the extension reloads.</p>
     </div>
   </main>


### PR DESCRIPTION
## Summary
This PR transitions the Firefox extension from unsigned/test mode to officially signed via Mozilla's Add-on Operations (AMO) platform, and updates the installation experience accordingly.

## Key Changes

- **CI/CD Pipeline**: Added a new step in the GitHub Actions workflow to sign the compiled Firefox extension using `web-ext sign` with AMO credentials before deploying to S3
- **Installation Instructions**: Simplified the install page by removing the need for manual Firefox configuration (`about:config` changes) since the extension is now officially signed
- **Manifest Updates**: Added Firefox-specific settings including minimum version requirement (109.0) and data collection permissions declaration
- **Deployment Logic**: Updated the Pulumi infrastructure code to prioritize signed extensions from `dist-extension-signed` directory, falling back to unsigned files if needed
- **UI/UX**: Removed "(test mode)" label from the download button and the informational note about test mode limitations, reflecting the extension's production-ready status
- **Tests**: Updated test expectations to match the simplified 3-step installation process (down from 6 steps)

## Implementation Details

The signing process uses the `web-ext` CLI tool with the `unlisted` channel, which allows the extension to be installed directly without appearing in the public Firefox Add-ons marketplace. AMO credentials are securely passed via GitHub secrets. The infrastructure code intelligently detects signed artifacts and uses them when available, maintaining backward compatibility with the unsigned build process.

https://claude.ai/code/session_017U1awvWF3T29zuuQnbfuxY