### PR TITLE
refactor: extract extension signing into reusable workflow ✅

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -27,6 +27,8 @@ Inspect the `.yml` files in this directory for implementation details. Summary:
 | `claude-PR-code-reviewer.yml` | Automated code review | CI succeeds on PR |
 | `claude-PR-code-review-auto-apply.yml` | Fix HIGH/MEDIUM priority issues | Claude review comment |
 | `claude-PR-conflict-fixer.yml` | Resolve merge conflicts | CI succeeds + conflicts detected |
+| `submit-extension-for-signing.yml` | Submit Firefox extension to AMO for signing | Called by `ci.yml` |
+| `sync-signed-extension.yml` | Sync signed Firefox extension from AMO to S3 | Schedule (every 12h) / manual |
 
 ## Prompt Files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,43 +67,12 @@ jobs:
       - run: PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack prod --yes
         working-directory: projects/hutch
 
-  deploy-extension:
+  submit-extension-for-signing:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: check
-    runs-on: ubuntu-latest
-    environment: prod
-    env:
+    uses: ./.github/workflows/submit-extension-for-signing.yml
+    secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ap-southeast-2
-      PULUMI_BACKEND_URL: s3://hutch-pulumi-state-278728209435-ap-southeast-2
-      PULUMI_CONFIG_PASSPHRASE: ''
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Deploy extension bucket infrastructure
-        run: pulumi up --stack prod --yes
-        working-directory: projects/firefox-extension
-
-      - name: Bump extension version
-        run: node projects/firefox-extension/scripts/bump-version.js ${{ github.run_number }}
-
-      - name: Build and package extension
-        run: npx nx run-many --target=compile --projects=browser-extension-core,firefox-extension
-
-      - name: Submit extension to AMO for signing
-        run: npx nx run firefox-extension:sign
-        env:
-          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
-          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+      AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+      AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}

--- a/.github/workflows/submit-extension-for-signing.yml
+++ b/.github/workflows/submit-extension-for-signing.yml
@@ -1,0 +1,53 @@
+name: Submit Extension for Signing
+
+on:
+  workflow_call:
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AMO_JWT_ISSUER:
+        required: true
+      AMO_JWT_SECRET:
+        required: true
+
+jobs:
+  submit-firefox-extension:
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ap-southeast-2
+      PULUMI_BACKEND_URL: s3://hutch-pulumi-state-278728209435-ap-southeast-2
+      PULUMI_CONFIG_PASSPHRASE: ''
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy extension bucket infrastructure
+        run: pulumi up --stack prod --yes
+        working-directory: projects/firefox-extension
+
+      - name: Bump extension version
+        run: node projects/firefox-extension/scripts/bump-version.js ${{ github.run_number }}
+
+      - name: Build and package extension
+        run: npx nx run-many --target=compile --projects=browser-extension-core,firefox-extension
+
+      - name: Submit extension to AMO for signing
+        run: npx nx run firefox-extension:sign
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}


### PR DESCRIPTION
Split the "Submit extension to AMO for signing" job from ci.yml into a
separate submit-extension-for-signing.yml reusable workflow. ci.yml now
calls the reusable workflow in the same position. Both workflows remain
Firefox-only for now, with future browser support planned.

https://claude.ai/code/session_01QbKqMwhHDU5rPQ1wvqe8h3