### PR TITLE
Add readUrl support for reading list items

### DIFF
--- a/projects/browser-extension-core/src/domain/reading-list-item.types.ts
+++ b/projects/browser-extension-core/src/domain/reading-list-item.types.ts
@@ -7,4 +7,5 @@ export interface ReadingListItem {
 	url: string;
 	title: string;
 	savedAt: Date;
+	readUrl?: string;
 }

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
@@ -35,6 +35,47 @@ describe("initSirenReadingList", () => {
 			expect(item.savedAt).toEqual(new Date(savedAt));
 		});
 
+		it("should include readUrl when server returns a read link", async () => {
+			const fetchFn = async () => new Response(JSON.stringify({
+				class: ["article"],
+				properties: {
+					id: "article-1",
+					url: "https://example.com/article",
+					title: "Article",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				},
+				links: [
+					{ rel: ["self"], href: "/queue/article-1" },
+					{ rel: ["read"], href: "/queue/article-1/read" },
+				],
+			}), { status: 201 });
+			const list = initSirenReadingList(createDeps(fetchFn));
+
+			const result = await list.saveUrl({ url: "https://example.com/article", title: "Ignored" });
+			const item = (result as Extract<typeof result, { ok: true }>).item;
+
+			expect(item.readUrl).toBe("http://localhost:3000/queue/article-1/read");
+		});
+
+		it("should have undefined readUrl when server returns no read link", async () => {
+			const fetchFn = async () => new Response(JSON.stringify({
+				class: ["article"],
+				properties: {
+					id: "article-1",
+					url: "https://example.com/article",
+					title: "Article",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				},
+				links: [{ rel: ["self"], href: "/queue/article-1" }],
+			}), { status: 201 });
+			const list = initSirenReadingList(createDeps(fetchFn));
+
+			const result = await list.saveUrl({ url: "https://example.com/article", title: "Ignored" });
+			const item = (result as Extract<typeof result, { ok: true }>).item;
+
+			expect(item.readUrl).toBeUndefined();
+		});
+
 		it("should throw when server returns an error", async () => {
 			const fetchFn = async () => new Response(null, { status: 422 });
 			const list = initSirenReadingList(createDeps(fetchFn));
@@ -163,6 +204,27 @@ describe("initSirenReadingList", () => {
 			const items = await list.getAllItems();
 
 			expect(items.map(i => i.url)).toEqual(["https://example.com/a", "https://example.com/b"]);
+		});
+
+		it("should include readUrl for items with read links", async () => {
+			const fetchFn = async () => new Response(JSON.stringify({
+				entities: [
+					{
+						properties: { id: "1", url: "https://example.com/a", title: "A", savedAt: "2026-01-15T10:00:00.000Z" },
+						links: [{ rel: ["self"], href: "/queue/1" }, { rel: ["read"], href: "/queue/1/read" }],
+					},
+					{
+						properties: { id: "2", url: "https://example.com/b", title: "B", savedAt: "2026-01-15T11:00:00.000Z" },
+						links: [{ rel: ["self"], href: "/queue/2" }],
+					},
+				],
+			}), { status: 200 });
+			const list = initSirenReadingList(createDeps(fetchFn));
+
+			const items = await list.getAllItems();
+
+			expect(items[0].readUrl).toBe("http://localhost:3000/queue/1/read");
+			expect(items[1].readUrl).toBeUndefined();
 		});
 
 		it("should return empty array when collection is empty", async () => {

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
@@ -26,8 +26,14 @@ const SirenPropertiesSchema = z.object({
 	savedAt: z.string(),
 });
 
+interface SirenLink {
+	rel: string[];
+	href: string;
+}
+
 interface SirenSubEntity {
 	properties?: Record<string, unknown>;
+	links?: SirenLink[];
 	actions?: Array<{ name: string; href: string; method: string }>;
 }
 
@@ -41,15 +47,21 @@ export interface SirenReadingListDeps {
 	fetchFn: typeof fetch;
 }
 
-function toReadingListItem(entity: SirenSubEntity): ReadingListItem {
+function findLinkHref(entity: SirenSubEntity, rel: string): string | undefined {
+	return entity.links?.find((link) => link.rel.includes(rel))?.href;
+}
+
+function toReadingListItem(entity: SirenSubEntity, serverUrl: string): ReadingListItem {
 	assert(entity.properties, "Server response entity missing properties");
 	const props = SirenPropertiesSchema.parse(entity.properties);
+	const readHref = findLinkHref(entity, "read");
 	return {
 		// Zod validates id is a string; branded type narrowing is safe after schema validation
 		id: props.id as ReadingListItemId,
 		url: props.url,
 		title: props.title,
 		savedAt: new Date(props.savedAt),
+		readUrl: readHref ? `${serverUrl}${readHref}` : undefined,
 	};
 }
 
@@ -81,7 +93,7 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 		}
 
 		const body = await response.json() as SirenSubEntity;
-		return { ok: true, item: toReadingListItem(body) };
+		return { ok: true, item: toReadingListItem(body, deps.serverUrl) };
 	};
 
 	const removeUrl: RemoveUrl = async (id) => {
@@ -118,7 +130,7 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 			return null;
 		}
 
-		return toReadingListItem(entities[0]);
+		return toReadingListItem(entities[0], deps.serverUrl);
 	};
 
 	const getAllItems: GetAllItems = async () => {
@@ -133,7 +145,7 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 		}
 
 		const body = await response.json() as SirenResponse;
-		return (body.entities ?? []).map(toReadingListItem);
+		return (body.entities ?? []).map((entity) => toReadingListItem(entity, deps.serverUrl));
 	};
 
 	return { saveUrl, removeUrl, findByUrl, getAllItems };

--- a/projects/extensions/chrome-extension/src/e2e/login-flow/save-link-actions.ts
+++ b/projects/extensions/chrome-extension/src/e2e/login-flow/save-link-actions.ts
@@ -95,9 +95,10 @@ export function createSaveLinkActions(config: {
 			);
 			const items = await driver.findElements(By.css(CSS_SELECTORS.listItemTitle));
 			const hrefs = await Promise.all(items.map(el => el.getAttribute("href")));
+			const readUrlPattern = /\/queue\/[a-f0-9]+\/read$/;
 			assert.ok(
-				hrefs.some(href => href === config.testUrl),
-				`Expected "${config.testUrl}" in list hrefs, but found: ${hrefs.join(", ")}`,
+				hrefs.some(href => href === config.testUrl || readUrlPattern.test(href)),
+				`Expected "${config.testUrl}" or a read URL in list hrefs, but found: ${hrefs.join(", ")}`,
 			);
 			config.progress.listVerified = true;
 		},

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.ts
@@ -134,7 +134,7 @@ function renderLinks(items: ReadingListItem[]) {
 
 		const link = document.createElement("a");
 		link.className = "list-view__item-title";
-		link.href = item.url;
+		link.href = item.readUrl ?? item.url;
 		link.textContent = item.title;
 		link.target = "_blank";
 		link.rel = "noopener noreferrer";

--- a/projects/hutch/src/runtime/web/api/article-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.test.ts
@@ -49,9 +49,21 @@ describe("toArticleSubEntity", () => {
 				savedAt: "2026-03-04T10:00:00.000Z",
 				readAt: null,
 			},
-			links: [{ rel: ["self"], href: "/queue/test-article-id" }],
+			links: [
+				{ rel: ["self"], href: "/queue/test-article-id" },
+				{ rel: ["read"], href: "/queue/test-article-id/read" },
+			],
 			actions: [{ name: "delete", href: "/queue/test-article-id/delete", method: "POST" }],
 		});
+	});
+
+	it("omits read link when article has no content", () => {
+		const article = makeArticle({ content: undefined });
+		const subEntity = toArticleSubEntity(article);
+
+		expect(subEntity.links).toEqual([
+			{ rel: ["self"], href: "/queue/test-article-id" },
+		]);
 	});
 
 	it("maps readAt when present", () => {

--- a/projects/hutch/src/runtime/web/api/article-siren.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.ts
@@ -1,7 +1,12 @@
 import type { SavedArticle } from "../../domain/article/article.types";
-import type { SirenEntity, SirenSubEntity } from "./siren";
+import type { SirenEntity, SirenLink, SirenSubEntity } from "./siren";
 
 export function toArticleSubEntity(article: SavedArticle): SirenSubEntity {
+	const links: SirenLink[] = [{ rel: ["self"], href: `/queue/${article.id}` }];
+	if (article.content) {
+		links.push({ rel: ["read"], href: `/queue/${article.id}/read` });
+	}
+
 	return {
 		class: ["article"],
 		rel: ["item"],
@@ -18,7 +23,7 @@ export function toArticleSubEntity(article: SavedArticle): SirenSubEntity {
 			savedAt: article.savedAt.toISOString(),
 			readAt: article.readAt?.toISOString() ?? null,
 		},
-		links: [{ rel: ["self"], href: `/queue/${article.id}` }],
+		links,
 		actions: [
 			{
 				name: "delete",


### PR DESCRIPTION
## Summary
This PR adds support for a `readUrl` property on reading list items, allowing the extension to link to a dedicated read view of articles when available from the server.

## Key Changes
- **Domain Model**: Added optional `readUrl` property to `ReadingListItem` interface
- **Siren Reading List**: 
  - Updated `toReadingListItem()` to extract and construct the `readUrl` from server response links with `rel: ["read"]`
  - Added `findLinkHref()` helper to locate links by relationship type
  - Updated all item conversion calls to pass `serverUrl` for URL construction
- **Server API**: 
  - Modified `toArticleSubEntity()` to include a read link when article content is available
  - Read link is omitted for articles without content
- **Chrome Extension**: Updated popup to use `readUrl` when available, falling back to the original `url`

## Implementation Details
- The `readUrl` is constructed by combining the server URL with the href from the "read" link in the Siren response
- The read link is only included in server responses when the article has content
- The feature gracefully degrades: items without a read link will have `readUrl` as `undefined` and the extension will use the original article URL

https://claude.ai/code/session_01JfakYAaYva8c535HWCYf3a