### PR TITLE
Simplify RESEND_API_KEY environment variable handling

### DIFF
--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -8,7 +8,7 @@ import { DomainRegistration } from "./domain-registration";
 import { DomainRedirect } from "./domain-redirect";
 import { HutchStorage } from "./hutch-storage";
 import { HutchStaticAssets } from "./hutch-static-assets";
-import { getEnv, requireEnv } from "../runtime/require-env";
+import { requireEnv } from "../runtime/require-env";
 
 const config = new pulumi.Config();
 const stage = config.require("stage");
@@ -139,9 +139,7 @@ const lambda = new HutchLambda("hutch", {
 		DYNAMODB_PASSWORD_RESET_TOKENS_TABLE: storage.passwordResetTokensTable.name,
 		GOOGLE_LOGIN_CLIENT_ID: requireEnv("GOOGLE_LOGIN_CLIENT_ID"),
 		GOOGLE_LOGIN_CLIENT_SECRET: requireEnv("GOOGLE_LOGIN_CLIENT_SECRET"),
-		RESEND_API_KEY: pulumi.runtime.isDryRun()
-			? (getEnv("RESEND_API_KEY") ?? "")
-			: requireEnv("RESEND_API_KEY"),
+		RESEND_API_KEY: requireEnv("RESEND_API_KEY"),
 		STATIC_BASE_URL: staticAssets.baseUrl,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		CONTENT_BUCKET_NAME: contentBucketName,


### PR DESCRIPTION
## Summary
Removed special-case handling for the `RESEND_API_KEY` environment variable during dry runs, simplifying the configuration logic by treating it consistently with other required environment variables.

## Changes
- Removed the `getEnv` import from `require-env` module as it's no longer needed
- Replaced conditional logic that allowed `RESEND_API_KEY` to be optional during dry runs with a straightforward `requireEnv()` call
- This ensures `RESEND_API_KEY` is always required, matching the behavior of other critical environment variables like `GOOGLE_LOGIN_CLIENT_ID` and `GOOGLE_LOGIN_CLIENT_SECRET`

## Implementation Details
The previous implementation used `pulumi.runtime.isDryRun()` to conditionally fall back to an empty string if the environment variable was missing during dry runs. This has been simplified to always require the variable, reducing code complexity and ensuring consistent environment variable validation across all deployment scenarios.

https://claude.ai/code/session_01PjKKo58uQvqeazLRSDJxG2