### PR TITLE
Add livereload script injection for development mode

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -14,6 +14,7 @@ import {
 import type { Component } from "./component.types";
 import { HtmlPage } from "./html-page";
 import { render } from "./render";
+import { getEnv } from "../require-env";
 
 const HEADER_TEMPLATE = readFileSync(join(__dirname, "header.template.html"), "utf-8");
 const FOOTER_TEMPLATE = readFileSync(join(__dirname, "footer.template.html"), "utf-8");
@@ -84,6 +85,10 @@ const NAV_SCRIPT = `
   });
 })();
 </script>`;
+
+const LIVERELOAD_SCRIPT = getEnv("LIVERELOAD")
+	? `\n<script src="http://localhost:35729/livereload.js?snipver=1"></script>`
+	: "";
 
 const OFFLINE_INDICATOR_SCRIPT = `
 <script>
@@ -189,7 +194,7 @@ function renderBaseTemplate(page: PageContent): string {
 		footer: renderFooter(),
 		navScript: NAV_SCRIPT,
 		offlineScript: OFFLINE_INDICATOR_SCRIPT,
-		scripts: page.scripts,
+		scripts: (page.scripts ?? "") + LIVERELOAD_SCRIPT,
 	});
 }
 


### PR DESCRIPTION
## Summary
Added support for injecting a livereload script into rendered pages when the `LIVERELOAD` environment variable is set, enabling automatic page refresh during development.

## Key Changes
- Imported `getEnv` utility from `require-env` module
- Created `LIVERELOAD_SCRIPT` constant that conditionally includes the livereload.js script tag based on the `LIVERELOAD` environment variable
- Modified the base template rendering to append the livereload script to the page scripts when enabled

## Implementation Details
- The livereload script is only injected when `LIVERELOAD` environment variable is truthy, keeping production builds unaffected
- The script points to the standard livereload server at `http://localhost:35729/livereload.js`
- The implementation safely handles cases where `page.scripts` may be undefined by using the nullish coalescing operator (`??`)

https://claude.ai/code/session_0114BvTMdPc2otZBeTwQXuNk