### PR TITLE
Centralize timeout configuration for Deepseek clients

### DIFF
--- a/projects/save-link/src/generate-summary/timeouts.test.ts
+++ b/projects/save-link/src/generate-summary/timeouts.test.ts
@@ -1,0 +1,14 @@
+import { GENERATE_SUMMARY_TIMEOUTS } from "./timeouts";
+
+describe("GENERATE_SUMMARY_TIMEOUTS", () => {
+	it("deepseek client aborts before the Lambda timeout", () => {
+		const lambdaMs = GENERATE_SUMMARY_TIMEOUTS.lambdaSeconds * 1000;
+		expect(GENERATE_SUMMARY_TIMEOUTS.deepseekMs).toBeLessThan(lambdaMs);
+	});
+
+	it("SQS visibility timeout is at least as long as the Lambda timeout", () => {
+		expect(GENERATE_SUMMARY_TIMEOUTS.sqsVisibilitySeconds).toBeGreaterThanOrEqual(
+			GENERATE_SUMMARY_TIMEOUTS.lambdaSeconds,
+		);
+	});
+});

--- a/projects/save-link/src/generate-summary/timeouts.ts
+++ b/projects/save-link/src/generate-summary/timeouts.ts
@@ -1,0 +1,8 @@
+// Shared between the Deepseek client (runtime) and the Lambda (infra) so the
+// client always aborts before the Lambda's own timeout kicks in — otherwise the
+// Lambda timeout swallows the Deepseek error and we lose the underlying cause.
+export const GENERATE_SUMMARY_TIMEOUTS = {
+	lambdaSeconds: 300,
+	sqsVisibilitySeconds: 300,
+	deepseekMs: 240_000,
+} as const;

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -22,6 +22,8 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import { requireEnv } from "../require-env";
+import { GENERATE_SUMMARY_TIMEOUTS } from "../generate-summary/timeouts";
+import { SELECT_CONTENT_TIMEOUTS } from "../select-content/timeouts";
 
 const config = new pulumi.Config();
 const alertEmail = config.require("alertEmail");
