### PR TITLE
Add email field to DynamoDB user projection in auth provider

### DIFF
--- a/projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts
+++ b/projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts
@@ -121,7 +121,7 @@ export function initDynamoDbAuth(deps: {
 		const normalizedEmail = normalizeEmail(email);
 		const row = await users.get(
 			{ email: normalizedEmail },
-			{ projection: ["userId", "emailVerified", "registeredAt"] },
+			{ projection: ["email", "userId", "emailVerified", "registeredAt"] },
 		);
 		if (!row) return null;
 		return {


### PR DESCRIPTION
## Summary
Updated the DynamoDB authentication provider to include the `email` field in the user data projection when retrieving user records.

## Changes
- Added `"email"` to the projection array in the `initDynamoDbAuth` function's user lookup query
- The projection now retrieves: `["email", "userId", "emailVerified", "registeredAt"]` instead of `["userId", "emailVerified", "registeredAt"]`

## Details
This change ensures that the normalized email address is included in the returned user object when querying DynamoDB, which may be necessary for subsequent operations or response data that require the email field to be present.

https://claude.ai/code/session_019decp3C5wcHL2DBhzCyiCA