### PR TITLE
fix(check-stuck-articles): exclude chrome:// browser-internal URLs

### DIFF
--- a/src/packages/check-stuck-articles/scripts/exclude-patterns.ts
+++ b/src/packages/check-stuck-articles/scripts/exclude-patterns.ts
@@ -15,6 +15,7 @@ export const EXCLUDE_PATTERNS: readonly RegExp[] = [
 	/:\/\/localhost/,
 	/^about:home$/,
 	/^about:newtab$/,
+	/^chrome:\/\//,
 	/278728209435-wu2vbie3\.ap-southeast-2\.console\.aws\.amazon\.com/,
 	/:\/\/medium\.com\/@fagnerbrack/,
 ];


### PR DESCRIPTION
## Summary

`chrome://` URLs (`chrome://extensions/`, `chrome://newtab/`) are browser-internal pages users accidentally save by clicking the extension on a new-tab or extensions page. They are the same class of unfetchable URL as the existing `about:home` and `about:newtab` entries.

The canary surfaced two such rows after `0663f93` deliberately removed the `chrome://` exclude as a test of the @claude handoff. Now that the handoff is verified end-to-end, this PR restores the exclude.

## Test plan

- [x] `pnpm nx run @packages/check-stuck-articles:check` passes locally
- [x] Once merged, the next manual canary run will go green again

Closes #188