### PR TITLE
Add e2e phase skipping based on CLAUDE_CODE_REMOTE env var

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,6 +13,14 @@ fi
 export PULUMI_CONFIG_PASSPHRASE=''
 export AWS_CONFIG_FILE="$PWD/.aws/config"
 
+# When static AWS credentials are present, unset AWS_PROFILE so the SDK uses
+# them. AWS_CONFIG_FILE points at profiles that only define `region`, so
+# leaving AWS_PROFILE set would make the SDK look there for credentials and
+# fail with "Could not load credentials from any providers".
+if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
+  unset AWS_PROFILE
+fi
+
 _pulumi_table() {
   grep "hutch:$1:" projects/hutch/Pulumi.prod.yaml | awk '{print $2}'
 }

--- a/enforce-coverage.config.base.js
+++ b/enforce-coverage.config.base.js
@@ -58,6 +58,11 @@ const BASE_EXCLUDE_PATTERNS = [
 
   // Browser-only code — WebExtension APIs, Canvas, DOM; not runnable in Node.js
   '**/*.browser.ts',
+
+  // E2E source — only exercised by e2e tests, which are skipped in
+  // CLAUDE_CODE_REMOTE environments (see test-phase-runner). When skipped,
+  // these files would otherwise tank coverage to 0%.
+  ...(process.env.CLAUDE_CODE_REMOTE === 'true' ? ['src/e2e/**'] : []),
 ]
 
 function validateC8Config(projectRoot) {

--- a/projects/extensions/chrome-extension/project.json
+++ b/projects/extensions/chrome-extension/project.json
@@ -9,7 +9,7 @@
       "outputs": ["{projectRoot}/dist-extension-compiled", "{projectRoot}/dist-extension-files"]
     },
     "check": {
-      "command": "pnpm lint && pnpm test-with-coverage && ([ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] || pnpm test:e2e)",
+      "command": "pnpm lint && pnpm test-with-coverage",
       "options": { "cwd": "{projectRoot}" }
     }
   }

--- a/projects/extensions/chrome-extension/run-tests.config.js
+++ b/projects/extensions/chrome-extension/run-tests.config.js
@@ -17,17 +17,20 @@ module.exports = {
       type: 'node-test',
       name: 'Running E2E unit tests',
       glob: 'dist/e2e/**/*.test.js',
+      e2e: true,
     },
     {
       type: 'script',
       name: 'Building extension for E2E tests',
       command: 'node scripts/build-extension.js',
       env: { HUTCH_SERVER_URL: `http://127.0.0.1:${port}` },
+      e2e: true,
     },
     {
       type: 'script',
       name: 'Installing Chrome for Testing',
       command: 'node scripts/install-chrome-for-testing.js',
+      e2e: true,
     },
     {
       type: 'node-test',
@@ -35,6 +38,7 @@ module.exports = {
       files: ['dist/e2e/login-flow/run.e2e-local.main.js'],
       timeout: 90000,
       env: { HEADLESS: 'true', E2E_PORT: port },
+      e2e: true,
     },
   ],
 };

--- a/projects/extensions/firefox-extension/project.json
+++ b/projects/extensions/firefox-extension/project.json
@@ -9,7 +9,7 @@
       "outputs": ["{projectRoot}/dist-extension-compiled", "{projectRoot}/dist-extension-files"]
     },
     "check": {
-      "command": "pnpm lint && pnpm test-with-coverage && ([ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] || pnpm test:e2e)",
+      "command": "pnpm lint && pnpm test-with-coverage",
       "options": { "cwd": "{projectRoot}" }
     }
   }

