### PR TITLE
feat(hutch,save-link): unified page-loading progress bar

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -45,6 +45,29 @@ const BUNDLES = [
 			"}).attach();",
 		].join("\n"),
 	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/shared/article-body/progress-bar.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "progress-bar.client.js"),
+		globalName: "ProgressBar",
+		footer: [
+			// HTMX fires htmx:afterSwap on the container around any swapped node,
+			// including OOB swaps targeting #article-body-progress. The listener
+			// re-anchors the bar against the new (tickAt, pct) so the rAF loop
+			// projects forward from there.
+			"ProgressBar.initProgressBars({",
+			"  document: window.document,",
+			"  now: function () { return Date.now(); },",
+			"  requestAnimationFrame: function (cb) { return window.requestAnimationFrame(cb); },",
+			"  cancelAnimationFrame: function (id) { window.cancelAnimationFrame(id); },",
+			"  addSwapListener: function (listener) {",
+			"    window.document.body.addEventListener('htmx:afterSwap', listener);",
+			"  }",
+			"});",
+		].join("\n"),
+	},
 ];
 
 function buildOptions(bundle) {

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -71,6 +71,7 @@ const { app: hutchApp, email } = createTestApp({
     httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,
     logError,
     logParseError: fixture.shared.logParseError,
+    now: fixture.shared.now,
   },
 })
 

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -283,6 +283,7 @@ export function createHutchApp(deps?: {
 		validateAccessToken,
 		httpErrorMessageMapping,
 		logParseError,
+		now: () => new Date(),
 	});
 
 	return { app, auth, articleStore, oauthModel };

--- a/projects/hutch/src/runtime/providers/article-crawl/article-crawl.types.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/article-crawl.types.ts
@@ -1,5 +1,7 @@
+import type { CrawlStage } from "../../web/shared/article-body/progress-mapping";
+
 export type ArticleCrawl =
-	| { status: "pending" }
+	| { status: "pending"; stage?: CrawlStage }
 	| { status: "ready" }
 	| { status: "failed"; reason: string };
 

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
@@ -62,6 +62,21 @@ describe("initDynamoDbArticleCrawl", () => {
 			expect(result).toEqual({ status: "pending" });
 		});
 
+		it("returns pending with stage when crawlStage is recorded", async () => {
+			const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
+				client: clientReturning({
+					url: URL,
+					crawlStatus: "pending",
+					crawlStage: "crawl-parsed",
+				}),
+				tableName: TABLE,
+			});
+
+			const result = await findArticleCrawlStatus(URL);
+
+			expect(result).toEqual({ status: "pending", stage: "crawl-parsed" });
+		});
+
 		it("returns ready when crawlStatus=ready", async () => {
 			const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
 				client: clientReturning({ url: URL, crawlStatus: "ready" }),

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
@@ -19,6 +19,15 @@ const ArticleCrawlRow = z.object({
 	url: z.string(),
 	crawlStatus: dynamoField(CrawlStatusSchema),
 	crawlFailureReason: dynamoField(z.string()),
+	crawlStage: dynamoField(
+		z.enum([
+			"crawl-fetching",
+			"crawl-fetched",
+			"crawl-parsed",
+			"crawl-metadata-written",
+			"crawl-content-uploaded",
+		]),
+	),
 });
 
 type ArticleCrawlRowShape = z.infer<typeof ArticleCrawlRow>;
@@ -34,7 +43,11 @@ function rowToArticleCrawl(
 		);
 		return { status: "failed", reason: row.crawlFailureReason };
 	}
-	if (row.crawlStatus === "pending") return { status: "pending" };
+	if (row.crawlStatus === "pending") {
+		return row.crawlStage
+			? { status: "pending", stage: row.crawlStage }
+			: { status: "pending" };
+	}
 	if (row.crawlStatus === "ready") return { status: "ready" };
 	// Legacy row (status attribute missing). Return undefined so the caller
 	// defers to whether S3 content exists — pre-S3-migration content lived in

--- a/projects/hutch/src/runtime/providers/article-crawl/in-memory-article-crawl.test.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/in-memory-article-crawl.test.ts
@@ -1,0 +1,59 @@
+import { initInMemoryArticleCrawl } from "./in-memory-article-crawl";
+
+const URL = "https://example.com/article";
+
+describe("initInMemoryArticleCrawl", () => {
+	describe("markCrawlStage", () => {
+		it("records the stage on a previously-pending row", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			await crawl.markCrawlPending({ url: URL });
+			await crawl.markCrawlStage({ url: URL, stage: "crawl-fetched" });
+
+			expect(await crawl.findArticleCrawlStatus(URL)).toEqual({
+				status: "pending",
+				stage: "crawl-fetched",
+			});
+		});
+
+		it("creates a pending+stage row when none existed", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			await crawl.markCrawlStage({ url: URL, stage: "crawl-fetching" });
+
+			expect(await crawl.findArticleCrawlStatus(URL)).toEqual({
+				status: "pending",
+				stage: "crawl-fetching",
+			});
+		});
+
+		it("does not regress a row that has already gone ready", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			await crawl.markCrawlReady({ url: URL });
+			await crawl.markCrawlStage({ url: URL, stage: "crawl-content-uploaded" });
+
+			expect(await crawl.findArticleCrawlStatus(URL)).toEqual({ status: "ready" });
+		});
+
+		it("does not regress a row that has already failed", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			await crawl.markCrawlFailed({ url: URL, reason: "blocked" });
+			await crawl.markCrawlStage({ url: URL, stage: "crawl-fetching" });
+
+			expect(await crawl.findArticleCrawlStatus(URL)).toEqual({
+				status: "failed",
+				reason: "blocked",
+			});
+		});
+
+		it("preserves the recorded stage when markCrawlPending is re-called (legacy-stub healing path)", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			await crawl.markCrawlPending({ url: URL });
+			await crawl.markCrawlStage({ url: URL, stage: "crawl-parsed" });
+			await crawl.markCrawlPending({ url: URL });
+
+			expect(await crawl.findArticleCrawlStatus(URL)).toEqual({
+				status: "pending",
+				stage: "crawl-parsed",
+			});
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/article-crawl/in-memory-article-crawl.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/in-memory-article-crawl.ts
@@ -1,4 +1,5 @@
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
+import type { CrawlStage } from "../../web/shared/article-body/progress-mapping";
 import type {
 	ArticleCrawl,
 	FindArticleCrawlStatus,
@@ -11,6 +12,10 @@ export type InMemoryMarkCrawlFailed = (params: {
 	url: string;
 	reason: string;
 }) => Promise<void>;
+export type InMemoryMarkCrawlStage = (params: {
+	url: string;
+	stage: CrawlStage;
+}) => Promise<void>;
 
 export function initInMemoryArticleCrawl(): {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
@@ -18,6 +23,7 @@ export function initInMemoryArticleCrawl(): {
 	forceMarkCrawlPending: ForceMarkCrawlPending;
 	markCrawlReady: InMemoryMarkCrawlReady;
 	markCrawlFailed: InMemoryMarkCrawlFailed;
+	markCrawlStage: InMemoryMarkCrawlStage;
 } {
 	const states = new Map<string, ArticleCrawl>();
 
@@ -30,7 +36,18 @@ export function initInMemoryArticleCrawl(): {
 		const id = ArticleResourceUniqueId.parse(url);
 		const current = states.get(id.value);
 		if (current?.status === "ready") return;
-		states.set(id.value, { status: "pending" });
+		// Preserve any previously recorded stage so the legacy-stub healing path
+		// (markCrawlPending called after the worker may have written a stage) does
+		// not reset the bar. Mirrors the DDB markCrawlPending UpdateExpression
+		// which only writes crawlStatus and leaves crawlStage untouched.
+		const existingStage =
+			current?.status === "pending" ? current.stage : undefined;
+		states.set(
+			id.value,
+			existingStage
+				? { status: "pending", stage: existingStage }
+				: { status: "pending" },
+		);
 	};
 
 	const forceMarkCrawlPending: ForceMarkCrawlPending = async ({ url }) => {
@@ -50,11 +67,22 @@ export function initInMemoryArticleCrawl(): {
 		states.set(id.value, { status: "failed", reason });
 	};
 
+	const markCrawlStage: InMemoryMarkCrawlStage = async ({ url, stage }) => {
+		const id = ArticleResourceUniqueId.parse(url);
+		const current = states.get(id.value);
+		// Stage only meaningful while pending — once a row reaches a terminal
+		// state (ready/failed) the worker may still emit a final stage but we
+		// must not regress to pending.
+		if (current?.status === "ready" || current?.status === "failed") return;
+		states.set(id.value, { status: "pending", stage });
+	};
+
 	return {
 		findArticleCrawlStatus,
 		markCrawlPending,
 		forceMarkCrawlPending,
 		markCrawlReady,
 		markCrawlFailed,
+		markCrawlStage,
 	};
 }

--- a/projects/hutch/src/runtime/providers/article-summary/article-summary.types.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/article-summary.types.ts
@@ -1,5 +1,7 @@
+import type { SummaryStage } from "../../web/shared/article-body/progress-mapping";
+
 export type GeneratedSummary =
-	| { status: "pending" }
+	| { status: "pending"; stage?: SummaryStage }
 	| { status: "ready"; summary: string; excerpt?: string }
 	| { status: "failed"; reason: string }
 	| { status: "skipped" };

--- a/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.test.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.test.ts
@@ -103,6 +103,22 @@ describe("initDynamoDbGeneratedSummary", () => {
 		expect(result).toEqual({ status: "pending" });
 	});
 
+	it("returns pending with stage when summaryStage is recorded", async () => {
+		const client = createFakeClient({
+			url: "https://example.com/article",
+			summaryStatus: "pending",
+			summaryStage: "summary-generating",
+		});
+		const { findGeneratedSummary } = initDynamoDbGeneratedSummary({
+			client: client as typeof client & DynamoDBDocumentClient,
+			tableName: "test-table",
+		});
+
+		const result = await findGeneratedSummary("https://example.com/article");
+
+		expect(result).toEqual({ status: "pending", stage: "summary-generating" });
+	});
+
 	it("returns failed with reason when status=failed", async () => {
 		const client = createFakeClient({
 			url: "https://example.com/article",

--- a/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.ts
@@ -21,6 +21,9 @@ const ArticleSummaryRow = z.object({
 	summaryExcerpt: dynamoField(z.string()),
 	summaryStatus: dynamoField(SummaryStatusSchema),
 	summaryFailureReason: dynamoField(z.string()),
+	summaryStage: dynamoField(
+		z.enum(["summary-started", "summary-generating"]),
+	),
 });
 
 type ArticleSummaryRowShape = z.infer<typeof ArticleSummaryRow>;
@@ -34,7 +37,11 @@ function rowToGeneratedSummary(
 		return { status: "failed", reason: row.summaryFailureReason };
 	}
 	if (row.summaryStatus === "skipped") return { status: "skipped" };
-	if (row.summaryStatus === "pending") return { status: "pending" };
+	if (row.summaryStatus === "pending") {
+		return row.summaryStage
+			? { status: "pending", stage: row.summaryStage }
+			: { status: "pending" };
+	}
 	// Legacy row (summaryStatus absent). A backfilled `summary` column means the
 	// row pre-dates the state machine but carried a pre-computed summary — expose
 	// as ready. Otherwise return undefined so the caller can re-prime the pipeline

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -136,6 +136,7 @@ interface AppDependencies {
 	readArticleContent: ReadArticleContent;
 	httpErrorMessageMapping: HttpErrorMessageMapping;
 	logParseError: LogParseError;
+	now: () => Date;
 }
 
 function requireAuth(req: Request, res: Response, next: NextFunction): void {
@@ -405,6 +406,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		httpErrorMessageMapping: deps.httpErrorMessageMapping,
 		logError: deps.logError,
 		logParseError: deps.logParseError,
+		now: deps.now,
 	});
 	app.use("/queue", extensionCors, dualAuthMiddleware, queueRouter);
 
@@ -421,6 +423,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		refreshArticleIfStale: deps.refreshArticleIfStale,
 		saveArticleGlobally: deps.saveArticleGlobally,
 		publishSaveAnonymousLink: deps.publishSaveAnonymousLink,
+		now: deps.now,
 	});
 	app.use("/view", viewRouter);
 
@@ -436,6 +439,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		findUserByEmail: deps.findUserByEmail,
 		adminEmails: deps.adminEmails,
 		serviceToken: deps.recrawlServiceToken,
+		now: deps.now,
 	});
 	app.use("/admin/recrawl", adminRecrawlRouter);
 

--- a/projects/hutch/src/runtime/test-app-fakes.ts
+++ b/projects/hutch/src/runtime/test-app-fakes.ts
@@ -194,6 +194,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 			forceMarkCrawlPending: articleCrawl.forceMarkCrawlPending,
 			markCrawlReady: articleCrawl.markCrawlReady,
 			markCrawlFailed: articleCrawl.markCrawlFailed,
+			markCrawlStage: articleCrawl.markCrawlStage,
 		},
 		parser: { parseArticle, crawlArticle },
 		events: {
@@ -225,6 +226,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 			httpErrorMessageMapping,
 			logError: createNoopLogError(),
 			logParseError: () => {},
+			now: () => new Date(),
 		},
 	};
 }

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -19,6 +19,7 @@ import type {
 import type {
 	InMemoryMarkCrawlFailed,
 	InMemoryMarkCrawlReady,
+	InMemoryMarkCrawlStage,
 } from "./providers/article-crawl/in-memory-article-crawl";
 import type { RefreshArticleIfStale } from "./providers/article-freshness/check-content-freshness";
 import type {
@@ -109,6 +110,7 @@ export interface ArticleCrawlBundle {
 	forceMarkCrawlPending: ForceMarkCrawlPending;
 	markCrawlReady: InMemoryMarkCrawlReady;
 	markCrawlFailed: InMemoryMarkCrawlFailed;
+	markCrawlStage: InMemoryMarkCrawlStage;
 }
 
 export interface ParserBundle {
@@ -173,6 +175,7 @@ export interface SharedBundle {
 	httpErrorMessageMapping: HttpErrorMessageMapping;
 	logError: (message: string, error?: Error) => void;
 	logParseError: LogParseError;
+	now: () => Date;
 }
 
 export interface TestAppFixture {
@@ -256,6 +259,7 @@ function flattenFixtureToAppDependencies(
 		googleAuth: fixture.google,
 		adminEmails: fixture.admin.adminEmails,
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,
+		now: fixture.shared.now,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -76,6 +76,7 @@ describe("Email verification", () => {
 				putPendingHtml: async () => {},
 				httpErrorMessageMapping,
 				logParseError: () => {},
+				now: () => new Date(),
 			});
 
 			const response = await request(app).post("/signup").type("form").send({

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -172,6 +172,7 @@ describe("Google auth routes", () => {
 					httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,
 					logError: (msg) => { errors.push(msg); },
 					logParseError: fixture.shared.logParseError,
+					now: fixture.shared.now,
 				},
 			});
 			const state = signState(freshState());

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
@@ -6,7 +6,10 @@ import type { ArticleCrawl } from "../../../providers/article-crawl/article-craw
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import type { PageBody } from "../../page-body.types";
 import { renderArticleBody } from "../../shared/article-body/article-body.component";
+import type { ProgressTick } from "../../shared/article-body/progress-mapping";
 import { RECRAWL_STYLES } from "./recrawl.styles";
+
+const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 
 export interface AdminRecrawlPageInput {
 	articleUrl: string;
@@ -17,6 +20,7 @@ export interface AdminRecrawlPageInput {
 	readerPollUrl?: string;
 	summary?: GeneratedSummary;
 	summaryPollUrl?: string;
+	progress?: ProgressTick;
 	contentSourceTier?: "tier-0" | "tier-1";
 	extensionInstallUrl?: string;
 }
@@ -46,6 +50,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 		summary: input.summary,
 		summaryPollUrl: input.summaryPollUrl,
 		summaryOpen: true,
+		progress: input.progress,
 		extensionInstallUrl: input.extensionInstallUrl,
 	});
 
@@ -62,6 +67,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 		styles: RECRAWL_STYLES,
 		bodyClass: "page-admin-recrawl",
 		content,
+		scripts: PROGRESS_BAR_SCRIPT,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -38,6 +38,7 @@ export interface AdminRecrawlDependencies {
 	findUserByEmail: FindUserByEmail;
 	adminEmails: readonly string[];
 	serviceToken: string;
+	now: () => Date;
 }
 
 function pollUrlBuilderFor(articleUrl: string): PollUrlBuilder {
@@ -130,6 +131,7 @@ function handleRecrawlArticle(
 			readerPollUrl: state.readerPollUrl,
 			summary: state.summary,
 			summaryPollUrl: state.summaryPollUrl,
+			progress: state.progress,
 			contentSourceTier: existing.contentSourceTier,
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		})).to("text/html");
@@ -199,6 +201,7 @@ export function initAdminRecrawlRoutes(deps: AdminRecrawlDependencies): Router {
 		findGeneratedSummary: deps.findGeneratedSummary,
 		markSummaryPending: deps.markSummaryPending,
 		readArticleContent: deps.readArticleContent,
+		now: deps.now,
 	});
 
 	router.use(noStore);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -68,6 +68,7 @@ interface QueueDependencies {
 	httpErrorMessageMapping: HttpErrorMessageMapping;
 	logError: (message: string, error?: Error) => void;
 	logParseError: LogParseError;
+	now: () => Date;
 }
 
 import type { SavedArticle } from "../../../domain/article/article.types";
@@ -418,6 +419,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				summaryPollUrl: state.summaryPollUrl,
 				crawl: state.crawl,
 				readerPollUrl: state.readerPollUrl,
+				progress: state.progress,
 				audioEnabled,
 				extensionInstallUrl: extensionInstallUrlIfMissing(req),
 			})),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -1616,6 +1616,7 @@ describe("Queue routes", () => {
  	forceMarkCrawlPending: fixture.articleCrawl.forceMarkCrawlPending,
  	markCrawlReady: fixture.articleCrawl.markCrawlReady,
  	markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
+ 	markCrawlStage: fixture.articleCrawl.markCrawlStage,
  },
 			});
 			const agent = await loginAgent(app, auth);
