### PR TITLE
Add read-it-later apps comparison blog post with table styling

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/best-read-it-later-apps-2026.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/best-read-it-later-apps-2026.md
@@ -1,0 +1,189 @@
+---
+title: "Best Read-It-Later Apps in 2026 (Honest Comparison)"
+description: "Honest comparison of read-it-later apps in 2026: Hutch, Readwise Reader, Instapaper, Raindrop.io, Karakeep, Wallabag, and Matter."
+slug: "best-read-it-later-apps-2026"
+date: "2026-04-07"
+author: "Fagner Brack"
+keywords: "read it later apps, Pocket alternative, Omnivore alternative, best read it later 2026, Readwise Reader, Instapaper, Karakeep, Wallabag, Raindrop, Matter, Hutch"
+---
+
+Mozilla acquired Pocket and then abandoned it. Omnivore shut down overnight after ElevenLabs acqui-hired the team. Millions of readers lost their save-for-later tool and started looking for a replacement.
+
+This page covers the real alternatives in 2026, with honest pros and cons for each, including Hutch's own limitations. I built Hutch, so I have an obvious bias. I wrote this to be fair anyway.
+
+## Quick Comparison
+
+| App | Price | AI Features | Open Source | Offline Reading | Platforms |
+|-----|-------|-------------|-------------|-----------------|-----------|
+| **Hutch** | A$3.99/mo | TL;DR summaries | Source-available (AGPL) | Planned | Web, Chrome, Firefox |
+| **Readwise Reader** | $8.99-12.99/mo | Ghostreader AI | No | Yes | Web, iOS, Android, Chrome, Firefox, Safari |
+| **Instapaper** | Free / Premium | No | No | Yes | Web, iOS, Android, Kobo |
+| **Raindrop.io** | Free / $3/mo | No | No | Pro only | Web, iOS, Android, Chrome, Firefox, Safari |
+| **Karakeep** | Free (self-hosted) | AI auto-tagging | Yes | Yes | Web, Chrome, Firefox |
+| **Wallabag** | Free (self-hosted) | No | Yes | Yes | Web, iOS, Android, Chrome, Firefox |
+| **Matter** | Free | AI co-reader | No | Yes | iOS, Android, Web |
+
+## Hutch
+
+I built Hutch after ten years of maintaining a personal reading system. Save an article with one click, read it later in a clean reader view, and get an AI-generated TL;DR for every piece. It runs on AWS in Sydney and operates under the Australian Privacy Act. The code is source-available under AGPL. Hutch is newer than most options here and still adding features. What it does today, it does well.
+
+**A$3.99/month**
+
+### Strengths
+
+- AI TL;DR summaries included in the base price. No upsell tier required.
+- Privacy-first: hosted in Australia, no tracking scripts, no third-party analytics. Data stays under Australian Privacy Act jurisdiction.
+- Source-available (AGPL). You can read every line of code that handles your data.
+
+### Limitations
+
+- No mobile app yet. No offline reading. The feature set is smaller than Readwise Reader or Instapaper.
+- Solo-built and newer. If you need a mature product with years of polish, Hutch is not there yet.
+
+**Best for:** Readers who want AI summaries and privacy without high cost, and who are comfortable with a product that is still growing.
+
+## Readwise Reader
+
+Readwise Reader packs more features than any other read-it-later app. It combines article saving, an RSS reader, YouTube transcript support, and highlighting tools into one interface. Ghostreader, its AI assistant, summarises, tags, and generates questions about your saved content. Highlights sync to Obsidian, Notion, Logseq, and other note-taking tools automatically. If you take knowledge management seriously, Reader is the tool that does the most.
+
+**$12.99/month (or $8.99/month billed annually)**
+
+### Strengths
+
+- The deepest feature set of any read-it-later app: RSS, highlights, annotations, YouTube transcripts, PDF support, and Ghostreader AI.
+- Highlight sync to Obsidian, Notion, and Logseq is best-in-class. Nothing else comes close for this workflow.
+- Polished mobile apps with genuine offline support.
+
+### Limitations
+
+- The most expensive option on this list by a wide margin.
+- The feature density can feel overwhelming if you just want to save articles and read them.
+
+**Best for:** Power users who want highlights synced to their note-taking system and are willing to pay for a premium, feature-complete experience.
+
+## Instapaper
+
+Instapaper is the original read-it-later app. It predates Pocket. Ownership changed several times: Marco Arment, then Betaworks, then Pinterest, and now Instant Paper, Inc. The core experience stayed clean and reliable through each transition. It is now the default reading app on Kobo e-readers, giving it a real edge for people who read on dedicated hardware. There are no AI features, but the reading experience is mature and comfortable.
+
+**Free (with optional premium tier)**
+
+### Strengths
+
+- The closest thing to a direct Pocket replacement: mature, stable, and focused on the core save-and-read workflow.
+- Native Kobo e-reader integration. Save an article on your phone, read it on your Kobo.
+- The free tier is genuinely usable without feeling limited.
+
+### Limitations
+
+- Development pace has been slow. No AI features and limited new functionality in recent years.
+- Has been acquired multiple times. That raises questions about long-term continuity, the same concern people had with Pocket.
+
+**Best for:** Readers who want a simple, proven Pocket replacement with Kobo support and do not need AI features.
+
+## Raindrop.io
+
+Raindrop.io is a bookmark manager first and a read-it-later tool second. It handles collections, nested folders, tags, and full-text search across saved pages. The Pro tier adds a permanent archive and reader view. It fits best if your main need is organising and finding links rather than long-form reading. The free tier is functional but lacks the reader view that makes it useful as a reading app.
+
+**Free / $3/month Pro**
+
+### Strengths
+
+- Strong organisation: nested collections, tags, full-text search, and filters.
+- Works well as a general-purpose bookmark manager alongside read-it-later use.
+- Affordable Pro tier with permanent page archiving.
+
+### Limitations
+
+- No reader view in the free tier. That limits its usefulness as a read-it-later app.
+- More of a bookmark manager than a reading tool. The reading experience is secondary to the organisation features.
+
+**Best for:** People who need a bookmark manager first and a read-it-later tool second, especially if they save a high volume of links across categories.
+
+## Karakeep (formerly Hoarder)
+
+Karakeep, previously known as Hoarder, is a self-hosted bookmarking and read-it-later app built for developers. It uses AI to auto-tag saved content and supports full-text search. Setup requires Docker and some comfort with self-hosting. The project is fully open source and growing fast in the developer community. If you want complete control over your data and enjoy running your own services, Karakeep is a strong option.
+
+**Free (self-hosted, requires Docker)**
+
+### Strengths
+
+- Fully open source with active development. AI auto-tagging works well out of the box.
+- Complete data ownership. Everything runs on your own infrastructure.
+- Growing developer community with regular releases and responsive maintainers.
+
+### Limitations
+
+- Requires Docker and self-hosting knowledge. Not suitable for non-technical users.
+- No managed hosting option. You handle backups, updates, and uptime yourself.
+
+**Best for:** Developers and self-hosters who want full data ownership with AI features and are comfortable with Docker.
+
+## Wallabag
+
+Wallabag is the longest-standing open source read-it-later application. It has been around since 2013 and supports self-hosting, article parsing, tagging, and export. A managed hosting option exists for a small fee. Wallabag does what it says. It saves articles and lets you read them later. The trade-off is a user interface that has not kept pace with modern expectations. It is functional but universally described as dated.
+
+**Free (self-hosted) or small fee for managed hosting**
+
+### Strengths
+
+- The most battle-tested open source option. Stable, reliable, and proven over many years.
+- Managed hosting available if you do not want to self-host.
+
+### Limitations
+
+- The user interface feels dated. This is the most common criticism, and it is fair.
+- No AI features. Development is slower than newer alternatives like Karakeep.
+
+**Best for:** Users who want a proven, self-hosted option and prioritise stability over modern design.
+
+## Matter
+
+Matter takes a different approach to read-it-later. It adds social discovery and AI co-reading features. It summarises articles, highlights key passages, and surfaces content based on what people in your network read. The social angle sets it apart but means it is less focused on the traditional save-and-read workflow. It works well as a reading companion but does not suit people who want a quiet, private reading list.
+
+**Free**
+
+### Strengths
+
+- AI co-reader features: automatic highlights, summaries, and key point extraction.
+- Social discovery surfaces interesting reading from your network.
+
+### Limitations
+
+- The social and discovery features can distract from the core read-it-later purpose.
+- Less focused on private, quiet reading. If you want a personal reading list without social elements, this is not the right fit.
+
+**Best for:** Readers who want AI-assisted reading with a social layer and are less concerned about a private, distraction-free experience.
+
+## How I Would Choose
+
+No single option is best for everyone. Your priorities determine the right pick.
+
+- **If you want the most features:** Readwise Reader. Nothing else matches its depth, especially for highlight sync to Obsidian or Notion.
+- **If you want to self-host:** Karakeep. It is the most actively developed self-hosted option with AI features included.
+- **If you want AI summaries without the complexity or cost:** Hutch. One price, no tiers, summaries included.
+- **If you want the simplest Pocket replacement:** Instapaper. Mature, stable, and it works on Kobo e-readers.
+- **If you need a bookmark manager that reads too:** Raindrop.io.
+- **If you want proven open source stability:** Wallabag.
+- **If you want social reading and AI co-reading:** Matter.
+
+## Frequently Asked Questions
+
+### What happened to Pocket?
+
+Mozilla acquired Pocket in 2017 and deprioritised it over time. Feature development slowed. The team was restructured. By 2025, Pocket was in maintenance mode. Users started looking for alternatives.
+
+### What happened to Omnivore?
+
+Omnivore was an open source read-it-later app with a loyal following. In late 2024, ElevenLabs acqui-hired the team and the service shut down with little notice. Users got a short window to export their data. Open source projects can disappear too, when the team moves on.
+
+### Do any of these apps import from Pocket?
+
+Most of them do. Readwise Reader, Instapaper, and Raindrop.io all support Pocket import. Hutch supports importing from a Pocket export file. Karakeep and Wallabag have import tools too. Check each app's documentation for the current import process.
+
+### Which app has the best mobile experience?
+
+Readwise Reader has the most polished mobile apps with full offline support. Instapaper's mobile apps are mature and reliable. Hutch does not have a native mobile app yet. The web app works on mobile browsers, but it is not the same as a dedicated app.
+
+### Is Hutch biased in this comparison?
+
+Yes, inherently. I built Hutch, so I have a stake in how it is perceived. I wrote this page to represent each app fairly and to be honest about Hutch's limitations: no mobile app, no offline reading, a smaller feature set, and a newer track record. Think this page is unfair? I want to hear about it.


