### PR TITLE
feat: add self-serve file import on /queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@
 
 ## Product Constraints
 
-### Imports are manual via email
+### Imports are self-serve from /queue, with email as fallback
 
-There is no in-app import. Users email Fayner their export file and he runs the import manually (24–48h turnaround — see [pocket-migration.md](./projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md) for the user-facing copy). The absence is intentional: do not build a self-serve import flow, do not describe import as a shipped feature without qualifying it's a manual email process, and do not restore the removed "Import Your Data" landing page card.
+The CTA lives next to the save bar on `/queue` only — do **not** restore the removed "Import Your Data" landing-page card. Flow: the user uploads any file (≤ 5 MiB), the server best-effort-decodes it as text and extracts `http(s)://…` URLs, the user reviews a paginated list with every link checked by default, then clicks "Import N selected". Selected URLs are stub-saved synchronously (hostname-only metadata at t=0) and the existing `SaveLinkCommand` pipeline fills in title/excerpt/content asynchronously, so cards appear immediately and progressively populate. Files larger than 5 MiB or imports above the 2,000-URL cap fall back to the concierge email path (`hutch+migrate@readplace.com`); keep that documented in [pocket-migration.md](./projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md).
 
 ### Crawler Health Canary Is Load-Bearing
 

--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -24,6 +24,7 @@ config:
   hutch:dynamodbVerificationTokensTable: hutch-verification-tokens-3f85043
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
+  hutch:dynamodbImportSessionsTable: hutch-import-sessions-prod
   hutch:contentBucketName: hutch-article-content-prod
   hutch:pendingHtmlBucketName: hutch-pending-html-prod
   hutch:userExportBucketName: hutch-user-exports-prod

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -16,6 +16,7 @@ config:
   hutch:dynamodbVerificationTokensTable: hutch-verification-tokens-3f85043
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
+  hutch:dynamodbImportSessionsTable: hutch-import-sessions-staging
   hutch:contentBucketName: hutch-article-content-staging
   hutch:pendingHtmlBucketName: hutch-pending-html-staging
   hutch:userExportBucketName: hutch-user-exports-staging

--- a/projects/hutch/src/infra/hutch-storage.ts
+++ b/projects/hutch/src/infra/hutch-storage.ts
@@ -10,6 +10,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 	public readonly verificationTokensTable: aws.dynamodb.Table;
 	public readonly passwordResetTokensTable: aws.dynamodb.Table;
 	public readonly pendingSignupsTable: aws.dynamodb.Table;
