### PR TITLE
Refactor styling and update legal/marketing copy

### DIFF
--- a/projects/firefox-extension/src/runtime/popup/popup.styles.css
+++ b/projects/firefox-extension/src/runtime/popup/popup.styles.css
@@ -364,7 +364,7 @@ h2 {
 
 .pagination__page--active {
   background: var(--popup-active-bg);
-  color: #FFFFFF;
+  color: var(--popup-bg);
   border-color: var(--popup-active-bg);
 }
 

--- a/projects/firefox-extension/src/runtime/popup/popup.template.html
+++ b/projects/firefox-extension/src/runtime/popup/popup.template.html
@@ -18,7 +18,7 @@
   </div>
 
   <div id="saved-view" class="view" hidden>
-    <p>Saved!</p>
+    <p>Article saved.</p>
     <button id="undo-button" class="button--secondary">Undo</button>
     <p class="shortcut-hint">Tip: Use <kbd>Ctrl</kbd>+<kbd>D</kbd> to save from any page</p>
   </div>

--- a/projects/hutch/src/runtime/web/auth/verification-email.ts
+++ b/projects/hutch/src/runtime/web/auth/verification-email.ts
@@ -6,17 +6,17 @@ export function buildVerificationEmailHtml(verifyUrl: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Verify your email — Hutch</title>
 </head>
-<body style="margin:0;padding:0;background-color:#F4F4F5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#F4F4F5;padding:40px 20px;">
+<body style="margin:0;padding:0;background-color:#F7F8FA;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#F7F8FA;padding:40px 20px;">
 <tr><td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:#FFFFFF;border-radius:8px;padding:40px;">
 <tr><td>
-<h1 style="margin:0 0 16px;font-size:24px;color:#18181B;">Verify your email</h1>
-<p style="margin:0 0 24px;font-size:16px;line-height:1.5;color:#3F3F46;">Click the button below to verify your email address and activate your Hutch account.</p>
-<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:#18181B;">
+<h1 style="margin:0 0 16px;font-size:24px;color:#1A202C;">Verify your email</h1>
+<p style="margin:0 0 24px;font-size:16px;line-height:1.5;color:#5A6170;">Click the button below to verify your email address and activate your Hutch account.</p>
+<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:#C8702A;">
 <a href="${escapeHtml(verifyUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:#FFFFFF;text-decoration:none;border-radius:6px;">Verify email</a>
 </td></tr></table>
-<p style="margin:24px 0 0;font-size:14px;line-height:1.5;color:#71717A;">If you didn't create a Hutch account, you can ignore this email.</p>
+<p style="margin:24px 0 0;font-size:14px;line-height:1.5;color:#8C919D;">If you didn't create a Hutch account, you can ignore this email.</p>
 </td></tr>
 </table>
 </td></tr>

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -207,7 +207,7 @@ describe("GET / with exhausted founding allocation", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const exhausted = doc.querySelector("[data-test-founding-exhausted]");
-		expect(exhausted?.textContent).toBe("The free allocation has exhausted! You might still be able to create an account for free while we develop the pricing system but it may require payment in a few months.");
+		expect(exhausted?.textContent).toBe("The free allocation has been reached. You might still be able to create an account for free while I develop the pricing system, but it may require payment in a few months.");
 
 		const fill = doc.querySelector(".founding-progress__fill") as HTMLElement;
 		expect(fill.getAttribute("style")).toBe("width: 100%");

--- a/projects/hutch/src/runtime/web/pages/home/home.styles.css
+++ b/projects/hutch/src/runtime/web/pages/home/home.styles.css
@@ -1,6 +1,6 @@
 .home-hero {
   background: linear-gradient(135deg, hsl(27 65% 47%) 0%, hsl(27 50% 35%) 100%);
-  color: #FFFFFF;
+  color: var(--color-on-brand);
   padding: 80px 20px 60px;
   text-align: center;
 }
@@ -66,13 +66,13 @@
 }
 
 .btn--primary {
-  background: #FFFFFF;
+  background: var(--color-on-brand);
   color: hsl(27 65% 40%);
 }
 
 .btn--secondary {
   background: rgba(255,255,255,0.15);
-  color: #FFFFFF;
+  color: var(--color-on-brand);
   border: 1px solid rgba(255,255,255,0.3);
 }
 
@@ -264,7 +264,7 @@
 
 .founding-progress__fill {
   height: 100%;
-  background: hsl(142 71% 45%);
+  background: var(--color-success);
   border-radius: 12px;
   transition: width 0.3s ease;
 }

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -111,7 +111,7 @@
           </div>
           <p class="founding-progress__label">{{userCount}} / {{foundingMemberLimit}} founding members</p>
           {{#if allocationExhausted}}
-          <p class="founding-progress__exhausted" data-test-founding-exhausted>The free allocation has exhausted! You might still be able to create an account for free while we develop the pricing system but it may require payment in a few months.</p>
+          <p class="founding-progress__exhausted" data-test-founding-exhausted>The free allocation has been reached. You might still be able to create an account for free while I develop the pricing system, but it may require payment in a few months.</p>
           {{/if}}
         </div>
         <div class="pricing-grid">

--- a/projects/hutch/src/runtime/web/pages/privacy/privacy.component.ts
+++ b/projects/hutch/src/runtime/web/pages/privacy/privacy.component.ts
@@ -12,7 +12,7 @@ export function PrivacyPage(): Component {
 		seo: {
 			title: "Privacy Policy — Hutch",
 			description:
-				"How Hutch handles your data. We collect only what's necessary to run the service and never sell your information.",
+				"How Hutch handles your data. Hutch collects only what's necessary to run the service and never sells your information.",
 			canonicalUrl: "https://hutch-app.com/privacy",
 			robots: "noindex, follow",
 		},

--- a/projects/hutch/src/runtime/web/pages/privacy/privacy.template.html
+++ b/projects/hutch/src/runtime/web/pages/privacy/privacy.template.html
@@ -4,12 +4,12 @@
       <p class="legal-page__updated">Last updated: 4 March 2026</p>
 
       <section class="legal-page__section">
-        <h2>Who we are</h2>
-        <p>Hutch ("we", "us", "our") is a read-it-later web application operated by Proficient Pty Ltd in Australia. Our website is <a href="https://hutch-app.com">hutch-app.com</a>.</p>
+        <h2>Who I am</h2>
+        <p>Hutch is a read-it-later web application operated by Proficient Pty Ltd in Australia. The website is <a href="https://hutch-app.com">hutch-app.com</a>.</p>
       </section>
 
       <section class="legal-page__section">
-        <h2>What data we collect</h2>
+        <h2>What data Hutch collects</h2>
         <ul>
           <li><strong>Account information:</strong> your email address, used for authentication and account recovery.</li>
           <li><strong>Saved articles:</strong> URLs, titles, and metadata of articles you save to your reading list.</li>
@@ -18,22 +18,22 @@
       </section>
 
       <section class="legal-page__section">
-        <h2>What we do not collect</h2>
+        <h2>What Hutch does not collect</h2>
         <ul>
-          <li>We do not use third-party analytics or tracking scripts.</li>
-          <li>We do not sell, rent, or share your personal data with third parties.</li>
-          <li>We do not read the content of the articles you save.</li>
+          <li>Hutch does not use third-party analytics or tracking scripts.</li>
+          <li>I do not sell, rent, or share your personal data with third parties.</li>
+          <li>I do not read the content of the articles you save.</li>
         </ul>
       </section>
 
       <section class="legal-page__section">
-        <h2>How we use your data</h2>
-        <p>We use your data solely to provide the Hutch service: authenticating your account, storing your reading list, and delivering the web application to your browser.</p>
+        <h2>How your data is used</h2>
+        <p>Your data is used solely to provide the Hutch service: authenticating your account, storing your reading list, and delivering the web application to your browser.</p>
       </section>
 
       <section class="legal-page__section">
         <h2>Where your data is stored</h2>
-        <p>Your data is stored on AWS infrastructure in the Asia-Pacific (Sydney) region. We use industry-standard security practices to protect your data.</p>
+        <p>Your data is stored on AWS infrastructure in the Asia-Pacific (Sydney) region. I use industry-standard security practices to protect your data.</p>
       </section>
 
       <section class="legal-page__section">
@@ -43,22 +43,22 @@
 
       <section class="legal-page__section">
         <h2>Cookies</h2>
-        <p>We use a single session cookie to keep you logged in. We do not use advertising or tracking cookies.</p>
+        <p>Hutch uses a single session cookie to keep you logged in. There are no advertising or tracking cookies.</p>
       </section>
 
       <section class="legal-page__section">
         <h2>Your rights</h2>
-        <p>You have the right to access, correct, export, or delete your personal data at any time. Contact us at the address below to exercise these rights.</p>
+        <p>You have the right to access, correct, export, or delete your personal data at any time. Contact me at the address below to exercise these rights.</p>
       </section>
 
       <section class="legal-page__section">
         <h2>Changes to this policy</h2>
-        <p>We may update this policy from time to time. We will notify registered users of material changes via email.</p>
+        <p>I may update this policy from time to time. I will notify registered users of material changes via email.</p>
       </section>
 
       <section class="legal-page__section">
         <h2>Contact</h2>
-        <p>If you have questions about this privacy policy, contact us at <a href="mailto:hutch+privacy@hutch-app.com">hutch+privacy@hutch-app.com</a>.</p>
+        <p>If you have questions about this privacy policy, contact me at <a href="mailto:hutch+privacy@hutch-app.com">hutch+privacy@hutch-app.com</a>.</p>
       </section>
     </div>
   </main>

--- a/projects/hutch/src/runtime/web/pages/reader/reader.styles.css
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.styles.css
@@ -7,7 +7,7 @@
 .reader__header {
   margin-bottom: 2rem;
   padding-bottom: 1.5rem;
-  border-bottom: 1px solid var(--color-border, #E0E0E0);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .reader__title {
@@ -15,7 +15,7 @@
   font-weight: 700;
   line-height: 1.3;
   margin: 0 0 0.75rem;
-  color: var(--color-text, #1A1A1A);
+  color: var(--color-text-primary);
 }
 
 .reader__meta {
@@ -23,14 +23,14 @@
   flex-wrap: wrap;
   gap: 0.75rem;
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #666);
+  color: var(--color-text-secondary);
 }
 
 .reader__back {
   display: inline-block;
   margin-bottom: 1rem;
   font-size: 0.875rem;
-  color: var(--color-link, #2B3A55);
+  color: var(--color-brand);
   text-decoration: none;
 }
 
@@ -42,7 +42,7 @@
   display: inline-block;
   margin-top: 0.5rem;
   font-size: 0.875rem;
-  color: var(--color-link, #2B3A55);
+  color: var(--color-brand);
   text-decoration: none;
 }
 
@@ -53,7 +53,7 @@
 .reader__content {
   font-size: 1.125rem;
   line-height: 1.8;
-  color: var(--color-text, #1A1A1A);
+  color: var(--color-text-primary);
 }
 
 .reader__content p {
@@ -84,20 +84,20 @@
 }
 
 .reader__content a {
-  color: var(--color-link, #2B3A55);
+  color: var(--color-brand);
 }
 
 .reader__content blockquote {
   margin: 1.5rem 0;
   padding: 0.5rem 0 0.5rem 1.25rem;
-  border-left: 3px solid var(--color-border, #E0E0E0);
-  color: var(--color-text-secondary, #666);
+  border-left: 3px solid var(--color-border);
+  color: var(--color-text-secondary);
 }
 
 .reader__content pre {
   overflow-x: auto;
   padding: 1rem;
-  background: var(--color-surface, #F5F5F5);
+  background: var(--color-surface);
   border-radius: 4px;
   font-size: 0.875rem;
   line-height: 1.5;
@@ -107,7 +107,7 @@
 .reader__content code {
   font-size: 0.875em;
   padding: 0.15em 0.3em;
-  background: var(--color-surface, #F5F5F5);
+  background: var(--color-surface);
   border-radius: 3px;
 }
 
@@ -132,7 +132,7 @@
 
 .reader__content figcaption {
   font-size: 0.875rem;
-  color: var(--color-text-secondary, #666);
+  color: var(--color-text-secondary);
   margin-top: 0.5rem;
   text-align: center;
 }
@@ -140,7 +140,7 @@
 .reader__no-content {
   text-align: center;
   padding: 3rem 1rem;
-  color: var(--color-text-secondary, #666);
+  color: var(--color-text-secondary);
 }
 
 .reader__no-content-title {
@@ -153,29 +153,11 @@
 }
 
 .reader__no-content-link {
-  color: var(--color-link, #2B3A55);
+  color: var(--color-brand);
   text-decoration: none;
   font-weight: 500;
 }
 
 .reader__no-content-link:hover {
   text-decoration: underline;
-}
-
-@media (prefers-color-scheme: dark) {
-  .reader__title {
-    color: var(--color-text, #E0E0E0);
-  }
-
-  .reader__content {
-    color: var(--color-text, #E0E0E0);
-  }
-
-  .reader__content pre {
-    background: var(--color-surface, #2A2A2A);
-  }
-
-  .reader__content code {
-    background: var(--color-surface, #2A2A2A);
-  }
 }

--- a/projects/hutch/src/runtime/web/pages/terms/terms.template.html
+++ b/projects/hutch/src/runtime/web/pages/terms/terms.template.html
@@ -15,7 +15,7 @@
 
       <section class="legal-page__section">
         <h2>Accounts</h2>
-        <p>You must provide a valid email address to create an account. You are responsible for maintaining the security of your account. You must notify us immediately if you become aware of any unauthorised use.</p>
+        <p>You must provide a valid email address to create an account. You are responsible for maintaining the security of your account. You must notify me immediately if you become aware of any unauthorised use.</p>
       </section>
 
       <section class="legal-page__section">
@@ -31,12 +31,12 @@
 
       <section class="legal-page__section">
         <h2>Your content</h2>
-        <p>You retain ownership of the URLs and metadata you save to Hutch. We do not claim any rights over your content. You can export or delete your data at any time.</p>
+        <p>You retain ownership of the URLs and metadata you save to Hutch. I do not claim any rights over your content. You can export or delete your data at any time.</p>
       </section>
 
       <section class="legal-page__section">
         <h2>Service availability</h2>
-        <p>We aim to keep Hutch available at all times but do not guarantee uninterrupted access. The Service is provided on an "as is" and "as available" basis. We may modify, suspend, or discontinue the Service at any time with reasonable notice.</p>
+        <p>I aim to keep Hutch available at all times but do not guarantee uninterrupted access. The Service is provided on an "as is" and "as available" basis. I may modify, suspend, or discontinue the Service at any time with reasonable notice.</p>
       </section>
 
       <section class="legal-page__section">
@@ -46,12 +46,12 @@
 
       <section class="legal-page__section">
         <h2>Termination</h2>
-        <p>You may close your account at any time. We reserve the right to suspend or terminate accounts that violate these terms.</p>
+        <p>You may close your account at any time. I reserve the right to suspend or terminate accounts that violate these terms.</p>
       </section>
 
       <section class="legal-page__section">
         <h2>Changes to these terms</h2>
-        <p>We may update these terms from time to time. We will notify registered users of material changes via email. Continued use of the Service after changes constitutes acceptance of the updated terms.</p>
+        <p>I may update these terms from time to time. I will notify registered users of material changes via email. Continued use of the Service after changes constitutes acceptance of the updated terms.</p>
       </section>
 
       <section class="legal-page__section">
@@ -61,7 +61,7 @@
 
       <section class="legal-page__section">
         <h2>Contact</h2>
-        <p>If you have questions about these terms, contact us at <a href="mailto:hutch+legal@hutch-app.com">hutch+legal@hutch-app.com</a>.</p>
+        <p>If you have questions about these terms, contact me at <a href="mailto:hutch+legal@hutch-app.com">hutch+legal@hutch-app.com</a>.</p>
       </section>
     </div>
   </main>


### PR DESCRIPTION
## Summary
This PR consolidates CSS custom properties usage, updates the privacy and terms pages to use first-person language, refreshes email template styling, and makes minor copy improvements across the application.

## Key Changes

**Styling & Design System:**
- Removed hardcoded color fallbacks from CSS variables in reader styles, relying on design system tokens (e.g., `var(--color-border)` instead of `var(--color-border, #E0E0E0)`)
- Standardized color variable names: `--color-text` → `--color-text-primary`, `--color-link` → `--color-brand`
- Removed dark mode media query from reader styles (now handled by design system)
- Updated verification email template with new color palette (#F7F8FA background, #C8702A button, #1A202C text)
- Updated home page to use design system variables for brand colors and success states

**Legal & Marketing Copy:**
- Changed privacy policy from corporate "we/us/our" language to first-person "I/me" perspective
- Updated privacy policy headings for clarity ("Who we are" → "Who I am", "What data we collect" → "What data Hutch collects")
- Applied similar first-person updates to terms of service
- Updated home page founding member message: "has exhausted" → "has been reached", "we develop" → "I develop"
- Minor copy refinements in Firefox extension popup ("Saved!" → "Article saved.")

**SEO & Metadata:**
- Updated privacy page meta description to reflect new copy style

## Implementation Details
- All changes maintain backward compatibility with existing design system tokens
- Email template colors align with updated brand guidelines
- Legal document changes reflect a shift to personal/individual operator branding

https://claude.ai/code/session_01V6b1Q2YG7uefEh2pXa75Sy