@@ -1666,6 +1667,7 @@ describe("Queue routes", () => {
  	forceMarkCrawlPending: fixture.articleCrawl.forceMarkCrawlPending,
  	markCrawlReady: fixture.articleCrawl.markCrawlReady,
  	markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
+ 	markCrawlStage: fixture.articleCrawl.markCrawlStage,
  },
 			});
 			const agent = await loginAgent(app, auth);
@@ -1715,6 +1717,7 @@ describe("Queue routes", () => {
 					forceMarkCrawlPending: fixture.articleCrawl.forceMarkCrawlPending,
 					markCrawlReady: fixture.articleCrawl.markCrawlReady,
 					markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
+					markCrawlStage: fixture.articleCrawl.markCrawlStage,
 				},
 				summary: {
 					findGeneratedSummary: async () => undefined,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
@@ -142,6 +142,7 @@ describe("POST /queue/save-html", () => {
 				httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,
 				logError: (_msg, err) => { if (err) errors.push(err); },
 				logParseError: fixture.shared.logParseError,
+				now: fixture.shared.now,
 			},
 		});
 		const accessToken = await createAccessToken(testApp);
@@ -236,6 +237,7 @@ describe("POST /queue/save-html", () => {
 				httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,
 				logError: () => {},
 				logParseError: (params) => { parseErrorCalls.push(params); },
+				now: fixture.shared.now,
 			},
 		});
 		const accessToken = await createAccessToken(testApp);

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -7,6 +7,7 @@ import type { GeneratedSummary } from "../../../providers/article-summary/articl
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { renderArticleBody } from "../../shared/article-body/article-body.component";
+import type { ProgressTick } from "../../shared/article-body/progress-mapping";
 import {
 	SHARE_BALLOON_SCRIPT,
 	renderShareBalloon,
@@ -16,6 +17,7 @@ import { READER_STYLES } from "./reader.styles";
 const CANONICAL_BASE_URL = "https://readplace.com";
 
 const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "utf-8");
