### PR TITLE
Add blog post: Why I Built an AI Reading App for Developers

### DIFF
--- a/content/blog/why-i-built-an-ai-reading-app-for-developers.md
+++ b/content/blog/why-i-built-an-ai-reading-app-for-developers.md
@@ -1,0 +1,65 @@
+# Why I Built an AI Reading App for Developers
+
+I've been reading programming articles obsessively for over 10 years.
+
+Not casually. Not "I'll bookmark this and never look at it again." I mean a real system — one that evolved from a janky script into a full pipeline, and eventually into an app called [Hutch](https://hutch.cloud).
+
+Let me tell you how I got here.
+
+## The Pipeline
+
+It started with Reddit. I was spending hours on r/programming, r/javascript, r/webdev — reading postmortems, architecture deep dives, opinions on frameworks I hadn't tried yet. Somewhere along the way I crossed 300k karma, which tells you less about the quality of my contributions and more about how much time I was spending there.
+
+I built a pipeline. Reddit posts I wanted to read got pushed into a Gmail queue. Every morning I'd scan the subject lines, open a few tabs, and read through them with my coffee. When I found something genuinely useful, I'd save it to a folder. When I didn't have time, which was most mornings, I'd star it and promise myself I'd come back.
+
+I almost never came back.
+
+Later, I started pasting articles into ChatGPT and asking for summaries. That actually helped — not as a replacement for reading, but as a filter. A two-paragraph summary told me whether the full article was worth 15 minutes. My reading throughput jumped from maybe 20–30% of my queue to around 70%. Not because I read faster. Because I chose better.
+
+That distinction matters.
+
+## The Developer Reading Problem
+
+Developers have a reading problem that's different from everyone else's. Our reading list isn't "interesting articles I saw on Twitter." It's professional development. It's the Stripe API migration guide. It's that postmortem from Cloudflare about the outage that took down half the internet for an hour. It's the blog post explaining why your ORM is lying to you about connection pooling.
+
+Saving a recipe and never making it is harmless. Saving a technical article about a vulnerability in a library you use and never reading it can actually cost you.
+
+The guilt is different too. Every unread article in the queue feels like falling behind. Like everyone else already read the thing about the new React compiler, and you're still stuck on the article from three weeks ago about database indexing strategies. The queue grows. The guilt compounds. Eventually you declare bankruptcy, archive everything, and start over.
+
+I've done that at least four times.
+
+## When AI Changed the Equation
+
+When I added AI summaries to my personal reading system, something clicked. The summaries weren't replacing the reading — they were replacing the triage. Instead of opening every article and skimming the first three paragraphs to decide if it was worth my time, I could read a summary and make that decision in 30 seconds.
+
+The articles I did read, I read properly. Start to finish. Because I'd already decided they were worth it.
+
+My queue stopped growing for the first time in years. Not because I was saving fewer things — I was saving more, actually — but because I was processing them faster. The backlog shrank from hundreds to dozens. I stopped feeling like I was drowning.
+
+That system, the one I'd been building and tweaking for a decade, is what became Hutch. An AI reading app for developers, built by a developer who spent 10 years trying to solve his own reading problem.
+
+## What Hutch Actually Is
+
+Hutch is my reading system rebuilt as an app. The AI summaries are built in from day one — not bolted on as a feature, but woven into how the whole thing works. You save an article, and by the time you open it, there's a summary waiting. You decide whether to read it now, read it later, or skip it entirely without the guilt.
+
+I built it for developers because I am one. The browser extension is fast — save a page and close the tab in under a second. The reader view is clean, because I've spent thousands of hours reading technical content and I know what gets in the way. The AI is useful without being patronising. It doesn't try to explain your own field to you. It gives you enough to decide.
+
+And the code is source-available. If you want to see how it works, you can read it. I spent years working on open source — I maintain [js-cookie](https://github.com/js-cookie/js-cookie), which sees over 22 billion annual hits through the jsdelivr CDN. Building in the open isn't a marketing strategy for me. It's just how I work.
+
+## Not a Pocket Replacement
+
+I need to be honest about something: Hutch isn't trying to be the next Pocket or Instapaper or Readwise. Those are good products. They solve the general read-it-later problem for a general audience.
+
+Hutch solves a specific problem for a specific audience. If you're a developer who saves technical articles, API documentation, architecture blog posts, and conference talk transcripts — and you feel the weight of that unread queue — this is the tool I built for you. Because it's the tool I built for me.
+
+The AI isn't there to summarise the internet. It's there to help you decide what deserves your attention. Your reading time is finite. Your queue is not. Something has to bridge that gap.
+
+## Ten Years of Reading, One App
+
+I sometimes think about what would have happened if I'd had this tool a decade ago. How many articles I saved and never read that might have changed how I approached a problem. How many postmortems I skipped that described the exact bug I'd spend three days debugging six months later.
+
+I can't get that time back. But I can build the thing I wish I'd had.
+
+That's Hutch. A quiet place for your reading, with just enough AI to make the queue manageable. Built by someone who's been fighting this problem for a very long time.
+
+If that sounds like your kind of tool, [give it a try](https://hutch.cloud).

--- a/content/blog/why-i-built-an-ai-reading-app-for-developers.md
+++ b/content/blog/why-i-built-an-ai-reading-app-for-developers.md
@@ -1,65 +1,83 @@
+---
+title: "Why I Built an AI Reading App for Developers"
+description: "A 10-year personal reading system, rebuilt as an app. How AI summaries changed the way I process my technical reading queue."
+slug: "why-i-built-an-ai-reading-app-for-developers"
+date: "2026-04-06"
+author: "Fagner Brack"
+keywords: "AI reading app for developers, read it later, developer tools, AI summaries"
+---
+
+BlogPostPage:
+- seo.title: "${post.title} — Hutch Blog"
+- seo.description: post.description
+- seo.canonicalUrl: "https://hutch-app.com/blog/${post.slug}"
+- seo.ogType: "article"
+- seo.author: post.author
+- seo.keywords: post.keywords
+- seo.robots: "index, follow"
+- seo.structuredData: BlogPosting schema with headline, description, datePublished, author (Person), publisher (Organization), url
+- bodyClass: "page-blog-post"
+
 # Why I Built an AI Reading App for Developers
 
-I've been reading programming articles obsessively for over 10 years.
+I've been reading programming articles for over 10 years.
 
-Not casually. Not "I'll bookmark this and never look at it again." I mean a real system — one that evolved from a janky script into a full pipeline, and eventually into an app called [Hutch](https://hutch.cloud).
-
-Let me tell you how I got here.
+Not casually. Not "I'll bookmark this and forget it." I had a real system. It started as a script, grew into a pipeline, and became an app called [Hutch](https://hutch.cloud).
 
 ## The Pipeline
 
-It started with Reddit. I was spending hours on r/programming, r/javascript, r/webdev — reading postmortems, architecture deep dives, opinions on frameworks I hadn't tried yet. Somewhere along the way I crossed 300k karma, which tells you less about the quality of my contributions and more about how much time I was spending there.
+It started on Reddit. I spent hours on r/programming, r/javascript, and r/webdev. I read postmortems, architecture deep dives, and opinions on frameworks I hadn't tried. Along the way I crossed 300,000 karma. That number says less about the quality of my posts and more about the time I put in.
 
-I built a pipeline. Reddit posts I wanted to read got pushed into a Gmail queue. Every morning I'd scan the subject lines, open a few tabs, and read through them with my coffee. When I found something genuinely useful, I'd save it to a folder. When I didn't have time, which was most mornings, I'd star it and promise myself I'd come back.
+I built a pipeline around it. Reddit posts I wanted to read got pushed into a Gmail queue. Every morning I scanned subject lines, opened a few tabs, and read them with coffee. When I found something useful, I saved it to a folder. When I didn't have time (most mornings), I starred it and promised myself I'd come back.
 
 I almost never came back.
 
-Later, I started pasting articles into ChatGPT and asking for summaries. That actually helped — not as a replacement for reading, but as a filter. A two-paragraph summary told me whether the full article was worth 15 minutes. My reading throughput jumped from maybe 20–30% of my queue to around 70%. Not because I read faster. Because I chose better.
+Later I started pasting articles into ChatGPT for summaries. That helped. Not as a replacement for reading, but as a filter. A two-paragraph summary told me whether a full article was worth 15 minutes of my time. My reading throughput jumped from 20-30% of my queue to about 70%. Not because I read faster. Because I picked better.
 
 That distinction matters.
 
 ## The Developer Reading Problem
 
-Developers have a reading problem that's different from everyone else's. Our reading list isn't "interesting articles I saw on Twitter." It's professional development. It's the Stripe API migration guide. It's that postmortem from Cloudflare about the outage that took down half the internet for an hour. It's the blog post explaining why your ORM is lying to you about connection pooling.
+Developers have a reading problem that looks nothing like anyone else's. Our reading list isn't "interesting stuff from Twitter." It's professional development. The Stripe API migration guide. That Cloudflare postmortem about the outage that took down half the internet for an hour. The blog post explaining why your ORM lies to you about connection pooling.
 
-Saving a recipe and never making it is harmless. Saving a technical article about a vulnerability in a library you use and never reading it can actually cost you.
+Saving a recipe and never cooking it is harmless. Saving a technical article about a vulnerability in a library you ship and never reading it can cost you real money.
 
-The guilt is different too. Every unread article in the queue feels like falling behind. Like everyone else already read the thing about the new React compiler, and you're still stuck on the article from three weeks ago about database indexing strategies. The queue grows. The guilt compounds. Eventually you declare bankruptcy, archive everything, and start over.
+The guilt hits different too. Every unread article feels like falling behind. Everyone else already read the thing about the new React compiler. You're still stuck on the database indexing post from three weeks ago. The queue grows. The guilt builds. You declare bankruptcy, archive everything, and start fresh.
 
 I've done that at least four times.
 
 ## When AI Changed the Equation
 
-When I added AI summaries to my personal reading system, something clicked. The summaries weren't replacing the reading — they were replacing the triage. Instead of opening every article and skimming the first three paragraphs to decide if it was worth my time, I could read a summary and make that decision in 30 seconds.
+I added AI summaries to my personal reading system in 2023. The change was immediate. The summaries didn't replace reading. They replaced triage. Before, I opened every article and skimmed the first three paragraphs to judge if it was worth my time. After, I read a summary and made that call in 30 seconds.
 
-The articles I did read, I read properly. Start to finish. Because I'd already decided they were worth it.
+The articles I did choose to read, I read properly. Start to finish. I had already decided they were worth it.
 
-My queue stopped growing for the first time in years. Not because I was saving fewer things — I was saving more, actually — but because I was processing them faster. The backlog shrank from hundreds to dozens. I stopped feeling like I was drowning.
+My queue stopped growing for the first time in years. I was saving more articles, not fewer. But I was processing them faster. The backlog shrank from hundreds to dozens. The weight lifted.
 
-That system, the one I'd been building and tweaking for a decade, is what became Hutch. An AI reading app for developers, built by a developer who spent 10 years trying to solve his own reading problem.
+That system is what became Hutch. An AI reading app for developers, built by a developer who spent 10 years trying to fix his own reading problem.
 
-## What Hutch Actually Is
+## What Hutch Is
 
-Hutch is my reading system rebuilt as an app. The AI summaries are built in from day one — not bolted on as a feature, but woven into how the whole thing works. You save an article, and by the time you open it, there's a summary waiting. You decide whether to read it now, read it later, or skip it entirely without the guilt.
+Hutch is my 10-year reading system rebuilt as an app. AI summaries are built in from day one. They aren't a feature bolted on after launch. They're part of how the whole thing works. You save an article. By the time you open it, there's a summary waiting. You decide: read it now, read it later, or skip it without guilt.
 
-I built it for developers because I am one. The browser extension is fast — save a page and close the tab in under a second. The reader view is clean, because I've spent thousands of hours reading technical content and I know what gets in the way. The AI is useful without being patronising. It doesn't try to explain your own field to you. It gives you enough to decide.
+I built it for developers because I am one. The browser extension is fast. Save a page and close the tab in under a second. The reader view is clean. I've spent thousands of hours reading technical content. I know what gets in the way. The AI gives you enough context to decide, without explaining your own field back to you.
 
-And the code is source-available. If you want to see how it works, you can read it. I spent years working on open source — I maintain [js-cookie](https://github.com/js-cookie/js-cookie), which sees over 22 billion annual hits through the jsdelivr CDN. Building in the open isn't a marketing strategy for me. It's just how I work.
+The code is source-available. If you want to see how it works, you can read it. I spent years on open source. I maintain [js-cookie](https://github.com/js-cookie/js-cookie), a library with over 22 billion annual hits through the jsdelivr CDN. Building in the open is how I've always worked.
 
 ## Not a Pocket Replacement
 
-I need to be honest about something: Hutch isn't trying to be the next Pocket or Instapaper or Readwise. Those are good products. They solve the general read-it-later problem for a general audience.
+I want to be clear about something. Hutch isn't trying to be the next Pocket, Instapaper, or Readwise. Those are good products. They solve the general read-it-later problem for a broad audience.
 
-Hutch solves a specific problem for a specific audience. If you're a developer who saves technical articles, API documentation, architecture blog posts, and conference talk transcripts — and you feel the weight of that unread queue — this is the tool I built for you. Because it's the tool I built for me.
+Hutch solves a narrow problem for a narrow audience. If you save technical articles, API documentation, architecture blog posts, and conference talk write-ups, and you feel the weight of that unread queue, this is the tool I built for you. Because it's the tool I built for me.
 
-The AI isn't there to summarise the internet. It's there to help you decide what deserves your attention. Your reading time is finite. Your queue is not. Something has to bridge that gap.
+The AI isn't there to summarize the internet. It helps you decide what deserves your attention. Your reading time is finite. Your queue is not. Something has to sit between the two.
 
 ## Ten Years of Reading, One App
 
-I sometimes think about what would have happened if I'd had this tool a decade ago. How many articles I saved and never read that might have changed how I approached a problem. How many postmortems I skipped that described the exact bug I'd spend three days debugging six months later.
+I think about what I would have done with this tool a decade ago. How many articles I saved and never read that could have changed how I approached a problem. How many postmortems I skipped that described the exact bug I spent three days tracking down six months later.
 
 I can't get that time back. But I can build the thing I wish I'd had.
 
-That's Hutch. A quiet place for your reading, with just enough AI to make the queue manageable. Built by someone who's been fighting this problem for a very long time.
+That's Hutch. A quiet place for your reading, with just enough AI to make the queue manageable. Built by someone who fought this problem for a very long time.
 
 If that sounds like your kind of tool, [give it a try](https://hutch.cloud).

--- a/projects/hutch/src/runtime/web/pages/blog/posts/why-i-built-an-ai-reading-app-for-developers.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/why-i-built-an-ai-reading-app-for-developers.md
@@ -2,23 +2,10 @@
 title: "Why I Built an AI Reading App for Developers"
 description: "A 10-year personal reading system, rebuilt as an app. How AI summaries changed the way I process my technical reading queue."
 slug: "why-i-built-an-ai-reading-app-for-developers"
-date: "2026-04-06"
+date: "2026-04-07"
 author: "Fagner Brack"
 keywords: "AI reading app for developers, read it later, developer tools, AI summaries"
 ---
-
-BlogPostPage:
-- seo.title: "${post.title} — Hutch Blog"
-- seo.description: post.description
-- seo.canonicalUrl: "https://hutch-app.com/blog/${post.slug}"
-- seo.ogType: "article"
-- seo.author: post.author
-- seo.keywords: post.keywords
-- seo.robots: "index, follow"
-- seo.structuredData: BlogPosting schema with headline, description, datePublished, author (Person), publisher (Organization), url
-- bodyClass: "page-blog-post"
-
-# Why I Built an AI Reading App for Developers
 
 I've been reading programming articles for over 10 years.
 

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../../test-app";
 import { getAllSlugs } from "../blog/blog.posts";
+import { createTestApp } from "../../../test-app";
 
 describe("GET /", () => {
 	const { app } = createTestApp();


### PR DESCRIPTION
## Summary
Added a new blog post to the Hutch website explaining the motivation and vision behind building an AI-powered reading app for developers.

## Changes
- Added new blog post markdown file: `why-i-built-an-ai-reading-app-for-developers.md`
  - Frontmatter includes title, description, slug, publication date (2026-04-07), author, and relevant keywords
  - Post content covers the author's 10-year personal reading system evolution, the specific reading challenges developers face, how AI summaries improved their workflow, and how this led to building Hutch
  - Clarifies Hutch's positioning as a specialized tool for technical reading rather than a general read-it-later competitor

## Notable Details
- The post is positioned as a founder narrative, establishing credibility through the author's open source background (js-cookie library)
- Emphasizes the practical problem being solved: managing technical reading queues and decision fatigue
- Highlights that AI summaries serve as a triage mechanism rather than a replacement for reading
- Includes clear call-to-action linking to the product

https://claude.ai/code/session_01LhWbkeVda11eLmndrpM6Vq