### PR TITLE
Show saved confirmation in popup after context menu save

### DIFF
--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -102,6 +102,13 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 		}
 	}
 
+	async function showSavedIconForActiveTab() {
+		const tab = await shell.getActiveTab();
+		if (tab?.id != null) {
+			await shell.setIcon.showSaved(tab.id);
+		}
+	}
+
 	return {
 		init() {
 			eventBus.emit("pre-init");
@@ -110,7 +117,18 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 				const guarded = auth.whenLoggedIn(() => saveFromContextMenu(info, tab));
 				emitResult("saved-current-tab", guarded);
 				if (guarded.ok) {
-					guarded.value.then(() => updateActiveTabIcon()).catch(() => {});
+					guarded.value
+						.then(async (result) => {
+							if (!result?.ok) return;
+							const url = info.menuItemId === "save-link-to-hutch" ? info.linkUrl : (info.pageUrl ?? tab?.url);
+							const title = info.menuItemId === "save-link-to-hutch" ? info.linkUrl : (tab?.title ?? url);
+							if (url) {
+								await shell.setJustSaved({ url, title: title ?? url });
+								await shell.openPopup();
+							}
+							await showSavedIconForActiveTab();
+						})
+						.catch(() => {});
 				}
 			});
 
@@ -137,7 +155,12 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 						}
 
 						if (result.action === "saved") {
-							updateActiveTabIcon().catch(() => {});
+							await shell.setJustSaved({
+								url: result.item.url,
+								title: result.item.title,
+							});
+							await shell.openPopup();
+							await showSavedIconForActiveTab();
 						}
 					})
 					.catch((err) => logger.error(err));

