### PR TITLE
feat(hutch): require Stripe subscription checkout before account creation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -33,6 +33,7 @@ export DYNAMODB_USERS_TABLE=$(_pulumi_table dynamodbUsersTable)
 export DYNAMODB_SESSIONS_TABLE=$(_pulumi_table dynamodbSessionsTable)
 export DYNAMODB_OAUTH_TABLE=$(_pulumi_table dynamodbOauthTable)
 export DYNAMODB_VERIFICATION_TOKENS_TABLE=$(_pulumi_table dynamodbVerificationTokensTable)
+export DYNAMODB_PENDING_SIGNUPS_TABLE=$(_pulumi_table dynamodbPendingSignupsTable)
 export CONTENT_BUCKET_NAME=$(_pulumi_save_link contentBucketName)
 export STATIC_BASE_URL=''
 export EVENT_BUS_NAME='hutch-event-bus-4202fdd'

--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -23,6 +23,7 @@ config:
   hutch:dynamodbOauthTable: hutch-oauth-ecd3db9
   hutch:dynamodbVerificationTokensTable: hutch-verification-tokens-3f85043
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
+  hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:contentBucketName: hutch-article-content-prod
   hutch:pendingHtmlBucketName: hutch-pending-html-prod
   hutch:excludedVisitorHashes: []

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -15,6 +15,7 @@ config:
   hutch:dynamodbOauthTable: hutch-oauth-ecd3db9
   hutch:dynamodbVerificationTokensTable: hutch-verification-tokens-3f85043
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
+  hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:contentBucketName: hutch-article-content-staging
   hutch:pendingHtmlBucketName: hutch-pending-html-staging
   hutch:excludedVisitorHashes: []

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import express from 'express'
 import { HutchLogger, consoleLogger, noopLogger } from '@packages/hutch-logger'
 import { createTestApp } from '../runtime/test-app'
@@ -16,6 +17,8 @@ import { DEFAULT_CRAWL_HEADERS, initCrawlArticle } from '@packages/crawl-article
 import { theInformationPreParser } from '../runtime/providers/article-parser/the-information-pre-parser'
 import { initInMemoryRefreshArticleContent } from '../runtime/providers/events/in-memory-refresh-article-content'
 import { initInMemoryUpdateFetchTimestamp } from '../runtime/providers/events/in-memory-update-fetch-timestamp'
+import { initInMemoryStripeCheckout } from '../runtime/providers/stripe-checkout/in-memory-stripe-checkout'
+import { CheckoutSessionIdSchema } from '../runtime/providers/stripe-checkout/stripe-checkout.schema'
 
 const PORT = Number(requireEnv('E2E_PORT'))
 const origin = `http://localhost:${PORT}`
@@ -56,8 +59,14 @@ const applyParseResult = createFakeApplyParseResult({
   parseArticle,
 })
 
