### PR TITLE
Integrate AI-generated summaries into article excerpts

### DIFF
--- a/projects/hutch/src/runtime/providers/article-summary/article-summary.helpers.test.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/article-summary.helpers.test.ts
@@ -49,7 +49,7 @@ describe("truncateForSeo", () => {
 
 		expect(result.length).toBeLessThanOrEqual(160);
 		expect(result.endsWith("…")).toBe(true);
-		expect(result).not.toMatch(/ …$/);
+		expect(result).toMatch(/\S…$/);
 	});
 
 	it("hard-cuts when the slice has no whitespace", () => {

--- a/projects/hutch/src/runtime/providers/article-summary/article-summary.helpers.test.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/article-summary.helpers.test.ts
@@ -1,0 +1,65 @@
+import { pickExcerpt, truncateForSeo } from "./article-summary.helpers";
+
+describe("pickExcerpt", () => {
+	it("returns the summary text when status is ready", () => {
+		expect(
+			pickExcerpt(
+				{ status: "ready", summary: "AI-generated summary." },
+				"Parsed excerpt.",
+			),
+		).toBe("AI-generated summary.");
+	});
+
+	it("returns the fallback when summary is undefined", () => {
+		expect(pickExcerpt(undefined, "Parsed excerpt.")).toBe("Parsed excerpt.");
+	});
+
+	it("returns the fallback when status is pending", () => {
+		expect(pickExcerpt({ status: "pending" }, "Parsed excerpt.")).toBe(
+			"Parsed excerpt.",
+		);
+	});
+
+	it("returns the fallback when status is failed", () => {
+		expect(
+			pickExcerpt({ status: "failed", reason: "boom" }, "Parsed excerpt."),
+		).toBe("Parsed excerpt.");
+	});
+
+	it("returns the fallback when status is skipped", () => {
+		expect(pickExcerpt({ status: "skipped" }, "Parsed excerpt.")).toBe(
+			"Parsed excerpt.",
+		);
+	});
+});
+
+describe("truncateForSeo", () => {
+	it("returns the text unchanged when within the limit", () => {
+		expect(truncateForSeo("Short and sweet.")).toBe("Short and sweet.");
+	});
+
+	it("returns the text unchanged when exactly at the limit", () => {
+		const text = "a".repeat(160);
+		expect(truncateForSeo(text)).toBe(text);
+	});
+
+	it("truncates at the last word boundary and appends an ellipsis", () => {
+		const long = `${"word ".repeat(40)}tail`;
+		const result = truncateForSeo(long);
+
+		expect(result.length).toBeLessThanOrEqual(160);
+		expect(result.endsWith("…")).toBe(true);
+		expect(result).not.toMatch(/ …$/);
+	});
+
+	it("hard-cuts when the slice has no whitespace", () => {
+		const noSpaces = "x".repeat(200);
+		const result = truncateForSeo(noSpaces);
+
+		expect(result).toBe(`${"x".repeat(159)}…`);
+	});
+
+	it("respects a custom maxChars argument", () => {
+		expect(truncateForSeo("hello world there", 11)).toBe("hello…");
+	});
+});

--- a/projects/hutch/src/runtime/providers/article-summary/article-summary.helpers.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/article-summary.helpers.ts
@@ -1,0 +1,21 @@
+import type { GeneratedSummary } from "./article-summary.types";
+
+export function pickExcerpt(
+	summary: GeneratedSummary | undefined,
+	fallback: string,
+): string {
+	return summary?.status === "ready" ? summary.summary : fallback;
+}
+
+const SEO_DESCRIPTION_MAX_CHARS = 160;
+
+export function truncateForSeo(
+	text: string,
+	maxChars: number = SEO_DESCRIPTION_MAX_CHARS,
+): string {
+	if (text.length <= maxChars) return text;
+	const slice = text.slice(0, maxChars - 1);
+	const lastSpace = slice.lastIndexOf(" ");
+	const cut = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+	return `${cut.trimEnd()}…`;
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -22,6 +22,7 @@ import type {
 } from "../../../providers/article-crawl/article-crawl.types";
 import type {
 	FindGeneratedSummary,
+	GeneratedSummary,
 	MarkSummaryPending,
 } from "../../../providers/article-summary/article-summary.types";
 import { initArticleReader } from "../../shared/article-reader/article-reader";
@@ -64,6 +65,14 @@ interface QueueDependencies {
 }
 
 import type { SavedArticle } from "../../../domain/article/article.types";
+
+async function loadSummaries(
+	findGeneratedSummary: FindGeneratedSummary,
+	articles: readonly SavedArticle[],
+): Promise<Map<string, GeneratedSummary | undefined>> {
+	const summaries = await Promise.all(articles.map((a) => findGeneratedSummary(a.url)));
+	return new Map(articles.map((a, i) => [a.url, summaries[i]] as const));
+}
 
 async function markUnreadIfRead(deps: Pick<QueueDependencies, "updateArticleStatus">, saved: SavedArticle): Promise<SavedArticle> {
 	if (saved.status === "read") {
@@ -188,7 +197,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			: (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
 		const totalArticles = (await deps.findArticlesByUser({ userId, page: 1, pageSize: 1 })).total;
 		const saveError = deps.httpErrorMessageMapping(req.query);
-		const vm = toQueueViewModel(result, urlState, { unreadCount, totalArticles, saveError });
+		const summaryByUrl = await loadSummaries(deps.findGeneratedSummary, result.articles);
+		const vm = toQueueViewModel(result, urlState, { unreadCount, totalArticles, saveError, summaryByUrl });
 		const extensionInstalled = req.cookies?.[COOKIE_NAME] === COOKIE_VALUE;
 		const onboardingDismissed = req.cookies?.[DISMISS_COOKIE_NAME] === ONBOARDING_VERSION;
 		const ua = req.headers["user-agent"] ?? "";
@@ -337,9 +347,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const urlState = parseQueueUrl({});
 			const result = await deps.findArticlesByUser({ userId });
 			const unreadCount = (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
+			const summaryByUrl = await loadSummaries(deps.findGeneratedSummary, result.articles);
 			const vm = toQueueViewModel(result, urlState, {
 				saveError: "Please enter a valid URL",
 				unreadCount,
+				summaryByUrl,
 			});
 			sendComponent(res, QueuePage(vm, { emailVerified: req.emailVerified, statusCode: 422 }));
 			return;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -70,8 +70,11 @@ async function loadSummaries(
 	findGeneratedSummary: FindGeneratedSummary,
 	articles: readonly SavedArticle[],
 ): Promise<Map<string, GeneratedSummary | undefined>> {
-	const summaries = await Promise.all(articles.map((a) => findGeneratedSummary(a.url)));
-	return new Map(articles.map((a, i) => [a.url, summaries[i]] as const));
+	const results = await Promise.allSettled(articles.map((a) => findGeneratedSummary(a.url)));
+	return new Map(articles.map((a, i) => {
+		const r = results[i];
+		return [a.url, r.status === "fulfilled" ? r.value : undefined] as const;
+	}));
 }
 
 async function markUnreadIfRead(deps: Pick<QueueDependencies, "updateArticleStatus">, saved: SavedArticle): Promise<SavedArticle> {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -5,6 +5,7 @@ import type {
 import { ReaderArticleHashId } from "../../../domain/article/reader-article-hash-id";
 import type { UserId } from "../../../domain/user/user.types";
 import type { FindArticlesResult } from "../../../providers/article-store/article-store.types";
+import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import { toQueueViewModel } from "./queue.viewmodel";
 
 const ARTICLE_URL = "https://example.com/post";
@@ -347,5 +348,41 @@ describe("toQueueViewModel", () => {
 		const vm = toQueueViewModel(makeResult([], 5), DEFAULT_FILTERS, { now: NOW });
 
 		expect(vm.totalArticles).toBe(5);
+	});
+
+	it("should replace metadata excerpt with the AI summary when status is ready", () => {
+		const article = makeArticle();
+		const summaryByUrl = new Map<string, GeneratedSummary | undefined>([
+			[ARTICLE_URL, { status: "ready", summary: "AI-generated summary." }],
+		]);
+		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, {
+			now: NOW,
+			summaryByUrl,
+		});
+
+		expect(vm.articles[0].excerpt).toBe("AI-generated summary.");
+	});
+
+	it("should fall back to the metadata excerpt when the summary is pending", () => {
+		const article = makeArticle();
+		const summaryByUrl = new Map<string, GeneratedSummary | undefined>([
+			[ARTICLE_URL, { status: "pending" }],
+		]);
+		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, {
+			now: NOW,
+			summaryByUrl,
+		});
+
+		expect(vm.articles[0].excerpt).toBe("An excerpt");
+	});
+
+	it("should fall back to the metadata excerpt when no summary record exists", () => {
+		const article = makeArticle();
+		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, {
+			now: NOW,
+			summaryByUrl: new Map(),
+		});
+
+		expect(vm.articles[0].excerpt).toBe("An excerpt");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -1,5 +1,7 @@
 import type { SavedArticle } from "../../../domain/article/article.types";
 import type { FindArticlesResult } from "../../../providers/article-store/article-store.types";
+import { pickExcerpt } from "../../../providers/article-summary/article-summary.helpers";
+import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import type { QueueUrlState } from "./queue.url";
 import { buildQueueUrl } from "./queue.url";
 
@@ -117,6 +119,7 @@ function toArticleViewModel(
 	article: SavedArticle,
 	now: Date,
 	returnQuery: string,
+	summary: GeneratedSummary | undefined,
 ): QueueArticleViewModel {
 	const readTime = article.estimatedReadTime;
 	const id = article.id.value;
@@ -124,7 +127,7 @@ function toArticleViewModel(
 		id,
 		title: article.metadata.title,
 		siteName: article.metadata.siteName,
-		excerpt: article.metadata.excerpt,
+		excerpt: pickExcerpt(summary, article.metadata.excerpt),
 		url: article.url,
 		readTimeLabel: `${readTime} min read`,
 		status: article.status,
@@ -139,7 +142,13 @@ function toArticleViewModel(
 export function toQueueViewModel(
 	result: FindArticlesResult,
 	filters: QueueUrlState,
-	options?: { now?: Date; saveError?: string; unreadCount?: number; totalArticles?: number },
+	options?: {
+		now?: Date;
+		saveError?: string;
+		unreadCount?: number;
+		totalArticles?: number;
+		summaryByUrl?: ReadonlyMap<string, GeneratedSummary | undefined>;
+	},
 ): QueueViewModel {
 	const now = options?.now ?? new Date();
 	const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize));
@@ -149,7 +158,9 @@ export function toQueueViewModel(
 	const returnQuery = queryIndex !== -1 ? queueUrl.slice(queryIndex) : "";
 
 	return {
-		articles: result.articles.map((a) => toArticleViewModel(a, now, returnQuery)),
+		articles: result.articles.map((a) =>
+			toArticleViewModel(a, now, returnQuery, options?.summaryByUrl?.get(a.url)),
+		),
 		filters,
 		isEmpty: result.total === 0,
 		totalPages,

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { SavedArticle } from "../../../domain/article/article.types";
 import type { ArticleCrawl } from "../../../providers/article-crawl/article-crawl.types";
+import { pickExcerpt, truncateForSeo } from "../../../providers/article-summary/article-summary.helpers";
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import { Base } from "../../base.component";
 import type { Component } from "../../component.types";
@@ -52,7 +53,7 @@ export function ReaderPage(
 	return Base({
 		seo: {
 			title: `${article.metadata.title} — Readplace Reader`,
-			description: article.metadata.excerpt,
+			description: truncateForSeo(pickExcerpt(options?.summary, article.metadata.excerpt)),
 			canonicalUrl: `/queue/${article.id.value}/read`,
 			robots: "noindex, nofollow",
 		},

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -5,6 +5,7 @@ import type {
 	Minutes,
 } from "../../../domain/article/article.types";
 import type { ArticleCrawl } from "../../../providers/article-crawl/article-crawl.types";
+import { pickExcerpt, truncateForSeo } from "../../../providers/article-summary/article-summary.helpers";
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import { requireEnv } from "../../../require-env";
 import { Base } from "../../base.component";
@@ -81,7 +82,9 @@ export function ViewPage(input: ViewPageInput): Component {
 	const ogImageAlt = input.metadata.imageUrl
 		? input.metadata.title
 		: DEFAULT_OG_ALT;
-	const description = input.metadata.excerpt || "View on Readplace.";
+	const description = truncateForSeo(
+		pickExcerpt(input.summary, input.metadata.excerpt) || "View on Readplace.",
+	);
 
 	const structuredData: Record<string, unknown> = {
 		"@context": "https://schema.org",


### PR DESCRIPTION
## Summary
This PR integrates AI-generated article summaries into the article display layer, allowing ready summaries to replace metadata excerpts while falling back gracefully when summaries are pending, failed, or unavailable.

## Key Changes
- **New helper functions** (`article-summary.helpers.ts`):
  - `pickExcerpt()`: Selects AI-generated summary when ready, otherwise returns fallback excerpt
  - `truncateForSeo()`: Truncates text to 160 characters (SEO description limit) with intelligent word-boundary breaking and ellipsis

- **Queue page integration**:
  - Added `loadSummaries()` helper to batch-load summaries for all articles in a page
  - Updated `toQueueViewModel()` to accept `summaryByUrl` map and pass summaries to article view models
  - Modified `toArticleViewModel()` to use `pickExcerpt()` for excerpt selection

- **Reader and View page updates**:
  - Both pages now use `pickExcerpt()` and `truncateForSeo()` for consistent summary handling
  - SEO descriptions are properly truncated to meet search engine limits

- **Comprehensive test coverage**:
  - Added 10 tests for helper functions covering all status states and edge cases
  - Added 3 integration tests in queue view model for summary fallback behavior

## Implementation Details
- Summaries are loaded asynchronously in parallel using `Promise.all()`
- Graceful fallback to metadata excerpts when summaries are undefined, pending, failed, or skipped
- Word-boundary truncation respects SEO limits while maintaining readability
- Hard-cut fallback for text without spaces (e.g., very long URLs)

https://claude.ai/code/session_01Hb2bybJqbSmfcePwNmHTfs