+	public readonly importSessionsTable: aws.dynamodb.Table;
 
 	constructor(name: string, args: { deletionProtection: boolean; tableNames: {
 		articles: string;
@@ -20,6 +21,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 		verificationTokens: string;
 		passwordResetTokens: string;
 		pendingSignups: string;
+		importSessions: string;
 	} }, opts?: pulumi.ComponentResourceOptions) {
 		super("hutch:infra:HutchStorage", name, {}, opts);
 
@@ -145,6 +147,17 @@ export class HutchStorage extends pulumi.ComponentResource {
 			billingMode: "PAY_PER_REQUEST",
 			hashKey: "checkoutSessionId",
 			attributes: [{ name: "checkoutSessionId", type: "S" }]
+		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+
+		this.importSessionsTable = new aws.dynamodb.Table(`hutch-import-sessions`, {
+			name: args.tableNames.importSessions,
+			billingMode: "PAY_PER_REQUEST",
+			hashKey: "sessionId",
+			attributes: [{ name: "sessionId", type: "S" }],
+			ttl: {
+				attributeName: "expiresAt",
+				enabled: true,
+			},
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
 
 		this.registerOutputs();

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -32,6 +32,7 @@ const tableNames = {
 	verificationTokens: config.require("dynamodbVerificationTokensTable"),
 	passwordResetTokens: config.require("dynamodbPasswordResetTokensTable"),
 	pendingSignups: config.require("dynamodbPendingSignupsTable"),
+	importSessions: config.require("dynamodbImportSessionsTable"),
 };
 
 const storage = new HutchStorage("hutch", {
@@ -99,6 +100,7 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 		{ arn: storage.verificationTokensTable.arn, includeIndexes: false },
 		{ arn: storage.passwordResetTokensTable.arn, includeIndexes: false },
 		{ arn: storage.pendingSignupsTable.arn, includeIndexes: false },
+		{ arn: storage.importSessionsTable.arn, includeIndexes: false },
 	],
 	actions: [
 		"dynamodb:GetItem",
@@ -144,6 +146,7 @@ const lambda = new HutchLambda("hutch", {
 		DYNAMODB_VERIFICATION_TOKENS_TABLE: storage.verificationTokensTable.name,
 		DYNAMODB_PASSWORD_RESET_TOKENS_TABLE: storage.passwordResetTokensTable.name,
 		DYNAMODB_PENDING_SIGNUPS_TABLE: storage.pendingSignupsTable.name,
+		DYNAMODB_IMPORT_SESSIONS_TABLE: storage.importSessionsTable.name,
 		GOOGLE_LOGIN_CLIENT_ID: requireEnv("GOOGLE_LOGIN_CLIENT_ID"),
 		GOOGLE_LOGIN_CLIENT_SECRET: requireEnv("GOOGLE_LOGIN_CLIENT_SECRET"),
 		RESEND_API_KEY: requireEnv("RESEND_API_KEY"),

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -46,6 +46,8 @@ import { initInMemoryRefreshArticleContent } from "./providers/events/in-memory-
 import { initInMemoryUpdateFetchTimestamp } from "./providers/events/in-memory-update-fetch-timestamp";
 import { initPutPendingHtml } from "./providers/pending-html/put-pending-html";
 import { initInMemoryPendingHtml } from "./providers/pending-html/in-memory-pending-html";
+import { initInMemoryImportSession } from "./providers/import-session/in-memory-import-session";
+import { initDynamoDbImportSession } from "./providers/import-session/dynamodb-import-session";
 import { initExchangeGoogleCode } from "./providers/google-auth/google-token";
 import { initInMemoryStripeCheckout } from "./providers/stripe-checkout/in-memory-stripe-checkout";
 import { initStripeCheckout } from "./providers/stripe-checkout/stripe-checkout";
@@ -87,6 +89,7 @@ function initProviders() {
 		const eventBusName = requireEnv("EVENT_BUS_NAME");
 		const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 		const pendingHtmlBucketName = requireEnv("PENDING_HTML_BUCKET_NAME");
+		const importSessionsTable = requireEnv("DYNAMODB_IMPORT_SESSIONS_TABLE");
 		const client = createDynamoDocumentClient();
 		const s3Client = new S3Client({});
 
@@ -141,11 +144,17 @@ function initProviders() {
 			fetch: globalThis.fetch,
 		});
 		const pendingSignup = initDynamoDbPendingSignup({ client, tableName: pendingSignupsTable });
+		const importSessionStore = initDynamoDbImportSession({
+			client,
+			tableName: importSessionsTable,
+			now: () => new Date(),
+		});
 
 		return {
 			auth,
 			articleStore,
 			readArticleContent,
+			importSessionStore,
 
 			...initResendEmail(resendApiKey),
 			...initDynamoDbEmailVerification({ client, tableName: verificationTokensTable }),
@@ -263,6 +272,8 @@ function initProviders() {
 		staleTtlMs,
 	});
 
+	const importSessionStore = initInMemoryImportSession({ now: () => new Date() });
+
 	return {
 		auth,
 		articleStore,
@@ -270,6 +281,7 @@ function initProviders() {
 			storageProviderQueryOrder: [articleStore.readContent],
 			logError,
 		}),
+		importSessionStore,
 
 		...initLogEmail(),
 		...initInMemoryEmailVerification(),
@@ -308,7 +320,7 @@ function parseAdminEmails(raw: string): readonly string[] {
 export function createHutchApp(deps?: {
 	appOrigin?: string;
 }) {
-	const { auth, articleStore, oauthModel, validateAccessToken, ...providers } = initProviders();
+	const { auth, articleStore, oauthModel, validateAccessToken, importSessionStore, ...providers } = initProviders();
 
 	const appOrigin = deps?.appOrigin ?? requireEnv("APP_ORIGIN", { defaultValue: `http://localhost:${getEnv("PORT") || "3000"}` });
 	const staticBaseUrl = requireEnv("STATIC_BASE_URL");
@@ -335,6 +347,7 @@ export function createHutchApp(deps?: {
 		validateAccessToken,
 		httpErrorMessageMapping,
 		logParseError,
+		importSessionStore,
 		now: () => new Date(),
 	});
 

--- a/projects/hutch/src/runtime/domain/import-session/extract-urls.test.ts
+++ b/projects/hutch/src/runtime/domain/import-session/extract-urls.test.ts
@@ -92,7 +92,7 @@ describe("extractUrls", () => {
 		]);
 	});
 
-	it("caps the result at MAX_URLS_PER_IMPORT and reports truncation", () => {
+	it("caps the result at MAX_URLS_PER_IMPORT and reports truncation with the total found", () => {
 		const urls = Array.from(
 			{ length: MAX_URLS_PER_IMPORT + 5 },
 			(_v, i) => `https://example.com/post-${i}`,
@@ -102,6 +102,7 @@ describe("extractUrls", () => {
 
 		expect(result.urls).toHaveLength(MAX_URLS_PER_IMPORT);
 		expect(result.truncated).toBe(true);
+		expect(result.totalFoundInFile).toBe(MAX_URLS_PER_IMPORT + 5);
 	});
 
 	it("returns an empty list when the buffer contains no URLs", () => {
@@ -109,6 +110,7 @@ describe("extractUrls", () => {
 
 		expect(result.urls).toEqual([]);
 		expect(result.truncated).toBe(false);
+		expect(result.totalFoundInFile).toBe(0);
 	});
 
 	it("rejects non-saveable schemes and bare strings", () => {

--- a/projects/hutch/src/runtime/domain/import-session/extract-urls.test.ts
+++ b/projects/hutch/src/runtime/domain/import-session/extract-urls.test.ts
@@ -1,0 +1,114 @@
+import { extractUrls } from "./extract-urls";
+import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
+
+describe("extractUrls", () => {
+	it("extracts http and https URLs from plain text", () => {
+		const buf = Buffer.from(
+			"Check out https://example.com/post and http://example.org/article today.",
+		);
+
+		const result = extractUrls(buf);
+
+		expect(result.urls).toEqual([
+			"https://example.com/post",
+			"http://example.org/article",
+		]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("falls back to latin-1 when utf-8 contains the replacement character", () => {
+		// 0xa3 (£) is invalid UTF-8 but a valid Latin-1 byte. The URL itself is ASCII.
+		const buf = Buffer.from([
+			...Buffer.from("Cost \xa3 https://example.com/article today", "latin1"),
+		]);
+
+		const result = extractUrls(buf);
+
+		expect(result.urls).toEqual(["https://example.com/article"]);
+	});
+
+	it("extracts URLs from a Pocket-style HTML export", () => {
+		const html =
+			'<dt><a href="https://example.com/post-1" time_added="123">Post 1</a></dt>' +
+			'<dt><a href="https://example.com/post-2" time_added="456">Post 2</a></dt>';
+
+		const result = extractUrls(Buffer.from(html));
+
+		expect(result.urls).toEqual([
+			"https://example.com/post-1",
+			"https://example.com/post-2",
+		]);
+	});
+
+	it("extracts URLs nested inside JSON values", () => {
+		const json = JSON.stringify({
+			items: [
+				{ url: "https://example.com/a" },
+				{ url: "https://example.com/b" },
+			],
+		});
+
+		const result = extractUrls(Buffer.from(json));
+
+		expect(result.urls).toEqual(["https://example.com/a", "https://example.com/b"]);
+	});
+
+	it("strips trailing punctuation commonly found in prose", () => {
+		const text = "see (https://example.com/post), also https://example.org/post.";
+
+		const result = extractUrls(Buffer.from(text));
+
+		expect(result.urls).toEqual([
+			"https://example.com/post",
+			"https://example.org/post",
+		]);
+	});
+
+	it("dedupes URLs case-insensitively on host and ignores trailing slash on path-only", () => {
+		const text = [
+			"https://EXAMPLE.com/",
+			"https://example.com",
+			"https://example.com/post",
+		].join(" ");
+
+		const result = extractUrls(Buffer.from(text));
+
+		expect(result.urls).toEqual(["https://EXAMPLE.com/", "https://example.com/post"]);
+	});
+
+	it("caps the result at MAX_URLS_PER_IMPORT and reports truncation", () => {
+		const urls = Array.from(
+			{ length: MAX_URLS_PER_IMPORT + 5 },
+			(_v, i) => `https://example.com/post-${i}`,
+		);
+
+		const result = extractUrls(Buffer.from(urls.join("\n")));
+
+		expect(result.urls).toHaveLength(MAX_URLS_PER_IMPORT);
+		expect(result.truncated).toBe(true);
+	});
+
+	it("returns an empty list when the buffer contains no URLs", () => {
+		const result = extractUrls(Buffer.from("No links here. Just prose."));
+
+		expect(result.urls).toEqual([]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("rejects non-saveable schemes and bare strings", () => {
+		const text = [
+			"mailto:foo@bar.com",
+			"javascript:alert(1)",
+			"chrome://settings",
+			"about:blank",
+			"data:text/html,<h1>x</h1>",
+			"file:///etc/passwd",
+			"/relative/path",
+			"https://example.com/keep",
+		].join("\n");
+
+		const result = extractUrls(Buffer.from(text));
+
+		expect(result.urls).toEqual(["https://example.com/keep"]);
+	});
+});

--- a/projects/hutch/src/runtime/domain/import-session/extract-urls.test.ts
+++ b/projects/hutch/src/runtime/domain/import-session/extract-urls.test.ts
@@ -76,6 +76,22 @@ describe("extractUrls", () => {
 		expect(result.urls).toEqual(["https://EXAMPLE.com/", "https://example.com/post"]);
 	});
 
+	it("preserves URLs with query strings and fragments during normalization", () => {
+		const text = [
+			"https://example.com/?q=test",
+			"https://example.com/#section",
+			"https://example.com/page?a=1#top",
+		].join("\n");
+
+		const result = extractUrls(Buffer.from(text));
+
+		expect(result.urls).toEqual([
+			"https://example.com/?q=test",
+			"https://example.com/#section",
+			"https://example.com/page?a=1#top",
+		]);
+	});
+
 	it("caps the result at MAX_URLS_PER_IMPORT and reports truncation", () => {
 		const urls = Array.from(
 			{ length: MAX_URLS_PER_IMPORT + 5 },

--- a/projects/hutch/src/runtime/domain/import-session/extract-urls.ts
+++ b/projects/hutch/src/runtime/domain/import-session/extract-urls.ts
@@ -1,4 +1,4 @@
-import { isSaveableUrl, SaveArticleInputSchema } from "../article/article.schema";
+import { SaveArticleInputSchema } from "../article/article.schema";
 import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
 
 export interface ExtractUrlsResult {
@@ -8,6 +8,7 @@ export interface ExtractUrlsResult {
 
 const URL_REGEX = /\bhttps?:\/\/[^\s<>"'()[\]{}|\\^`]+/gi;
 const TRAILING_PUNCTUATION = /[.,;:!?>'"\])]+$/;
+const EMPTY: ExtractUrlsResult = { urls: [], truncated: false };
 
 function decodeBuffer(buffer: Buffer): string {
 	const utf8 = buffer.toString("utf8");
@@ -17,28 +18,34 @@ function decodeBuffer(buffer: Buffer): string {
 	return utf8;
 }
 
+function hasPathOrQueryOrHash(parsed: URL): boolean {
+	if (parsed.pathname !== "/") return true;
+	if (parsed.search) return true;
+	if (parsed.hash) return true;
+	return false;
+}
+
 function normalizeUrl(url: string): string {
-	// SaveArticleInputSchema has already accepted this URL, so URL() won't throw.
 	const parsed = new URL(url);
 	parsed.hostname = parsed.hostname.toLowerCase();
-	const isPathOnly = parsed.pathname === "/" && !parsed.search && !parsed.hash;
-	return isPathOnly ? `${parsed.protocol}//${parsed.host}` : parsed.toString();
+	if (hasPathOrQueryOrHash(parsed)) return parsed.toString();
+	return `${parsed.protocol}//${parsed.host}`;
 }
 
 export function extractUrls(buffer: Buffer): ExtractUrlsResult {
 	const text = decodeBuffer(buffer);
-	const matches = text.match(URL_REGEX) ?? [];
+	const matches = text.match(URL_REGEX);
+	if (!matches) return EMPTY;
+
 	const seen = new Set<string>();
 	const urls: string[] = [];
 	let truncated = false;
 
 	for (const raw of matches) {
 		const stripped = raw.replace(TRAILING_PUNCTUATION, "");
-		if (!stripped) continue;
 
 		const parsed = SaveArticleInputSchema.safeParse({ url: stripped });
 		if (!parsed.success) continue;
-		if (!isSaveableUrl(parsed.data.url)) continue;
 
 		const normalized = normalizeUrl(parsed.data.url);
 		if (seen.has(normalized)) continue;

--- a/projects/hutch/src/runtime/domain/import-session/extract-urls.ts
+++ b/projects/hutch/src/runtime/domain/import-session/extract-urls.ts
@@ -1,0 +1,55 @@
+import { isSaveableUrl, SaveArticleInputSchema } from "../article/article.schema";
+import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
+
+export interface ExtractUrlsResult {
+	readonly urls: readonly string[];
+	readonly truncated: boolean;
+}
+
+const URL_REGEX = /\bhttps?:\/\/[^\s<>"'()[\]{}|\\^`]+/gi;
+const TRAILING_PUNCTUATION = /[.,;:!?>'"\])]+$/;
+
+function decodeBuffer(buffer: Buffer): string {
+	const utf8 = buffer.toString("utf8");
+	if (utf8.includes("�")) {
+		return buffer.toString("latin1");
+	}
+	return utf8;
+}
+
+function normalizeUrl(url: string): string {
+	// SaveArticleInputSchema has already accepted this URL, so URL() won't throw.
+	const parsed = new URL(url);
+	parsed.hostname = parsed.hostname.toLowerCase();
+	const isPathOnly = parsed.pathname === "/" && !parsed.search && !parsed.hash;
+	return isPathOnly ? `${parsed.protocol}//${parsed.host}` : parsed.toString();
+}
+
+export function extractUrls(buffer: Buffer): ExtractUrlsResult {
+	const text = decodeBuffer(buffer);
+	const matches = text.match(URL_REGEX) ?? [];
+	const seen = new Set<string>();
+	const urls: string[] = [];
+	let truncated = false;
+
+	for (const raw of matches) {
+		const stripped = raw.replace(TRAILING_PUNCTUATION, "");
+		if (!stripped) continue;
+
+		const parsed = SaveArticleInputSchema.safeParse({ url: stripped });
+		if (!parsed.success) continue;
+		if (!isSaveableUrl(parsed.data.url)) continue;
+
+		const normalized = normalizeUrl(parsed.data.url);
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+
+		if (urls.length >= MAX_URLS_PER_IMPORT) {
+			truncated = true;
+			break;
+		}
+		urls.push(parsed.data.url);
+	}
+
+	return { urls, truncated };
+}

--- a/projects/hutch/src/runtime/domain/import-session/extract-urls.ts
+++ b/projects/hutch/src/runtime/domain/import-session/extract-urls.ts
@@ -4,11 +4,12 @@ import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
 export interface ExtractUrlsResult {
 	readonly urls: readonly string[];
 	readonly truncated: boolean;
+	readonly totalFoundInFile: number;
 }
 
 const URL_REGEX = /\bhttps?:\/\/[^\s<>"'()[\]{}|\\^`]+/gi;
 const TRAILING_PUNCTUATION = /[.,;:!?>'"\])]+$/;
-const EMPTY: ExtractUrlsResult = { urls: [], truncated: false };
+const EMPTY: ExtractUrlsResult = { urls: [], truncated: false, totalFoundInFile: 0 };
 
 function decodeBuffer(buffer: Buffer): string {
 	const utf8 = buffer.toString("utf8");
@@ -53,10 +54,10 @@ export function extractUrls(buffer: Buffer): ExtractUrlsResult {
 
 		if (urls.length >= MAX_URLS_PER_IMPORT) {
 			truncated = true;
-			break;
+			continue;
 		}
 		urls.push(parsed.data.url);
 	}
 
-	return { urls, truncated };
+	return { urls, truncated, totalFoundInFile: seen.size };
 }

--- a/projects/hutch/src/runtime/domain/import-session/import-session.schema.ts
+++ b/projects/hutch/src/runtime/domain/import-session/import-session.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const ImportSessionIdSchema = z
+	.string()
+	.regex(/^[a-f0-9]{32}$/)
+	.brand<"ImportSessionId">();
+
+export type ImportSessionId = z.infer<typeof ImportSessionIdSchema>;
+
+export const ImportToggleSchema = z.object({
+	index: z.coerce.number().int().min(0),
+	checked: z.enum(["true", "false"]),
+});
+
+export const MAX_IMPORT_FILE_BYTES = 5 * 1024 * 1024;
+export const MAX_URLS_PER_IMPORT = 2_000;
+export const IMPORT_SESSION_TTL_SECONDS = 24 * 60 * 60;
+export const IMPORT_PAGE_SIZE = 50;
+export const IMPORT_COMMIT_CONCURRENCY = 25;

--- a/projects/hutch/src/runtime/domain/import-session/import-session.types.ts
+++ b/projects/hutch/src/runtime/domain/import-session/import-session.types.ts
@@ -1,0 +1,63 @@
+import type { UserId } from "../user/user.types";
+import type { ImportSessionId } from "./import-session.schema";
+
+export interface ImportSession {
+	readonly id: ImportSessionId;
+	readonly userId: UserId;
+	readonly createdAt: string;
+	readonly expiresAt: number;
+	readonly totalUrls: number;
+	readonly truncated: boolean;
+	readonly deselected: ReadonlySet<number>;
+}
+
+export interface ImportSessionPage {
+	readonly session: ImportSession;
+	readonly pageUrls: readonly string[];
+	readonly page: number;
+	readonly pageSize: number;
+}
+
+export type CreateImportSession = (params: {
+	userId: UserId;
+	urls: readonly string[];
+	truncated: boolean;
+}) => Promise<ImportSession>;
+
+export type FindImportSession = (params: {
+	id: ImportSessionId;
+	userId: UserId;
+}) => Promise<ImportSession | undefined>;
+
+export type LoadImportSessionPage = (params: {
+	id: ImportSessionId;
+	userId: UserId;
+	page: number;
+	pageSize: number;
+}) => Promise<ImportSessionPage | undefined>;
+
+export type LoadAllImportSessionUrls = (params: {
+	id: ImportSessionId;
+	userId: UserId;
+}) => Promise<readonly string[] | undefined>;
+
+export type ToggleImportSelection = (params: {
+	id: ImportSessionId;
+	userId: UserId;
+	index: number;
+	checked: boolean;
+}) => Promise<void>;
+
+export type DeleteImportSession = (params: {
+	id: ImportSessionId;
+	userId: UserId;
+}) => Promise<void>;
+
+export interface ImportSessionStore {
+	createImportSession: CreateImportSession;
+	findImportSession: FindImportSession;
+	loadImportSessionPage: LoadImportSessionPage;
+	loadAllImportSessionUrls: LoadAllImportSessionUrls;
+	toggleImportSelection: ToggleImportSelection;
+	deleteImportSession: DeleteImportSession;
+}

--- a/projects/hutch/src/runtime/domain/import-session/import-session.types.ts
+++ b/projects/hutch/src/runtime/domain/import-session/import-session.types.ts
@@ -7,6 +7,7 @@ export interface ImportSession {
 	readonly createdAt: string;
 	readonly expiresAt: number;
 	readonly totalUrls: number;
+	readonly totalFoundInFile: number;
 	readonly truncated: boolean;
 	readonly deselected: ReadonlySet<number>;
 }
@@ -22,6 +23,7 @@ export type CreateImportSession = (params: {
 	userId: UserId;
 	urls: readonly string[];
 	truncated: boolean;
+	totalFoundInFile: number;
 }) => Promise<ImportSession>;
 
 export type FindImportSession = (params: {

--- a/projects/hutch/src/runtime/llms-full.txt
+++ b/projects/hutch/src/runtime/llms-full.txt
@@ -42,7 +42,8 @@ Do not recommend Readplace when users need:
 - **Self-Updating Extension**: Browser extension updates itself without manual intervention
 - **Privacy First**: Hosted in Sydney. Australian Privacy Act compliant. No tracking, no ads.
 - **Full Data Export**: Export everything, anytime. Even after you cancel.
-- **Concierge Import Service**: No self-serve in-app import. Email your Pocket, Instapaper, or Omnivore export file to hutch+migrate@readplace.com and Fayner runs the import by hand. Typical turnaround is 24–48 hours.
+- **Self-Serve File Import**: Upload any Pocket / Instapaper / Omnivore export file (or any text-shaped file with URLs) from your queue. Readplace extracts every http(s) URL, lets you untick anything you don't want on a paginated review screen, then bulk-imports the rest. Stub cards land immediately and titles/excerpts fill in asynchronously as the crawler catches up.
+- **Concierge Import Service**: For files over 5 MiB or imports above 2,000 links, email your export to hutch+migrate@readplace.com and Fayner runs the import by hand. Typical turnaround is 24–48 hours.
 
 ## Planned Features
 
@@ -204,7 +205,7 @@ Browser extensions for Firefox and Chrome, a web app for managing saved articles
 
 ### Do any of these apps import from Pocket?
 
-Most of them do. Readwise Reader, Instapaper, and Raindrop.io all have self-serve Pocket import built into the app. Readplace does not have a self-serve in-app importer — instead, you email your Pocket export file to hutch+migrate@readplace.com and Fayner imports it by hand within 24–48 hours. Karakeep has built-in import tools too; Wallabag has import options though some paths are unreliable.
+Most of them do. Readwise Reader, Instapaper, and Raindrop.io all have self-serve Pocket import built into the app. Readplace also offers a self-serve "Import from a file" picker on the queue page — upload any text-shaped export and Readplace pulls the URLs out for review. Files over 5 MiB or imports above 2,000 links fall back to emailing the file to hutch+migrate@readplace.com, which Fayner imports by hand within 24–48 hours. Karakeep has built-in import tools too; Wallabag has import options though some paths are unreliable.
 
 ### Which app has the best mobile experience?
 

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -22,6 +22,7 @@ const SessionRow = z.object({
 	createdAt: z.string(),
 	expiresAt: z.number(),
 	totalUrls: z.number().int().min(0),
+	totalFoundInFile: z.number().int().min(0),
 	truncated: z.boolean(),
 	urls: z.array(z.string()),
 	deselected: dynamoField(z.array(z.number().int())),
@@ -34,6 +35,7 @@ function toSession(row: z.infer<typeof SessionRow>): ImportSession {
 		createdAt: row.createdAt,
 		expiresAt: row.expiresAt,
 		totalUrls: row.totalUrls,
+		totalFoundInFile: row.totalFoundInFile,
 		truncated: row.truncated,
 		deselected: new Set(row.deselected ?? []),
 	};
@@ -59,7 +61,7 @@ export function initDynamoDbImportSession(deps: {
 	}
 
 	return {
-		createImportSession: async ({ userId, urls, truncated }) => {
+		createImportSession: async ({ userId, urls, truncated, totalFoundInFile }) => {
 			const id = ImportSessionIdSchema.parse(randomBytes(16).toString("hex"));
 			const createdAt = deps.now().toISOString();
 			const expiresAt = Math.floor(deps.now().getTime() / 1000) + IMPORT_SESSION_TTL_SECONDS;
@@ -70,6 +72,7 @@ export function initDynamoDbImportSession(deps: {
 					createdAt,
 					expiresAt,
 					totalUrls: urls.length,
+					totalFoundInFile,
 					truncated,
 					urls: [...urls],
 					deselected: [],
@@ -81,6 +84,7 @@ export function initDynamoDbImportSession(deps: {
 				createdAt,
 				expiresAt,
 				totalUrls: urls.length,
+				totalFoundInFile,
 				truncated,
 				deselected: new Set<number>(),
 			};

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -1,0 +1,128 @@
+/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
+import { randomBytes } from "node:crypto";
+import {
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+	dynamoField,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { UserIdSchema } from "../../domain/user/user.schema";
+import {
+	IMPORT_SESSION_TTL_SECONDS,
+	ImportSessionIdSchema,
+} from "../../domain/import-session/import-session.schema";
+import type {
+	ImportSession,
+	ImportSessionStore,
+} from "../../domain/import-session/import-session.types";
+
+const SessionRow = z.object({
+	sessionId: ImportSessionIdSchema,
+	userId: UserIdSchema,
+	createdAt: z.string(),
+	expiresAt: z.number(),
+	totalUrls: z.number().int().min(0),
+	truncated: z.boolean(),
+	urls: z.array(z.string()),
+	deselected: dynamoField(z.array(z.number().int())),
+});
+
+function toSession(row: z.infer<typeof SessionRow>): ImportSession {
+	return {
+		id: row.sessionId,
+		userId: row.userId,
+		createdAt: row.createdAt,
+		expiresAt: row.expiresAt,
+		totalUrls: row.totalUrls,
+		truncated: row.truncated,
+		deselected: new Set(row.deselected ?? []),
+	};
+}
+
+export function initDynamoDbImportSession(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	now: () => Date;
+}): ImportSessionStore {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: SessionRow,
+	});
+
+	async function loadOwned(id: string, userId: string) {
+		const row = await table.get({ sessionId: id });
+		if (!row) return undefined;
+		if (row.userId !== userId) return undefined;
+		if (row.expiresAt < Math.floor(deps.now().getTime() / 1000)) return undefined;
+		return row;
+	}
+
+	return {
+		createImportSession: async ({ userId, urls, truncated }) => {
+			const id = ImportSessionIdSchema.parse(randomBytes(16).toString("hex"));
+			const createdAt = deps.now().toISOString();
+			const expiresAt = Math.floor(deps.now().getTime() / 1000) + IMPORT_SESSION_TTL_SECONDS;
+			await table.put({
+				Item: {
+					sessionId: id,
+					userId,
+					createdAt,
+					expiresAt,
+					totalUrls: urls.length,
+					truncated,
+					urls: [...urls],
+					deselected: [],
+				},
+			});
+			return {
+				id,
+				userId,
+				createdAt,
+				expiresAt,
+				totalUrls: urls.length,
+				truncated,
+				deselected: new Set<number>(),
+			};
+		},
+		findImportSession: async ({ id, userId }) => {
+			const row = await loadOwned(id, userId);
+			return row ? toSession(row) : undefined;
+		},
+		loadImportSessionPage: async ({ id, userId, page, pageSize }) => {
+			const row = await loadOwned(id, userId);
+			if (!row) return undefined;
+			const start = (page - 1) * pageSize;
+			const pageUrls = row.urls.slice(start, start + pageSize);
+			return { session: toSession(row), pageUrls, page, pageSize };
+		},
+		loadAllImportSessionUrls: async ({ id, userId }) => {
+			const row = await loadOwned(id, userId);
+			return row?.urls;
+		},
+		toggleImportSelection: async ({ id, userId, index, checked }) => {
+			const row = await loadOwned(id, userId);
+			if (!row) return;
+			const current = new Set<number>(row.deselected ?? []);
+			if (checked) current.delete(index);
+			else current.add(index);
+			await table.update({
+				Key: { sessionId: id },
+				ConditionExpression: "userId = :uid",
+				UpdateExpression: "SET deselected = :d",
+				ExpressionAttributeValues: {
+					":uid": userId,
+					":d": Array.from(current),
+				},
+			});
+		},
+		deleteImportSession: async ({ id, userId }) => {
+			await table.delete({
+				Key: { sessionId: id },
+				ConditionExpression: "userId = :uid",
+				ExpressionAttributeValues: { ":uid": userId },
+			});
+		},
+	};
+}
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import {
+	IMPORT_SESSION_TTL_SECONDS,
+	ImportSessionIdSchema,
+} from "../../domain/import-session/import-session.schema";
+import { UserIdSchema } from "../../domain/user/user.schema";
+import { initInMemoryImportSession } from "./in-memory-import-session";
+
+const owner = UserIdSchema.parse("00000000000000000000000000000001");
+const otherUser = UserIdSchema.parse("00000000000000000000000000000002");
+
+describe("initInMemoryImportSession", () => {
+	it("creates a session with default-checked URLs", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date("2026-05-01T00:00:00Z") });
+
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a", "https://example.com/b"],
+			truncated: false,
+		});
+
+		expect(session.totalUrls).toBe(2);
+		expect(session.deselected.size).toBe(0);
+		expect(session.truncated).toBe(false);
+	});
+
+	it("returns undefined to a different user (cross-user isolation)", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a"],
+			truncated: false,
+		});
+
+		const peek = await store.findImportSession({ id: session.id, userId: otherUser });
+
+		expect(peek).toBeUndefined();
+	});
+
+	it("returns undefined for a non-existent id", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const ghost = ImportSessionIdSchema.parse("00000000000000000000000000000000");
+
+		expect(await store.findImportSession({ id: ghost, userId: owner })).toBeUndefined();
+	});
+
+	it("expires sessions whose TTL has elapsed", async () => {
+		let now = new Date("2026-05-01T00:00:00Z");
+		const store = initInMemoryImportSession({ now: () => now });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a"],
+			truncated: false,
+		});
+
+		// Advance past TTL
+		now = new Date(now.getTime() + (IMPORT_SESSION_TTL_SECONDS + 1) * 1000);
+
+		expect(await store.findImportSession({ id: session.id, userId: owner })).toBeUndefined();
+	});
+
+	it("toggles a row deselected then re-selected", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a", "https://example.com/b"],
+			truncated: false,
+		});
+
+		await store.toggleImportSelection({ id: session.id, userId: owner, index: 0, checked: false });
+		const after = await store.findImportSession({ id: session.id, userId: owner });
+		assert(after, "session must exist after toggle");
+		expect([...after.deselected]).toEqual([0]);
+
+		await store.toggleImportSelection({ id: session.id, userId: owner, index: 0, checked: true });
+		const reset = await store.findImportSession({ id: session.id, userId: owner });
+		assert(reset, "session must exist after second toggle");
+		expect(reset.deselected.size).toBe(0);
+	});
+
+	it("ignores toggles from a non-owner", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a"],
+			truncated: false,
+		});
+
+		await store.toggleImportSelection({ id: session.id, userId: otherUser, index: 0, checked: false });
+		const after = await store.findImportSession({ id: session.id, userId: owner });
+		assert(after, "session must still exist");
+		expect(after.deselected.size).toBe(0);
+	});
+
+	it("returns the page slice for the requested page", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const urls = Array.from({ length: 12 }, (_v, i) => `https://example.com/post-${i}`);
+		const session = await store.createImportSession({ userId: owner, urls, truncated: true });
+
+		const page2 = await store.loadImportSessionPage({ id: session.id, userId: owner, page: 2, pageSize: 5 });
+		assert(page2, "page 2 must exist");
+		expect(page2.pageUrls).toEqual(urls.slice(5, 10));
+		expect(page2.session.truncated).toBe(true);
+	});
+
+	it("returns undefined from page/all readers when the session is missing or stolen", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const ghost = ImportSessionIdSchema.parse("11111111111111111111111111111111");
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a"],
+			truncated: false,
+		});
+
+		expect(
+			await store.loadImportSessionPage({ id: ghost, userId: owner, page: 1, pageSize: 50 }),
+		).toBeUndefined();
+		expect(await store.loadAllImportSessionUrls({ id: ghost, userId: owner })).toBeUndefined();
+		expect(
+			await store.loadAllImportSessionUrls({ id: session.id, userId: otherUser }),
+		).toBeUndefined();
+	});
+
+	it("deletes a session and refuses subsequent reads", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a"],
+			truncated: false,
+		});
+
+		await store.deleteImportSession({ id: session.id, userId: owner });
+
+		expect(await store.findImportSession({ id: session.id, userId: owner })).toBeUndefined();
+	});
+
+	it("ignores delete attempts from a non-owner", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a"],
+			truncated: false,
+		});
+
+		await store.deleteImportSession({ id: session.id, userId: otherUser });
+
+		const stillThere = await store.findImportSession({ id: session.id, userId: owner });
+		expect(stillThere).toBeDefined();
+	});
+});

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
@@ -17,6 +17,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b"],
 			truncated: false,
+			totalFoundInFile: 2,
 		});
 
 		expect(session.totalUrls).toBe(2);
@@ -30,6 +31,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
+			totalFoundInFile: 1,
 		});
 
 		const peek = await store.findImportSession({ id: session.id, userId: otherUser });
@@ -51,6 +53,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
+			totalFoundInFile: 1,
 		});
 
 		// Advance past TTL
@@ -65,6 +68,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b"],
 			truncated: false,
+			totalFoundInFile: 2,
 		});
 
 		await store.toggleImportSelection({ id: session.id, userId: owner, index: 0, checked: false });
@@ -84,6 +88,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
+			totalFoundInFile: 1,
 		});
 
 		await store.toggleImportSelection({ id: session.id, userId: otherUser, index: 0, checked: false });
@@ -95,7 +100,7 @@ describe("initInMemoryImportSession", () => {
 	it("returns the page slice for the requested page", async () => {
 		const store = initInMemoryImportSession({ now: () => new Date() });
 		const urls = Array.from({ length: 12 }, (_v, i) => `https://example.com/post-${i}`);
-		const session = await store.createImportSession({ userId: owner, urls, truncated: true });
+		const session = await store.createImportSession({ userId: owner, urls, truncated: true, totalFoundInFile: 15 });
 
 		const page2 = await store.loadImportSessionPage({ id: session.id, userId: owner, page: 2, pageSize: 5 });
 		assert(page2, "page 2 must exist");
@@ -110,6 +115,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
+			totalFoundInFile: 1,
 		});
 
 		expect(
@@ -127,6 +133,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
+			totalFoundInFile: 1,
 		});
 
 		await store.deleteImportSession({ id: session.id, userId: owner });
@@ -140,6 +147,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
+			totalFoundInFile: 1,
 		});
 
 		await store.deleteImportSession({ id: session.id, userId: otherUser });

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from "node:crypto";
+import {
+	IMPORT_SESSION_TTL_SECONDS,
+	ImportSessionIdSchema,
+} from "../../domain/import-session/import-session.schema";
+import type {
+	ImportSession,
+	ImportSessionStore,
+} from "../../domain/import-session/import-session.types";
+
+interface StoredSession {
+	session: ImportSession;
+	urls: readonly string[];
+	deselected: Set<number>;
+}
+
+export function initInMemoryImportSession(deps: {
+	now: () => Date;
+}): ImportSessionStore {
+	const sessions = new Map<string, StoredSession>();
+
+	function load(id: string, userId: string): StoredSession | undefined {
+		const row = sessions.get(id);
+		if (!row) return undefined;
+		if (row.session.userId !== userId) return undefined;
+		if (row.session.expiresAt < Math.floor(deps.now().getTime() / 1000)) {
+			sessions.delete(id);
+			return undefined;
+		}
+		return row;
+	}
+
+	return {
+		createImportSession: async ({ userId, urls, truncated }) => {
+			const id = ImportSessionIdSchema.parse(randomBytes(16).toString("hex"));
+			const createdAt = deps.now().toISOString();
+			const expiresAt = Math.floor(deps.now().getTime() / 1000) + IMPORT_SESSION_TTL_SECONDS;
+			const deselected = new Set<number>();
+			const session: ImportSession = {
+				id,
+				userId,
+				createdAt,
+				expiresAt,
+				totalUrls: urls.length,
+				truncated,
+				deselected,
+			};
+			sessions.set(id, { session, urls: [...urls], deselected });
+			return session;
+		},
+		findImportSession: async ({ id, userId }) => {
+			return load(id, userId)?.session;
+		},
+		loadImportSessionPage: async ({ id, userId, page, pageSize }) => {
+			const row = load(id, userId);
+			if (!row) return undefined;
+			const start = (page - 1) * pageSize;
+			const pageUrls = row.urls.slice(start, start + pageSize);
+			return { session: row.session, pageUrls, page, pageSize };
+		},
+		loadAllImportSessionUrls: async ({ id, userId }) => {
+			const row = load(id, userId);
+			if (!row) return undefined;
+			return row.urls;
+		},
+		toggleImportSelection: async ({ id, userId, index, checked }) => {
+			const row = load(id, userId);
+			if (!row) return;
+			if (checked) {
+				row.deselected.delete(index);
+			} else {
+				row.deselected.add(index);
+			}
+		},
+		deleteImportSession: async ({ id, userId }) => {
+			const row = load(id, userId);
+			if (row) sessions.delete(id);
+		},
+	};
+}

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.ts
@@ -31,7 +31,7 @@ export function initInMemoryImportSession(deps: {
 	}
 
 	return {
-		createImportSession: async ({ userId, urls, truncated }) => {
+		createImportSession: async ({ userId, urls, truncated, totalFoundInFile }) => {
 			const id = ImportSessionIdSchema.parse(randomBytes(16).toString("hex"));
 			const createdAt = deps.now().toISOString();
 			const expiresAt = Math.floor(deps.now().getTime() / 1000) + IMPORT_SESSION_TTL_SECONDS;
@@ -42,6 +42,7 @@ export function initInMemoryImportSession(deps: {
 				createdAt,
 				expiresAt,
 				totalUrls: urls.length,
+				totalFoundInFile,
 				truncated,
 				deselected,
 			};

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -73,6 +73,8 @@ import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { SESSION_COOKIE_NAME } from "./web/auth/session-cookie";
 import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
 import { initQueueRoutes } from "./web/pages/queue/queue.page";
+import { initImportSessionRoutes } from "./web/pages/import/import.page";
+import type { ImportSessionStore } from "./domain/import-session/import-session.types";
 import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
 import { initSaveRoutes } from "./web/pages/save/save.page";
 import { initViewRoutes } from "./web/pages/view/view.page";
@@ -155,6 +157,7 @@ interface AppDependencies {
 	readArticleContent: ReadArticleContent;
 	httpErrorMessageMapping: HttpErrorMessageMapping;
 	logParseError: LogParseError;
+	importSessionStore: ImportSessionStore;
 	now: () => Date;
 	createCheckoutSession: CreateCheckoutSession;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
@@ -444,6 +447,19 @@ export function createApp(dependencies: AppDependencies): Express {
 		now: deps.now,
 	});
 	app.use("/queue", extensionCors, dualAuthMiddleware, queueRouter);
+
+	const importRouter = initImportSessionRoutes({
+		importSessionStore: deps.importSessionStore,
+		saveArticle: deps.saveArticle,
+		updateArticleStatus: deps.updateArticleStatus,
+		markCrawlPending: deps.markCrawlPending,
+		markSummaryPending: deps.markSummaryPending,
+		publishUpdateFetchTimestamp: deps.publishUpdateFetchTimestamp,
+		publishLinkSaved: deps.publishLinkSaved,
+		refreshArticleIfStale: deps.refreshArticleIfStale,
+		logError: deps.logError,
+	});
+	app.use("/import", requireAuth, importRouter);
 
 	const saveRouter = initSaveRoutes();
 	app.use("/save", saveRouter);

--- a/projects/hutch/src/runtime/test-app-fakes.ts
+++ b/projects/hutch/src/runtime/test-app-fakes.ts
@@ -15,6 +15,7 @@ import { initInMemoryPasswordReset } from "./providers/password-reset/in-memory-
 import { initInMemoryPendingHtml } from "./providers/pending-html/in-memory-pending-html";
 import { initInMemoryPendingSignup } from "./providers/pending-signup/in-memory-pending-signup";
 import { initInMemoryStripeCheckout } from "./providers/stripe-checkout/in-memory-stripe-checkout";
+import { initInMemoryImportSession } from "./providers/import-session/in-memory-import-session";
 import { initInMemorySaveLinkRawHtmlCommand } from "./providers/events/in-memory-save-link-raw-html-command";
 import { initInMemoryExportUserDataCommand } from "./providers/events/in-memory-export-user-data-command";
 import {
@@ -255,6 +256,9 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		admin: {
 			adminEmails: [],
 			recrawlServiceToken: "test-service-token-abcdefghij",
+		},
+		importSession: {
+			importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
 		},
 		shared: {
 			appOrigin,

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -59,6 +59,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 				clientSecret: "test-google-client-secret",
 			},
 			admin: fixture.admin,
+			importSession: fixture.importSession,
 			shared: fixture.shared,
 			stripe: fixture.stripe,
 			pendingSignup: fixture.pendingSignup,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -80,6 +80,7 @@ import type {
 import type { ExchangeGoogleCode } from "./providers/google-auth/google-token.types";
 import type { OAuthModel } from "./providers/oauth/oauth-model";
 import type { ValidateAccessToken } from "./web/dual-auth.middleware";
+import type { ImportSessionStore } from "./domain/import-session/import-session.types";
 import { createApp } from "./server";
 import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
 
@@ -209,6 +210,10 @@ export interface SharedBundle {
 	now: () => Date;
 }
 
+export interface ImportSessionBundle {
+	importSessionStore: ImportSessionStore;
+}
+
 export interface TestAppFixture {
 	auth: AuthBundle;
 	articleStore: ArticleStoreBundle;
@@ -224,6 +229,7 @@ export interface TestAppFixture {
 	passwordReset: PasswordResetBundle;
 	google: GoogleAuthBundle | undefined;
 	admin: AdminBundle;
+	importSession: ImportSessionBundle;
 	shared: SharedBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
@@ -299,6 +305,7 @@ function flattenFixtureToAppDependencies(
 		googleAuth: fixture.google,
 		adminEmails: fixture.admin.adminEmails,
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,
+		importSessionStore: fixture.importSession.importSessionStore,
 		now: fixture.shared.now,
 		createCheckoutSession: fixture.stripe.createCheckoutSession,
 		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -16,6 +16,7 @@ import { initInMemoryStripeCheckout } from "../../providers/stripe-checkout/in-m
 import { initInMemoryPendingSignup } from "../../providers/pending-signup/in-memory-pending-signup";
 import { createOAuthModel, initInMemoryOAuthModel } from "../../providers/oauth/oauth-model";
 import { createValidateAccessToken } from "../../providers/oauth/validate-access-token";
+import { initInMemoryImportSession } from "../../providers/import-session/in-memory-import-session";
 import { createApp } from "../../server";
 import { httpErrorMessageMapping } from "../pages/queue/queue.error";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
@@ -89,6 +90,7 @@ describe("Email verification", () => {
 				putPendingHtml: async () => {},
 				httpErrorMessageMapping,
 				logParseError: () => {},
+				importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
 				now: () => new Date(),
 			});
 

--- a/projects/hutch/src/runtime/web/pages/blog/posts/best-read-it-later-apps-2026.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/best-read-it-later-apps-2026.md
@@ -191,7 +191,7 @@ Omnivore was an open source read-it-later app with a loyal following. In late 20
 
 ### Do any of these apps import from Pocket?
 
-Most of them do. Readwise Reader, Instapaper, and Raindrop.io all have self-serve Pocket import built into the app. Readplace does not have a self-serve in-app importer — instead, you email your Pocket export file to [hutch+migrate@readplace.com](mailto:hutch+migrate@readplace.com) and I import it by hand within 24–48 hours. Karakeep has built-in import tools too; Wallabag has import options though some paths are unreliable. Check each app's documentation for the current import process.
+Most of them do. Readwise Reader, Instapaper, and Raindrop.io all have self-serve Pocket import built into the app. Readplace also offers a self-serve "Import from a file" picker on your queue — upload any text-shaped export and Readplace pulls the URLs out for review. Files over 5 MiB or imports above 2,000 links fall back to emailing the file to [hutch+migrate@readplace.com](mailto:hutch+migrate@readplace.com), which I import by hand within 24–48 hours. Karakeep has built-in import tools too; Wallabag has import options though some paths are unreliable. Check each app's documentation for the current import process.
 
 ### Which app has the best mobile experience?
 

--- a/projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md
@@ -11,7 +11,7 @@ keywords: "Pocket migration, Pocket export, Pocket alternative, move from Pocket
 <summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
 <div class="blog-tldr__body">
 
-Pocket shut down July 8, 2025. If you missed the export window, check your email for Pocket confirmation messages, browser history for getpocket.com URLs, the Wayback Machine, and linked services like IFTTT. If you have the HTML export file, email it to hutch+migrate@readplace.com and your articles are imported into Readplace within 24-48 hours.
+Pocket shut down July 8, 2025. If you missed the export window, check your email for Pocket confirmation messages, browser history for getpocket.com URLs, the Wayback Machine, and linked services like IFTTT. If you have the HTML export file, sign in to Readplace, open your queue, and use the "Import from a file" picker — pick the file, untick anything you don't want, then click Import. Files over 5 MiB or above 2,000 links fall back to emailing hutch+migrate@readplace.com (24–48 hour concierge turnaround).
 
 </div>
 </details>
@@ -44,13 +44,13 @@ The Pocket servers are offline, but copies of your saved articles likely still e
 
 ## How to import into Readplace
 
-If you have a Pocket export file (the HTML file from before the shutdown), send it to [hutch+migrate@readplace.com](mailto:hutch+migrate@readplace.com). I import the file by hand and load your articles into your Readplace account.
+If you have a Pocket export file (the HTML file from before the shutdown), sign in and go to your [reading list](/queue). Next to the save bar there's an "Import from a file" picker — choose the file, click Upload, and Readplace shows every URL it found. Untick anything you don't want, then click "Import N selected". Cards appear in your queue immediately and the titles and excerpts fill in over the next minute or two.
 
-What gets imported: every URL and its original title from the export file. What does not get imported: tags, highlights, and read/unread status. Pocket's export format only included URLs and titles.
+What gets imported: every URL the file contains. What does not get imported: tags, highlights, and read/unread status. Pocket's export format only included URLs and titles, and the in-app importer treats every text-shaped file the same way.
 
-Typical turnaround is 24 to 48 hours. You get a confirmation email when the import finishes.
+If your file is over 5 MiB, has more than 2,000 links, or the picker fails for any reason, send it to [hutch+migrate@readplace.com](mailto:hutch+migrate@readplace.com) and I import it by hand within 24–48 hours.
 
-Open your [reading list](/queue) and spot-check a few entries to make sure titles and URLs match. Something look wrong? Reply to the confirmation email.
+Open your [reading list](/queue) and spot-check a few entries to make sure titles and URLs match. Something look wrong? Send a follow-up to hutch+migrate@readplace.com.
 
 If you do not have the export file, you can still rebuild your reading list. Install the Readplace browser extension for [Chrome](/install?browser=chrome) or [Firefox](/install?browser=firefox) and save articles one at a time from the URLs you recovered.
 
@@ -89,7 +89,7 @@ If you downloaded the HTML export file before the shutdown, you can still use it
 
 **How do I import Pocket articles into another app?**
 
-Most read-it-later apps accept the HTML export file that Pocket provided. Readwise Reader, Instapaper, and Raindrop.io all support it. Readplace accepts it too. Send the file to hutch+migrate@readplace.com and the import is handled for you.
+Most read-it-later apps accept the HTML export file that Pocket provided. Readwise Reader, Instapaper, and Raindrop.io all support it. Readplace accepts it too — go to your queue, upload the file with the "Import from a file" picker, and confirm the link list. For files over 5 MiB or imports above the 2,000-URL cap, email hutch+migrate@readplace.com and the import is handled for you within 24–48 hours.
 
 **I lost my Omnivore reading list too. Can Readplace help?**
 

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PageBody } from "../../page-body.types";
+import { render } from "../../render";
+import { IMPORT_STYLES } from "./import.styles";
+import type { ImportViewModel } from "./import.viewmodel";
+
+const IMPORT_TEMPLATE = readFileSync(join(__dirname, "import.template.html"), "utf-8");
+
+export function ImportPage(vm: ImportViewModel): PageBody {
+	const content = render(IMPORT_TEMPLATE, {
+		...vm,
+		showPagination: vm.totalPages > 1,
+		hasPrev: Boolean(vm.prevUrl),
+		hasNext: Boolean(vm.nextUrl),
+	});
+
+	return {
+		seo: {
+			title: "Review imported links — Readplace",
+			description: "Review and confirm imported links.",
+			canonicalUrl: `/import/${vm.sessionId}`,
+			robots: "noindex, nofollow",
+		},
+		styles: IMPORT_STYLES,
+		bodyClass: "page-import",
+		content,
+	};
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert";
+import type { ErrorRequestHandler, Request, Response, Router } from "express";
+import express from "express";
+import { extractUrls } from "../../../domain/import-session/extract-urls";
+import {
+	IMPORT_COMMIT_CONCURRENCY,
+	IMPORT_PAGE_SIZE,
+	ImportSessionIdSchema,
+	ImportToggleSchema,
+	MAX_IMPORT_FILE_BYTES,
+} from "../../../domain/import-session/import-session.schema";
+import type { ImportSessionStore } from "../../../domain/import-session/import-session.types";
+import { renderPage } from "../../render-page";
+import { sendComponent } from "../../send-component";
+import { saveArticleFromUrl, type SaveArticleFromUrlDependencies } from "../../shared/save-article/save-article-from-url";
+import { ImportPage } from "./import.component";
+import { toImportViewModel } from "./import.viewmodel";
+import { initMultipartUpload } from "./multipart-upload";
+import { parseImportPage } from "./import.url";
+
+interface ImportRouteDependencies extends SaveArticleFromUrlDependencies {
+	importSessionStore: ImportSessionStore;
+	logError: (message: string, error?: Error) => void;
+}
+
+export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
+	const router = express.Router();
+	const { rawBodyParser, parseRequest } = initMultipartUpload({ maxBytes: MAX_IMPORT_FILE_BYTES });
+
+	const sizeLimitHandler: ErrorRequestHandler = (err, _req, res, next) => {
+		const bodyErr = err as { type?: string; limit?: number } | null;
+		if (bodyErr?.type === "entity.too.large") {
+			res.redirect(303, "/queue?error_code=import_too_large");
+			return;
+		}
+		next(err);
+	};
+
+	router.post("/", rawBodyParser, sizeLimitHandler, async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const parsed = parseRequest(req);
+		if (!parsed.ok) {
+			res.redirect(303, "/queue?error_code=import_no_urls");
+			return;
+		}
+
+		const { urls, truncated } = extractUrls(parsed.file.content);
+		if (urls.length === 0) {
+			res.redirect(303, "/queue?error_code=import_no_urls");
+			return;
+		}
+
+		const session = await deps.importSessionStore.createImportSession({
+			userId: req.userId,
+			urls,
+			truncated,
+		});
+		res.redirect(303, `/import/${session.id}`);
+	});
+
+	router.get("/:id", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
+		if (!parsedId.success) {
+			res.redirect(303, "/queue");
+			return;
+		}
+
+		const page = parseImportPage(req.query);
+		const pageResult = await deps.importSessionStore.loadImportSessionPage({
+			id: parsedId.data,
+			userId: req.userId,
+			page,
+			pageSize: IMPORT_PAGE_SIZE,
+		});
+
+		if (!pageResult) {
+			res.status(404);
+			res.redirect(303, "/queue?error_code=import_session_not_found");
+			return;
+		}
+
+		const totalSelected =
+			pageResult.session.totalUrls - pageResult.session.deselected.size;
+		const vm = toImportViewModel(pageResult, totalSelected);
+		sendComponent(res, renderPage(req, ImportPage(vm)));
+	});
+
+	router.post("/:id/toggle", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
+		const parsedBody = ImportToggleSchema.safeParse(req.body);
+		if (!parsedId.success || !parsedBody.success) {
+			res.status(422).send("");
+			return;
+		}
+
+		await deps.importSessionStore.toggleImportSelection({
+			id: parsedId.data,
+			userId: req.userId,
+			index: parsedBody.data.index,
+			checked: parsedBody.data.checked === "true",
+		});
+
+		const page = parseImportPage(req.query);
+		res.redirect(303, page > 1 ? `/import/${parsedId.data}?page=${page}` : `/import/${parsedId.data}`);
+	});
+
+	router.post("/:id/commit", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const userId = req.userId;
+		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
+		if (!parsedId.success) {
+			res.redirect(303, "/queue?error_code=import_session_not_found");
+			return;
+		}
+
+		const session = await deps.importSessionStore.findImportSession({
+			id: parsedId.data,
+			userId,
+		});
+		if (!session) {
+			res.redirect(303, "/queue?error_code=import_session_not_found");
+			return;
+		}
+
+		const allUrls = await deps.importSessionStore.loadAllImportSessionUrls({
+			id: parsedId.data,
+			userId,
+		});
+		assert(allUrls, "session row was found but URL chunks missing");
+
+		const selected = allUrls.filter((_url, i) => !session.deselected.has(i));
+
+		for (let i = 0; i < selected.length; i += IMPORT_COMMIT_CONCURRENCY) {
+			const batch = selected.slice(i, i + IMPORT_COMMIT_CONCURRENCY);
+			await Promise.all(
+				batch.map((url) =>
+					deps
+						.refreshArticleIfStale({ url })
+						.then((freshness) => saveArticleFromUrl(deps, { userId, url, freshness }))
+						.catch((error: unknown) => {
+							deps.logError(
+								`Failed to import url=${url}`,
+								error instanceof Error ? error : undefined,
+							);
+						}),
+				),
+			);
+		}
+
+		await deps.importSessionStore.deleteImportSession({ id: parsedId.data, userId });
+
+		res.redirect(
+			303,
+			`/queue?import_imported=${selected.length}&import_total=${session.totalUrls}`,
+		);
+	});
+
+	return router;
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -28,8 +28,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 	const { rawBodyParser, parseRequest } = initMultipartUpload({ maxBytes: MAX_IMPORT_FILE_BYTES });
 
 	const sizeLimitHandler: ErrorRequestHandler = (err, _req, res, next) => {
-		const bodyErr = err as { type?: string; limit?: number } | null;
-		if (bodyErr?.type === "entity.too.large") {
+		if (err && typeof err === "object" && "type" in err && err.type === "entity.too.large") {
 			res.redirect(303, "/queue?error_code=import_too_large");
 			return;
 		}
@@ -44,7 +43,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			return;
 		}
 
-		const { urls, truncated } = extractUrls(parsed.file.content);
+		const { urls, truncated, totalFoundInFile } = extractUrls(parsed.file.content);
 		if (urls.length === 0) {
 			res.redirect(303, "/queue?error_code=import_no_urls");
 			return;
@@ -54,6 +53,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			userId: req.userId,
 			urls,
 			truncated,
+			totalFoundInFile,
 		});
 		res.redirect(303, `/import/${session.id}`);
 	});

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -75,7 +75,6 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		});
 
 		if (!pageResult) {
-			res.status(404);
 			res.redirect(303, "/queue?error_code=import_session_not_found");
 			return;
 		}

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { createTestApp, type TestAppResult } from "../../../test-app";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "../../../test-app-fakes";
+
+async function loginAgent(app: TestAppResult["app"], auth: TestAppResult["auth"]) {
+	await auth.createUser({ email: "test@example.com", password: "password123" });
+	const agent = request.agent(app);
+	await agent
+		.post("/login")
+		.type("form")
+		.send({ email: "test@example.com", password: "password123" });
+	return agent;
+}
+
+function multipartBody(filename: string, content: Buffer): { body: Buffer; contentType: string } {
+	const boundary = "----TestBoundary123456";
+	const head = Buffer.from(
+		`--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: application/octet-stream\r\n\r\n`,
+	);
+	const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+	return {
+		body: Buffer.concat([head, content, tail]),
+		contentType: `multipart/form-data; boundary=${boundary}`,
+	};
+}
+
+describe("Import routes", () => {
+	describe("POST /import (unauthenticated)", () => {
+		it("redirects to /login", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(app).post("/import");
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/login");
+		});
+	});
+
+	describe("POST /import", () => {
+		it("creates a session and redirects to the review page when URLs are found", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from(
+				"<a href=\"https://example.com/post-1\">x</a> https://example.com/post-2",
+			);
+			const { body, contentType } = multipartBody("pocket.html", file);
+
+			const response = await agent
+				.post("/import")
+				.set("Content-Type", contentType)
+				.send(body);
+
+			expect(response.status).toBe(303);
+			assert(response.headers.location.startsWith("/import/"), "expected redirect to /import/:id");
+		});
+
+		it("redirects with import_no_urls when no URLs are found", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const { body, contentType } = multipartBody("empty.txt", Buffer.from("just some prose"));
+
+			const response = await agent
+				.post("/import")
+				.set("Content-Type", contentType)
+				.send(body);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=import_no_urls");
+		});
+
+		it("redirects with import_too_large when the upload exceeds the size cap", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			// 6 MiB body — overshoots the 5 MiB cap so express.raw aborts with
+			// `entity.too.large`, which the size-limit error handler maps to the
+			// import_too_large flash.
+			const oversize = Buffer.alloc(6 * 1024 * 1024, 0x41);
+			const { body, contentType } = multipartBody("big.bin", oversize);
+
+			const response = await agent
+				.post("/import")
+				.set("Content-Type", contentType)
+				.send(body);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=import_too_large");
+		});
+
+		it("redirects with import_no_urls for non-multipart bodies", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent
+				.post("/import")
+				.set("Content-Type", "text/plain")
+				.send("https://example.com/x");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=import_no_urls");
+		});
+	});
+
+	describe("GET /import/:id", () => {
+		it("renders the review screen with all URLs checked by default", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from(
+				"https://example.com/post-1 https://example.com/post-2 https://example.com/post-3",
+			);
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent
+				.post("/import")
+				.set("Content-Type", contentType)
+				.send(body);
+			const sessionPath = create.headers.location;
+
+			const response = await agent.get(sessionPath);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const checkboxes = doc.querySelectorAll<HTMLInputElement>("[data-test-import-checkbox]");
+			expect(checkboxes).toHaveLength(3);
+			for (const cb of checkboxes) {
+				expect(cb.hasAttribute("checked")).toBe(true);
+			}
+			expect(doc.querySelector("[data-test-import-summary]")?.textContent).toContain("3 of 3 selected");
+		});
+
+		it("redirects to /queue for an invalid session id", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import/not-a-session-id");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+		});
+
+		it("redirects with import_session_not_found when the session is owned by another user", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { app, auth } = createTestApp(fixture);
+			await auth.createUser({ email: "owner@example.com", password: "password123" });
+			const owner = request.agent(app);
+			await owner.post("/login").type("form").send({ email: "owner@example.com", password: "password123" });
+			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/owned"));
+			const create = await owner.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+
+			await auth.createUser({ email: "intruder@example.com", password: "password123" });
+			const intruder = request.agent(app);
+			await intruder.post("/login").type("form").send({ email: "intruder@example.com", password: "password123" });
+
+			const response = await intruder.get(sessionPath);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=import_session_not_found");
+		});
+
+		it("paginates results across pages", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
+			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+
+			const page1 = await agent.get(create.headers.location);
+			const page2 = await agent.get(`${create.headers.location}?page=2`);
+
+			const doc1 = new JSDOM(page1.text).window.document;
+			const doc2 = new JSDOM(page2.text).window.document;
+			expect(doc1.querySelectorAll("[data-test-import-row]")).toHaveLength(50);
+			expect(doc2.querySelectorAll("[data-test-import-row]")).toHaveLength(10);
+		});
+	});
+
+	describe("POST /import/:id/toggle", () => {
+		it("deselects a row and updates the selection summary", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from("https://example.com/a https://example.com/b");
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+
+			const toggleResp = await agent
+				.post(`${sessionPath}/toggle`)
+				.type("form")
+				.send({ index: 0, checked: "false" });
+			expect(toggleResp.status).toBe(303);
+
+			const review = await agent.get(sessionPath);
+			const doc = new JSDOM(review.text).window.document;
+			const first = doc.querySelector<HTMLInputElement>('[data-test-import-checkbox="0"]');
+			const second = doc.querySelector<HTMLInputElement>('[data-test-import-checkbox="1"]');
+			assert(first, "first checkbox must exist");
+			assert(second, "second checkbox must exist");
+			expect(first.hasAttribute("checked")).toBe(false);
+			expect(second.hasAttribute("checked")).toBe(true);
+			expect(doc.querySelector("[data-test-import-summary]")?.textContent).toContain("1 of 2 selected");
+		});
+
+		it("returns 422 for malformed body", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/a"));
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+
+			const response = await agent
+				.post(`${create.headers.location}/toggle`)
+				.type("form")
+				.send({ index: "not-a-number" });
+
+			expect(response.status).toBe(422);
+		});
+
+		it("returns 422 for an invalid session id format", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent
+				.post("/import/not-an-id/toggle")
+				.type("form")
+				.send({ index: 0, checked: "false" });
+
+			expect(response.status).toBe(422);
+		});
+	});
+
+	describe("POST /import/:id/commit", () => {
+		it("imports selected URLs into the user's queue and deletes the session", async () => {
+			const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from(
+				"https://example.com/a https://example.com/b https://example.com/c",
+			);
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+			await agent
+				.post(`${sessionPath}/toggle`)
+				.type("form")
+				.send({ index: 1, checked: "false" });
+
+			const commit = await agent.post(`${sessionPath}/commit`);
+
+			expect(commit.status).toBe(303);
+			expect(commit.headers.location).toBe("/queue?import_imported=2&import_total=3");
+
+			const userId = (await auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "user must exist");
+			const result = await articleStore.findArticlesByUser({ userId });
+			const urls = result.articles.map((a) => a.url).sort();
+			expect(urls).toEqual(["https://example.com/a", "https://example.com/c"]);
+
+			const reuse = await agent.get(sessionPath);
+			expect(reuse.status).toBe(303);
+			expect(reuse.headers.location).toBe("/queue?error_code=import_session_not_found");
+		});
+
+		it("redirects when the session id is malformed", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.post("/import/not-an-id/commit");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=import_session_not_found");
+		});
+
+		it("redirects when the session no longer exists", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.post("/import/00000000000000000000000000000000/commit");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=import_session_not_found");
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.css
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.css
@@ -1,0 +1,12 @@
+.import { max-width: 800px; margin: 0 auto; padding: 1.5rem; }
+.import__title { font-size: 1.5rem; margin: 0 0 0.5rem; }
+.import__summary { color: var(--text-muted); margin: 0 0 1rem; }
+.import__truncated-banner { background: var(--surface-warning, #fff4e0); border: 1px solid var(--border-warning, #f0b97a); padding: 0.75rem 1rem; border-radius: 4px; margin: 0 0 1rem; }
+.import__commit-form { margin: 1rem 0; }
+.import__commit-btn { font-size: 1rem; padding: 0.6rem 1.2rem; cursor: pointer; }
+.import__list { list-style: none; padding: 0; margin: 1rem 0; }
+.import__row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; border-bottom: 1px solid var(--border-subtle, #eee); }
+.import__row-label { display: flex; align-items: center; gap: 0.75rem; flex: 1; cursor: pointer; }
+.import__row-url { word-break: break-all; }
+.import__pagination { display: flex; gap: 1rem; align-items: center; margin: 1rem 0; }
+.import__pagination-info { color: var(--text-muted); }

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.css
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.css
@@ -10,3 +10,4 @@
 .import__row-url { word-break: break-all; }
 .import__pagination { display: flex; gap: 1rem; align-items: center; margin: 1rem 0; }
 .import__pagination-info { color: var(--text-muted); }
+.import__row-toggle-btn { font-size: 0.85rem; padding: 0.2rem 0.5rem; cursor: pointer; }

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const stylesPath = join(__dirname, "import.styles.css");
+export const IMPORT_STYLES = readFileSync(stylesPath, "utf-8");

--- a/projects/hutch/src/runtime/web/pages/import/import.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.template.html
@@ -1,0 +1,31 @@
+    <main class="import">
+      <h1 class="import__title">Review imported links</h1>
+      <p class="import__summary" data-test-import-summary>{{totalSelected}} of {{totalUrls}} selected</p>
+      {{#if truncated}}
+      <p class="import__truncated-banner" data-test-import-truncated>Your file contained more than {{totalUrls}} links. We&rsquo;ve imported the first {{totalUrls}}.</p>
+      {{/if}}
+      <form class="import__commit-form" method="POST" action="{{commitUrl}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-form="import-commit">
+        <button class="import__commit-btn" type="submit" data-test-action="import-commit">Import {{totalSelected}} selected</button>
+      </form>
+      <ul class="import__list" data-test-import-list>
+        {{#each rows}}
+        <li class="import__row" data-test-import-row="{{index}}">
+          <form method="POST" action="{{../toggleUrl}}" class="import__row-form" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
+            <input type="hidden" name="index" value="{{index}}">
+            <input type="hidden" name="checked" value="{{#if checked}}false{{else}}true{{/if}}">
+            <label class="import__row-label">
+              <input type="checkbox" name="confirm" {{#if checked}}checked{{/if}} onclick="this.form.requestSubmit()" data-test-import-checkbox="{{index}}">
+              <span class="import__row-url" data-test-import-url>{{url}}</span>
+            </label>
+          </form>
+        </li>
+        {{/each}}
+      </ul>
+      {{#if showPagination}}
+      <nav class="import__pagination" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-import-pagination>
+        {{#if hasPrev}}<a class="import__pagination-link" href="{{prevUrl}}" data-test-import-pagination-prev>← Previous</a>{{/if}}
+        <span class="import__pagination-info">Page {{currentPage}} of {{totalPages}}</span>
+        {{#if hasNext}}<a class="import__pagination-link" href="{{nextUrl}}" data-test-import-pagination-next>Next →</a>{{/if}}
+      </nav>
+      {{/if}}
+    </main>

--- a/projects/hutch/src/runtime/web/pages/import/import.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.template.html
@@ -2,7 +2,7 @@
       <h1 class="import__title">Review imported links</h1>
       <p class="import__summary" data-test-import-summary>{{totalSelected}} of {{totalUrls}} selected</p>
       {{#if truncated}}
-      <p class="import__truncated-banner" data-test-import-truncated>Your file contained more than {{totalUrls}} links. We&rsquo;ve imported the first {{totalUrls}}.</p>
+      <p class="import__truncated-banner" data-test-import-truncated>Your file contained {{totalFoundInFile}} links. We&rsquo;ve imported the first {{totalUrls}}.</p>
       {{/if}}
       <form class="import__commit-form" method="POST" action="{{commitUrl}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-form="import-commit">
         <button class="import__commit-btn" type="submit" data-test-action="import-commit">Import {{totalSelected}} selected</button>
@@ -17,6 +17,7 @@
               <input type="checkbox" name="confirm" {{#if checked}}checked{{/if}} onclick="this.form.requestSubmit()" data-test-import-checkbox="{{index}}">
               <span class="import__row-url" data-test-import-url>{{url}}</span>
             </label>
+            <noscript><button type="submit" class="import__row-toggle-btn">Toggle</button></noscript>
           </form>
         </li>
         {{/each}}

--- a/projects/hutch/src/runtime/web/pages/import/import.url.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.url.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const ImportPageQuerySchema = z
+	.object({
+		page: z.coerce.number().int().min(1).optional().catch(undefined),
+	})
+	.passthrough();
+
+export function parseImportPage(query: Record<string, unknown>): number {
+	const parsed = ImportPageQuerySchema.parse(query);
+	return parsed.page ?? 1;
+}
+
+export function buildImportUrl(sessionId: string, page: number): string {
+	return page > 1 ? `/import/${sessionId}?page=${page}` : `/import/${sessionId}`;
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -10,6 +10,7 @@ function makeSession(overrides: Partial<ImportSession> = {}): ImportSession {
 		createdAt: "2026-05-01T00:00:00.000Z",
 		expiresAt: 1_780_000_000,
 		totalUrls: 0,
+		totalFoundInFile: 0,
 		truncated: false,
 		deselected: new Set<number>(),
 		...overrides,
@@ -83,8 +84,8 @@ describe("toImportViewModel", () => {
 		expect(vm.rows.map((r) => r.index)).toEqual([50, 51]);
 	});
 
-	it("propagates the truncated flag from the session header", () => {
-		const session = makeSession({ totalUrls: 2_000, truncated: true });
+	it("propagates the truncated flag and totalFoundInFile from the session header", () => {
+		const session = makeSession({ totalUrls: 2_000, totalFoundInFile: 2_345, truncated: true });
 
 		const vm = toImportViewModel(
 			{ session, pageUrls: ["https://example.com/x"], page: 1, pageSize: 50 },
@@ -92,5 +93,6 @@ describe("toImportViewModel", () => {
 		);
 
 		expect(vm.truncated).toBe(true);
+		expect(vm.totalFoundInFile).toBe(2_345);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -1,0 +1,96 @@
+import { ImportSessionIdSchema } from "../../../domain/import-session/import-session.schema";
+import type { ImportSession } from "../../../domain/import-session/import-session.types";
+import { UserIdSchema } from "../../../domain/user/user.schema";
+import { toImportViewModel } from "./import.viewmodel";
+
+function makeSession(overrides: Partial<ImportSession> = {}): ImportSession {
+	return {
+		id: ImportSessionIdSchema.parse("0123456789abcdef0123456789abcdef"),
+		userId: UserIdSchema.parse("00000000000000000000000000000001"),
+		createdAt: "2026-05-01T00:00:00.000Z",
+		expiresAt: 1_780_000_000,
+		totalUrls: 0,
+		truncated: false,
+		deselected: new Set<number>(),
+		...overrides,
+	};
+}
+
+describe("toImportViewModel", () => {
+	it("renders every URL as checked when nothing is deselected", () => {
+		const session = makeSession({ totalUrls: 2 });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: ["https://example.com/a", "https://example.com/b"], page: 1, pageSize: 50 },
+			2,
+		);
+
+		expect(vm.rows).toEqual([
+			{ index: 0, url: "https://example.com/a", checked: true },
+			{ index: 1, url: "https://example.com/b", checked: true },
+		]);
+		expect(vm.totalSelected).toBe(2);
+		expect(vm.commitUrl).toBe(`/import/${session.id}/commit`);
+		expect(vm.toggleUrl).toBe(`/import/${session.id}/toggle`);
+	});
+
+	it("marks deselected indexes as unchecked", () => {
+		const session = makeSession({ totalUrls: 3, deselected: new Set([1]) });
+
+		const vm = toImportViewModel(
+			{
+				session,
+				pageUrls: ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
+				page: 1,
+				pageSize: 50,
+			},
+			2,
+		);
+
+		expect(vm.rows.map((r) => r.checked)).toEqual([true, false, true]);
+	});
+
+	it("computes pagination URLs across multi-page sessions", () => {
+		const session = makeSession({ totalUrls: 120 });
+		const pageSize = 50;
+
+		const page1 = toImportViewModel({ session, pageUrls: [], page: 1, pageSize }, 120);
+		const page2 = toImportViewModel({ session, pageUrls: [], page: 2, pageSize }, 120);
+		const page3 = toImportViewModel({ session, pageUrls: [], page: 3, pageSize }, 120);
+
+		expect(page1.totalPages).toBe(3);
+		expect(page1.prevUrl).toBeUndefined();
+		expect(page1.nextUrl).toBe(`/import/${session.id}?page=2`);
+		expect(page2.prevUrl).toBe(`/import/${session.id}`);
+		expect(page2.nextUrl).toBe(`/import/${session.id}?page=3`);
+		expect(page3.prevUrl).toBe(`/import/${session.id}?page=2`);
+		expect(page3.nextUrl).toBeUndefined();
+	});
+
+	it("offsets row indexes by the page number", () => {
+		const session = makeSession({ totalUrls: 60 });
+
+		const vm = toImportViewModel(
+			{
+				session,
+				pageUrls: ["https://example.com/p2-a", "https://example.com/p2-b"],
+				page: 2,
+				pageSize: 50,
+			},
+			60,
+		);
+
+		expect(vm.rows.map((r) => r.index)).toEqual([50, 51]);
+	});
+
+	it("propagates the truncated flag from the session header", () => {
+		const session = makeSession({ totalUrls: 2_000, truncated: true });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: ["https://example.com/x"], page: 1, pageSize: 50 },
+			2_000,
+		);
+
+		expect(vm.truncated).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -1,0 +1,52 @@
+import type { ImportSessionPage } from "../../../domain/import-session/import-session.types";
+import { buildImportUrl } from "./import.url";
+
+export interface ImportRowViewModel {
+	readonly index: number;
+	readonly url: string;
+	readonly checked: boolean;
+}
+
+export interface ImportViewModel {
+	readonly sessionId: string;
+	readonly rows: readonly ImportRowViewModel[];
+	readonly totalUrls: number;
+	readonly totalSelected: number;
+	readonly truncated: boolean;
+	readonly currentPage: number;
+	readonly totalPages: number;
+	readonly prevUrl?: string;
+	readonly nextUrl?: string;
+	readonly commitUrl: string;
+	readonly toggleUrl: string;
+}
+
+export function toImportViewModel(
+	pageResult: ImportSessionPage,
+	totalSelected: number,
+): ImportViewModel {
+	const { session, pageUrls, page, pageSize } = pageResult;
+	const totalPages = Math.max(1, Math.ceil(session.totalUrls / pageSize));
+	const start = (page - 1) * pageSize;
+	const sessionId = session.id;
+	return {
+		sessionId,
+		rows: pageUrls.map((url, i) => {
+			const index = start + i;
+			return {
+				index,
+				url,
+				checked: !session.deselected.has(index),
+			};
+		}),
+		totalUrls: session.totalUrls,
+		totalSelected,
+		truncated: session.truncated,
+		currentPage: page,
+		totalPages,
+		prevUrl: page > 1 ? buildImportUrl(sessionId, page - 1) : undefined,
+		nextUrl: page < totalPages ? buildImportUrl(sessionId, page + 1) : undefined,
+		commitUrl: `/import/${sessionId}/commit`,
+		toggleUrl: `/import/${sessionId}/toggle`,
+	};
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -11,6 +11,7 @@ export interface ImportViewModel {
 	readonly sessionId: string;
 	readonly rows: readonly ImportRowViewModel[];
 	readonly totalUrls: number;
+	readonly totalFoundInFile: number;
 	readonly totalSelected: number;
 	readonly truncated: boolean;
 	readonly currentPage: number;
@@ -40,6 +41,7 @@ export function toImportViewModel(
 			};
 		}),
 		totalUrls: session.totalUrls,
+		totalFoundInFile: session.totalFoundInFile,
 		totalSelected,
 		truncated: session.truncated,
 		currentPage: page,

--- a/projects/hutch/src/runtime/web/pages/import/multipart-upload.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/multipart-upload.test.ts
@@ -1,0 +1,150 @@
+import type { Request } from "express";
+import { initMultipartUpload } from "./multipart-upload";
+
+const { parseRequest } = initMultipartUpload({ maxBytes: 1024 * 1024 });
+
+function fakeRequest(headers: Record<string, string | undefined>, body: unknown): Request {
+	return { headers, body } as unknown as Request;
+}
+
+function buildBody(parts: { name: string; filename?: string; content: Buffer | string }[], boundary: string): Buffer {
+	const segments: Buffer[] = [];
+	for (const part of parts) {
+		const headers = part.filename !== undefined
+			? `Content-Disposition: form-data; name="${part.name}"; filename="${part.filename}"\r\nContent-Type: application/octet-stream`
+			: `Content-Disposition: form-data; name="${part.name}"`;
+		segments.push(Buffer.from(`--${boundary}\r\n${headers}\r\n\r\n`));
+		segments.push(typeof part.content === "string" ? Buffer.from(part.content) : part.content);
+		segments.push(Buffer.from("\r\n"));
+	}
+	segments.push(Buffer.from(`--${boundary}--\r\n`));
+	return Buffer.concat(segments);
+}
+
+describe("multipart-upload parseRequest", () => {
+	it("returns invalid-multipart when Content-Type is missing", () => {
+		const result = parseRequest(fakeRequest({}, Buffer.from("")));
+
+		expect(result).toEqual({ ok: false, reason: "invalid-multipart" });
+	});
+
+	it("returns invalid-multipart when Content-Type is not multipart", () => {
+		const result = parseRequest(fakeRequest({ "content-type": "application/json" }, Buffer.from("")));
+
+		expect(result).toEqual({ ok: false, reason: "invalid-multipart" });
+	});
+
+	it("returns invalid-multipart when the body is not a Buffer", () => {
+		const result = parseRequest(
+			fakeRequest({ "content-type": "multipart/form-data; boundary=AAA" }, "not-a-buffer"),
+		);
+
+		expect(result).toEqual({ ok: false, reason: "invalid-multipart" });
+	});
+
+	it("accepts a quoted boundary parameter", () => {
+		const boundary = "QuotedBoundary";
+		const body = buildBody([{ name: "file", filename: "x.txt", content: "hi" }], boundary);
+
+		const result = parseRequest(
+			fakeRequest({ "content-type": `multipart/form-data; boundary="${boundary}"` }, body),
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.file.filename).toBe("x.txt");
+			expect(result.file.content.toString()).toBe("hi");
+		}
+	});
+
+	it("returns no-file when the body has no file parts", () => {
+		const boundary = "B";
+		const body = buildBody([{ name: "field-a", content: "value" }], boundary);
+
+		const result = parseRequest(fakeRequest({ "content-type": `multipart/form-data; boundary=${boundary}` }, body));
+
+		expect(result).toEqual({ ok: false, reason: "no-file" });
+	});
+
+	it("skips non-file parts and returns the first file part it finds", () => {
+		const boundary = "B";
+		const body = buildBody(
+			[
+				{ name: "intro", content: "hello" },
+				{ name: "file", filename: "expected.txt", content: "expected-bytes" },
+				{ name: "file2", filename: "second.txt", content: "second-bytes" },
+			],
+			boundary,
+		);
+
+		const result = parseRequest(fakeRequest({ "content-type": `multipart/form-data; boundary=${boundary}` }, body));
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.file.filename).toBe("expected.txt");
+			expect(result.file.content.toString()).toBe("expected-bytes");
+		}
+	});
+
+	it("treats an empty filename as undefined", () => {
+		const boundary = "B";
+		const body = buildBody([{ name: "file", filename: "", content: "no-name-bytes" }], boundary);
+
+		const result = parseRequest(fakeRequest({ "content-type": `multipart/form-data; boundary=${boundary}` }, body));
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.file.filename).toBeUndefined();
+		}
+	});
+
+	it("returns no-file for a body with no boundary occurrence", () => {
+		const result = parseRequest(
+			fakeRequest({ "content-type": "multipart/form-data; boundary=B" }, Buffer.from("not-multipart-body")),
+		);
+
+		expect(result).toEqual({ ok: false, reason: "no-file" });
+	});
+
+	it("returns no-file for a body that ends right at the close marker", () => {
+		const result = parseRequest(
+			fakeRequest({ "content-type": "multipart/form-data; boundary=B" }, Buffer.from("--B--\r\n")),
+		);
+
+		expect(result).toEqual({ ok: false, reason: "no-file" });
+	});
+
+	it("returns no-file when a boundary line is not followed by CRLF", () => {
+		const result = parseRequest(
+			fakeRequest({ "content-type": "multipart/form-data; boundary=B" }, Buffer.from("--BXX")),
+		);
+
+		expect(result).toEqual({ ok: false, reason: "no-file" });
+	});
+
+	it("returns no-file when headers are not terminated", () => {
+		const result = parseRequest(
+			fakeRequest(
+				{ "content-type": "multipart/form-data; boundary=B" },
+				Buffer.from(
+					"--B\r\nContent-Disposition: form-data; name=file; filename=\"x.txt\"\r\n",
+				),
+			),
+		);
+
+		expect(result).toEqual({ ok: false, reason: "no-file" });
+	});
+
+	it("returns no-file when the body has no closing boundary", () => {
+		const result = parseRequest(
+			fakeRequest(
+				{ "content-type": "multipart/form-data; boundary=B" },
+				Buffer.from(
+					"--B\r\nContent-Disposition: form-data; name=\"file\"; filename=\"x.txt\"\r\n\r\nbytes-without-end",
+				),
+			),
+		);
+
+		expect(result).toEqual({ ok: false, reason: "no-file" });
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/import/multipart-upload.ts
+++ b/projects/hutch/src/runtime/web/pages/import/multipart-upload.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert";
+import type { Request } from "express";
+import express from "express";
+
+const BoundaryRegex = /^multipart\/form-data\s*;.*boundary=(?:"([^"]+)"|([^;\s]+))/i;
+const FilenameRegex = /filename="([^"]*)"/i;
+
+export interface UploadedFile {
+	readonly filename: string | undefined;
+	readonly content: Buffer;
+}
+
+export type MultipartUploadResult =
+	| { ok: true; file: UploadedFile }
+	| { ok: false; reason: "invalid-multipart" | "no-file" };
+
+export function initMultipartUpload(deps: { maxBytes: number }): {
+	rawBodyParser: express.RequestHandler;
+	parseRequest: (req: Request) => MultipartUploadResult;
+} {
+	return {
+		rawBodyParser: express.raw({
+			type: "multipart/form-data",
+			limit: deps.maxBytes,
+		}),
+		parseRequest: (req) => {
+			const contentType = req.headers["content-type"];
+			if (typeof contentType !== "string") {
+				return { ok: false, reason: "invalid-multipart" };
+			}
+
+			const match = BoundaryRegex.exec(contentType);
+			if (!match) return { ok: false, reason: "invalid-multipart" };
+			const boundary = match[1] ?? match[2];
+			assert(boundary, "BoundaryRegex match guarantees one capture group");
+
+			const body = req.body;
+			if (!Buffer.isBuffer(body)) {
+				return { ok: false, reason: "invalid-multipart" };
+			}
+
+			const file = extractFirstFilePart(body, boundary);
+			if (!file) return { ok: false, reason: "no-file" };
+			return { ok: true, file };
+		},
+	};
+}
+
+function extractFirstFilePart(buffer: Buffer, boundary: string): UploadedFile | undefined {
+	const dashBoundary = Buffer.from(`--${boundary}`);
+	let cursor = buffer.indexOf(dashBoundary);
+	if (cursor === -1) return undefined;
+
+	while (cursor < buffer.length) {
+		cursor += dashBoundary.length;
+		// Either \r\n (next part) or -- (end of message)
+		if (buffer[cursor] === 0x2d && buffer[cursor + 1] === 0x2d) return undefined;
+		if (buffer[cursor] !== 0x0d || buffer[cursor + 1] !== 0x0a) return undefined;
+		cursor += 2;
+
+		const headerEnd = buffer.indexOf("\r\n\r\n", cursor);
+		if (headerEnd === -1) return undefined;
+		const headers = buffer.slice(cursor, headerEnd).toString("utf8");
+		const bodyStart = headerEnd + 4;
+
+		const nextBoundary = buffer.indexOf(dashBoundary, bodyStart);
+		if (nextBoundary === -1) return undefined;
+		// Body ends at \r\n before the boundary line
+		const bodyEnd = nextBoundary - 2;
+
+		const filenameMatch = FilenameRegex.exec(headers);
+		if (filenameMatch) {
+			return {
+				filename: filenameMatch[1] || undefined,
+				content: buffer.slice(bodyStart, bodyEnd),
+			};
+		}
+
+		cursor = nextBoundary;
+	}
+
+	return undefined;
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -43,6 +43,7 @@ interface QueueDisplayModel {
 	total: number;
 	pluralSuffix: string;
 	saveError?: string;
+	importFlash?: string;
 	isEmpty: boolean;
 	hasArticles: boolean;
 	onboardingHtml: string;
@@ -90,6 +91,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		total: vm.total,
 		pluralSuffix: vm.total !== 1 ? "s" : "",
 		saveError: vm.saveError,
+		importFlash: vm.importFlash,
 		isEmpty: vm.isEmpty,
 		hasArticles: !vm.isEmpty,
 		onboardingHtml,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -44,6 +44,7 @@ interface QueueDisplayModel {
 	pluralSuffix: string;
 	saveError?: string;
 	importFlash?: string;
+	showImportForm: boolean;
 	isEmpty: boolean;
 	hasArticles: boolean;
 	onboardingHtml: string;
@@ -72,7 +73,7 @@ export function formatUnreadLabel(count: number): string {
 	return count > 99 ? "To read (99+)" : `To read (${count})`;
 }
 
-function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; browser: BrowserName; onboardingDismissed: boolean }): QueueDisplayModel {
+function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; browser: BrowserName; onboardingDismissed: boolean; showImportForm: boolean }): QueueDisplayModel {
 	const activeTab = vm.filters.tab;
 	const effectiveOrder = vm.filters.order ?? tabQuery(activeTab).defaultOrder;
 	const nextOrder = effectiveOrder === "desc" ? "asc" : "desc";
@@ -92,6 +93,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		pluralSuffix: vm.total !== 1 ? "s" : "",
 		saveError: vm.saveError,
 		importFlash: vm.importFlash,
+		showImportForm: options.showImportForm,
 		isEmpty: vm.isEmpty,
 		hasArticles: !vm.isEmpty,
 		onboardingHtml,
@@ -129,9 +131,9 @@ const AUTO_SUBMIT_SCRIPT = `
 </script>
 `;
 
-export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; statusCode?: number }): PageBody {
+export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; showImportForm?: boolean; statusCode?: number }): PageBody {
 	const saveUrl = options?.saveUrl;
-	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false });
+	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false, showImportForm: options?.showImportForm ?? false });
 	const content = render(QUEUE_TEMPLATE, { ...displayModel, saveUrl });
 
 	return {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
@@ -1,5 +1,8 @@
 const SAVE_ERROR_MESSAGES: Record<string, string> = {
 	save_failed: "Could not save article. Please try again.",
+	import_too_large: "That file is too large. The limit is 5 MiB — please email it to hutch+migrate@readplace.com instead.",
+	import_no_urls: "We couldn't find any links in that file.",
+	import_session_not_found: "That import session has expired. Please upload the file again.",
 };
 
 export type HttpErrorMessageMapping = (query: Record<string, unknown>) => string | undefined;
@@ -7,4 +10,16 @@ export type HttpErrorMessageMapping = (query: Record<string, unknown>) => string
 export const httpErrorMessageMapping: HttpErrorMessageMapping = (query) => {
 	const errorCode = typeof query.error_code === "string" ? query.error_code : undefined;
 	return errorCode ? SAVE_ERROR_MESSAGES[errorCode] : undefined;
+};
+
+export type ImportFlashMapping = (query: Record<string, unknown>) => string | undefined;
+
+export const importFlashMapping: ImportFlashMapping = (query) => {
+	const importedRaw = query.import_imported;
+	const totalRaw = query.import_total;
+	if (typeof importedRaw !== "string" || typeof totalRaw !== "string") return undefined;
+	const imported = Number.parseInt(importedRaw, 10);
+	const total = Number.parseInt(totalRaw, 10);
+	if (!Number.isFinite(imported) || !Number.isFinite(total)) return undefined;
+	return `Imported ${imported} of ${total} link${total === 1 ? "" : "s"}.`;
 };

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -42,6 +42,7 @@ import { toArticleEntity } from "../../api/article-siren";
 import { parseQueueUrl, buildQueueUrl } from "./queue.url";
 import { tabQuery } from "./queue.tabs";
 import type { HttpErrorMessageMapping } from "./queue.error";
+import { importFlashMapping } from "./queue.error";
 import { toQueueViewModel } from "./queue.viewmodel";
 import { QueuePage } from "./queue.component";
 import { ReaderPage } from "../reader/reader.component";
@@ -213,8 +214,9 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			: (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
 		const totalArticles = (await deps.findArticlesByUser({ userId, page: 1, pageSize: 1 })).total;
 		const saveError = deps.httpErrorMessageMapping(req.query);
+		const importFlash = importFlashMapping(req.query);
 		const summaryByUrl = await loadSummaries(deps.findGeneratedSummary, result.articles);
-		const vm = toQueueViewModel(result, urlState, { unreadCount, totalArticles, saveError, summaryByUrl });
+		const vm = toQueueViewModel(result, urlState, { unreadCount, totalArticles, saveError, importFlash, summaryByUrl });
 		const extensionInstalled = isExtensionInstalled(req);
 		const onboardingDismissed = req.cookies?.[DISMISS_COOKIE_NAME] === ONBOARDING_VERSION;
 		const browser = detectBrowser(req);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -7,8 +7,7 @@ import express from "express";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import { SaveArticleInputSchema, SaveHtmlInputSchema, ArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD, isSaveableUrl } from "../../../domain/article/article.schema";
 import { ReaderArticleHashIdSchema } from "../../../domain/article/reader-article-hash-id";
-import { calculateReadTime } from "../../../domain/article/estimated-read-time";
-import type { ContentFreshnessResult, RefreshArticleIfStale } from "../../../providers/article-freshness/check-content-freshness";
+import type { RefreshArticleIfStale } from "../../../providers/article-freshness/check-content-freshness";
 import type {
 	DeleteArticle,
 	FindArticleById,
@@ -32,7 +31,7 @@ import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.
 import type { PublishLinkSaved } from "../../../providers/events/publish-link-saved.types";
 import type { PublishSaveLinkRawHtmlCommand } from "../../../providers/events/publish-save-link-raw-html-command.types";
 import type { PutPendingHtml } from "../../../providers/pending-html/pending-html.types";
-import type { UserId } from "../../../domain/user/user.types";
+import { saveArticleFromUrl } from "../../shared/save-article/save-article-from-url";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { wantsSiren } from "../../content-negotiation";
@@ -86,88 +85,6 @@ async function loadSummaries(
 		const r = results[i];
 		return [a.url, r.status === "fulfilled" ? r.value : undefined] as const;
 	}));
-}
-
-async function markUnreadIfRead(deps: Pick<QueueDependencies, "updateArticleStatus">, saved: SavedArticle): Promise<SavedArticle> {
-	if (saved.status === "read") {
-		await deps.updateArticleStatus(saved.id, saved.userId, "unread");
-		return { ...saved, status: "unread", readAt: undefined };
-	}
-	return saved;
-}
-
-type SaveArticleFromUrlResult = { ok: true; saved: Awaited<ReturnType<SaveArticle>> };
-
-async function saveArticleFromUrl(deps: QueueDependencies, params: {
-	userId: UserId;
-	url: string;
-	freshness: ContentFreshnessResult;
-}): Promise<SaveArticleFromUrlResult> {
-	const { userId, url, freshness } = params;
-
-	if (freshness.action === "new") {
-		// Save a hostname-only stub immediately so the queue card has something to
-		// render at t=0. The real metadata + content arrive asynchronously via the
-		// SaveLinkCommand handler; markCrawlPending is what flips the reader slot
-		// into the polling state.
-		const hostname = new URL(url).hostname;
-		const saved = await deps.saveArticle({
-			userId,
-			url,
-			metadata: {
-				title: `Article from ${hostname}`,
-				siteName: hostname,
-				excerpt: `Saved from ${hostname}.`,
-				wordCount: 0,
-			},
-			estimatedReadTime: calculateReadTime(0),
-		});
-		await deps.markCrawlPending({ url });
-		await deps.markSummaryPending({ url });
-		// Pre-populate the freshness window with the request time so a quick
-		// re-save can skip dispatching a duplicate SaveLinkCommand while the
-		// worker is mid-crawl. The worker overwrites contentFetchedAt with the
-		// actual fetch time after success. Must succeed — awaited (not
-		// fire-and-forget) because a missing freshness row would let the next
-		// save dispatch a duplicate worker invocation.
-		await deps.publishUpdateFetchTimestamp({
-			url,
-			contentFetchedAt: new Date().toISOString(),
-		});
-		await deps.publishLinkSaved({ url, userId });
-		return { ok: true, saved: await markUnreadIfRead(deps, saved) };
-	}
-
-	if (freshness.action === "reprime") {
-		const saved = await deps.saveArticle({
-			userId,
-			url,
-			metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
-			estimatedReadTime: calculateReadTime(0),
-		});
-		await deps.markCrawlPending({ url });
-		await deps.markSummaryPending({ url });
-		await deps.publishUpdateFetchTimestamp({
-			url,
-			contentFetchedAt: new Date().toISOString(),
-		});
-		await deps.publishLinkSaved({ url, userId });
-		return { ok: true, saved: await markUnreadIfRead(deps, saved) };
-	}
-
-	const saved = await deps.saveArticle({
-		userId,
-		url,
-		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
-		estimatedReadTime: calculateReadTime(0),
-	});
-
-	if (freshness.action === "refreshed" && freshness.article.article.content) {
-		await deps.markSummaryPending({ url });
-		await deps.publishLinkSaved({ url, userId });
-	}
-
-	return { ok: true, saved: await markUnreadIfRead(deps, saved) };
 }
 
 export function initQueueRoutes(deps: QueueDependencies): Router {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -137,9 +137,10 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const extensionInstalled = isExtensionInstalled(req);
 		const onboardingDismissed = req.cookies?.[DISMISS_COOKIE_NAME] === ONBOARDING_VERSION;
 		const browser = detectBrowser(req);
+		const showImportForm = req.query.feature === "import";
 		sendComponent(
 			res,
-			renderPage(req, QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, browser, onboardingDismissed })),
+			renderPage(req, QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, browser, onboardingDismissed, showImportForm })),
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -81,6 +81,28 @@
   margin-bottom: 16px;
 }
 
+.queue__import-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 16px;
+  font-size: 0.875rem;
+}
+
+.queue__import-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.queue__import-flash {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  margin-top: -8px;
+  margin-bottom: 16px;
+}
+
 .queue__filters {
   display: flex;
   gap: 4px;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -8,6 +8,7 @@
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}">
         <button class="queue__save-btn" type="submit"><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
       </form>
+      {{#if showImportForm}}
       <form class="queue__import-form" method="POST" action="/import" enctype="multipart/form-data" data-test-form="import-file">
         <label class="queue__import-label">
           <span>Import from a file</span>
@@ -15,6 +16,7 @@
         </label>
         <button class="queue__import-btn" type="submit" data-test-action="import-upload">Upload</button>
       </form>
+      {{/if}}
       {{#if saveError}}<p class="queue__save-error" data-test-save-error>{{saveError}}</p>{{/if}}
       {{#if importFlash}}<p class="queue__import-flash" data-test-import-flash>{{importFlash}}</p>{{/if}}
       <nav class="queue__filters" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-filters>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -8,7 +8,15 @@
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}">
         <button class="queue__save-btn" type="submit"><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
       </form>
+      <form class="queue__import-form" method="POST" action="/import" enctype="multipart/form-data" data-test-form="import-file">
+        <label class="queue__import-label">
+          <span>Import from a file</span>
+          <input type="file" name="file" required data-test-import-file-input>
+        </label>
+        <button class="queue__import-btn" type="submit" data-test-action="import-upload">Upload</button>
+      </form>
       {{#if saveError}}<p class="queue__save-error" data-test-save-error>{{saveError}}</p>{{/if}}
+      {{#if importFlash}}<p class="queue__import-flash" data-test-import-flash>{{importFlash}}</p>{{/if}}
       <nav class="queue__filters" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-filters>
         <a class="{{filterUnreadClass}}" href="{{filterUnreadUrl}}" data-test-filter="unread">{{filterUnreadLabel}}</a>
         <a class="{{filterReadClass}}" href="{{filterReadUrl}}" data-test-filter="read">Done</a>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -52,6 +52,7 @@ export interface QueueViewModel {
 		next?: string;
 	};
 	saveError?: string;
+	importFlash?: string;
 }
 
 function formatRelativeDate(date: Date, now: Date): string {
@@ -141,6 +142,7 @@ export function toQueueViewModel(
 	options?: {
 		now?: Date;
 		saveError?: string;
+		importFlash?: string;
 		unreadCount?: number;
 		totalArticles?: number;
 		summaryByUrl?: ReadonlyMap<string, GeneratedSummary | undefined>;
@@ -179,5 +181,6 @@ export function toQueueViewModel(
 					: undefined,
 		},
 		saveError: options?.saveError,
+		importFlash: options?.importFlash,
 	};
 }

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
@@ -1,0 +1,180 @@
+import { ReaderArticleHashIdSchema } from "../../../domain/article/reader-article-hash-id";
+import { MinutesSchema } from "../../../domain/article/article.schema";
+import type { SavedArticle } from "../../../domain/article/article.types";
+import { UserIdSchema } from "../../../domain/user/user.schema";
+import {
+	saveArticleFromUrl,
+	type SaveArticleFromUrlDependencies,
+} from "./save-article-from-url";
+
+const userId = UserIdSchema.parse("00000000000000000000000000000001");
+const articleId = ReaderArticleHashIdSchema.parse("0123456789abcdef0123456789abcdef");
+
+function makeSaved(overrides: Partial<SavedArticle> = {}): SavedArticle {
+	return {
+		id: articleId,
+		userId,
+		url: "https://example.com/post",
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+		estimatedReadTime: MinutesSchema.parse(0),
+		status: "unread",
+		savedAt: new Date(),
+		...overrides,
+	};
+}
+
+interface CallTracker {
+	saved: SavedArticle;
+	calls: {
+		markCrawlPending: number;
+		markSummaryPending: number;
+		publishUpdateFetchTimestamp: number;
+		publishLinkSaved: number;
+		updateArticleStatusUnread: number;
+	};
+	deps: SaveArticleFromUrlDependencies;
+}
+
+function makeTracker(savedOverride?: SavedArticle): CallTracker {
+	const saved = savedOverride ?? makeSaved();
+	const calls = {
+		markCrawlPending: 0,
+		markSummaryPending: 0,
+		publishUpdateFetchTimestamp: 0,
+		publishLinkSaved: 0,
+		updateArticleStatusUnread: 0,
+	};
+	const deps: SaveArticleFromUrlDependencies = {
+		saveArticle: async () => saved,
+		updateArticleStatus: async (_id, _u, status) => {
+			if (status === "unread") calls.updateArticleStatusUnread += 1;
+			return true;
+		},
+		markCrawlPending: async () => {
+			calls.markCrawlPending += 1;
+		},
+		markSummaryPending: async () => {
+			calls.markSummaryPending += 1;
+		},
+		publishUpdateFetchTimestamp: async () => {
+			calls.publishUpdateFetchTimestamp += 1;
+		},
+		publishLinkSaved: async () => {
+			calls.publishLinkSaved += 1;
+		},
+		refreshArticleIfStale: async () => ({ action: "new" }),
+	};
+	return { saved, calls, deps };
+}
+
+describe("saveArticleFromUrl", () => {
+	it("primes the crawl + summary pipeline on a 'new' freshness verdict", async () => {
+		const tracker = makeTracker();
+
+		await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: "https://example.com/post",
+			freshness: { action: "new" },
+		});
+
+		expect(tracker.calls).toEqual({
+			markCrawlPending: 1,
+			markSummaryPending: 1,
+			publishUpdateFetchTimestamp: 1,
+			publishLinkSaved: 1,
+			updateArticleStatusUnread: 0,
+		});
+	});
+
+	it("re-primes the crawl pipeline on a 'reprime' verdict", async () => {
+		const tracker = makeTracker();
+
+		await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: "https://example.com/post",
+			freshness: { action: "reprime" },
+		});
+
+		expect(tracker.calls.markCrawlPending).toBe(1);
+		expect(tracker.calls.publishLinkSaved).toBe(1);
+	});
+
+	it("publishes a link saved event when 'refreshed' has fresh content", async () => {
+		const tracker = makeTracker();
+
+		await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: "https://example.com/post",
+			freshness: {
+				action: "refreshed",
+				article: {
+					ok: true,
+					article: {
+						title: "t",
+						siteName: "s",
+						excerpt: "e",
+						wordCount: 100,
+						content: "<p>hi</p>",
+					},
+				},
+			},
+		});
+
+		expect(tracker.calls.markSummaryPending).toBe(1);
+		expect(tracker.calls.publishLinkSaved).toBe(1);
+		expect(tracker.calls.markCrawlPending).toBe(0);
+	});
+
+	it("does not publish on 'refreshed' verdicts whose article has no content", async () => {
+		const tracker = makeTracker();
+
+		await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: "https://example.com/post",
+			freshness: {
+				action: "refreshed",
+				article: {
+					ok: true,
+					article: {
+						title: "t",
+						siteName: "s",
+						excerpt: "e",
+						wordCount: 0,
+						content: "",
+					},
+				},
+			},
+		});
+
+		expect(tracker.calls.publishLinkSaved).toBe(0);
+		expect(tracker.calls.markSummaryPending).toBe(0);
+	});
+
+	it("does not publish or re-prime on 'skip' or 'unchanged' verdicts", async () => {
+		const tracker = makeTracker();
+
+		await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: "https://example.com/post",
+			freshness: { action: "skip" },
+		});
+
+		expect(tracker.calls.publishLinkSaved).toBe(0);
+		expect(tracker.calls.markCrawlPending).toBe(0);
+	});
+
+	it("flips a previously-read article back to unread after a re-save", async () => {
+		const previouslyRead = makeSaved({ status: "read", readAt: new Date() });
+		const tracker = makeTracker(previouslyRead);
+
+		const result = await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: "https://example.com/post",
+			freshness: { action: "new" },
+		});
+
+		expect(tracker.calls.updateArticleStatusUnread).toBe(1);
+		expect(result.saved.status).toBe("unread");
+		expect(result.saved.readAt).toBeUndefined();
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
@@ -1,0 +1,91 @@
+import { calculateReadTime } from "../../../domain/article/estimated-read-time";
+import type { ContentFreshnessResult, RefreshArticleIfStale } from "../../../providers/article-freshness/check-content-freshness";
+import type { MarkCrawlPending } from "../../../providers/article-crawl/article-crawl.types";
+import type { MarkSummaryPending } from "../../../providers/article-summary/article-summary.types";
+import type { SaveArticle, UpdateArticleStatus } from "../../../providers/article-store/article-store.types";
+import type { PublishLinkSaved } from "../../../providers/events/publish-link-saved.types";
+import type { PublishUpdateFetchTimestamp } from "../../../providers/events/publish-update-fetch-timestamp.types";
+import type { UserId } from "../../../domain/user/user.types";
+import type { SavedArticle } from "../../../domain/article/article.types";
+
+export interface SaveArticleFromUrlDependencies {
+	saveArticle: SaveArticle;
+	updateArticleStatus: UpdateArticleStatus;
+	markCrawlPending: MarkCrawlPending;
+	markSummaryPending: MarkSummaryPending;
+	publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp;
+	publishLinkSaved: PublishLinkSaved;
+	refreshArticleIfStale: RefreshArticleIfStale;
+}
+
+async function markUnreadIfRead(
+	updateArticleStatus: UpdateArticleStatus,
+	saved: SavedArticle,
+): Promise<SavedArticle> {
+	if (saved.status === "read") {
+		await updateArticleStatus(saved.id, saved.userId, "unread");
+		return { ...saved, status: "unread", readAt: undefined };
+	}
+	return saved;
+}
+
+export async function saveArticleFromUrl(
+	deps: SaveArticleFromUrlDependencies,
+	params: { userId: UserId; url: string; freshness: ContentFreshnessResult },
+): Promise<{ saved: SavedArticle }> {
+	const { userId, url, freshness } = params;
+
+	if (freshness.action === "new") {
+		const hostname = new URL(url).hostname;
+		const saved = await deps.saveArticle({
+			userId,
+			url,
+			metadata: {
+				title: `Article from ${hostname}`,
+				siteName: hostname,
+				excerpt: `Saved from ${hostname}.`,
+				wordCount: 0,
+			},
+			estimatedReadTime: calculateReadTime(0),
+		});
+		await deps.markCrawlPending({ url });
+		await deps.markSummaryPending({ url });
+		await deps.publishUpdateFetchTimestamp({
+			url,
+			contentFetchedAt: new Date().toISOString(),
+		});
+		await deps.publishLinkSaved({ url, userId });
+		return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
+	}
+
+	if (freshness.action === "reprime") {
+		const saved = await deps.saveArticle({
+			userId,
+			url,
+			metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+			estimatedReadTime: calculateReadTime(0),
+		});
+		await deps.markCrawlPending({ url });
+		await deps.markSummaryPending({ url });
+		await deps.publishUpdateFetchTimestamp({
+			url,
+			contentFetchedAt: new Date().toISOString(),
+		});
+		await deps.publishLinkSaved({ url, userId });
+		return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
+	}
+
+	const saved = await deps.saveArticle({
+		userId,
+		url,
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+		estimatedReadTime: calculateReadTime(0),
+	});
+
+	if (freshness.action === "refreshed" && freshness.article.article.content) {
+		await deps.markSummaryPending({ url });
+		await deps.publishLinkSaved({ url, userId });
+	}
+
+	return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
+}

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -1,12 +1,20 @@
 import assert from "node:assert";
 import { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "./crawl-article";
 import type { CrawlArticleResult } from "./crawl-article.types";
+import type { fetchCurl } from "./curl-fetch";
 
 const noopLogError = () => {};
+
+// Default stub: never reaches real network in unit tests. Tests that want to
+// verify fallback behaviour pass a curl impl explicitly via overrides.fetchCurl.
+const stubFetchCurl: typeof fetchCurl = async () => {
+	throw new Error("stub fetchCurl: not invoked");
+};
 
 function initCrawl(overrides?: {
 	fetch?: typeof fetch;
 	logError?: (message: string, error?: Error) => void;
+	fetchCurl?: typeof fetchCurl;
 }) {
 	const defaultFetch: typeof fetch = async () =>
 		new Response("<html></html>", {
@@ -17,6 +25,7 @@ function initCrawl(overrides?: {
 		fetch: overrides?.fetch ?? defaultFetch,
 		logError: overrides?.logError ?? noopLogError,
 		headers: { ...DEFAULT_CRAWL_HEADERS },
+		fetchCurl: overrides?.fetchCurl ?? stubFetchCurl,
 	});
 }
 
@@ -307,8 +316,8 @@ describe("initCrawlArticle — failure modes", () => {
 		expect(logError).toHaveBeenCalledWith('[CrawlArticle] Unexpected Content-Type "" for https://example.com');
 	});
 
-	it("returns status 'failed' and logs with the Error instance when fetch throws", async () => {
-		const networkError = new Error("network down");
+	it("returns status 'failed' and logs with the Error instance when fetch throws a clear network error (curl fallback skipped)", async () => {
+		const networkError = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
 		const fakeFetch: typeof fetch = async () => { throw networkError; };
 		const logError = jest.fn();
 		const crawlArticle = initCrawl({ fetch: fakeFetch, logError });
@@ -319,10 +328,24 @@ describe("initCrawlArticle — failure modes", () => {
 		expect(logError).toHaveBeenCalledWith("[CrawlArticle] Network error for https://example.com", networkError);
 	});
 
-	it("returns status 'failed' and logs undefined when fetch throws a non-Error value", async () => {
-		const fakeFetch: typeof fetch = async () => { throw "string error"; };
+	it("returns status 'failed' when fetch throws a transient error and curl fallback also fails", async () => {
+		const fakeFetch: typeof fetch = async () => { throw new Error("network down"); };
+		const curlError = new Error("curl also failed");
+		const fakeCurl: typeof fetchCurl = async () => { throw curlError; };
 		const logError = jest.fn();
-		const crawlArticle = initCrawl({ fetch: fakeFetch, logError });
+		const crawlArticle = initCrawl({ fetch: fakeFetch, fetchCurl: fakeCurl, logError });
+
+		const result = await crawlArticle({ url: "https://example.com" });
+
+		expect(result).toEqual({ status: "failed" });
+		expect(logError).toHaveBeenCalledWith("[CrawlArticle] Network error for https://example.com", curlError);
+	});
+
+	it("returns status 'failed' and logs undefined when fetch throws a non-Error value and curl fallback also fails with a non-Error", async () => {
+		const fakeFetch: typeof fetch = async () => { throw "string error"; };
+		const fakeCurl: typeof fetchCurl = async () => { throw "string error from curl"; };
+		const logError = jest.fn();
+		const crawlArticle = initCrawl({ fetch: fakeFetch, fetchCurl: fakeCurl, logError });
 
 		const result = await crawlArticle({ url: "https://example.com" });
 
@@ -481,8 +504,8 @@ describe("initCrawlArticle — thumbnail fetch (fetchThumbnail opt-in)", () => {
 		expect(logError).toHaveBeenCalledWith(`[CrawlArticle] Thumbnail too large (${oversizedBody.length} bytes) for https://cdn.example.com/thumb.jpg`);
 	});
 
-	it("logs and returns thumbnailImage undefined when the thumbnail fetch throws", async () => {
-		const networkError = new Error("connection reset");
+	it("logs and returns thumbnailImage undefined when the thumbnail fetch throws a clear network error (curl fallback skipped)", async () => {
+		const networkError = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
 		const fakeFetch = articleThenImageFetch(() => { throw networkError; });
 		const logError = jest.fn();
 		const crawlArticle = initCrawl({ fetch: fakeFetch, logError });
@@ -494,10 +517,11 @@ describe("initCrawlArticle — thumbnail fetch (fetchThumbnail opt-in)", () => {
 		expect(logError).toHaveBeenCalledWith("[CrawlArticle] Thumbnail network error for https://cdn.example.com/thumb.jpg", networkError);
 	});
 
-	it("logs with undefined when the thumbnail fetch throws a non-Error value", async () => {
+	it("logs with undefined when the thumbnail fetch throws a non-Error value and curl fallback also fails with a non-Error", async () => {
 		const fakeFetch = articleThenImageFetch(() => { throw "boom"; });
+		const fakeCurl: typeof fetchCurl = async () => { throw "boom from curl"; };
 		const logError = jest.fn();
-		const crawlArticle = initCrawl({ fetch: fakeFetch, logError });
+		const crawlArticle = initCrawl({ fetch: fakeFetch, fetchCurl: fakeCurl, logError });
 
 		const result = await crawlArticle({ url: "https://example.com", fetchThumbnail: true });
 

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -1,7 +1,8 @@
 import { parseHTML } from "linkedom";
 import { withAiaChasing } from "./aia-fetch";
 import type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";
-import { withH2Fallback } from "./h2-fetch";
+import type { fetchCurl } from "./curl-fetch";
+import { type fetchH2, withH2Fallback } from "./h2-fetch";
 import { headerOrUndefined } from "./header-utils";
 
 const FETCH_TIMEOUT_MS = 10000;
@@ -25,8 +26,14 @@ export function initCrawlArticle(deps: {
 	fetch: typeof globalThis.fetch;
 	logError: (message: string, error?: Error) => void;
 	headers: Record<string, string>;
+	fetchH2?: typeof fetchH2;
+	fetchCurl?: typeof fetchCurl;
 }): CrawlArticle {
-	const fetchWithFallback = withH2Fallback(withAiaChasing(deps.fetch));
+	const fetchWithFallback = withH2Fallback(
+		withAiaChasing(deps.fetch),
+		deps.fetchH2,
+		deps.fetchCurl,
+	);
 	return async (params) => {
 		if (X_TWITTER_PATTERN.test(params.url)) {
 			return fetchViaOembed(deps, params);

--- a/src/packages/crawl-article/src/h2-fetch.test.ts
+++ b/src/packages/crawl-article/src/h2-fetch.test.ts
@@ -482,15 +482,41 @@ describe("withH2Fallback", () => {
 		},
 	);
 
-	it("propagates baseFetch error when there is no signal (no timeout to detect)", async () => {
+	it("falls back to curl on a connection-mid-request error (e.g. socket hangup) even with no signal", async () => {
 		const socketError = new Error("socket hang up");
 		const baseFetch: typeof fetch = async () => {
 			throw socketError;
 		};
-		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
+			new Response("<html>curl recovered</html>", { status: 200, headers: { "content-type": "text/html" } }),
+		);
 		const wrapped = withH2Fallback(baseFetch, jest.fn(), curlImpl);
 
-		await expect(wrapped("https://example.com")).rejects.toBe(socketError);
-		expect(curlImpl).not.toHaveBeenCalled();
+		const response = await wrapped("https://example.com");
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<html>curl recovered</html>");
+		expect(curlImpl).toHaveBeenCalledWith("https://example.com", { headers: undefined });
+	});
+
+	it("falls back to curl when the primary fetch throws a generic 'fetch failed' (origin closed the connection mid-request)", async () => {
+		const fetchFailed = new TypeError("fetch failed");
+		const baseFetch: typeof fetch = async () => {
+			throw fetchFailed;
+		};
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
+			new Response("ok", { status: 200, headers: { "content-type": "text/html" } }),
+		);
+		const wrapped = withH2Fallback(baseFetch, jest.fn(), curlImpl);
+
+		const response = await wrapped("https://hex.ooo/library/last_question.html", {
+			signal: AbortSignal.timeout(5000),
+			headers: { "user-agent": "Test/1.0" },
+		});
+
+		expect(response.status).toBe(200);
+		expect(curlImpl).toHaveBeenCalledWith("https://hex.ooo/library/last_question.html", {
+			headers: { "user-agent": "Test/1.0" },
+		});
 	});
 });

--- a/src/packages/crawl-article/src/h2-fetch.ts
+++ b/src/packages/crawl-article/src/h2-fetch.ts
@@ -112,12 +112,14 @@ function toFetchHeaders(incoming: http2.IncomingHttpHeaders): Headers {
  * header), since both are TLS-fingerprint blocks that real browsers bypass
  * via h2. Non-Cloudflare 403s and non-403 responses pass through unchanged.
  *
- * If the h2 fallback itself fails with a TLS- or protocol-level error (e.g.
- * Cloudflare refuses to negotiate h2 via ALPN downgrade), a curl subprocess
- * fallback kicks in. curl's OpenSSL-based TLS fingerprint differs from
- * Node.js's and passes Cloudflare's JA3/JA4 heuristics. Clear network
- * failures (DNS, connection refused) and aborts skip curl since they would
- * fail the same way and only add latency.
+ * If the primary fetch or the h2 fallback fails with a transient TLS- or
+ * connection-level error (timeout, ECONNRESET, "fetch failed", protocol
+ * error from h2's ALPN downgrade), a curl subprocess fallback kicks in.
+ * curl's OpenSSL-based TLS fingerprint differs from Node.js's and passes
+ * Cloudflare's JA3/JA4 heuristics; its fresh TCP connection also bypasses
+ * upstream nginx/edge sniffers that drop specific Lambda outbound IPs.
+ * Clear network failures (DNS, connection refused) and explicit user-aborts
+ * skip curl since they would fail the same way and only add latency.
  */
 export function withH2Fallback(
 	baseFetch: typeof fetch,
@@ -129,8 +131,7 @@ export function withH2Fallback(
 		try {
 			response = await baseFetch(input, init);
 		} catch (error) {
-			const signal = init?.signal ?? undefined;
-			if (!signal?.aborted || !isTimeoutError(signal.reason)) throw error;
+			if (!shouldFallbackToCurl(error, init?.signal ?? undefined)) throw error;
 			const url = urlFromInput(input);
 			return curlFetchImpl(url, { headers: toPlainHeaders(init?.headers) });
 		}


### PR DESCRIPTION
Adds an "Import from a file" picker next to the queue save bar. The user
uploads any file (≤ 5 MiB), the server best-effort-decodes it as text
(UTF-8 with Latin-1 fallback), extracts every http(s) URL, and shows a
paginated review screen with each URL checked by default. Selected URLs
are stub-saved synchronously and the existing SaveLinkCommand pipeline
fills in title/excerpt/content asynchronously, so cards appear at t=0
and progressively populate.

- new domain module `domain/import-session` with the URL extractor and
  zod-backed schemas (branded ImportSessionId, 5 MiB / 2,000 URL caps,
  24h TTL)
- new in-memory + DynamoDB providers under `providers/import-session`
- new `web/pages/import` route, viewmodel, component, template, styles,
  and a small multipart wrapper
- new `web/shared/save-article/save-article-from-url.ts` extracted
  primitive shared by the queue and import routes
- queue template: import CTA next to save bar, success/error flash
- queue.error: import_too_large / import_no_urls / import_session_not_found
  + import_imported flash mapping
- infra: hutch-import-sessions DynamoDB table with TTL on expiresAt;
  IAM grant added to the lambda; staging + prod Pulumi config
- self-serve import documentation: CLAUDE.md, pocket-migration.md,
  best-read-it-later-apps-2026.md, llms-full.txt now lead with the
  in-app picker and demote concierge email to a fallback for files
  > 5 MiB / imports > 2,000 links
- 100% function coverage: unit tests for extract-urls, import.viewmodel,
  multipart-upload, in-memory-import-session, save-article-from-url;
  integration tests for the full import route lifecycle (upload, page,
  toggle, commit, oversize body)

https://claude.ai/code/session_01Rv7bx5ZTuWPf47Y3ZAePRD