### PR TITLE
Rebrand blog posts from Hutch to Readplace

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -228,6 +228,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			"readplace-vs-instapaper": "0.8",
 			"how-ai-tldr-actually-works": "0.8",
 			"free-read-it-later-apps-2026": "0.8",
+			"readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later": "0.8",
 		};
 
 		const pages: { loc: string; priority: string; changefreq: string; lastmod: string }[] = [

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -224,8 +224,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		const blogPriorityMap: Record<string, string> = {
 			"best-read-it-later-apps-2026": "0.9",
 			"omnivore-alternative": "0.9",
-			"hutch-vs-readwise-reader": "0.8",
-			"hutch-vs-instapaper": "0.8",
+			"readplace-vs-readwise-reader": "0.8",
+			"readplace-vs-instapaper": "0.8",
 			"how-ai-tldr-actually-works": "0.8",
 			"free-read-it-later-apps-2026": "0.8",
 		};

--- a/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
@@ -6,6 +6,12 @@ import { BlogPostPage } from "./blog-post.component";
 import { NotFoundPage } from "../not-found";
 import { getAllPosts, findPostBySlug } from "./blog.posts";
 
+const SLUG_REDIRECTS: Record<string, string> = {
+	"hutch-vs-readwise-reader": "readplace-vs-readwise-reader",
+	"hutch-vs-instapaper": "readplace-vs-instapaper",
+	"hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later": "readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later",
+};
+
 export function initBlogRoutes(): Router {
 	const router = express.Router();
 
@@ -15,6 +21,11 @@ export function initBlogRoutes(): Router {
 	});
 
 	router.get("/:slug", (req: Request, res: Response) => {
+		const newSlug = SLUG_REDIRECTS[req.params.slug];
+		if (newSlug) {
+			res.redirect(301, `/blog/${newSlug}`);
+			return;
+		}
 		const post = findPostBySlug(req.params.slug);
 		if (!post) {
 			sendComponent(res, NotFoundPage());

--- a/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
@@ -167,6 +167,28 @@ describe("GET /blog/:slug", () => {
 	});
 });
 
+describe("old hutch-vs-* slug redirects", () => {
+	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+	it("should 301 redirect hutch-vs-readwise-reader to readplace-vs-readwise-reader", async () => {
+		const response = await request(app).get("/blog/hutch-vs-readwise-reader");
+		expect(response.status).toBe(301);
+		expect(response.headers.location).toBe("/blog/readplace-vs-readwise-reader");
+	});
+
+	it("should 301 redirect hutch-vs-instapaper to readplace-vs-instapaper", async () => {
+		const response = await request(app).get("/blog/hutch-vs-instapaper");
+		expect(response.status).toBe(301);
+		expect(response.headers.location).toBe("/blog/readplace-vs-instapaper");
+	});
+
+	it("should 301 redirect hutch-vs-karakeep to readplace-vs-karakeep", async () => {
+		const response = await request(app).get("/blog/hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later");
+		expect(response.status).toBe(301);
+		expect(response.headers.location).toBe("/blog/readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later");
+	});
+});
+
 describe("hutch-app.com blog redirect", () => {
 	it("should 301 redirect /blog to readplace.com", async () => {
 		const { app } = createTestApp(

--- a/projects/hutch/src/runtime/web/pages/blog/posts/how-ai-tldr-actually-works.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/how-ai-tldr-actually-works.md
@@ -4,7 +4,7 @@ description: "Readplace uses AI to generate short article summaries for triage, 
 slug: "how-ai-tldr-actually-works"
 date: "2026-04-06"
 author: "Fayner Brack"
-keywords: "ai summary, read it later, article tl;dr, deepseek, ai slop, hutch app"
+keywords: "ai summary, read it later, article tl;dr, deepseek, ai slop, readplace app"
 ---
 
 <details class="blog-tldr">

--- a/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-instapaper.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-instapaper.md
@@ -1,10 +1,10 @@
 ---
 title: "Readplace vs Instapaper: Two Different Approaches to Read-It-Later"
 description: "A fair comparison of two read-it-later apps that took different paths after Pocket shut down. One is familiar and stable. The other bets on AI and active development."
-slug: "hutch-vs-instapaper"
+slug: "readplace-vs-instapaper"
 date: "2026-04-07"
 author: "Fayner Brack"
-keywords: "instapaper alternative, read it later, hutch vs instapaper, pocket replacement, AI summaries"
+keywords: "instapaper alternative, read it later, readplace vs instapaper, pocket replacement, AI summaries"
 ---
 
 <details class="blog-tldr">

--- a/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later.md
@@ -1,10 +1,10 @@
 ---
 title: "Readplace vs Karakeep: Hosted vs Self-Hosted Read-It-Later"
 description: "A fair comparison of two developer-focused read-it-later tools, one self-hosted and one managed, and the tradeoffs each makes."
-slug: "hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later"
+slug: "readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later"
 date: "2026-04-06"
 author: "Fayner Brack"
-keywords: "karakeep, hoarder, hutch, read it later, self-hosted, pocket alternative"
+keywords: "karakeep, hoarder, readplace, read it later, self-hosted, pocket alternative"
 ---
 
 <details class="blog-tldr">

--- a/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-readwise-reader.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-readwise-reader.md
@@ -1,10 +1,10 @@
 ---
 title: "Readplace vs Readwise Reader: Which Read-It-Later App Is Right for You?"
 description: "A fair look at two read-it-later apps with AI. Where Readwise wins, where Readplace wins, and how to pick the right one for you."
-slug: "hutch-vs-readwise-reader"
+slug: "readplace-vs-readwise-reader"
 date: "2026-04-06"
 author: "Fayner Brack"
-keywords: "hutch vs readwise, read it later app, readwise alternative, read it later AI"
+keywords: "readplace vs readwise, read it later app, readwise alternative, read it later AI"
 ---
 
 <details class="blog-tldr">

--- a/projects/hutch/src/runtime/web/pages/blog/posts/save-hacker-news-articles-for-later.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/save-hacker-news-articles-for-later.md
@@ -4,7 +4,7 @@ description: "You open 15 tabs from the HN front page and read 3. The rest haunt
 slug: "save-hacker-news-articles-for-later"
 date: "2026-04-07"
 author: "Fayner Brack"
-keywords: "hacker news, save articles, read it later, hn reader, hutch"
+keywords: "hacker news, save articles, read it later, hn reader, readplace"
 ---
 
 <details class="blog-tldr">


### PR DESCRIPTION
## Summary
This PR updates blog post content and metadata to reflect a product rebrand from "Hutch" to "Readplace" across the blog section of the application.

## Key Changes
- Updated blog post slugs in the sitemap priority configuration to use "readplace" instead of "hutch"
- Renamed three blog post files to reflect the new product name:
  - `hutch-vs-readwise-reader.md` → `readplace-vs-readwise-reader.md`
  - `hutch-vs-instapaper.md` → `readplace-vs-instapaper.md`
  - `hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later.md` → `readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later.md`
- Updated frontmatter metadata in all three blog posts:
  - Changed `slug` fields from "hutch-*" to "readplace-*"
  - Updated `keywords` fields to reference "readplace" instead of "hutch"

## Implementation Details
The changes maintain consistency across the blog infrastructure by updating both the server-side routing configuration and the blog post metadata. All SEO-relevant fields (slugs and keywords) have been updated to ensure proper indexing and discoverability under the new product name.

https://claude.ai/code/session_01SLjjiYGZJZhp2ymvAbsH5U