### PR TITLE
feat(infra): enable deletion protection on users and articles DynamoDB tables ✅

### DIFF
--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -83,6 +83,7 @@ class HutchStorage {
 	constructor(_name: string) {
 		this.articlesTable = new aws.dynamodb.Table(`hutch-articles`, {
 			billingMode: "PAY_PER_REQUEST",
+			deletionProtectionEnabled: true,
 			hashKey: "id",
 			attributes: [
 				{ name: "id", type: "S" },
@@ -101,6 +102,7 @@ class HutchStorage {
 
 		this.usersTable = new aws.dynamodb.Table(`hutch-users`, {
 			billingMode: "PAY_PER_REQUEST",
+			deletionProtectionEnabled: true,
 			hashKey: "email",
 			attributes: [
 				{ name: "email", type: "S" },


### PR DESCRIPTION
These tables contain critical data that must never be accidentally deleted.
Deletion protection must be disabled manually before any table deletion.

https://claude.ai/code/session_011FHhM8U6sDcCjcJREZjKx4