### PR TITLE
Add blog post: How to Get AI Summary of Any Web Page

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/how-to-get-ai-summary-of-any-web-page.md
+++ b/projects/hutch/src/runtime/web/pages/blog/how-to-get-ai-summary-of-any-web-page.md
@@ -1,75 +1,73 @@
 ---
 title: "How to Get an AI Summary of Any Web Page (Without Leaving Your Browser)"
-description: "Three ways to summarise long articles with AI, from copy-paste to browser extensions to read-it-later apps with built-in summaries."
-date: 2026-04-06
+description: "Three ways to summarise long articles with AI, from copy-paste to one-click read-it-later apps with built-in summaries."
+slug: "how-to-get-ai-summary-of-any-web-page"
+date: "2026-04-06"
 author: "Fagner Brack"
-slug: how-to-get-ai-summary-of-any-web-page
 keywords: "AI summary, summarize web page, article summarizer, browser extension, read it later, TL;DR"
 ---
 
 # How to Get an AI Summary of Any Web Page (Without Leaving Your Browser)
 
-You've found an article. It's 4,000 words. You have two minutes before your next meeting. You need to know if it's worth your time.
+You found an article. It's 4,000 words. You have two minutes before your next meeting. You need to know if it's worth reading.
 
-This happens a dozen times a day. Someone shares a link in Slack, you spot a promising headline in your feed, a newsletter lands with five longform pieces. You can't read them all right now. But you need to decide: save it, skip it, or skim it.
+This happens a dozen times a day. Someone drops a link in Slack. A newsletter lands with five longform pieces. A promising headline catches your eye. You can't read them all right now. But you need to decide: save it, skip it, or skim it.
 
-AI summarisation solves this. Here are three ways to do it, ranked from most manual to most integrated.
+AI can summarise any of these in seconds. Here are three ways to do it, ranked from most manual to most integrated.
 
 ## Option 1: Copy-Paste Into ChatGPT
 
-The brute-force method. Open the article, select all, copy, switch to ChatGPT, paste, type "summarise this," hit enter.
+Open the article. Select all. Copy. Switch to ChatGPT. Paste. Type "summarise this." Hit enter.
 
-It works. The summary is usually decent. But the process has friction:
+It works. The summary is decent. But the process has friction:
 
 1. You leave the page you're reading.
 2. You paste a wall of text into a chat window.
 3. You read the summary in ChatGPT, then switch back to the article.
-4. If you want to save the article for later, that's a separate step.
-5. The summary lives in your ChatGPT history, disconnected from the article itself.
+4. Saving the article for later is a separate step.
+5. The summary sits in your ChatGPT history, disconnected from the article.
 
 For a one-off, this is fine. For something you do ten times a day, it's a lot of tab-switching.
 
 ## Option 2: Use a Browser Extension Summariser
 
-Several browser extensions will summarise the page you're currently viewing. Click the icon, get a summary in a popup or sidebar.
+Several browser extensions summarise the page you're viewing. Click the icon. Get a summary in a popup or sidebar.
 
 This is faster than copy-paste. No tab-switching. The summary appears right where you are.
 
-The tradeoff: the summary only exists while the tab is open. Close the tab and it's gone. There's no reading list, no way to revisit the summary tomorrow, no connection between "I summarised this" and "I want to read this later." The summary and the article live in two different places, if the summary survives at all.
+But the summary only exists while the tab is open. Close the tab and it's gone. There's no reading list, no way to revisit the summary tomorrow. The summary and the article live in two different places, if the summary survives at all.
 
-If your goal is just "do I keep reading right now or not," this works. If your goal is "triage this into my reading pipeline," you need something more.
+Does your goal stop at "do I keep reading right now"? Then this works. If you want to triage articles into a reading pipeline, you need something more.
 
 ## Option 3: Save to a Read-It-Later App With Built-In AI Summary
 
-This is where the workflow collapses into a single step. You save the article to your reading list, and the summary generates automatically. One action, two outcomes: the article is saved and the TL;DR is ready.
+This is where the workflow becomes a single step. You save the article to your reading list. The summary generates on its own. One action, two outcomes: the article is saved and the TL;DR is ready.
 
-The summary persists alongside the article. When you open your reading list later, you can scan summaries to decide what to read first. No context lost. No second tool.
+The summary stays with the article. Open your reading list later and scan summaries to decide what to read first. No lost context. No second tool.
 
 This is how I built Hutch to work.
 
 ## How Hutch Does This
 
