### PR TITLE
Change CI workflow environment from prod to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
-    environment: prod
+    environment: ci
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
Updated the GitHub Actions CI workflow to use the `ci` environment instead of `prod` for the check job.

## Changes
- Modified `.github/workflows/ci.yml` to change the `environment` setting from `prod` to `ci` in the check job

## Details
This change ensures that CI/CD pipeline runs use the appropriate environment configuration and secrets associated with the `ci` environment rather than production environment settings. This is a best practice to keep CI/CD operations separate from production deployments.

https://claude.ai/code/session_011UZvtMBKHbAR97FJ8a46L3