### PR TITLE
Skip URL validation when saving pages from the app itself

### DIFF
--- a/projects/browser-extension-core/src/index.ts
+++ b/projects/browser-extension-core/src/index.ts
@@ -28,6 +28,7 @@ export { filterByUrl } from "./popup/filter-by-url";
 export { paginateItems } from "./popup/paginate-items";
 export { avatarColor } from "./popup/avatar-color";
 export { relativeTime } from "./popup/relative-time";
+export { isAppUrl } from "./popup/is-app-url";
 export {
 	MENU_ITEM_SAVE_PAGE,
 	MENU_ITEM_SAVE_LINK,

--- a/projects/browser-extension-core/src/popup/is-app-url.test.ts
+++ b/projects/browser-extension-core/src/popup/is-app-url.test.ts
@@ -2,26 +2,26 @@ import { isAppUrl } from "./is-app-url";
 
 describe("isAppUrl", () => {
 	it("returns true when tab is on the same origin as serverUrl", () => {
-		expect(isAppUrl("https://hutch-app.com/queue", "https://hutch-app.com")).toBe(true);
+		expect(isAppUrl({ tabUrl: "https://hutch-app.com/queue", serverUrl: "https://hutch-app.com" })).toBe(true);
 	});
 
 	it("returns true for localhost dev server", () => {
-		expect(isAppUrl("http://127.0.0.1:3000/queue", "http://127.0.0.1:3000")).toBe(true);
+		expect(isAppUrl({ tabUrl: "http://127.0.0.1:3000/queue", serverUrl: "http://127.0.0.1:3000" })).toBe(true);
 	});
 
 	it("returns false for a different domain", () => {
-		expect(isAppUrl("https://example.com/article", "https://hutch-app.com")).toBe(false);
+		expect(isAppUrl({ tabUrl: "https://example.com/article", serverUrl: "https://hutch-app.com" })).toBe(false);
 	});
 
 	it("returns false for different ports on localhost", () => {
-		expect(isAppUrl("http://127.0.0.1:4000/page", "http://127.0.0.1:3000")).toBe(false);
+		expect(isAppUrl({ tabUrl: "http://127.0.0.1:4000/page", serverUrl: "http://127.0.0.1:3000" })).toBe(false);
 	});
 
 	it("returns false for invalid tab URL", () => {
-		expect(isAppUrl("not-a-url", "https://hutch-app.com")).toBe(false);
+		expect(isAppUrl({ tabUrl: "not-a-url", serverUrl: "https://hutch-app.com" })).toBe(false);
 	});
 
 	it("returns true for nested paths on the server", () => {
-		expect(isAppUrl("https://hutch-app.com/read/abc123", "https://hutch-app.com")).toBe(true);
+		expect(isAppUrl({ tabUrl: "https://hutch-app.com/read/abc123", serverUrl: "https://hutch-app.com" })).toBe(true);
 	});
 });

--- a/projects/browser-extension-core/src/popup/is-app-url.test.ts
+++ b/projects/browser-extension-core/src/popup/is-app-url.test.ts
@@ -1,0 +1,27 @@
+import { isAppUrl } from "./is-app-url";
+
+describe("isAppUrl", () => {
+	it("returns true when tab is on the same origin as serverUrl", () => {
+		expect(isAppUrl("https://hutch-app.com/queue", "https://hutch-app.com")).toBe(true);
+	});
+
+	it("returns true for localhost dev server", () => {
+		expect(isAppUrl("http://127.0.0.1:3000/queue", "http://127.0.0.1:3000")).toBe(true);
+	});
+
+	it("returns false for a different domain", () => {
+		expect(isAppUrl("https://example.com/article", "https://hutch-app.com")).toBe(false);
+	});
+
+	it("returns false for different ports on localhost", () => {
+		expect(isAppUrl("http://127.0.0.1:4000/page", "http://127.0.0.1:3000")).toBe(false);
+	});
+
+	it("returns false for invalid tab URL", () => {
+		expect(isAppUrl("not-a-url", "https://hutch-app.com")).toBe(false);
+	});
+
+	it("returns true for nested paths on the server", () => {
+		expect(isAppUrl("https://hutch-app.com/read/abc123", "https://hutch-app.com")).toBe(true);
+	});
+});

--- a/projects/browser-extension-core/src/popup/is-app-url.ts
+++ b/projects/browser-extension-core/src/popup/is-app-url.ts
@@ -1,0 +1,9 @@
+export function isAppUrl(tabUrl: string, serverUrl: string): boolean {
+	try {
+		const tabOrigin = new URL(tabUrl).origin;
+		const serverOrigin = new URL(serverUrl).origin;
+		return tabOrigin === serverOrigin;
+	} catch {
+		return false;
+	}
+}

--- a/projects/browser-extension-core/src/popup/is-app-url.ts
+++ b/projects/browser-extension-core/src/popup/is-app-url.ts
@@ -1,7 +1,7 @@
-export function isAppUrl(tabUrl: string, serverUrl: string): boolean {
+export function isAppUrl(urls: { tabUrl: string; serverUrl: string }): boolean {
 	try {
-		const tabOrigin = new URL(tabUrl).origin;
-		const serverOrigin = new URL(serverUrl).origin;
+		const tabOrigin = new URL(urls.tabUrl).origin;
+		const serverOrigin = new URL(urls.serverUrl).origin;
 		return tabOrigin === serverOrigin;
 	} catch {
 		return false;

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.ts
@@ -6,8 +6,10 @@ import type {
 	SaveUrlResult,
 	RemoveUrlResult,
 } from "browser-extension-core";
-import { filterByUrl, paginateItems, avatarColor, relativeTime } from "browser-extension-core";
+import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+
+declare const __SERVER_URL__: string;
 
 const logger = HutchLogger.from(consoleLogger);
 
@@ -223,6 +225,11 @@ async function getActiveTab(): Promise<{ url: string; title: string } | null> {
 async function saveAndShowList() {
 	const activeTab = await getActiveTab();
 	if (!activeTab) {
+		await showListView();
+		return;
+	}
+
+	if (isAppUrl(activeTab.url, __SERVER_URL__)) {
 		await showListView();
 		return;
 	}

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.ts
@@ -229,7 +229,7 @@ async function saveAndShowList() {
 		return;
 	}
 
-	if (isAppUrl(activeTab.url, __SERVER_URL__)) {
+	if (isAppUrl({ tabUrl: activeTab.url, serverUrl: __SERVER_URL__ })) {
 		await showListView();
 		return;
 	}

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.ts
@@ -5,8 +5,10 @@ import type {
 	SaveUrlResult,
 	RemoveUrlResult,
 } from "browser-extension-core";
-import { filterByUrl, paginateItems, avatarColor, relativeTime } from "browser-extension-core";
+import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+
+declare const __SERVER_URL__: string;
 
 const logger = HutchLogger.from(consoleLogger);
 
@@ -222,6 +224,11 @@ async function getActiveTab(): Promise<{ url: string; title: string } | null> {
 async function saveAndShowList() {
 	const activeTab = await getActiveTab();
 	if (!activeTab) {
+		await showListView();
+		return;
+	}
+
+	if (isAppUrl(activeTab.url, __SERVER_URL__)) {
 		await showListView();
 		return;
 	}

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.ts
@@ -228,7 +228,7 @@ async function saveAndShowList() {
 		return;
 	}
 
-	if (isAppUrl(activeTab.url, __SERVER_URL__)) {
+	if (isAppUrl({ tabUrl: activeTab.url, serverUrl: __SERVER_URL__ })) {
 		await showListView();
 		return;
 	}


### PR DESCRIPTION
## Summary
This PR adds logic to skip URL validation when a user attempts to save a page that is already on the Hutch app itself, improving the user experience by immediately showing the list view instead of attempting to validate the current app URL.

## Key Changes
- **New utility function `isAppUrl()`**: Created a reusable function in `browser-extension-core` that compares the origin of a tab URL against the server URL, with proper error handling for invalid URLs
- **Comprehensive test coverage**: Added 6 test cases covering success cases (same origin, localhost with ports, nested paths) and failure cases (different domains, port mismatches, invalid URLs)
- **Updated popup logic**: Modified both Chrome and Firefox extension popup handlers to check if the active tab is already on the app before attempting URL validation
- **Exported new utility**: Added `isAppUrl` to the core library's public exports for use across extensions

## Implementation Details
- The `isAppUrl()` function uses the `URL` API to extract and compare origins, ensuring robust handling of various URL formats
- When a user tries to save while already on the app (detected via origin matching), the extension immediately displays the list view instead of sending a validation request
- The `__SERVER_URL__` is injected at build time and used to determine the app's origin

https://claude.ai/code/session_01P2bdBgzGMc1QvXsDE8VAcT