### PR TITLE
Gate article saves by URL scheme

### DIFF
--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -1,6 +1,6 @@
 import type { ReadingListItem, ReadingListItemId } from "./domain/reading-list-item.types";
 import type { Auth, GuardedResult } from "./auth/auth.types";
-import type { SaveUrlResult, RemoveUrlResult, SaveUrl, RemoveUrl, FindByUrl, GetAllItems } from "./reading-list/reading-list.types";
+import type { SaveUrlResult, RemoveUrlResult, SaveUrl, RemoveUrl, FindByUrl, GetAllItems, GetSaveableSchemes } from "./reading-list/reading-list.types";
 import type { BrowserShell } from "./shell.types";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { createEventBus } from "./event-bus";
@@ -15,6 +15,7 @@ export interface ReadingList {
 	removeUrl: RemoveUrl;
 	findByUrl: FindByUrl;
 	getAllItems: GetAllItems;
+	getSaveableSchemes: GetSaveableSchemes;
 }
 
 export type ResultCallbacks<T> = {
@@ -33,7 +34,7 @@ export interface Core {
 	logout(): void;
 	save(resource: "current-tab", data: { url: string; title: string; rawHtml?: string }): void;
 	remove(resource: "item", data: { id: ReadingListItemId }): void;
-	fetch(resource: "reading-list"): void;
+	fetch(resource: "reading-list" | "saveable-schemes"): void;
 	check(resource: "url", data: { url: string }): void;
 
 	on(event: "pre-init", handler: () => void): void;
@@ -43,12 +44,14 @@ export interface Core {
 	on(event: "saved-current-tab", handler: ResultCallbacks<SaveUrlResult>): void;
 	on(event: "removed-item", handler: ResultCallbacks<RemoveUrlResult>): void;
 	on(event: "fetched-reading-list", handler: ResultCallbacks<ReadingListItem[]>): void;
+	on(event: "fetched-saveable-schemes", handler: ResultCallbacks<readonly string[]>): void;
 	on(event: "checked-url", handler: ResultCallbacks<ReadingListItem | null>): void;
 
 	once(event: "logged-in", handler: ResultCallbacks<void>): void;
 	once(event: "saved-current-tab", handler: ResultCallbacks<SaveUrlResult>): void;
 	once(event: "removed-item", handler: ResultCallbacks<RemoveUrlResult>): void;
 	once(event: "fetched-reading-list", handler: ResultCallbacks<ReadingListItem[]>): void;
+	once(event: "fetched-saveable-schemes", handler: ResultCallbacks<readonly string[]>): void;
 	once(event: "checked-url", handler: ResultCallbacks<ReadingListItem | null>): void;
 }
 
@@ -207,7 +210,12 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 			}
 		},
 
