### PR TITLE
Phase 3: stuck-articles canary (workflow_dispatch only)

### DIFF
--- a/.github/workflows/stuck-articles-canary.yml
+++ b/.github/workflows/stuck-articles-canary.yml
@@ -28,6 +28,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ap-southeast-2
       DYNAMODB_ARTICLES_TABLE: hutch-articles-cda0a08
+      READPLACE_ORIGIN: https://readplace.com
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/stuck-articles-canary.yml
+++ b/.github/workflows/stuck-articles-canary.yml
@@ -1,0 +1,46 @@
+name: Stuck articles canary
+
+# Read-only DDB scan against the prod articles table that fails the run with
+# one node:test sub-test per article whose state machines never reached a
+# terminal-good state. A green run means there are no stuck articles.
+#
+# Manually triggered only — Phase 4 of the schema-bound canaries plan adds
+# the daily cron schedule. Triggering this from the Actions UI lets the shape
+# be validated against current prod (currently 0 stuck rows) before automation
+# turns it on.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stuck-articles-canary:
+    runs-on: ubuntu-latest
+    # Bind to the prod environment so AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+    # resolve to the prod-scoped credentials — the canary scans the prod
+    # articles table by name (DYNAMODB_ARTICLES_TABLE below).
+    environment: prod
+    timeout-minutes: 10
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ap-southeast-2
+      DYNAMODB_ARTICLES_TABLE: hutch-articles-cda0a08
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run stuck articles canary
+        run: pnpm nx run @packages/check-stuck-articles:check-stuck-articles

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,25 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  src/packages/check-stuck-articles:
+    dependencies:
+      '@packages/article-state-types':
+        specifier: workspace:*
+        version: link:../article-state-types
+      '@packages/hutch-storage-client':
+        specifier: workspace:*
+        version: link:../hutch-storage-client
+      zod:
+        specifier: 4.1.13
+        version: 4.1.13
+    devDependencies:
+      concurrently:
+        specifier: 9.2.1
+        version: 9.2.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   src/packages/check-unused-css:
     dependencies:
       purgecss:

--- a/src/packages/check-stuck-articles/biome.json
+++ b/src/packages/check-stuck-articles/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../../../biome.config.base.json"]
+}

