### PR TITLE
fix: auto-heal failed crawls when viewing an article

### DIFF
--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -40,6 +40,7 @@ const { publishRefreshArticleContent } = initInMemoryRefreshArticleContent({ log
 const { publishUpdateFetchTimestamp } = initInMemoryUpdateFetchTimestamp({ logger: eventLogger })
 const { refreshArticleIfStale } = initRefreshArticleIfStale({
   findArticleFreshness: fixture.articleStore.findArticleFreshness,
+  findArticleCrawlStatus: fixture.articleCrawl.findArticleCrawlStatus,
   crawlArticle,
   parseHtml,
   publishRefreshArticleContent,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -103,6 +103,7 @@ function initProviders() {
 		const { putPendingHtml } = initPutPendingHtml({ client: new S3Client({}), bucketName: pendingHtmlBucketName });
 		const { refreshArticleIfStale } = initRefreshArticleIfStale({
 			findArticleFreshness: articleStore.findArticleFreshness,
+			findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
 			crawlArticle,
 			parseHtml,
 			publishRefreshArticleContent,
@@ -208,6 +209,7 @@ function initProviders() {
 	const stubMarkSummaryPending = async (_params: { url: string }) => {};
 	const { refreshArticleIfStale } = initRefreshArticleIfStale({
 		findArticleFreshness: articleStore.findArticleFreshness,
+		findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
 		crawlArticle,
 		parseHtml,
 		publishRefreshArticleContent,

--- a/projects/hutch/src/runtime/providers/article-freshness/check-content-freshness.test.ts
+++ b/projects/hutch/src/runtime/providers/article-freshness/check-content-freshness.test.ts
@@ -3,6 +3,7 @@ import { initRefreshArticleIfStale } from "./check-content-freshness";
 function createDeps(overrides?: Record<string, unknown>) {
 	return {
 		findArticleFreshness: async (_url: string) => null,
+		findArticleCrawlStatus: async (_url: string) => undefined,
 		crawlArticle: async () => ({ status: "failed" as const }),
 		parseHtml: () => ({
 			ok: true as const,
@@ -32,12 +33,41 @@ describe("refreshArticleIfStale", () => {
 		expect(result.action).toBe("new");
 	});
 
+	it("returns action 'reprime' when crawl status is failed", async () => {
+		const deps = createDeps({
+			findArticleFreshness: async () => ({
+				contentFetchedAt: "2026-03-20T09:00:00Z",
+			}),
+			findArticleCrawlStatus: async () => ({ status: "failed" as const, reason: "blocked" }),
+		});
+		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
+
+		const result = await refreshArticleIfStale({ url: "https://example.com/article" });
+
+		expect(result.action).toBe("reprime");
+	});
+
+	it("returns action 'reprime' when crawl status is undefined (legacy stub)", async () => {
+		const deps = createDeps({
+			findArticleFreshness: async () => ({
+				contentFetchedAt: "2026-03-20T09:00:00Z",
+			}),
+			findArticleCrawlStatus: async () => undefined,
+		});
+		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
+
+		const result = await refreshArticleIfStale({ url: "https://example.com/article" });
+
+		expect(result.action).toBe("reprime");
+	});
+
 	it("returns action 'skip' when contentFetchedAt is within TTL", async () => {
 		const deps = createDeps({
 			findArticleFreshness: async () => ({
 				etag: '"abc"',
 				contentFetchedAt: "2026-03-20T09:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 		});
 		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
 
@@ -53,6 +83,7 @@ describe("refreshArticleIfStale", () => {
 				etag: '"abc"',
 				contentFetchedAt: "2026-03-19T00:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 			crawlArticle: async () => ({ status: "not-modified" as const }),
 			publishUpdateFetchTimestamp: async () => { publishCalled.push("timestamp"); },
 		});
@@ -72,6 +103,7 @@ describe("refreshArticleIfStale", () => {
 				lastModified: "Wed, 19 Mar 2026 00:00:00 GMT",
 				contentFetchedAt: "2026-03-19T00:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 			crawlArticle: async (params: { url: string; etag?: string; lastModified?: string }) => {
 				capturedParams.push(params);
 				return { status: "not-modified" as const };
@@ -95,6 +127,7 @@ describe("refreshArticleIfStale", () => {
 				etag: '"abc"',
 				contentFetchedAt: "2026-03-19T00:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 			crawlArticle: async () => ({
 				status: "fetched" as const,
 				html: "<html>New content</html>",
@@ -116,6 +149,7 @@ describe("refreshArticleIfStale", () => {
 			findArticleFreshness: async () => ({
 				contentFetchedAt: "2026-03-19T00:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 			crawlArticle: async () => ({
 				status: "fetched" as const,
 				html: "<html>Fresh</html>",
@@ -129,11 +163,12 @@ describe("refreshArticleIfStale", () => {
 		expect(result.action).toBe("refreshed");
 	});
 
-	it("returns action 'skip' when crawlArticle returns failed", async () => {
+	it("returns action 'skip' when crawlArticle returns failed on re-crawl", async () => {
 		const deps = createDeps({
 			findArticleFreshness: async () => ({
 				contentFetchedAt: "2026-03-19T00:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 			crawlArticle: async () => ({ status: "failed" as const }),
 		});
 		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
@@ -149,6 +184,7 @@ describe("refreshArticleIfStale", () => {
 				etag: '"abc"',
 				contentFetchedAt: "2026-03-19T00:00:00Z",
 			}),
+			findArticleCrawlStatus: async () => ({ status: "ready" as const }),
 			crawlArticle: async () => ({
 				status: "fetched" as const,
 				html: "<html>Bad content</html>",

--- a/projects/hutch/src/runtime/providers/article-freshness/check-content-freshness.ts
+++ b/projects/hutch/src/runtime/providers/article-freshness/check-content-freshness.ts
@@ -3,6 +3,7 @@ import type {
 	ParseArticleResult,
 	ParseHtml,
 } from "../article-parser/article-parser.types";
+import type { FindArticleCrawlStatus } from "../article-crawl/article-crawl.types";
 import type { FindArticleFreshness } from "../article-store/article-store.types";
 import type { PublishRefreshArticleContent } from "../events/publish-refresh-article-content.types";
 import type { PublishUpdateFetchTimestamp } from "../events/publish-update-fetch-timestamp.types";
@@ -10,6 +11,7 @@ import { calculateReadTime } from "../../domain/article/estimated-read-time";
 
 export type ContentFreshnessResult =
 	| { action: "new" }
+	| { action: "reprime" }
 	| { action: "skip" }
 	| { action: "unchanged" }
 	| { action: "refreshed"; article: ParseArticleResult & { ok: true } };
@@ -20,6 +22,7 @@ export type RefreshArticleIfStale = (params: {
 
 export function initRefreshArticleIfStale(deps: {
 	findArticleFreshness: FindArticleFreshness;
+	findArticleCrawlStatus: FindArticleCrawlStatus;
 	crawlArticle: CrawlArticle;
 	parseHtml: ParseHtml;
 	publishRefreshArticleContent: PublishRefreshArticleContent;
@@ -32,6 +35,11 @@ export function initRefreshArticleIfStale(deps: {
 
 		if (!freshness) {
 			return { action: "new" };
+		}
+
+		const crawl = await deps.findArticleCrawlStatus(params.url);
+		if (!crawl || crawl.status === "failed") {
+			return { action: "reprime" };
 		}
 
 		if (freshness.contentFetchedAt) {

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -416,6 +416,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		markSummaryPending: deps.markSummaryPending,
 		findArticleCrawlStatus: deps.findArticleCrawlStatus,
 		markCrawlPending: deps.markCrawlPending,
+		refreshArticleIfStale: deps.refreshArticleIfStale,
 		saveArticleGlobally: deps.saveArticleGlobally,
 		publishSaveAnonymousLink: deps.publishSaveAnonymousLink,
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
@@ -26,6 +26,7 @@ describe("Queue freshness integration", () => {
 
 		const { refreshArticleIfStale } = initRefreshArticleIfStale({
 			findArticleFreshness: fixture.articleStore.findArticleFreshness,
+			findArticleCrawlStatus: fixture.articleCrawl.findArticleCrawlStatus,
 			crawlArticle: async (params) => {
 				if (!params.etag && !params.lastModified) {
 					return {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -115,6 +115,23 @@ async function saveArticleFromUrl(deps: QueueDependencies, params: {
 		return { ok: true, saved: await markUnreadIfRead(deps, saved) };
 	}
 
+	if (freshness.action === "reprime") {
+		const saved = await deps.saveArticle({
+			userId,
+			url,
+			metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+			estimatedReadTime: calculateReadTime(0),
+		});
+		await deps.markCrawlPending({ url });
+		await deps.markSummaryPending({ url });
+		await deps.publishUpdateFetchTimestamp({
+			url,
+			contentFetchedAt: new Date().toISOString(),
+		});
+		await deps.publishLinkSaved({ url, userId });
+		return { ok: true, saved: await markUnreadIfRead(deps, saved) };
+	}
+
 	const saved = await deps.saveArticle({
 		userId,
 		url,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
+import { MinutesSchema } from "../../../domain/article/article.schema";
 import { createTestApp, type TestAppResult } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
@@ -117,6 +118,37 @@ describe("Queue routes", () => {
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector("[data-test-save-error]")?.textContent).toBe("Could not save article. Please try again.");
+		});
+
+		it("re-primes pipeline when refreshArticleIfStale returns reprime", async () => {
+			const publishedLinkSaved: { url: string; userId: string }[] = [];
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { app, auth, articleStore, articleCrawl } = createTestApp({
+				...fixture,
+				events: {
+					publishLinkSaved: async (params) => { publishedLinkSaved.push(params); },
+					publishSaveAnonymousLink: fixture.events.publishSaveAnonymousLink,
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+				},
+				freshness: { refreshArticleIfStale: async () => ({ action: "reprime" }) },
+			});
+			const agent = await loginAgent(app, auth);
+			await articleStore.saveArticleGlobally({
+				url: "https://example.com/article",
+				metadata: { title: "Failed", siteName: "example.com", excerpt: "", wordCount: 0 },
+				estimatedReadTime: MinutesSchema.parse(0),
+			});
+			await articleCrawl.markCrawlFailed({ url: "https://example.com/article", reason: "blocked" });
+
+			const response = await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/article" });
+
+			expect(response.status).toBe(303);
+			expect(publishedLinkSaved).toHaveLength(1);
+			expect(publishedLinkSaved[0].url).toBe("https://example.com/article");
 		});
 
 		it("should bump a re-saved article to the top so #latest-saved points to it", async () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -108,8 +108,9 @@ function handleViewArticle(deps: ViewDependencies) {
 		// instead of sitting on "Generating summary…" forever on every view.
 		const isLegacyStub =
 			cached !== null && existingCrawl === undefined && existingSummary === undefined;
+		const isCrawlFailed = existingCrawl?.status === "failed";
 
-		if (!cached || isLegacyStub) {
+		if (!cached || isLegacyStub || isCrawlFailed) {
 			if (!cached) {
 				// First visit for this URL — save a hostname-only stub so the reader
 				// and summary slots can render metadata while the worker populates

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -16,6 +16,7 @@ import type {
 	FindArticleCrawlStatus,
 	MarkCrawlPending,
 } from "../../../providers/article-crawl/article-crawl.types";
+import type { RefreshArticleIfStale } from "../../../providers/article-freshness/check-content-freshness";
 import type {
 	FindGeneratedSummary,
 	MarkSummaryPending,
@@ -38,6 +39,7 @@ interface ViewDependencies {
 	markSummaryPending: MarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
+	refreshArticleIfStale: RefreshArticleIfStale;
 	saveArticleGlobally: SaveArticleGlobally;
 	publishSaveAnonymousLink: PublishSaveAnonymousLink;
 }
@@ -95,38 +97,26 @@ function handleViewArticle(deps: ViewDependencies) {
 		}
 		const articleUrl = parsedUrl.data;
 
-		const cached = await deps.findArticleByUrl(articleUrl);
-		const existingCrawl = cached
-			? await deps.findArticleCrawlStatus(articleUrl)
-			: undefined;
-		const existingSummary = cached
-			? await deps.findGeneratedSummary(articleUrl)
-			: undefined;
-		// A cached row with neither crawlStatus nor summaryStatus is a legacy
-		// stub written before the state machines existed. Re-prime the pipeline
-		// and re-publish the anonymous-save event so it reaches a terminal state
-		// instead of sitting on "Generating summary…" forever on every view.
-		const isLegacyStub =
-			cached !== null && existingCrawl === undefined && existingSummary === undefined;
-		const isCrawlFailed = existingCrawl?.status === "failed";
+		const freshness = await deps.refreshArticleIfStale({ url: articleUrl });
 
-		if (!cached || isLegacyStub || isCrawlFailed) {
-			if (!cached) {
-				// First visit for this URL — save a hostname-only stub so the reader
-				// and summary slots can render metadata while the worker populates
-				// content + real metadata asynchronously.
-				const hostname = hostnameFrom(articleUrl);
-				await deps.saveArticleGlobally({
-					url: articleUrl,
-					metadata: {
-						title: hostname,
-						siteName: hostname,
-						excerpt: "",
-						wordCount: 0,
-					},
-					estimatedReadTime: calculateReadTime(0),
-				});
-			}
+		if (freshness.action === "new") {
+			const hostname = hostnameFrom(articleUrl);
+			await deps.saveArticleGlobally({
+				url: articleUrl,
+				metadata: {
+					title: hostname,
+					siteName: hostname,
+					excerpt: "",
+					wordCount: 0,
+				},
+				estimatedReadTime: calculateReadTime(0),
+			});
+			await deps.markCrawlPending({ url: articleUrl });
+			await deps.markSummaryPending({ url: articleUrl });
+			await deps.publishSaveAnonymousLink({ url: articleUrl });
+		}
+
+		if (freshness.action === "reprime") {
 			await deps.markCrawlPending({ url: articleUrl });
 			await deps.markSummaryPending({ url: articleUrl });
 			await deps.publishSaveAnonymousLink({ url: articleUrl });

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1289,7 +1289,7 @@ describe("View routes", () => {
 			).toBe("<p>Cached body.</p>");
 		});
 
-		it("renders cached metadata with the unavailable reader fallback when only metadata is cached (no content available)", async () => {
+		it("re-crawls a previously failed article on view, rendering the failed state when the retry also fails", async () => {
 			const parseSpy = jest.fn(
 				async (_url: string): Promise<ParseArticleResult> => ({
 					ok: false,
@@ -1332,8 +1332,7 @@ describe("View routes", () => {
 			const response = await request(app).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
-			// Terminal crawl state short-circuits re-priming: parser is not invoked.
-			expect(parseSpy).not.toHaveBeenCalled();
+			expect(parseSpy).toHaveBeenCalled();
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-slot]");
 			assert(slot, "reader slot must be rendered");
@@ -1502,6 +1501,45 @@ describe("View routes", () => {
 				},
 				estimatedReadTime: MinutesSchema.parse(0),
 			});
+
+			await request(app).get(`/view/${ENCODED}`);
+
+			expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: ARTICLE_URL });
+		});
+
+		it("re-primes the pipeline for a cached article with a failed crawl status", async () => {
+			const parseArticle: ParseArticle = async () => buildParseResult();
+			const publishSaveAnonymousLink = jest.fn(async () => {});
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const { app, articleStore, articleCrawl } = createTestApp({
+				...fixture,
+				parser: {
+					parseArticle,
+					crawlArticle: fixture.parser.crawlArticle,
+				},
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishSaveAnonymousLink: publishSaveAnonymousLink,
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+				},
+			});
+			await articleStore.saveArticleGlobally({
+				url: ARTICLE_URL,
+				metadata: {
+					title: "Previously Failed",
+					siteName: "example.com",
+					excerpt: "An article that failed to crawl.",
+					wordCount: 0,
+				},
+				estimatedReadTime: MinutesSchema.parse(0),
+			});
+			await articleCrawl.markCrawlFailed({ url: ARTICLE_URL, reason: "exceeded SQS maxReceiveCount" });
 
 			await request(app).get(`/view/${ENCODED}`);
 

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1257,6 +1257,7 @@ describe("View routes", () => {
 					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
 					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
 				},
+				freshness: { refreshArticleIfStale: async () => ({ action: "skip" }) },
 			});
 			await articleStore.saveArticle({
 				userId: UserIdSchema.parse("seed-user"),
@@ -1315,6 +1316,7 @@ describe("View routes", () => {
 					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
 					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
 				},
+				freshness: { refreshArticleIfStale: async () => ({ action: "reprime" }) },
 			});
 			await articleStore.saveArticle({
 				userId: UserIdSchema.parse("seed-user"),
@@ -1441,6 +1443,7 @@ describe("View routes", () => {
 					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
 					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
 				},
+				freshness: { refreshArticleIfStale: async () => ({ action: "skip" }) },
 				summary:{
  	findGeneratedSummary: findGeneratedSummary,
  	markSummaryPending: fixture.summary.markSummaryPending,
@@ -1464,12 +1467,10 @@ describe("View routes", () => {
 		});
 
 		it("re-primes the pipeline for a legacy stub (cached row with no crawl and no summary state)", async () => {
-			// A stub row written before the crawl+summary state machines existed
-			// carries metadata but neither crawlStatus nor summaryStatus. Without
-			// a re-prime the row sits undefined/undefined forever and the UI
-			// polls "Generating summary…" indefinitely. The view handler must
-			// detect this and re-publish SaveAnonymousLinkCommand so the worker
-			// populates the state-machine rows.
+			// refreshArticleIfStale returns "reprime" for legacy stubs (freshness
+			// exists but crawl status is undefined). The view handler then
+			// re-publishes SaveAnonymousLinkCommand so the worker populates the
+			// state-machine rows.
 			const parseArticle: ParseArticle = async () => buildParseResult();
 			const publishSaveAnonymousLink = jest.fn(async () => {});
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
@@ -1490,6 +1491,7 @@ describe("View routes", () => {
 					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
 					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
 				},
+				freshness: { refreshArticleIfStale: async () => ({ action: "reprime" }) },
 			});
 			await articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
@@ -1528,6 +1530,7 @@ describe("View routes", () => {
 					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
 					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
 				},
+				freshness: { refreshArticleIfStale: async () => ({ action: "reprime" }) },
 			});
 			await articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,


### PR DESCRIPTION
When a user visits `/view/<url>` for an article whose crawl previously failed, re-prime the crawl pipeline instead of showing the permanent error. This reduces false-positive stuck-article canary alerts for transient failures that self-resolve on next page load.

Closes #190

Generated with [Claude Code](https://claude.ai/code)