+// E2E-specific Stripe checkout: generates local URLs so the browser can follow
+// the redirect chain (POST /signup → local checkout → /auth/checkout/success)
+// instead of hitting the unreachable https://checkout.stripe.test domain.
+const e2eStripe = initInMemoryStripeCheckout({ checkoutBaseUrl: `${origin}/e2e/stripe-checkout` })
+
 const { app: hutchApp, email } = createTestApp({
   ...fixture,
+  stripe: e2eStripe,
   parser: { parseArticle, crawlArticle },
   events: {
     publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
@@ -82,6 +91,17 @@ const server = express()
 // Expose sent emails for E2E tests (password reset flow needs the reset token from email)
 server.get('/e2e/sent-emails', (_req, res) => {
   res.json(email.getSentEmails())
+})
+
+// Simulated Stripe Checkout: marks the session as paid and redirects to the
+// success URL (replacing {CHECKOUT_SESSION_ID} the same way real Stripe does).
+server.get('/e2e/stripe-checkout/:id', (req, res) => {
+  const sessionId = CheckoutSessionIdSchema.parse(req.params.id)
+  e2eStripe.markPaid(sessionId)
+  const next = req.query.next
+  assert(typeof next === 'string', 'next query param required')
+  const successUrl = next.replace('{CHECKOUT_SESSION_ID}', sessionId)
+  res.redirect(303, successUrl)
 })
 
 // Deterministic crawl-failure fixture: any GET returns 500 so tests can exercise

--- a/projects/hutch/src/infra/hutch-storage.ts
+++ b/projects/hutch/src/infra/hutch-storage.ts
@@ -9,6 +9,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 	public readonly oauthTable: aws.dynamodb.Table;
 	public readonly verificationTokensTable: aws.dynamodb.Table;
 	public readonly passwordResetTokensTable: aws.dynamodb.Table;
+	public readonly pendingSignupsTable: aws.dynamodb.Table;
 
 	constructor(name: string, args: { deletionProtection: boolean; tableNames: {
 		articles: string;
@@ -18,6 +19,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 		oauth: string;
 		verificationTokens: string;
 		passwordResetTokens: string;
+		pendingSignups: string;
 	} }, opts?: pulumi.ComponentResourceOptions) {
 		super("hutch:infra:HutchStorage", name, {}, opts);
 
@@ -129,6 +131,17 @@ export class HutchStorage extends pulumi.ComponentResource {
 			billingMode: "PAY_PER_REQUEST",
 			hashKey: "token",
 			attributes: [{ name: "token", type: "S" }],
+			ttl: {
+				attributeName: "expiresAt",
+				enabled: true,
+			},
+		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+
+		this.pendingSignupsTable = new aws.dynamodb.Table(`hutch-pending-signups`, {
+			name: args.tableNames.pendingSignups,
+			billingMode: "PAY_PER_REQUEST",
+			hashKey: "checkoutSessionId",
+			attributes: [{ name: "checkoutSessionId", type: "S" }],
 			ttl: {
 				attributeName: "expiresAt",
 				enabled: true,

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -27,6 +27,7 @@ const tableNames = {
 	oauth: config.require("dynamodbOauthTable"),
 	verificationTokens: config.require("dynamodbVerificationTokensTable"),
 	passwordResetTokens: config.require("dynamodbPasswordResetTokensTable"),
+	pendingSignups: config.require("dynamodbPendingSignupsTable"),
 };
 
 const storage = new HutchStorage("hutch", {
@@ -93,6 +94,7 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 		{ arn: storage.oauthTable.arn, includeIndexes: true },
 		{ arn: storage.verificationTokensTable.arn, includeIndexes: false },
 		{ arn: storage.passwordResetTokensTable.arn, includeIndexes: false },
+		{ arn: storage.pendingSignupsTable.arn, includeIndexes: false },
 	],
 	actions: [
 		"dynamodb:GetItem",
@@ -137,9 +139,12 @@ const lambda = new HutchLambda("hutch", {
 		DYNAMODB_OAUTH_TABLE: storage.oauthTable.name,
 		DYNAMODB_VERIFICATION_TOKENS_TABLE: storage.verificationTokensTable.name,
 		DYNAMODB_PASSWORD_RESET_TOKENS_TABLE: storage.passwordResetTokensTable.name,
+		DYNAMODB_PENDING_SIGNUPS_TABLE: storage.pendingSignupsTable.name,
 		GOOGLE_LOGIN_CLIENT_ID: requireEnv("GOOGLE_LOGIN_CLIENT_ID"),
 		GOOGLE_LOGIN_CLIENT_SECRET: requireEnv("GOOGLE_LOGIN_CLIENT_SECRET"),
 		RESEND_API_KEY: requireEnv("RESEND_API_KEY"),
+		STRIPE_SECRET_KEY: requireEnv("STRIPE_SECRET_KEY"),
+		STRIPE_PRICE_ID: requireEnv("STRIPE_PRICE_ID"),
 		STATIC_BASE_URL: staticAssets.baseUrl,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		CONTENT_BUCKET_NAME: contentBucketName,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -45,6 +45,10 @@ import { initInMemoryUpdateFetchTimestamp } from "./providers/events/in-memory-u
 import { initPutPendingHtml } from "./providers/pending-html/put-pending-html";
 import { initInMemoryPendingHtml } from "./providers/pending-html/in-memory-pending-html";
 import { initExchangeGoogleCode } from "./providers/google-auth/google-token";
+import { initInMemoryStripeCheckout } from "./providers/stripe-checkout/in-memory-stripe-checkout";
+import { initStripeCheckout } from "./providers/stripe-checkout/stripe-checkout";
+import { initInMemoryPendingSignup } from "./providers/pending-signup/in-memory-pending-signup";
+import { initDynamoDbPendingSignup } from "./providers/pending-signup/dynamodb-pending-signup";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initLogParseError, type ParseErrorEvent } from "@packages/hutch-infra-components";
 import { createApp } from "./server";
@@ -71,10 +75,13 @@ function initProviders() {
 		const oauthTable = requireEnv("DYNAMODB_OAUTH_TABLE");
 		const verificationTokensTable = requireEnv("DYNAMODB_VERIFICATION_TOKENS_TABLE");
 		const passwordResetTokensTable = requireEnv("DYNAMODB_PASSWORD_RESET_TOKENS_TABLE");
+		const pendingSignupsTable = requireEnv("DYNAMODB_PENDING_SIGNUPS_TABLE");
 		const googleClientId = requireEnv("GOOGLE_LOGIN_CLIENT_ID");
 		const googleClientSecret = requireEnv("GOOGLE_LOGIN_CLIENT_SECRET");
 		const appOriginForRedirect = requireEnv("APP_ORIGIN");
 		const resendApiKey = requireEnv("RESEND_API_KEY");
+		const stripeApiKey = requireEnv("STRIPE_SECRET_KEY");
+		const stripePriceId = requireEnv("STRIPE_PRICE_ID");
 		const eventBusName = requireEnv("EVENT_BUS_NAME");
 		const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 		const pendingHtmlBucketName = requireEnv("PENDING_HTML_BUCKET_NAME");
@@ -125,6 +132,13 @@ function initProviders() {
 			clientSecret: googleClientSecret,
 		};
 
+		const stripe = initStripeCheckout({
+			apiKey: stripeApiKey,
+			priceId: stripePriceId,
+			fetch: globalThis.fetch,
+		});
+		const pendingSignup = initDynamoDbPendingSignup({ client, tableName: pendingSignupsTable });
+
 		return {
 			auth,
 			articleStore,
@@ -133,6 +147,8 @@ function initProviders() {
 			...initResendEmail(resendApiKey),
 			...initDynamoDbEmailVerification({ client, tableName: verificationTokensTable }),
 			...initDynamoDbPasswordReset({ client, tableName: passwordResetTokensTable }),
+			...stripe,
+			...pendingSignup,
 			googleAuth,
 			oauthModel,
 			validateAccessToken: createValidateAccessToken(oauthModel),
@@ -155,6 +171,8 @@ function initProviders() {
 	const auth = initInMemoryAuth();
 	const articleStore = initInMemoryArticleStore();
 	const oauthModel = createOAuthModel(initInMemoryOAuthModel());
+	const devStripe = initInMemoryStripeCheckout();
+	const devPendingSignup = initInMemoryPendingSignup();
 	const devGoogleClientId = getEnv("GOOGLE_LOGIN_CLIENT_ID");
 	const devGoogleClientSecret = getEnv("GOOGLE_LOGIN_CLIENT_SECRET");
 	assert(
@@ -251,6 +269,10 @@ function initProviders() {
 		...initLogEmail(),
 		...initInMemoryEmailVerification(),
 		...initInMemoryPasswordReset(),
+		createCheckoutSession: devStripe.createCheckoutSession,
+		retrieveCheckoutSession: devStripe.retrieveCheckoutSession,
+		storePendingSignup: devPendingSignup.storePendingSignup,
+		consumePendingSignup: devPendingSignup.consumePendingSignup,
 		googleAuth,
 		oauthModel,
 		validateAccessToken: createValidateAccessToken(oauthModel),

--- a/projects/hutch/src/runtime/providers/auth/auth.types.ts
+++ b/projects/hutch/src/runtime/providers/auth/auth.types.ts
@@ -13,6 +13,11 @@ export type CreateUser = (credentials: {
 	password: string;
 }) => Promise<CreateUserResult>;
 
+export type CreateUserWithPasswordHash = (credentials: {
+	email: string;
+	passwordHash: string;
+}) => Promise<CreateUserResult>;
+
 export type VerifyCredentials = (credentials: {
 	email: string;
 	password: string;

--- a/projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts
+++ b/projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts
@@ -13,6 +13,7 @@ import type {
 	CreateGoogleUser,
 	CreateSession,
 	CreateUser,
+	CreateUserWithPasswordHash,
 	DestroySession,
 	FindUserByEmail,
 	GetSessionUserId,
@@ -47,6 +48,7 @@ export function initDynamoDbAuth(deps: {
 	sessionsTableName: string;
 }): {
 	createUser: CreateUser;
+	createUserWithPasswordHash: CreateUserWithPasswordHash;
 	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
 	verifyCredentials: VerifyCredentials;
@@ -74,6 +76,30 @@ export function initDynamoDbAuth(deps: {
 		const normalizedEmail = normalizeEmail(email);
 		const userId = UserIdSchema.parse(randomBytes(16).toString("hex"));
 		const passwordHash = await hashPassword(password);
+
+		try {
+			await users.put({
+				Item: {
+					email: normalizedEmail,
+					userId,
+					passwordHash,
+					emailVerified: false,
+					registeredAt: new Date().toISOString(),
+				},
+				ConditionExpression: "attribute_not_exists(email)",
+			});
+			return { ok: true, userId };
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) {
+				return { ok: false, reason: "email-already-exists" };
+			}
+			throw error;
+		}
+	};
+
+	const createUserWithPasswordHash: CreateUserWithPasswordHash = async ({ email, passwordHash }) => {
+		const normalizedEmail = normalizeEmail(email);
+		const userId = UserIdSchema.parse(randomBytes(16).toString("hex"));
 
 		try {
 			await users.put({
@@ -209,6 +235,7 @@ export function initDynamoDbAuth(deps: {
 
 	return {
 		createUser,
+		createUserWithPasswordHash,
 		createGoogleUser,
 		findUserByEmail,
 		verifyCredentials,

--- a/projects/hutch/src/runtime/providers/auth/in-memory-auth.ts
+++ b/projects/hutch/src/runtime/providers/auth/in-memory-auth.ts
@@ -7,6 +7,7 @@ import type {
 	CreateGoogleUser,
 	CreateSession,
 	CreateUser,
+	CreateUserWithPasswordHash,
 	DestroySession,
 	FindUserByEmail,
 	GetSessionUserId,
@@ -34,6 +35,7 @@ interface StoredSession {
 
 export function initInMemoryAuth(): {
 	createUser: CreateUser;
+	createUserWithPasswordHash: CreateUserWithPasswordHash;
 	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
 	verifyCredentials: VerifyCredentials;
@@ -58,6 +60,26 @@ export function initInMemoryAuth(): {
 
 		const userId = UserIdSchema.parse(randomBytes(16).toString("hex"));
 		const passwordHash = await hashPassword(password);
+
+		users.set(normalizedEmail, {
+			id: userId,
+			email: normalizedEmail,
+			passwordHash,
+			emailVerified: false,
+			registeredAt: new Date().toISOString(),
+		});
+
+		return { ok: true, userId };
+	};
+
+	const createUserWithPasswordHash: CreateUserWithPasswordHash = async ({ email, passwordHash }) => {
+		const normalizedEmail = normalizeEmail(email);
+
+		if (users.has(normalizedEmail)) {
+			return { ok: false, reason: "email-already-exists" };
+		}
+
+		const userId = UserIdSchema.parse(randomBytes(16).toString("hex"));
 
 		users.set(normalizedEmail, {
 			id: userId,
@@ -161,6 +183,7 @@ export function initInMemoryAuth(): {
 
 	return {
 		createUser,
+		createUserWithPasswordHash,
 		createGoogleUser,
 		findUserByEmail,
 		verifyCredentials,

--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
@@ -1,0 +1,92 @@
+/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
+import {
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+	dynamoField,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { UserIdSchema } from "../../domain/user/user.schema";
+import { CheckoutSessionIdSchema } from "../stripe-checkout/stripe-checkout.schema";
+import type {
+	ConsumePendingSignup,
+	PendingSignup,
+	StorePendingSignup,
+} from "./pending-signup.types";
+
+/** Pending signups expire after 1 hour — Stripe checkout sessions live for 24h but
+ * we don't want to keep abandoned hashed passwords any longer than necessary. */
+const TTL_SECONDS = 60 * 60;
+
+const PendingSignupRow = z.object({
+	checkoutSessionId: CheckoutSessionIdSchema,
+	method: z.enum(["email", "google"]),
+	email: z.string(),
+	passwordHash: dynamoField(z.string()),
+	userId: dynamoField(UserIdSchema),
+	returnUrl: dynamoField(z.string()),
+	expiresAt: z.number(),
+});
+
+export function initDynamoDbPendingSignup(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+}): {
+	storePendingSignup: StorePendingSignup;
+	consumePendingSignup: ConsumePendingSignup;
+} {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: PendingSignupRow,
+	});
+
+	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup }) => {
+		const expiresAt = Math.floor(Date.now() / 1000) + TTL_SECONDS;
+		await table.put({
+			Item: {
+				checkoutSessionId,
+				method: signup.method,
+				email: signup.email,
+				...(signup.method === "email" ? { passwordHash: signup.passwordHash } : {}),
+				...(signup.method === "google" ? { userId: signup.userId } : {}),
+				...(signup.returnUrl ? { returnUrl: signup.returnUrl } : {}),
+				expiresAt,
+			},
+		});
+	};
+
+	const consumePendingSignup: ConsumePendingSignup = async (checkoutSessionId) => {
+		const { Attributes } = await table.delete({
+			Key: { checkoutSessionId },
+			ReturnValues: "ALL_OLD",
+		});
+		if (!Attributes) return null;
+		if (Attributes.expiresAt < Math.floor(Date.now() / 1000)) return null;
+
+		const returnUrl = Attributes.returnUrl ?? undefined;
+		if (Attributes.method === "email") {
+			const passwordHash = Attributes.passwordHash;
+			if (!passwordHash) return null;
+			const signup: PendingSignup = {
+				method: "email",
+				email: Attributes.email,
+				passwordHash,
+				...(returnUrl ? { returnUrl } : {}),
+			};
+			return signup;
+		}
+
+		const userId = Attributes.userId;
+		if (!userId) return null;
+		const signup: PendingSignup = {
+			method: "google",
+			email: Attributes.email,
+			userId,
+			...(returnUrl ? { returnUrl } : {}),
+		};
+		return signup;
+	};
+
+	return { storePendingSignup, consumePendingSignup };
+}
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.test.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "../../domain/user/user.schema";
+import { CheckoutSessionIdSchema } from "../stripe-checkout/stripe-checkout.schema";
+import { initInMemoryPendingSignup } from "./in-memory-pending-signup";
+
+describe("initInMemoryPendingSignup", () => {
+	it("returns null for an unknown checkout session", async () => {
+		const { consumePendingSignup } = initInMemoryPendingSignup();
+		const result = await consumePendingSignup(CheckoutSessionIdSchema.parse("cs_test_unknown"));
+		expect(result).toBeNull();
+	});
+
+	it("returns the stored email signup once and then null", async () => {
+		const { storePendingSignup, consumePendingSignup } = initInMemoryPendingSignup();
+		const checkoutSessionId = CheckoutSessionIdSchema.parse("cs_test_email");
+		await storePendingSignup({
+			checkoutSessionId,
+			signup: { method: "email", email: "buyer@example.com", passwordHash: "hash:hex" },
+		});
+
+		const first = await consumePendingSignup(checkoutSessionId);
+		assert(first, "first consume should return the stored signup");
+		expect(first.method).toBe("email");
+		if (first.method === "email") {
+			expect(first.email).toBe("buyer@example.com");
+			expect(first.passwordHash).toBe("hash:hex");
+		}
+
+		const second = await consumePendingSignup(checkoutSessionId);
+		expect(second).toBeNull();
+	});
+
+	it("returns the stored google signup once and then null", async () => {
+		const { storePendingSignup, consumePendingSignup } = initInMemoryPendingSignup();
+		const checkoutSessionId = CheckoutSessionIdSchema.parse("cs_test_google");
+		const userId = UserIdSchema.parse("u-google-123");
+		await storePendingSignup({
+			checkoutSessionId,
+			signup: { method: "google", email: "google@example.com", userId, returnUrl: "/save" },
+		});
+
+		const first = await consumePendingSignup(checkoutSessionId);
+		assert(first, "first consume should return the stored google signup");
+		expect(first.method).toBe("google");
+		if (first.method === "google") {
+			expect(first.email).toBe("google@example.com");
+			expect(first.userId).toBe(userId);
+			expect(first.returnUrl).toBe("/save");
+		}
+
+		const second = await consumePendingSignup(checkoutSessionId);
+		expect(second).toBeNull();
+	});
+});

--- a/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.ts
@@ -1,0 +1,26 @@
+import type { CheckoutSessionId } from "../stripe-checkout/stripe-checkout.types";
+import type {
+	ConsumePendingSignup,
+	PendingSignup,
+	StorePendingSignup,
+} from "./pending-signup.types";
+
+export function initInMemoryPendingSignup(): {
+	storePendingSignup: StorePendingSignup;
+	consumePendingSignup: ConsumePendingSignup;
+} {
+	const store = new Map<CheckoutSessionId, PendingSignup>();
+
+	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup }) => {
+		store.set(checkoutSessionId, signup);
+	};
+
+	const consumePendingSignup: ConsumePendingSignup = async (checkoutSessionId) => {
+		const signup = store.get(checkoutSessionId);
+		if (!signup) return null;
+		store.delete(checkoutSessionId);
+		return signup;
+	};
+
+	return { storePendingSignup, consumePendingSignup };
+}

--- a/projects/hutch/src/runtime/providers/pending-signup/pending-signup.types.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/pending-signup.types.ts
@@ -1,0 +1,17 @@
+/* c8 ignore start -- type-only file, no runtime code */
+import type { UserId } from "../../domain/user/user.types";
+import type { CheckoutSessionId } from "../stripe-checkout/stripe-checkout.types";
+
+export type PendingSignup =
+	| { method: "email"; email: string; passwordHash: string; returnUrl?: string }
+	| { method: "google"; email: string; userId: UserId; returnUrl?: string };
+
+export type StorePendingSignup = (params: {
+	checkoutSessionId: CheckoutSessionId;
+	signup: PendingSignup;
+}) => Promise<void>;
+
+export type ConsumePendingSignup = (
+	checkoutSessionId: CheckoutSessionId,
+) => Promise<PendingSignup | null>;
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { initInMemoryStripeCheckout } from "./in-memory-stripe-checkout";
+import { CheckoutSessionIdSchema } from "./stripe-checkout.schema";
+
+describe("initInMemoryStripeCheckout", () => {
+	it("returns a checkout URL containing the success URL", async () => {
+		const stripe = initInMemoryStripeCheckout();
+
+		const session = await stripe.createCheckoutSession({
+			customerEmail: "test@example.com",
+			successUrl: "https://app.test/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "https://app.test/signup",
+		});
+
+		expect(session.id).toMatch(/^cs_test_/);
+		expect(session.url).toContain("https://checkout.stripe.test/");
+		expect(session.url).toContain(encodeURIComponent("https://app.test/auth/checkout/success"));
+		expect(stripe.getCheckoutUrl(session.id)).toBe(session.url);
+	});
+
+	it("returns unpaid status until markPaid is called", async () => {
+		const stripe = initInMemoryStripeCheckout();
+		const session = await stripe.createCheckoutSession({
+			customerEmail: "buyer@example.com",
+			successUrl: "https://app.test/ok",
+			cancelUrl: "https://app.test/cancel",
+		});
+
+		const before = await stripe.retrieveCheckoutSession(session.id);
+		assert.equal(before.ok, true);
+		if (before.ok) {
+			expect(before.paid).toBe(false);
+			expect(before.customerEmail).toBe("buyer@example.com");
+		}
+
+		stripe.markPaid(session.id);
+
+		const after = await stripe.retrieveCheckoutSession(session.id);
+		assert.equal(after.ok, true);
+		if (after.ok) expect(after.paid).toBe(true);
+	});
+
+	it("returns not-found when retrieving an unknown session", async () => {
+		const stripe = initInMemoryStripeCheckout();
+		const result = await stripe.retrieveCheckoutSession(
+			CheckoutSessionIdSchema.parse("cs_test_unknown"),
+		);
+		expect(result).toEqual({ ok: false, reason: "not-found" });
+	});
+
+	it("throws when marking an unknown session as paid", () => {
+		const stripe = initInMemoryStripeCheckout();
+		expect(() => stripe.markPaid(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
+			/No checkout session/,
+		);
+	});
+
+	it("throws when looking up the URL of an unknown session", () => {
+		const stripe = initInMemoryStripeCheckout();
+		expect(() => stripe.getCheckoutUrl(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
+			/No checkout URL/,
+		);
+	});
+});

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
@@ -18,6 +18,19 @@ describe("initInMemoryStripeCheckout", () => {
 		expect(stripe.getCheckoutUrl(session.id)).toBe(session.url);
 	});
 
+	it("uses custom checkoutBaseUrl when provided", async () => {
+		const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "http://localhost:9999/e2e/stripe-checkout" });
+
+		const session = await stripe.createCheckoutSession({
+			customerEmail: "test@example.com",
+			successUrl: "http://localhost:9999/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "http://localhost:9999/signup",
+		});
+
+		expect(session.url).toContain("http://localhost:9999/e2e/stripe-checkout/");
+		expect(session.url).not.toContain("checkout.stripe.test");
+	});
+
 	it("returns unpaid status until markPaid is called", async () => {
 		const stripe = initInMemoryStripeCheckout();
 		const session = await stripe.createCheckoutSession({

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
@@ -11,7 +11,7 @@ interface StoredSession {
 	paid: boolean;
 }
 
-export function initInMemoryStripeCheckout(): {
+export function initInMemoryStripeCheckout(opts?: { checkoutBaseUrl?: string }): {
 	createCheckoutSession: CreateCheckoutSession;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	markPaid: (id: CheckoutSessionId) => void;
@@ -19,11 +19,12 @@ export function initInMemoryStripeCheckout(): {
 } {
 	const sessions = new Map<CheckoutSessionId, StoredSession>();
 	const urls = new Map<CheckoutSessionId, string>();
+	const baseUrl = opts?.checkoutBaseUrl ?? "https://checkout.stripe.test";
 
 	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl }) => {
 		const id = CheckoutSessionIdSchema.parse(`cs_test_${randomBytes(12).toString("hex")}`);
 		sessions.set(id, { customerEmail, paid: false });
-		const url = `https://checkout.stripe.test/${id}?next=${encodeURIComponent(successUrl)}`;
+		const url = `${baseUrl}/${id}?next=${encodeURIComponent(successUrl)}`;
 		urls.set(id, url);
 		return { id, url };
 	};

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
@@ -1,0 +1,50 @@
+import { randomBytes } from "node:crypto";
+import { CheckoutSessionIdSchema } from "./stripe-checkout.schema";
+import type {
+	CheckoutSessionId,
+	CreateCheckoutSession,
+	RetrieveCheckoutSession,
+} from "./stripe-checkout.types";
+
+interface StoredSession {
+	customerEmail: string;
+	paid: boolean;
+}
+
+export function initInMemoryStripeCheckout(): {
+	createCheckoutSession: CreateCheckoutSession;
+	retrieveCheckoutSession: RetrieveCheckoutSession;
+	markPaid: (id: CheckoutSessionId) => void;
+	getCheckoutUrl: (id: CheckoutSessionId) => string;
+} {
+	const sessions = new Map<CheckoutSessionId, StoredSession>();
+	const urls = new Map<CheckoutSessionId, string>();
+
+	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl }) => {
+		const id = CheckoutSessionIdSchema.parse(`cs_test_${randomBytes(12).toString("hex")}`);
+		sessions.set(id, { customerEmail, paid: false });
+		const url = `https://checkout.stripe.test/${id}?next=${encodeURIComponent(successUrl)}`;
+		urls.set(id, url);
+		return { id, url };
+	};
+
+	const retrieveCheckoutSession: RetrieveCheckoutSession = async (id) => {
+		const session = sessions.get(id);
+		if (!session) return { ok: false, reason: "not-found" };
+		return { ok: true, paid: session.paid, customerEmail: session.customerEmail };
+	};
+
+	const markPaid = (id: CheckoutSessionId) => {
+		const session = sessions.get(id);
+		if (!session) throw new Error(`No checkout session: ${id}`);
+		session.paid = true;
+	};
+
+	const getCheckoutUrl = (id: CheckoutSessionId): string => {
+		const url = urls.get(id);
+		if (!url) throw new Error(`No checkout URL: ${id}`);
+		return url;
+	};
+
+	return { createCheckoutSession, retrieveCheckoutSession, markPaid, getCheckoutUrl };
+}

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.schema.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import type { CheckoutSessionId } from "./stripe-checkout.types";
+
+export const CheckoutSessionIdSchema = z
+	.string()
+	.min(1)
+	.transform((s): CheckoutSessionId => s as CheckoutSessionId);

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -1,0 +1,109 @@
+/* c8 ignore start -- thin Stripe API wrapper, tested via integration */
+import { z } from "zod";
+import { CheckoutSessionIdSchema } from "./stripe-checkout.schema";
+import type {
+	CreateCheckoutSession,
+	RetrieveCheckoutSession,
+} from "./stripe-checkout.types";
+
+const STRIPE_API = "https://api.stripe.com/v1";
+
+const CreateSessionResponse = z.object({
+	id: CheckoutSessionIdSchema,
+	url: z.string().url(),
+});
+
+const RetrieveSessionResponse = z.object({
+	customer_email: z.string().nullish(),
+	customer_details: z.object({ email: z.string().nullish() }).nullish(),
+	payment_status: z.enum(["paid", "unpaid", "no_payment_required"]),
+});
+
+const StripeErrorResponse = z.object({
+	error: z.object({
+		code: z.string().optional(),
+		message: z.string().optional(),
+		type: z.string().optional(),
+	}),
+});
+
+export function initStripeCheckout(deps: {
+	apiKey: string;
+	priceId: string;
+	fetch: typeof globalThis.fetch;
+}): {
+	createCheckoutSession: CreateCheckoutSession;
+	retrieveCheckoutSession: RetrieveCheckoutSession;
+} {
+	const authHeader = { Authorization: `Bearer ${deps.apiKey}` };
+
+	const createCheckoutSession: CreateCheckoutSession = async ({
+		customerEmail,
+		successUrl,
+		cancelUrl,
+	}) => {
+		const body = new URLSearchParams({
+			mode: "subscription",
+			"line_items[0][price]": deps.priceId,
+			"line_items[0][quantity]": "1",
+			customer_email: customerEmail,
+			success_url: successUrl,
+			cancel_url: cancelUrl,
+			"payment_method_types[0]": "card",
+			allow_promotion_codes: "true",
+		});
+
+		const response = await deps.fetch(`${STRIPE_API}/checkout/sessions`, {
+			method: "POST",
+			headers: {
+				...authHeader,
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body: body.toString(),
+		});
+
+		const json = await response.json();
+		if (!response.ok) {
+			const parsed = StripeErrorResponse.safeParse(json);
+			const message = parsed.success
+				? parsed.data.error.message ?? "Stripe error"
+				: "Stripe error";
+			throw new Error(`Stripe createCheckoutSession failed (${response.status}): ${message}`);
+		}
+
+		const parsed = CreateSessionResponse.parse(json);
+		return { id: parsed.id, url: parsed.url };
+	};
+
+	const retrieveCheckoutSession: RetrieveCheckoutSession = async (id) => {
+		const response = await deps.fetch(`${STRIPE_API}/checkout/sessions/${encodeURIComponent(id)}`, {
+			method: "GET",
+			headers: authHeader,
+		});
+
+		if (response.status === 404) {
+			return { ok: false, reason: "not-found" };
+		}
+
+		const json = await response.json();
+		if (!response.ok) {
+			const parsed = StripeErrorResponse.safeParse(json);
+			const code = parsed.success ? parsed.data.error.code : undefined;
+			if (code === "resource_missing") return { ok: false, reason: "not-found" };
+			const message = parsed.success ? parsed.data.error.message ?? "Stripe error" : "Stripe error";
+			throw new Error(`Stripe retrieveCheckoutSession failed (${response.status}): ${message}`);
+		}
+
+		const parsed = RetrieveSessionResponse.parse(json);
+		const customerEmail =
+			parsed.customer_details?.email ?? parsed.customer_email ?? "";
+		return {
+			ok: true,
+			paid: parsed.payment_status === "paid" || parsed.payment_status === "no_payment_required",
+			customerEmail,
+		};
+	};
+
+	return { createCheckoutSession, retrieveCheckoutSession };
+}
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.types.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.types.ts
@@ -1,0 +1,19 @@
+/* c8 ignore start -- type-only file, no runtime code */
+export type CheckoutSessionId = string & { readonly __brand: "CheckoutSessionId" };
+
+export interface CheckoutSession {
+	id: CheckoutSessionId;
+	url: string;
+}
+
+export type CreateCheckoutSession = (params: {
+	customerEmail: string;
+	successUrl: string;
+	cancelUrl: string;
+}) => Promise<CheckoutSession>;
+
+export type RetrieveCheckoutSession = (id: CheckoutSessionId) => Promise<
+	| { ok: true; paid: boolean; customerEmail: string }
+	| { ok: false; reason: "not-found" }
+>;
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -10,6 +10,7 @@ import type {
 	CreateGoogleUser,
 	CreateSession,
 	CreateUser,
+	CreateUserWithPasswordHash,
 	DestroySession,
 	FindUserByEmail,
 	GetSessionUserId,
@@ -19,6 +20,14 @@ import type {
 	UserExistsByEmail,
 	VerifyCredentials,
 } from "./providers/auth/auth.types";
+import type {
+	CreateCheckoutSession,
+	RetrieveCheckoutSession,
+} from "./providers/stripe-checkout/stripe-checkout.types";
+import type {
+	ConsumePendingSignup,
+	StorePendingSignup,
+} from "./providers/pending-signup/pending-signup.types";
 import type { ExchangeGoogleCode } from "./providers/google-auth/google-token.types";
 import type {
 	DeleteArticle,
@@ -90,6 +99,7 @@ interface AppDependencies {
 	appOrigin: string;
 	staticBaseUrl: string;
 	createUser: CreateUser;
+	createUserWithPasswordHash: CreateUserWithPasswordHash;
 	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
 	verifyCredentials: VerifyCredentials;
@@ -141,6 +151,10 @@ interface AppDependencies {
 	httpErrorMessageMapping: HttpErrorMessageMapping;
 	logParseError: LogParseError;
 	now: () => Date;
+	createCheckoutSession: CreateCheckoutSession;
+	retrieveCheckoutSession: RetrieveCheckoutSession;
+	storePendingSignup: StorePendingSignup;
+	consumePendingSignup: ConsumePendingSignup;
 }
 
 function requireAuth(req: Request, res: Response, next: NextFunction): void {
@@ -345,7 +359,9 @@ export function createApp(dependencies: AppDependencies): Express {
 	app.use("/embed", initEmbedRoutes({ appOrigin }));
 
 	const authRouter = initAuthRoutes({
-		createUser: deps.createUser,
+		createUserWithPasswordHash: deps.createUserWithPasswordHash,
+		createGoogleUser: deps.createGoogleUser,
+		findUserByEmail: deps.findUserByEmail,
 		verifyCredentials: deps.verifyCredentials,
 		createSession: deps.createSession,
 		destroySession: deps.destroySession,
@@ -355,6 +371,11 @@ export function createApp(dependencies: AppDependencies): Express {
 		sendEmail: deps.sendEmail,
 		createVerificationToken: deps.createVerificationToken,
 		verifyEmailToken: deps.verifyEmailToken,
+		createCheckoutSession: deps.createCheckoutSession,
+		retrieveCheckoutSession: deps.retrieveCheckoutSession,
+		storePendingSignup: deps.storePendingSignup,
+		consumePendingSignup: deps.consumePendingSignup,
+		appOrigin,
 		baseUrl: deps.baseUrl,
 		logError: deps.logError,
 	});
@@ -366,11 +387,12 @@ export function createApp(dependencies: AppDependencies): Express {
 			googleClientSecret: deps.googleAuth.clientSecret,
 			appOrigin,
 			createSession: deps.createSession,
-			createGoogleUser: deps.createGoogleUser,
 			findUserByEmail: deps.findUserByEmail,
 			countUsers,
 			markEmailVerified: deps.markEmailVerified,
 			exchangeGoogleCode: deps.googleAuth.exchangeGoogleCode,
+			createCheckoutSession: deps.createCheckoutSession,
+			storePendingSignup: deps.storePendingSignup,
 			logError: deps.logError,
 		});
 		app.use(googleAuthRouter);

--- a/projects/hutch/src/runtime/test-app-fakes.ts
+++ b/projects/hutch/src/runtime/test-app-fakes.ts
@@ -13,6 +13,8 @@ import { initInMemoryEmail } from "./providers/email/in-memory-email";
 import { initInMemoryEmailVerification } from "./providers/email-verification/in-memory-email-verification";
 import { initInMemoryPasswordReset } from "./providers/password-reset/in-memory-password-reset";
 import { initInMemoryPendingHtml } from "./providers/pending-html/in-memory-pending-html";
+import { initInMemoryPendingSignup } from "./providers/pending-signup/in-memory-pending-signup";
+import { initInMemoryStripeCheckout } from "./providers/stripe-checkout/in-memory-stripe-checkout";
 import { initInMemorySaveLinkRawHtmlCommand } from "./providers/events/in-memory-save-link-raw-html-command";
 import {
 	createOAuthModel,
@@ -194,6 +196,8 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		logger: noopLogger,
 	});
 	const oauthModel = createOAuthModel(initInMemoryOAuthModel(), { appOrigin });
+	const stripe = initInMemoryStripeCheckout();
+	const pendingSignup = initInMemoryPendingSignup();
 
 	return {
 		auth,
@@ -254,5 +258,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 			logParseError: () => {},
 			now: () => new Date(),
 		},
+		stripe,
+		pendingSignup,
 	};
 }

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -60,6 +60,8 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			},
 			admin: fixture.admin,
 			shared: fixture.shared,
+			stripe: fixture.stripe,
+			pendingSignup: fixture.pendingSignup,
 		});
 
 		expect(typeof result.app).toBe("function");

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -29,6 +29,7 @@ import type {
 	CreateGoogleUser,
 	CreateSession,
 	CreateUser,
+	CreateUserWithPasswordHash,
 	DestroySession,
 	FindUserByEmail,
 	GetSessionUserId,
@@ -38,6 +39,15 @@ import type {
 	UserExistsByEmail,
 	VerifyCredentials,
 } from "./providers/auth/auth.types";
+import type {
+	CheckoutSessionId,
+	CreateCheckoutSession,
+	RetrieveCheckoutSession,
+} from "./providers/stripe-checkout/stripe-checkout.types";
+import type {
+	ConsumePendingSignup,
+	StorePendingSignup,
+} from "./providers/pending-signup/pending-signup.types";
 import type {
 	ArticleMetadata,
 	Minutes,
@@ -73,6 +83,7 @@ import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
 
 export interface AuthBundle {
 	createUser: CreateUser;
+	createUserWithPasswordHash: CreateUserWithPasswordHash;
 	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
 	verifyCredentials: VerifyCredentials;
@@ -84,6 +95,18 @@ export interface AuthBundle {
 	markSessionEmailVerified: MarkSessionEmailVerified;
 	userExistsByEmail: UserExistsByEmail;
 	updatePassword: UpdatePassword;
+}
+
+export interface StripeCheckoutBundle {
+	createCheckoutSession: CreateCheckoutSession;
+	retrieveCheckoutSession: RetrieveCheckoutSession;
+	markPaid: (id: CheckoutSessionId) => void;
+	getCheckoutUrl: (id: CheckoutSessionId) => string;
+}
+
+export interface PendingSignupBundle {
+	storePendingSignup: StorePendingSignup;
+	consumePendingSignup: ConsumePendingSignup;
 }
 
 export interface ArticleStoreBundle {
@@ -198,6 +221,8 @@ export interface TestAppFixture {
 	google: GoogleAuthBundle | undefined;
 	admin: AdminBundle;
 	shared: SharedBundle;
+	stripe: StripeCheckoutBundle;
+	pendingSignup: PendingSignupBundle;
 }
 
 export interface TestAppResult {
@@ -210,6 +235,8 @@ export interface TestAppResult {
 	email: EmailBundle;
 	emailVerification: EmailVerificationBundle;
 	passwordReset: PasswordResetBundle;
+	stripe: StripeCheckoutBundle;
+	pendingSignup: PendingSignupBundle;
 }
 
 function flattenFixtureToAppDependencies(
@@ -223,6 +250,7 @@ function flattenFixtureToAppDependencies(
 		logParseError: fixture.shared.logParseError,
 		httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,
 		createUser: fixture.auth.createUser,
+		createUserWithPasswordHash: fixture.auth.createUserWithPasswordHash,
 		createGoogleUser: fixture.auth.createGoogleUser,
 		findUserByEmail: fixture.auth.findUserByEmail,
 		verifyCredentials: fixture.auth.verifyCredentials,
@@ -266,6 +294,10 @@ function flattenFixtureToAppDependencies(
 		adminEmails: fixture.admin.adminEmails,
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,
 		now: fixture.shared.now,
+		createCheckoutSession: fixture.stripe.createCheckoutSession,
+		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,
+		storePendingSignup: fixture.pendingSignup.storePendingSignup,
+		consumePendingSignup: fixture.pendingSignup.consumePendingSignup,
 	};
 }
 
@@ -281,5 +313,7 @@ export function createTestApp(fixture: TestAppFixture): TestAppResult {
 		email: fixture.email,
 		emailVerification: fixture.emailVerification,
 		passwordReset: fixture.passwordReset,
+		stripe: fixture.stripe,
+		pendingSignup: fixture.pendingSignup,
 	};
 }

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -52,7 +52,7 @@ export function LoginPage(data: AuthFormData, options?: { statusCode?: number })
 		passwordField: toFieldViewModel(errors, "password"),
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
-			caption: "First 100 accounts are free, forever.",
+			caption: "Founding members: $3.99/mo, locked forever.",
 		}),
 	});
 
@@ -99,7 +99,7 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
-			caption: "First 100 accounts are free, forever.",
+			caption: "Founding members: $3.99/mo, locked forever.",
 		}),
 	});
 

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -107,7 +107,7 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		seo: {
 			title: "Sign up — Readplace",
 			description:
-				"Create a free Readplace account and start saving articles to read later.",
+				"Create a Readplace account and start saving articles to read later.",
 			canonicalUrl: "/signup",
 		},
 		styles: AUTH_STYLES,

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -49,11 +49,7 @@ export function LoginPage(data: AuthFormData, options?: { statusCode?: number })
 		globalError: data.globalError,
 		returnUrl: data.returnUrl ? encodeURIComponent(data.returnUrl) : undefined,
 		emailField: toFieldViewModel(errors, "email"),
-		passwordField: toFieldViewModel(errors, "password"),
-		foundingProgressHtml: renderFoundingProgress({
-			userCount: data.userCount,
-			caption: "First 100 accounts are free, forever.",
-		}),
+		passwordField: toFieldViewModel(errors, "password")
 	});
 
 	return {
@@ -99,7 +95,6 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
-			caption: "First 100 accounts are free, forever.",
 		}),
 	});
 

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -52,7 +52,7 @@ export function LoginPage(data: AuthFormData, options?: { statusCode?: number })
 		passwordField: toFieldViewModel(errors, "password"),
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
-			caption: "Founding members: $3.99/mo, locked forever.",
+			caption: "First 100 accounts are free, forever.",
 		}),
 	});
 
@@ -99,7 +99,7 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
-			caption: "Founding members: $3.99/mo, locked forever.",
+			caption: "First 100 accounts are free, forever.",
 		}),
 	});
 

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -1,21 +1,34 @@
 import type { Request, Response, Router } from "express";
 import express from "express";
+import { z } from "zod";
 import type {
 	CountUsers,
+	CreateGoogleUser,
 	CreateSession,
-	CreateUser,
+	CreateUserWithPasswordHash,
 	DestroySession,
+	FindUserByEmail,
 	MarkEmailVerified,
 	MarkSessionEmailVerified,
 	VerifyCredentials,
 } from "../../providers/auth/auth.types";
+import { hashPassword } from "../../providers/auth/password";
+import type { UserId } from "../../domain/user/user.types";
 import type { SendEmail } from "../../providers/email/email.types";
 import type {
 	CreateVerificationToken,
 	VerifyEmailToken,
 } from "../../providers/email-verification/email-verification.types";
 import { VerificationTokenSchema } from "../../providers/email-verification/email-verification.schema";
-import { z } from "zod";
+import type {
+	ConsumePendingSignup,
+	StorePendingSignup,
+} from "../../providers/pending-signup/pending-signup.types";
+import { CheckoutSessionIdSchema } from "../../providers/stripe-checkout/stripe-checkout.schema";
+import type {
+	CreateCheckoutSession,
+	RetrieveCheckoutSession,
+} from "../../providers/stripe-checkout/stripe-checkout.types";
 import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { LoginSchema, SignupSchema } from "./auth.schema";
@@ -27,11 +40,14 @@ import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
+const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
 
 interface AuthDependencies {
-	createUser: CreateUser;
+	createUserWithPasswordHash: CreateUserWithPasswordHash;
+	createGoogleUser: CreateGoogleUser;
+	findUserByEmail: FindUserByEmail;
 	verifyCredentials: VerifyCredentials;
 	createSession: CreateSession;
 	destroySession: DestroySession;
@@ -41,6 +57,11 @@ interface AuthDependencies {
 	sendEmail: SendEmail;
 	createVerificationToken: CreateVerificationToken;
 	verifyEmailToken: VerifyEmailToken;
+	createCheckoutSession: CreateCheckoutSession;
+	retrieveCheckoutSession: RetrieveCheckoutSession;
+	storePendingSignup: StorePendingSignup;
+	consumePendingSignup: ConsumePendingSignup;
+	appOrigin: string;
 	baseUrl: string;
 	logError: (message: string, error?: Error) => void;
 }
@@ -53,6 +74,36 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		logError: deps.logError,
 		logPrefix: "[Auth]",
 	});
+
+	const buildSuccessUrl = (returnUrl: string | undefined): string => {
+		/** Stripe substitutes {CHECKOUT_SESSION_ID} server-side, so the URL must
+		 * contain the literal placeholder — we cannot URL-encode the braces. */
+		const returnSuffix = returnUrl ? `&return=${encodeURIComponent(returnUrl)}` : "";
+		return `${deps.appOrigin}/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}${returnSuffix}`;
+	};
+
+	const buildCancelUrl = (path: "/signup", returnUrl: string | undefined): string => {
+		const suffix = returnUrl ? `?return=${encodeURIComponent(returnUrl)}` : "";
+		return `${deps.appOrigin}${path}${suffix}`;
+	};
+
+	const sendVerificationEmail = (userId: UserId, email: string): void => {
+		deps.createVerificationToken({ userId, email })
+			.then((token) => {
+				const verifyUrl = `${deps.baseUrl}/verify-email?token=${token}`;
+				const html = buildVerificationEmailHtml(verifyUrl);
+				return deps.sendEmail({
+					from: EMAIL_FROM,
+					to: email,
+					bcc: "readplace+account_verifications@readplace.com",
+					subject: "Verify your email — Readplace",
+					html,
+				});
+			})
+			.catch((err) => {
+				deps.logError("[Email] Verification email failed", err instanceof Error ? err : new Error(String(err)));
+			});
+	};
 
 	router.get("/login", async (req: Request, res: Response) => {
 		if (req.userId) {
@@ -142,9 +193,9 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 
 		const { email, password } = parsed.data;
-		const createResult = await deps.createUser({ email, password });
 
-		if (!createResult.ok) {
+		const existing = await deps.findUserByEmail(email);
+		if (existing) {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				res,
@@ -161,25 +212,112 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			return;
 		}
 
-		const sessionId = await deps.createSession({ userId: createResult.userId, emailVerified: false });
-		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
-		res.redirect(303, parseReturnUrl(req.query));
+		const passwordHash = await hashPassword(password);
 
-		deps.createVerificationToken({ userId: createResult.userId, email })
-			.then((token) => {
-				const verifyUrl = `${deps.baseUrl}/verify-email?token=${token}`;
-				const html = buildVerificationEmailHtml(verifyUrl);
-				return deps.sendEmail({
-					from: EMAIL_FROM,
-					to: email,
-					bcc: "readplace+account_verifications@readplace.com",
-					subject: "Verify your email — Readplace",
-					html,
-				});
-			})
-			.catch((err) => {
-				deps.logError("[Email] Verification email failed", err instanceof Error ? err : new Error(String(err)));
+		const checkout = await deps.createCheckoutSession({
+			customerEmail: email,
+			successUrl: buildSuccessUrl(returnUrl),
+			cancelUrl: buildCancelUrl("/signup", returnUrl),
+		});
+
+		await deps.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "email",
+				email,
+				passwordHash,
+				...(returnUrl ? { returnUrl } : {}),
+			},
+		});
+
+		res.redirect(303, checkout.url);
+	});
+
+	router.get("/auth/checkout/success", async (req: Request, res: Response) => {
+		const parsedQuery = CheckoutSuccessQuerySchema.safeParse(req.query);
+		if (!parsedQuery.success) {
+			const userCount = await fetchUserCount();
+			sendComponent(
+				res,
+				renderPage(req, SignupPage(
+					{
+						userCount,
+						globalError: "Missing checkout session — please start again.",
+					},
+					{ statusCode: 400 },
+				)),
+			);
+			return;
+		}
+
+		const checkoutSessionId = CheckoutSessionIdSchema.parse(parsedQuery.data.session_id);
+		const session = await deps.retrieveCheckoutSession(checkoutSessionId);
+
+		const renderFailure = async (statusCode: number, globalError: string) => {
+			const userCount = await fetchUserCount();
+			sendComponent(
+				res,
+				renderPage(req, SignupPage({ userCount, globalError }, { statusCode })),
+			);
+		};
+
+		if (!session.ok) {
+			await renderFailure(404, "Checkout session not found — please start again.");
+			return;
+		}
+
+		if (!session.paid) {
+			await renderFailure(402, "Payment was not completed. Please try again.");
+			return;
+		}
+
+		const pending = await deps.consumePendingSignup(checkoutSessionId);
+		if (!pending) {
+			await renderFailure(409, "This checkout link has already been used.");
+			return;
+		}
+
+		const returnPath = parseReturnUrl({ return: pending.returnUrl });
+
+		if (pending.method === "email") {
+			const created = await deps.createUserWithPasswordHash({
+				email: pending.email,
+				passwordHash: pending.passwordHash,
 			});
+			if (!created.ok) {
+				await renderFailure(409, "An account with this email already exists. Please sign in.");
+				return;
+			}
+
+			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
+			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			sendVerificationEmail(created.userId, pending.email);
+			res.redirect(303, returnPath);
+			return;
+		}
+
+		const created = await deps.createGoogleUser({
+			email: pending.email,
+			userId: pending.userId,
+		});
+		if (!created.ok) {
+			const lookup = await deps.findUserByEmail(pending.email);
+			if (!lookup) {
+				await renderFailure(500, "Account creation failed. Please contact support.");
+				return;
+			}
+			if (!lookup.emailVerified) {
+				await deps.markEmailVerified(pending.email);
+			}
+			const sessionId = await deps.createSession({ userId: lookup.userId, emailVerified: true });
+			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.redirect(303, returnPath);
+			return;
+		}
+
+		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
+		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+		res.redirect(303, returnPath);
 	});
 
 	router.get("/verify-email", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -583,7 +583,7 @@ describe("Auth routes", () => {
 			const loginDoc = new JSDOM((await request(app).get("/login")).text).window.document;
 			const loginExhausted = loginDoc.querySelector("[data-test-founding-exhausted]");
 			assert(loginExhausted, "exhausted message must be rendered on /login");
-			expect(loginExhausted.textContent).toContain("The free allocation has been exhausted");
+			expect(loginExhausted.textContent).toContain("All 100 founding member spots have been claimed");
 			expect(loginExhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 			expect(
 				loginDoc.querySelector("[data-test-founding-progress] .founding-progress__fill")?.getAttribute("style"),
@@ -595,7 +595,7 @@ describe("Auth routes", () => {
 			const signupDoc = new JSDOM((await request(app).get("/signup")).text).window.document;
 			const signupExhausted = signupDoc.querySelector("[data-test-founding-exhausted]");
 			assert(signupExhausted, "exhausted message must be rendered on /signup");
-			expect(signupExhausted.textContent).toContain("The free allocation has been exhausted");
+			expect(signupExhausted.textContent).toContain("All 100 founding member spots have been claimed");
 			expect(signupExhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 		}, 30000);
 	});

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -536,7 +536,7 @@ describe("Auth routes", () => {
 
 			const caption = doc.querySelector("[data-test-founding-caption]");
 			assert(caption, "founding caption must be rendered");
-			expect(caption.textContent).toBe("Founding members: $3.99/mo, locked forever.");
+			expect(caption.textContent).toBe("First 100 accounts are free, forever.");
 		});
 
 		it("should render an explanatory caption on /signup for visitors who skipped the homepage", async () => {
@@ -545,7 +545,7 @@ describe("Auth routes", () => {
 
 			const caption = doc.querySelector("[data-test-founding-caption]");
 			assert(caption, "founding caption must be rendered");
-			expect(caption.textContent).toBe("Founding members: $3.99/mo, locked forever.");
+			expect(caption.textContent).toBe("First 100 accounts are free, forever.");
 		});
 
 		it("should keep the progress bar on POST /login 422 responses", async () => {
@@ -583,7 +583,7 @@ describe("Auth routes", () => {
 			const loginDoc = new JSDOM((await request(app).get("/login")).text).window.document;
 			const loginExhausted = loginDoc.querySelector("[data-test-founding-exhausted]");
 			assert(loginExhausted, "exhausted message must be rendered on /login");
-			expect(loginExhausted.textContent).toContain("All 100 founding member spots have been claimed");
+			expect(loginExhausted.textContent).toContain("The free allocation has been exhausted");
 			expect(loginExhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 			expect(
 				loginDoc.querySelector("[data-test-founding-progress] .founding-progress__fill")?.getAttribute("style"),
@@ -595,7 +595,7 @@ describe("Auth routes", () => {
 			const signupDoc = new JSDOM((await request(app).get("/signup")).text).window.document;
 			const signupExhausted = signupDoc.querySelector("[data-test-founding-exhausted]");
 			assert(signupExhausted, "exhausted message must be rendered on /signup");
-			expect(signupExhausted.textContent).toContain("All 100 founding member spots have been claimed");
+			expect(signupExhausted.textContent).toContain("The free allocation has been exhausted");
 			expect(signupExhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 		}, 30000);
 	});

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -507,55 +507,10 @@ describe("Auth routes", () => {
 	describe("Founding members progress", () => {
 		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		it("should render the progress bar on GET /login with zero users", async () => {
-			const response = await request(app).get("/login");
-			const doc = new JSDOM(response.text).window.document;
-
-			const label = doc.querySelector("[data-test-founding-progress] .founding-progress__label");
-			expect(label?.textContent).toBe("0 / 100 founding members");
-
-			const fill = doc.querySelector("[data-test-founding-progress] .founding-progress__fill");
-			expect(fill?.getAttribute("style")).toBe("width: 0%");
-
-			const exhausted = doc.querySelector("[data-test-founding-exhausted]");
-			assert(exhausted, "exhausted message must be rendered");
-			expect(exhausted.classList.contains("founding-progress__exhausted--hidden")).toBe(true);
-		});
-
 		it("should render the progress bar on GET /signup with zero users", async () => {
 			const response = await request(app).get("/signup");
 			const doc = new JSDOM(response.text).window.document;
 
-			const label = doc.querySelector("[data-test-founding-progress] .founding-progress__label");
-			expect(label?.textContent).toBe("0 / 100 founding members");
-		});
-
-		it("should render an explanatory caption on /login for visitors who skipped the homepage", async () => {
-			const response = await request(app).get("/login");
-			const doc = new JSDOM(response.text).window.document;
-
-			const caption = doc.querySelector("[data-test-founding-caption]");
-			assert(caption, "founding caption must be rendered");
-			expect(caption.textContent).toBe("First 100 accounts are free, forever.");
-		});
-
-		it("should render an explanatory caption on /signup for visitors who skipped the homepage", async () => {
-			const response = await request(app).get("/signup");
-			const doc = new JSDOM(response.text).window.document;
-
-			const caption = doc.querySelector("[data-test-founding-caption]");
-			assert(caption, "founding caption must be rendered");
-			expect(caption.textContent).toBe("First 100 accounts are free, forever.");
-		});
-
-		it("should keep the progress bar on POST /login 422 responses", async () => {
-			const response = await request(app)
-				.post("/login")
-				.type("form")
-				.send({ email: "test@example.com", password: "wrongpassword" });
-
-			expect(response.status).toBe(422);
-			const doc = new JSDOM(response.text).window.document;
 			const label = doc.querySelector("[data-test-founding-progress] .founding-progress__label");
 			expect(label?.textContent).toBe("0 / 100 founding members");
 		});
@@ -574,23 +529,11 @@ describe("Auth routes", () => {
 	});
 
 	describe("Founding members progress — exhausted allocation", () => {
-		it("should render the exhausted message on both /login and /signup when over the limit", async () => {
+		it("should render the exhausted message on /signup when over the limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			for (let i = 0; i < 101; i++) {
 				await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 			}
-
-			const loginDoc = new JSDOM((await request(app).get("/login")).text).window.document;
-			const loginExhausted = loginDoc.querySelector("[data-test-founding-exhausted]");
-			assert(loginExhausted, "exhausted message must be rendered on /login");
-			expect(loginExhausted.textContent).toContain("The free allocation has been exhausted");
-			expect(loginExhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
-			expect(
-				loginDoc.querySelector("[data-test-founding-progress] .founding-progress__fill")?.getAttribute("style"),
-			).toBe("width: 100%");
-			expect(
-				loginDoc.querySelector("[data-test-founding-progress] .founding-progress__label")?.textContent,
-			).toBe("101 / 100 founding members");
 
 			const signupDoc = new JSDOM((await request(app).get("/signup")).text).window.document;
 			const signupExhausted = signupDoc.querySelector("[data-test-founding-exhausted]");

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -7,6 +7,7 @@ import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "../../test-app-fakes";
+import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 
 describe("Auth routes", () => {
 	describe("GET /login", () => {
@@ -213,7 +214,7 @@ describe("Auth routes", () => {
 	});
 
 	describe("POST /signup", () => {
-		it("should create user and redirect to /queue", async () => {
+		it("should redirect new visitors to a Stripe checkout URL", async () => {
 			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const response = await request(app).post("/signup").type("form").send({
@@ -223,56 +224,67 @@ describe("Auth routes", () => {
 			});
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
-			expect(response.headers["set-cookie"].length).toBeGreaterThan(0);
+			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
 		});
 
-		it("should redirect to return URL after successful signup", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		it("should create the account on successful Stripe checkout and redirect to /queue", async () => {
+			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
-				.post("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest")
-				.type("form")
-				.send({
-					email: "new@example.com",
-					password: "password123",
-					confirmPassword: "password123",
-				});
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
+				email: "new@example.com",
+				password: "password123",
+			});
 
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/oauth/authorize?client_id=test");
+			expect(successResponse.status).toBe(303);
+			expect(successResponse.headers.location).toBe("/queue");
+			expect(successResponse.headers["set-cookie"].length).toBeGreaterThan(0);
+		});
+
+		it("should redirect to return URL after successful Stripe checkout", async () => {
+			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
+				email: "new@example.com",
+				password: "password123",
+				returnUrl: "/oauth/authorize?client_id=test",
+			});
+
+			expect(successResponse.status).toBe(303);
+			expect(successResponse.headers.location).toBe("/oauth/authorize?client_id=test");
 		});
 
 		it("should ignore protocol-relative return URLs on signup", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
-				.post("/signup?return=%2F%2Fevil.com")
-				.type("form")
-				.send({
-					email: "new@example.com",
-					password: "password123",
-					confirmPassword: "password123",
-				});
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
+				email: "new@example.com",
+				password: "password123",
+				returnUrl: "//evil.com",
+			});
 
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
+			expect(successResponse.status).toBe(303);
+			expect(successResponse.headers.location).toBe("/queue");
 		});
 
 		it("should ignore non-relative return URLs on signup", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
-				.post("/signup?return=https%3A%2F%2Fevil.com")
-				.type("form")
-				.send({
-					email: "new@example.com",
-					password: "password123",
-					confirmPassword: "password123",
-				});
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
+				email: "new@example.com",
+				password: "password123",
+				returnUrl: "https://evil.com",
+			});
 
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
+			expect(successResponse.status).toBe(303);
+			expect(successResponse.headers.location).toBe("/queue");
 		});
 
 		it("should show error for duplicate email", async () => {
@@ -524,7 +536,7 @@ describe("Auth routes", () => {
 
 			const caption = doc.querySelector("[data-test-founding-caption]");
 			assert(caption, "founding caption must be rendered");
-			expect(caption.textContent).toBe("First 100 accounts are free, forever.");
+			expect(caption.textContent).toBe("Founding members: $3.99/mo, locked forever.");
 		});
 
 		it("should render an explanatory caption on /signup for visitors who skipped the homepage", async () => {
@@ -533,7 +545,7 @@ describe("Auth routes", () => {
 
 			const caption = doc.querySelector("[data-test-founding-caption]");
 			assert(caption, "founding caption must be rendered");
-			expect(caption.textContent).toBe("First 100 accounts are free, forever.");
+			expect(caption.textContent).toBe("Founding members: $3.99/mo, locked forever.");
 		});
 
 		it("should keep the progress bar on POST /login 422 responses", async () => {

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { createTestApp } from "../../test-app";
+import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "../../test-app-fakes";
+import { CheckoutSessionIdSchema } from "../../providers/stripe-checkout/stripe-checkout.schema";
+import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
+
+describe("GET /auth/checkout/success", () => {
+	it("renders an error and 400 when the session_id query param is missing", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(app).get("/auth/checkout/success");
+
+		expect(response.status).toBe(400);
+		const doc = new JSDOM(response.text).window.document;
+		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain(
+			"Missing checkout session",
+		);
+	});
+
+	it("renders 404 when Stripe says the session does not exist", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(app).get("/auth/checkout/success?session_id=cs_test_unknown");
+
+		expect(response.status).toBe(404);
+		const doc = new JSDOM(response.text).window.document;
+		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not found");
+	});
+
+	it("renders 402 when the checkout has not been paid yet", async () => {
+		const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const signup = await request(app).post("/signup").type("form").send({
+			email: "unpaid@example.com",
+			password: "password123",
+			confirmPassword: "password123",
+		});
+		const checkoutSessionId = CheckoutSessionIdSchema.parse(
+			new URL(signup.headers.location).pathname.replace(/^\//, ""),
+		);
+
+		const response = await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
+		);
+
+		expect(response.status).toBe(402);
+		const doc = new JSDOM(response.text).window.document;
+		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not completed");
+		// Side note: keeps the unused stripe deconstruction warning quiet
+		expect(typeof stripe.markPaid).toBe("function");
+	});
+
+	it("renders 409 when the checkout has been paid but the pending signup was already consumed", async () => {
+		const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const { checkoutSessionId } = await completeStripeSignup({
+			app,
+			stripe,
+			email: "double@example.com",
+			password: "password123",
+		});
+
+		const replay = await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
+		);
+
+		expect(replay.status).toBe(409);
+		const doc = new JSDOM(replay.text).window.document;
+		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("already been used");
+	});
+
+	it("creates the user, sets a session cookie, and redirects to /queue on first paid visit", async () => {
+		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const { successResponse } = await completeStripeSignup({
+			app,
+			stripe,
+			email: "buyer@example.com",
+			password: "password123",
+		});
+
+		expect(successResponse.status).toBe(303);
+		expect(successResponse.headers.location).toBe("/queue");
+		expect(successResponse.headers["set-cookie"].length).toBeGreaterThan(0);
+
+		const lookup = await auth.findUserByEmail("buyer@example.com");
+		assert(lookup, "expected user to be persisted after Stripe success");
+		expect(lookup.emailVerified).toBe(false);
+
+		const credentials = await auth.verifyCredentials({
+			email: "buyer@example.com",
+			password: "password123",
+		});
+		expect(credentials.ok).toBe(true);
+	});
+
+	it("renders 409 when the email has been claimed since the Stripe redirect started", async () => {
+		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const signup = await request(app).post("/signup").type("form").send({
+			email: "race@example.com",
+			password: "password123",
+			confirmPassword: "password123",
+		});
+		const checkoutSessionId = CheckoutSessionIdSchema.parse(
+			new URL(signup.headers.location).pathname.replace(/^\//, ""),
+		);
+		stripe.markPaid(checkoutSessionId);
+
+		await auth.createUser({ email: "race@example.com", password: "different-password" });
+
+		const response = await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
+		);
+
+		expect(response.status).toBe(409);
+		const doc = new JSDOM(response.text).window.document;
+		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("already exists");
+	});
+
+	it("creates a Google user with a verified email after Stripe success", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const { app, auth, stripe, pendingSignup } = createTestApp(fixture);
+		const { UserIdSchema } = await import("../../domain/user/user.schema");
+
+		const checkout = await stripe.createCheckoutSession({
+			customerEmail: "google-buyer@example.com",
+			successUrl: "http://localhost:3000/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "http://localhost:3000/login",
+		});
+		await pendingSignup.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "google",
+				email: "google-buyer@example.com",
+				userId: UserIdSchema.parse("u-google-checkout-1"),
+			},
+		});
+		stripe.markPaid(checkout.id);
+
+		const response = await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
+		);
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
+		const lookup = await auth.findUserByEmail("google-buyer@example.com");
+		assert(lookup, "google user should exist after success");
+		expect(lookup.emailVerified).toBe(true);
+		expect(lookup.userId).toBe("u-google-checkout-1");
+	});
+
+	it("logs the existing user in when a Google sign-up arrives for an email that already exists", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const { app, auth, stripe, pendingSignup } = createTestApp(fixture);
+		const { UserIdSchema } = await import("../../domain/user/user.schema");
+
+		const existing = await auth.createUser({
+			email: "preexisting@example.com",
+			password: "password123",
+		});
+		assert(existing.ok, "setup");
+
+		const checkout = await stripe.createCheckoutSession({
+			customerEmail: "preexisting@example.com",
+			successUrl: "http://localhost:3000/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "http://localhost:3000/login",
+		});
+		await pendingSignup.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "google",
+				email: "preexisting@example.com",
+				userId: UserIdSchema.parse("u-google-different"),
+			},
+		});
+		stripe.markPaid(checkout.id);
+
+		const response = await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
+		);
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
+		const lookup = await auth.findUserByEmail("preexisting@example.com");
+		assert(lookup, "user should still exist");
+		expect(lookup.userId).toBe(existing.userId);
+		expect(lookup.emailVerified).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -12,20 +12,24 @@ import { initInMemoryArticleStore } from "../../providers/article-store/in-memor
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import { initInMemoryEmailVerification } from "../../providers/email-verification/in-memory-email-verification";
 import { initInMemoryPasswordReset } from "../../providers/password-reset/in-memory-password-reset";
+import { initInMemoryStripeCheckout } from "../../providers/stripe-checkout/in-memory-stripe-checkout";
+import { initInMemoryPendingSignup } from "../../providers/pending-signup/in-memory-pending-signup";
 import { createOAuthModel, initInMemoryOAuthModel } from "../../providers/oauth/oauth-model";
 import { createValidateAccessToken } from "../../providers/oauth/validate-access-token";
 import { createApp } from "../../server";
 import { httpErrorMessageMapping } from "../pages/queue/queue.error";
+import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 
 describe("Email verification", () => {
-	describe("POST /signup", () => {
-		it("should send a verification email on successful signup", async () => {
-			const { app, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+	describe("POST /signup → Stripe → success", () => {
+		it("should send a verification email after successful Stripe checkout", async () => {
+			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			await request(app).post("/signup").type("form").send({
+			await completeStripeSignup({
+				app,
+				stripe,
 				email: "new@example.com",
 				password: "password123",
-				confirmPassword: "password123",
 			});
 
 			const sent = email.getSentEmails();
@@ -42,6 +46,8 @@ describe("Email verification", () => {
 			const oauthModel = createOAuthModel(initInMemoryOAuthModel());
 			const emailVerification = initInMemoryEmailVerification();
 			const passwordReset = initInMemoryPasswordReset();
+			const stripe = initInMemoryStripeCheckout();
+			const pendingSignup = initInMemoryPendingSignup();
 
 			let resolveErrorLogged: () => void;
 			const errorLogged = new Promise<void>((resolve) => {
@@ -58,6 +64,10 @@ describe("Email verification", () => {
 				readArticleContent: (url: string) => articleStore.readContent(ArticleResourceUniqueId.parse(url)),
 				...emailVerification,
 				...passwordReset,
+				createCheckoutSession: stripe.createCheckoutSession,
+				retrieveCheckoutSession: stripe.retrieveCheckoutSession,
+				storePendingSignup: pendingSignup.storePendingSignup,
+				consumePendingSignup: pendingSignup.consumePendingSignup,
 				sendEmail: async () => { throw new Error("Email service down"); },
 				baseUrl: "http://localhost:3000",
 				logError: () => { resolveErrorLogged(); },
@@ -81,17 +91,18 @@ describe("Email verification", () => {
 				now: () => new Date(),
 			});
 
-			const response = await request(app).post("/signup").type("form").send({
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
 				email: "fail-email@example.com",
 				password: "password123",
-				confirmPassword: "password123",
 			});
 
-			expect(response.status).toBe(303);
+			expect(successResponse.status).toBe(303);
 			await errorLogged;
 		});
 
-		it("should not send a verification email when signup fails", async () => {
+		it("should not send a verification email when signup fails (duplicate email)", async () => {
 			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			await auth.createUser({ email: "existing@example.com", password: "password123" });
 
@@ -107,12 +118,13 @@ describe("Email verification", () => {
 
 	describe("GET /verify-email", () => {
 		it("should verify email with a valid token", async () => {
-			const { app, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			await request(app).post("/signup").type("form").send({
+			await completeStripeSignup({
+				app,
+				stripe,
 				email: "verify@example.com",
 				password: "password123",
-				confirmPassword: "password123",
 			});
 
 			const sent = email.getSentEmails();
@@ -148,12 +160,13 @@ describe("Email verification", () => {
 		});
 
 		it("should reject a token that has already been used", async () => {
-			const { app, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			await request(app).post("/signup").type("form").send({
+			await completeStripeSignup({
+				app,
+				stripe,
 				email: "once@example.com",
 				password: "password123",
-				confirmPassword: "password123",
 			});
 
 			const sent = email.getSentEmails();
@@ -170,15 +183,16 @@ describe("Email verification", () => {
 		});
 
 		it("should mark email as verified after successful verification", async () => {
-			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const signupResponse = await request(app).post("/signup").type("form").send({
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
 				email: "flag@example.com",
 				password: "password123",
-				confirmPassword: "password123",
 			});
 
-			const cookies = signupResponse.headers["set-cookie"];
+			const cookies = successResponse.headers["set-cookie"];
 			const cookieString = Array.isArray(cookies) ? cookies[0] : cookies;
 			const sessionMatch = cookieString.match(/hutch_sid=([^;]+)/);
 			assert(sessionMatch, "Expected session cookie");
@@ -201,15 +215,16 @@ describe("Email verification", () => {
 		});
 
 		it("should not mark email as verified when token is invalid", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const signupResponse = await request(app).post("/signup").type("form").send({
+			const { successResponse } = await completeStripeSignup({
+				app,
+				stripe,
 				email: "noverify@example.com",
 				password: "password123",
-				confirmPassword: "password123",
 			});
 
-			const cookies = signupResponse.headers["set-cookie"];
+			const cookies = successResponse.headers["set-cookie"];
 			const cookieString = Array.isArray(cookies) ? cookies[0] : cookies;
 			const sessionMatch = cookieString.match(/hutch_sid=([^;]+)/);
 			assert(sessionMatch, "Expected session cookie");

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -1,18 +1,17 @@
-import assert from "node:assert";
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { Request, Response, Router } from "express";
 import express from "express";
 import { z } from "zod";
 import { UserIdSchema } from "../../domain/user/user.schema";
-import type { UserId } from "../../domain/user/user.types";
 import type {
 	CountUsers,
-	CreateGoogleUser,
 	CreateSession,
 	FindUserByEmail,
 	MarkEmailVerified,
 } from "../../providers/auth/auth.types";
 import type { ExchangeGoogleCode } from "../../providers/google-auth/google-token.types";
+import type { StorePendingSignup } from "../../providers/pending-signup/pending-signup.types";
+import type { CreateCheckoutSession } from "../../providers/stripe-checkout/stripe-checkout.types";
 import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
@@ -39,11 +38,12 @@ interface GoogleAuthDependencies {
 	googleClientSecret: string;
 	appOrigin: string;
 	createSession: CreateSession;
-	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
 	countUsers: CountUsers;
 	markEmailVerified: MarkEmailVerified;
 	exchangeGoogleCode: ExchangeGoogleCode;
+	createCheckoutSession: CreateCheckoutSession;
+	storePendingSignup: StorePendingSignup;
 	logError: (message: string, error?: Error) => void;
 }
 
@@ -138,31 +138,42 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 			return;
 		}
 
-		const getOrCreateUserId = async (): Promise<UserId> => {
-			const existing = await deps.findUserByEmail(tokenResult.email);
-			if (existing) {
-				if (!existing.emailVerified) {
-					await deps.markEmailVerified(tokenResult.email);
-				}
-				return existing.userId;
-			}
-
-			const newUserId = UserIdSchema.parse(randomBytes(16).toString("hex"));
-			const created = await deps.createGoogleUser({ email: tokenResult.email, userId: newUserId });
-			if (created.ok) return newUserId;
-
-			const raced = await deps.findUserByEmail(tokenResult.email);
-			assert(raced, "createGoogleUser said email-already-exists but findUserByEmail missed");
-			if (!raced.emailVerified) {
+		const existing = await deps.findUserByEmail(tokenResult.email);
+		if (existing) {
+			if (!existing.emailVerified) {
 				await deps.markEmailVerified(tokenResult.email);
 			}
-			return raced.userId;
-		};
+			const sessionId = await deps.createSession({ userId: existing.userId, emailVerified: true });
+			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.redirect(303, parseReturnUrl({ return: stateData.returnUrl }));
+			return;
+		}
 
-		const userId = await getOrCreateUserId();
-		const sessionId = await deps.createSession({ userId, emailVerified: true });
-		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
-		res.redirect(303, parseReturnUrl({ return: stateData.returnUrl }));
+		const newUserId = UserIdSchema.parse(randomBytes(16).toString("hex"));
+		const safeReturnUrl = extractReturnUrl({ return: stateData.returnUrl });
+		const returnSuffix = safeReturnUrl
+			? `&return=${encodeURIComponent(safeReturnUrl)}`
+			: "";
+		const successUrl = `${deps.appOrigin}/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}${returnSuffix}`;
+		const cancelUrl = `${deps.appOrigin}/login`;
+
+		const checkout = await deps.createCheckoutSession({
+			customerEmail: tokenResult.email,
+			successUrl,
+			cancelUrl,
+		});
+
+		await deps.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "google",
+				email: tokenResult.email,
+				userId: newUserId,
+				...(safeReturnUrl ? { returnUrl: safeReturnUrl } : {}),
+			},
+		});
+
+		res.redirect(303, checkout.url);
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -10,6 +10,7 @@ import {
 
 import { GoogleIdSchema } from "../../providers/google-auth/google-auth.schema";
 import type { ExchangeGoogleCode } from "../../providers/google-auth/google-token.types";
+import { CheckoutSessionIdSchema } from "../../providers/stripe-checkout/stripe-checkout.schema";
 
 const TEST_CLIENT_ID = "test-google-client-id";
 const TEST_CLIENT_SECRET = "test-google-client-secret";
@@ -204,7 +205,7 @@ describe("Google auth routes", () => {
 			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not verified");
 		});
 
-		it("should create a new user and redirect to /queue by default", async () => {
+		it("should redirect a brand-new user to a Stripe checkout URL", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth } = createTestApp({
 				...fixture,
@@ -221,16 +222,48 @@ describe("Google auth routes", () => {
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
-			expect(cookiesFrom(response).join(";")).toContain("hutch_sid=");
+			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
+
+			const lookup = await auth.findUserByEmail("brand-new@example.com");
+			expect(lookup).toBeNull();
+		});
+
+		it("should create the Google user only after successful Stripe checkout", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { app, auth, stripe } = createTestApp({
+				...fixture,
+				google: {
+					exchangeGoogleCode: stubExchange({ email: "brand-new@example.com" }),
+					clientId: "test-google-client-id",
+					clientSecret: "test-google-client-secret",
+				},
+			});
+			const state = signState(freshState());
+			const agent = request.agent(app);
+			const callbackResponse = await agent
+				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
+				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
+			const stripeUrl = callbackResponse.headers.location;
+			const checkoutSessionId = CheckoutSessionIdSchema.parse(
+				new URL(stripeUrl).pathname.replace(/^\//, ""),
+			);
+			stripe.markPaid(checkoutSessionId);
+
+			const successResponse = await agent.get(
+				`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
+			);
+
+			expect(successResponse.status).toBe(303);
+			expect(successResponse.headers.location).toBe("/queue");
+			expect(cookiesFrom(successResponse).join(";")).toContain("hutch_sid=");
 
 			const lookup = await auth.findUserByEmail("brand-new@example.com");
 			expect(lookup?.emailVerified).toBe(true);
 		});
 
-		it("should redirect to return URL from state payload", async () => {
+		it("should preserve the return URL through the Stripe checkout boundary", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const { app, stripe } = createTestApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "return@example.com" }),
@@ -239,13 +272,21 @@ describe("Google auth routes", () => {
 				},
 			});
 			const state = signState(freshState({ returnUrl: "/save?url=https%3A%2F%2Fexample.com" }));
-
-			const response = await request(app)
+			const agent = request.agent(app);
+			const callbackResponse = await agent
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
+			const checkoutSessionId = CheckoutSessionIdSchema.parse(
+				new URL(callbackResponse.headers.location).pathname.replace(/^\//, ""),
+			);
+			stripe.markPaid(checkoutSessionId);
 
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/save?url=https%3A%2F%2Fexample.com");
+			const successResponse = await agent.get(
+				`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
+			);
+
+			expect(successResponse.status).toBe(303);
+			expect(successResponse.headers.location).toBe("/save?url=https%3A%2F%2Fexample.com");
 		});
 
 		it("should reuse an existing verified email/password account and keep the password working", async () => {

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import type { SuperTest, Test } from "supertest";
+import request from "supertest";
+import type { Express } from "express";
+import { CheckoutSessionIdSchema } from "../../../providers/stripe-checkout/stripe-checkout.schema";
+import type { CheckoutSessionId } from "../../../providers/stripe-checkout/stripe-checkout.types";
+
+interface StripeBundle {
+	markPaid: (id: CheckoutSessionId) => void;
+}
+
+/** Drives an email-signup flow through the Stripe checkout boundary in a single
+ * step: posts to /signup, asserts the redirect to the Stripe URL, marks the
+ * session paid via the in-memory Stripe fake, then GETs the success URL using
+ * the shared agent so the session cookie persists. */
+export async function completeStripeSignup(params: {
+	app: Express;
+	stripe: StripeBundle;
+	email: string;
+	password: string;
+	returnUrl?: string;
+	agent?: SuperTest<Test>;
+}): Promise<{
+	signupResponse: import("supertest").Response;
+	successResponse: import("supertest").Response;
+	checkoutSessionId: CheckoutSessionId;
+}> {
+	const agent = params.agent ?? request.agent(params.app);
+	const signupPath = params.returnUrl
+		? `/signup?return=${encodeURIComponent(params.returnUrl)}`
+		: "/signup";
+	const signupResponse = await agent
+		.post(signupPath)
+		.type("form")
+		.send({
+			email: params.email,
+			password: params.password,
+			confirmPassword: params.password,
+		});
+
+	assert.equal(signupResponse.status, 303, "signup should redirect to Stripe");
+	const stripeUrl = signupResponse.headers.location;
+	assert(stripeUrl?.startsWith("https://checkout.stripe.test/"), `unexpected redirect: ${stripeUrl}`);
+	const checkoutSessionId = CheckoutSessionIdSchema.parse(
+		new URL(stripeUrl).pathname.replace(/^\//, ""),
+	);
+
+	params.stripe.markPaid(checkoutSessionId);
+
+	const successResponse = await agent.get(
+		`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
+	);
+	return { signupResponse, successResponse, checkoutSessionId };
+}

--- a/projects/hutch/src/runtime/web/pages/blog/posts/free-read-it-later-apps-2026.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/free-read-it-later-apps-2026.md
@@ -2,7 +2,7 @@
 title: "Free Read-It-Later Apps in 2026: What You Actually Get"
 description: "An honest look at what free really means for read-it-later apps, from hosted tiers to self-hosted options to paying a few dollars a month."
 slug: "free-read-it-later-apps-2026"
-date: "2026-04-06"
+date: "2026-05-01"
 author: "Fayner Brack"
 keywords: "free read it later app, read it later free, instapaper free, wallabag, karakeep, raindrop free tier"
 ---
@@ -78,7 +78,7 @@ Self-hosting trades money for time and expertise. That's a legitimate choice. Ju
 
 I built Readplace after realising I needed a read-it-later app I could trust to still exist in ten years. The approach is simple. You pay for the product, and the product stays alive.
 
-Readplace costs $3.99/month. The first 100 founding members get that rate locked forever.
+Readplace is free for the first 100 founding members. After that, it's $3.99/month.
 
 The price is the business model. There is no venture capital to run out, no acqui-hire that pulls the team onto someone else's priorities, and no ad network that needs your reading data. Subscriptions pay for servers and development. If the product is good enough that people keep paying, it keeps running.
 
@@ -93,6 +93,6 @@ That's not the right choice for everyone. If you want free and you're comfortabl
 | Karakeep | $0 + server + time | Full control, self-hosted | Your own maintenance burden |
 | Wallabag | $0 + server + time | Full control, self-hosted | Your own maintenance burden |
 | Browser bookmarks | $0 | Zero dependencies | No reader view, no offline, no organisation |
-| Readplace | $3.99/mo (founding rate, locked) | Hosted, maintained, no ads | Paying money for software |
+| Readplace | Free (founding), then $3.99/mo | Hosted, maintained, no ads | Paying money for software |
 
 Pick the tradeoff you're comfortable with. Just make sure you know what it is.

--- a/projects/hutch/src/runtime/web/pages/blog/posts/free-read-it-later-apps-2026.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/free-read-it-later-apps-2026.md
@@ -78,7 +78,7 @@ Self-hosting trades money for time and expertise. That's a legitimate choice. Ju
 
 I built Readplace after realising I needed a read-it-later app I could trust to still exist in ten years. The approach is simple. You pay for the product, and the product stays alive.
 
-Readplace is free for the first 100 founding members. After that, it's $3.99/month.
+Readplace costs $3.99/month. The first 100 founding members get that rate locked forever.
 
 The price is the business model. There is no venture capital to run out, no acqui-hire that pulls the team onto someone else's priorities, and no ad network that needs your reading data. Subscriptions pay for servers and development. If the product is good enough that people keep paying, it keeps running.
 
@@ -93,6 +93,6 @@ That's not the right choice for everyone. If you want free and you're comfortabl
 | Karakeep | $0 + server + time | Full control, self-hosted | Your own maintenance burden |
 | Wallabag | $0 + server + time | Full control, self-hosted | Your own maintenance burden |
 | Browser bookmarks | $0 | Zero dependencies | No reader view, no offline, no organisation |
-| Readplace | Free (founding), then $3.99/mo | Hosted, maintained, no ads | Paying money for software |
+| Readplace | $3.99/mo (founding rate, locked) | Hosted, maintained, no ads | Paying money for software |
 
 Pick the tradeoff you're comfortable with. Just make sure you know what it is.

--- a/projects/hutch/src/runtime/web/pages/blog/posts/omnivore-alternative.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/omnivore-alternative.md
@@ -2,7 +2,7 @@
 title: "Omnivore Shut Down. Here's a Read-It-Later App That Won't."
 description: "Omnivore shut down with two weeks notice. Readplace is a privacy-first read-it-later app built by a developer and no VC funding."
 slug: "omnivore-alternative"
-date: "2026-04-04"
+date: "2026-05-01"
 author: "Fayner Brack"
 keywords: "Omnivore alternative, Omnivore replacement, Omnivore shut down, read it later app, ElevenLabs Omnivore, Readwise Reader alternative, Pocket alternative"
 ---
@@ -87,7 +87,7 @@ $3.99/month. TL;DR summaries are included.
 
 Readwise Reader is a great choice for power users at $12.99/month. Readplace is simpler and cheaper. A focused read-it-later tool, not a full research platform.
 
-The first 100 founding members get $3.99/mo locked at that rate forever. [Sign up here](https://readplace.com/signup).
+The first 100 founding members get full access free, forever. [Sign up here](https://readplace.com/signup).
 
 ## Common questions from Omnivore users
 
@@ -97,9 +97,9 @@ ElevenLabs acquired Omnivore on November 1, 2024, and shut it down on November 1
 
 The team moved to ElevenLabs to work on text-to-speech, not reading tools. Omnivore is not coming back.
 
-**Is there an affordable Omnivore alternative?**
+**Is there a free Omnivore alternative?**
 
-Readplace costs $3.99/month. The first 100 founding members get that rate locked forever. Self-hosted alternatives like Karakeep and Wallabag are free but require you to run your own server. Readwise Reader is the most feature-complete option at $12.99/month.
+Readplace is free for the first 100 founding members. Full access, forever. After that, it costs $3.99/month. Self-hosted alternatives like Karakeep and Wallabag are free but require you to run your own server. Readwise Reader is the most feature-complete option at $12.99/month.
 
 **Can I import my Omnivore data into Readplace?**
 

--- a/projects/hutch/src/runtime/web/pages/blog/posts/omnivore-alternative.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/omnivore-alternative.md
@@ -87,7 +87,7 @@ $3.99/month. TL;DR summaries are included.
 
 Readwise Reader is a great choice for power users at $12.99/month. Readplace is simpler and cheaper. A focused read-it-later tool, not a full research platform.
 
-The first 100 founding members get full access free, forever. [Sign up here](https://readplace.com/signup).
+The first 100 founding members get $3.99/mo locked at that rate forever. [Sign up here](https://readplace.com/signup).
 
 ## Common questions from Omnivore users
 
@@ -97,9 +97,9 @@ ElevenLabs acquired Omnivore on November 1, 2024, and shut it down on November 1
 
 The team moved to ElevenLabs to work on text-to-speech, not reading tools. Omnivore is not coming back.
 
-**Is there a free Omnivore alternative?**
+**Is there an affordable Omnivore alternative?**
 
-Readplace is free for the first 100 founding members. Full access, forever. After that, it costs $3.99/month. Self-hosted alternatives like Karakeep and Wallabag are free but require you to run your own server. Readwise Reader is the most feature-complete option at $12.99/month.
+Readplace costs $3.99/month. The first 100 founding members get that rate locked forever. Self-hosted alternatives like Karakeep and Wallabag are free but require you to run your own server. Readwise Reader is the most feature-complete option at $12.99/month.
 
 **Can I import my Omnivore data into Readplace?**
 

--- a/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-instapaper.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-instapaper.md
@@ -2,7 +2,7 @@
 title: "Readplace vs Instapaper: Two Different Approaches to Read-It-Later"
 description: "A fair comparison of two read-it-later apps that took different paths after Pocket shut down. One is familiar and stable. The other bets on AI and active development."
 slug: "readplace-vs-instapaper"
-date: "2026-04-07"
+date: "2026-05-01"
 author: "Fayner Brack"
 keywords: "instapaper alternative, read it later, readplace vs instapaper, pocket replacement, AI summaries"
 ---
@@ -56,7 +56,7 @@ Readplace is browser-first. It's a web app with a browser extension, not a nativ
 
 Readplace is hosted in Australia. Your reading data stays on Australian infrastructure under Australian privacy law. That matters if you care about where your data lives.
 
-On pricing: Readplace costs $3.99 per month. The first 100 founding members get that rate locked forever. There's no free tier the way Instapaper offers one. Readplace is a paid product from the start.
+On pricing: the first 100 Readplace members got a free founding-member tier. After that, the price is $3.99 per month. There's no ongoing free tier the way Instapaper offers one. Readplace is a paid product from the start.
 
 The other side of that trade-off: Readplace ships new features every week. It's a product you can watch evolve in real time. That momentum is real, but so is the risk that comes with any newer product.
 
@@ -68,7 +68,7 @@ The other side of that trade-off: Readplace ships new features every week. It's 
 | **AI summaries** | No | Yes |
 | **Mobile apps** | iOS and Android | Browser-based (no native apps) |
 | **Browser extension** | Yes | Yes (Firefox, Chrome) |
-| **Free tier** | Yes | No |
+| **Free tier** | Yes | Founding members only (first 100) |
 | **Paid price** | $5.99/mo or $59.99/yr | $3.99/mo |
 | **E-reader integration** | Kobo (built-in) | No |
 | **Pocket import** | Yes | Yes |

--- a/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-instapaper.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/readplace-vs-instapaper.md
@@ -56,7 +56,7 @@ Readplace is browser-first. It's a web app with a browser extension, not a nativ
 
 Readplace is hosted in Australia. Your reading data stays on Australian infrastructure under Australian privacy law. That matters if you care about where your data lives.
 
-On pricing: the first 100 Readplace members got a free founding-member tier. After that, the price is $3.99 per month. There's no ongoing free tier the way Instapaper offers one. Readplace is a paid product from the start.
+On pricing: Readplace costs $3.99 per month. The first 100 founding members get that rate locked forever. There's no free tier the way Instapaper offers one. Readplace is a paid product from the start.
 
 The other side of that trade-off: Readplace ships new features every week. It's a product you can watch evolve in real time. That momentum is real, but so is the risk that comes with any newer product.
 
@@ -68,7 +68,7 @@ The other side of that trade-off: Readplace ships new features every week. It's 
 | **AI summaries** | No | Yes |
 | **Mobile apps** | iOS and Android | Browser-based (no native apps) |
 | **Browser extension** | Yes | Yes (Firefox, Chrome) |
-| **Free tier** | Yes | Founding members only (first 100) |
+| **Free tier** | Yes | No |
 | **Paid price** | $5.99/mo or $59.99/yr | $3.99/mo |
 | **E-reader integration** | Kobo (built-in) | No |
 | **Pocket import** | Yes | Yes |

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -135,14 +135,14 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 					softwareVersion: "1.0",
 					datePublished: "2026-03-01",
 					inLanguage: "en",
-					isAccessibleForFree: false,
+					isAccessibleForFree: true,
 					offers: [
 						{
 							"@type": "Offer",
 							name: "Founding Member",
-							price: "3.99",
+							price: "0",
 							priceCurrency: "USD",
-							description: "$3.99/mo locked forever for the first 100 founding members",
+							description: "Free forever for the first 100 founding members",
 							eligibleQuantity: {
 								"@type": "QuantitativeValue",
 								value: 100,
@@ -235,10 +235,10 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 						},
 						{
 							"@type": "Question",
-							name: "How much does Readplace cost?",
+							name: "Is Readplace free?",
 							acceptedAnswer: {
 								"@type": "Answer",
-								text: "Readplace costs $3.99/month. The first 100 founding members get that rate locked forever. TL;DR summaries are included.",
+								text: "The first 100 founding members get full access free, forever. After that, $3.99/month — includes TL;DR summaries.",
 							},
 						},
 						{

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -135,14 +135,14 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 					softwareVersion: "1.0",
 					datePublished: "2026-03-01",
 					inLanguage: "en",
-					isAccessibleForFree: true,
+					isAccessibleForFree: false,
 					offers: [
 						{
 							"@type": "Offer",
 							name: "Founding Member",
-							price: "0",
+							price: "3.99",
 							priceCurrency: "USD",
-							description: "Free forever for the first 100 founding members",
+							description: "$3.99/mo locked forever for the first 100 founding members",
 							eligibleQuantity: {
 								"@type": "QuantitativeValue",
 								value: 100,
@@ -235,10 +235,10 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 						},
 						{
 							"@type": "Question",
-							name: "Is Readplace free?",
+							name: "How much does Readplace cost?",
 							acceptedAnswer: {
 								"@type": "Answer",
-								text: "The first 100 founding members get full access free, forever. After that, $3.99/month — includes TL;DR summaries.",
+								text: "Readplace costs $3.99/month. The first 100 founding members get that rate locked forever. TL;DR summaries are included.",
 							},
 						},
 						{

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -190,7 +190,7 @@ describe("GET /", () => {
 		const plans = pricingSection?.querySelectorAll(".pricing-card");
 		expect(plans?.length).toBe(1);
 		expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__name')?.textContent).toBe("Founding Member");
-		expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__price')?.textContent).toContain("$0");
+		expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__price')?.textContent).toContain("$3.99");
 	});
 
 	it("should render the founding members progress bar with zero users", async () => {
@@ -336,7 +336,7 @@ describe("GET / with exhausted founding allocation", () => {
 
 		const exhausted = doc.querySelector("[data-test-founding-exhausted]");
 		assert(exhausted, "exhausted message must be rendered");
-		expect(exhausted.textContent).toBe("The free allocation has been exhausted. You might still be able to create an account for free while I develop the pricing system but it may require payment in a few months.");
+		expect(exhausted.textContent).toBe("All 100 founding member spots have been claimed. New accounts are $3.99/mo.");
 		expect(exhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 
 		const fill = doc.querySelector(".founding-progress__fill");

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -336,7 +336,7 @@ describe("GET / with exhausted founding allocation", () => {
 
 		const exhausted = doc.querySelector("[data-test-founding-exhausted]");
 		assert(exhausted, "exhausted message must be rendered");
-		expect(exhausted.textContent).toBe("The free allocation has been exhausted. You might still be able to create an account for free while I develop the pricing system but it may require payment if you registered after the first 100 founding members.");
+		expect(exhausted.textContent).toBe("The free allocation has been exhausted. Join now for only $3.99/month.");
 		expect(exhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 
 		const fill = doc.querySelector(".founding-progress__fill");

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -190,7 +190,7 @@ describe("GET /", () => {
 		const plans = pricingSection?.querySelectorAll(".pricing-card");
 		expect(plans?.length).toBe(1);
 		expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__name')?.textContent).toBe("Founding Member");
-		expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__price')?.textContent).toContain("$3.99");
+		expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__price')?.textContent).toContain("$0");
 	});
 
 	it("should render the founding members progress bar with zero users", async () => {
@@ -336,7 +336,7 @@ describe("GET / with exhausted founding allocation", () => {
 
 		const exhausted = doc.querySelector("[data-test-founding-exhausted]");
 		assert(exhausted, "exhausted message must be rendered");
-		expect(exhausted.textContent).toBe("All 100 founding member spots have been claimed. New accounts are $3.99/mo.");
+		expect(exhausted.textContent).toBe("The free allocation has been exhausted. You might still be able to create an account for free while I develop the pricing system but it may require payment if you registered after the first 100 founding members.");
 		expect(exhausted.classList.contains("founding-progress__exhausted--visible")).toBe(true);
 
 		const fill = doc.querySelector(".founding-progress__fill");

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -229,15 +229,15 @@
     <section id="pricing" class="home-pricing" data-test-section="pricing" aria-label="Pricing">
       <div class="home-pricing__container">
         <div class="section-header">
-          <h2 class="section-header__title">$3.99/mo — founding member rate, locked forever.</h2>
+          <h2 class="section-header__title">Free for the first 100 members.</h2>
         </div>
         {{{foundingProgressHtml}}}
         <div class="pricing-grid">
           <div class="pricing-card pricing-card--featured" data-test-plan="founding">
             <span class="pricing-card__badge">First 100 Users</span>
             <h3 class="pricing-card__name">Founding Member</h3>
-            <p class="pricing-card__price">$3.99<span class="pricing-card__price-suffix">/mo</span></p>
-            <p class="pricing-card__description">Be one of the first 100 founding members. $3.99/mo, locked at this rate forever. Help shape the product. Includes TL;DR summaries.</p>
+            <p class="pricing-card__price">$0<span class="pricing-card__price-suffix"> forever</span></p>
+            <p class="pricing-card__description">Be one of the first 100 users. Get full access free, forever. Help shape the product. $3.99/month for everyone else &mdash; includes TL;DR summaries.</p>
             <ul class="pricing-card__features">
               <li class="pricing-card__feature">Save unlimited articles</li>
               <li class="pricing-card__feature">Firefox and Chrome extensions</li>

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -229,15 +229,15 @@
     <section id="pricing" class="home-pricing" data-test-section="pricing" aria-label="Pricing">
       <div class="home-pricing__container">
         <div class="section-header">
-          <h2 class="section-header__title">Free for the first 100 members.</h2>
+          <h2 class="section-header__title">$3.99/mo — founding member rate, locked forever.</h2>
         </div>
         {{{foundingProgressHtml}}}
         <div class="pricing-grid">
           <div class="pricing-card pricing-card--featured" data-test-plan="founding">
             <span class="pricing-card__badge">First 100 Users</span>
             <h3 class="pricing-card__name">Founding Member</h3>
-            <p class="pricing-card__price">$0<span class="pricing-card__price-suffix"> forever</span></p>
-            <p class="pricing-card__description">Be one of the first 100 users. Get full access free, forever. Help shape the product. $3.99/month for everyone else &mdash; includes TL;DR summaries.</p>
+            <p class="pricing-card__price">$3.99<span class="pricing-card__price-suffix">/mo</span></p>
+            <p class="pricing-card__description">Be one of the first 100 founding members. $3.99/mo, locked at this rate forever. Help shape the product. Includes TL;DR summaries.</p>
             <ul class="pricing-card__features">
               <li class="pricing-card__feature">Save unlimited articles</li>
               <li class="pricing-card__feature">Firefox and Chrome extensions</li>

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.component.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.component.ts
@@ -9,8 +9,8 @@ const FOUNDING_PROGRESS_TEMPLATE = readFileSync(
 	"utf-8",
 );
 
-export function renderFoundingProgress(input: { userCount: number; caption?: string }): string {
-	const { userCount, caption } = input;
+export function renderFoundingProgress(input: { userCount: number }): string {
+	const { userCount } = input;
 	const progressPercent = Math.min(
 		Math.round((userCount / FOUNDING_MEMBER_LIMIT) * 100),
 		100,
@@ -23,7 +23,6 @@ export function renderFoundingProgress(input: { userCount: number; caption?: str
 		userCount,
 		foundingMemberLimit: FOUNDING_MEMBER_LIMIT,
 		progressPercent,
-		exhaustedStateClass,
-		caption,
+		exhaustedStateClass
 	});
 }

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.styles.css
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.styles.css
@@ -25,13 +25,6 @@
   font-weight: 500;
 }
 
-.founding-progress__caption {
-  font-size: 0.75rem;
-  color: var(--muted-foreground);
-  margin-top: 4px;
-  line-height: 1.4;
-}
-
 .founding-progress__exhausted {
   font-size: 0.875rem;
   color: var(--muted-foreground);

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.template.html
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.template.html
@@ -4,5 +4,5 @@
   </div>
   <p class="founding-progress__label">{{userCount}} / {{foundingMemberLimit}} founding members</p>
   {{#if caption}}<p class="founding-progress__caption" data-test-founding-caption>{{caption}}</p>{{/if}}
-  <p class="founding-progress__exhausted {{exhaustedStateClass}}" data-test-founding-exhausted>All 100 founding member spots have been claimed. New accounts are $3.99/mo.</p>
+  <p class="founding-progress__exhausted {{exhaustedStateClass}}" data-test-founding-exhausted>The free allocation has been exhausted. You might still be able to create an account for free while I develop the pricing system but it may require payment if you registered after the first 100 founding members.</p>
 </div>

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.template.html
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.template.html
@@ -3,6 +3,5 @@
     <div class="founding-progress__fill" style="width: {{progressPercent}}%"></div>
   </div>
   <p class="founding-progress__label">{{userCount}} / {{foundingMemberLimit}} founding members</p>
-  {{#if caption}}<p class="founding-progress__caption" data-test-founding-caption>{{caption}}</p>{{/if}}
-  <p class="founding-progress__exhausted {{exhaustedStateClass}}" data-test-founding-exhausted>The free allocation has been exhausted. You might still be able to create an account for free while I develop the pricing system but it may require payment if you registered after the first 100 founding members.</p>
+  <p class="founding-progress__exhausted {{exhaustedStateClass}}" data-test-founding-exhausted>The free allocation has been exhausted. Join now for only $3.99/month.</p>
 </div>

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.template.html
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.template.html
@@ -4,5 +4,5 @@
   </div>
   <p class="founding-progress__label">{{userCount}} / {{foundingMemberLimit}} founding members</p>
   {{#if caption}}<p class="founding-progress__caption" data-test-founding-caption>{{caption}}</p>{{/if}}
-  <p class="founding-progress__exhausted {{exhaustedStateClass}}" data-test-founding-exhausted>The free allocation has been exhausted. You might still be able to create an account for free while I develop the pricing system but it may require payment in a few months.</p>
+  <p class="founding-progress__exhausted {{exhaustedStateClass}}" data-test-founding-exhausted>All 100 founding member spots have been claimed. New accounts are $3.99/mo.</p>
 </div>


### PR DESCRIPTION
Email and Google sign-ups now redirect to a Stripe Checkout session for the
$3.99/mo founding-member subscription before any user row is persisted. The
account is only created after Stripe reports the session as paid via the new
GET /auth/checkout/success callback.

- Add a `stripe-checkout` provider (real fetch-based + in-memory test impl)
  exposing `createCheckoutSession` / `retrieveCheckoutSession`.
- Add a `pending-signup` provider (DynamoDB + in-memory) keyed by Stripe
  checkout session id with a 1h TTL so an abandoned checkout cannot leave
  hashed credentials lingering.
- Add `createUserWithPasswordHash` to the auth provider so the email signup
  flow can hash before the redirect and persist the hash unchanged after the
  Stripe round-trip.
- Re-route POST /signup and the Google OAuth callback for new accounts through
  Stripe; the success route validates payment, consumes the pending signup,
  finalizes the account, sets the session cookie, and (for email signups)
  fires the verification email.
- Validate `return` URLs both before storing and after consuming the pending
  signup so an attacker cannot smuggle an off-origin redirect through the
  Stripe boundary.
- Provision the `hutch-pending-signups` DynamoDB table and pipe
  `STRIPE_SECRET_KEY` / `STRIPE_PRICE_ID` env vars into the Lambda; add the
  matching `dynamodbPendingSignupsTable` config to both Pulumi stacks.