--- a/src/packages/check-stuck-articles/knip.config.ts
+++ b/src/packages/check-stuck-articles/knip.config.ts
@@ -2,11 +2,8 @@ import type { KnipConfig } from "knip";
 
 export default {
 	entry: [
-		// Canary entrypoint invoked by the nx `check-stuck-articles` target and
-		// the stuck-articles-canary workflow. Compiled to
-		// dist/scripts/check-stuck-articles.js and run with `node --test`.
-		// Requires the exclude patterns table (exclude-patterns.ts) as a direct import.
 		"scripts/check-stuck-articles.ts",
+		"scripts/classify-row.ts",
 		"scripts/exclude-patterns.ts",
 	],
 	ignoreDependencies: [

--- a/src/packages/check-stuck-articles/knip.config.ts
+++ b/src/packages/check-stuck-articles/knip.config.ts
@@ -1,0 +1,19 @@
+import type { KnipConfig } from "knip";
+
+export default {
+	entry: [
+		// Canary entrypoint invoked by the nx `check-stuck-articles` target and
+		// the stuck-articles-canary workflow. Compiled to
+		// dist/scripts/check-stuck-articles.js and run with `node --test`.
+		// Requires the exclude patterns table (exclude-patterns.ts) as a direct import.
+		"scripts/check-stuck-articles.ts",
+		"scripts/exclude-patterns.ts",
+	],
+	ignoreDependencies: [
+		// knip doesn't resolve workspace subpath for @packages/* imports
+		// (consistent with the same workaround in projects/hutch and crawl-article)
+		"@packages/article-state-types",
+		"@packages/hutch-storage-client",
+	],
+	ignoreBinaries: ["knip", "biome"],
+} satisfies KnipConfig;

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "compile": "tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint scripts\" \"knip\"",
-    "check": "pnpm lint",
+    "test": "node --test dist/scripts/classify-row.test.js",
+    "check": "pnpm lint && pnpm test",
     "check-infra": "echo 'No infrastructure — canary script'"
   },
   "dependencies": {

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@packages/check-stuck-articles",
+  "version": "1.0.0",
+  "description": "Read-only DDB scan canary that fails when articles are stuck in non-terminal state machine states (summary or crawl)",
+  "main": "dist/scripts/check-stuck-articles.js",
+  "private": true,
+  "scripts": {
+    "compile": "tsc",
+    "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint scripts\" \"knip\"",
+    "check": "pnpm lint",
+    "check-infra": "echo 'No infrastructure — canary script'"
+  },
+  "dependencies": {
+    "@packages/article-state-types": "workspace:*",
+    "@packages/hutch-storage-client": "workspace:*",
+    "zod": "4.1.13"
+  },
+  "devDependencies": {
+    "concurrently": "9.2.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/src/packages/check-stuck-articles/project.json
+++ b/src/packages/check-stuck-articles/project.json
@@ -2,8 +2,9 @@
   "name": "@packages/check-stuck-articles",
   "targets": {
     "check": {
-      "command": "pnpm lint",
-      "options": { "cwd": "{projectRoot}" }
+      "command": "pnpm check",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["compile"]
     },
     "check-stuck-articles": {
       "command": "node --test --test-reporter=spec dist/scripts/check-stuck-articles.js",

--- a/src/packages/check-stuck-articles/project.json
+++ b/src/packages/check-stuck-articles/project.json
@@ -1,0 +1,14 @@
+{
+  "name": "@packages/check-stuck-articles",
+  "targets": {
+    "check": {
+      "command": "pnpm lint",
+      "options": { "cwd": "{projectRoot}" }
+    },
+    "check-stuck-articles": {
+      "command": "node --test --test-reporter=spec dist/scripts/check-stuck-articles.js",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["compile"]
+    }
+  }
+}

--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -23,9 +23,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
-	type CrawlStatus,
 	CrawlStatusSchema,
-	type SummaryStatus,
 	SummaryStatusSchema,
 } from "@packages/article-state-types";
 import {
@@ -34,6 +32,7 @@ import {
 	dynamoField,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
+import { type StuckReason, classifyRow } from "./classify-row";
 import { EXCLUDE_PATTERNS } from "./exclude-patterns";
 
 function requireEnv(name: string): string {
@@ -63,75 +62,6 @@ const StuckArticleRow = z.object({
 	contentFetchedAt: dynamoField(z.string()),
 	summary: dynamoField(z.string()),
 });
-type StuckArticleRow = z.infer<typeof StuckArticleRow>;
-
-type StuckReason =
-	| "summary-pending"
-	| "summary-failed"
-	| "crawl-pending"
-	| "crawl-failed"
-	| "legacy-stub";
-
-/**
- * Map a row to the reasons it is "stuck". Empty array = the row is healthy
- * (terminal-good state machines, or a legacy row carrying a pre-state-machine
- * `summary`). The two switches use exhaustive `never` defaults so a new
- * SummaryStatus or CrawlStatus added to @packages/article-state-types breaks
- * `tsc --noEmit` until the classifier handles it.
- */
-function classifyRow(
-	row: Pick<StuckArticleRow, "summaryStatus" | "crawlStatus" | "summary">,
-): StuckReason[] {
-	const reasons: StuckReason[] = [];
-	if (row.summaryStatus !== undefined) {
-		switch (row.summaryStatus) {
-			case "pending":
-				reasons.push("summary-pending");
-				break;
-			case "failed":
-				reasons.push("summary-failed");
-				break;
-			case "ready":
-			case "skipped":
-				break;
-			default: {
-				const _exhaustive: never = row.summaryStatus;
-				throw new Error(
-					`Unhandled summaryStatus '${String(_exhaustive satisfies SummaryStatus)}' — extend classifyRow.`,
-				);
-			}
-		}
-	}
-	if (row.crawlStatus !== undefined) {
-		switch (row.crawlStatus) {
-			case "pending":
-				reasons.push("crawl-pending");
-				break;
-			case "failed":
-				reasons.push("crawl-failed");
-				break;
-			case "ready":
-				break;
-			default: {
-				const _exhaustive: never = row.crawlStatus;
-				throw new Error(
-					`Unhandled crawlStatus '${String(_exhaustive satisfies CrawlStatus)}' — extend classifyRow.`,
-				);
-			}
-		}
-	}
-	// Legacy stub: row predates both state machines AND has no pre-computed
-	// summary. Such rows are visible to readers as a permanent loading spinner
-	// because no worker will ever drive them forward.
-	if (
-		row.summaryStatus === undefined &&
-		row.crawlStatus === undefined &&
-		row.summary === undefined
-	) {
-		reasons.push("legacy-stub");
-	}
-	return reasons;
-}
 
 function isExcluded(url: string): boolean {
 	return EXCLUDE_PATTERNS.some((pattern) => pattern.test(url));

--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -15,9 +15,8 @@
  *   - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (the SDK reads these directly)
  *   - DYNAMODB_ARTICLES_TABLE
  *
- * Optional env:
- *   - READPLACE_ORIGIN (defaults to https://readplace.com — used to build
- *     admin recrawl URLs in the failing-test message for each stuck row)
+ *   - READPLACE_ORIGIN (used to build admin recrawl URLs in the
+ *     failing-test message for each stuck row)
  *
  * Run via: pnpm nx run @packages/check-stuck-articles:check-stuck-articles
  */
@@ -45,7 +44,7 @@ function requireEnv(name: string): string {
 
 const REGION = requireEnv("AWS_REGION");
 const TABLE = requireEnv("DYNAMODB_ARTICLES_TABLE");
-const ORIGIN = process.env.READPLACE_ORIGIN ?? "https://readplace.com";
+const ORIGIN = requireEnv("READPLACE_ORIGIN");
 
 /**
  * Loose row schema for the canary's projection. Every attribute except `url`

--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Stuck-articles canary.
+ *
+ * Read-only DDB scan: returns one failing node:test sub-test per article
+ * whose state machines never reached a terminal-good state. Zero stuck
+ * rows = green. Replaces /tmp/list-stuck-articles.sh — same FilterExpression
+ * and same exclude-regex semantics, but the classifier and the Zod schemas
+ * are bound to @packages/article-state-types so a new summaryStatus or
+ * crawlStatus value upstream fails `tsc --noEmit` immediately, instead of
+ * producing a quiet false-negative on tomorrow's cron.
+ *
+ * Required env:
+ *   - AWS_REGION
+ *   - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (the SDK reads these directly)
+ *   - DYNAMODB_ARTICLES_TABLE
+ *
+ * Optional env:
+ *   - READPLACE_ORIGIN (defaults to https://readplace.com — used to build
+ *     admin recrawl URLs in the failing-test message for each stuck row)
+ *
+ * Run via: pnpm nx run @packages/check-stuck-articles:check-stuck-articles
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	type CrawlStatus,
+	CrawlStatusSchema,
+	type SummaryStatus,
+	SummaryStatusSchema,
+} from "@packages/article-state-types";
+import {
+	createDynamoDocumentClient,
+	defineDynamoTable,
+	dynamoField,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { EXCLUDE_PATTERNS } from "./exclude-patterns";
+
+function requireEnv(name: string): string {
+	const value = process.env[name];
+	assert(value, `${name} env var is required`);
+	return value;
+}
+
+const REGION = requireEnv("AWS_REGION");
+const TABLE = requireEnv("DYNAMODB_ARTICLES_TABLE");
+const ORIGIN = process.env.READPLACE_ORIGIN ?? "https://readplace.com";
+
+/**
+ * Loose row schema for the canary's projection. Every attribute except `url`
+ * is wrapped in `dynamoField` so absent attributes (which DDB returns as
+ * `null`) are normalised to `undefined`. The status enums are imported from
+ * @packages/article-state-types so adding a new status to the production
+ * schemas surfaces here as a tsc error in `classifyRow`.
+ */
+const StuckArticleRow = z.object({
+	url: z.string(),
+	originalUrl: dynamoField(z.string()),
+	summaryStatus: dynamoField(SummaryStatusSchema),
+	crawlStatus: dynamoField(CrawlStatusSchema),
+	summaryFailureReason: dynamoField(z.string()),
+	crawlFailureReason: dynamoField(z.string()),
+	contentFetchedAt: dynamoField(z.string()),
+	summary: dynamoField(z.string()),
+});
+type StuckArticleRow = z.infer<typeof StuckArticleRow>;
+
+type StuckReason =
+	| "summary-pending"
+	| "summary-failed"
+	| "crawl-pending"
+	| "crawl-failed"
+	| "legacy-stub";
+
+/**
+ * Map a row to the reasons it is "stuck". Empty array = the row is healthy
+ * (terminal-good state machines, or a legacy row carrying a pre-state-machine
+ * `summary`). The two switches use exhaustive `never` defaults so a new
+ * SummaryStatus or CrawlStatus added to @packages/article-state-types breaks
+ * `tsc --noEmit` until the classifier handles it.
+ */
+function classifyRow(
+	row: Pick<StuckArticleRow, "summaryStatus" | "crawlStatus" | "summary">,
+): StuckReason[] {
+	const reasons: StuckReason[] = [];
+	if (row.summaryStatus !== undefined) {
+		switch (row.summaryStatus) {
+			case "pending":
+				reasons.push("summary-pending");
+				break;
+			case "failed":
+				reasons.push("summary-failed");
+				break;
+			case "ready":
+			case "skipped":
+				break;
+			default: {
+				const _exhaustive: never = row.summaryStatus;
+				throw new Error(
+					`Unhandled summaryStatus '${String(_exhaustive satisfies SummaryStatus)}' — extend classifyRow.`,
+				);
+			}
+		}
+	}
+	if (row.crawlStatus !== undefined) {
+		switch (row.crawlStatus) {
+			case "pending":
+				reasons.push("crawl-pending");
+				break;
+			case "failed":
+				reasons.push("crawl-failed");
+				break;
+			case "ready":
+				break;
+			default: {
+				const _exhaustive: never = row.crawlStatus;
+				throw new Error(
+					`Unhandled crawlStatus '${String(_exhaustive satisfies CrawlStatus)}' — extend classifyRow.`,
+				);
+			}
+		}
+	}
+	// Legacy stub: row predates both state machines AND has no pre-computed
+	// summary. Such rows are visible to readers as a permanent loading spinner
+	// because no worker will ever drive them forward.
+	if (
+		row.summaryStatus === undefined &&
+		row.crawlStatus === undefined &&
+		row.summary === undefined
+	) {
+		reasons.push("legacy-stub");
+	}
+	return reasons;
+}
+
+function isExcluded(url: string): boolean {
+	return EXCLUDE_PATTERNS.some((pattern) => pattern.test(url));
+}
+
+interface StuckRow {
+	originalUrl: string;
+	reasons: StuckReason[];
+	contentFetchedAt: string | undefined;
+	failureReason: string | undefined;
+	recrawlUrl: string;
+}
+
+async function collectStuckRows(): Promise<StuckRow[]> {
+	const client = createDynamoDocumentClient({ region: REGION });
+	const table = defineDynamoTable({
+		client,
+		tableName: TABLE,
+		schema: StuckArticleRow,
+	});
+	const stuck: StuckRow[] = [];
+	let skippedNoOriginal = 0;
+	let excludedDomain = 0;
+	let lastEvaluatedKey: Record<string, unknown> | undefined;
+	do {
+		const page = await table.scan({
+			FilterExpression:
+				"summaryStatus IN (:pending, :failed) " +
+				"OR crawlStatus IN (:pending, :failed) " +
+				"OR (attribute_not_exists(summaryStatus) AND attribute_not_exists(crawlStatus) AND attribute_not_exists(summary))",
+			ProjectionExpression:
+				"originalUrl, #u, summaryStatus, crawlStatus, summaryFailureReason, crawlFailureReason, contentFetchedAt, summary",
+			ExpressionAttributeNames: { "#u": "url" },
+			ExpressionAttributeValues: { ":pending": "pending", ":failed": "failed" },
+			ExclusiveStartKey: lastEvaluatedKey,
+		});
+		for (const row of page.items) {
+			const reasons = classifyRow(row);
+			if (reasons.length === 0) continue;
+			if (row.originalUrl === undefined) {
+				skippedNoOriginal += 1;
+				continue;
+			}
+			if (isExcluded(row.originalUrl)) {
+				excludedDomain += 1;
+				continue;
+			}
+			stuck.push({
+				originalUrl: row.originalUrl,
+				reasons,
+				contentFetchedAt: row.contentFetchedAt,
+				failureReason: row.summaryFailureReason ?? row.crawlFailureReason,
+				recrawlUrl: `${ORIGIN}/admin/recrawl/${encodeURIComponent(row.originalUrl)}`,
+			});
+		}
+		lastEvaluatedKey = page.lastEvaluatedKey;
+	} while (lastEvaluatedKey !== undefined);
+	if (skippedNoOriginal > 0) {
+		process.stderr.write(`[info] skipped ${skippedNoOriginal} row(s) without originalUrl\n`);
+	}
+	if (excludedDomain > 0) {
+		process.stderr.write(`[info] excluded ${excludedDomain} row(s) by domain filter\n`);
+	}
+	return stuck;
+}
+
+test("Stuck articles canary", async (t) => {
+	const stuck = await collectStuckRows();
+	for (const row of stuck) {
+		const label = `[${row.reasons.join(",")}] ${row.originalUrl}`;
+		await t.test(label, () => {
+			assert.fail(
+				`Stuck article — fetched: ${row.contentFetchedAt ?? "-"}; failure: ${row.failureReason ?? "-"}; recrawl: ${row.recrawlUrl}`,
+			);
+		});
+	}
+});

--- a/src/packages/check-stuck-articles/scripts/classify-row.test.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyRow } from "./classify-row";
+
+describe("classifyRow", () => {
+	describe("summaryStatus", () => {
+		it("returns summary-pending for pending", () => {
+			const reasons = classifyRow({ summaryStatus: "pending", crawlStatus: "ready", summary: undefined });
+			assert.deepStrictEqual(reasons, ["summary-pending"]);
+		});
+
+		it("returns summary-failed for failed", () => {
+			const reasons = classifyRow({ summaryStatus: "failed", crawlStatus: "ready", summary: undefined });
+			assert.deepStrictEqual(reasons, ["summary-failed"]);
+		});
+
+		it("returns no reason for ready", () => {
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: undefined });
+			assert.deepStrictEqual(reasons, []);
+		});
+
+		it("returns no reason for skipped", () => {
+			const reasons = classifyRow({ summaryStatus: "skipped", crawlStatus: "ready", summary: undefined });
+			assert.deepStrictEqual(reasons, []);
+		});
+	});
+
+	describe("crawlStatus", () => {
+		it("returns crawl-pending for pending", () => {
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "pending", summary: undefined });
+			assert.deepStrictEqual(reasons, ["crawl-pending"]);
+		});
+
+		it("returns crawl-failed for failed", () => {
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "failed", summary: undefined });
+			assert.deepStrictEqual(reasons, ["crawl-failed"]);
+		});
+
+		it("returns no reason for ready", () => {
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: undefined });
+			assert.deepStrictEqual(reasons, []);
+		});
+	});
+
+	describe("combined statuses", () => {
+		it("returns both reasons when summary and crawl are pending", () => {
+			const reasons = classifyRow({ summaryStatus: "pending", crawlStatus: "pending", summary: undefined });
+			assert.deepStrictEqual(reasons, ["summary-pending", "crawl-pending"]);
+		});
+
+		it("returns both reasons when summary and crawl are failed", () => {
+			const reasons = classifyRow({ summaryStatus: "failed", crawlStatus: "failed", summary: undefined });
+			assert.deepStrictEqual(reasons, ["summary-failed", "crawl-failed"]);
+		});
+	});
+
+	describe("legacy stub", () => {
+		it("returns legacy-stub when all fields are undefined", () => {
+			const reasons = classifyRow({ summaryStatus: undefined, crawlStatus: undefined, summary: undefined });
+			assert.deepStrictEqual(reasons, ["legacy-stub"]);
+		});
+
+		it("returns no reason when summary exists but statuses are undefined", () => {
+			const reasons = classifyRow({ summaryStatus: undefined, crawlStatus: undefined, summary: "some text" });
+			assert.deepStrictEqual(reasons, []);
+		});
+	});
+});