-		fetch(_resource) {
+		fetch(resource) {
+			if (resource === "saveable-schemes") {
+				const guarded = auth.whenLoggedIn(() => readingList.getSaveableSchemes());
+				emitResult("fetched-saveable-schemes", guarded);
+				return;
+			}
 			const guarded = auth.whenLoggedIn(() => readingList.getAllItems());
 			emitResult("fetched-reading-list", guarded);
 		},

--- a/projects/browser-extension-core/src/e2e-actions/pagination-actions.ts
+++ b/projects/browser-extension-core/src/e2e-actions/pagination-actions.ts
@@ -12,8 +12,8 @@ export interface PaginationProgress {
 	verifiedBackOnPage1: boolean;
 }
 
-/** Total items = 1 auto-saved popup URL + 1 save-link action + PAGINATION_LINK_COUNT = 12, exceeding the 10-per-page threshold. */
-const PAGINATION_LINK_COUNT = 10;
+/** Total items = 1 save-link action + PAGINATION_LINK_COUNT = 12, exceeding the 10-per-page threshold. */
+const PAGINATION_LINK_COUNT = 11;
 const ACTIVE_PAGE_SELECTOR = `#${ELEMENT_IDS.pagination} .pagination__page--active`;
 const NEXT_PAGE_SELECTOR = `#${ELEMENT_IDS.pagination} button[aria-label="Next page"]`;
 const PREV_PAGE_SELECTOR = `#${ELEMENT_IDS.pagination} button[aria-label="Previous page"]`;

--- a/projects/browser-extension-core/src/index.ts
+++ b/projects/browser-extension-core/src/index.ts
@@ -38,13 +38,14 @@ export type {
 	ArticleItem,
 	BoundAction,
 } from "./reading-list/siren-reading-list";
-export type { SaveUrl, RemoveUrl, FindByUrl, GetAllItems } from "./reading-list/reading-list.types";
+export type { SaveUrl, RemoveUrl, FindByUrl, GetAllItems, GetSaveableSchemes } from "./reading-list/reading-list.types";
 export type { PopupMessage } from "./popup-message.types";
 export { filterByUrl } from "./popup/filter-by-url";
 export { paginateItems } from "./popup/paginate-items";
 export { avatarColor } from "./popup/avatar-color";
 export { relativeTime } from "./popup/relative-time";
 export { isAppUrl } from "./popup/is-app-url";
+export { isSaveableScheme } from "./popup/is-saveable-scheme";
 export {
 	MENU_ITEM_SAVE_PAGE,
 	MENU_ITEM_SAVE_LINK,

--- a/projects/browser-extension-core/src/popup-message.types.ts
+++ b/projects/browser-extension-core/src/popup-message.types.ts
@@ -5,5 +5,6 @@ export type PopupMessage =
 	| { type: "remove-item"; id: ReadingListItemId }
 	| { type: "check-url"; url: string }
 	| { type: "get-all-items" }
+	| { type: "get-saveable-schemes" }
 	| { type: "login" }
 	| { type: "logout" };

--- a/projects/browser-extension-core/src/popup/is-saveable-scheme.test.ts
+++ b/projects/browser-extension-core/src/popup/is-saveable-scheme.test.ts
@@ -1,0 +1,56 @@
+import { isSaveableScheme } from "./is-saveable-scheme";
+
+describe("isSaveableScheme", () => {
+	const allowedSchemes = ["http", "https"];
+
+	it("returns true for an http URL", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "http://example.com/article", allowedSchemes }),
+		).toBe(true);
+	});
+
+	it("returns true for an https URL", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "https://example.com/article", allowedSchemes }),
+		).toBe(true);
+	});
+
+	it("returns false for chrome:// internal pages", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "chrome://newtab/", allowedSchemes }),
+		).toBe(false);
+	});
+
+	it("returns false for about: pages", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "about:blank", allowedSchemes }),
+		).toBe(false);
+	});
+
+	it("returns false for file: URLs", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "file:///etc/hosts", allowedSchemes }),
+		).toBe(false);
+	});
+
+	it("returns false for view-source: URLs", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "view-source:https://example.com", allowedSchemes }),
+		).toBe(false);
+	});
+
+	it("returns false for an unparseable URL", () => {
+		expect(
+			isSaveableScheme({ tabUrl: "not a url", allowedSchemes }),
+		).toBe(false);
+	});
+
+	it("respects an extended scheme list from the server", () => {
+		expect(
+			isSaveableScheme({
+				tabUrl: "ftp://example.com/file.txt",
+				allowedSchemes: ["http", "https", "ftp"],
+			}),
+		).toBe(true);
+	});
+});

--- a/projects/browser-extension-core/src/popup/is-saveable-scheme.ts
+++ b/projects/browser-extension-core/src/popup/is-saveable-scheme.ts
@@ -1,0 +1,11 @@
+export function isSaveableScheme(params: {
+	tabUrl: string;
+	allowedSchemes: readonly string[];
+}): boolean {
+	try {
+		const protocol = new URL(params.tabUrl).protocol.replace(/:$/, "");
+		return params.allowedSchemes.includes(protocol);
+	} catch {
+		return false;
+	}
+}

--- a/projects/browser-extension-core/src/reading-list/reading-list.types.ts
+++ b/projects/browser-extension-core/src/reading-list/reading-list.types.ts
@@ -26,3 +26,5 @@ export type FindByUrl = (
 ) => Promise<ReadingListItem | null>;
 
 export type GetAllItems = () => Promise<ReadingListItem[]>;
+
+export type GetSaveableSchemes = () => Promise<readonly string[]>;

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
@@ -2160,6 +2160,97 @@ describe("initSirenReadingList", () => {
 		});
 	});
 