@@ -58,7 +60,7 @@ const eventBus = HutchEventBus.fromPlatformStack(config);
 // --- Queues ---
 
 const generateSummaryQueue = new HutchSQS("generate-summary", {
-	visibilityTimeoutSeconds: 300,
+	visibilityTimeoutSeconds: GENERATE_SUMMARY_TIMEOUTS.sqsVisibilitySeconds,
 });
 
 const linkSavedQueue = new HutchSQS("link-saved", {
@@ -245,7 +247,7 @@ new HutchDLQEventHandler("save-anonymous-link-dlq", {
 // CrawlArticleCompletedEvent (every successful selection).
 
 const selectMostCompleteContentQueue = new HutchSQS("select-most-complete-content", {
-	visibilityTimeoutSeconds: 90,
+	visibilityTimeoutSeconds: SELECT_CONTENT_TIMEOUTS.sqsVisibilitySeconds,
 });
 
 const selectMostCompleteContentDynamodb = new HutchDynamoDBAccess("select-most-complete-content-dynamodb", {
@@ -258,7 +260,7 @@ const selectMostCompleteContentLambda = new HutchLambda("select-most-complete-co
 	outputDir: ".lib/select-most-complete-content",
 	assetDir: "./src",
 	memorySize: 256,
-	timeout: 60,
+	timeout: SELECT_CONTENT_TIMEOUTS.lambdaSeconds,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
@@ -305,7 +307,7 @@ const generateSummaryLambda = new HutchLambda("generate-summary", {
 	outputDir: ".lib/generate-summary",
 	assetDir: "./src",
 	memorySize: 512,
-	timeout: 45,
+	timeout: GENERATE_SUMMARY_TIMEOUTS.lambdaSeconds,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		DEEPSEEK_API_KEY: deepseekApiKey,

--- a/projects/save-link/src/runtime/generate-summary.main.ts
+++ b/projects/save-link/src/runtime/generate-summary.main.ts
@@ -8,6 +8,7 @@ import { initFindArticleContent } from "../save-link/find-article-content";
 import { initLinkSummariser } from "../generate-summary/link-summariser";
 import { initCreateDeepseekMessage } from "../generate-summary/create-deepseek-message";
 import { MAX_SUMMARY_LENGTH } from "../generate-summary/max-summary-length";
+import { GENERATE_SUMMARY_TIMEOUTS } from "../generate-summary/timeouts";
 import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { stripHtml } from "../generate-summary/strip-html";
 import { initGenerateSummaryHandler } from "../generate-summary/generate-summary-handler";
@@ -18,7 +19,11 @@ const eventBusName = requireEnv("EVENT_BUS_NAME");
 
 const dynamoClient = createDynamoDocumentClient();
 const s3Client = new S3Client({});
-const deepseekClient = new OpenAI({ apiKey: deepseekApiKey, baseURL: "https://api.deepseek.com", timeout: 60_000 });
+const deepseekClient = new OpenAI({
+	apiKey: deepseekApiKey,
+	baseURL: "https://api.deepseek.com",
+	timeout: GENERATE_SUMMARY_TIMEOUTS.deepseekMs,
+});
 
 const createMessage = initCreateDeepseekMessage({
 	createChatCompletion: (params) => deepseekClient.chat.completions.create(params),

--- a/projects/save-link/src/runtime/select-most-complete-content.main.ts
+++ b/projects/save-link/src/runtime/select-most-complete-content.main.ts
@@ -7,6 +7,7 @@ import { requireEnv } from "../require-env";
 import { initReadTierSource } from "../select-content/read-tier-source";
 import { initListAvailableTierSources } from "../select-content/list-available-tier-sources";
 import { initSelectMostCompleteContent } from "../select-content/select-content";
+import { SELECT_CONTENT_TIMEOUTS } from "../select-content/timeouts";
 import { initPromoteTierToCanonical } from "../select-content/promote-tier-to-canonical";
 import { initFindContentSourceTier } from "../select-content/find-content-source-tier";
 import { initSelectMostCompleteContentHandler } from "../select-content/select-most-complete-content-handler";
@@ -21,7 +22,7 @@ const dynamoClient = createDynamoDocumentClient();
 const deepseekClient = new OpenAI({
 	apiKey: deepseekApiKey,
 	baseURL: "https://api.deepseek.com",
-	timeout: 45_000, // below Lambda's 60s timeout to leave headroom for post-selection S3/DynamoDB ops
+	timeout: SELECT_CONTENT_TIMEOUTS.deepseekMs,
 });
 
 const { readTierSource } = initReadTierSource({

--- a/projects/save-link/src/select-content/timeouts.test.ts
+++ b/projects/save-link/src/select-content/timeouts.test.ts
@@ -1,0 +1,14 @@
+import { SELECT_CONTENT_TIMEOUTS } from "./timeouts";
+
+describe("SELECT_CONTENT_TIMEOUTS", () => {
+	it("deepseek client aborts before the Lambda timeout", () => {
+		const lambdaMs = SELECT_CONTENT_TIMEOUTS.lambdaSeconds * 1000;
+		expect(SELECT_CONTENT_TIMEOUTS.deepseekMs).toBeLessThan(lambdaMs);
+	});
+
+	it("SQS visibility timeout is at least as long as the Lambda timeout", () => {
+		expect(SELECT_CONTENT_TIMEOUTS.sqsVisibilitySeconds).toBeGreaterThanOrEqual(
+			SELECT_CONTENT_TIMEOUTS.lambdaSeconds,
+		);
+	});
+});

--- a/projects/save-link/src/select-content/timeouts.ts
+++ b/projects/save-link/src/select-content/timeouts.ts
@@ -1,0 +1,8 @@
+// Shared between the Deepseek client (runtime) and the Lambda (infra) so the
+// client always aborts before the Lambda's own timeout kicks in — otherwise the
+// Lambda timeout swallows the Deepseek error and we lose the underlying cause.
+export const SELECT_CONTENT_TIMEOUTS = {
+	lambdaSeconds: 300,
+	sqsVisibilitySeconds: 300,
+	deepseekMs: 240_000,
+} as const;

--- a/projects/save-link/src/select-content/timeouts.ts
+++ b/projects/save-link/src/select-content/timeouts.ts
@@ -4,5 +4,5 @@
 export const SELECT_CONTENT_TIMEOUTS = {
 	lambdaSeconds: 300,
 	sqsVisibilitySeconds: 300,
-	deepseekMs: 240_000,
+	deepseekMs: 240_000, // 60s headroom for post-selection S3/DynamoDB ops
 } as const;


### PR DESCRIPTION
## Summary
Extracted timeout configurations for the `generate-summary` and `select-most-complete-content` Lambda functions into centralized constant files. This ensures that Deepseek client timeouts are always shorter than Lambda timeouts, preventing Lambda timeout errors from masking underlying API failures.

## Key Changes
- Created `projects/save-link/src/generate-summary/timeouts.ts` with centralized timeout constants (Lambda: 300s, SQS visibility: 300s, Deepseek client: 240s)
- Created `projects/save-link/src/select-content/timeouts.ts` with matching timeout constants
- Updated infrastructure code to use these constants instead of hardcoded values:
  - `generate-summary` Lambda timeout: 45s → 300s
  - `generate-summary` SQS visibility: 300s (now explicit)
  - `select-most-complete-content` Lambda timeout: 60s → 300s
  - `select-most-complete-content` SQS visibility: 90s → 300s
- Updated runtime clients to use the centralized timeout constants:
  - `generate-summary` Deepseek client: 60s → 240s
  - `select-most-complete-content` Deepseek client: 45s → 240s
- Added test suites for both timeout configurations to verify:
  - Deepseek client aborts before Lambda timeout
  - SQS visibility timeout is at least as long as Lambda timeout

## Implementation Details
The timeout constants are defined as shared objects that are imported by both infrastructure (Pulumi) and runtime code, ensuring consistency across deployment and execution. The 60-second buffer between Deepseek client timeout (240s) and Lambda timeout (300s) provides headroom for post-API operations while ensuring client errors surface before Lambda timeout errors.

https://claude.ai/code/session_01TL3Rcidenvyq4pFs8999xK