### PR TITLE
refactor(hutch): move emailVerified from component props to route-level composition

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -183,6 +183,8 @@ function renderBaseTemplate(page: PageContent): string {
 	});
 }
 
+export type PageBody = Omit<PageContent, "isAuthenticated" | "emailVerified">;
+
 export function Base(page: PageContent): Component {
 	return HtmlPage(renderBaseTemplate(page));
 }

--- a/projects/hutch/src/runtime/web/oauth/oauth.component.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../base.component";
-import type { Component } from "../component.types";
+import type { PageBody } from "../base.component";
 import { render } from "../render";
 
 const OAUTH_AUTHORIZE_TEMPLATE = readFileSync(join(__dirname, "oauth-authorize.template.html"), "utf-8");
@@ -13,7 +12,6 @@ interface AuthorizePageParams {
 	redirectUri: string;
 	codeChallenge: string;
 	state?: string;
-	emailVerified?: boolean;
 }
 
 const OAUTH_AUTHORIZE_STYLES = `
@@ -87,10 +85,10 @@ const OAUTH_CALLBACK_STYLES = `
 }
 `;
 
-export function OAuthAuthorizePage(params: AuthorizePageParams): Component {
+export function OAuthAuthorizePage(params: AuthorizePageParams): PageBody {
 	const content = render(OAUTH_AUTHORIZE_TEMPLATE, params);
 
-	return Base({
+	return {
 		seo: {
 			title: `Authorize ${params.clientName} — Hutch`,
 			description: `${params.clientName} is requesting access to your Hutch account.`,
@@ -100,13 +98,11 @@ export function OAuthAuthorizePage(params: AuthorizePageParams): Component {
 		styles: OAUTH_AUTHORIZE_STYLES,
 		bodyClass: "page-oauth-authorize",
 		content,
-		isAuthenticated: true,
-		emailVerified: params.emailVerified,
-	});
+	};
 }
 
-export function OAuthCallbackPage(options?: { emailVerified?: boolean }): Component {
-	return Base({
+export function OAuthCallbackPage(): PageBody {
+	return {
 		seo: {
 			title: "Authorization Complete — Hutch",
 			description: "OAuth authorization is complete.",
@@ -116,7 +112,5 @@ export function OAuthCallbackPage(options?: { emailVerified?: boolean }): Compon
 		styles: OAUTH_CALLBACK_STYLES,
 		bodyClass: "page-oauth-callback",
 		content: render(OAUTH_CALLBACK_TEMPLATE, {}),
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -4,6 +4,7 @@ import request from "supertest";
 import type { Token } from "@node-oauth/oauth2-server";
 import { createTestApp } from "../../test-app";
 import type { UserId } from "../../domain/user/user.types";
+import { Base } from "../base.component";
 import { OAuthAuthorizePage, OAuthCallbackPage } from "./oauth.component";
 
 function generatePKCE() {
@@ -18,12 +19,12 @@ const TEST_REDIRECT_URI = "http://127.0.0.1:3000/oauth/callback";
 
 describe("OAuthAuthorizePage", () => {
 	it("returns 415 for unsupported media type", () => {
-		const component = OAuthAuthorizePage({
+		const component = Base(OAuthAuthorizePage({
 			clientName: "Test App",
 			clientId: "test-client",
 			redirectUri: "http://localhost/callback",
 			codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-		});
+		}));
 		const result = component.to("application/vnd.siren+json");
 
 		expect(result.statusCode).toBe(415);
@@ -33,7 +34,7 @@ describe("OAuthAuthorizePage", () => {
 
 describe("OAuthCallbackPage", () => {
 	it("returns 415 for unsupported media type", () => {
-		const result = OAuthCallbackPage().to("application/vnd.siren+json");
+		const result = Base(OAuthCallbackPage()).to("application/vnd.siren+json");
 
 		expect(result.statusCode).toBe(415);
 		expect(result.body).toBe("");

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import ExpressOAuthServer from "@node-oauth/express-oauth-server";
 import type { OAuthModel } from "../../providers/oauth/oauth-model";
 import { getClient, validateRedirectUri } from "../../providers/oauth/oauth-clients";
+import { Base } from "../base.component";
 import { OAuthAuthorizePage, OAuthCallbackPage } from "./oauth.component";
 
 const authorizeQuerySchema = z.object({
@@ -72,12 +73,15 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 			return;
 		}
 
-		const result = OAuthAuthorizePage({
-			clientName: client.name,
-			clientId: client_id,
-			redirectUri: redirect_uri,
-			codeChallenge: parsed.data.code_challenge,
-			state,
+		const result = Base({
+			...OAuthAuthorizePage({
+				clientName: client.name,
+				clientId: client_id,
+				redirectUri: redirect_uri,
+				codeChallenge: parsed.data.code_challenge,
+				state,
+			}),
+			isAuthenticated: true,
 			emailVerified: req.emailVerified,
 		}).to("text/html");
 		res.status(result.statusCode).type("html").send(result.body);
@@ -159,7 +163,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 	});
 
 	router.get("/callback", (req: Request, res: Response) => {
-		const result = OAuthCallbackPage({ emailVerified: req.emailVerified }).to("text/html");
+		const result = Base({ ...OAuthCallbackPage(), isAuthenticated: true, emailVerified: req.emailVerified }).to("text/html");
 		res.status(result.statusCode).type("html").send(result.body);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/export/export.component.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.component.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../base.component";
 import { render } from "../../render";
 import { EXPORT_STYLES } from "./export.styles";
 
 const EXPORT_TEMPLATE = readFileSync(join(__dirname, "export.template.html"), "utf-8");
 
-export function ExportPage(options?: { emailVerified?: boolean }): Component {
-	return Base({
+export function ExportPage(): PageBody {
+	return {
 		seo: {
 			title: "Export Your Data — Hutch",
 			description: "Download all your saved articles and data from Hutch.",
@@ -18,7 +17,5 @@ export function ExportPage(options?: { emailVerified?: boolean }): Component {
 		styles: EXPORT_STYLES,
 		bodyClass: "page-export",
 		content: render(EXPORT_TEMPLATE, {}),
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/export/export.page.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.page.ts
@@ -4,6 +4,7 @@ import express from "express";
 import type { FindArticlesByUser } from "../../../providers/article-store/article-store.types";
 import type { UserId } from "../../../domain/user/user.types";
 import type { SavedArticle } from "../../../domain/article/article.types";
+import { Base } from "../../base.component";
 import { ExportPage } from "./export.component";
 
 interface ExportDependencies {
@@ -51,7 +52,7 @@ export function initExportRoutes(deps: ExportDependencies): Router {
 	const router = express.Router();
 
 	router.get("/", (req: Request, res: Response) => {
-		const html = ExportPage({ emailVerified: req.emailVerified }).to("text/html");
+		const html = Base({ ...ExportPage(), isAuthenticated: true, emailVerified: req.emailVerified }).to("text/html");
 		res.status(html.statusCode).type("html").send(html.body);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../base.component";
 import { render } from "../../render";
 import { QUEUE_STYLES } from "./queue.styles";
 import type { QueueArticleViewModel, QueueViewModel } from "./queue.viewmodel";
@@ -128,11 +127,11 @@ const MARK_READ_ON_CLICK_SCRIPT = `
 })();
 </script>`;
 
-export function QueuePage(vm: QueueViewModel, options?: { emailVerified?: boolean }): Component {
+export function QueuePage(vm: QueueViewModel): PageBody {
 	const displayModel = toQueueDisplayModel(vm);
 	const content = render(QUEUE_TEMPLATE, displayModel);
 
-	return Base({
+	return {
 		seo: {
 			title: "My Queue — Hutch",
 			description: "Your saved articles reading queue.",
@@ -143,7 +142,5 @@ export function QueuePage(vm: QueueViewModel, options?: { emailVerified?: boolea
 		bodyClass: "page-queue",
 		content,
 		scripts: MARK_READ_ON_CLICK_SCRIPT,
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -12,6 +12,7 @@ import type {
 	UpdateArticleStatus,
 } from "../../../providers/article-store/article-store.types";
 import type { UserId } from "../../../domain/user/user.types";
+import { Base } from "../../base.component";
 import { wantsSiren } from "../../content-negotiation";
 import { SIREN_MEDIA_TYPE } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
@@ -56,7 +57,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		}
 
 		const vm = toQueueViewModel(result, urlState);
-		const html = QueuePage(vm, { emailVerified: req.emailVerified }).to("text/html");
+		const html = Base({ ...QueuePage(vm), isAuthenticated: true, emailVerified: req.emailVerified }).to("text/html");
 		res.status(html.statusCode).type("html").send(html.body);
 	});
 
@@ -70,7 +71,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const vm = toQueueViewModel(result, urlState, {
 				saveError: "Please enter a valid URL",
 			});
-			const html = QueuePage(vm, { emailVerified: req.emailVerified }).to("text/html");
+			const html = Base({ ...QueuePage(vm), isAuthenticated: true, emailVerified: req.emailVerified }).to("text/html");
 			res.status(422).type("html").send(html.body);
 			return;
 		}
@@ -83,7 +84,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const vm = toQueueViewModel(result, urlState, {
 				saveError: `Could not parse article: ${parseResult.reason}`,
 			});
-			const html = QueuePage(vm, { emailVerified: req.emailVerified }).to("text/html");
+			const html = Base({ ...QueuePage(vm), isAuthenticated: true, emailVerified: req.emailVerified }).to("text/html");
 			res.status(422).type("html").send(html.body);
 			return;
 		}
@@ -117,7 +118,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			return;
 		}
 
-		const html = ReaderPage(article, { emailVerified: req.emailVerified }).to("text/html");
+		const html = Base({ ...ReaderPage(article), isAuthenticated: true, emailVerified: req.emailVerified }).to("text/html");
 		res.status(html.statusCode).type("html").send(html.body);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { SavedArticle } from "../../../domain/article/article.types";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../base.component";
 import { render } from "../../render";
 import { READER_STYLES } from "./reader.styles";
 
@@ -24,12 +23,12 @@ function renderReaderContent(article: SavedArticle): string {
 	});
 }
 
-export function ReaderPage(article: SavedArticle, options?: { emailVerified?: boolean }): Component {
+export function ReaderPage(article: SavedArticle): PageBody {
 	const content = render(READER_TEMPLATE, {
 		innerContent: renderReaderContent(article),
 	});
 
-	return Base({
+	return {
 		seo: {
 			title: `${article.metadata.title} — Hutch Reader`,
 			description: article.metadata.excerpt,
@@ -39,7 +38,5 @@ export function ReaderPage(article: SavedArticle, options?: { emailVerified?: bo
 		styles: READER_STYLES,
 		bodyClass: "page-reader",
 		content,
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }


### PR DESCRIPTION
Components no longer accept or forward emailVerified. Instead, they
return a PageBody (page content without auth context), and route
handlers compose it with Base() adding isAuthenticated and
emailVerified from the request. This eliminates the boilerplate of
threading emailVerified through 5 component signatures.

https://claude.ai/code/session_01Fv67aymf4gBKoqKSUHLAsD