+	describe("getSaveableSchemes", () => {
+		it("returns the schemes published on save-article's url field", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: JSON.stringify({
+							class: ["collection", "articles"],
+							entities: [],
+							links: [{ rel: ["self"], href: "/queue" }],
+							actions: [
+								{
+									name: "save-article",
+									href: "/queue",
+									method: "POST",
+									type: "application/json",
+									fields: [
+										{ name: "url", type: "url", schemes: ["http", "https"] },
+									],
+								},
+							],
+						}),
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			expect(await list.getSaveableSchemes()).toEqual(["http", "https"]);
+		});
+
+		it("falls back to the default scheme list when the server omits schemes", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse(),
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			expect(await list.getSaveableSchemes()).toEqual(["http", "https"]);
+		});
+
+		it("falls back to the default scheme list when save-article is absent", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: JSON.stringify({
+							entities: [],
+							actions: [],
+							links: [{ rel: ["self"], href: "/queue" }],
+						}),
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			expect(await list.getSaveableSchemes()).toEqual(["http", "https"]);
+		});
+
+		it("propagates an extended scheme set from the server", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: JSON.stringify({
+							entities: [],
+							links: [{ rel: ["self"], href: "/queue" }],
+							actions: [
+								{
+									name: "save-article",
+									href: "/queue",
+									method: "POST",
+									type: "application/json",
+									fields: [
+										{ name: "url", type: "url", schemes: ["http", "https", "ftp"] },
+									],
+								},
+							],
+						}),
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			expect(await list.getSaveableSchemes()).toEqual([
+				"http",
+				"https",
+				"ftp",
+			]);
+		});
+	});
+
 	describe("authHeaders error handling", () => {
 		it("throws when access token is null", async () => {
 			const { fetchFn } = createRoutingFetch({

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
@@ -8,9 +8,12 @@ import { UnauthorizedError } from "../auth/unauthorized-error";
 import type {
 	FindByUrl,
 	GetAllItems,
+	GetSaveableSchemes,
 	RemoveUrl,
 	SaveUrl,
 } from "./reading-list.types";
+
+const DEFAULT_SAVEABLE_SCHEMES: readonly string[] = ["http", "https"];
 
 const SIREN_MEDIA_TYPE = "application/vnd.siren+json";
 
@@ -38,7 +41,13 @@ const SirenActionSchema = z.object({
 	method: z.string(),
 	type: z.string().optional(),
 	fields: z
-		.array(z.object({ name: z.string(), type: z.string() }))
+		.array(
+			z.object({
+				name: z.string(),
+				type: z.string(),
+				schemes: z.array(z.string()).optional(),
+			}),
+		)
 		.optional(),
 });
 
@@ -95,6 +104,13 @@ export type BoundAction = (
 export type NavigationResult = {
 	items: ArticleItem[];
 	actions: Record<string, BoundAction>;
+};
+
+/** Returned by the walker's entry-point fetch. Carries raw field descriptors for
+ * each collection action so callers can inspect declared metadata (e.g. saveable
+ * URL schemes) without re-fetching the entry point. */
+type EntryPointResult = NavigationResult & {
+	actionFields: Record<string, SirenAction["fields"]>;
 };
 
 export type ArticleItem = ReadingListItem & {
@@ -328,7 +344,7 @@ const ENTRY_POINT = "/";
 export function initExtension(
 	handlers: Map<string, ActionHandler>,
 	deps: ExtensionDeps,
-): () => Promise<NavigationResult> {
+): () => Promise<EntryPointResult> {
 	let resolvedUrl: string | null = null;
 	const navigationCache = new Map<
 		string,
@@ -396,10 +412,14 @@ export function initExtension(
 	function parseResponse(
 		body: SirenCollectionResponse,
 		doFetch: DoFetch,
-	): NavigationResult {
+	): EntryPointResult {
 		const items = (body.entities ?? []).map((e) => resolveItem(e, doFetch));
 		const actions = bindCollectionActions(body.actions ?? [], doFetch);
-		return { items, actions };
+		const actionFields: Record<string, SirenAction["fields"]> = {};
+		for (const sirenAction of body.actions ?? []) {
+			actionFields[sirenAction.name] = sirenAction.fields;
+		}
+		return { items, actions, actionFields };
 	}
 
 	return async () => {
@@ -440,6 +460,7 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 	removeUrl: RemoveUrl;
 	findByUrl: FindByUrl;
 	getAllItems: GetAllItems;
+	getSaveableSchemes: GetSaveableSchemes;
 } {
 	const understandings = groupOf(
 		initSaveArticleUnderstanding(),
@@ -519,5 +540,13 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 		return collection.items;
 	};
 
-	return { saveUrl, removeUrl, findByUrl, getAllItems };
+	const getSaveableSchemes: GetSaveableSchemes = async () => {
+		const collection = await start();
+		const urlField = collection.actionFields["save-article"]?.find(
+			(f) => f.name === "url",
+		);
+		return urlField?.schemes ?? DEFAULT_SAVEABLE_SCHEMES;
+	};
+
+	return { saveUrl, removeUrl, findByUrl, getAllItems, getSaveableSchemes };
 }

--- a/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
@@ -303,6 +303,18 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 					pending.then(sendResponse);
 					break;
 				}
+				case "get-saveable-schemes": {
+					const pending = new Promise<unknown>((resolve) => {
+						core.once("fetched-saveable-schemes", {
+							success: (value: readonly string[]) =>
+								resolve({ ok: true, value }),
+							failure: (err) => resolve({ ok: false, ...err }),
+						});
+					});
+					core.fetch("saveable-schemes");
+					pending.then(sendResponse);
+					break;
+				}
 			}
 		});
 

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -7,7 +7,7 @@ import type {
 	SaveUrlResult,
 	RemoveUrlResult,
 } from "browser-extension-core";
-import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl } from "browser-extension-core";
+import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, isSaveableScheme } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 
 declare const __APP_DOMAINS__: string[];
@@ -248,6 +248,26 @@ async function saveAndShowList() {
 	if (!activeTab) throw new Error("No active tab or URL parameters");
 
 	if (isAppUrl({ tabUrl: activeTab.url, appDomains: __APP_DOMAINS__ })) {
+		await showListView();
+		return;
+	}
+
+	const schemesResult = (await send({
+		type: "get-saveable-schemes",
+	})) as GuardedResult<readonly string[]>;
+
+	if (isNotLoggedIn(schemesResult)) {
+		await performLogout();
+		return;
+	}
+
+	if (
+		schemesResult.ok &&
+		!isSaveableScheme({
+			tabUrl: activeTab.url,
+			allowedSchemes: schemesResult.value,
+		})
+	) {
 		await showListView();
 		return;
 	}

--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -310,6 +310,18 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 					pending.then(sendResponse);
 					break;
 				}
+				case "get-saveable-schemes": {
+					const pending = new Promise<unknown>((resolve) => {
+						core.once("fetched-saveable-schemes", {
+							success: (value: readonly string[]) =>
+								resolve({ ok: true, value }),
+							failure: (err) => resolve({ ok: false, ...err }),
+						});
+					});
+					core.fetch("saveable-schemes");
+					pending.then(sendResponse);
+					break;
+				}
 			}
 		});
 

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -6,7 +6,7 @@ import type {
 	SaveUrlResult,
 	RemoveUrlResult,
 } from "browser-extension-core";
-import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl } from "browser-extension-core";
+import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, isSaveableScheme } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 
 declare const __APP_DOMAINS__: string[];
