### PR TITLE
Redirect authenticated users away from login and signup pages

### DIFF
--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -55,6 +55,10 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 	const router = express.Router();
 
 	router.get("/login", (req: Request, res: Response) => {
+		if (req.userId) {
+			res.redirect(303, "/queue");
+			return;
+		}
 		const returnUrl = typeof req.query.return === "string" ? req.query.return : undefined;
 		const result = LoginPage({ returnUrl }).to("text/html");
 		res.status(result.statusCode).type("html").send(result.body);
@@ -93,7 +97,11 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		res.redirect(303, redirectTo);
 	});
 
-	router.get("/signup", (_req: Request, res: Response) => {
+	router.get("/signup", (req: Request, res: Response) => {
+		if (req.userId) {
+			res.redirect(303, "/queue");
+			return;
+		}
 		const result = SignupPage().to("text/html");
 		res.status(result.statusCode).type("html").send(result.body);
 	});

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -15,6 +15,19 @@ describe("Auth routes", () => {
 			expect(doc.querySelector('input[name="password"]')?.getAttribute("type")).toBe("password");
 		});
 
+		it("should redirect authenticated user to /queue", async () => {
+			const { app, auth } = createTestApp();
+			await auth.createUser({ email: "test@example.com", password: "password123" });
+
+			const agent = request.agent(app);
+			await agent.post("/login").type("form").send({ email: "test@example.com", password: "password123" });
+
+			const response = await agent.get("/login");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+		});
+
 		it("should include return URL in form action when provided", async () => {
 			const { app } = createTestApp();
 			const response = await request(app).get("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
@@ -119,6 +132,19 @@ describe("Auth routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector('[data-test-form="signup"]')?.getAttribute("action")).toBe("/signup");
 			expect(doc.querySelector('input[name="confirmPassword"]')?.getAttribute("type")).toBe("password");
+		});
+
+		it("should redirect authenticated user to /queue", async () => {
+			const { app, auth } = createTestApp();
+			await auth.createUser({ email: "test@example.com", password: "password123" });
+
+			const agent = request.agent(app);
+			await agent.post("/login").type("form").send({ email: "test@example.com", password: "password123" });
+
+			const response = await agent.get("/signup");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
 		});
 	});
 


### PR DESCRIPTION
## Summary
This PR adds authentication checks to the login and signup routes to redirect already-authenticated users to the `/queue` page, improving the user experience by preventing authenticated users from accessing authentication pages.

## Key Changes
- **GET /login route**: Added check to redirect authenticated users (those with `req.userId`) to `/queue` with a 303 status code
- **GET /signup route**: Added the same authentication check to redirect authenticated users to `/queue`
- **Test coverage**: Added comprehensive tests for both routes to verify the redirect behavior works correctly for authenticated users

## Implementation Details
- The redirect uses HTTP 303 (See Other) status code, which is appropriate for redirecting after a successful authentication state change
- The authentication check uses the existing `req.userId` property that's already available in the request object
- The redirect happens before any page rendering, ensuring authenticated users never see the login/signup forms
- Tests verify the complete flow: user creation → login → redirect verification on subsequent page access

https://claude.ai/code/session_01LmBXqjHfpfgtWS1ZUZDNM3