--- a/projects/extensions/firefox-extension/run-tests.config.js
+++ b/projects/extensions/firefox-extension/run-tests.config.js
@@ -17,18 +17,21 @@ module.exports = {
       type: 'node-test',
       name: 'Running E2E unit tests',
       glob: 'dist/e2e/**/*.test.js',
+      e2e: true,
     },
     {
       type: 'script',
       name: 'Building extension for E2E tests',
       command: 'node scripts/build-extension.js',
       env: { HUTCH_SERVER_URL: `http://127.0.0.1:${port}` },
+      e2e: true,
     },
     {
       type: 'node-test',
       name: 'Running E2E tests',
       files: ['dist/e2e/login-flow/run.e2e-local.main.js'],
       env: { HEADLESS: 'true', E2E_PORT: port },
+      e2e: true,
     },
   ],
 };

--- a/projects/hutch/project.json
+++ b/projects/hutch/project.json
@@ -12,7 +12,7 @@
       "options": { "cwd": "{projectRoot}" }
     },
     "check": {
-      "command": "pnpm lint && pnpm test-with-coverage && ([ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] || pnpm test:e2e)",
+      "command": "pnpm lint && pnpm test-with-coverage",
       "options": { "cwd": "{projectRoot}" }
     },
     "test": {},

--- a/projects/hutch/run-tests.config.js
+++ b/projects/hutch/run-tests.config.js
@@ -24,6 +24,7 @@ module.exports = {
       config: 'playwright.config.local-dev.ts',
       browsers: ['chromium'],
       env: { HEADLESS: 'true', E2E_PORT: port },
+      e2e: true,
     },
   ],
 };

--- a/src/packages/test-phase-runner/src/run-test-phases.test.ts
+++ b/src/packages/test-phase-runner/src/run-test-phases.test.ts
@@ -2,7 +2,7 @@ import type { ExecSyncOptions } from "node:child_process";
 import { defaultDeps, initTestPhaseRunner } from "./run-test-phases";
 import type { ResolvedPhase, TestPhaseRunnerDeps } from "./run-test-phases";
 
-function createInMemoryDeps() {
+function createInMemoryDeps(overrides: Partial<TestPhaseRunnerDeps> = {}) {
 	const executedCommands: Array<{ command: string; cwd?: string | URL; env?: NodeJS.ProcessEnv }> = [];
 
 	const deps: TestPhaseRunnerDeps = {
@@ -15,6 +15,8 @@ function createInMemoryDeps() {
 			return ["dist/e2e/test1.test.js", "dist/e2e/test2.test.js"];
 		},
 		log: () => {},
+		shouldSkipE2E: () => false,
+		...overrides,
 	};
 
 	return { deps, executedCommands };
@@ -66,6 +68,7 @@ describe("jest phase resolution", () => {
 			name: "unit tests",
 			command: 'node_modules/.bin/jest --testMatch="**/dist/**/*.test.js" --testTimeout=10000 --runInBand',
 			skip: false,
+			e2e: false,
 		});
 	});
 
@@ -214,6 +217,7 @@ describe("script phase resolution", () => {
 			name: "Building extension",
 			command: "node scripts/build-extension.js",
 			env: { HUTCH_SERVER_URL: "http://127.0.0.1:3000" },
+			e2e: false,
 		});
 	});
 });