@@ -247,6 +247,26 @@ async function saveAndShowList() {
 	if (!activeTab) throw new Error("No active tab or URL parameters");
 
 	if (isAppUrl({ tabUrl: activeTab.url, appDomains: __APP_DOMAINS__ })) {
+		await showListView();
+		return;
+	}
+
+	const schemesResult = (await send({
+		type: "get-saveable-schemes",
+	})) as GuardedResult<readonly string[]>;
+
+	if (isNotLoggedIn(schemesResult)) {
+		await performLogout();
+		return;
+	}
+
+	if (
+		schemesResult.ok &&
+		!isSaveableScheme({
+			tabUrl: activeTab.url,
+			allowedSchemes: schemesResult.value,
+		})
+	) {
 		await showListView();
 		return;
 	}

--- a/projects/hutch/src/runtime/domain/article/article.schema.test.ts
+++ b/projects/hutch/src/runtime/domain/article/article.schema.test.ts
@@ -1,8 +1,14 @@
-import { SaveArticleInputSchema } from "./article.schema";
+import { SaveArticleInputSchema, SaveHtmlInputSchema, SAVEABLE_URL_SCHEMES } from "./article.schema";
 
 describe("SaveArticleInputSchema", () => {
 	it("accepts a valid URL", () => {
 		const result = SaveArticleInputSchema.safeParse({ url: "https://example.com/article" });
+
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts an http URL", () => {
+		const result = SaveArticleInputSchema.safeParse({ url: "http://example.com/article" });
 
 		expect(result.success).toBe(true);
 	});
@@ -17,5 +23,35 @@ describe("SaveArticleInputSchema", () => {
 		const result = SaveArticleInputSchema.safeParse({ url: "not-a-url" });
 
 		expect(result.success).toBe(false);
+	});
+
+	it("rejects non-saveable schemes", () => {
+		for (const url of [
+			"chrome://newtab/",
+			"about:blank",
+			"file:///etc/hosts",
+			"view-source:https://example.com",
+			"ftp://example.com/file",
+		]) {
+			const result = SaveArticleInputSchema.safeParse({ url });
+			expect(result.success).toBe(false);
+		}
+	});
+});
+
+describe("SaveHtmlInputSchema", () => {
+	it("rejects non-saveable schemes", () => {
+		const result = SaveHtmlInputSchema.safeParse({
+			url: "chrome://newtab/",
+			rawHtml: "<html></html>",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("SAVEABLE_URL_SCHEMES", () => {
+	it("publishes http and https as saveable", () => {
+		expect(SAVEABLE_URL_SCHEMES).toEqual(["http", "https"]);
 	});
 });

--- a/projects/hutch/src/runtime/domain/article/article.schema.ts
+++ b/projects/hutch/src/runtime/domain/article/article.schema.ts
@@ -1,8 +1,20 @@
 import { z } from "zod";
 import type { Minutes } from "./article.types";
 
+/** Schemes the save pipeline can crawl. Published on the save-article and save-html
+ * Siren actions so clients can gate non-saveable tabs (chrome://, about:, file://...)
+ * before attempting a save. */
+export const SAVEABLE_URL_SCHEMES = ["http", "https"] as const;
+
+const SaveableUrl = z
+	.url({ message: "Please enter a valid URL" })
+	.refine(
+		(value) => SAVEABLE_URL_SCHEMES.some((s) => value.startsWith(`${s}:`)),
+		{ message: "URL scheme is not supported" },
+	);
+
 export const SaveArticleInputSchema = z.object({
-	url: z.url({ message: "Please enter a valid URL" }),
+	url: SaveableUrl,
 });
 
 export const MAX_RAW_HTML_BYTES = 10 * 1024 * 1024;
@@ -14,7 +26,7 @@ export const MAX_RAW_HTML_BYTES = 10 * 1024 * 1024;
 export const MAX_RAW_HTML_REQUEST_BYTES = MAX_RAW_HTML_BYTES + 1024 * 1024;
 
 export const SaveHtmlInputSchema = z.object({
-	url: z.url({ message: "Please enter a valid URL" }),
+	url: SaveableUrl,
 	rawHtml: z.string().min(1).max(MAX_RAW_HTML_BYTES),
 	title: z.string().max(2048).optional(),
 });

--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -237,6 +237,21 @@ describe("POST /queue (Siren save article)", () => {
 		expect(response.body.properties.code).toBe("invalid-url");
 	});
 
+	it("returns 422 for a non-saveable scheme", async () => {
+		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(testApp);
+
+		const response = await request(testApp.app)
+			.post("/queue")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.set("Authorization", `Bearer ${accessToken}`)
+			.set("Content-Type", "application/json")
+			.send({ url: "chrome://newtab/" });
+
+		expect(response.status).toBe(422);
+		expect(response.body.properties.code).toBe("invalid-url");
+	});
+
 	it("returns 401 without token", async () => {
 		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 

--- a/projects/hutch/src/runtime/web/api/collection-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.test.ts
@@ -202,6 +202,25 @@ describe("toArticleCollectionEntity", () => {
 		expect(saveAction?.fields?.some((f) => f.name === "url")).toBe(true);
 	});
 
+	it("publishes saveable url schemes on save-article and save-html", () => {
+		const result: FindArticlesResult = {
+			articles: [],
+			total: 0,
+			page: 1,
+			pageSize: 20,
+		};
+
+		const entity = toArticleCollectionEntity(result, {});
+
+		const saveArticle = entity.actions?.find((a) => a.name === "save-article");
+		const saveHtml = entity.actions?.find((a) => a.name === "save-html");
+		const saveArticleUrl = saveArticle?.fields?.find((f) => f.name === "url");
+		const saveHtmlUrl = saveHtml?.fields?.find((f) => f.name === "url");
+
+		expect(saveArticleUrl?.schemes).toEqual(["http", "https"]);
+		expect(saveHtmlUrl?.schemes).toEqual(["http", "https"]);
+	});
+
 	it("includes search action with filter fields", () => {
 		const result: FindArticlesResult = {
 			articles: [],

--- a/projects/hutch/src/runtime/web/api/collection-siren.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.ts
@@ -3,6 +3,7 @@ import type {
 	SortOrder,
 } from "../../providers/article-store/article-store.types";
 import type { ArticleStatus } from "../../domain/article/article.types";
+import { SAVEABLE_URL_SCHEMES } from "../../domain/article/article.schema";
 import type { SirenEntity, SirenLink } from "./siren";
 import { toArticleSubEntity } from "./article-siren";
 
@@ -66,7 +67,7 @@ export function toArticleCollectionEntity(
 				href: "/queue",
 				method: "POST",
 				type: "application/json",
-				fields: [{ name: "url", type: "url" }],
+				fields: [{ name: "url", type: "url", schemes: SAVEABLE_URL_SCHEMES }],
 			},
 			{
 				name: "save-html",
@@ -74,7 +75,7 @@ export function toArticleCollectionEntity(
 				method: "POST",
 				type: "application/json",
 				fields: [
-					{ name: "url", type: "url" },
+					{ name: "url", type: "url", schemes: SAVEABLE_URL_SCHEMES },
 					{ name: "rawHtml", type: "text" },
 					{ name: "title", type: "text" },
 				],

--- a/projects/hutch/src/runtime/web/api/siren.ts
+++ b/projects/hutch/src/runtime/web/api/siren.ts
@@ -2,6 +2,10 @@ interface SirenField {
 	name: string;
 	type: string;
 	value?: string | number;
+	/** Allowed URL schemes for fields whose `type` is "url". Lets clients gate
+	 * non-saveable tabs without a server round trip. Not part of the Siren spec —
+	 * this is the readplace API's published vocabulary. */
+	schemes?: readonly string[];
 }
 
 export interface SirenAction {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -3,7 +3,7 @@ import { DISMISS_COOKIE_NAME } from "@packages/onboarding-extension-signal";
 import type { ErrorRequestHandler, Request, Response, Router } from "express";
 import express from "express";
 import type { LogParseError } from "@packages/hutch-infra-components";
-import { SaveArticleInputSchema, SaveHtmlInputSchema, ArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD } from "../../../domain/article/article.schema";
+import { SaveArticleInputSchema, SaveHtmlInputSchema, ArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD, SAVEABLE_URL_SCHEMES } from "../../../domain/article/article.schema";
 import { ReaderArticleHashIdSchema } from "../../../domain/article/reader-article-hash-id";
 import { calculateReadTime } from "../../../domain/article/estimated-read-time";
 import type { ContentFreshnessResult, RefreshArticleIfStale } from "../../../providers/article-freshness/check-content-freshness";
@@ -276,7 +276,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 							href: "/queue",
 							method: "POST",
 							type: "application/json",
-							fields: [{ name: "url", type: "url" }],
+							fields: [{ name: "url", type: "url", schemes: SAVEABLE_URL_SCHEMES }],
 						},
 					],
 				}),


### PR DESCRIPTION
## Summary
This change adds URL scheme validation to prevent users from attempting to save articles from unsupported URL schemes (like `chrome://`, `about:`, `file://`, etc.). The server now publishes allowed URL schemes via the Siren API, and the browser extension validates the current tab's URL scheme before attempting to save.

## Key Changes

- **Server-side validation**: Added `SAVEABLE_URL_SCHEMES` constant (`["http", "https"]`) and created a `SaveableUrl` Zod schema that validates both URL format and scheme. Applied to both `SaveArticleInputSchema` and `SaveHtmlInputSchema`.

- **Siren API enhancement**: Extended the Siren field schema to include an optional `schemes` property. The `/queue` collection endpoint now publishes allowed schemes on the `save-article` and `save-html` action fields.

- **Reading list API**: Added `getSaveableSchemes()` method to the reading list interface that extracts schemes from the `save-article` action's URL field, with fallback to default schemes if not specified.

- **Browser extension validation**: Created `isSaveableScheme()` utility function that checks if a tab's URL protocol is in the allowed schemes list. Integrated into both Chrome and Firefox popup handlers to validate the current tab before initiating a save, showing the reading list instead if the scheme is unsupported.

- **Core messaging**: Extended the Core interface to support `"saveable-schemes"` fetch requests and `"fetched-saveable-schemes"` events, with corresponding message handlers in both browser extensions.

## Implementation Details

- The `isSaveableScheme()` function safely parses URLs and gracefully handles invalid URLs by returning `false`
- Server validation uses Zod's `refine()` to check scheme prefixes, ensuring consistency with client-side validation
- The Siren field `schemes` property is optional and not part of the standard Siren spec—it's part of the readplace API's published vocabulary
- Scheme validation happens before any network requests, improving UX by preventing failed save attempts

https://claude.ai/code/session_01HJ6yRBoAWeUeVkh5CcC7eL