-1. **Click the browser extension** on any article. Firefox or Chrome, one click, keyboard shortcut, or right-click menu.
-2. **The article saves to your reading list.** Title, URL, and full content are captured.
-3. **A TL;DR generates automatically.** Within seconds, a plain-language summary appears on your reading list, covering the most important specific points from the article.
-4. **Scan your list later.** Each saved article shows its TL;DR right in the list view. Decide what to read in full, what to skip, what to come back to next week.
+1. **Click the browser extension** on any article. Firefox or Chrome. One click, keyboard shortcut, or right-click menu.
+2. **The article saves to your reading list.** Hutch captures the title, URL, and full content.
+3. **A TL;DR generates within seconds.** A plain-language summary appears on your reading list. It covers the most important points from the article.
+4. **Scan your list later.** Each saved article shows its TL;DR in the list view. Decide what to read in full, what to skip, what to revisit next week.
 
-No copy-paste. No separate summarisation tool. No lost context. The summary lives with the article, not in a chat window you'll never scroll back to.
+No copy-paste. No separate summarisation tool. The summary lives with the article, not in a chat window you'll never scroll back to.
 
-The summaries are written in plain language, short sentences, active voice. They cover specific points from the article rather than vague overviews. Numbers, dates, and named facts where available.
+The summaries use plain language, short sentences, and active voice. They include specific points from the article: numbers, dates, and named facts where available.
 
 ## When a Standalone Summariser Is Better
 
-A read-it-later app with built-in summaries covers the most common case: web articles you find during your day. But there are situations where a standalone tool makes more sense:
+A read-it-later app covers the most common case: web articles you find during your day. But standalone tools work better for a few specific situations:
 
-- **PDFs and documents.** If you're working with a local PDF, academic paper, or a file that isn't a web page, a tool like ChatGPT or Claude handles these well. Upload the file, ask for a summary.
-- **Academic papers with complex structure.** When you need the summary to focus on methodology, results, or a specific section, a conversational AI lets you ask follow-up questions.
-- **Private or paywalled content.** If the content requires authentication or lives behind a paywall that a browser extension can't access, copy-paste into a standalone tool might be your only option.
+- **PDFs and local documents.** A tool like ChatGPT or Claude handles uploaded files well. Upload the PDF, ask for a summary.
+- **Academic papers.** When you need the summary to focus on methodology or results, a conversational AI lets you ask follow-up questions.
+- **Paywalled content.** If the page sits behind authentication that a browser extension can't reach, copy-paste into a standalone tool is your best option.
 
-For everything else, the pattern is simple: if it's a web page and you might want to read it later, save it to your reading list and let the summary come to you.
+## The Short Version
 
-## The Takeaway
+The best summarisation workflow has the fewest steps between "I found this" and "I know what it says." For web articles, that means saving and summarising in one action. The summary stays with the article in your reading list. No extra tools. No lost context.
 
