### PR TITLE
Externalize Pulumi stack configuration to environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       AWS_REGION: ap-southeast-2
       PULUMI_BACKEND_URL: s3://hutch-pulumi-state-278728209435-ap-southeast-2
       PULUMI_CONFIG_PASSPHRASE: ''
+      PULUMI_STACK: prod
       PERSISTENCE: development
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +79,7 @@ jobs:
       AWS_REGION: ap-southeast-2
       PULUMI_BACKEND_URL: s3://hutch-pulumi-state-572337278115-ap-southeast-2
       PULUMI_CONFIG_PASSPHRASE: ''
+      PULUMI_STACK: staging
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +97,7 @@ jobs:
 
       - run: npx nx compile hutch
 
-      - run: PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack staging --yes
+      - run: PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack "$PULUMI_STACK" --yes
         working-directory: projects/hutch
 
   hutch-deploy-to-prod:
@@ -109,6 +111,7 @@ jobs:
       AWS_REGION: ap-southeast-2
       PULUMI_BACKEND_URL: s3://hutch-pulumi-state-278728209435-ap-southeast-2
       PULUMI_CONFIG_PASSPHRASE: ''
+      PULUMI_STACK: prod
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
     steps:
       - uses: actions/checkout@v4
@@ -126,7 +129,7 @@ jobs:
 
       - run: npx nx compile hutch
 
-      - run: PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack prod --yes
+      - run: PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack "$PULUMI_STACK" --yes
         working-directory: projects/hutch
 
   # Commenting the Firefox extension deploy to prod due to every submission making my signing review go back to the end of the queue

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -28,9 +28,9 @@
     "compile": "rm -rf dist && tsc && node scripts/copy-static-assets.js",
     "check-unused-css": "node scripts/check-unused-css.js",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\" \"pnpm check-unused-css\"",
-    "check-infra": "if [ \"$CLAUDECODE\" = 1 ]; then echo 'Skipping check-infra in Claude Code environment'; else PULUMI_CONFIG_PASSPHRASE='' pulumi preview; fi",
+    "check-infra": "if [ \"$CLAUDECODE\" = 1 ]; then echo 'Skipping check-infra in Claude Code environment'; else PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack \"${PULUMI_STACK:?PULUMI_STACK is not set}\"; fi",
     "check": "pnpm compile && pnpm lint && pnpm test-with-coverage && pnpm check-infra",
-    "deploy": "PULUMI_CONFIG_PASSPHRASE='' pulumi up"
+    "deploy": "PULUMI_CONFIG_PASSPHRASE='' pulumi up --stack \"${PULUMI_STACK:?PULUMI_STACK is not set}\""
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1001.0",


### PR DESCRIPTION
## Summary
This PR refactors Pulumi stack configuration to use environment variables instead of hardcoding stack names in commands. This improves consistency across CI/CD workflows and local development scripts.

## Key Changes
- Added `PULUMI_STACK` environment variable to all CI workflow jobs:
  - `hutch-check` job: set to `prod`
  - `hutch-deploy-to-staging` job: set to `staging`
  - `hutch-deploy-to-prod` job: set to `prod`
- Updated Pulumi commands to use `$PULUMI_STACK` variable instead of hardcoded stack names:
  - CI workflow: `pulumi up --stack "$PULUMI_STACK" --yes`
  - `check-infra` script: `pulumi preview --stack "${PULUMI_STACK:?PULUMI_STACK is not set}"`
  - `deploy` script: `pulumi up --stack "${PULUMI_STACK:?PULUMI_STACK is not set}"`
- Added parameter expansion validation (`${PULUMI_STACK:?...}`) to npm scripts to ensure the variable is set before execution

## Implementation Details
- The environment variable approach provides a single source of truth for stack configuration per job
- Parameter expansion with error checking in npm scripts prevents accidental deployments to wrong stacks
- This pattern makes it easier to add new environments or modify stack assignments in the future

https://claude.ai/code/session_01K2dcgqhtd7jHpmmyWZZshC