--- a/projects/browser-extension-core/src/shell.types.ts
+++ b/projects/browser-extension-core/src/shell.types.ts
@@ -3,10 +3,13 @@ import type { SetIcon } from "./icon-status";
 export interface BrowserShell {
 	onShortcutPressed: (handler: () => void) => void;
 	openLoginScreen: (params: { url: string; title: string }) => void;
+	openPopup: () => Promise<void>;
 	focusLoginWindow: () => void;
 	getActiveTab: () => Promise<{ id?: number; url: string; title: string } | null>;
 	queryActiveTabs: () => Promise<Array<{ id?: number; url?: string; title?: string }>>;
 	setIcon: SetIcon;
+	setJustSaved: (data: { url: string; title: string }) => Promise<void>;
+	getAndClearJustSaved: () => Promise<{ url: string; title: string } | null>;
 	createContextMenus: () => void;
 	onContextMenuClicked: (handler: (info: {
 		menuItemId: string;

--- a/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
@@ -38,6 +38,8 @@ const tokenStorage: TokenStorage = {
 	},
 };
 
+const JUST_SAVED_KEY = "hutch_just_saved";
+
 let loginWindow: { id: number; tabId: number; tabUrl: string } | null = null;
 
 const shell: BrowserShell = {
@@ -48,6 +50,22 @@ const shell: BrowserShell = {
 			}
 			return undefined;
 		});
+	},
+
+	async openPopup() {
+		await chrome.action.openPopup();
+	},
+
+	async setJustSaved(data) {
+		await browser.storage.local.set({ [JUST_SAVED_KEY]: data });
+	},
+
+	async getAndClearJustSaved() {
+		const result = await browser.storage.local.get(JUST_SAVED_KEY);
+		const raw = result[JUST_SAVED_KEY];
+		if (!raw) return null;
+		await browser.storage.local.remove(JUST_SAVED_KEY);
+		return raw as { url: string; title: string };
 	},
 
 	openLoginScreen({ url, title }) {

--- a/projects/extensions/chrome-extension/src/runtime/chrome.d.ts
+++ b/projects/extensions/chrome-extension/src/runtime/chrome.d.ts
@@ -1,4 +1,8 @@
 declare namespace chrome {
+	namespace action {
+		function openPopup(): Promise<void>;
+	}
+
 	namespace offscreen {
 		type Reason =
 			| "TESTING"

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -14,6 +14,16 @@ declare const __SERVER_URL__: string;
 
 const logger = HutchLogger.from(consoleLogger);
 
+const JUST_SAVED_KEY = "hutch_just_saved";
+
+async function getAndClearJustSaved(): Promise<{ url: string; title: string } | null> {
+	const result = await browser.storage.local.get(JUST_SAVED_KEY);
+	const raw = result[JUST_SAVED_KEY];
+	if (!raw) return null;
+	await browser.storage.local.remove(JUST_SAVED_KEY);
+	return raw as { url: string; title: string };
+}
+
 function showView(id: string) {
 	for (const view of document.querySelectorAll(".view")) {
 		(view as HTMLElement).hidden = true;
@@ -324,10 +334,18 @@ if (shortcutHint) {
 	}
 }
 
-saveAndShowList().catch((error) => {
-	logger.error("Failed to initialize popup:", error);
-	showView("list-view");
-	const listError = document.getElementById("list-error");
-	if (listError) listError.hidden = false;
-});
+getAndClearJustSaved()
+	.then((justSaved) => {
+		if (justSaved) {
+			showView("saved-view");
+			return;
+		}
+		return saveAndShowList();
+	})
+	.catch((error) => {
+		logger.error("Failed to initialize popup:", error);
+		showView("list-view");
+		const listError = document.getElementById("list-error");
+		if (listError) listError.hidden = false;
+	});
 /* c8 ignore stop */

--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -38,6 +38,8 @@ const tokenStorage: TokenStorage = {
 	},
 };
 
+const JUST_SAVED_KEY = "hutch_just_saved";
+
 let loginWindow: { id: number; tabId: number; tabUrl: string } | null = null;
 
 const shell: BrowserShell = {
@@ -48,6 +50,22 @@ const shell: BrowserShell = {
 			}
 			return undefined;
 		});
+	},
+
+	async openPopup() {
+		await browser.browserAction.openPopup();
+	},
+
+	async setJustSaved(data) {
+		await browser.storage.local.set({ [JUST_SAVED_KEY]: data });
+	},
+
+	async getAndClearJustSaved() {
+		const result = await browser.storage.local.get(JUST_SAVED_KEY);
+		const raw = result[JUST_SAVED_KEY];
+		if (!raw) return null;
+		await browser.storage.local.remove(JUST_SAVED_KEY);
+		return raw as { url: string; title: string };
 	},
 
 	openLoginScreen({ url, title }) {

--- a/projects/extensions/firefox-extension/src/runtime/browser.d.ts
+++ b/projects/extensions/firefox-extension/src/runtime/browser.d.ts
@@ -75,6 +75,7 @@ declare namespace browser {
 			imageData?: Record<number, ImageData>;
 		}): Promise<void>;
 
+		function openPopup(): Promise<void>;
 	}
 
 	namespace windows {

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -13,6 +13,16 @@ declare const __SERVER_URL__: string;
 
 const logger = HutchLogger.from(consoleLogger);
 
+const JUST_SAVED_KEY = "hutch_just_saved";
+
+async function getAndClearJustSaved(): Promise<{ url: string; title: string } | null> {
+	const result = await browser.storage.local.get(JUST_SAVED_KEY);
+	const raw = result[JUST_SAVED_KEY];
+	if (!raw) return null;
+	await browser.storage.local.remove(JUST_SAVED_KEY);
+	return raw as { url: string; title: string };
+}
+
 function showView(id: string) {
 	for (const view of document.querySelectorAll(".view")) {
 		(view as HTMLElement).hidden = true;
@@ -320,10 +330,18 @@ if (shortcutHint) {
 	}
 }
 
-saveAndShowList().catch((error) => {
-	logger.error("Failed to initialize popup:", error);
-	showView("list-view");
-	const listError = document.getElementById("list-error");
-	if (listError) listError.hidden = false;
-});
+getAndClearJustSaved()
+	.then((justSaved) => {
+		if (justSaved) {
+			showView("saved-view");
+			return;
+		}
+		return saveAndShowList();
+	})
+	.catch((error) => {
+		logger.error("Failed to initialize popup:", error);
+		showView("list-view");
+		const listError = document.getElementById("list-error");
+		if (listError) listError.hidden = false;
+	});
 /* c8 ignore stop */


### PR DESCRIPTION
## Summary
This PR enhances the user experience when saving items via the context menu by automatically opening the popup and displaying a confirmation view showing what was just saved.

## Key Changes
- **Added "just saved" state management**: Introduced `setJustSaved()` and `getAndClearJustSaved()` methods to the `BrowserShell` interface to persist and retrieve recently saved item data via browser storage
- **Auto-open popup on save**: When a user saves via context menu, the popup now automatically opens via `openPopup()` method (implemented for both Chrome and Firefox)
- **Show saved confirmation view**: The popup now displays a "saved-view" when it detects a recently saved item, providing immediate visual feedback to the user
- **Updated initialization flow**: Modified popup initialization to check for saved state first before loading the normal list view
- **Added helper function**: Created `showSavedIconForActiveTab()` to update the extension icon after successful saves

## Implementation Details
- The saved item data (URL and title) is stored in browser local storage with key `hutch_just_saved`
- Data is automatically cleared after being retrieved by the popup, ensuring it only displays once
- Both Chrome and Firefox extensions receive identical implementations with browser-specific API calls (`chrome.action.openPopup()` vs `browser.browserAction.openPopup()`)
- The feature works for both context menu saves (page/link) and sidebar saves
- Error handling is preserved - if popup initialization fails, it falls back to the normal list view with error display

https://claude.ai/code/session_01Xo5FP2w6hmxMpQZQpvcSS9