### PR TITLE
Separate authentication state from page body rendering

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -70,6 +70,7 @@ import { initBlogRoutes } from "./web/pages/blog";
 import { getAllPostMetadata } from "./web/pages/blog/blog.posts";
 import { initDualAuth, type ValidateAccessToken } from "./web/dual-auth.middleware";
 import { initOAuthRoutes } from "./web/oauth/oauth.routes";
+import { renderPage } from "./web/render-page";
 import { sendComponent } from "./web/send-component";
 import { wantsSiren } from "./web/content-negotiation";
 import { HomePage } from "./web/pages/home";
@@ -293,15 +294,15 @@ export function createApp(dependencies: AppDependencies): Express {
 			: ua.includes("Chrome/") ? "chrome"
 			: "other";
 		const userCount = await countUsers().catch(() => 0);
-		sendComponent(res, HomePage({ userCount, staticBaseUrl, browser }));
+		sendComponent(res, renderPage(req, HomePage({ userCount, staticBaseUrl, browser })));
 	});
 
-	app.get("/privacy", (_req: Request, res: Response) => {
-		sendComponent(res, PrivacyPage());
+	app.get("/privacy", (req: Request, res: Response) => {
+		sendComponent(res, renderPage(req, PrivacyPage()));
 	});
 
-	app.get("/terms", (_req: Request, res: Response) => {
-		sendComponent(res, TermsPage());
+	app.get("/terms", (req: Request, res: Response) => {
+		sendComponent(res, renderPage(req, TermsPage()));
 	});
 
 	// Path-uniqued article fixture for staging e2e tests. The :id segment is
@@ -312,8 +313,8 @@ export function createApp(dependencies: AppDependencies): Express {
 	// Lambda; tests (NODE_ENV=test via Jest) and local dev (NODE_ENV unset)
 	// both expose it.
 	if (getEnv("NODE_ENV") !== "production") {
-		app.get("/e2e/article/:id", (_req: Request, res: Response) => {
-			sendComponent(res, E2EFixturePage());
+		app.get("/e2e/article/:id", (req: Request, res: Response) => {
+			sendComponent(res, renderPage(req, E2EFixturePage()));
 		});
 	}
 
@@ -323,7 +324,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			fetchFirefoxDownloadUrl(),
 			fetchChromeDownloadUrl(),
 		]);
-		sendComponent(res, InstallPage({ firefox, chrome, browser }));
+		sendComponent(res, renderPage(req, InstallPage({ firefox, chrome, browser })));
 	});
 
 	const blogRouter = initBlogRoutes();
@@ -449,8 +450,8 @@ export function createApp(dependencies: AppDependencies): Express {
 	app.use("/oauth/revoke", extensionCors);
 	app.use("/oauth", oauthRouter);
 
-	app.use((_req: Request, res: Response) => {
-		sendComponent(res, NotFoundPage());
+	app.use((req: Request, res: Response) => {
+		sendComponent(res, renderPage(req, NotFoundPage()));
 	});
 
 	return app;

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../base.component";
-import type { Component } from "../component.types";
+import type { PageBody } from "../page-body.types";
 import { render } from "../render";
 import { renderFoundingProgress } from "../shared/founding-progress/founding-progress.component";
 import { AUTH_STYLES } from "./auth.styles";
@@ -41,7 +40,7 @@ function toFieldViewModel(
 	};
 }
 
-export function LoginPage(data: AuthFormData, options?: { statusCode?: number }): Component {
+export function LoginPage(data: AuthFormData, options?: { statusCode?: number }): PageBody {
 	const email = data.email ?? "";
 	const errors = data.errors;
 
@@ -57,7 +56,7 @@ export function LoginPage(data: AuthFormData, options?: { statusCode?: number })
 		}),
 	});
 
-	return Base({
+	return {
 		seo: {
 			title: "Sign in — Readplace",
 			description: "Sign in to your Readplace read-it-later account.",
@@ -67,13 +66,13 @@ export function LoginPage(data: AuthFormData, options?: { statusCode?: number })
 		bodyClass: "page-login",
 		content,
 		statusCode: options?.statusCode,
-	});
+	};
 }
 
-export function VerifyEmailPage(data: { success: boolean; error?: string }): Component {
+export function VerifyEmailPage(data: { success: boolean; error?: string }): PageBody {
 	const content = render(VERIFY_EMAIL_TEMPLATE, data);
 
-	return Base({
+	return {
 		seo: {
 			title: "Verify email — Readplace",
 			description: "Email verification for your Readplace account.",
@@ -84,10 +83,10 @@ export function VerifyEmailPage(data: { success: boolean; error?: string }): Com
 		bodyClass: "page-verify-email",
 		content,
 		statusCode: data.success ? 200 : 400,
-	});
+	};
 }
 
-export function SignupPage(data: AuthFormData, options?: { statusCode?: number }): Component {
+export function SignupPage(data: AuthFormData, options?: { statusCode?: number }): PageBody {
 	const email = data.email ?? "";
 	const errors = data.errors;
 
@@ -104,7 +103,7 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		}),
 	});
 
-	return Base({
+	return {
 		seo: {
 			title: "Sign up — Readplace",
 			description:
@@ -115,13 +114,13 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		bodyClass: "page-signup",
 		content,
 		statusCode: options?.statusCode,
-	});
+	};
 }
 
 export function ForgotPasswordPage(
 	data?: { email?: string; errors?: FieldError[]; globalError?: string; sent?: boolean },
 	options?: { statusCode?: number },
-): Component {
+): PageBody {
 	const email = data?.email ?? "";
 	const errors = data?.errors;
 
@@ -132,7 +131,7 @@ export function ForgotPasswordPage(
 		emailField: toFieldViewModel(errors, "email"),
 	});
 
-	return Base({
+	return {
 		seo: {
 			title: "Forgot password — Readplace",
 			description: "Reset your Readplace account password.",
@@ -143,13 +142,13 @@ export function ForgotPasswordPage(
 		bodyClass: "page-forgot-password",
 		content,
 		statusCode: options?.statusCode,
-	});
+	};
 }
 
 export function ResetPasswordPage(
 	data: { token?: string; errors?: FieldError[]; globalError?: string; success?: boolean; error?: string },
 	options?: { statusCode?: number },
-): Component {
+): PageBody {
 	const errors = data.errors;
 
 	const content = render(RESET_PASSWORD_TEMPLATE, {
@@ -161,7 +160,7 @@ export function ResetPasswordPage(
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
 	});
 
-	return Base({
+	return {
 		seo: {
 			title: "Reset password — Readplace",
 			description: "Set a new password for your Readplace account.",
@@ -172,5 +171,5 @@ export function ResetPasswordPage(
 		bodyClass: "page-reset-password",
 		content,
 		statusCode: options?.statusCode,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../providers/email-verification/email-verification.types";
 import { VerificationTokenSchema } from "../../providers/email-verification/email-verification.schema";
 import { z } from "zod";
+import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { LoginSchema, SignupSchema } from "./auth.schema";
 import { LoginPage, SignupPage, VerifyEmailPage } from "./auth.component";
@@ -60,7 +61,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 		const returnUrl = extractReturnUrl(req.query);
 		const userCount = await fetchUserCount();
-		sendComponent(res, LoginPage({ returnUrl, userCount }));
+		sendComponent(res, renderPage(req, LoginPage({ returnUrl, userCount })));
 	});
 
 	router.post("/login", async (req: Request, res: Response) => {
@@ -71,7 +72,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				res,
-				LoginPage(
+				renderPage(req, LoginPage(
 					{
 						returnUrl,
 						userCount,
@@ -79,7 +80,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						errors: flattenZodErrors(parsed.error.issues),
 					},
 					{ statusCode: 422 },
-				),
+				)),
 			);
 			return;
 		}
@@ -91,7 +92,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				res,
-				LoginPage(
+				renderPage(req, LoginPage(
 					{
 						returnUrl,
 						userCount,
@@ -99,7 +100,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						globalError: "Invalid email or password",
 					},
 					{ statusCode: 422 },
-				),
+				)),
 			);
 			return;
 		}
@@ -116,7 +117,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 		const returnUrl = extractReturnUrl(req.query);
 		const userCount = await fetchUserCount();
-		sendComponent(res, SignupPage({ returnUrl, userCount }));
+		sendComponent(res, renderPage(req, SignupPage({ returnUrl, userCount })));
 	});
 
 	router.post("/signup", async (req: Request, res: Response) => {
@@ -127,7 +128,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				res,
-				SignupPage(
+				renderPage(req, SignupPage(
 					{
 						returnUrl,
 						userCount,
@@ -135,7 +136,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						errors: flattenZodErrors(parsed.error.issues),
 					},
 					{ statusCode: 422 },
-				),
+				)),
 			);
 			return;
 		}
@@ -147,7 +148,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				res,
-				SignupPage(
+				renderPage(req, SignupPage(
 					{
 						returnUrl,
 						userCount,
@@ -155,7 +156,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						globalError: "An account with this email already exists",
 					},
 					{ statusCode: 422 },
-				),
+				)),
 			);
 			return;
 		}
@@ -188,10 +189,10 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!token) {
 			sendComponent(
 				res,
-				VerifyEmailPage({
+				renderPage(req, VerifyEmailPage({
 					success: false,
 					error: "No verification token provided.",
-				}),
+				})),
 			);
 			return;
 		}
@@ -201,10 +202,10 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!verifyResult.ok) {
 			sendComponent(
 				res,
-				VerifyEmailPage({
+				renderPage(req, VerifyEmailPage({
 					success: false,
 					error: "This verification link is invalid or has already been used.",
-				}),
+				})),
 			);
 			return;
 		}
@@ -216,7 +217,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			await deps.markSessionEmailVerified(sessionId);
 		}
 
