### PR TITLE
Add blog post on AI summaries in reading apps

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/ai-summaries-belong-in-your-reading-app.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/ai-summaries-belong-in-your-reading-app.md
@@ -1,0 +1,66 @@
+---
+title: "Why AI Summaries Belong in Your Reading App"
+description: "AI summaries help you choose what to read, not skip the reading. Here is how Hutch uses them as a triage tool."
+slug: "ai-summaries-belong-in-your-reading-app"
+date: "2026-04-07"
+author: "Fagner Brack"
+keywords: "AI summaries, read it later, reading app, article triage, Hutch"
+---
+
+You saved that long piece on distributed systems three weeks ago. Before that, a deep report on housing policy. Before that, something about the history of tool-making that someone on Mastodon called "absolutely required reading."
+
+You meant to read all of them. You still do.
+
+You won't.
+
+This is not a personal failing. You find interesting things faster than you can read them. The gap between "saved" and "read" grows every day. The list becomes a quiet source of guilt.
+
+Most people I talk to have hit some version of reading list bankruptcy. You look at 200 unread articles. You feel the weight. You either clear the list and start over or just stop opening the app. The fresh start never fixes the root problem. You save based on curiosity, and curiosity is not limited by the hours in a day.
+
+## Why Your Reading List Becomes a Graveyard
+
+Every article in your queue looked worthwhile when you saved it. A headline caught your eye. A trusted source shared it. The topic matched something on your mind. You tapped "save." Two seconds. Done. It felt like progress.
+
+But saving and reading are two different acts. Saving is cheap and fast. Reading demands focus, time, and the willingness to sit with someone else's thinking for twenty minutes or an hour. That cost gap is enormous, and it grows each day.
+
+The result is a queue where new articles bury old ones. Nothing is ranked. The only signal you have is a title and a thumbnail. You either read things in order (arbitrary) or scroll through the list guessing which article is worth your time.
+
+The real problem is not the reading. It is the choosing.
+
+## AI Summaries as Triage, Not Replacement
+
+When I started thinking about AI summaries for Hutch, the risk was obvious. Give people a summary, and they read the summary instead of the article. You have turned a reading app into a "not reading" app. The AI ate the content.
+
+That framing misses what actually happens. People do not skip articles because a summary exists. They skip articles because they cannot tell which ones deserve their time. The list is opaque. Every item looks the same. So they read nothing, or they read whatever sits on top.
+
+A summary changes that. Not by replacing the article, but by giving you enough information to decide. Is this the distributed systems piece that covers the specific trade-off you care about, or a rehash of the same consensus? Is the housing policy article data-driven analysis or opinion dressed as reporting?
+
+Two paragraphs of summary answer those questions in thirty seconds. Then you make a real choice: read it now, save it for the weekend, or let it go. No guilt, because you know what you are passing on.
+
+That is triage. Emergency rooms work the same way. Not every patient gets the same treatment at the same time. Someone looks at the situation and decides what needs attention first. Your reading list deserves the same approach.
+
+## How Hutch Implements This
+
+Hutch generates one TL;DR summary per article, not per user. When someone saves an article, Hutch checks for an existing summary. If one exists, it loads right away. If not, Hutch generates one and caches it for everyone.
+
+This is a deliberate choice. A summary of a published article does not need to be personal. The article says what it says. What changes between readers is whether the content matches their interests. The summary gives them enough to make that call on their own.
+
+DeepSeek powers the summaries. The cost is included in the subscription. There is no "bring your own API key" setup, no configuration screen, no token budget to manage. You save an article. The summary appears. I want this feature to feel invisible, the way good tools do. Present when you need it. Out of your way when you do not.
+
+## The Line Between Useful AI and Slop
+
+There is a version of AI in reading apps that I find troubling. Auto-summarise your entire queue. Present a daily digest. Call it "reading." At that point, you are not reading the web. You are reading what a model thinks the web said. That is slop: AI-generated content that displaces the thing it claims to help with.
+
+Hutch does not do this. It does not summarise your whole queue. It does not generate a newsletter of your saved articles. It does not present AI output as a substitute for sitting with a well-argued essay or a carefully reported story.
+
+What Hutch does is show you a summary when you look at an article you already chose to save. You picked it. You showed interest. The summary helps you decide if it is worth your hour. That serves your agency. It does not replace your thinking.
+
+Does this distinction matter? Yes, and here is why. A triage tool sharpens your judgement by giving you better information. A digest replaces your judgement by making the decisions for you. One of those is useful. The other slowly erodes the thing that made your reading list interesting in the first place: your own curiosity and taste.
+
+## Read the Web, Not the Slop
+
+I built Hutch because I wanted a reading app that respects both the content and the reader. AI summaries fit that vision only when they are bounded. They help you engage with what you saved. They do not abstract it away.
+
+The summary is a filter, not a substitute. It exists so the articles you choose to read are the ones that truly deserve your attention. And the articles you skip? You skip them with full knowledge of what you are passing on.
+
+Your reading list does not have to be a graveyard. It just needs a better way to decide what is worth reading next.


### PR DESCRIPTION
## Summary
Added a new blog post discussing the role of AI summaries in reading applications, specifically how Hutch implements them as a triage tool rather than a replacement for reading.

## Changes
- Added new blog post: `ai-summaries-belong-in-your-reading-app.md`
  - Explores the problem of reading list bankruptcy and decision paralysis
  - Explains how AI summaries function as a triage mechanism for article selection
  - Details Hutch's implementation approach: single cached summary per article powered by DeepSeek
  - Distinguishes between useful AI tools (summaries for informed decision-making) and problematic AI slop (auto-digests that replace reading)
  - Emphasizes that summaries serve reader agency by providing better information for choosing what to read, not by replacing the reading itself

## Notable Details
- Post metadata includes publication date (2026-04-07), author (Fagner Brack), and relevant keywords
- Structured with clear section headers to guide readers through the problem, solution, and philosophy
- Focuses on the distinction between AI as a decision-support tool versus AI as content replacement

https://claude.ai/code/session_012ar5KwK9aJoXtFSTGFxHHK