### PR TITLE
fix(chrome-extension): enable E2E tests in CI with sandbox flags

### DIFF
--- a/projects/chrome-extension/run-tests.config.js
+++ b/projects/chrome-extension/run-tests.config.js
@@ -1,23 +1,3 @@
-const localE2ePhases = process.env.CI ? [] : [
-  {
-    type: 'script',
-    name: 'Building extension for E2E tests',
-    command: 'node scripts/build-extension.js',
-    env: { HUTCH_SERVER_URL: 'http://127.0.0.1:3001' },
-  },
-  {
-    type: 'script',
-    name: 'Installing Chrome for Testing',
-    command: 'node scripts/install-chrome-for-testing.js',
-  },
-  {
-    type: 'node-test',
-    name: 'Running E2E tests',
-    files: ['dist/e2e/login-flow/run.e2e-local.js'],
-    env: { HEADLESS: 'true' },
-  },
-];
-
 module.exports = {
   projectName: 'Chrome Extension',
   phases: [
@@ -34,6 +14,22 @@ module.exports = {
       name: 'Running E2E unit tests',
       glob: 'dist/e2e/**/*.test.js',
     },
-    ...localE2ePhases,
+    {
+      type: 'script',
+      name: 'Building extension for E2E tests',
+      command: 'node scripts/build-extension.js',
+      env: { HUTCH_SERVER_URL: 'http://127.0.0.1:3001' },
+    },
+    {
+      type: 'script',
+      name: 'Installing Chrome for Testing',
+      command: 'node scripts/install-chrome-for-testing.js',
+    },
+    {
+      type: 'node-test',
+      name: 'Running E2E tests',
+      files: ['dist/e2e/login-flow/run.e2e-local.js'],
+      env: { HEADLESS: 'true' },
+    },
   ],
 };

--- a/projects/chrome-extension/src/e2e/login-flow/run.e2e-local.ts
+++ b/projects/chrome-extension/src/e2e/login-flow/run.e2e-local.ts
@@ -73,6 +73,9 @@ test("should complete OAuth login flow and save a link to the list", async () =>
 	}
 	options.addArguments(`--load-extension=${EXTENSION_DIR}`);
 	options.addArguments("--disable-search-engine-choice-screen");
+	// CI runs in a container-like environment without a user namespace
+	options.addArguments("--no-sandbox");
+	options.addArguments("--disable-dev-shm-usage");
 
 	// Chrome 137+ removed --load-extension in branded Google Chrome.
 	// Use Chrome for Testing which still supports it.


### PR DESCRIPTION
The Chrome E2E tests hung in CI because the Chrome for Testing binary
cannot start without --no-sandbox and --disable-dev-shm-usage in the
container-like GitHub Actions environment. Add both flags and remove
the CI skip guard so the E2E phases run everywhere.

https://claude.ai/code/session_01TvfDkioJE31zaMEAyPeDgS