--- a/src/packages/check-stuck-articles/scripts/classify-row.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.ts
@@ -1,0 +1,70 @@
+import type { CrawlStatus, SummaryStatus } from "@packages/article-state-types";
+
+export type StuckReason =
+	| "summary-pending"
+	| "summary-failed"
+	| "crawl-pending"
+	| "crawl-failed"
+	| "legacy-stub";
+
+/**
+ * Map a row to the reasons it is "stuck". Empty array = the row is healthy
+ * (terminal-good state machines, or a legacy row carrying a pre-state-machine
+ * `summary`). The two switches use exhaustive `never` defaults so a new
+ * SummaryStatus or CrawlStatus added to @packages/article-state-types breaks
+ * `tsc --noEmit` until the classifier handles it.
+ */
+export function classifyRow(
+	row: {
+		summaryStatus: SummaryStatus | undefined;
+		crawlStatus: CrawlStatus | undefined;
+		summary: string | undefined;
+	},
+): StuckReason[] {
+	const reasons: StuckReason[] = [];
+	if (row.summaryStatus !== undefined) {
+		switch (row.summaryStatus) {
+			case "pending":
+				reasons.push("summary-pending");
+				break;
+			case "failed":
+				reasons.push("summary-failed");
+				break;
+			case "ready":
+			case "skipped":
+				break;
+			default: {
+				const _exhaustive: never = row.summaryStatus;
+				throw new Error(
+					`Unhandled summaryStatus '${String(_exhaustive satisfies SummaryStatus)}' — extend classifyRow.`,
+				);
+			}
+		}
+	}
+	if (row.crawlStatus !== undefined) {
+		switch (row.crawlStatus) {
+			case "pending":
+				reasons.push("crawl-pending");
+				break;
+			case "failed":
+				reasons.push("crawl-failed");
+				break;
+			case "ready":
+				break;
+			default: {
+				const _exhaustive: never = row.crawlStatus;
+				throw new Error(
+					`Unhandled crawlStatus '${String(_exhaustive satisfies CrawlStatus)}' — extend classifyRow.`,
+				);
+			}
+		}
+	}
+	if (
+		row.summaryStatus === undefined &&
+		row.crawlStatus === undefined &&
+		row.summary === undefined
+	) {
+		reasons.push("legacy-stub");
+	}
+	return reasons;
+}

