### PR TITLE
Add blog post on summarisation within reading workflows

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/summarising-inside-your-reading-app.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/summarising-inside-your-reading-app.md
@@ -1,0 +1,60 @@
+---
+title: "The Case for Summarising Inside Your Reading App (Not in a Separate Tool)"
+description: "Most AI summarisers are standalone tools you paste into and forget. Summarisation becomes more useful when it lives inside the app where you already read."
+slug: "summarising-inside-your-reading-app"
+date: "2026-04-07"
+author: "Fagner Brack"
+keywords: "ai summariser, article summariser, read it later, tldr, quillbot alternative, reading workflow"
+---
+
+AI summarisers are everywhere. QuillBot, TLDR This, Scholarcy. They all work the same way. You paste a URL, get a summary, and close the tab. They do this well. For a quick summary of one article, any of them will work.
+
+But what happens after the summary?
+
+## The standalone summariser problem
+
+Most AI summarisers are transactional. You open a tab. You paste a link. You read the output. You close the tab. There is no before or after. No memory of what you summarised last week. No queue of what still waits for you.
+
+That works for a one-off task. You need a quick answer about one article, and you get it. But reading is not a one-off task. It is a daily practice. You find articles throughout the day. You read some right away. You save most for later. And "later" needs a system, not a clipboard.
+
+The real question is not "can I summarise this article?" It is "of everything I saved this week, what deserves my time tonight?"
+
+A standalone summariser cannot answer that. It does not know what you saved. It does not know what you already read. It does not know what has been sitting in your queue for three weeks.
+
+## Summarisation without a reading workflow is a dead end
+
+Here is what happens with standalone summarisers in practice. Someone sends you a link. You are not sure it is worth 15 minutes. You paste it into TLDR This, skim the output, and decide. Then the summary disappears. The article disappears. If you skipped it, there is no "maybe later." If you read it, there is no record that you found it useful.
+
+Nothing accumulates. There is no archive. No way to look back at a month of reading and see what you finished versus what you skipped. The summary exists alone, cut off from everything else you read.
+
+This is the core limitation. Summarisation is treated as a feature of a tool. It should be a feature of a workflow.
+
+## What changes when summarisation lives inside the reading app
+
+In Hutch, summarisation is not a separate step. You save an article and a TL;DR generates on its own. You do not paste a URL into a summariser. You save the article the way you always would, and the summary is there when you check your queue.
+
+The workflow works like this:
+
+1. You find an article worth saving. You press the browser extension button.
+2. The article lands in your queue. A TL;DR generates in the background.
+3. Later, you open Hutch and scan your queue. The summaries help you sort: read this one now, save that one for the weekend, skip this one entirely.
+4. You pick an article and open the reader view. Clean layout. No distractions. Just the text.
+5. The article stays in your archive. You can search for it later.
+
+The summary is not the product. The summary helps you make better choices about what to read, inside a system that already tracks your reading.
+
+## The workflow matters more than the summary quality
+
+This is the counterintuitive part. A less polished summary inside a full reading workflow is more useful than a perfect summary on its own.
+
+Why? Because the value of a summary is in the decision it helps you make. Decisions need context. Say you have 30 saved articles and want to pick three for tonight. You need summaries next to each one, in the same interface, so you can compare and choose. No amount of summary quality makes up for pasting 30 URLs into a separate tool one at a time.
+
+QuillBot and TLDR This are good tools. Scholarcy does strong work on academic papers. I am not arguing they do summarisation badly. I am arguing that summarisation in isolation solves a smaller problem than most people realise.
+
+The bigger problem: I have more to read than I have time to read. I need a system that helps me choose where to spend my attention. Summarisation is one input into that system. But it is not the system itself.
+
+## A quiet feature inside a reading practice
+
+Hutch is not an AI summariser. It is a read-it-later app where summarisation is one part of a larger reading workflow: saving, triaging, reading, archiving. The TL;DR helps you decide what is worth your time. It does not replace reading.
+
+For a one-off summary of a single article right now, the standalone tools will serve you well. But if you want to build a reading practice where you actually get through the things you save, then where the summary lives matters as much as how good it is.


### PR DESCRIPTION
## Summary
Added a new blog post discussing the advantages of integrating summarisation features directly into reading applications rather than using standalone summarisation tools.

## Changes
- Added new blog post: `summarising-inside-your-reading-app.md`
  - Explores the limitations of transactional, standalone AI summarisers (QuillBot, TLDR This, Scholarcy)
  - Argues that summarisation is more valuable when integrated into a complete reading workflow
  - Describes how Hutch implements summarisation as part of a larger save-triage-read-archive system
  - Emphasizes that workflow context matters more than summary quality in isolation
  - Published date: April 7, 2026
  - Author: Fagner Brack

## Notable Details
The post positions summarisation as a supporting feature within a reading practice rather than a standalone product, using Hutch's read-it-later implementation as a practical example of this integrated approach.

https://claude.ai/code/session_01UoCiRKVY8YHSk6RTUSqb52