-		sendComponent(res, VerifyEmailPage({ success: true }));
+		sendComponent(res, renderPage(req, VerifyEmailPage({ success: true })));
 	});
 
 	router.post("/logout", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../providers/password-reset/password-reset.types";
 import { PasswordResetTokenSchema } from "../../providers/password-reset/password-reset.schema";
 import { z } from "zod";
+import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { ForgotPasswordSchema, ResetPasswordSchema } from "./auth.schema";
 import { ForgotPasswordPage, ResetPasswordPage } from "./auth.component";
@@ -31,8 +32,8 @@ interface ForgotPasswordDependencies {
 export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Router {
 	const router = express.Router();
 
-	router.get("/forgot-password", (_req: Request, res: Response) => {
-		sendComponent(res, ForgotPasswordPage());
+	router.get("/forgot-password", (req: Request, res: Response) => {
+		sendComponent(res, renderPage(req, ForgotPasswordPage()));
 	});
 
 	router.post("/forgot-password", async (req: Request, res: Response) => {
@@ -41,20 +42,20 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 		if (!parsed.success) {
 			sendComponent(
 				res,
-				ForgotPasswordPage(
+				renderPage(req, ForgotPasswordPage(
 					{
 						email: req.body?.email,
 						errors: flattenZodErrors(parsed.error.issues),
 					},
 					{ statusCode: 422 },
-				),
+				)),
 			);
 			return;
 		}
 
 		const { email } = parsed.data;
 
-		sendComponent(res, ForgotPasswordPage({ sent: true }));
+		sendComponent(res, renderPage(req, ForgotPasswordPage({ sent: true })));
 
 		deps.userExistsByEmail(email)
 			.then(async (exists) => {
@@ -82,12 +83,12 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 		if (!token) {
 			sendComponent(
 				res,
-				ResetPasswordPage({ error: "No reset token provided." }, { statusCode: 400 }),
+				renderPage(req, ResetPasswordPage({ error: "No reset token provided." }, { statusCode: 400 })),
 			);
 			return;
 		}
 
-		sendComponent(res, ResetPasswordPage({ token }));
+		sendComponent(res, renderPage(req, ResetPasswordPage({ token })));
 	});
 
 	router.post("/reset-password", async (req: Request, res: Response) => {
@@ -97,7 +98,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 		if (!token) {
 			sendComponent(
 				res,
-				ResetPasswordPage({ error: "No reset token provided." }, { statusCode: 400 }),
+				renderPage(req, ResetPasswordPage({ error: "No reset token provided." }, { statusCode: 400 })),
 			);
 			return;
 		}
@@ -107,13 +108,13 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 		if (!parsed.success) {
 			sendComponent(
 				res,
-				ResetPasswordPage(
+				renderPage(req, ResetPasswordPage(
 					{
 						token,
 						errors: flattenZodErrors(parsed.error.issues),
 					},
 					{ statusCode: 422 },
-				),
+				)),
 			);
 			return;
 		}
@@ -123,17 +124,17 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 		if (!verifyResult.ok) {
 			sendComponent(
 				res,
-				ResetPasswordPage(
+				renderPage(req, ResetPasswordPage(
 					{ error: "This reset link is invalid or has already been used." },
 					{ statusCode: 400 },
-				),
+				)),
 			);
 			return;
 		}
 
 		await deps.updatePassword({ email: verifyResult.email, password: parsed.data.password });
 
-		sendComponent(res, ResetPasswordPage({ success: true }));
+		sendComponent(res, renderPage(req, ResetPasswordPage({ success: true })));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -13,6 +13,7 @@ import type {
 	MarkEmailVerified,
 } from "../../providers/auth/auth.types";
 import type { ExchangeGoogleCode } from "../../providers/google-auth/google-token.types";
+import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
 import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "./session-cookie";
@@ -102,7 +103,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 
 		const renderError = async (globalError: string) => {
 			const userCount = await fetchUserCount();
-			sendComponent(res, LoginPage({ userCount, globalError }, { statusCode: 400 }));
+			sendComponent(res, renderPage(req, LoginPage({ userCount, globalError }, { statusCode: 400 })));
 		};
 
 		if (!parsedQuery.success || !stateCookie || parsedQuery.data.state !== stateCookie) {

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -1,13 +1,18 @@
-import type { Request } from "express";
+import type { UserId } from "../domain/user/user.types";
+
+export interface BannerStateSource {
+	userId?: UserId;
+	emailVerified?: boolean;
+}
 
 export interface BannerState {
 	isAuthenticated: boolean;
 	emailVerified: boolean | undefined;
 }
 
-export function bannerStateFromRequest(req: Request): BannerState {
+export function bannerStateFromRequest(source: BannerStateSource): BannerState {
 	return {
-		isAuthenticated: Boolean(req.userId),
-		emailVerified: req.emailVerified,
+		isAuthenticated: Boolean(source.userId),
+		emailVerified: source.emailVerified,
 	};
 }

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -1,0 +1,13 @@
+import type { Request } from "express";
+
+export interface BannerState {
+	isAuthenticated: boolean;
+	emailVerified: boolean | undefined;
+}
+
+export function bannerStateFromRequest(req: Request): BannerState {
+	return {
+		isAuthenticated: Boolean(req.userId),
+		emailVerified: req.emailVerified,
+	};
+}

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -71,8 +71,9 @@ describe("Base component", () => {
 		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		expect(doc.querySelector('[data-test-nav-item="login"]')).not.toBeNull();
-		expect(doc.querySelector('[data-test-nav-item="queue"]')).toBeNull();
+		const nav = doc.querySelector("[data-test-nav-variant]");
+		assert(nav, "nav container must be rendered");
+		expect(nav.getAttribute("data-test-nav-variant")).toBe("guest");
 	});
 
 	it("should render authenticated navigation when state is authenticated", () => {
@@ -80,9 +81,9 @@ describe("Base component", () => {
 		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		expect(doc.querySelector('[data-test-nav-item="queue"]')).not.toBeNull();
-		expect(doc.querySelector('[data-test-nav-item="logout"]')).not.toBeNull();
-		expect(doc.querySelector('[data-test-nav-item="login"]')).toBeNull();
+		const nav = doc.querySelector("[data-test-nav-variant]");
+		assert(nav, "nav container must be rendered");
+		expect(nav.getAttribute("data-test-nav-variant")).toBe("authenticated");
 	});
 
 	it("should include the footer with copyright", () => {

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
-import { Base, type PageContent } from "./base.component";
+import { Base } from "./base.component";
+import type { BannerState } from "./banner-state";
 import type { SupportedMediaType } from "./component.types";
+import type { PageBody } from "./page-body.types";
 
-function createTestPageContent(overrides: Partial<PageContent> = {}): PageContent {
+function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
 	return {
 		seo: {
 			title: "Test Page",
@@ -16,10 +18,12 @@ function createTestPageContent(overrides: Partial<PageContent> = {}): PageConten
 	};
 }
 
+const GUEST_STATE: BannerState = { isAuthenticated: false, emailVerified: undefined };
+
 describe("Base component", () => {
 	it("should render a complete HTML page with the provided title", () => {
-		const page = createTestPageContent({ seo: { title: "My Title", description: "Desc", canonicalUrl: "https://readplace.com" } });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody({ seo: { title: "My Title", description: "Desc", canonicalUrl: "https://readplace.com" } });
+		const result = Base(page, GUEST_STATE).to("text/html");
 
 		expect(result.statusCode).toBe(200);
 		const doc = new JSDOM(result.body).window.document;
@@ -27,8 +31,8 @@ describe("Base component", () => {
 	});
 
 	it("should render the Readplace brand name in the header", () => {
-		const page = createTestPageContent();
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const brand = doc.querySelector(".header__brand") as HTMLAnchorElement;
@@ -37,8 +41,8 @@ describe("Base component", () => {
 	});
 
 	it("should include page content in the body", () => {
-		const page = createTestPageContent({ content: "<main><h1>Hello World</h1></main>" });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody({ content: "<main><h1>Hello World</h1></main>" });
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const heading = doc.querySelector("main h1");
@@ -46,25 +50,44 @@ describe("Base component", () => {
 	});
 
 	it("should apply bodyClass when provided", () => {
-		const page = createTestPageContent({ bodyClass: "page-home" });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody({ bodyClass: "page-home" });
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		expect(doc.body.classList.contains("page-home")).toBe(true);
 	});
 
 	it("should include navigation links", () => {
-		const page = createTestPageContent();
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const navLinks = doc.querySelectorAll(".nav__link");
 		expect(navLinks.length).toBeGreaterThan(0);
 	});
 
+	it("should render guest navigation when state is unauthenticated", () => {
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="login"]')).not.toBeNull();
+		expect(doc.querySelector('[data-test-nav-item="queue"]')).toBeNull();
+	});
+
+	it("should render authenticated navigation when state is authenticated", () => {
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="queue"]')).not.toBeNull();
+		expect(doc.querySelector('[data-test-nav-item="logout"]')).not.toBeNull();
+		expect(doc.querySelector('[data-test-nav-item="login"]')).toBeNull();
+	});
+
 	it("should include the footer with copyright", () => {
-		const page = createTestPageContent();
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const footer = doc.querySelector(".footer__copyright");
@@ -72,8 +95,8 @@ describe("Base component", () => {
 	});
 
 	it("should include the offline banner", () => {
-		const page = createTestPageContent();
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector(".offline-banner");
@@ -81,8 +104,8 @@ describe("Base component", () => {
 	});
 
 	it("should set meta description from seo", () => {
-		const page = createTestPageContent({ seo: { title: "T", description: "My desc", canonicalUrl: "https://readplace.com" } });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody({ seo: { title: "T", description: "My desc", canonicalUrl: "https://readplace.com" } });
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const meta = doc.querySelector('meta[name="description"]');
@@ -90,15 +113,15 @@ describe("Base component", () => {
 	});
 
 	it("should return 415 for unsupported media type", () => {
-		const page = createTestPageContent();
-		const result = Base(page).to("application/vnd.siren+json" as SupportedMediaType);
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("application/vnd.siren+json" as SupportedMediaType);
 
 		expect(result.statusCode).toBe(415);
 		expect(result.body).toBe("");
 	});
 
 	it("should render structured data when provided", () => {
-		const page = createTestPageContent({
+		const page = createTestPageBody({
 			seo: {
 				title: "T",
 				description: "D",
@@ -106,7 +129,7 @@ describe("Base component", () => {
 				structuredData: [{ "@context": "https://schema.org", "@type": "WebSite", name: "Readplace" }],
 			},
 		});
-		const result = Base(page).to("text/html");
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const ldJson = doc.querySelector('script[type="application/ld+json"]');
@@ -115,8 +138,8 @@ describe("Base component", () => {
 	});
 
 	it("should show verification banner when authenticated and email not verified", () => {
-		const page = createTestPageContent({ isAuthenticated: true, emailVerified: false });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -126,8 +149,8 @@ describe("Base component", () => {
 	});
 
 	it("should hide verification banner when email is verified", () => {
-		const page = createTestPageContent({ isAuthenticated: true, emailVerified: true });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -136,8 +159,8 @@ describe("Base component", () => {
 	});
 
 	it("should hide verification banner when not authenticated", () => {
-		const page = createTestPageContent({ isAuthenticated: false, emailVerified: false });
-		const result = Base(page).to("text/html");
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: false, emailVerified: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -145,9 +168,9 @@ describe("Base component", () => {
 		expect(banner.classList.contains("verify-banner--hidden")).toBe(true);
 	});
 
-	it("should hide verification banner when emailVerified is not provided", () => {
-		const page = createTestPageContent({ isAuthenticated: true });
-		const result = Base(page).to("text/html");
+	it("should hide verification banner when emailVerified is undefined", () => {
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: undefined }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -156,10 +179,10 @@ describe("Base component", () => {
 	});
 
 	it("should rewrite relative canonical URLs to absolute readplace.com URLs", () => {
-		const page = createTestPageContent({
+		const page = createTestPageBody({
 			seo: { title: "T", description: "D", canonicalUrl: "/login" },
 		});
-		const result = Base(page).to("text/html");
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		expect(
@@ -173,14 +196,14 @@ describe("Base component", () => {
 	});
 
 	it("should leave absolute readplace.com canonical URLs unchanged", () => {
-		const page = createTestPageContent({
+		const page = createTestPageBody({
 			seo: {
 				title: "T",
 				description: "D",
 				canonicalUrl: "https://readplace.com/blog/my-post",
 			},
 		});
-		const result = Base(page).to("text/html");
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		expect(
@@ -189,14 +212,14 @@ describe("Base component", () => {
 	});
 
 	it("should rewrite non-readplace hosts to readplace.com in canonical URLs", () => {
-		const page = createTestPageContent({
+		const page = createTestPageBody({
 			seo: {
 				title: "T",
 				description: "D",
 				canonicalUrl: "https://hutch-app.com/queue",
 			},
 		});
-		const result = Base(page).to("text/html");
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		expect(
@@ -205,14 +228,14 @@ describe("Base component", () => {
 	});
 
 	it("should preserve query string when normalizing canonical URLs", () => {
-		const page = createTestPageContent({
+		const page = createTestPageBody({
 			seo: {
 				title: "T",
 				description: "D",
 				canonicalUrl: "/install?browser=firefox",
 			},
 		});
-		const result = Base(page).to("text/html");
+		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		expect(

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -11,42 +11,18 @@ import {
 	VERIFY_BANNER_STYLES,
 	UTILITY_STYLES,
 } from "./base.styles";
+import type { BannerState } from "./banner-state";
 import type { Component } from "./component.types";
 import { HtmlPage } from "./html-page";
+import type { PageBody, SeoMetadata } from "./page-body.types";
 import { render } from "./render";
 import { getEnv, requireEnv } from "../require-env";
+
+export type { SeoMetadata } from "./page-body.types";
 
 const HEADER_TEMPLATE = readFileSync(join(__dirname, "header.template.html"), "utf-8");
 const FOOTER_TEMPLATE = readFileSync(join(__dirname, "footer.template.html"), "utf-8");
 const BASE_TEMPLATE = readFileSync(join(__dirname, "base.template.html"), "utf-8");
-
-export interface SeoMetadata {
-	title: string;
-	description: string;
-	canonicalUrl: string;
-	ogImage?: string;
-	ogImageAlt?: string;
-	ogImageType?: string;
-	twitterImage?: string;
-	twitterSite?: string;
-	ogType?: "website" | "article";
-	robots?: string;
-	author?: string;
-	keywords?: string;
-	structuredData?: object[];
-}
-
-export interface PageContent {
-	seo: SeoMetadata;
-	styles: string;
-	headerVariant?: "default" | "transparent";
-	bodyClass?: string;
-	content: string;
-	scripts?: string;
-	isAuthenticated?: boolean;
-	emailVerified?: boolean;
-	statusCode?: number;
-}
 
 function renderHeader(
 	variant: "default" | "transparent",
@@ -168,9 +144,9 @@ function renderStructuredData(data: object[] | undefined): string {
 		.join("\n  ");
 }
 
-function renderBaseTemplate(page: PageContent): string {
-	const headerVariant = page.headerVariant || "default";
-	const seo = page.seo;
+function renderBaseTemplate(body: PageBody, state: BannerState): string {
+	const headerVariant = body.headerVariant || "default";
+	const seo: SeoMetadata = body.seo;
 
 	const ogType = seo.ogType || "website";
 	const robots = seo.robots || "index, follow";
@@ -199,18 +175,18 @@ function renderBaseTemplate(page: PageContent): string {
 		footerStyles: FOOTER_STYLES,
 		offlineBannerStyles: OFFLINE_BANNER_STYLES,
 		verifyBannerStyles: VERIFY_BANNER_STYLES,
-		showVerificationBanner: page.isAuthenticated === true && page.emailVerified === false,
-		pageStyles: page.styles,
-		bodyClass: page.bodyClass,
-		header: renderHeader(headerVariant, page.isAuthenticated ?? false),
-		content: page.content,
+		showVerificationBanner: state.isAuthenticated && state.emailVerified === false,
+		pageStyles: body.styles,
+		bodyClass: body.bodyClass,
+		header: renderHeader(headerVariant, state.isAuthenticated),
+		content: body.content,
 		footer: renderFooter(),
 		navScript: NAV_SCRIPT,
 		offlineScript: OFFLINE_INDICATOR_SCRIPT,
-		scripts: HTMX_SCRIPTS + (page.scripts ?? "") + LIVERELOAD_SCRIPT,
+		scripts: HTMX_SCRIPTS + (body.scripts ?? "") + LIVERELOAD_SCRIPT,
 	});
 }
 
-export function Base(page: PageContent): Component {
-	return HtmlPage(renderBaseTemplate(page), page.statusCode);
+export function Base(body: PageBody, state: BannerState): Component {
+	return HtmlPage(renderBaseTemplate(body, state), body.statusCode);
 }

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -18,8 +18,6 @@ import type { PageBody, SeoMetadata } from "./page-body.types";
 import { render } from "./render";
 import { getEnv, requireEnv } from "../require-env";
 
-export type { SeoMetadata } from "./page-body.types";
-
 const HEADER_TEMPLATE = readFileSync(join(__dirname, "header.template.html"), "utf-8");
 const FOOTER_TEMPLATE = readFileSync(join(__dirname, "footer.template.html"), "utf-8");
 const BASE_TEMPLATE = readFileSync(join(__dirname, "base.template.html"), "utf-8");

--- a/projects/hutch/src/runtime/web/header.template.html
+++ b/projects/hutch/src/runtime/web/header.template.html
@@ -8,7 +8,7 @@
           <span class="nav__toggle-bar"></span>
         </button>
         <div id="nav-menu" class="nav__menu">
-          <ul class="nav__list">
+          <ul class="nav__list" data-test-nav-variant="{{#if isAuthenticated}}authenticated{{else}}guest{{/if}}">
             {{#if isAuthenticated}}
             <li><a href="/queue" class="nav__link" data-test-nav-item="queue">Queue</a></li>
             <li><a href="/export" class="nav__link" data-test-nav-item="export">Export</a></li>

--- a/projects/hutch/src/runtime/web/oauth/oauth.component.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../base.component";
-import type { Component } from "../component.types";
+import type { PageBody } from "../page-body.types";
 import { render } from "../render";
 
 const OAUTH_AUTHORIZE_TEMPLATE = readFileSync(join(__dirname, "oauth-authorize.template.html"), "utf-8");
@@ -13,7 +12,6 @@ interface AuthorizePageParams {
 	redirectUri: string;
 	codeChallenge: string;
 	state?: string;
-	emailVerified?: boolean;
 }
 
 const OAUTH_AUTHORIZE_STYLES = `
@@ -87,10 +85,10 @@ const OAUTH_CALLBACK_STYLES = `
 }
 `;
 
-export function OAuthAuthorizePage(params: AuthorizePageParams): Component {
+export function OAuthAuthorizePage(params: AuthorizePageParams): PageBody {
 	const content = render(OAUTH_AUTHORIZE_TEMPLATE, params);
 
-	return Base({
+	return {
 		seo: {
 			title: `Authorize ${params.clientName} — Readplace`,
 			description: `${params.clientName} is requesting access to your Readplace account.`,
@@ -100,13 +98,11 @@ export function OAuthAuthorizePage(params: AuthorizePageParams): Component {
 		styles: OAUTH_AUTHORIZE_STYLES,
 		bodyClass: "page-oauth-authorize",
 		content,
-		isAuthenticated: true,
-		emailVerified: params.emailVerified,
-	});
+	};
 }
 
-export function OAuthCallbackPage(options?: { emailVerified?: boolean }): Component {
-	return Base({
+export function OAuthCallbackPage(): PageBody {
+	return {
 		seo: {
 			title: "Authorization Complete — Readplace",
 			description: "OAuth authorization is complete.",
@@ -116,7 +112,5 @@ export function OAuthCallbackPage(options?: { emailVerified?: boolean }): Compon
 		styles: OAUTH_CALLBACK_STYLES,
 		bodyClass: "page-oauth-callback",
 		content: render(OAUTH_CALLBACK_TEMPLATE, {}),
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../../test-app-fakes";
 
 import type { UserId } from "../../domain/user/user.types";
-import { OAuthAuthorizePage, OAuthCallbackPage } from "./oauth.component";
 
 function generatePKCE() {
 	const verifier = randomBytes(32).toString("base64url");
@@ -20,30 +19,6 @@ function generatePKCE() {
 const TEST_USER_ID = "test-user-123" as UserId;
 const TEST_CLIENT_ID = "hutch-firefox-extension";
 const TEST_REDIRECT_URI = "http://127.0.0.1:3000/oauth/callback";
-
-describe("OAuthAuthorizePage", () => {
-	it("returns 415 for unsupported media type", () => {
-		const component = OAuthAuthorizePage({
-			clientName: "Test App",
-			clientId: "test-client",
-			redirectUri: "http://localhost/callback",
-			codeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-		});
-		const result = component.to("application/vnd.siren+json");
-
-		expect(result.statusCode).toBe(415);
-		expect(result.body).toBe("");
-	});
-});
-
-describe("OAuthCallbackPage", () => {
-	it("returns 415 for unsupported media type", () => {
-		const result = OAuthCallbackPage().to("application/vnd.siren+json");
-
-		expect(result.statusCode).toBe(415);
-		expect(result.body).toBe("");
-	});
-});
 
 describe("OAuth routes", () => {
 	describe("GET /oauth/authorize", () => {

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import ExpressOAuthServer from "@node-oauth/express-oauth-server";
 import type { OAuthModel } from "../../providers/oauth/oauth-model";
 import { getClient, validateRedirectUri } from "../../providers/oauth/oauth-clients";
+import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { OAuthAuthorizePage, OAuthCallbackPage } from "./oauth.component";
 
@@ -75,14 +76,13 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 
 		sendComponent(
 			res,
-			OAuthAuthorizePage({
+			renderPage(req, OAuthAuthorizePage({
 				clientName: client.name,
 				clientId: client_id,
 				redirectUri: redirect_uri,
 				codeChallenge: parsed.data.code_challenge,
 				state,
-				emailVerified: req.emailVerified,
-			}),
+			})),
 		);
 	});
 
@@ -163,7 +163,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 	});
 
 	router.get("/callback", (req: Request, res: Response) => {
-		sendComponent(res, OAuthCallbackPage({ emailVerified: req.emailVerified }));
+		sendComponent(res, renderPage(req, OAuthCallbackPage()));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/page-body.types.ts
+++ b/projects/hutch/src/runtime/web/page-body.types.ts
@@ -1,0 +1,25 @@
+export interface SeoMetadata {
+	title: string;
+	description: string;
+	canonicalUrl: string;
+	ogImage?: string;
+	ogImageAlt?: string;
+	ogImageType?: string;
+	twitterImage?: string;
+	twitterSite?: string;
+	ogType?: "website" | "article";
+	robots?: string;
+	author?: string;
+	keywords?: string;
+	structuredData?: object[];
+}
+
+export interface PageBody {
+	seo: SeoMetadata;
+	styles: string;
+	headerVariant?: "default" | "transparent";
+	bodyClass?: string;
+	content: string;
+	scripts?: string;
+	statusCode?: number;
+}

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl-landing.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl-landing.component.ts
@@ -1,14 +1,11 @@
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { RECRAWL_STYLES } from "./recrawl.styles";
 
 /**
  * Minimal landing for the operator. Submits a URL to /admin/recrawl which
  * redirects to /admin/recrawl/:url and triggers a fresh crawl on every hit.
  */
-export function AdminRecrawlLandingPage(input: {
-	isAuthenticated: boolean;
-}): Component {
+export function AdminRecrawlLandingPage(): PageBody {
 	const content = `
     <main class="admin-recrawl" data-test-admin-recrawl-landing>
       <h1>Admin recrawl</h1>
@@ -26,7 +23,7 @@ export function AdminRecrawlLandingPage(input: {
       </form>
     </main>`;
 
-	return Base({
+	return {
 		seo: {
 			title: "Admin recrawl | Readplace",
 			description: "Operator endpoint. Not for public consumption.",
@@ -36,6 +33,5 @@ export function AdminRecrawlLandingPage(input: {
 		styles: RECRAWL_STYLES,
 		bodyClass: "page-admin-recrawl",
 		content,
-		isAuthenticated: input.isAuthenticated,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
@@ -4,8 +4,7 @@ import type {
 } from "../../../domain/article/article.types";
 import type { ArticleCrawl } from "../../../providers/article-crawl/article-crawl.types";
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { renderArticleBody } from "../../shared/article-body/article-body.component";
 import { RECRAWL_STYLES } from "./recrawl.styles";
 
@@ -19,7 +18,6 @@ export interface AdminRecrawlPageInput {
 	summary?: GeneratedSummary;
 	summaryPollUrl?: string;
 	contentSourceTier?: "tier-0" | "tier-1";
-	isAuthenticated: boolean;
 }
 
 /**
@@ -35,7 +33,7 @@ export interface AdminRecrawlPageInput {
  * Rows written before the selector existed have no `contentSourceTier`
  * column and surface as "(legacy)".
  */
-export function AdminRecrawlPage(input: AdminRecrawlPageInput): Component {
+export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 	const innerContent = renderArticleBody({
 		title: input.metadata.title,
 		siteName: input.metadata.siteName,
@@ -52,7 +50,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): Component {
 	const tierBadge = renderTierBadge(input.contentSourceTier);
 	const content = `<main class="admin-recrawl" data-test-admin-recrawl>${tierBadge}<article class="admin-recrawl__body">${innerContent}</article></main>`;
 
-	return Base({
+	return {
 		seo: {
 			title: `Admin recrawl: ${input.metadata.title}`,
 			description: "Operator recrawl view. Not for public consumption.",
@@ -62,8 +60,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): Component {
 		styles: RECRAWL_STYLES,
 		bodyClass: "page-admin-recrawl",
 		content,
-		isAuthenticated: input.isAuthenticated,
-	});
+	};
 }
 
 function renderTierBadge(tier: "tier-0" | "tier-1" | undefined): string {

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../../providers/article-summary/article-summary.types";
 import type { PublishSaveAnonymousLink } from "../../../providers/events/publish-save-anonymous-link.types";
 import type { FindUserByEmail } from "../../../providers/auth/auth.types";
+import { renderPage } from "../../render-page";
 import { initArticleReader } from "../../shared/article-reader/article-reader";
 import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.types";
 import { SaveErrorPage } from "../save/save-error.component";
@@ -52,11 +53,11 @@ function noStore(_req: Request, res: Response, next: NextFunction): void {
 	next();
 }
 
-function renderNotFound(res: Response) {
-	const html = SaveErrorPage({
+function renderNotFound(req: Request, res: Response) {
+	const html = renderPage(req, SaveErrorPage({
 		redirectUrl: "/admin/recrawl",
 		linkLabel: "Back to recrawl",
-	}).to("text/html");
+	})).to("text/html");
 	res.status(404).type("html").send(html.body);
 }
 
@@ -64,15 +65,13 @@ function handleLanding(req: Request, res: Response): void {
 	const submittedUrl =
 		typeof req.query.url === "string" ? req.query.url : undefined;
 	if (submittedUrl === undefined) {
-		const html = AdminRecrawlLandingPage({
-			isAuthenticated: Boolean(req.userId),
-		}).to("text/html");
+		const html = renderPage(req, AdminRecrawlLandingPage()).to("text/html");
 		res.status(html.statusCode).type("html").send(html.body);
 		return;
 	}
 	const parsed = RecrawlUrlSchema.safeParse(submittedUrl);
 	if (!parsed.success) {
-		renderNotFound(res);
+		renderNotFound(req, res);
 		return;
 	}
 	res.redirect(302, `/admin/recrawl/${encodeURIComponent(parsed.data)}`);
@@ -92,7 +91,7 @@ function handleRecrawlArticle(
 		const normalizedUrl = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
 		const parsed = RecrawlUrlSchema.safeParse(normalizedUrl);
 		if (!parsed.success) {
-			renderNotFound(res);
+			renderNotFound(req, res);
 			return;
 		}
 		const articleUrl = parsed.data;
@@ -101,7 +100,7 @@ function handleRecrawlArticle(
 		if (!existing) {
 			// The endpoint is explicitly for human intervention on an existing
 			// saved URL. Do not create a stub; surface 404.
-			renderNotFound(res);
+			renderNotFound(req, res);
 			return;
 		}
 
@@ -121,7 +120,7 @@ function handleRecrawlArticle(
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 		});
 
-		const html = AdminRecrawlPage({
+		const html = renderPage(req, AdminRecrawlPage({
 			articleUrl,
 			metadata: existing.metadata,
 			estimatedReadTime: existing.estimatedReadTime,
@@ -131,8 +130,7 @@ function handleRecrawlArticle(
 			summary: state.summary,
 			summaryPollUrl: state.summaryPollUrl,
 			contentSourceTier: existing.contentSourceTier,
-			isAuthenticated: Boolean(req.userId),
-		}).to("text/html");
+		})).to("text/html");
 		assert(
 			state.crawl?.status === "pending",
 			"force-pending + resolveReaderState must leave the crawl in 'pending'",

--- a/projects/hutch/src/runtime/web/pages/blog/blog-index.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-index.component.ts
@@ -1,15 +1,14 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { BLOG_STYLES } from "./blog.styles";
 import type { BlogPost } from "./blog.posts";
 
 const BLOG_INDEX_TEMPLATE = readFileSync(join(__dirname, "blog-index.template.html"), "utf-8");
 
-export function BlogIndexPage(params: { posts: BlogPost[] }): Component {
-	return Base({
+export function BlogIndexPage(params: { posts: BlogPost[] }): PageBody {
+	return {
 		seo: {
 			title: "Blog — Readplace",
 			description:
@@ -20,5 +19,5 @@ export function BlogIndexPage(params: { posts: BlogPost[] }): Component {
 		styles: BLOG_STYLES,
 		bodyClass: "page-blog",
 		content: render(BLOG_INDEX_TEMPLATE, { posts: params.posts }),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
@@ -1,17 +1,16 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { BLOG_STYLES } from "./blog.styles";
 import type { BlogPost } from "./blog.posts";
 
 const BLOG_POST_TEMPLATE = readFileSync(join(__dirname, "blog-post.template.html"), "utf-8");
 
-export function BlogPostPage(params: { post: BlogPost }): Component {
+export function BlogPostPage(params: { post: BlogPost }): PageBody {
 	const { post } = params;
 
-	return Base({
+	return {
 		seo: {
 			title: `${post.title} — Readplace Blog`,
 			description: post.description,
@@ -54,5 +53,5 @@ export function BlogPostPage(params: { post: BlogPost }): Component {
 			author: post.author,
 			htmlContent: post.htmlContent,
 		}),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, Router } from "express";
 import express from "express";
+import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { BlogIndexPage } from "./blog-index.component";
 import { BlogPostPage } from "./blog-post.component";
@@ -9,18 +10,18 @@ import { getAllPosts, findPostBySlug } from "./blog.posts";
 export function initBlogRoutes(): Router {
 	const router = express.Router();
 
-	router.get("/", (_req: Request, res: Response) => {
+	router.get("/", (req: Request, res: Response) => {
 		const posts = getAllPosts();
-		sendComponent(res, BlogIndexPage({ posts }));
+		sendComponent(res, renderPage(req, BlogIndexPage({ posts })));
 	});
 
 	router.get("/:slug", (req: Request, res: Response) => {
 		const post = findPostBySlug(req.params.slug);
 		if (!post) {
-			sendComponent(res, NotFoundPage());
+			sendComponent(res, renderPage(req, NotFoundPage()));
 			return;
 		}
-		sendComponent(res, BlogPostPage({ post }));
+		sendComponent(res, renderPage(req, BlogPostPage({ post })));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/e2e-fixture/e2e-fixture.component.ts
+++ b/projects/hutch/src/runtime/web/pages/e2e-fixture/e2e-fixture.component.ts
@@ -1,13 +1,12 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 
 const TEMPLATE = readFileSync(join(__dirname, "e2e-fixture.template.html"), "utf-8");
 
-export function E2EFixturePage(): Component {
-	return Base({
+export function E2EFixturePage(): PageBody {
+	return {
 		seo: {
 			title: "Readplace E2E test fixture article",
 			description: "Static fixture used by Readplace's end-to-end tests against staging.",
@@ -16,5 +15,5 @@ export function E2EFixturePage(): Component {
 		},
 		styles: "",
 		content: render(TEMPLATE, {}),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/export/export.component.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.component.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { EXPORT_STYLES } from "./export.styles";
 
 const EXPORT_TEMPLATE = readFileSync(join(__dirname, "export.template.html"), "utf-8");
 
-export function ExportPage(options?: { emailVerified?: boolean }): Component {
-	return Base({
+export function ExportPage(): PageBody {
+	return {
 		seo: {
 			title: "Export Your Data — Readplace",
 			description: "Download all your saved articles and data from Readplace.",
@@ -18,7 +17,5 @@ export function ExportPage(options?: { emailVerified?: boolean }): Component {
 		styles: EXPORT_STYLES,
 		bodyClass: "page-export",
 		content: render(EXPORT_TEMPLATE, {}),
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/export/export.page.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.page.ts
@@ -4,6 +4,7 @@ import express from "express";
 import type { FindArticlesByUser } from "../../../providers/article-store/article-store.types";
 import type { SavedArticle } from "../../../domain/article/article.types";
 import type { UserId } from "../../../domain/user/user.types";
+import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { ExportPage } from "./export.component";
 
@@ -52,7 +53,7 @@ export function initExportRoutes(deps: ExportDependencies): Router {
 	const router = express.Router();
 
 	router.get("/", (req: Request, res: Response) => {
-		sendComponent(res, ExportPage({ emailVerified: req.emailVerified }));
+		sendComponent(res, renderPage(req, ExportPage()));
 	});
 
 	router.get("/download", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { switchHelpers } from "../../handlebars-switch";
 import { renderFoundingProgress } from "../../shared/founding-progress/founding-progress.component";
@@ -100,10 +99,10 @@ const HOME_SCROLL_HINT_SCRIPT = `<script>
 })();
 </script>`;
 
-export function HomePage(params: { userCount: number; staticBaseUrl: string; browser: "firefox" | "chrome" | "other" }): Component {
+export function HomePage(params: { userCount: number; staticBaseUrl: string; browser: "firefox" | "chrome" | "other" }): PageBody {
 	const { userCount, staticBaseUrl, browser } = params;
 	const foundingProgressHtml = renderFoundingProgress({ userCount });
-	return Base({
+	return {
 		seo: {
 			title: "Readplace — Read-It-Later App | Save Articles, Read Them Later",
 			description:
@@ -352,5 +351,5 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 				},
 			],
 		}, { helpers: switchHelpers }),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { switchHelpers } from "../../handlebars-switch";
 import { INSTALL_PAGE_STYLES } from "./install.styles";
@@ -29,8 +28,8 @@ export async function fetchChromeDownloadUrl(): Promise<string | null> {
 	return CHROME_WEB_STORE_URL;
 }
 
-export function InstallPage(params: { firefox: string | null; chrome: string | null; browser: "firefox" | "chrome" }): Component {
-	return Base({
+export function InstallPage(params: { firefox: string | null; chrome: string | null; browser: "firefox" | "chrome" }): PageBody {
+	return {
 		seo: {
 			title: "Install Readplace Browser Extension",
 			description:
@@ -44,5 +43,5 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 			firefoxDownloadUrl: params.firefox,
 			chromeDownloadUrl: params.chrome,
 		}, { helpers: switchHelpers }),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/not-found/not-found.component.ts
+++ b/projects/hutch/src/runtime/web/pages/not-found/not-found.component.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { NOT_FOUND_STYLES } from "./not-found.styles";
 
 const NOT_FOUND_TEMPLATE = readFileSync(join(__dirname, "not-found.template.html"), "utf-8");
 
-export function NotFoundPage(): Component {
-	return Base({
+export function NotFoundPage(): PageBody {
+	return {
 		seo: {
 			title: "Page Not Found — Readplace",
 			description: "The page you are looking for does not exist.",
@@ -19,5 +18,5 @@ export function NotFoundPage(): Component {
 		bodyClass: "page-not-found",
 		content: render(NOT_FOUND_TEMPLATE, {}),
 		statusCode: 404,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/privacy/privacy.component.ts
+++ b/projects/hutch/src/runtime/web/pages/privacy/privacy.component.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { LEGAL_PAGE_STYLES } from "./privacy.styles";
 
 const PRIVACY_TEMPLATE = readFileSync(join(__dirname, "privacy.template.html"), "utf-8");
 
-export function PrivacyPage(): Component {
-	return Base({
+export function PrivacyPage(): PageBody {
+	return {
 		seo: {
 			title: "Privacy Policy — Readplace",
 			description:
@@ -19,5 +18,5 @@ export function PrivacyPage(): Component {
 		styles: LEGAL_PAGE_STYLES,
 		bodyClass: "page-privacy",
 		content: render(PRIVACY_TEMPLATE, {}),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
 import { OnboardingChecklist, ONBOARDING_STYLES } from "../../onboarding/onboarding.component";
 import type { BrowserName } from "../../onboarding/onboarding.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { QUEUE_STYLES } from "./queue.styles";
 import type { ArticleAction, QueueArticleViewModel, QueueViewModel } from "./queue.viewmodel";
@@ -128,12 +127,12 @@ const AUTO_SUBMIT_SCRIPT = `
 </script>
 `;
 
-export function QueuePage(vm: QueueViewModel, options?: { emailVerified?: boolean; saveUrl?: string; extensionInstalled?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; statusCode?: number }): Component {
+export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; statusCode?: number }): PageBody {
 	const saveUrl = options?.saveUrl;
 	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false });
 	const content = render(QUEUE_TEMPLATE, { ...displayModel, saveUrl });
 
-	return Base({
+	return {
 		seo: {
 			title: "My Queue — Readplace",
 			description: "Your saved articles reading queue.",
@@ -144,8 +143,6 @@ export function QueuePage(vm: QueueViewModel, options?: { emailVerified?: boolea
 		bodyClass: "page-queue",
 		content,
 		scripts: saveUrl ? AUTO_SUBMIT_SCRIPT : undefined,
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
 		statusCode: options?.statusCode,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -30,6 +30,7 @@ import type { PublishLinkSaved } from "../../../providers/events/publish-link-sa
 import type { PublishSaveLinkRawHtmlCommand } from "../../../providers/events/publish-save-link-raw-html-command.types";
 import type { PutPendingHtml } from "../../../providers/pending-html/pending-html.types";
 import type { UserId } from "../../../domain/user/user.types";
+import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { wantsSiren } from "../../content-negotiation";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
@@ -195,7 +196,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const browser = ua.includes("Firefox/") ? "firefox" as const : ua.includes("Chrome/") ? "chrome" as const : "other" as const;
 		sendComponent(
 			res,
-			QueuePage(vm, { emailVerified: req.emailVerified, saveUrl: filterUrl, extensionInstalled, browser, onboardingDismissed }),
+			renderPage(req, QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, browser, onboardingDismissed })),
 		);
 	});
 
@@ -341,7 +342,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				saveError: "Please enter a valid URL",
 				unreadCount,
 			});
-			sendComponent(res, QueuePage(vm, { emailVerified: req.emailVerified, statusCode: 422 }));
+			sendComponent(res, renderPage(req, QueuePage(vm, { statusCode: 422 })));
 			return;
 		}
 
@@ -393,14 +394,13 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 		sendComponent(
 			res,
-			ReaderPage({ ...article, content: state.content }, {
-				emailVerified: req.emailVerified,
+			renderPage(req, ReaderPage({ ...article, content: state.content }, {
 				summary: state.summary,
 				summaryPollUrl: state.summaryPollUrl,
 				crawl: state.crawl,
 				readerPollUrl: state.readerPollUrl,
 				audioEnabled,
-			}),
+			})),
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -3,8 +3,7 @@ import { join } from "node:path";
 import type { SavedArticle } from "../../../domain/article/article.types";
 import type { ArticleCrawl } from "../../../providers/article-crawl/article-crawl.types";
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { renderArticleBody } from "../../shared/article-body/article-body.component";
 import {
@@ -20,14 +19,13 @@ const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "u
 export function ReaderPage(
 	article: SavedArticle,
 	options?: {
-		emailVerified?: boolean;
 		summary?: GeneratedSummary;
 		summaryPollUrl?: string;
 		crawl?: ArticleCrawl;
 		readerPollUrl?: string;
 		audioEnabled?: boolean;
 	},
-): Component {
+): PageBody {
 	const innerContent = renderArticleBody({
 		title: article.metadata.title,
 		siteName: article.metadata.siteName,
@@ -49,7 +47,7 @@ export function ReaderPage(
 	});
 	const content = render(READER_TEMPLATE, { innerContent, shareBalloon });
 
-	return Base({
+	return {
 		seo: {
 			title: `${article.metadata.title} — Readplace Reader`,
 			description: article.metadata.excerpt,
@@ -60,7 +58,5 @@ export function ReaderPage(
 		bodyClass: "page-reader",
 		content,
 		scripts: SHARE_BALLOON_SCRIPT,
-		isAuthenticated: true,
-		emailVerified: options?.emailVerified,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/save/save-error.component.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-error.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { SAVE_ERROR_STYLES } from "./save-error.styles";
 
@@ -22,8 +21,8 @@ const COUNTDOWN_SCRIPT = `<script>
 })();
 </script>`;
 
-export function SaveErrorPage(input: { redirectUrl: string; linkLabel: string }): Component {
-	return Base({
+export function SaveErrorPage(input: { redirectUrl: string; linkLabel: string }): PageBody {
+	return {
 		seo: {
 			title: "No URL provided — Readplace",
 			description: "The save link is missing a URL parameter.",
@@ -39,5 +38,5 @@ export function SaveErrorPage(input: { redirectUrl: string; linkLabel: string })
 			linkLabel: input.linkLabel,
 		}),
 		scripts: COUNTDOWN_SCRIPT,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/save/save.page.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.page.ts
@@ -1,6 +1,7 @@
 import type { Router } from "express";
 import express from "express";
 import { z } from "zod";
+import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "./save-error.component";
@@ -22,7 +23,7 @@ export function initSaveRoutes(): Router {
 		if (!url) {
 			const redirectUrl = req.userId ? "/queue" : "/";
 			const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
-			sendComponent(res, SaveErrorPage({ redirectUrl, linkLabel }));
+			sendComponent(res, renderPage(req, SaveErrorPage({ redirectUrl, linkLabel })));
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/terms/terms.component.ts
+++ b/projects/hutch/src/runtime/web/pages/terms/terms.component.ts
@@ -1,14 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { LEGAL_PAGE_STYLES } from "../privacy/privacy.styles";
 
 const TERMS_TEMPLATE = readFileSync(join(__dirname, "terms.template.html"), "utf-8");
 
-export function TermsPage(): Component {
-	return Base({
+export function TermsPage(): PageBody {
+	return {
 		seo: {
 			title: "Terms of Service — Readplace",
 			description:
@@ -19,5 +18,5 @@ export function TermsPage(): Component {
 		styles: LEGAL_PAGE_STYLES,
 		bodyClass: "page-terms",
 		content: render(TERMS_TEMPLATE, {}),
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view-landing.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-landing.component.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { VIEW_LANDING_STYLES } from "./view-landing.styles";
 
@@ -10,12 +9,8 @@ const VIEW_LANDING_TEMPLATE = readFileSync(
 	"utf-8",
 );
 
-export interface ViewLandingPageInput {
-	isAuthenticated: boolean;
-}
-
-export function ViewLandingPage(input: ViewLandingPageInput): Component {
-	return Base({
+export function ViewLandingPage(): PageBody {
+	return {
 		seo: {
 			title: "Reader view — paste a link to read distraction-free | Readplace",
 			description:
@@ -27,6 +22,5 @@ export function ViewLandingPage(input: ViewLandingPageInput): Component {
 		styles: VIEW_LANDING_STYLES,
 		bodyClass: "page-view-landing",
 		content: render(VIEW_LANDING_TEMPLATE, {}),
-		isAuthenticated: input.isAuthenticated,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import type { Minutes } from "../../../domain/article/article.types";
+import { Base } from "../../base.component";
 import { ViewPage, type ViewPageInput } from "./view.component";
 
 const baseInput: ViewPageInput = {
@@ -25,7 +26,7 @@ const baseInput: ViewPageInput = {
 };
 
 function render(input = baseInput) {
-	const html = ViewPage(input).to("text/html").body;
+	const html = Base(ViewPage(input), { isAuthenticated: false, emailVerified: undefined }).to("text/html").body;
 	return new JSDOM(html).window.document;
 }
 

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -7,8 +7,7 @@ import type {
 import type { ArticleCrawl } from "../../../providers/article-crawl/article-crawl.types";
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import { requireEnv } from "../../../require-env";
-import { Base } from "../../base.component";
-import type { Component } from "../../component.types";
+import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { renderArticleBody } from "../../shared/article-body/article-body.component";
 import {
@@ -47,7 +46,7 @@ export interface ViewPageInput {
 	actions: ViewAction[];
 }
 
-export function ViewPage(input: ViewPageInput): Component {
+export function ViewPage(input: ViewPageInput): PageBody {
 	const innerContent = renderArticleBody({
 		title: input.metadata.title,
 		siteName: input.metadata.siteName,
@@ -95,7 +94,7 @@ export function ViewPage(input: ViewPageInput): Component {
 		structuredData.image = input.metadata.imageUrl;
 	}
 
-	return Base({
+	return {
 		seo: {
 			title: `${input.metadata.title} | Reader View`,
 			description,
@@ -111,6 +110,5 @@ export function ViewPage(input: ViewPageInput): Component {
 		bodyClass: "page-view",
 		content,
 		scripts: SHARE_BALLOON_SCRIPT,
-		isAuthenticated: false,
-	});
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -22,6 +22,7 @@ import type {
 	MarkSummaryPending,
 } from "../../../providers/article-summary/article-summary.types";
 import type { PublishSaveAnonymousLink } from "../../../providers/events/publish-save-anonymous-link.types";
+import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { initArticleReader } from "../../shared/article-reader/article-reader";
 import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.types";
@@ -47,7 +48,7 @@ interface ViewDependencies {
 function renderError(req: Request, res: Response) {
 	const redirectUrl = req.userId ? "/queue" : "/";
 	const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
-	sendComponent(res, SaveErrorPage({ redirectUrl, linkLabel }));
+	sendComponent(res, renderPage(req, SaveErrorPage({ redirectUrl, linkLabel })));
 }
 
 function hostnameFrom(validatedUrl: string): string {
@@ -65,10 +66,7 @@ function handleViewLanding(req: Request, res: Response) {
 	const submittedUrl =
 		typeof req.query.url === "string" ? req.query.url : undefined;
 	if (submittedUrl === undefined) {
-		sendComponent(
-			res,
-			ViewLandingPage({ isAuthenticated: Boolean(req.userId) }),
-		);
+		sendComponent(res, renderPage(req, ViewLandingPage()));
 		return;
 	}
 	const parsed = ViewUrlSchema.safeParse(submittedUrl);
@@ -153,7 +151,7 @@ function handleViewArticle(deps: ViewDependencies) {
 
 		sendComponent(
 			res,
-			ViewPage({
+			renderPage(req, ViewPage({
 				articleUrl,
 				metadata,
 				estimatedReadTime,
@@ -163,7 +161,7 @@ function handleViewArticle(deps: ViewDependencies) {
 				summary: state.summary,
 				summaryPollUrl: state.summaryPollUrl,
 				actions,
-			}),
+			})),
 		);
 	};
 }

--- a/projects/hutch/src/runtime/web/render-page.test.ts
+++ b/projects/hutch/src/runtime/web/render-page.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import type { Request } from "express";
 import { JSDOM } from "jsdom";
 import { UserIdSchema } from "../domain/user/user.schema";
+import type { BannerStateSource } from "./banner-state";
 import type { PageBody } from "./page-body.types";
 import { renderPage } from "./render-page";
 
@@ -19,33 +19,35 @@ function createTestPageBody(): PageBody {
 
 const USER_ID = UserIdSchema.parse("user-1");
 
-function createRequest(overrides: Partial<Request> = {}): Request {
-	return overrides as Request;
+function createSource(overrides: Partial<BannerStateSource> = {}): BannerStateSource {
+	return { ...overrides };
 }
 
 describe("renderPage", () => {
 	it("should render guest navigation for an unauthenticated request", () => {
-		const result = renderPage(createRequest(), createTestPageBody()).to("text/html");
+		const result = renderPage(createSource(), createTestPageBody()).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		expect(doc.querySelector('[data-test-nav-item="login"]')).not.toBeNull();
-		expect(doc.querySelector('[data-test-nav-item="queue"]')).toBeNull();
+		const nav = doc.querySelector("[data-test-nav-variant]");
+		assert(nav, "nav container must be rendered");
+		expect(nav.getAttribute("data-test-nav-variant")).toBe("guest");
 	});
 
 	it("should render authenticated navigation for a request with a userId", () => {
 		const result = renderPage(
-			createRequest({ userId: USER_ID, emailVerified: true }),
+			createSource({ userId: USER_ID, emailVerified: true }),
 			createTestPageBody(),
 		).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		expect(doc.querySelector('[data-test-nav-item="queue"]')).not.toBeNull();
-		expect(doc.querySelector('[data-test-nav-item="logout"]')).not.toBeNull();
+		const nav = doc.querySelector("[data-test-nav-variant]");
+		assert(nav, "nav container must be rendered");
+		expect(nav.getAttribute("data-test-nav-variant")).toBe("authenticated");
 	});
 
 	it("should show the verification banner for an authenticated, unverified request", () => {
 		const result = renderPage(
-			createRequest({ userId: USER_ID, emailVerified: false }),
+			createSource({ userId: USER_ID, emailVerified: false }),
 			createTestPageBody(),
 		).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
@@ -57,7 +59,7 @@ describe("renderPage", () => {
 
 	it("should hide the verification banner for an authenticated, verified request", () => {
 		const result = renderPage(
-			createRequest({ userId: USER_ID, emailVerified: true }),
+			createSource({ userId: USER_ID, emailVerified: true }),
 			createTestPageBody(),
 		).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
@@ -69,7 +71,7 @@ describe("renderPage", () => {
 
 	it("should hide the verification banner for a request without an emailVerified flag", () => {
 		const result = renderPage(
-			createRequest({ userId: USER_ID }),
+			createSource({ userId: USER_ID }),
 			createTestPageBody(),
 		).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
@@ -80,7 +82,7 @@ describe("renderPage", () => {
 	});
 
 	it("should hide the verification banner for an unauthenticated request", () => {
-		const result = renderPage(createRequest(), createTestPageBody()).to("text/html");
+		const result = renderPage(createSource(), createTestPageBody()).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");

--- a/projects/hutch/src/runtime/web/render-page.test.ts
+++ b/projects/hutch/src/runtime/web/render-page.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import type { Request } from "express";
+import { JSDOM } from "jsdom";
+import { UserIdSchema } from "../domain/user/user.schema";
+import type { PageBody } from "./page-body.types";
+import { renderPage } from "./render-page";
+
+function createTestPageBody(): PageBody {
+	return {
+		seo: {
+			title: "Test Page",
+			description: "Test description",
+			canonicalUrl: "https://readplace.com/test",
+		},
+		styles: "",
+		content: "<main><p>Test content</p></main>",
+	};
+}
+
+const USER_ID = UserIdSchema.parse("user-1");
+
+function createRequest(overrides: Partial<Request> = {}): Request {
+	return overrides as Request;
+}
+
+describe("renderPage", () => {
+	it("should render guest navigation for an unauthenticated request", () => {
+		const result = renderPage(createRequest(), createTestPageBody()).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="login"]')).not.toBeNull();
+		expect(doc.querySelector('[data-test-nav-item="queue"]')).toBeNull();
+	});
+
+	it("should render authenticated navigation for a request with a userId", () => {
+		const result = renderPage(
+			createRequest({ userId: USER_ID, emailVerified: true }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="queue"]')).not.toBeNull();
+		expect(doc.querySelector('[data-test-nav-item="logout"]')).not.toBeNull();
+	});
+
+	it("should show the verification banner for an authenticated, unverified request", () => {
+		const result = renderPage(
+			createRequest({ userId: USER_ID, emailVerified: false }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-verify-banner]");
+		assert(banner, "verify banner must be rendered");
+		expect(banner.classList.contains("verify-banner--visible")).toBe(true);
+	});
+
+	it("should hide the verification banner for an authenticated, verified request", () => {
+		const result = renderPage(
+			createRequest({ userId: USER_ID, emailVerified: true }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-verify-banner]");
+		assert(banner, "verify banner must be rendered");
+		expect(banner.classList.contains("verify-banner--hidden")).toBe(true);
+	});
+
+	it("should hide the verification banner for a request without an emailVerified flag", () => {
+		const result = renderPage(
+			createRequest({ userId: USER_ID }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-verify-banner]");
+		assert(banner, "verify banner must be rendered");
+		expect(banner.classList.contains("verify-banner--hidden")).toBe(true);
+	});
+
+	it("should hide the verification banner for an unauthenticated request", () => {
+		const result = renderPage(createRequest(), createTestPageBody()).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-verify-banner]");
+		assert(banner, "verify banner must be rendered");
+		expect(banner.classList.contains("verify-banner--hidden")).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/render-page.ts
+++ b/projects/hutch/src/runtime/web/render-page.ts
@@ -1,0 +1,9 @@
+import type { Request } from "express";
+import { Base } from "./base.component";
+import { bannerStateFromRequest } from "./banner-state";
+import type { Component } from "./component.types";
+import type { PageBody } from "./page-body.types";
+
+export function renderPage(req: Request, body: PageBody): Component {
+	return Base(body, bannerStateFromRequest(req));
+}

--- a/projects/hutch/src/runtime/web/render-page.ts
+++ b/projects/hutch/src/runtime/web/render-page.ts
@@ -1,9 +1,9 @@
-import type { Request } from "express";
 import { Base } from "./base.component";
+import type { BannerStateSource } from "./banner-state";
 import { bannerStateFromRequest } from "./banner-state";
 import type { Component } from "./component.types";
 import type { PageBody } from "./page-body.types";
 
-export function renderPage(req: Request, body: PageBody): Component {
-	return Base(body, bannerStateFromRequest(req));
+export function renderPage(source: BannerStateSource, body: PageBody): Component {
+	return Base(body, bannerStateFromRequest(source));
 }


### PR DESCRIPTION
## Summary
Refactored the page rendering architecture to separate authentication/banner state from page body content. This improves separation of concerns by having page components return only content structure (`PageBody`), while authentication state is derived from the request and applied during final rendering.

## Key Changes

- **Created new types and utilities:**
  - `PageBody` interface: Contains page content, SEO metadata, and styling (moved from `PageContent`)
  - `BannerState` interface: Encapsulates authentication and email verification state
  - `bannerStateFromRequest()`: Extracts banner state from Express request object
  - `renderPage()`: New helper function that combines `PageBody` with request-derived `BannerState` to produce final `Component`

- **Updated `Base` component:**
  - Changed signature from `Base(page: PageContent)` to `Base(body: PageBody, state: BannerState)`
  - Removed `isAuthenticated` and `emailVerified` from `PageBody`
  - Banner state now passed explicitly, making dependencies clear

- **Refactored all page components:**
  - Changed return type from `Component` to `PageBody` for all page builders (LoginPage, HomePage, QueuePage, etc.)
  - Removed `isAuthenticated` and `emailVerified` parameters from component functions
  - Components now focus solely on content generation

- **Updated all route handlers:**
  - Wrapped `PageBody` results with `renderPage(req, body)` before sending
  - This centralizes authentication state extraction and ensures consistent behavior

- **Added comprehensive tests:**
  - New `render-page.test.ts` validates authentication state handling in the rendering pipeline
  - Updated `base.component.test.ts` with new test cases for guest vs. authenticated navigation

## Implementation Details

The refactoring maintains backward compatibility in behavior while improving code organization. Page components are now pure content generators that don't need to know about authentication, making them easier to test and reason about. Authentication state is consistently derived from the request at the rendering boundary, eliminating the need to pass it through multiple layers.

https://claude.ai/code/session_016k8KYY3c4ED8L6Fcd49qUV