@@ -426,6 +430,128 @@ describe("runAllPhases execution", () => {
 
 		expect(executedCommands[0].command).toContain("*.test.js");
 		expect(executedCommands[1].command).toContain("*.integration.js");
+	});
+});
+
+describe("e2e phase skipping", () => {
+	it("skips phases marked e2e when shouldSkipE2E returns true", async () => {
+		const { deps, executedCommands } = createInMemoryDeps({ shouldSkipE2E: () => true });
+		const runner = createRunner(deps);
+		const plan = runner.createTestPlan({
+			config: {
+				projectName: "My Project",
+				phases: [
+					{ type: "jest", name: "unit tests", testMatch: "**/dist/**/*.test.js", timeout: 10000 },
+					{ type: "node-test", name: "E2E unit tests", files: ["test.e2e.js"], e2e: true },
+					{ type: "script", name: "Build for E2E", command: "node build.js", e2e: true },
+					{
+						type: "playwright",
+						name: "E2E tests",
+						config: "playwright.config.ts",
+						browsers: ["chromium"],
+						e2e: true,
+					},
+				],
+			},
+			projectRoot: "/projects/test",
+		});
+
+		await plan.runAllPhases();
+
+		expect(executedCommands).toHaveLength(1);
+		expect(executedCommands[0].command).toContain("jest");
+	});
+
+	it("runs phases marked e2e when shouldSkipE2E returns false", async () => {
+		const { deps, executedCommands } = createInMemoryDeps({ shouldSkipE2E: () => false });
+		const runner = createRunner(deps);
+		const plan = runner.createTestPlan({
+			config: {
+				projectName: "My Project",
+				phases: [
+					{ type: "node-test", name: "E2E tests", files: ["test.e2e.js"], e2e: true },
+				],
+			},
+			projectRoot: "/projects/test",
+		});
+
+		await plan.runAllPhases();
+
+		expect(executedCommands).toHaveLength(1);
+		expect(executedCommands[0].command).toBe("node --test test.e2e.js");
+	});
+
+	it("defaults to e2e: false on resolved phases when not specified", () => {
+		const runner = createRunner();
+		const plan = runner.createTestPlan({
+			config: {
+				projectName: "My Project",
+				phases: [
+					{ type: "jest", name: "unit tests", testMatch: "**/*.test.js", timeout: 10000 },
+					{ type: "node-test", name: "E2E tests", files: ["test.e2e.js"] },
+					{ type: "script", name: "Build", command: "node build.js" },
+					{
+						type: "playwright",
+						name: "E2E tests",
+						config: "playwright.config.ts",
+						browsers: ["chromium"],
+					},
+				],
+			},
+			projectRoot: "/projects/test",
+		});
+
+		expect(plan.phases.map((p) => p.e2e)).toEqual([false, false, false, false]);
+	});
+
+	it("propagates e2e: true onto resolved phases", () => {
+		const runner = createRunner();
+		const plan = runner.createTestPlan({
+			config: {
+				projectName: "My Project",
+				phases: [
+					{ type: "jest", name: "e2e jest", testMatch: "**/e2e/*.test.js", timeout: 10000, e2e: true },
+					{ type: "node-test", name: "e2e node", files: ["test.e2e.js"], e2e: true },
+					{ type: "script", name: "build for e2e", command: "node build.js", e2e: true },
+					{
+						type: "playwright",
+						name: "e2e playwright",
+						config: "playwright.config.ts",
+						browsers: ["chromium"],
+						e2e: true,
+					},
+				],
+			},
+			projectRoot: "/projects/test",
+		});
+
+		expect(plan.phases.map((p) => p.e2e)).toEqual([true, true, true, true]);
+	});
+});
+
+describe("defaultDeps.shouldSkipE2E", () => {
+	const originalValue = process.env.CLAUDE_CODE_REMOTE;
+	afterEach(() => {
+		if (originalValue === undefined) {
+			delete process.env.CLAUDE_CODE_REMOTE;
+		} else {
+			process.env.CLAUDE_CODE_REMOTE = originalValue;
+		}
+	});
+
+	it("returns true when CLAUDE_CODE_REMOTE=true", () => {
+		process.env.CLAUDE_CODE_REMOTE = "true";
+		expect(defaultDeps.shouldSkipE2E()).toBe(true);
+	});
+
+	it("returns false when CLAUDE_CODE_REMOTE is unset", () => {
+		delete process.env.CLAUDE_CODE_REMOTE;
+		expect(defaultDeps.shouldSkipE2E()).toBe(false);
+	});
+
+	it("returns false when CLAUDE_CODE_REMOTE has a different value", () => {
+		process.env.CLAUDE_CODE_REMOTE = "1";
+		expect(defaultDeps.shouldSkipE2E()).toBe(false);
 	});
 });
 

