### PR TITLE
Remove "shaped by users" messaging from homepage

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -61,8 +61,8 @@
     <section id="roadmap" class="home-features" data-test-section="roadmap" aria-label="Planned features">
       <div class="section-header">
         <p class="section-header__label">What's Coming</p>
-        <h2 class="section-header__title">Built in public. Shaped by users.</h2>
-        <p class="section-header__subtitle">I'm planning to build these. Vote on what matters most to you on the <a href="https://www.reddit.com/r/hutchapp">Reddit community</a>.</p>
+        <h2 class="section-header__title">Built in public. One feature at a time.</h2>
+        <p class="section-header__subtitle">Here's what I'm planning to build next.</p>
       </div>
       <div class="home-features__grid">
         {{#each plannedFeatures}}


### PR DESCRIPTION
## Summary
- Removed "Shaped by users" from the roadmap section title, replaced with "One feature at a time"
- Removed subtitle encouraging users to vote on features via Reddit
- Replaced with neutral "Here's what I'm planning to build next"

This avoids setting the expectation that users guide development direction, which can lead to feature creep that's hard to maintain.

## Test plan
- [ ] Verify homepage renders correctly with updated roadmap section text
- [ ] Confirm no broken links or layout issues in the roadmap section

https://claude.ai/code/session_01Nx3HfoyWkjWLsd2g4Co7Yh