### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       STATIC_BASE_URL: 'https://d2uoxssv1ey7em.cloudfront.net'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -51,7 +51,7 @@ jobs:
       firefox-extension: ${{ steps.detect.outputs.firefox-extension }}
       chrome-extension: ${{ steps.detect.outputs.chrome-extension }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -89,13 +89,13 @@ jobs:
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -119,13 +119,13 @@ jobs:
       PULUMI_BACKEND_URL: s3://hutch-pulumi-state-572337278115-ap-southeast-2
       PULUMI_CONFIG_PASSPHRASE: ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-staging-results
           path: projects/hutch/test-results-staging/
@@ -176,13 +176,13 @@ jobs:
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/claude-PR-CI-failure-fixer.yml
+++ b/.github/workflows/claude-PR-CI-failure-fixer.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Remove ci-fix-attempt label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check if we should attempt a fix and post @claude comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |

--- a/.github/workflows/claude-PR-code-review-auto-apply.yml
+++ b/.github/workflows/claude-PR-code-review-auto-apply.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Remove auto-fix-attempt label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Check iteration count and post @claude fix request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |

--- a/.github/workflows/claude-PR-code-reviewer.yml
+++ b/.github/workflows/claude-PR-code-reviewer.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Post @claude code review request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |

--- a/.github/workflows/claude-PR-conflict-fixer.yml
+++ b/.github/workflows/claude-PR-conflict-fixer.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check all open PRs for conflicts
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |

--- a/.github/workflows/claude-listener.yml
+++ b/.github/workflows/claude-listener.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/publish-chrome-extension.yml
+++ b/.github/workflows/publish-chrome-extension.yml
@@ -27,13 +27,13 @@ jobs:
       PULUMI_BACKEND_URL: s3://hutch-pulumi-state-278728209435-ap-southeast-2
       PULUMI_CONFIG_PASSPHRASE: ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/submit-ff-extension-for-signing.yml
+++ b/.github/workflows/submit-ff-extension-for-signing.yml
@@ -23,13 +23,13 @@ jobs:
       PULUMI_BACKEND_URL: s3://hutch-pulumi-state-278728209435-ap-southeast-2
       PULUMI_CONFIG_PASSPHRASE: ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/sync-signed-extension.yml
+++ b/.github/workflows/sync-signed-extension.yml
@@ -17,9 +17,9 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ap-southeast-2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 


### PR DESCRIPTION
## Summary
This PR updates all GitHub Actions used across the CI/CD workflows to their latest major versions to benefit from security patches, performance improvements, and new features.

## Key Changes
- **actions/checkout**: v4 → v6 (across all workflows)
- **actions/setup-node**: v4 → v6 (across all workflows)
- **actions/upload-artifact**: v4 → v7 (in ci.yml)
- **actions/github-script**: v7 → v8 (across all script-based workflows)

## Affected Workflows
- `.github/workflows/ci.yml`
- `.github/workflows/claude-PR-CI-failure-fixer.yml`
- `.github/workflows/claude-PR-code-review-auto-apply.yml`
- `.github/workflows/claude-listener.yml`
- `.github/workflows/publish-chrome-extension.yml`
- `.github/workflows/submit-ff-extension-for-signing.yml`
- `.github/workflows/sync-signed-extension.yml`
- `.github/workflows/claude-PR-code-reviewer.yml`
- `.github/workflows/claude-PR-conflict-fixer.yml`

## Notes
All action upgrades maintain backward compatibility with the existing workflow configurations. No changes to workflow logic or behavior are required.

https://claude.ai/code/session_01WCxJ3ifnW5b7v6Adfpyo8L