### PR TITLE
Rename e2e-server to e2e-server.main and remove coverage ignore comments

### DIFF
--- a/projects/hutch/knip.config.ts
+++ b/projects/hutch/knip.config.ts
@@ -33,6 +33,6 @@ export default {
 	},
 	playwright: {
 		config: ["playwright.config.local-dev.ts"],
-		entry: ["src/e2e/**/*.e2e-local.ts", "src/e2e/e2e-server.ts"],
+		entry: ["src/e2e/**/*.e2e-local.ts", "src/e2e/e2e-server.main.ts"],
 	},
 } satisfies KnipConfig;

--- a/projects/hutch/playwright.config.local-dev.ts
+++ b/projects/hutch/playwright.config.local-dev.ts
@@ -12,7 +12,7 @@ export default createPlaywrightConfig({
   video: 'off',
   launchOptions: {},
   webServer: {
-    command: 'tsx src/e2e/e2e-server.ts',
+    command: 'tsx src/e2e/e2e-server.main.ts',
     url: serverUrl,
     reuseExistingServer: true,
     stdout: 'pipe',

--- a/projects/hutch/run-tests.config.js
+++ b/projects/hutch/run-tests.config.js
@@ -24,7 +24,7 @@ module.exports = {
       config: 'playwright.config.local-dev.ts',
       browsers: ['chromium'],
       server: {
-        command: ['node', 'dist/e2e/e2e-server.js'],
+        command: ['node', 'dist/e2e/e2e-server.main.js'],
         url: `http://localhost:${port}`,
         stripCoverage: true,
       },

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start -- composition root, no logic to test */
 import assert from 'node:assert'
 import express from 'express'
 import { HutchLogger, consoleLogger } from '@packages/hutch-logger'
@@ -32,4 +31,3 @@ process.on('SIGINT', () => process.exit(0))
 server.listen(PORT, () => {
   logger.info(`E2E server running on http://localhost:${PORT}`)
 })
-/* c8 ignore stop */


### PR DESCRIPTION
## Summary
Renamed the E2E server entry point file from `e2e-server.ts` to `e2e-server.main.ts` and removed coverage ignore comments from the file.

## Key Changes
- Renamed `src/e2e/e2e-server.ts` to `src/e2e/e2e-server.main.ts`
- Updated all references to the renamed file across configuration files:
  - `knip.config.ts`: Updated entry point reference
  - `playwright.config.local-dev.ts`: Updated server command reference
  - `run-tests.config.js`: Updated compiled server command reference
- Removed `c8 ignore start` and `c8 ignore stop` comments from the E2E server file

## Implementation Details
The renaming appears to follow a naming convention for main entry points (`.main.ts` suffix). The removal of coverage ignore comments suggests the file may now be included in code coverage analysis, or the comments were deemed unnecessary.

https://claude.ai/code/session_018KWsnyKxo4PeovuAbgyrtc