--- a/src/packages/check-stuck-articles/scripts/exclude-patterns.ts
+++ b/src/packages/check-stuck-articles/scripts/exclude-patterns.ts
@@ -1,0 +1,21 @@
+/**
+ * URLs matching any of these regexes are not real articles — own-domain pages,
+ * browser-internal URLs, the AWS console, and the user's own Medium profile
+ * root. Rows whose `originalUrl` matches an entry are dropped before the
+ * canary classifies them, so a stuck row pointing at one of these targets
+ * does not flag the run red.
+ *
+ * Mirrors EXCLUDE_PATTERNS in /tmp/list-stuck-articles.sh — the bash variant
+ * the canary replaces. Add a new entry only if the pattern represents a class
+ * of URL that is genuinely never a real article.
+ */
+export const EXCLUDE_PATTERNS: readonly RegExp[] = [
+	/:\/\/hutch-app\.com/,
+	/:\/\/readplace\.com/,
+	/:\/\/localhost/,
+	/^chrome:\/\//,
+	/^about:home$/,
+	/^about:newtab$/,
+	/278728209435-wu2vbie3\.ap-southeast-2\.console\.aws\.amazon\.com/,
+	/:\/\/medium\.com\/@fagnerbrack/,
+];

--- a/src/packages/check-stuck-articles/tsconfig.json
+++ b/src/packages/check-stuck-articles/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.config.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/packages/check-stuck-articles/tsconfig.lint.json
+++ b/src/packages/check-stuck-articles/tsconfig.lint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/src/packages/hutch-storage-client/src/define-table.ts
+++ b/src/packages/hutch-storage-client/src/define-table.ts
@@ -62,13 +62,18 @@ export type DynamoTable<TSchema extends z.ZodObject> = {
 	}>;
 
 	/**
-	 * Scan passthrough. Returns parsed items and the SDK-reported count.
-	 * When `Select: "COUNT"` is used, `items` will be empty and `count`
-	 * holds the matching row count.
+	 * Scan passthrough. Returns parsed items, the SDK-reported count, and
+	 * `LastEvaluatedKey` so callers can drive pagination (pass it back as
+	 * `ExclusiveStartKey`). When `Select: "COUNT"` is used, `items` will be
+	 * empty and `count` holds the matching row count.
 	 */
 	scan: (
 		input?: WithoutTable<ScanCommandInput>,
-	) => Promise<{ items: z.infer<TSchema>[]; count: number }>;
+	) => Promise<{
+		items: z.infer<TSchema>[];
+		count: number;
+		lastEvaluatedKey?: Record<string, unknown>;
+	}>;
 };
 
 /**
@@ -137,7 +142,11 @@ export function defineDynamoTable<TSchema extends z.ZodObject>(config: {
 				new ScanCommand({ TableName: tableName, ...(input ?? {}) }),
 			);
 			const items = (result.Items ?? []).map((item) => schema.parse(item));
-			return { items, count: result.Count ?? 0 };
+			return {
+				items,
+				count: result.Count ?? 0,
+				lastEvaluatedKey: result.LastEvaluatedKey,
+			};
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- New `@packages/check-stuck-articles` package with a read-only DDB scan canary that fails the run with one `node:test` sub-test per article whose state machines never reached a terminal-good state. Zero stuck rows = green.
- `classifyRow` uses exhaustive `switch` + `never` defaults bound to `SummaryStatusSchema` and `CrawlStatusSchema` from `@packages/article-state-types` — adding a new status upstream now fails `tsc --noEmit` immediately, instead of producing a silent false-negative on tomorrow's cron.
- New `.github/workflows/stuck-articles-canary.yml`, `workflow_dispatch` only — Phase 4 will add the daily 06:30 AEST cron once the shape is validated against current prod (0 stuck rows) from the Actions UI.
- Tiny extension to `hutch-storage-client.scan()` to also return `lastEvaluatedKey`, mirroring `query()`. Pure addition; existing consumers ignore the new field.

This is Phase 3 of the schema-bound canaries plan (Phase 1 = shared `@packages/article-state-types`, Phase 2 = tier-1 canary in TS). Replaces the throwaway `/tmp/list-stuck-articles.sh` from the IAM-fix RCA session — same `FilterExpression`, same exclude regexes, but the classifier is now compile-time bound to the production status enums.

## Test plan
- [x] `pnpm nx run @packages/check-stuck-articles:check` — green (lint + tsc + knip)
- [x] `pnpm nx run @packages/check-stuck-articles:compile` — green
- [x] `pnpm check` (workspace-wide) — green; the two earlier hutch flakes were jest-worker shutdown races on unrelated UI tests (`queue.route.test`, `view.route.test`) and cleared on rerun
- [ ] Trigger `Stuck articles canary` from the Actions UI against current prod (0 stuck rows) — must go green
- [ ] Red-path verification: temporarily write a stuck row, re-run, confirm one failing sub-test with `[reasons] originalUrl` label and a recrawl URL in the failure message
- [ ] Bump status enum locally (e.g. add a fake `SummaryStatusSchema` value) and confirm `tsc --noEmit` fails inside `classifyRow` before merge — proves the schema binding is load-bearing