### PR DESCRIPTION
## Summary
Added a comprehensive blog post comparing read-it-later apps in 2026, including Hutch alongside competitors like Readwise Reader, Instapaper, Raindrop.io, Karakeep, Wallabag, and Matter. Implemented table styling to support the comparison matrix and updated tests to cover the new content.

## Key Changes
- **New blog post**: `best-read-it-later-apps-2026.md` with honest pros/cons analysis for 7 read-it-later apps, including transparent discussion of Hutch's limitations
- **Table styling**: Added comprehensive CSS rules for responsive table rendering with hover effects, proper spacing, and mobile overflow handling
- **Test updates**: 
  - Updated blog index test to handle multiple blog cards instead of assuming a single card
  - Added tests to verify the new comparison post renders correctly and contains the comparison table
  - Updated sitemap test to include the new blog post URL

## Implementation Details
- Table styling uses `display: block` with `overflow-x: auto` for mobile responsiveness
- Table headers and cells include proper padding, borders, and color variables for consistency with the design system
- The blog post includes a quick comparison table, detailed sections for each app, selection guidance, and FAQ
- Post maintains transparency about the author's bias (Fagner Brack built Hutch) while providing fair comparisons

https://claude.ai/code/session_01Y1vwoYpouPQVkK2vZSdfVP