### PR TITLE
Fix extension version bumps to only trigger on compile changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,18 @@ jobs:
           echo "Final deploy list: $PROJECTS"
           echo "Non-platform: $NON_PLATFORM"
 
+          # Extension publish gates only fire when the compile target is affected,
+          # so test-only changes in dependencies (e.g. hutch *.test.ts) don't bump
+          # the Web Store / AMO version. compile inputs use `^production`, which
+          # excludes test files via the namedInputs in nx.json.
+          COMPILE_AFFECTED=$(pnpm nx show projects --affected --target=compile --json)
+
           # Set outputs for downstream jobs to use in their `if:` conditions
           echo "platform-affected=$(echo "$PROJECTS" | jq -e 'index("platform")' > /dev/null 2>&1 && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "non-platform-projects=$NON_PLATFORM" >> "$GITHUB_OUTPUT"
           echo "has-non-platform=$(echo "$NON_PLATFORM" | jq -e 'length > 0' > /dev/null 2>&1 && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "ff-affected=$(echo "$PROJECTS" | jq -e 'index("firefox-extension")' > /dev/null 2>&1 && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "chrome-affected=$(echo "$PROJECTS" | jq -e 'index("chrome-extension")' > /dev/null 2>&1 && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "ff-affected=$(echo "$COMPILE_AFFECTED" | jq -e 'index("firefox-extension")' > /dev/null 2>&1 && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "chrome-affected=$(echo "$COMPILE_AFFECTED" | jq -e 'index("chrome-extension")' > /dev/null 2>&1 && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
   # Platform (EventBridge bus, shared infra) must deploy before any other project
   # because other projects depend on platform resources (e.g. event bus ARN)


### PR DESCRIPTION
## Summary
Updated the CI workflow to use compile-target affected projects when determining whether to publish Firefox and Chrome extensions, instead of using all affected projects. This prevents test-only changes in dependencies from triggering unnecessary version bumps in the Web Store and AMO.

## Changes
- Added `COMPILE_AFFECTED` variable that queries projects affected by the `compile` target, which respects the `^production` namedInputs configuration that excludes test files
- Updated `ff-affected` and `chrome-affected` output conditions to check `COMPILE_AFFECTED` instead of `PROJECTS`
- Added explanatory comments documenting why compile-target filtering is necessary for extension publishing gates

## Implementation Details
The compile target uses `^production` inputs as defined in nx.json, which automatically excludes test files (e.g., `*.test.ts`) from the dependency graph. This ensures that test-only changes in shared dependencies like hutch won't trigger extension version bumps, while actual code changes that affect compilation will still properly trigger publishes.

https://claude.ai/code/session_01Qwyonz8167a8ybf5RLqPqZ