+const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 
 export function ReaderPage(
 	article: SavedArticle,
@@ -24,6 +26,7 @@ export function ReaderPage(
 		summaryPollUrl?: string;
 		crawl?: ArticleCrawl;
 		readerPollUrl?: string;
+		progress?: ProgressTick;
 		audioEnabled?: boolean;
 		extensionInstallUrl?: string;
 	},
@@ -39,6 +42,7 @@ export function ReaderPage(
 		summary: options?.summary,
 		summaryPollUrl: options?.summaryPollUrl,
 		summaryOpen: true,
+		progress: options?.progress,
 		audioEnabled: options?.audioEnabled,
 		backLink: { href: "/queue", label: "← Back to queue" },
 		extensionInstallUrl: options?.extensionInstallUrl,
@@ -60,6 +64,6 @@ export function ReaderPage(
 		styles: READER_STYLES,
 		bodyClass: "page-reader",
 		content,
-		scripts: SHARE_BALLOON_SCRIPT,
+		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -11,6 +11,7 @@ import { requireEnv } from "../../../require-env";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { renderArticleBody } from "../../shared/article-body/article-body.component";
+import type { ProgressTick } from "../../shared/article-body/progress-mapping";
 import {
 	SHARE_BALLOON_SCRIPT,
 	renderShareBalloon,
@@ -18,6 +19,7 @@ import {
 import { VIEW_STYLES } from "./view.styles";
 
 const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
+const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 
 const CANONICAL_BASE_URL = "https://readplace.com";
 const DEFAULT_OG_IMAGE = `${STATIC_BASE_URL}/og-image-1200x630.png`;
@@ -44,6 +46,7 @@ export interface ViewPageInput {
 	readerPollUrl?: string;
 	summary?: GeneratedSummary;
 	summaryPollUrl?: string;
+	progress?: ProgressTick;
 	actions: ViewAction[];
 	extensionInstallUrl?: string;
 }
@@ -60,6 +63,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		summary: input.summary,
 		summaryPollUrl: input.summaryPollUrl,
 		summaryOpen: true,
+		progress: input.progress,
 		extensionInstallUrl: input.extensionInstallUrl,
 	});
 
@@ -114,6 +118,6 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		styles: VIEW_STYLES,
 		bodyClass: "page-view",
 		content,
-		scripts: SHARE_BALLOON_SCRIPT,
+		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -44,6 +44,7 @@ interface ViewDependencies {
 	refreshArticleIfStale: RefreshArticleIfStale;
 	saveArticleGlobally: SaveArticleGlobally;
 	publishSaveAnonymousLink: PublishSaveAnonymousLink;
+	now: () => Date;
 }
 
 function renderError(req: Request, res: Response) {
@@ -161,6 +162,7 @@ function handleViewArticle(deps: ViewDependencies) {
 				readerPollUrl: state.readerPollUrl,
 				summary: state.summary,
 				summaryPollUrl: state.summaryPollUrl,
+				progress: state.progress,
 				actions,
 				extensionInstallUrl: extensionInstallUrlIfMissing(req),
 			})),

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -949,6 +949,7 @@ describe("View routes", () => {
  	forceMarkCrawlPending: fixture.articleCrawl.forceMarkCrawlPending,
  	markCrawlReady: fixture.articleCrawl.markCrawlReady,
  	markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
+ 	markCrawlStage: fixture.articleCrawl.markCrawlStage,
  },
 				summary:{
  	findGeneratedSummary: findGeneratedSummary,

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
@@ -5,6 +5,8 @@ import type { ArticleCrawl } from "../../../providers/article-crawl/article-craw
 import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import { requireEnv } from "../../../require-env";
 import { render } from "../../render";
+import { renderProgressBar } from "./progress-bar.component";
+import type { ProgressTick } from "./progress-mapping";
 import { renderReaderSlot } from "./reader-slot/reader-slot.component";
 import { renderSummarySlot } from "./summary-slot/summary-slot.component";
 
@@ -29,6 +31,13 @@ export interface ArticleBodyInput {
 	audioEnabled?: boolean;
 	backLink?: { href: string; label: string };
 	extensionInstallUrl?: string;
+	/**
+	 * Single unified progress tick. When omitted (everything terminal, or
+	 * crawl-failed) the bar still renders but in its hidden state so OOB
+	 * progress-bar swaps from poll responses remain valid even when the
+	 * initial SSR bar was hidden.
+	 */
+	progress?: ProgressTick;
 }
 
 export function renderArticleBody(input: ArticleBodyInput): string {
@@ -47,6 +56,8 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		summaryOpen: input.summaryOpen,
 	});
 
+	const progressBarHtml = renderProgressBar({ progress: input.progress });
+
 	return render(ARTICLE_BODY_TEMPLATE, {
 		title: input.title,
 		siteName: input.siteName,
@@ -54,6 +65,7 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		url: input.url,
 		readerSlotHtml,
 		summarySlotHtml,
+		progressBarHtml,
 		audioEnabled: input.audioEnabled,
 		backLink: input.backLink,
 		staticBaseUrl: STATIC_BASE_URL,

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -266,6 +266,36 @@
   text-align: center;
 }
 
+.article-body__progress {
+  width: 100%;
+  height: 4px;
+  background: var(--color-border);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+}
+
+.article-body__progress--hidden {
+  display: none;
+}
+
+.article-body__progress--visible {
+  display: block;
+}
+
+.article-body__progress-fill {
+  height: 100%;
+  background: var(--color-brand);
+  /**
+   * 1. SSR sets width inline. Each HTMX swap drops in a fresh inline width;
+   *    150ms linear smooths the per-poll jump. Between polls the
+   *    progress-bar.client.ts loop overwrites the inline width via rAF for
+   *    sub-second updates, and we want that to look continuous rather than
+   *    chasing a 150ms ease-in-out.
+   */
+  transition: width 150ms linear; /* 1 */
+}
+
 .article-body__reader-slot--pending {
   display: block;
   padding: 2rem 1.5rem;

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
@@ -7,6 +7,7 @@
       </div>
       <a class="article-body__original-link" href="{{url}}" target="_blank" rel="noopener" data-test-original-link>View original</a>
     </div>
+    {{{progressBarHtml}}}
     {{{summarySlotHtml}}}
     {{#if audioEnabled}}<div class="article-body__audio-slot article-body__audio-slot--visible" data-test-audio-player><div class="article-body__audio-player">
       <audio controls preload="metadata" src="{{staticBaseUrl}}/sample-audio.opus" data-audio-element></audio>

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.test.ts
@@ -1,0 +1,239 @@
+import { JSDOM } from "jsdom";
+import {
+	type BarTick,
+	computeRate,
+	initProgressBars,
+	projectPct,
+	readProgressAttrs,
+} from "./progress-bar.client";
+
+function barAt(pct: number, tickAt: string): string {
+	return `<div id="article-body-progress" class="article-body__progress" data-progress-bar data-progress-pct="${pct}" data-progress-tick-at="${tickAt}" data-progress-stage="crawl-fetched"><div class="article-body__progress-fill" data-progress-fill style="width: ${pct}%"></div></div>`;
+}
+
+function makeDoc(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
+}
+
+describe("computeRate", () => {
+	it("returns the per-ms slope between two ticks", () => {
+		const prev: BarTick = { tickAtMs: 1000, pct: 25 };
+		const next: BarTick = { tickAtMs: 4000, pct: 55 };
+
+		expect(computeRate(prev, next)).toBeCloseTo(0.01);
+	});
+
+	it("floors at 0 when the server reports a regression (worker redelivery)", () => {
+		const prev: BarTick = { tickAtMs: 1000, pct: 90 };
+		const next: BarTick = { tickAtMs: 4000, pct: 55 };
+
+		expect(computeRate(prev, next)).toBe(0);
+	});
+
+	it("returns 0 when both ticks share a timestamp (clock skew)", () => {
+		const prev: BarTick = { tickAtMs: 1000, pct: 25 };
+		const next: BarTick = { tickAtMs: 1000, pct: 55 };
+
+		expect(computeRate(prev, next)).toBe(0);
+	});
+});
+
+describe("projectPct", () => {
+	it("projects forward at the given rate", () => {
+		expect(
+			projectPct({ lastPct: 25, rate: 0.01, elapsedMs: 1000, cap: 99 }),
+		).toBe(35);
+	});
+
+	it("caps at the supplied ceiling so the bar never closes ahead of the server", () => {
+		expect(
+			projectPct({ lastPct: 95, rate: 0.05, elapsedMs: 1000, cap: 99 }),
+		).toBe(99);
+	});
+
+	it("does not regress below the last anchor when rate is 0", () => {
+		expect(
+			projectPct({ lastPct: 55, rate: 0, elapsedMs: 5000, cap: 99 }),
+		).toBe(55);
+	});
+});
+
+describe("readProgressAttrs", () => {
+	it("parses pct and tickAtMs from the bar attributes", () => {
+		const doc = makeDoc(barAt(25, "2026-04-25T12:00:00.000Z"));
+		const bar = doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		const attrs = readProgressAttrs(bar);
+
+		expect(attrs).toEqual({
+			pct: 25,
+			tickAtMs: Date.parse("2026-04-25T12:00:00.000Z"),
+		});
+	});
+
+	it("returns tickAtMs: undefined when the SSR fallback emitted an empty tick-at", () => {
+		const doc = makeDoc(barAt(5, ""));
+		const bar = doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		const attrs = readProgressAttrs(bar);
+
+		expect(attrs).toEqual({ pct: 5, tickAtMs: undefined });
+	});
+
+	it("returns undefined when data-progress-pct is absent (defensive — production templates always emit it)", () => {
+		const doc = makeDoc(
+			`<div data-progress-bar data-progress-tick-at=""><div data-progress-fill></div></div>`,
+		);
+		const bar = doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		expect(readProgressAttrs(bar)).toBeUndefined();
+	});
+
+	it("returns undefined when data-progress-pct is not a finite number", () => {
+		const doc = makeDoc(
+			`<div data-progress-bar data-progress-pct="abc" data-progress-tick-at=""><div data-progress-fill></div></div>`,
+		);
+		const bar = doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		expect(readProgressAttrs(bar)).toBeUndefined();
+	});
+
+	it("returns tickAtMs: undefined when data-progress-tick-at fails to parse", () => {
+		const doc = makeDoc(
+			`<div data-progress-bar data-progress-pct="25" data-progress-tick-at="not-a-date"><div data-progress-fill></div></div>`,
+		);
+		const bar = doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		expect(readProgressAttrs(bar)).toEqual({ pct: 25, tickAtMs: undefined });
+	});
+});
+
+describe("initProgressBars", () => {
+	function setup(html: string) {
+		const doc = makeDoc(html);
+		let nowMs = Date.parse("2026-04-25T12:00:00.000Z");
+		const swapListeners: Array<() => void> = [];
+		const rafCalls: Array<() => void> = [];
+		const controller = initProgressBars({
+			document: doc,
+			now: () => nowMs,
+			requestAnimationFrame: (cb) => {
+				rafCalls.push(cb);
+				return rafCalls.length;
+			},
+			cancelAnimationFrame: () => {},
+			addSwapListener: (listener) => {
+				swapListeners.push(listener);
+			},
+		});
+		return {
+			doc,
+			controller,
+			advance(ms: number) {
+				nowMs += ms;
+			},
+			runFrame() {
+				const cb = rafCalls.shift();
+				if (cb) cb();
+			},
+			fireSwap() {
+				for (const l of swapListeners) l();
+			},
+			fillWidth() {
+				return doc.querySelector<HTMLElement>(".article-body__progress-fill")
+					?.style.width;
+			},
+		};
+	}
+
+	it("anchors the bar at the SSR pct on first scan and projects forward on subsequent rAF ticks", () => {
+		const env = setup(barAt(25, "2026-04-25T12:00:00.000Z"));
+
+		// Advance past the SSR anchor so the second tick produces a positive dt
+		// against the first, then land a fresh server tick at +3s.
+		env.advance(3000);
+		const bar = env.doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+		bar.setAttribute("data-progress-pct", "55");
+		bar.setAttribute(
+			"data-progress-tick-at",
+			"2026-04-25T12:00:03.000Z",
+		);
+		env.fireSwap();
+
+		// 1500ms after the second tick — at the observed rate (10pct/sec) the
+		// bar should project forward from 55% toward but not past 99%.
+		env.advance(1500);
+		env.runFrame();
+
+		const width = env.fillWidth();
+		if (!width) throw new Error("fill width must be set");
+		const pct = Number.parseFloat(width);
+		expect(pct).toBeGreaterThan(55);
+		expect(pct).toBeLessThanOrEqual(99);
+
+		env.controller.stop();
+	});
+
+	it("stops projecting once the bar is removed from the DOM", () => {
+		const env = setup(barAt(25, "2026-04-25T12:00:00.000Z"));
+		const bar = env.doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		bar.remove();
+		env.advance(1000);
+		env.runFrame();
+
+		// fill is detached with the bar — no error, no stale write
+		env.controller.stop();
+	});
+
+	it("re-scans the DOM on swap and skips a tick that matches the existing anchor (no-op rescan)", () => {
+		const env = setup(barAt(25, "2026-04-25T12:00:00.000Z"));
+
+		// fireSwap with the same attributes — the bar should not advance.
+		env.fireSwap();
+
+		const widthBefore = env.fillWidth();
+		expect(widthBefore).toBe("25%");
+		env.controller.stop();
+	});
+
+	it("anchors against deps.now() when the SSR bar emits an empty tick-at, then absorbs the first real tick", () => {
+		const env = setup(barAt(15, ""));
+
+		const bar = env.doc.querySelector("[data-progress-bar]");
+		if (!bar) throw new Error("bar must be present");
+
+		// Land a real tick after a 3s wait — the rate is computed from the
+		// gap between the deps.now() anchor and this real tick.
+		env.advance(3000);
+		bar.setAttribute("data-progress-pct", "35");
+		bar.setAttribute(
+			"data-progress-tick-at",
+			"2026-04-25T12:00:03.000Z",
+		);
+		env.fireSwap();
+
+		// Re-scan with no real tick still on (incomingTickMs undefined) is also
+		// a no-op — exercise the early return.
+		bar.setAttribute("data-progress-tick-at", "");
+		env.fireSwap();
+
+		env.controller.stop();
+	});
+
+	it("stops the rAF loop when the controller's stop() is called", () => {
+		const env = setup(barAt(25, "2026-04-25T12:00:00.000Z"));
+		env.controller.stop();
+		// runFrame after stop should be a no-op (the queued frame still fires
+		// but bails on the `stopped` guard).
+		env.advance(1000);
+		env.runFrame();
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import {
 	type BarTick,
@@ -62,7 +63,7 @@ describe("readProgressAttrs", () => {
 	it("parses pct and tickAtMs from the bar attributes", () => {
 		const doc = makeDoc(barAt(25, "2026-04-25T12:00:00.000Z"));
 		const bar = doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		const attrs = readProgressAttrs(bar);
 
@@ -75,7 +76,7 @@ describe("readProgressAttrs", () => {
 	it("returns tickAtMs: undefined when the SSR fallback emitted an empty tick-at", () => {
 		const doc = makeDoc(barAt(5, ""));
 		const bar = doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		const attrs = readProgressAttrs(bar);
 
@@ -87,7 +88,7 @@ describe("readProgressAttrs", () => {
 			`<div data-progress-bar data-progress-tick-at=""><div data-progress-fill></div></div>`,
 		);
 		const bar = doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		expect(readProgressAttrs(bar)).toBeUndefined();
 	});
@@ -97,7 +98,7 @@ describe("readProgressAttrs", () => {
 			`<div data-progress-bar data-progress-pct="abc" data-progress-tick-at=""><div data-progress-fill></div></div>`,
 		);
 		const bar = doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		expect(readProgressAttrs(bar)).toBeUndefined();
 	});
@@ -107,7 +108,7 @@ describe("readProgressAttrs", () => {
 			`<div data-progress-bar data-progress-pct="25" data-progress-tick-at="not-a-date"><div data-progress-fill></div></div>`,
 		);
 		const bar = doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		expect(readProgressAttrs(bar)).toEqual({ pct: 25, tickAtMs: undefined });
 	});
@@ -158,7 +159,7 @@ describe("initProgressBars", () => {
 		// against the first, then land a fresh server tick at +3s.
 		env.advance(3000);
 		const bar = env.doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 		bar.setAttribute("data-progress-pct", "55");
 		bar.setAttribute(
 			"data-progress-tick-at",
@@ -172,7 +173,7 @@ describe("initProgressBars", () => {
 		env.runFrame();
 
 		const width = env.fillWidth();
-		if (!width) throw new Error("fill width must be set");
+		assert(width, "fill width must be set");
 		const pct = Number.parseFloat(width);
 		expect(pct).toBeGreaterThan(55);
 		expect(pct).toBeLessThanOrEqual(99);
@@ -183,7 +184,7 @@ describe("initProgressBars", () => {
 	it("stops projecting once the bar is removed from the DOM", () => {
 		const env = setup(barAt(25, "2026-04-25T12:00:00.000Z"));
 		const bar = env.doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		bar.remove();
 		env.advance(1000);
@@ -208,7 +209,7 @@ describe("initProgressBars", () => {
 		const env = setup(barAt(15, ""));
 
 		const bar = env.doc.querySelector("[data-progress-bar]");
-		if (!bar) throw new Error("bar must be present");
+		assert(bar, "bar must be present");
 
 		// Land a real tick after a 3s wait — the rate is computed from the
 		// gap between the deps.now() anchor and this real tick.

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.ts
@@ -1,0 +1,207 @@
+/**
+ * Client-side animation for the unified article-body progress bar.
+ *
+ * The bar is a single element with id="article-body-progress" carrying
+ *   data-progress-pct      (latest percentage from the server)
+ *   data-progress-tick-at  (ISO timestamp of the latest server tick)
+ *   data-progress-stage    (stage name; opaque to the bar)
+ *
+ * The server emits a fresh bar via `hx-swap-oob` on every reader/summary
+ * poll response (every 3s). Between swaps the bar would be static; this
+ * module records (tickAt, pct) and extrapolates linearly so the fill
+ * advances smoothly at the observed rate.
+ *
+ * One bar covers both the crawl and summary pipelines — see
+ * progress-mapping.ts for the unified percentage scale.
+ */
+
+export interface BarTick {
+	tickAtMs: number;
+	pct: number;
+}
+
+/**
+ * Inline assertion. Cannot use `node:assert` because esbuild bundles this
+ * module for the browser and `node:assert` is not resolvable in a browser
+ * target.
+ */
+function assert(cond: unknown, message: string): asserts cond {
+	if (!cond) throw new Error(message);
+}
+
+/**
+ * Linear rate between two ticks, floored at 0 so a regression (worker
+ * redelivery) doesn't pull the bar backwards mid-frame.
+ */
+export function computeRate(prev: BarTick, next: BarTick): number {
+	const dt = next.tickAtMs - prev.tickAtMs;
+	if (dt <= 0) return 0;
+	const rate = (next.pct - prev.pct) / dt;
+	return rate > 0 ? rate : 0;
+}
+
+/**
+ * Project a percentage forward from the last observed tick, capped so the
+ * bar never crowds 100% before the server confirms summary-complete.
+ */
+export function projectPct(args: {
+	lastPct: number;
+	rate: number;
+	elapsedMs: number;
+	cap: number;
+}): number {
+	const projected = args.lastPct + args.rate * args.elapsedMs;
+	if (projected > args.cap) return args.cap;
+	if (projected < args.lastPct) return args.lastPct;
+	return projected;
+}
+
+export interface ProgressBarAttrs {
+	pct: number;
+	tickAtMs: number | undefined;
+}
+
+/**
+ * Read the data-progress-* attributes off the bar element. Returns
+ * `tickAtMs: undefined` when the SSR fallback used an empty tickAt — in that
+ * case the client should not extrapolate, only render the static SSR pct
+ * until the first poll lands a real timestamp.
+ */
+export function readProgressAttrs(
+	bar: Element,
+): ProgressBarAttrs | undefined {
+	const pctRaw = bar.getAttribute("data-progress-pct");
+	if (pctRaw === null) return undefined;
+	const pct = Number.parseFloat(pctRaw);
+	if (!Number.isFinite(pct)) return undefined;
+	const tickAtRaw = bar.getAttribute("data-progress-tick-at");
+	if (tickAtRaw === null || tickAtRaw === "") {
+		return { pct, tickAtMs: undefined };
+	}
+	const tickAtMs = Date.parse(tickAtRaw);
+	if (!Number.isFinite(tickAtMs)) return { pct, tickAtMs: undefined };
+	return { pct, tickAtMs };
+}
+
+/** Narrow shape of the fill element. Avoids referring to the global
+ * `HTMLElement` constructor which is not available in Jest's Node env. */
+interface BarFill {
+	style: { width: string };
+}
+
+interface BarState {
+	prev: BarTick | undefined;
+	last: BarTick;
+	rate: number;
+	fill: BarFill;
+}
+
+interface ProgressBarDeps {
+	document: Document;
+	now: () => number;
+	requestAnimationFrame: (cb: () => void) => number;
+	cancelAnimationFrame: (id: number) => void;
+	addSwapListener: (listener: () => void) => void;
+}
+
+interface ProgressBarController {
+	scan(): void;
+	stop(): void;
+}
+
+const PROGRESS_CAP = 99;
+
+export function initProgressBars(deps: ProgressBarDeps): ProgressBarController {
+	const states = new WeakMap<Element, BarState>();
+	const tracked: Element[] = [];
+	let rafId: number | undefined;
+	let stopped = false;
+
+	function findBars(): Element[] {
+		return Array.from(deps.document.querySelectorAll("[data-progress-bar]"));
+	}
+
+	function syncBar(bar: Element): void {
+		const attrs = readProgressAttrs(bar);
+		assert(attrs, "bar must carry data-progress-pct (template invariant)");
+		const fill: BarFill | null = bar.querySelector<HTMLElement>(
+			":scope > [data-progress-fill]",
+		);
+		assert(fill, "bar must contain a [data-progress-fill] child");
+
+		const existing = states.get(bar);
+		const incomingTickMs = attrs.tickAtMs;
+
+		if (existing === undefined) {
+			// First time seeing this bar. Anchor at the SSR-supplied pct. If the
+			// server did not emit a real timestamp (empty SSR fallback), anchor
+			// against deps.now() so a later real tick still produces a positive
+			// elapsed window for computeRate.
+			const anchorTickAtMs = incomingTickMs ?? deps.now();
+			states.set(bar, {
+				prev: undefined,
+				last: { pct: attrs.pct, tickAtMs: anchorTickAtMs },
+				rate: 0,
+				fill,
+			});
+			tracked.push(bar);
+			return;
+		}
+
+		// Re-scan saw no real server tick (still on SSR fallback) — leave the
+		// existing anchor in place.
+		if (incomingTickMs === undefined) return;
+
+		// Same server tick we already absorbed (re-scan without a real swap).
+		if (incomingTickMs === existing.last.tickAtMs) return;
+
+		const newTick: BarTick = { pct: attrs.pct, tickAtMs: incomingTickMs };
+		states.set(bar, {
+			prev: existing.last,
+			last: newTick,
+			rate: computeRate(existing.last, newTick),
+			fill,
+		});
+	}
+
+	function tick(): void {
+		if (stopped) return;
+		const now = deps.now();
+		// Iterate a stable snapshot — DOM mutations can splice the live list.
+		for (let i = tracked.length - 1; i >= 0; i -= 1) {
+			const bar = tracked[i];
+			if (!bar.isConnected) {
+				tracked.splice(i, 1);
+				continue;
+			}
+			const state = states.get(bar);
+			assert(state, "tracked bar must have a state entry");
+			const elapsed = now - state.last.tickAtMs;
+			const projected = projectPct({
+				lastPct: state.last.pct,
+				rate: state.rate,
+				elapsedMs: elapsed,
+				cap: PROGRESS_CAP,
+			});
+			state.fill.style.width = `${projected}%`;
+		}
+		rafId = deps.requestAnimationFrame(tick);
+	}
+
+	function scan(): void {
+		const bars = findBars();
+		for (const bar of bars) syncBar(bar);
+	}
+
+	deps.addSwapListener(scan);
+	scan();
+	rafId = deps.requestAnimationFrame(tick);
+
+	return {
+		scan,
+		stop(): void {
+			stopped = true;
+			if (rafId !== undefined) deps.cancelAnimationFrame(rafId);
+		},
+	};
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.component.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { renderProgressBar, renderProgressBarOob } from "./progress-bar.component";
+
+function parse(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
+}
+
+describe("renderProgressBar", () => {
+	it("renders a visible bar with the stage, pct and tickAt as data attributes", () => {
+		const doc = parse(
+			renderProgressBar({
+				progress: {
+					stage: "crawl-parsed",
+					pct: 29,
+					tickAt: "2026-04-25T12:00:00.000Z",
+				},
+			}),
+		);
+
+		const bar = doc.querySelector("[data-test-progress-bar]");
+		assert(bar, "bar must be rendered");
+		expect(bar.classList.contains("article-body__progress--visible")).toBe(true);
+		expect(bar.getAttribute("data-progress-stage")).toBe("crawl-parsed");
+		expect(bar.getAttribute("data-progress-pct")).toBe("29");
+		expect(bar.getAttribute("data-progress-tick-at")).toBe(
+			"2026-04-25T12:00:00.000Z",
+		);
+		expect(bar.hasAttribute("hx-swap-oob")).toBe(false);
+
+		const fill = bar.querySelector<HTMLElement>(".article-body__progress-fill");
+		assert(fill, "progress fill must be rendered");
+		expect(fill.style.width).toBe("29%");
+	});
+
+	it("renders the bar in its hidden state when progress is undefined so HTMX OOB swaps still have a target", () => {
+		const doc = parse(renderProgressBar({ progress: undefined }));
+
+		const bar = doc.querySelector("[data-test-progress-bar]");
+		assert(bar, "bar element must always be present");
+		expect(bar.classList.contains("article-body__progress--hidden")).toBe(true);
+	});
+
+	it("uses a stable id so HTMX hx-swap-oob can target the live element across swaps", () => {
+		const doc = parse(
+			renderProgressBar({
+				progress: {
+					stage: "summary-generating",
+					pct: 90,
+					tickAt: "2026-04-25T12:00:00.000Z",
+				},
+			}),
+		);
+
+		expect(doc.querySelector("#article-body-progress")).not.toBeNull();
+	});
+});
+
+describe("renderProgressBarOob", () => {
+	it("emits the same bar carrying hx-swap-oob for inclusion in poll responses", () => {
+		const html = renderProgressBarOob({
+			progress: {
+				stage: "summary-generating",
+				pct: 90,
+				tickAt: "2026-04-25T12:00:00.000Z",
+			},
+		});
+		const doc = parse(html);
+
+		const bar = doc.querySelector("#article-body-progress");
+		assert(bar, "OOB bar must be rendered");
+		expect(bar.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(bar.getAttribute("data-progress-pct")).toBe("90");
+	});
+
+	it("emits a hidden OOB bar when progress is undefined so the live bar collapses on terminal polls", () => {
+		const html = renderProgressBarOob({ progress: undefined });
+		const doc = parse(html);
+
+		const bar = doc.querySelector("#article-body-progress");
+		assert(bar, "OOB bar must be rendered even when progress is undefined");
+		expect(bar.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(bar.classList.contains("article-body__progress--hidden")).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.component.test.ts
@@ -52,7 +52,9 @@ describe("renderProgressBar", () => {
 			}),
 		);
 
-		expect(doc.querySelector("#article-body-progress")).not.toBeNull();
+		const bar = doc.querySelector("#article-body-progress");
+		assert(bar, "bar must carry a stable id for HTMX OOB swaps");
+		expect(bar.getAttribute("id")).toBe("article-body-progress");
 	});
 });
 

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.component.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render } from "../../render";
+import type { ProgressTick } from "./progress-mapping";
+
+const TEMPLATE = readFileSync(join(__dirname, "progress-bar.template.html"), "utf-8");
+
+export interface ProgressBarInput {
+	progress: ProgressTick | undefined;
+}
+
+function renderTemplate(args: {
+	progress: ProgressTick | undefined;
+	oob: boolean;
+}): string {
+	if (args.progress === undefined) {
+		return render(TEMPLATE, {
+			visibilityClass: "article-body__progress--hidden",
+			stage: "",
+			pct: 0,
+			tickAt: "",
+			oob: args.oob,
+		});
+	}
+	return render(TEMPLATE, {
+		visibilityClass: "article-body__progress--visible",
+		stage: args.progress.stage,
+		pct: args.progress.pct,
+		tickAt: args.progress.tickAt,
+		oob: args.oob,
+	});
+}
+
+/**
+ * Renders the unified progress bar. The element is always emitted so HTMX OOB
+ * swaps targeting `#article-body-progress` always have something to replace,
+ * and so the per-state class — not display:none on a missing element — drives
+ * visibility. When `progress` is undefined the bar collapses to its hidden
+ * state (post-crawl-ready+summary-complete or post-crawl-failed).
+ */
+export function renderProgressBar(input: ProgressBarInput): string {
+	return renderTemplate({ progress: input.progress, oob: false });
+}
+
+/**
+ * The same bar wrapped in an `hx-swap-oob` envelope for inclusion in slot
+ * poll responses. HTMX pulls the element out of the response body, replaces
+ * the live `#article-body-progress` element on the page, and discards the
+ * rest before swapping the primary fragment into the slot. The OOB attribute
+ * is rendered conditionally by the template so we never reparse our own
+ * markup with a regex.
+ */
+export function renderProgressBarOob(input: ProgressBarInput): string {
+	return renderTemplate({ progress: input.progress, oob: true });
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.template.html
@@ -1,0 +1,1 @@
+<div id="article-body-progress" class="article-body__progress {{visibilityClass}}"{{#if oob}} hx-swap-oob="outerHTML"{{/if}} data-test-progress-bar data-progress-bar data-progress-stage="{{stage}}" data-progress-pct="{{pct}}" data-progress-tick-at="{{tickAt}}"><div class="article-body__progress-fill" data-progress-fill style="width: {{pct}}%"></div></div>

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-mapping.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-mapping.test.ts
@@ -1,0 +1,42 @@
+import {
+	CRAWL_STAGES,
+	CRAWL_STAGE_TO_PCT,
+	SUMMARY_STAGES,
+	SUMMARY_STAGE_TO_PCT,
+	crawlStagePct,
+	summaryStagePct,
+} from "./progress-mapping";
+
+describe("progress-mapping", () => {
+	it("orders crawl stages monotonically", () => {
+		const pcts = CRAWL_STAGES.map((s) => CRAWL_STAGE_TO_PCT[s]);
+		const sorted = [...pcts].sort((a, b) => a - b);
+		expect(pcts).toEqual(sorted);
+	});
+
+	it("orders summary stages monotonically", () => {
+		const pcts = SUMMARY_STAGES.map((s) => SUMMARY_STAGE_TO_PCT[s]);
+		const sorted = [...pcts].sort((a, b) => a - b);
+		expect(pcts).toEqual(sorted);
+	});
+
+	it("places summary stages strictly after the highest crawl stage so the bar never regresses when crawl flips ready", () => {
+		const lastCrawl = Math.max(
+			...CRAWL_STAGES.map((s) => CRAWL_STAGE_TO_PCT[s]),
+		);
+		const firstSummary = Math.min(
+			...SUMMARY_STAGES.map((s) => SUMMARY_STAGE_TO_PCT[s]),
+		);
+		expect(firstSummary).toBeGreaterThan(lastCrawl);
+	});
+
+	it("starts the unified scale above 0 so the bar is visible immediately on crawl-fetching", () => {
+		expect(crawlStagePct("crawl-fetching")).toBeGreaterThan(0);
+	});
+
+	it("keeps every summary stage below 100 so the projected bar can hover under the cap until the server flips status", () => {
+		for (const stage of SUMMARY_STAGES) {
+			expect(summaryStagePct(stage)).toBeLessThan(100);
+		}
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-mapping.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-mapping.ts
@@ -1,0 +1,54 @@
+/**
+ * Unified progress mapping for the single article-body progress bar.
+ *
+ * The page has two pending sub-states (crawl, summary) but exposes one bar to
+ * the reader. Crawl stages live on the lower half of the 0–100 scale and
+ * summary stages on the upper half so the bar marches forward across both
+ * pipelines without ever moving backwards when crawl flips ready and the
+ * summary worker takes over.
+ *
+ * Only stages observable to a poll are listed: terminal "ready"-like stages
+ * (crawl-ready, summary-complete) are not included because by the time the
+ * worker writes them the row's status attribute has already flipped to a
+ * terminal value, and `buildUnifiedProgress` drops the bar entirely.
+ */
+
+export const CRAWL_STAGE_TO_PCT = {
+	"crawl-fetching": 5,
+	"crawl-fetched": 17,
+	"crawl-parsed": 29,
+	"crawl-metadata-written": 41,
+	"crawl-content-uploaded": 53,
+} as const;
+
+export type CrawlStage = keyof typeof CRAWL_STAGE_TO_PCT;
+
+export const CRAWL_STAGES = Object.keys(CRAWL_STAGE_TO_PCT) as readonly CrawlStage[];
+
+export const SUMMARY_STAGE_TO_PCT = {
+	"summary-started": 65,
+	"summary-generating": 90,
+} as const;
+
+export type SummaryStage = keyof typeof SUMMARY_STAGE_TO_PCT;
+
+export const SUMMARY_STAGES = Object.keys(SUMMARY_STAGE_TO_PCT) as readonly SummaryStage[];
+
+export const DEFAULT_CRAWL_STAGE: CrawlStage = "crawl-fetching";
+export const DEFAULT_SUMMARY_STAGE: SummaryStage = "summary-started";
+
+export type ProgressStage = CrawlStage | SummaryStage;
+
+export interface ProgressTick {
+	stage: ProgressStage;
+	pct: number;
+	tickAt: string;
+}
+
+export function crawlStagePct(stage: CrawlStage): number {
+	return CRAWL_STAGE_TO_PCT[stage];
+}
+
+export function summaryStagePct(stage: SummaryStage): number {
+	return SUMMARY_STAGE_TO_PCT[stage];
+}

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -45,6 +45,8 @@ interface FakeState {
 	markSummaryPendingCalls: number;
 }
 
+const FIXED_NOW = new Date("2026-04-25T12:00:00.000Z");
+
 function initFakeDeps(initial?: Partial<FakeState>): {
 	state: FakeState;
 	deps: {
@@ -53,6 +55,7 @@ function initFakeDeps(initial?: Partial<FakeState>): {
 		findGeneratedSummary: FindGeneratedSummary;
 		markSummaryPending: MarkSummaryPending;
 		readArticleContent: ReadArticleContent;
+		now: () => Date;
 	};
 } {
 	const state: FakeState = {
@@ -74,6 +77,7 @@ function initFakeDeps(initial?: Partial<FakeState>): {
 			if (state.summary === undefined) state.summary = { status: "pending" };
 		},
 		readArticleContent: async () => state.content,
+		now: () => FIXED_NOW,
 	};
 	return { state, deps };
 }
@@ -106,6 +110,115 @@ describe("initArticleReader", () => {
 			expect(result.content).toBeUndefined();
 			expect(result.readerPollUrl).toBe("/test/reader?poll=1");
 			expect(result.summaryPollUrl).toBe("/test/summary?poll=1");
+		});
+
+		it("emits a unified progress tick driven by the crawl stage while crawl is pending", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "pending", stage: "crawl-parsed" },
+				summary: { status: "pending" },
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.progress).toEqual({
+				stage: "crawl-parsed",
+				pct: 29,
+				tickAt: FIXED_NOW.toISOString(),
+			});
+		});
+
+		it("falls back to crawl-fetching at the bottom of the bar when no crawl stage has been recorded yet", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "pending" },
+				summary: { status: "pending" },
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.progress).toEqual({
+				stage: "crawl-fetching",
+				pct: 5,
+				tickAt: FIXED_NOW.toISOString(),
+			});
+		});
+
+		it("hands the unified bar over to the summary stage once the crawl has gone ready", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				summary: { status: "pending", stage: "summary-generating" },
+				content: "<p>body</p>",
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.progress).toEqual({
+				stage: "summary-generating",
+				pct: 90,
+				tickAt: FIXED_NOW.toISOString(),
+			});
+		});
+
+		it("falls back to summary-started at the bottom of the summary range when no summary stage has been recorded yet", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				summary: { status: "pending" },
+				content: "<p>body</p>",
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.progress).toEqual({
+				stage: "summary-started",
+				pct: 65,
+				tickAt: FIXED_NOW.toISOString(),
+			});
+		});
+
+		it("hides the bar once both pipelines are terminal", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				summary: { status: "ready", summary: "TL;DR" },
+				content: "<p>body</p>",
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.progress).toBeUndefined();
+		});
+
+		it("hides the bar when the crawl has failed (summary slot collapses; the bar would just stall)", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "failed", reason: "blocked" },
+				summary: { status: "pending" },
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.progress).toBeUndefined();
 		});
 
 		it("omits readerPollUrl when the crawl is ready", async () => {
@@ -290,6 +403,27 @@ describe("initArticleReader", () => {
 			expect(slot.hasAttribute("hx-get")).toBe(false);
 		});
 
+		it("includes the unified progress bar as an hx-swap-oob fragment so the bar updates without a separate poll", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				summary: { status: "pending", stage: "summary-generating" },
+			});
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleSummaryPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			const bar = doc.querySelector("#article-body-progress");
+			assert(bar, "progress bar OOB element must accompany the slot fragment");
+			expect(bar.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			expect(bar.getAttribute("data-progress-stage")).toBe("summary-generating");
+			expect(bar.getAttribute("data-progress-pct")).toBe("90");
+		});
+
 		it("renders a ready summary expanded (summaryOpen: true) and stops polling", async () => {
 			const { deps } = initFakeDeps({
 				crawl: { status: "ready" },
@@ -368,6 +502,27 @@ describe("initArticleReader", () => {
 			assert(slot, "reader slot must be rendered");
 			expect(slot.getAttribute("data-reader-status")).toBe("pending");
 			expect(slot.hasAttribute("hx-get")).toBe(false);
+		});
+
+		it("includes the unified progress bar as an hx-swap-oob fragment driven by the recorded crawl stage", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "pending", stage: "crawl-content-uploaded" },
+				content: undefined,
+			});
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			const bar = doc.querySelector("#article-body-progress");
+			assert(bar, "progress bar OOB element must accompany the slot fragment");
+			expect(bar.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			expect(bar.getAttribute("data-progress-stage")).toBe("crawl-content-uploaded");
+			expect(bar.getAttribute("data-progress-pct")).toBe("53");
 		});
 
 		it("renders the ready reader with content when the crawl is ready", async () => {

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
@@ -1,5 +1,17 @@
+import type { ArticleCrawl } from "../../../providers/article-crawl/article-crawl.types";
+import type { GeneratedSummary } from "../../../providers/article-summary/article-summary.types";
 import type { Component } from "../../component.types";
 import { HtmlPage } from "../../html-page";
+import { renderProgressBarOob } from "../article-body/progress-bar.component";
+import {
+	CRAWL_STAGE_TO_PCT,
+	type CrawlStage,
+	DEFAULT_CRAWL_STAGE,
+	DEFAULT_SUMMARY_STAGE,
+	type ProgressTick,
+	SUMMARY_STAGE_TO_PCT,
+	type SummaryStage,
+} from "../article-body/progress-mapping";
 import { renderReaderSlot } from "../article-body/reader-slot/reader-slot.component";
 import { renderSummarySlot } from "../article-body/summary-slot/summary-slot.component";
 import type {
@@ -10,6 +22,45 @@ import type {
 } from "./article-reader.types";
 
 const MAX_POLLS = 40;
+
+/**
+ * Single-bar progress: pick the further-along pipeline. While the crawl is
+ * pending, drive the bar from the crawl stage on the lower half of the
+ * unified scale. Once the crawl is ready (or undefined-with-content, the
+ * legacy-row path) the summary takes over on the upper half.
+ *
+ * Returns undefined when there is nothing left to animate — both pipelines
+ * terminal, or the crawl has failed and the summary slot has collapsed
+ * (rendering a half-full bar there would just stall forever).
+ */
+function buildUnifiedProgress(
+	crawl: ArticleCrawl | undefined,
+	summary: GeneratedSummary | undefined,
+	now: Date,
+): ProgressTick | undefined {
+	if (crawl?.status === "failed") return undefined;
+
+	if (crawl?.status === "pending") {
+		const stage: CrawlStage = crawl.stage ?? DEFAULT_CRAWL_STAGE;
+		return {
+			stage,
+			pct: CRAWL_STAGE_TO_PCT[stage],
+			tickAt: now.toISOString(),
+		};
+	}
+
+	const summaryStatus = summary?.status ?? "pending";
+	if (summaryStatus !== "pending") return undefined;
+
+	const recordedStage =
+		summary?.status === "pending" ? summary.stage : undefined;
+	const stage: SummaryStage = recordedStage ?? DEFAULT_SUMMARY_STAGE;
+	return {
+		stage,
+		pct: SUMMARY_STAGE_TO_PCT[stage],
+		tickAt: now.toISOString(),
+	};
+}
 
 export function initArticleReader(deps: ArticleReaderDeps): {
 	resolveReaderState: (params: ResolveReaderStateParams) => Promise<ReaderState>;
@@ -49,7 +100,14 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 			crawl?.status === "pending" || (crawl === undefined && content === undefined);
 		const readerPollUrl = shouldPollReader ? pollUrlBuilder.reader(1) : undefined;
 
-		return { content, crawl, summary, readerPollUrl, summaryPollUrl };
+		return {
+			content,
+			crawl,
+			summary,
+			readerPollUrl,
+			summaryPollUrl,
+			progress: buildUnifiedProgress(crawl, summary, deps.now()),
+		};
 	}
 
 	async function handleSummaryPoll(params: HandlePollParams): Promise<Component> {
@@ -61,19 +119,39 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 		const summaryPollUrl = !crawlFailed && status === "pending" && pollCount < MAX_POLLS
 			? pollUrlBuilder.summary(pollCount + 1)
 			: undefined;
-		return HtmlPage(renderSummarySlot({ crawl, summary, summaryPollUrl, summaryOpen: true }));
+		const slot = renderSummarySlot({
+			crawl,
+			summary,
+			summaryPollUrl,
+			summaryOpen: true,
+		});
+		const oobBar = renderProgressBarOob({
+			progress: buildUnifiedProgress(crawl, summary, deps.now()),
+		});
+		return HtmlPage(slot + oobBar);
 	}
 
 	async function handleReaderPoll(params: HandlePollParams): Promise<Component> {
 		const { articleUrl, pollCount, pollUrlBuilder, extensionInstallUrl } = params;
 		const crawl = await deps.findArticleCrawlStatus(articleUrl);
+		const summary = await deps.findGeneratedSummary(articleUrl);
 		const content = await deps.readArticleContent(articleUrl);
 		const shouldPollReader =
 			crawl?.status === "pending" || (crawl === undefined && content === undefined);
 		const readerPollUrl = shouldPollReader && pollCount < MAX_POLLS
 			? pollUrlBuilder.reader(pollCount + 1)
 			: undefined;
-		return HtmlPage(renderReaderSlot({ crawl, content, url: articleUrl, readerPollUrl, extensionInstallUrl }));
+		const slot = renderReaderSlot({
+			crawl,
+			content,
+			url: articleUrl,
+			readerPollUrl,
+			extensionInstallUrl,
+		});
+		const oobBar = renderProgressBarOob({
+			progress: buildUnifiedProgress(crawl, summary, deps.now()),
+		});
+		return HtmlPage(slot + oobBar);
 	}
 
 	return { resolveReaderState, handleSummaryPoll, handleReaderPoll };

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.types.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.types.ts
@@ -13,6 +13,7 @@ import type {
 	MarkSummaryPending,
 } from "../../../providers/article-summary/article-summary.types";
 import type { ReadArticleContent } from "../../../providers/article-store/read-article-content";
+import type { ProgressTick } from "../article-body/progress-mapping";
 
 export interface ArticleReaderDeps {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
@@ -20,6 +21,7 @@ export interface ArticleReaderDeps {
 	findGeneratedSummary: FindGeneratedSummary;
 	markSummaryPending: MarkSummaryPending;
 	readArticleContent: ReadArticleContent;
+	now: () => Date;
 }
 
 export interface ArticleSnapshot {
@@ -39,6 +41,14 @@ export interface ReaderState {
 	summary: GeneratedSummary | undefined;
 	readerPollUrl: string | undefined;
 	summaryPollUrl: string | undefined;
+	/**
+	 * Single unified progress tick driving the article-body progress bar.
+	 * Computed from whichever pipeline (crawl → summary) is currently in flight,
+	 * mapped onto a 0–100 scale. `undefined` once both pipelines are terminal
+	 * (or the crawl has failed — we hide the bar instead of stalling at a
+	 * percentage that will never advance).
+	 */
+	progress: ProgressTick | undefined;
 }
 
 export interface ResolveReaderStateParams {

--- a/projects/save-link/src/crawl-article-state/article-crawl.types.ts
+++ b/projects/save-link/src/crawl-article-state/article-crawl.types.ts
@@ -3,3 +3,24 @@ export type MarkCrawlFailed = (params: {
 	url: string;
 	reason: string;
 }) => Promise<void>;
+
+/**
+ * Worker-side stage strings for the unified article-body progress bar. Mirrors
+ * the hutch progress-mapping CrawlStage union — kept as a literal type here so
+ * the save-link package does not take a cross-project relative import on the
+ * percentage table. The worker only writes the stage name; the reader maps
+ * stage → pct at render time. Terminal stages are omitted because by the time
+ * the worker would write them the row's status attribute has already flipped
+ * to a terminal value, which the reader respects ahead of any stage write.
+ */
+export type CrawlStage =
+	| "crawl-fetching"
+	| "crawl-fetched"
+	| "crawl-parsed"
+	| "crawl-metadata-written"
+	| "crawl-content-uploaded";
+
+export type MarkCrawlStage = (params: {
+	url: string;
+	stage: CrawlStage;
+}) => Promise<void>;

--- a/projects/save-link/src/crawl-article-state/dynamodb-article-crawl.test.ts
+++ b/projects/save-link/src/crawl-article-state/dynamodb-article-crawl.test.ts
@@ -93,6 +93,49 @@ describe("initDynamoDbArticleCrawl (unit)", () => {
 		});
 	});
 
+	describe("markCrawlStage", () => {
+		it("issues an unconditional UpdateItem that sets crawlStage", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { markCrawlStage } = initDynamoDbArticleCrawl({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await markCrawlStage({ url: URL, stage: "crawl-fetched" });
+
+			const command = received as {
+				input: {
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.UpdateExpression).toBe("SET crawlStage = :stage");
+			expect(command.input.ConditionExpression).toBeUndefined();
+			expect(command.input.ExpressionAttributeValues?.[":stage"]).toBe(
+				"crawl-fetched",
+			);
+		});
+
+		it("rethrows DynamoDB errors so a stage-write outage is observable in worker logs", async () => {
+			const client = createFakeClient(() => {
+				throw new Error("throttled");
+			});
+			const { markCrawlStage } = initDynamoDbArticleCrawl({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await expect(
+				markCrawlStage({ url: URL, stage: "crawl-fetching" }),
+			).rejects.toThrow("throttled");
+		});
+	});
+
 	describe("error handling", () => {
 		it("swallows ConditionalCheckFailedException on markCrawlFailed (ready row preserved)", async () => {
 			const client = createFakeClient(() => {

--- a/projects/save-link/src/crawl-article-state/dynamodb-article-crawl.ts
+++ b/projects/save-link/src/crawl-article-state/dynamodb-article-crawl.ts
@@ -5,7 +5,11 @@ import {
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id";
-import type { MarkCrawlFailed, MarkCrawlReady } from "./article-crawl.types";
+import type {
+	MarkCrawlFailed,
+	MarkCrawlReady,
+	MarkCrawlStage,
+} from "./article-crawl.types";
 
 const CrawlStateRow = z.object({
 	url: z.string(),
@@ -28,6 +32,7 @@ export function initDynamoDbArticleCrawl(deps: {
 }): {
 	markCrawlReady: MarkCrawlReady;
 	markCrawlFailed: MarkCrawlFailed;
+	markCrawlStage: MarkCrawlStage;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
@@ -71,5 +76,19 @@ export function initDynamoDbArticleCrawl(deps: {
 		);
 	};
 
-	return { markCrawlReady, markCrawlFailed };
+	const markCrawlStage: MarkCrawlStage = async ({ url, stage }) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		// Unconditional write: stages are monotonic by code order in the
+		// save-link worker, the worker is the only writer, and SQS redelivery
+		// just repeats the same sequence. We accept a brief regression on
+		// redelivery rather than the cost of a conditional check at every
+		// milestone.
+		await table.update({
+			Key: { url: articleResourceUniqueId.value },
+			UpdateExpression: "SET crawlStage = :stage",
+			ExpressionAttributeValues: { ":stage": stage },
+		});
+	};
+
+	return { markCrawlReady, markCrawlFailed, markCrawlStage };
 }

--- a/projects/save-link/src/generate-summary/article-summary.types.ts
+++ b/projects/save-link/src/generate-summary/article-summary.types.ts
@@ -28,6 +28,20 @@ export type MarkSummaryPending = (params: { url: string }) => Promise<void>;
 export type MarkSummaryFailed = (params: { url: string; reason: string }) => Promise<void>;
 export type MarkSummarySkipped = (params: { url: string }) => Promise<void>;
 
+/**
+ * Worker-side stage strings for the unified article-body progress bar.
+ * Mirrors the hutch progress-mapping SummaryStage union — kept as a literal
+ * type to keep the save-link package free of cross-project relative imports.
+ * Terminal stages are omitted because by the time the worker would write
+ * them the row's status attribute has already flipped to a terminal value.
+ */
+export type SummaryStage = "summary-started" | "summary-generating";
+
+export type MarkSummaryStage = (params: {
+	url: string;
+	stage: SummaryStage;
+}) => Promise<void>;
+
 export type DocumentBlock = {
 	type: "document";
 	source: { type: "text"; media_type: "text/plain"; data: string };

--- a/projects/save-link/src/generate-summary/dynamodb-generated-summary.integration.ts
+++ b/projects/save-link/src/generate-summary/dynamodb-generated-summary.integration.ts
@@ -135,6 +135,19 @@ describe("dynamoDbGeneratedSummary (integration)", () => {
 		assert.deepEqual(result, { status: "skipped" });
 	});
 
+	it("markSummaryStage writes a stage attribute without regressing pending status", async () => {
+		const client = createDynamoDocumentClient();
+		const { findGeneratedSummary, markSummaryPending, markSummaryStage } =
+			initDynamoDbGeneratedSummary({ client, tableName });
+
+		const url = `https://example.com/${randomUUID()}`;
+		await markSummaryPending({ url });
+		await markSummaryStage({ url, stage: "summary-generating" });
+
+		const result = await findGeneratedSummary(url);
+		assert.deepEqual(result, { status: "pending" });
+	});
+
 	it("saveGeneratedSummary clears a prior failure reason when the retry succeeds", async () => {
 		const client = createDynamoDocumentClient();
 		const { findGeneratedSummary, markSummaryPending, markSummaryFailed, saveGeneratedSummary } =

--- a/projects/save-link/src/generate-summary/dynamodb-generated-summary.test.ts
+++ b/projects/save-link/src/generate-summary/dynamodb-generated-summary.test.ts
@@ -122,6 +122,35 @@ describe("initDynamoDbGeneratedSummary (unit)", () => {
 		});
 	});
 
+	describe("markSummaryStage", () => {
+		it("issues an unconditional UpdateItem that sets summaryStage", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { markSummaryStage } = initDynamoDbGeneratedSummary({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await markSummaryStage({ url: URL, stage: "summary-generating" });
+
+			const command = received as {
+				input: {
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.UpdateExpression).toBe("SET summaryStage = :stage");
+			expect(command.input.ConditionExpression).toBeUndefined();
+			expect(command.input.ExpressionAttributeValues?.[":stage"]).toBe(
+				"summary-generating",
+			);
+		});
+	});
+
 	describe("mark functions — error handling", () => {
 		it("swallows ConditionalCheckFailedException (ready row preserved)", async () => {
 			const client = createFakeClient(() => {

--- a/projects/save-link/src/generate-summary/dynamodb-generated-summary.ts
+++ b/projects/save-link/src/generate-summary/dynamodb-generated-summary.ts
@@ -14,6 +14,7 @@ import type {
 	MarkSummaryFailed,
 	MarkSummaryPending,
 	MarkSummarySkipped,
+	MarkSummaryStage,
 	SaveGeneratedSummary,
 } from "./article-summary.types";
 
@@ -67,6 +68,7 @@ export function initDynamoDbGeneratedSummary(deps: {
 	markSummaryPending: MarkSummaryPending;
 	markSummaryFailed: MarkSummaryFailed;
 	markSummarySkipped: MarkSummarySkipped;
+	markSummaryStage: MarkSummaryStage;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
@@ -152,11 +154,25 @@ export function initDynamoDbGeneratedSummary(deps: {
 		);
 	};
 
+	const markSummaryStage: MarkSummaryStage = async ({ url, stage }) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		// Unconditional: stage writes are monotonic by code order in the
+		// summariser. SQS redelivery just rewrites the same sequence; we accept
+		// a brief regression on redelivery rather than the cost of a conditional
+		// check at every milestone.
+		await table.update({
+			Key: { url: articleResourceUniqueId.value },
+			UpdateExpression: "SET summaryStage = :stage",
+			ExpressionAttributeValues: { ":stage": stage },
+		});
+	};
+
 	return {
 		findGeneratedSummary,
 		saveGeneratedSummary,
 		markSummaryPending,
 		markSummaryFailed,
 		markSummarySkipped,
+		markSummaryStage,
 	};
 }

--- a/projects/save-link/src/generate-summary/link-summariser.test.ts
+++ b/projects/save-link/src/generate-summary/link-summariser.test.ts
@@ -4,6 +4,7 @@ import type {
 	CreateAiMessage,
 	FindGeneratedSummary,
 	MarkSummarySkipped,
+	MarkSummaryStage,
 	SaveGeneratedSummary,
 } from "./article-summary.types";
 
@@ -18,6 +19,7 @@ const noCache: FindGeneratedSummary = async () => undefined;
 const pendingCache: FindGeneratedSummary = async () => ({ status: "pending" });
 const noopSave: SaveGeneratedSummary = async () => {};
 const noopMarkSkipped: MarkSummarySkipped = async () => {};
+const noopMarkStage: MarkSummaryStage = async () => {};
 const identity = (text: string) => text;
 
 describe("initLinkSummariser", () => {
@@ -30,6 +32,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: pendingCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => true,
@@ -56,6 +59,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: noCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -93,6 +97,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: pendingCache,
 			saveGeneratedSummary,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -131,6 +136,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: noCache,
 			saveGeneratedSummary,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -160,6 +166,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: noCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -186,6 +193,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: cachedSummary,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -209,6 +217,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: skippedCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -238,6 +247,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: failedCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -267,6 +277,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: pendingCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -296,6 +307,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: noCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,
@@ -320,6 +332,7 @@ describe("initLinkSummariser", () => {
 			findGeneratedSummary: noCache,
 			saveGeneratedSummary: noopSave,
 			markSummarySkipped: noopMarkSkipped,
+			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
 			isTooShortToSummarize: () => false,

--- a/projects/save-link/src/generate-summary/link-summariser.ts
+++ b/projects/save-link/src/generate-summary/link-summariser.ts
@@ -6,6 +6,7 @@ import type {
 	CreateAiMessage,
 	FindGeneratedSummary,
 	MarkSummarySkipped,
+	MarkSummaryStage,
 	SaveGeneratedSummary,
 	SummarizeArticle,
 } from "./article-summary.types";
@@ -39,11 +40,13 @@ export function initLinkSummariser(deps: {
 	findGeneratedSummary: FindGeneratedSummary;
 	saveGeneratedSummary: SaveGeneratedSummary;
 	markSummarySkipped: MarkSummarySkipped;
+	markSummaryStage: MarkSummaryStage;
 	logger: HutchLogger;
 	cleanContent: (html: string) => string;
 	isTooShortToSummarize: (cleanedText: string) => boolean;
 }): { summarizeArticle: SummarizeArticle } {
 	const summarizeArticle: SummarizeArticle = async (params) => {
+		await deps.markSummaryStage({ url: params.url, stage: "summary-started" });
 		const cached = await deps.findGeneratedSummary(params.url);
 		// "failed" is retryable on redrive; "ready" and "skipped" are terminal — short-circuit those.
 		if (cached?.status === "ready" || cached?.status === "skipped") {
@@ -60,6 +63,7 @@ export function initLinkSummariser(deps: {
 			return null;
 		}
 
+		await deps.markSummaryStage({ url: params.url, stage: "summary-generating" });
 		const response = await deps.createMessage({
 			model: "deepseek-chat",
 			max_tokens: 10240,

--- a/projects/save-link/src/runtime/generate-summary.main.ts
+++ b/projects/save-link/src/runtime/generate-summary.main.ts
@@ -51,6 +51,7 @@ const { summarizeArticle } = initLinkSummariser({
 	findGeneratedSummary: summaryStore.findGeneratedSummary,
 	saveGeneratedSummary: summaryStore.saveGeneratedSummary,
 	markSummarySkipped: summaryStore.markSummarySkipped,
+	markSummaryStage: summaryStore.markSummaryStage,
 });
 
 const { publishEvent } = initEventBridgePublisher({

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -52,7 +52,7 @@ const { updateFetchTimestamp } = initUpdateFetchTimestamp({
 	tableName: articlesTable,
 });
 
-const { markCrawlReady, markCrawlFailed } = initDynamoDbArticleCrawl({
+const { markCrawlReady, markCrawlFailed, markCrawlStage } = initDynamoDbArticleCrawl({
 	client,
 	tableName: articlesTable,
 });
@@ -110,6 +110,7 @@ export const handler = initSaveAnonymousLinkCommandHandler({
 	updateFetchTimestamp,
 	markCrawlReady,
 	markCrawlFailed,
+	markCrawlStage,
 	publishEvent,
 	downloadMedia,
 	processContent,

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -52,7 +52,7 @@ const { updateFetchTimestamp } = initUpdateFetchTimestamp({
 	tableName: articlesTable,
 });
 
-const { markCrawlReady, markCrawlFailed } = initDynamoDbArticleCrawl({
+const { markCrawlReady, markCrawlFailed, markCrawlStage } = initDynamoDbArticleCrawl({
 	client,
 	tableName: articlesTable,
 });
@@ -110,6 +110,7 @@ export const handler = initSaveLinkCommandHandler({
 	updateFetchTimestamp,
 	markCrawlReady,
 	markCrawlFailed,
+	markCrawlStage,
 	publishEvent,
 	downloadMedia,
 	processContent,

--- a/projects/save-link/src/save-link/save-anonymous-link-command-handler.test.ts
+++ b/projects/save-link/src/save-link/save-anonymous-link-command-handler.test.ts
@@ -81,6 +81,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		markCrawlReady: jest.fn().mockResolvedValue(undefined),
 		markCrawlFailed: jest.fn().mockResolvedValue(undefined),
+		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		downloadMedia: noopDownloadMedia,
 		processContent,

--- a/projects/save-link/src/save-link/save-anonymous-link-command-handler.ts
+++ b/projects/save-link/src/save-link/save-anonymous-link-command-handler.ts
@@ -6,7 +6,11 @@ import {
 	SaveAnonymousLinkCommand,
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed, MarkCrawlReady } from "../crawl-article-state/article-crawl.types";
+import type {
+	MarkCrawlFailed,
+	MarkCrawlReady,
+	MarkCrawlStage,
+} from "../crawl-article-state/article-crawl.types";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia } from "./download-media";
 import type { PutImageObject } from "./s3-put-image-object";
@@ -24,6 +28,7 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	markCrawlReady: MarkCrawlReady;
 	markCrawlFailed: MarkCrawlFailed;
+	markCrawlStage: MarkCrawlStage;
 	publishEvent: PublishEvent;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
@@ -44,6 +49,7 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		markCrawlReady: deps.markCrawlReady,
 		markCrawlFailed: deps.markCrawlFailed,
+		markCrawlStage: deps.markCrawlStage,
 		downloadMedia: deps.downloadMedia,
 		processContent: deps.processContent,
 		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,

--- a/projects/save-link/src/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/save-link/save-link-command-handler.test.ts
@@ -82,6 +82,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		markCrawlReady: jest.fn().mockResolvedValue(undefined),
 		markCrawlFailed: jest.fn().mockResolvedValue(undefined),
+		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		downloadMedia: noopDownloadMedia,
 		processContent,

--- a/projects/save-link/src/save-link/save-link-command-handler.ts
+++ b/projects/save-link/src/save-link/save-link-command-handler.ts
@@ -6,7 +6,11 @@ import {
 	SaveLinkCommand,
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed, MarkCrawlReady } from "../crawl-article-state/article-crawl.types";
+import type {
+	MarkCrawlFailed,
+	MarkCrawlReady,
+	MarkCrawlStage,
+} from "../crawl-article-state/article-crawl.types";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia } from "./download-media";
 import type { PutImageObject } from "./s3-put-image-object";
@@ -24,6 +28,7 @@ export function initSaveLinkCommandHandler(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	markCrawlReady: MarkCrawlReady;
 	markCrawlFailed: MarkCrawlFailed;
+	markCrawlStage: MarkCrawlStage;
 	publishEvent: PublishEvent;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
@@ -44,6 +49,7 @@ export function initSaveLinkCommandHandler(deps: {
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		markCrawlReady: deps.markCrawlReady,
 		markCrawlFailed: deps.markCrawlFailed,
+		markCrawlStage: deps.markCrawlStage,
 		downloadMedia: deps.downloadMedia,
 		processContent: deps.processContent,
 		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,

--- a/projects/save-link/src/save-link/save-link-work.ts
+++ b/projects/save-link/src/save-link/save-link-work.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle, ThumbnailImage } from "@packages/crawl-article";
-import type { MarkCrawlFailed, MarkCrawlReady } from "../crawl-article-state/article-crawl.types";
+import type {
+	MarkCrawlFailed,
+	MarkCrawlReady,
+	MarkCrawlStage,
+} from "../crawl-article-state/article-crawl.types";
 import { ArticleResourceUniqueId } from "./article-resource-unique-id";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia, DownloadedMedia } from "./download-media";
@@ -23,6 +27,7 @@ export function initSaveLinkWork(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	markCrawlReady: MarkCrawlReady;
 	markCrawlFailed: MarkCrawlFailed;
+	markCrawlStage: MarkCrawlStage;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
 	imagesCdnBaseUrl: string;
@@ -41,6 +46,7 @@ export function initSaveLinkWork(deps: {
 		updateFetchTimestamp,
 		markCrawlReady,
 		markCrawlFailed,
+		markCrawlStage,
 		downloadMedia,
 		processContent,
 		imagesCdnBaseUrl,
@@ -64,6 +70,7 @@ export function initSaveLinkWork(deps: {
 	};
 
 	const saveLinkWork = async (url: string): Promise<void> => {
+		await markCrawlStage({ url, stage: "crawl-fetching" });
 		const crawlResult = await crawlArticle({ url, fetchThumbnail: true });
 		if (crawlResult.status !== "fetched") {
 			const reason = `crawl-${crawlResult.status}`;
@@ -71,6 +78,7 @@ export function initSaveLinkWork(deps: {
 			await emitTier1Failure(url);
 			throw new Error(`crawl failed for ${url}: ${reason}`);
 		}
+		await markCrawlStage({ url, stage: "crawl-fetched" });
 
 		const parseResult = parseHtml({ url, html: crawlResult.html });
 		if (!parseResult.ok) {
@@ -86,6 +94,7 @@ export function initSaveLinkWork(deps: {
 		}
 
 		const { article } = parseResult;
+		await markCrawlStage({ url, stage: "crawl-parsed" });
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
 
 		const media = await downloadMedia({
@@ -107,6 +116,7 @@ export function initSaveLinkWork(deps: {
 					imagesCdnBaseUrl,
 				})
 			: article.imageUrl;
+		await markCrawlStage({ url, stage: "crawl-metadata-written" });
 
 		await putTierSource({
 			url,
@@ -121,6 +131,7 @@ export function initSaveLinkWork(deps: {
 				imageUrl: resolvedImageUrl,
 			},
 		});
+		await markCrawlStage({ url, stage: "crawl-content-uploaded" });
 
 		await updateFetchTimestamp({
 			url,


### PR DESCRIPTION
## Summary
- Adds a single 0–100% progress bar that animates across the crawl and summary pipelines, anchored on server polls and projected forward via `requestAnimationFrame` between polls.
- Server emits a `hx-swap-oob` bar on every reader/summary poll response so the bar updates without a separate poll cycle.
- Reimplementation of #194 against current `main`, with the three low-priority review observations fixed in the implementation rather than left as follow-ups.

## Low-priority issues addressed (vs #194)
1. **OOB attribute injection no longer regex-based.** `progress-bar.template.html` carries an optional `{{#if oob}} hx-swap-oob="outerHTML"{{/if}}`; `renderProgressBarOob` calls `render()` with `oob: true` instead of `.replace()`-ing emitted HTML.
2. **Dropped redundant `markCrawlStage("crawl-ready")`** after `markCrawlReady` in `save-link-work.ts`. Once `crawl.status === "ready"` the bar already switches to summary, so the stage write was unobservable. `crawl-ready` removed from the `CrawlStage` union and percentage table.
3. **Dropped `summary-content-loaded`** — the original PR wrote it back-to-back with `summary-generating`, so a 3s poll never observed it. Removed both the write and the mapping entry.
4. **Dropped `summary-complete`** — written after `saveGeneratedSummary` flips status to `ready`, at which point the bar is already hidden. Removed for the same reason.

## Mapping after dropping unobservable stages
- Crawl (5 stages): `crawl-fetching` 5, `crawl-fetched` 17, `crawl-parsed` 29, `crawl-metadata-written` 41, `crawl-content-uploaded` 53
- Summary (2 stages): `summary-started` 65, `summary-generating` 90
- Client-side cap at 99% so the bar never crowds 100% before the server confirms a terminal state

## Notable implementation details
- Worker writes are unconditional (`SET crawlStage = :stage` / `SET summaryStage = :stage`); SQS redelivery just rewrites the same monotonic sequence.
- `buildUnifiedProgress` returns `undefined` when both pipelines are terminal, or when the crawl has failed (rendering a half-full bar that never advances would look broken).
- Empty-`tickAt` SSR fallback is honored: the client anchors against `deps.now()` so the first real server tick still produces a positive elapsed window for `computeRate`.
- `markCrawlPending` preserves any previously recorded stage in the in-memory provider (mirrors the DDB `UpdateExpression` which only touches `crawlStatus`), so the legacy-stub healing path doesn't reset the bar.

## Test plan
- [x] `pnpm check` — 16 projects, all coverage thresholds met (100% functions, overall 99.51% statements / 97.16% branches)
- [ ] Manual: save a fresh URL, watch the bar march from 5% through ~53% as crawl progresses, jump to 65% when crawl flips ready, project toward 99% during the summary wait, and disappear when the summary lands
- [ ] Manual: save a URL that fails to crawl — bar should hide once crawl flips `failed`
- [ ] Manual: re-save a URL with a cached summary — bar should not appear (both pipelines already terminal)