### PR TITLE
Remove reload button from popup UI

### DIFF
--- a/projects/firefox-extension/src/runtime/popup/popup.styles.css
+++ b/projects/firefox-extension/src/runtime/popup/popup.styles.css
@@ -174,27 +174,6 @@ h2 {
   gap: 8px;
 }
 
-/**
- * 1. Override the filled primary style — reload is a utility action
- */
-.list-view__reload {
-  background: transparent; /* 1 */
-  color: var(--popup-heading);
-  font-size: 18px;
-  padding: 4px 8px;
-  line-height: 1;
-  border: 1px solid var(--popup-border);
-  border-radius: 6px;
-  cursor: pointer;
-  font-family: inherit;
-  transition: background-color 0.15s ease;
-}
-
-.list-view__reload:hover {
-  background: var(--popup-surface);
-  color: var(--popup-heading);
-}
-
 .list-view__logout {
   background: transparent;
   color: var(--popup-label);

--- a/projects/firefox-extension/src/runtime/popup/popup.template.html
+++ b/projects/firefox-extension/src/runtime/popup/popup.template.html
@@ -34,7 +34,6 @@
     <div class="list-view__header">
       <h2 class="list-view__title">My List</h2>
       <div class="list-view__actions">
-        <button id="reload-button" class="list-view__reload" title="Reload">&#x21bb;</button>
         <button id="logout-button" class="list-view__logout" title="Log out">Log out</button>
       </div>
     </div>

--- a/projects/firefox-extension/src/runtime/popup/popup.ts
+++ b/projects/firefox-extension/src/runtime/popup/popup.ts
@@ -284,12 +284,6 @@ document
 	});
 
 document
-	.getElementById("reload-button")
-	?.addEventListener("click", async () => {
-		await loadAllItems();
-	});
-
-document
 	.getElementById("logout-button")
 	?.addEventListener("click", async () => {
 		await send({ type: "logout" });


### PR DESCRIPTION
## Summary
Removed the reload button functionality from the Firefox extension popup interface, including its UI element, styling, and event listener logic.

## Key Changes
- Removed the reload button HTML element (`<button id="reload-button">`) from the popup template
- Deleted the `.list-view__reload` and `.list-view__reload:hover` CSS styles
- Removed the click event listener that triggered `loadAllItems()` when the reload button was clicked

## Details
The reload button was a utility action in the popup's header that allowed users to manually refresh the list. This change simplifies the UI by removing this functionality, likely in favor of automatic list updates or other refresh mechanisms.

https://claude.ai/code/session_012yZ7xX916Ht6Lsr7ncEqYq