### PR TITLE
fix(save-link): mark summary failed when crawl DLQ fires

### DIFF
--- a/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.test.ts
@@ -1,6 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initSaveAnonymousLinkDlqHandler } from "./save-anonymous-link-dlq-handler";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -48,12 +49,14 @@ function createSqsEvent(
 }
 
 describe("initSaveAnonymousLinkDlqHandler", () => {
-	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
+	it("marks the crawl and summary as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initSaveAnonymousLinkDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -68,6 +71,10 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 			url: "https://example.com/failed",
 			reason: "exceeded SQS maxReceiveCount",
 		});
+		expect(markSummaryFailed).toHaveBeenCalledWith({
+			url: "https://example.com/failed",
+			reason: "crawl failed",
+		});
 		expect(publishEvent).toHaveBeenCalledWith({
 			source: "hutch.save-link",
 			detailType: "CrawlArticleFailed",
@@ -81,10 +88,12 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 
 	it("throws on an invalid command envelope", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn();
+		const markSummaryFailed: MarkSummaryFailed = jest.fn();
 		const publishEvent: PublishEvent = jest.fn();
 
 		const handler = initSaveAnonymousLinkDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -105,6 +114,7 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 
 		await expect(handler(invalidEvent, stubContext, () => {})).rejects.toThrow();
 		expect(markCrawlFailed).not.toHaveBeenCalled();
+		expect(markSummaryFailed).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 });

--- a/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.ts
@@ -6,9 +6,11 @@ import {
 	SaveAnonymousLinkCommand,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 
 interface SaveAnonymousLinkDlqHandlerDeps {
 	markCrawlFailed: MarkCrawlFailed;
+	markSummaryFailed: MarkSummaryFailed;
 	publishEvent: PublishEvent;
 	logger: HutchLogger;
 }
@@ -17,7 +19,7 @@ interface SaveAnonymousLinkDlqHandlerDeps {
 export function initSaveAnonymousLinkDlqHandler(
 	deps: SaveAnonymousLinkDlqHandlerDeps,
 ): SQSHandler {
-	const { markCrawlFailed, publishEvent, logger } = deps;
+	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -32,6 +34,7 @@ export function initSaveAnonymousLinkDlqHandler(
 			});
 
 			await markCrawlFailed({ url: command.url, reason });
+			await markSummaryFailed({ url: command.url, reason: "crawl failed" });
 
 			await publishEvent({
 				source: CrawlArticleFailedEvent.source,

--- a/projects/save-link/src/crawl-article-state/save-link-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-dlq-handler.test.ts
@@ -1,6 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initSaveLinkDlqHandler } from "./save-link-dlq-handler";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -48,12 +49,14 @@ function createSqsEvent(
 }
 
 describe("initSaveLinkDlqHandler", () => {
-	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
+	it("marks the crawl and summary as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initSaveLinkDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -68,6 +71,10 @@ describe("initSaveLinkDlqHandler", () => {
 			url: "https://example.com/failed",
 			reason: "exceeded SQS maxReceiveCount",
 		});
+		expect(markSummaryFailed).toHaveBeenCalledWith({
+			url: "https://example.com/failed",
+			reason: "crawl failed",
+		});
 		expect(publishEvent).toHaveBeenCalledWith({
 			source: "hutch.save-link",
 			detailType: "CrawlArticleFailed",
@@ -81,10 +88,12 @@ describe("initSaveLinkDlqHandler", () => {
 
 	it("throws on an invalid command envelope", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn();
+		const markSummaryFailed: MarkSummaryFailed = jest.fn();
 		const publishEvent: PublishEvent = jest.fn();
 
 		const handler = initSaveLinkDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -105,6 +114,7 @@ describe("initSaveLinkDlqHandler", () => {
 
 		await expect(handler(invalidEvent, stubContext, () => {})).rejects.toThrow();
 		expect(markCrawlFailed).not.toHaveBeenCalled();
+		expect(markSummaryFailed).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 });

--- a/projects/save-link/src/crawl-article-state/save-link-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-dlq-handler.ts
@@ -6,16 +6,18 @@ import {
 	SaveLinkCommand,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 
 interface SaveLinkDlqHandlerDeps {
 	markCrawlFailed: MarkCrawlFailed;
+	markSummaryFailed: MarkSummaryFailed;
 	publishEvent: PublishEvent;
 	logger: HutchLogger;
 }
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initSaveLinkDlqHandler(deps: SaveLinkDlqHandlerDeps): SQSHandler {
-	const { markCrawlFailed, publishEvent, logger } = deps;
+	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -30,6 +32,7 @@ export function initSaveLinkDlqHandler(deps: SaveLinkDlqHandlerDeps): SQSHandler
 			});
 
 			await markCrawlFailed({ url: command.url, reason });
+			await markSummaryFailed({ url: command.url, reason: "crawl failed" });
 
 			await publishEvent({
 				source: CrawlArticleFailedEvent.source,

--- a/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.test.ts
@@ -1,6 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initSaveLinkRawHtmlDlqHandler } from "./save-link-raw-html-dlq-handler";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -48,12 +49,14 @@ function createSqsEvent(
 }
 
 describe("initSaveLinkRawHtmlDlqHandler", () => {
-	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
+	it("marks the crawl and summary as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initSaveLinkRawHtmlDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -68,6 +71,10 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 			url: "https://example.com/failed",
 			reason: "exceeded SQS maxReceiveCount",
 		});
+		expect(markSummaryFailed).toHaveBeenCalledWith({
+			url: "https://example.com/failed",
+			reason: "crawl failed",
+		});
 		expect(publishEvent).toHaveBeenCalledWith({
 			source: "hutch.save-link",
 			detailType: "CrawlArticleFailed",
@@ -81,10 +88,12 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 
 	it("throws on an invalid command envelope", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn();
+		const markSummaryFailed: MarkSummaryFailed = jest.fn();
 		const publishEvent: PublishEvent = jest.fn();
 
 		const handler = initSaveLinkRawHtmlDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -105,6 +114,7 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 
 		await expect(handler(invalidEvent, stubContext, () => {})).rejects.toThrow();
 		expect(markCrawlFailed).not.toHaveBeenCalled();
+		expect(markSummaryFailed).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 });

--- a/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.ts
@@ -6,16 +6,18 @@ import {
 	SaveLinkRawHtmlCommand,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 
 interface SaveLinkRawHtmlDlqHandlerDeps {
 	markCrawlFailed: MarkCrawlFailed;
+	markSummaryFailed: MarkSummaryFailed;
 	publishEvent: PublishEvent;
 	logger: HutchLogger;
 }
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initSaveLinkRawHtmlDlqHandler(deps: SaveLinkRawHtmlDlqHandlerDeps): SQSHandler {
-	const { markCrawlFailed, publishEvent, logger } = deps;
+	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -30,6 +32,7 @@ export function initSaveLinkRawHtmlDlqHandler(deps: SaveLinkRawHtmlDlqHandlerDep
 			});
 
 			await markCrawlFailed({ url: command.url, reason });
+			await markSummaryFailed({ url: command.url, reason: "crawl failed" });
 
 			await publishEvent({
 				source: CrawlArticleFailedEvent.source,

--- a/projects/save-link/src/runtime/save-anonymous-link-dlq.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-dlq.main.ts
@@ -3,6 +3,7 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { requireEnv } from "../require-env";
 import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initSaveAnonymousLinkDlqHandler } from "../crawl-article-state/save-anonymous-link-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
@@ -15,6 +16,11 @@ const crawlStore = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
+const summaryStore = initDynamoDbGeneratedSummary({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
@@ -22,6 +28,7 @@ const { publishEvent } = initEventBridgePublisher({
 
 export const handler = initSaveAnonymousLinkDlqHandler({
 	markCrawlFailed: crawlStore.markCrawlFailed,
+	markSummaryFailed: summaryStore.markSummaryFailed,
 	publishEvent,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/save-link-dlq.main.ts
+++ b/projects/save-link/src/runtime/save-link-dlq.main.ts
@@ -3,6 +3,7 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { requireEnv } from "../require-env";
 import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initSaveLinkDlqHandler } from "../crawl-article-state/save-link-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
@@ -15,6 +16,11 @@ const crawlStore = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
+const summaryStore = initDynamoDbGeneratedSummary({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
@@ -22,6 +28,7 @@ const { publishEvent } = initEventBridgePublisher({
 
 export const handler = initSaveLinkDlqHandler({
 	markCrawlFailed: crawlStore.markCrawlFailed,
+	markSummaryFailed: summaryStore.markSummaryFailed,
 	publishEvent,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/save-link-raw-html-dlq.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-dlq.main.ts
@@ -3,6 +3,7 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { requireEnv } from "../require-env";
 import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initSaveLinkRawHtmlDlqHandler } from "../crawl-article-state/save-link-raw-html-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
@@ -15,6 +16,11 @@ const crawlStore = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
+const summaryStore = initDynamoDbGeneratedSummary({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
@@ -22,6 +28,7 @@ const { publishEvent } = initEventBridgePublisher({
 
 export const handler = initSaveLinkRawHtmlDlqHandler({
 	markCrawlFailed: crawlStore.markCrawlFailed,
+	markSummaryFailed: summaryStore.markSummaryFailed,
 	publishEvent,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/select-most-complete-content-dlq.main.ts
+++ b/projects/save-link/src/runtime/select-most-complete-content-dlq.main.ts
@@ -3,6 +3,7 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { requireEnv } from "../require-env";
 import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initSelectMostCompleteContentDlqHandler } from "../select-content/select-most-complete-content-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
@@ -15,6 +16,11 @@ const crawlStore = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
+const summaryStore = initDynamoDbGeneratedSummary({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
@@ -22,6 +28,7 @@ const { publishEvent } = initEventBridgePublisher({
 
 export const handler = initSelectMostCompleteContentDlqHandler({
 	markCrawlFailed: crawlStore.markCrawlFailed,
+	markSummaryFailed: summaryStore.markSummaryFailed,
 	publishEvent,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.test.ts
+++ b/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.test.ts
@@ -1,6 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initSelectMostCompleteContentDlqHandler } from "./select-most-complete-content-dlq-handler";
 import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -48,12 +49,14 @@ function createSqsEvent(
 }
 
 describe("initSelectMostCompleteContentDlqHandler", () => {
-	it("marks crawl failed and publishes CrawlArticleFailedEvent when a TierContentExtractedEvent message exhausts retries", async () => {
+	it("marks crawl and summary failed and publishes CrawlArticleFailedEvent when a TierContentExtractedEvent message exhausts retries", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initSelectMostCompleteContentDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -68,6 +71,10 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 			url: "https://example.com/failed",
 			reason: "exceeded SQS maxReceiveCount",
 		});
+		expect(markSummaryFailed).toHaveBeenCalledWith({
+			url: "https://example.com/failed",
+			reason: "crawl failed",
+		});
 		expect(publishEvent).toHaveBeenCalledWith({
 			source: "hutch.save-link",
 			detailType: "CrawlArticleFailed",
@@ -81,10 +88,12 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 
 	it("works without userId (anonymous source)", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initSelectMostCompleteContentDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -102,6 +111,7 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 	it("throws on invalid envelope detail", async () => {
 		const handler = initSelectMostCompleteContentDlqHandler({
 			markCrawlFailed: jest.fn(),
+			markSummaryFailed: jest.fn(),
 			publishEvent: jest.fn(),
 			logger: noopLogger,
 		});

--- a/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.ts
+++ b/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.ts
@@ -6,9 +6,11 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 
 interface SelectMostCompleteContentDlqHandlerDeps {
 	markCrawlFailed: MarkCrawlFailed;
+	markSummaryFailed: MarkSummaryFailed;
 	publishEvent: PublishEvent;
 	logger: HutchLogger;
 }
@@ -17,7 +19,7 @@ interface SelectMostCompleteContentDlqHandlerDeps {
 export function initSelectMostCompleteContentDlqHandler(
 	deps: SelectMostCompleteContentDlqHandlerDeps,
 ): SQSHandler {
-	const { markCrawlFailed, publishEvent, logger } = deps;
+	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -33,6 +35,7 @@ export function initSelectMostCompleteContentDlqHandler(
 			});
 
 			await markCrawlFailed({ url: detail.url, reason });
+			await markSummaryFailed({ url: detail.url, reason: "crawl failed" });
 
 			await publishEvent({
 				source: CrawlArticleFailedEvent.source,


### PR DESCRIPTION
When a crawl message exhausts SQS maxReceiveCount, the DLQ handler marks crawlStatus=failed but left summaryStatus=pending — the summary pipeline never fires because no content arrives. Add markSummaryFailed to all four crawl DLQ handlers so summaryStatus reaches a terminal state alongside crawlStatus.

Closes #204

Generated with [Claude Code](https://claude.ai/code)