-The best summarisation workflow is the one with the fewest steps between "I found this" and "I know what it says." For web articles, that means saving and summarising in a single action, with the summary persisting alongside the article in your reading list.
-
-[Try Hutch free](https://hutch-app.com) and see how it fits into your reading workflow.
+[Try Hutch free](https://hutch-app.com) and see how it fits your reading workflow.

--- a/projects/hutch/src/runtime/web/pages/blog/how-to-get-ai-summary-of-any-web-page.md
+++ b/projects/hutch/src/runtime/web/pages/blog/how-to-get-ai-summary-of-any-web-page.md
@@ -1,0 +1,75 @@
+---
+title: "How to Get an AI Summary of Any Web Page (Without Leaving Your Browser)"
+description: "Three ways to summarise long articles with AI, from copy-paste to browser extensions to read-it-later apps with built-in summaries."
+date: 2026-04-06
+author: "Fagner Brack"
+slug: how-to-get-ai-summary-of-any-web-page
+keywords: "AI summary, summarize web page, article summarizer, browser extension, read it later, TL;DR"
+---
+
+# How to Get an AI Summary of Any Web Page (Without Leaving Your Browser)
+
+You've found an article. It's 4,000 words. You have two minutes before your next meeting. You need to know if it's worth your time.
+
+This happens a dozen times a day. Someone shares a link in Slack, you spot a promising headline in your feed, a newsletter lands with five longform pieces. You can't read them all right now. But you need to decide: save it, skip it, or skim it.
+
+AI summarisation solves this. Here are three ways to do it, ranked from most manual to most integrated.
+
+## Option 1: Copy-Paste Into ChatGPT
+
+The brute-force method. Open the article, select all, copy, switch to ChatGPT, paste, type "summarise this," hit enter.
+
+It works. The summary is usually decent. But the process has friction:
+
+1. You leave the page you're reading.
+2. You paste a wall of text into a chat window.
+3. You read the summary in ChatGPT, then switch back to the article.
+4. If you want to save the article for later, that's a separate step.
+5. The summary lives in your ChatGPT history, disconnected from the article itself.
+
+For a one-off, this is fine. For something you do ten times a day, it's a lot of tab-switching.
+
+## Option 2: Use a Browser Extension Summariser
+
+Several browser extensions will summarise the page you're currently viewing. Click the icon, get a summary in a popup or sidebar.
+
+This is faster than copy-paste. No tab-switching. The summary appears right where you are.
+
+The tradeoff: the summary only exists while the tab is open. Close the tab and it's gone. There's no reading list, no way to revisit the summary tomorrow, no connection between "I summarised this" and "I want to read this later." The summary and the article live in two different places, if the summary survives at all.
+
+If your goal is just "do I keep reading right now or not," this works. If your goal is "triage this into my reading pipeline," you need something more.
+
+## Option 3: Save to a Read-It-Later App With Built-In AI Summary
+
+This is where the workflow collapses into a single step. You save the article to your reading list, and the summary generates automatically. One action, two outcomes: the article is saved and the TL;DR is ready.
+
+The summary persists alongside the article. When you open your reading list later, you can scan summaries to decide what to read first. No context lost. No second tool.
+
+This is how I built Hutch to work.
+
+## How Hutch Does This
+
+1. **Click the browser extension** on any article. Firefox or Chrome, one click, keyboard shortcut, or right-click menu.
+2. **The article saves to your reading list.** Title, URL, and full content are captured.
+3. **A TL;DR generates automatically.** Within seconds, a plain-language summary appears on your reading list, covering the most important specific points from the article.
+4. **Scan your list later.** Each saved article shows its TL;DR right in the list view. Decide what to read in full, what to skip, what to come back to next week.
+
+No copy-paste. No separate summarisation tool. No lost context. The summary lives with the article, not in a chat window you'll never scroll back to.
+
+The summaries are written in plain language, short sentences, active voice. They cover specific points from the article rather than vague overviews. Numbers, dates, and named facts where available.
+
+## When a Standalone Summariser Is Better
+
+A read-it-later app with built-in summaries covers the most common case: web articles you find during your day. But there are situations where a standalone tool makes more sense:
+
+- **PDFs and documents.** If you're working with a local PDF, academic paper, or a file that isn't a web page, a tool like ChatGPT or Claude handles these well. Upload the file, ask for a summary.
+- **Academic papers with complex structure.** When you need the summary to focus on methodology, results, or a specific section, a conversational AI lets you ask follow-up questions.
+- **Private or paywalled content.** If the content requires authentication or lives behind a paywall that a browser extension can't access, copy-paste into a standalone tool might be your only option.
+
+For everything else, the pattern is simple: if it's a web page and you might want to read it later, save it to your reading list and let the summary come to you.
+
+## The Takeaway
+
+The best summarisation workflow is the one with the fewest steps between "I found this" and "I know what it says." For web articles, that means saving and summarising in a single action, with the summary persisting alongside the article in your reading list.
+
+[Try Hutch free](https://hutch-app.com) and see how it fits into your reading workflow.

--- a/projects/hutch/src/runtime/web/pages/blog/posts/how-to-get-ai-summary-of-any-web-page.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/how-to-get-ai-summary-of-any-web-page.md
@@ -7,8 +7,6 @@ author: "Fagner Brack"
 keywords: "AI summary, summarize web page, article summarizer, browser extension, read it later, TL;DR"
 ---
 
-# How to Get an AI Summary of Any Web Page (Without Leaving Your Browser)
-
 You found an article. It's 4,000 words. You have two minutes before your next meeting. You need to know if it's worth reading.
 
 This happens a dozen times a day. Someone drops a link in Slack. A newsletter lands with five longform pieces. A promising headline catches your eye. You can't read them all right now. But you need to decide: save it, skip it, or skim it.


### PR DESCRIPTION
## Summary
Added a new blog post about AI-powered web page summarization techniques and how Hutch implements this feature as part of its read-it-later workflow.

## Changes
- Created new blog post markdown file: `how-to-get-ai-summary-of-any-web-page.md`
  - Compares three approaches to summarizing web content: copy-paste into ChatGPT, browser extension summarizers, and integrated read-it-later apps with built-in AI summaries
  - Explains Hutch's implementation of one-click article saving with automatic TL;DR generation
  - Discusses use cases where standalone summarization tools remain preferable (PDFs, academic papers, paywalled content)
  - Includes metadata: publication date (2026-04-06), author (Fagner Brack), and relevant SEO keywords

## Notable Details
- Post positions Hutch's summarization feature as the optimal workflow for web articles by eliminating friction between discovery and understanding
- Emphasizes the importance of keeping summaries contextually linked to source articles rather than scattered across separate tools
- Provides practical guidance on when alternative summarization approaches are more appropriate

https://claude.ai/code/session_01BukEQe6eBRij7i1re7ypxk