### PR TITLE
feat(hutch): remove showUrl toggle from queue page ✅

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -33,7 +33,6 @@ interface QueueDisplayModel {
 	total: number;
 	pluralSuffix: string;
 	saveError?: string;
-	showUrl: boolean;
 	isEmpty: boolean;
 	hasArticles: boolean;
 	articles: ArticleDisplayModel[];
@@ -45,8 +44,6 @@ interface QueueDisplayModel {
 	filterUnreadUrl: string;
 	filterReadUrl: string;
 	filterArchivedUrl: string;
-	showUrlToggleUrl: string;
-	showUrlToggleLabel: string;
 	sortUrl: string;
 	sortLabel: string;
 	showPagination: boolean;
@@ -72,7 +69,6 @@ function toQueueDisplayModel(vm: QueueViewModel): QueueDisplayModel {
 		total: vm.total,
 		pluralSuffix: vm.total !== 1 ? "s" : "",
 		saveError: vm.saveError,
-		showUrl: vm.filters.showUrl === true,
 		isEmpty: vm.isEmpty,
 		hasArticles: !vm.isEmpty,
 		articles: vm.articles.map(toArticleDisplayModel),
@@ -84,8 +80,6 @@ function toQueueDisplayModel(vm: QueueViewModel): QueueDisplayModel {
 		filterUnreadUrl: vm.filterUrls.unread,
 		filterReadUrl: vm.filterUrls.read,
 		filterArchivedUrl: vm.filterUrls.archived,
-		showUrlToggleUrl: vm.showUrlToggle.url,
-		showUrlToggleLabel: vm.showUrlToggle.label,
 		sortUrl,
 		sortLabel,
 		showPagination: vm.totalPages > 1,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -239,58 +239,6 @@ describe("Queue routes", () => {
 		});
 	});
 
-	describe("Show URL toggle", () => {
-		it("should not show article URLs by default", async () => {
-			const { app, auth } = createTestApp();
-			const agent = await loginAgent(app, auth);
-
-			await agent
-				.post("/queue/save")
-				.type("form")
-				.send({ url: "https://example.com/article" });
-
-			const response = await agent.get("/queue");
-			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-article-url]")).toBeNull();
-		});
-
-		it("should show article URLs when showUrl=true", async () => {
-			const { app, auth } = createTestApp();
-			const agent = await loginAgent(app, auth);
-
-			await agent
-				.post("/queue/save")
-				.type("form")
-				.send({ url: "https://example.com/article" });
-
-			const response = await agent.get("/queue?showUrl=true");
-			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-article-url]")?.textContent).toBe("https://example.com/article");
-		});
-
-		it("should render Show URLs toggle link", async () => {
-			const { app, auth } = createTestApp();
-			const agent = await loginAgent(app, auth);
-
-			const response = await agent.get("/queue");
-			const doc = new JSDOM(response.text).window.document;
-			const toggle = doc.querySelector("[data-test-show-url]");
-			expect(toggle?.textContent).toBe("Show URLs");
-			expect(toggle?.getAttribute("href")).toContain("showUrl=true");
-		});
-
-		it("should render Hide URLs toggle link when URLs are shown", async () => {
-			const { app, auth } = createTestApp();
-			const agent = await loginAgent(app, auth);
-
-			const response = await agent.get("/queue?showUrl=true");
-			const doc = new JSDOM(response.text).window.document;
-			const toggle = doc.querySelector("[data-test-show-url]");
-			expect(toggle?.textContent).toBe("Hide URLs");
-			expect(toggle?.getAttribute("href")).toBe("/queue");
-		});
-	});
-
 	describe("Thumbnail", () => {
 		it("should render thumbnail when article has og:image", async () => {
 			const fetchHtml = async (_url: string) =>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -182,16 +182,6 @@
   color: var(--primary);
 }
 
-.queue-article__url {
-  font-size: 0.75rem;
-  color: var(--muted-foreground);
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-bottom: 2px;
-}
-
 .queue-article__meta {
   font-size: 0.8125rem;
   color: var(--muted-foreground);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -15,7 +15,6 @@
         <a class="{{filterArchivedClass}}" href="{{filterArchivedUrl}}" data-test-filter="archived">Archived</a>
       </nav>
       <div class="queue__sort">
-        <a class="queue__sort-link" href="{{showUrlToggleUrl}}" data-test-show-url>{{showUrlToggleLabel}}</a>
         <a class="queue__sort-link" href="{{sortUrl}}" data-test-sort>{{sortLabel}}</a>
       </div>
       {{#if isEmpty}}
@@ -34,7 +33,6 @@
               {{#if isUnread}}<span class="queue-article__unread-dot" aria-label="Unread"></span>{{/if}}
               <a class="queue-article__title" href="{{linkUrl}}"{{#if isExternalLink}} target="_blank" rel="noopener"{{/if}} data-test-article-title>{{title}}</a>
             </div>
-            {{#if ../showUrl}}<span class="queue-article__url" data-test-article-url>{{url}}</span>{{/if}}
             <div class="queue-article__meta">
               <span>{{siteName}}</span>
               <span>{{readTimeLabel}}</span>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
@@ -3,7 +3,7 @@ import { buildQueueUrl, parseQueueUrl } from "./queue.url";
 describe("parseQueueUrl", () => {
 	it("should return defaults for empty query", () => {
 		const state = parseQueueUrl({});
-		expect(state).toEqual({ status: undefined, order: "desc", page: 1, showUrl: undefined });
+		expect(state).toEqual({ status: undefined, order: "desc", page: 1 });
 	});
 
 	it("should parse valid status", () => {
@@ -35,18 +35,6 @@ describe("parseQueueUrl", () => {
 		expect(parseQueueUrl({ page: "0" }).page).toBe(1);
 	});
 
-	it("should parse showUrl flag", () => {
-		expect(parseQueueUrl({ showUrl: "true" }).showUrl).toBe(true);
-	});
-
-	it("should default showUrl to undefined when not set", () => {
-		expect(parseQueueUrl({}).showUrl).toBeUndefined();
-	});
-
-	it("should ignore invalid showUrl values", () => {
-		expect(parseQueueUrl({ showUrl: "false" }).showUrl).toBeUndefined();
-		expect(parseQueueUrl({ showUrl: "yes" }).showUrl).toBeUndefined();
-	});
 });
 
 describe("buildQueueUrl", () => {
@@ -81,11 +69,4 @@ describe("buildQueueUrl", () => {
 		expect(url).toContain("page=3");
 	});
 
-	it("should include showUrl when true", () => {
-		expect(buildQueueUrl({ showUrl: true })).toBe("/queue?showUrl=true");
-	});
-
-	it("should omit showUrl when not set", () => {
-		expect(buildQueueUrl({})).toBe("/queue");
-	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -5,7 +5,6 @@ export interface QueueUrlState {
 	status?: ArticleStatus;
 	order: SortOrder;
 	page: number;
-	showUrl?: boolean;
 }
 
 const VALID_STATUSES: ArticleStatus[] = ["unread", "read", "archived"];
@@ -23,9 +22,7 @@ export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 	const rawPage = Number(query.page);
 	const page = Number.isInteger(rawPage) && rawPage >= 1 ? rawPage : 1;
 
-	const showUrl = query.showUrl === "true" ? true : undefined;
-
-	return { status, order, page, showUrl };
+	return { status, order, page };
 }
 
 export function buildQueueUrl(state: Partial<QueueUrlState>): string {
@@ -39,9 +36,6 @@ export function buildQueueUrl(state: Partial<QueueUrlState>): string {
 	}
 	if (state.page && state.page > 1) {
 		params.set("page", String(state.page));
-	}
-	if (state.showUrl) {
-		params.set("showUrl", "true");
 	}
 
 	const qs = params.toString();

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -106,21 +106,6 @@ describe("toQueueViewModel", () => {
 		expect(vm.filterUrls.read).toBe("/queue?status=read");
 	});
 
-	it("should include show URL toggle with 'Show URLs' when showUrl is off", () => {
-		const vm = toQueueViewModel(makeResult([]), DEFAULT_FILTERS, { now: NOW });
-
-		expect(vm.showUrlToggle.label).toBe("Show URLs");
-		expect(vm.showUrlToggle.url).toContain("showUrl=true");
-	});
-
-	it("should include show URL toggle with 'Hide URLs' when showUrl is on", () => {
-		const filters = { ...DEFAULT_FILTERS, showUrl: true as const };
-		const vm = toQueueViewModel(makeResult([]), filters, { now: NOW });
-
-		expect(vm.showUrlToggle.label).toBe("Hide URLs");
-		expect(vm.showUrlToggle.url).toBe("/queue");
-	});
-
 	it("should set isUnread to true for unread articles", () => {
 		const article = makeArticle({ status: "unread" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -34,10 +34,6 @@ export interface QueueViewModel {
 		prev?: string;
 		next?: string;
 	};
-	showUrlToggle: {
-		label: string;
-		url: string;
-	};
 	saveError?: string;
 }
 
@@ -110,9 +106,6 @@ export function toQueueViewModel(
 					? buildQueueUrl({ ...filters, page: result.page + 1 })
 					: undefined,
 		},
-		showUrlToggle: filters.showUrl
-			? { label: "Hide URLs", url: buildQueueUrl({ ...filters, showUrl: undefined }) }
-			: { label: "Show URLs", url: buildQueueUrl({ ...filters, showUrl: true }) },
 		saveError: options?.saveError,
 	};
 }


### PR DESCRIPTION
The URL toggle is unnecessary since users can see URLs by hovering
over or clicking article links. Removes the toggle from URL state,
view model, component, template, styles, and all related tests.

https://claude.ai/code/session_01LjTLbBboez3Mcr4apfTTAY