--- a/src/packages/test-phase-runner/src/run-test-phases.ts
+++ b/src/packages/test-phase-runner/src/run-test-phases.ts
@@ -10,6 +10,7 @@ interface JestPhase {
 	timeout: number;
 	testPathIgnorePatterns?: string;
 	passWithNoTests?: boolean;
+	e2e?: boolean;
 }
 
 interface NodeTestPhase {
@@ -19,6 +20,7 @@ interface NodeTestPhase {
 	files?: string[];
 	timeout?: number;
 	env?: Record<string, string>;
+	e2e?: boolean;
 }
 
 interface ScriptPhase {
@@ -26,6 +28,7 @@ interface ScriptPhase {
 	name: string;
 	command: string;
 	env?: Record<string, string>;
+	e2e?: boolean;
 }
 
 interface PlaywrightPhase {
@@ -34,6 +37,7 @@ interface PlaywrightPhase {
 	config: string;
 	browsers: string[];
 	env?: Record<string, string>;
+	e2e?: boolean;
 }
 
 export type TestPhase = JestPhase | NodeTestPhase | ScriptPhase | PlaywrightPhase;
@@ -48,6 +52,7 @@ interface ResolvedJestPhase {
 	name: string;
 	command: string;
 	skip: false;
+	e2e: boolean;
 }
 
 interface ResolvedNodeTestPhase {
@@ -57,6 +62,7 @@ interface ResolvedNodeTestPhase {
 	env: Record<string, string>;
 	files: string[];
 	skip: boolean;
+	e2e: boolean;
 }
 
 interface ResolvedScriptPhase {
@@ -64,6 +70,7 @@ interface ResolvedScriptPhase {
 	name: string;
 	command: string;
 	env: Record<string, string>;
+	e2e: boolean;
 }
 
 interface ResolvedPlaywrightPhase {
@@ -72,6 +79,7 @@ interface ResolvedPlaywrightPhase {
 	browserInstallCommand: string;
 	testCommand: string;
 	env: Record<string, string>;
+	e2e: boolean;
 }
 
 export type ResolvedPhase =
@@ -89,11 +97,13 @@ export interface TestPlan {
 type ExecSyncFn = (command: string, options: ExecSyncOptions) => Buffer | string;
 type GlobSyncFn = (pattern: string) => string[];
 type LogFn = (message: string) => void;
+type ShouldSkipE2EFn = () => boolean;
 
 export interface TestPhaseRunnerDeps {
 	execSync: ExecSyncFn;
 	globSync: GlobSyncFn;
 	log: LogFn;
+	shouldSkipE2E: ShouldSkipE2EFn;
 }
 
 function resolveJestPhase(phase: JestPhase): ResolvedJestPhase {
@@ -109,7 +119,7 @@ function resolveJestPhase(phase: JestPhase): ResolvedJestPhase {
 	if (phase.passWithNoTests) {
 		parts.push("--passWithNoTests");
 	}
-	return { type: "jest", name: phase.name, command: parts.join(" "), skip: false };
+	return { type: "jest", name: phase.name, command: parts.join(" "), skip: false, e2e: phase.e2e === true };
 }
 
 function resolveNodeTestPhase(phase: NodeTestPhase, globSync: GlobSyncFn): ResolvedNodeTestPhase {
@@ -122,11 +132,11 @@ function resolveNodeTestPhase(phase: NodeTestPhase, globSync: GlobSyncFn): Resol
 	const skip = files.length === 0;
 	const timeoutFlag = phase.timeout ? ` --test-timeout=${phase.timeout}` : "";
 	const command = skip ? "" : `node --test${timeoutFlag} ${files.join(" ")}`;
-	return { type: "node-test", name: phase.name, command, env: phase.env ?? {}, files, skip };
+	return { type: "node-test", name: phase.name, command, env: phase.env ?? {}, files, skip, e2e: phase.e2e === true };
 }
 
 function resolveScriptPhase(phase: ScriptPhase): ResolvedScriptPhase {
-	return { type: "script", name: phase.name, command: phase.command, env: phase.env ?? {} };
+	return { type: "script", name: phase.name, command: phase.command, env: phase.env ?? {}, e2e: phase.e2e === true };
 }
 
 function resolvePlaywrightPhase(phase: PlaywrightPhase): ResolvedPlaywrightPhase {
@@ -137,6 +147,7 @@ function resolvePlaywrightPhase(phase: PlaywrightPhase): ResolvedPlaywrightPhase
 		browserInstallCommand: `node_modules/.bin/playwright install --with-deps ${browsers}`,
 		testCommand: `node_modules/.bin/playwright test --config ${phase.config}`,
 		env: phase.env ?? {},
+		e2e: phase.e2e === true,
 	};
 }
 
@@ -144,6 +155,7 @@ export const defaultDeps: TestPhaseRunnerDeps = {
 	execSync: defaultExecSync as ExecSyncFn,
 	globSync: defaultGlobSync,
 	log: console.log,
+	shouldSkipE2E: () => process.env.CLAUDE_CODE_REMOTE === "true",
 };
 
 export function initTestPhaseRunner(deps: TestPhaseRunnerDeps) {
@@ -201,8 +213,14 @@ export function initTestPhaseRunner(deps: TestPhaseRunnerDeps) {
 				projectName: input.config.projectName,
 				phases: resolvedPhases,
 				async runAllPhases() {
+					const skipE2E = deps.shouldSkipE2E();
 					for (const phase of resolvedPhases) {
 						const displayName = `${input.config.projectName} - ${phase.name}`;
+
+						if (phase.e2e && skipE2E) {
+							deps.log(`\n=== ${displayName} - skipped (CLAUDE_CODE_REMOTE) ===\n`);
+							continue;
+						}
 
 						if (phase.type === "node-test" && phase.skip) {
 							continue;


### PR DESCRIPTION
## Summary
This PR adds support for skipping end-to-end (e2e) test phases in remote environments by introducing an `e2e` flag to test phase configurations and a `shouldSkipE2E` dependency that checks the `CLAUDE_CODE_REMOTE` environment variable.

## Key Changes

- **Added `e2e` flag to all phase types**: JestPhase, NodeTestPhase, ScriptPhase, and PlaywrightPhase now support an optional `e2e?: boolean` property to mark phases as e2e tests.

- **Added `shouldSkipE2E` dependency**: Introduced a new `ShouldSkipE2EFn` type and `shouldSkipE2E` method to `TestPhaseRunnerDeps`. The default implementation returns `true` when `CLAUDE_CODE_REMOTE=true`.

- **Implemented e2e phase skipping logic**: Modified `runAllPhases()` to skip phases marked with `e2e: true` when `shouldSkipE2E()` returns true, with appropriate logging.

- **Updated resolved phase types**: All `ResolvedPhase` types now include an `e2e: boolean` property (defaulting to false when not specified in the config).

- **Marked e2e phases in configs**: Updated test configuration files for chrome-extension, firefox-extension, and hutch projects to mark their e2e phases with `e2e: true`.

- **Simplified project.json check commands**: Removed conditional e2e test execution from project.json files since e2e skipping is now handled by the test-phase-runner itself.

- **Updated coverage exclusion**: Modified enforce-coverage.config.base.js to exclude e2e source files from coverage when `CLAUDE_CODE_REMOTE=true`.

- **Fixed .envrc AWS credentials handling**: Added logic to unset `AWS_PROFILE` when static AWS credentials are present to prevent credential resolution failures.

## Implementation Details

- The `e2e` property is propagated from input phase configs to resolved phases during phase resolution
- E2e phases are skipped before execution, not filtered from the plan, allowing visibility into what would have run
- The feature is backward compatible—phases without the `e2e` flag default to `e2e: false`
- Comprehensive test coverage added for e2e skipping behavior and the `shouldSkipE2E` dependency

https://claude.ai/code/session_01RRA6nUaW4nfDwUEozr6sgv