### PR TITLE
Handle promotion race condition in article reader polling

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -362,6 +362,24 @@ describe("initArticleReader", () => {
 
 			expect(result.readerPollUrl).toBeUndefined();
 		});
+
+		it("emits readerPollUrl when crawl is ready but content is undefined (promotion race)", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				summary: { status: "ready", summary: "TL;DR" },
+				content: undefined,
+			});
+			const reader = initArticleReader(deps);
+
+			const result = await reader.resolveReaderState({
+				article: makeSnapshot(),
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			expect(result.crawl).toEqual({ status: "ready" });
+			expect(result.content).toBeUndefined();
+			expect(result.readerPollUrl).toBe("/test/reader?poll=1");
+		});
 	});
 
 	describe("handleSummaryPoll", () => {
@@ -561,6 +579,43 @@ describe("initArticleReader", () => {
 			assert(slot, "reader slot must be rendered");
 			expect(slot.getAttribute("data-reader-status")).toBe("pending");
 			expect(slot.getAttribute("hx-get")).toBe("/test/reader?poll=6");
+		});
+
+		it("emits the next poll URL when crawl is ready but content is undefined (promotion race)", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				content: undefined,
+			});
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 5,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const slot = parse(toHtml(component)).querySelector("[data-test-reader-slot]");
+			assert(slot, "reader slot must be rendered");
+			expect(slot.getAttribute("data-reader-status")).toBe("pending");
+			expect(slot.getAttribute("hx-get")).toBe("/test/reader?poll=6");
+		});
+
+		it("stops at MAX_POLLS=40 even when stuck in the promotion race", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				content: undefined,
+			});
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 40,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const slot = parse(toHtml(component)).querySelector("[data-test-reader-slot]");
+			assert(slot, "reader slot must be rendered");
+			expect(slot.hasAttribute("hx-get")).toBe(false);
 		});
 
 		it("renders the reader as failed when the crawl has failed", async () => {

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
@@ -24,6 +24,24 @@ import type {
 const MAX_POLLS = 40;
 
 /**
+ * 1. Pending: the normal in-flight case.
+ * 2. Read-after-write race: markCrawlPending hasn't propagated yet.
+ * 3. Promotion race: save-link-work flipped crawlStatus="ready" but
+ *    select-most-complete-content-handler hasn't copied the canonical S3
+ *    object yet, so readArticleContent still returns undefined. MAX_POLLS
+ *    bounds the wait if the canonical write genuinely never lands.
+ */
+function shouldKeepPollingReader(
+	crawl: ArticleCrawl | undefined,
+	content: string | undefined,
+): boolean {
+	if (crawl?.status === "pending") return true; /* 1 */
+	if (crawl === undefined && content === undefined) return true; /* 2 */
+	if (crawl?.status === "ready" && content === undefined) return true; /* 3 */
+	return false;
+}
+
+/**
  * Single-bar progress: pick the further-along pipeline. While the crawl is
  * pending, drive the bar from the crawl stage on the lower half of the
  * unified scale. Once the crawl is ready (or undefined-with-content, the
@@ -92,13 +110,9 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 		const summaryPollUrl = summaryStatus === "pending"
 			? pollUrlBuilder.summary(1)
 			: undefined;
-		// Poll while the crawl is pending, and also when crawl is undefined with
-		// no content yet — that combination is usually a read-after-write race
-		// where markCrawlPending hasn't propagated, so polling lets the slot
-		// recover once the next read sees the durable state.
-		const shouldPollReader =
-			crawl?.status === "pending" || (crawl === undefined && content === undefined);
-		const readerPollUrl = shouldPollReader ? pollUrlBuilder.reader(1) : undefined;
+		const readerPollUrl = shouldKeepPollingReader(crawl, content)
+			? pollUrlBuilder.reader(1)
+			: undefined;
 
 		return {
 			content,
@@ -136,9 +150,7 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 		const crawl = await deps.findArticleCrawlStatus(articleUrl);
 		const summary = await deps.findGeneratedSummary(articleUrl);
 		const content = await deps.readArticleContent(articleUrl);
-		const shouldPollReader =
-			crawl?.status === "pending" || (crawl === undefined && content === undefined);
-		const readerPollUrl = shouldPollReader && pollCount < MAX_POLLS
+		const readerPollUrl = shouldKeepPollingReader(crawl, content) && pollCount < MAX_POLLS
 			? pollUrlBuilder.reader(pollCount + 1)
 			: undefined;
 		const slot = renderReaderSlot({


### PR DESCRIPTION
## Summary
This PR adds handling for a "promotion race" condition in the article reader where the crawl status becomes "ready" but the content hasn't been copied to the canonical S3 location yet, causing `readArticleContent` to return undefined.

## Key Changes
- Extracted polling logic into a new `shouldKeepPollingReader()` function that handles three scenarios:
  1. **Pending**: Normal in-flight case where crawl status is "pending"
  2. **Read-after-write race**: Both crawl and content are undefined (markCrawlPending hasn't propagated)
  3. **Promotion race**: Crawl status is "ready" but content is still undefined (canonical S3 object hasn't been copied yet)

- Updated `resolveReaderState()` to emit a `readerPollUrl` when in the promotion race condition, allowing the UI to continue polling
- Updated `handleReaderPoll()` to continue polling during the promotion race, with `MAX_POLLS=40` as a safety bound to prevent infinite polling if the canonical write never lands

## Implementation Details
- The `shouldKeepPollingReader()` function consolidates the polling decision logic with clear documentation of each race condition
- Both `resolveReaderState()` and `handleReaderPoll()` now use the same polling logic for consistency
- Added comprehensive test coverage for the promotion race scenario, including edge cases like hitting the MAX_POLLS limit

https://claude.ai/code/session_01Ba7Guv382s4gGc9p33CquV