### PR TITLE
Add blog post comparing Hutch vs Readwise Reader

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/hutch-vs-readwise-reader.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/hutch-vs-readwise-reader.md
@@ -1,0 +1,117 @@
+---
+title: "Hutch vs Readwise Reader: Which Read-It-Later App Is Right for You?"
+description: "A fair look at two read-it-later apps with AI. Where Readwise wins, where Hutch wins, and how to pick the right one for you."
+slug: "hutch-vs-readwise-reader"
+date: "2026-04-06"
+author: "Fagner Brack"
+keywords: "hutch vs readwise, read it later app, readwise alternative, read it later AI"
+---
+
+# Hutch vs Readwise Reader: Which Read-It-Later App Is Right for You?
+
+Hutch and Readwise Reader both save articles from the web. Both strip away ads and clutter. Both use AI to help you read faster.
+
+But they serve different people.
+
+Readwise Reader is a full reading platform with dozens of integrations. Hutch is smaller, cheaper, and built around privacy and simplicity. I build Hutch, so I'm biased. But I've tried to be fair here. Readwise is a good product. Where it's better, I'll say so.
+
+## Quick Comparison
+
+| | Hutch | Readwise Reader |
+|---|---|---|
+| **Price** | A$3.99/mo | US$12.99/mo (US$8.99/mo annual) |
+| **AI summaries** | Global TL;DR (included) | Ghostreader (inline AI, Q&A, more advanced) |
+| **Highlights** | Coming soon | Full highlighting with sync to Obsidian, Notion, Logseq |
+| **RSS reader** | No | Yes, built in |
+| **Newsletter inbox** | Gmail import (in progress) | Dedicated email inbox |
+| **Reader view** | Yes | Yes |
+| **Privacy** | Hosted in Sydney, AU. Australian Privacy Act | US-based |
+| **Source code** | AGPL source-available | Proprietary |
+| **Maturity** | Newer, leaner | More mature, more features |
+
+## Price
+
+Hutch costs A$3.99 per month. Readwise Reader costs US$12.99 per month, or US$8.99 per month on an annual plan.
+
+That makes Hutch roughly a third of the price. Both include AI features at no extra cost. No add-ons, no usage caps.
+
+Readwise's pricing is fair for what you get. It has more features. But if you want something simpler, paying three times as much for features you won't use doesn't make sense.
+
+## AI Features
+
+Both apps use AI. They take different paths.
+
+Hutch gives you a TL;DR summary for every saved article. Open an article and you see a short summary at the top. It helps you decide: read the full piece, or skip it. This is included in the base price.
+
+Readwise offers Ghostreader. It generates inline highlights, answers questions about an article, and handles more complex AI tasks. If you want to ask questions about what you're reading, Ghostreader goes further than what Hutch offers today.
+
+Hutch covers the most common need: quick summaries to sort your reading list. Readwise gives you the full AI toolkit.
+
+## Highlights and Knowledge Management
+
+This is where Readwise wins, and I want to be direct about it.
+
+Readwise was built around highlighting from day one. You can highlight passages, tag them, and review them with spaced repetition. You can sync everything to Obsidian, Notion, and Logseq. Years of work have gone into this feature set.
+
+Hutch has highlights on the roadmap. They haven't shipped yet. If you need deep highlighting with Obsidian sync today, Readwise is the better choice.
+
+## RSS
+
+Readwise Reader includes a full RSS reader. You subscribe to feeds and new posts show up next to your saved articles.
+
+Hutch does not have RSS. It may not get it. I'd rather do fewer things well than add features that pull focus from the core reading experience. If RSS matters to you, Readwise has it and Hutch doesn't.
+
+## Newsletter Inbox
+
+Readwise gives you a dedicated email address for newsletters. Subscribe with that address and articles appear in your reading list.
+
+I'm building something different for Hutch. Gmail import will pull newsletter content from your existing inbox. No extra email address to manage. It's not shipped yet, but that's the direction.
+
+## Reader View
+
+Both apps do this well. Save an article and you get a clean, readable version. No ads, no popups, no clutter. This is the baseline for any read-it-later app, and both deliver.
+
+## Privacy
+
+Hutch runs on servers in Sydney, Australia. It operates under the Australian Privacy Act. Your reading data stays in Australian infrastructure.
+
+Readwise is a US-based company. Its servers are in the US, and US data privacy laws apply.
+
+Does this matter to you? If you care about where your data lives and which laws govern it, this is a real difference. If jurisdiction isn't something you think about, it won't change your decision.
+
+## Source Code
+
+Hutch is source-available under the AGPL licence. You can read the code, audit it, and verify what happens with your data. If I say your data is handled a certain way, you can check for yourself.
+
+Readwise is closed-source. You trust the company based on their track record and policies. That's how most software works. But if code transparency matters to you, Hutch offers something Readwise does not.
+
+## Maturity
+
+Readwise Reader has been around longer. The feature set is broader. The integrations run deeper. A larger team and a bigger user base mean more feedback and more polish.
+
+Hutch is newer. That means fewer features. It also means less complexity. If you want a focused tool that does the core job without a learning curve, there's value in that. But if you need advanced features today, Readwise has them.
+
+## Choose Readwise Reader If...
+
+- Highlighting and syncing to Obsidian, Notion, or Logseq is part of your daily workflow.
+- You want RSS feeds alongside your saved articles.
+- You need Ghostreader's AI to ask questions about articles and generate inline highlights.
+- You want a mature product with a wide range of integrations.
+
+## Choose Hutch If...
+
+- You want a simpler read-it-later app and don't want to pay for features you won't use.
+- AI summaries for sorting your reading list are enough. You don't need inline AI Q&A.
+- You prefer your reading data hosted in Australia under Australian privacy law.
+- You value source-available software and want to see the code behind the product.
+- You prefer a focused tool that does fewer things well.
+
+## What's Coming
+
+I'm not trying to copy Readwise feature by feature. I'm building a reading app that's simple, private, and affordable, with AI that helps you read more of what matters.
+
+Highlights are the next major feature. Gmail newsletter import comes after that. The gap will narrow over time.
+
+If you need deep highlighting with Obsidian sync today, Readwise is the better choice. If you want a simpler, more affordable reading app with AI summaries and stronger privacy, that's what I'm building.
+
+You can try Hutch at [hutch.page](https://hutch.page).


### PR DESCRIPTION
## Summary
Added a new blog post that provides a fair comparison between Hutch and Readwise Reader read-it-later applications, highlighting the strengths and weaknesses of each platform to help users choose the right tool for their needs.

## Changes
- Added new blog post markdown file: `hutch-vs-readwise-reader.md`
  - Comprehensive comparison table covering pricing, features, and capabilities
  - Detailed sections on AI features, highlighting, RSS, newsletters, privacy, and source code
  - Clear guidance on when to choose each platform
  - Honest assessment of Readwise's advantages while positioning Hutch's unique value propositions

## Notable Details
- Post is authored by Fagner Brack with publication date of April 6, 2026
- Includes SEO-friendly keywords and meta description
- Structured with clear sections and a comparison table for easy scanning
- Maintains transparency about the author's bias while providing balanced analysis
- Includes call-to-action linking to hutch.page

https://claude.ai/code/session_01Wdbpx9CjQ25gSkFUnAvLfP