### PR TITLE
Add blog post: A System for Technical Reading That Actually Works

### DIFF
--- a/content/blog/a-system-for-technical-reading-that-actually-works.md
+++ b/content/blog/a-system-for-technical-reading-that-actually-works.md
@@ -1,0 +1,69 @@
+# A System for Technical Reading That Actually Works
+
+You have a bookmark folder called "To Read." You last opened it in 2023. There are 47 articles in it. Maybe 53. You stopped counting. You saved them with the best of intentions — this one about database indexing looked important, that deep dive on event sourcing seemed like exactly what you needed for the project you were working on three jobs ago.
+
+You've read maybe five of them.
+
+This isn't a personal failing. It's a systems problem. And after 10 years of refining how I read technical content, I can tell you: the fix isn't discipline. It's design.
+
+## Why Your Reading List Is a Graveyard
+
+Most developers treat saving and reading as one decision. You find an article, you think "I should read this," and you save it somewhere — a bookmark, a tab, a Slack message to yourself. The problem is that saving feels productive. It scratches the same itch as actually reading. Your brain gets a tiny hit of accomplishment, and the article disappears into a list you'll never revisit.
+
+Three things are usually broken:
+
+**No triage system.** Everything you save has equal weight. A 20-minute deep dive on distributed consensus sits next to a 3-minute post about a CSS trick. When you finally open your reading list, the wall of undifferentiated links feels overwhelming, so you close it and go back to Twitter.
+
+**No reading ritual.** You save articles throughout the day but never carve out time to actually read them. Reading gets squeezed into the cracks — waiting for a build, sitting in a meeting you shouldn't be in — and those cracks are too small for anything substantial.
+
+**No friction reduction.** When you do sit down to read, the original page is cluttered with pop-ups, newsletter modals, sticky headers, and sidebar ads. You spend more energy fighting the page than absorbing the content. Eventually you give up and watch a YouTube video instead.
+
+## The System That Fixed It for Me
+
+I've been iterating on this for about 10 years now. Started with Instapaper, moved through Pocket, tried Notion databases and Raindrop collections and plain text files. What I landed on isn't complicated, but every piece matters.
+
+### Save everything. Filter nothing.
+
+This is counterintuitive, but it's the most important part. When you find an article that looks interesting, save it immediately. Don't evaluate it. Don't think "will I actually read this?" Don't try to categorise it. Just save it.
+
+The reason: filtering at save time is procrastination disguised as curation. You spend 30 seconds deciding if an article is "worth saving," and that friction compounds. After a few times, your brain starts skipping the save step entirely because it associates it with a decision you don't want to make.
+
+Save the article. Move on. Triage comes later.
+
+### Triage weekly with AI summaries.
+
+Once a week — Sunday morning for me, but pick whatever works — open your reading list and scan it. This is where AI summaries change the game. Instead of opening each article to figure out if it's worth your time, you read a two-sentence summary and make a fast call: star it for reading, or archive it.
+
+Archiving isn't deleting. It's acknowledging that this article isn't relevant right now. Maybe it will be later. Maybe it won't. Either way, it's out of your active list, and your active list stays manageable.
+
+I archive about 70% of what I save. That's not a waste — it means I'm capturing broadly and filtering precisely, which is exactly what a good system should do.
+
+### Read in reader view. Always.
+
+This one is non-negotiable for me. When I sit down to read, I strip away everything except the text. No ads. No navigation. No "recommended articles" sidebar pulling my attention. Dark mode if it's evening. Clean typography. One article filling the screen.
+
+The difference this makes is hard to overstate. Reading a technical article in reader view versus reading it on the original site is like the difference between reading a book in a quiet room and reading it in a shopping centre. The content is identical. The experience is not.
+
+### Build a rhythm.
+
+Systems only work if they're habitual. I attached reading to things I already do every day:
+
+- **Morning coffee** = one article. Usually something I starred during triage. Medium length, moderately technical.
+- **Commute** = one article. Saved offline the night before so it loads instantly on the train.
+- **Weekend morning** = deep reads. The long ones. The 30-minute architectural deep dives. The papers. This is when I have the mental space for them.
+
+That's roughly 8–10 articles a week. It doesn't sound like much, but it compounds. Over a year, that's 400+ articles read deliberately instead of 45 rotting in a bookmark folder.
+
+The key word is *rhythm*, not *schedule*. If I skip a morning, I skip it. The habit is resilient because it's attached to existing routines, not bolted onto my calendar as another obligation.
+
+## The Tool I Built Around This
+
+After years of wishing my read-it-later app worked the way I actually read, I started building [Hutch](https://www.hutch.reading). It's a read-it-later app designed around this exact workflow — save fast, triage with summaries, read without distractions.
+
+I'm not going to pitch you on features. If the system I described above resonates, Hutch is the tool I built to support it. If you're happy with your current setup, the system works regardless of what app you use. The principles matter more than the tool.
+
+## Start Smaller Than You Think
+
+If you take one thing from this: don't try to overhaul your reading habits in a weekend. Just start saving articles without judging them. Next week, spend 15 minutes triaging. The week after, try reading one article in reader view with your morning coffee.
+
+The system builds itself once you remove the friction. And that bookmark folder from 2023? Archive the whole thing. You're not going to read those articles, and that's fine. Start fresh. Start small. Read one thing today.

--- a/content/blog/a-system-for-technical-reading-that-actually-works.md
+++ b/content/blog/a-system-for-technical-reading-that-actually-works.md
@@ -1,69 +1,101 @@
+---
+title: "A System for Technical Reading That Actually Works"
+description: "You save 50 articles and read 5. After 10 years of refining a personal reading system, here's what actually fixed it."
+slug: "reading-system-that-works"
+date: "2026-04-06"
+author: "Fagner Brack"
+keywords: "technical reading, read it later, reading habits, developer productivity, reading system"
+---
+
+<!--
+BlogPostPage:
+- seo.title: "${post.title} — Hutch Blog"
+- seo.description: post.description
+- seo.canonicalUrl: "https://hutch-app.com/blog/${post.slug}"
+- seo.ogType: "article"
+- seo.author: post.author
+- seo.keywords: post.keywords
+- seo.robots: "index, follow"
+- seo.structuredData: BlogPosting schema with headline, description, datePublished, author (Person), publisher (Organization), url
+- bodyClass: "page-blog-post"
+-->
+
 # A System for Technical Reading That Actually Works
 
-You have a bookmark folder called "To Read." You last opened it in 2023. There are 47 articles in it. Maybe 53. You stopped counting. You saved them with the best of intentions — this one about database indexing looked important, that deep dive on event sourcing seemed like exactly what you needed for the project you were working on three jobs ago.
+You have a bookmark folder called "To Read." You last opened it in 2023. There are 47 articles in it. Maybe 53. You stopped counting.
+
+You saved them with good intentions. That database indexing article looked important. That event sourcing post seemed perfect for a project you were working on three jobs ago.
 
 You've read maybe five of them.
 
-This isn't a personal failing. It's a systems problem. And after 10 years of refining how I read technical content, I can tell you: the fix isn't discipline. It's design.
+This is not a discipline problem. It is a systems problem. I've spent 10 years refining how I read technical content. The fix is not willpower. It is design.
 
 ## Why Your Reading List Is a Graveyard
 
-Most developers treat saving and reading as one decision. You find an article, you think "I should read this," and you save it somewhere — a bookmark, a tab, a Slack message to yourself. The problem is that saving feels productive. It scratches the same itch as actually reading. Your brain gets a tiny hit of accomplishment, and the article disappears into a list you'll never revisit.
+Most developers treat saving and reading as one decision. You find an article. You think "I should read this." You save it to a bookmark, a tab, or a Slack message to yourself.
+
+Saving feels productive. It scratches the same itch as reading. Your brain gets a small hit of accomplishment, and the article vanishes into a list you will never reopen.
 
 Three things are usually broken:
 
-**No triage system.** Everything you save has equal weight. A 20-minute deep dive on distributed consensus sits next to a 3-minute post about a CSS trick. When you finally open your reading list, the wall of undifferentiated links feels overwhelming, so you close it and go back to Twitter.
+**No triage system.** Every saved article has equal weight. A 20-minute piece on distributed consensus sits next to a 3-minute CSS trick. You open your reading list, see a wall of undifferentiated links, feel overwhelmed, and close it. Then you go back to Twitter.
 
-**No reading ritual.** You save articles throughout the day but never carve out time to actually read them. Reading gets squeezed into the cracks — waiting for a build, sitting in a meeting you shouldn't be in — and those cracks are too small for anything substantial.
+**No reading ritual.** You save articles throughout the day but never set aside time to read them. Reading gets squeezed into gaps: waiting for a build, sitting in a meeting you should not be in. Those gaps are too small for anything real.
 
-**No friction reduction.** When you do sit down to read, the original page is cluttered with pop-ups, newsletter modals, sticky headers, and sidebar ads. You spend more energy fighting the page than absorbing the content. Eventually you give up and watch a YouTube video instead.
+**No friction reduction.** You sit down to read, and the original page fights you. Pop-ups. Newsletter modals. Sticky headers. Sidebar ads. You spend more energy battling the page than absorbing the content. You give up and watch a YouTube video instead.
 
 ## The System That Fixed It for Me
 
-I've been iterating on this for about 10 years now. Started with Instapaper, moved through Pocket, tried Notion databases and Raindrop collections and plain text files. What I landed on isn't complicated, but every piece matters.
+I have iterated on this for about 10 years. I started with Instapaper. I moved through Pocket. I tried Notion databases, Raindrop collections, and plain text files. What I landed on is not complicated, but every piece matters.
 
 ### Save everything. Filter nothing.
 
-This is counterintuitive, but it's the most important part. When you find an article that looks interesting, save it immediately. Don't evaluate it. Don't think "will I actually read this?" Don't try to categorise it. Just save it.
+This sounds counterintuitive. It is the most important part.
 
-The reason: filtering at save time is procrastination disguised as curation. You spend 30 seconds deciding if an article is "worth saving," and that friction compounds. After a few times, your brain starts skipping the save step entirely because it associates it with a decision you don't want to make.
+When you find an interesting article, save it right away. Do not evaluate it. Do not think "will I actually read this?" Do not try to categorize it. Just save it.
+
+Here is why: filtering at save time is procrastination disguised as curation. You spend 30 seconds deciding if an article is "worth saving." That friction adds up. After a few rounds, your brain starts skipping the save step entirely. It now links saving with a decision you do not want to make.
 
 Save the article. Move on. Triage comes later.
 
 ### Triage weekly with AI summaries.
 
-Once a week — Sunday morning for me, but pick whatever works — open your reading list and scan it. This is where AI summaries change the game. Instead of opening each article to figure out if it's worth your time, you read a two-sentence summary and make a fast call: star it for reading, or archive it.
+Once a week, open your reading list and scan it. Sunday morning works for me, but pick what fits your schedule.
 
-Archiving isn't deleting. It's acknowledging that this article isn't relevant right now. Maybe it will be later. Maybe it won't. Either way, it's out of your active list, and your active list stays manageable.
+This is where AI summaries change everything. You do not need to open each article to judge its value. You read a two-sentence summary and make a fast call: star it for reading, or archive it.
 
-I archive about 70% of what I save. That's not a waste — it means I'm capturing broadly and filtering precisely, which is exactly what a good system should do.
+Archiving is not deleting. It means this article is not relevant right now. Maybe it will be later. Maybe not. Either way, it is out of your active list, and your active list stays small.
+
+I archive about 70% of what I save. That is not waste. It means I capture broadly and filter with precision.
 
 ### Read in reader view. Always.
 
-This one is non-negotiable for me. When I sit down to read, I strip away everything except the text. No ads. No navigation. No "recommended articles" sidebar pulling my attention. Dark mode if it's evening. Clean typography. One article filling the screen.
+This is non-negotiable for me. When I sit down to read, I strip away everything except the text. No ads. No navigation. No "recommended articles" sidebar. Dark mode in the evening. Clean type. One article filling the screen.
 
-The difference this makes is hard to overstate. Reading a technical article in reader view versus reading it on the original site is like the difference between reading a book in a quiet room and reading it in a shopping centre. The content is identical. The experience is not.
+Does this actually make a difference? It is enormous. Reading a technical article in reader view versus reading it on the original site is the difference between a quiet room and a crowded mall. Same content. Completely different experience.
 
 ### Build a rhythm.
 
-Systems only work if they're habitual. I attached reading to things I already do every day:
+Systems work only when they become habits. I attached reading to things I already do every day:
 
-- **Morning coffee** = one article. Usually something I starred during triage. Medium length, moderately technical.
+- **Morning coffee** = one article. Something I starred during triage. Medium length, moderately technical.
 - **Commute** = one article. Saved offline the night before so it loads instantly on the train.
-- **Weekend morning** = deep reads. The long ones. The 30-minute architectural deep dives. The papers. This is when I have the mental space for them.
+- **Weekend morning** = deep reads. The long ones. The 30-minute architecture pieces. The papers. This is when I have the mental space for them.
 
-That's roughly 8–10 articles a week. It doesn't sound like much, but it compounds. Over a year, that's 400+ articles read deliberately instead of 45 rotting in a bookmark folder.
+That adds up to roughly 8 to 10 articles a week. Over a year, that is 400+ articles read with intention. Compare that to 45 links collecting dust in a bookmark folder.
 
-The key word is *rhythm*, not *schedule*. If I skip a morning, I skip it. The habit is resilient because it's attached to existing routines, not bolted onto my calendar as another obligation.
+The key word is *rhythm*, not *schedule*. If I skip a morning, I skip it. The habit holds up because it is tied to routines I already have, not added to my calendar as another obligation.
 
 ## The Tool I Built Around This
 
-After years of wishing my read-it-later app worked the way I actually read, I started building [Hutch](https://www.hutch.reading). It's a read-it-later app designed around this exact workflow — save fast, triage with summaries, read without distractions.
+After years of wishing my read-it-later app matched the way I actually read, I started building [Hutch](https://hutch-app.com). It is a read-it-later app designed around this exact workflow: save fast, triage with summaries, read without distractions.
 
-I'm not going to pitch you on features. If the system I described above resonates, Hutch is the tool I built to support it. If you're happy with your current setup, the system works regardless of what app you use. The principles matter more than the tool.
+I am not going to pitch you on features. If this system resonates, Hutch is the tool I built to support it. If you are happy with your current setup, the system works no matter what app you use. The principles matter more than the tool.
 
 ## Start Smaller Than You Think
 
-If you take one thing from this: don't try to overhaul your reading habits in a weekend. Just start saving articles without judging them. Next week, spend 15 minutes triaging. The week after, try reading one article in reader view with your morning coffee.
+Do not try to overhaul your reading habits in a weekend. Start by saving articles without judging them. Next week, spend 15 minutes triaging. The week after, try reading one article in reader view with your morning coffee.
 
-The system builds itself once you remove the friction. And that bookmark folder from 2023? Archive the whole thing. You're not going to read those articles, and that's fine. Start fresh. Start small. Read one thing today.
+The system builds itself once you remove the friction.
+
+And that bookmark folder from 2023? Archive the whole thing. You are not going to read those articles. That is fine. Start fresh. Start small. Read one thing today.

--- a/projects/hutch/src/runtime/web/pages/blog/posts/reading-system-that-works.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/reading-system-that-works.md
@@ -2,25 +2,10 @@
 title: "A System for Technical Reading That Actually Works"
 description: "You save 50 articles and read 5. After 10 years of refining a personal reading system, here's what actually fixed it."
 slug: "reading-system-that-works"
-date: "2026-04-06"
+date: "2026-04-07"
 author: "Fagner Brack"
 keywords: "technical reading, read it later, reading habits, developer productivity, reading system"
 ---
-
-<!--
-BlogPostPage:
-- seo.title: "${post.title} — Hutch Blog"
-- seo.description: post.description
-- seo.canonicalUrl: "https://hutch-app.com/blog/${post.slug}"
-- seo.ogType: "article"
-- seo.author: post.author
-- seo.keywords: post.keywords
-- seo.robots: "index, follow"
-- seo.structuredData: BlogPosting schema with headline, description, datePublished, author (Person), publisher (Organization), url
-- bodyClass: "page-blog-post"
--->
-
-# A System for Technical Reading That Actually Works
 
 You have a bookmark folder called "To Read." You last opened it in 2023. There are 47 articles in it. Maybe 53. You stopped counting.
 


### PR DESCRIPTION
## Summary
Added a new blog post about building an effective personal reading system for technical content. The post shares a 10-year refined approach to managing "read it later" articles and introduces the Hutch app as a tool supporting this workflow.

## Changes
- Added new markdown blog post at `projects/hutch/src/runtime/web/pages/blog/posts/reading-system-that-works.md`
  - Frontmatter with metadata: title, description, slug, date, author, and keywords
  - Comprehensive guide covering:
    - Common problems with reading lists (no triage, no ritual, no friction reduction)
    - Four-part system: save everything without filtering, weekly AI-powered triage, reader view for distraction-free reading, and building sustainable reading habits
    - Practical implementation examples (morning coffee reads, commute reading, weekend deep dives)
    - Introduction to Hutch as the supporting tool
    - Actionable advice for getting started

## Implementation Details
- Post uses standard markdown with frontmatter format consistent with existing blog structure
- Includes clear section headers and emphasis on practical, implementable advice
- Balances educational content with subtle product positioning for Hutch
- Approximately 1,100 words with accessible, conversational tone

https://claude.ai/code/session_01GhLMpaxi3dBiVdAtMd87Px