### PR TITLE
Refactor mark-read action to use POST with status endpoint

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -12,7 +12,6 @@ const QUEUE_TEMPLATE = readFileSync(join(__dirname, "queue.template.html"), "utf
 
 interface ActionDisplayModel extends ArticleAction {
 	buttonClass: string;
-	boost: boolean;
 }
 
 interface ArticleDisplayModel extends QueueArticleViewModel {
@@ -27,7 +26,6 @@ function toActionDisplayModel(action: ArticleAction): ActionDisplayModel {
 		buttonClass: action.testAction === "delete"
 			? "queue-article__action-btn queue-article__action-btn--delete"
 			: "queue-article__action-btn",
-		boost: !action.pageReload,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -492,11 +492,11 @@ describe("Queue routes", () => {
 			const actionForms = doc.querySelectorAll(".queue-article__action-form");
 
 			expect(actionForms.length).toBe(2);
-			expect(doc.querySelector("[data-test-action='mark-read']")?.textContent).toBe("Read");
+			expect(doc.querySelector("[data-test-action='mark-read']")?.textContent).toBe("Mark as read");
 			expect(doc.querySelector("[data-test-action='delete']")?.textContent).toBe("×");
 		});
 
-		it("should disable htmx boost on the read action form", async () => {
+		it("should enable htmx boost on the mark-read action form", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(app, auth);
 
@@ -509,10 +509,10 @@ describe("Queue routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			const readForm = doc.querySelector("[data-test-action='mark-read']")?.closest("form");
 
-			expect(readForm?.getAttribute("hx-boost")).toBe("false");
-			expect(readForm?.hasAttribute("hx-target")).toBe(false);
-			expect(readForm?.hasAttribute("hx-select")).toBe(false);
-			expect(readForm?.hasAttribute("hx-swap")).toBe(false);
+			expect(readForm?.getAttribute("hx-boost")).toBe("true");
+			expect(readForm?.getAttribute("hx-target")).toBe("main");
+			expect(readForm?.getAttribute("hx-select")).toBe("main");
+			expect(readForm?.getAttribute("hx-swap")).toBe("outerHTML show:none");
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -42,7 +42,7 @@
           </div>
           <div class="queue-article__actions">
             {{#each actions}}
-            <form method="{{method}}" action="{{url}}" class="queue-article__action-form" hx-boost="{{boost}}"{{#if boost}} hx-target="main" hx-select="main" hx-swap="outerHTML show:none"{{/if}}>
+            <form method="{{method}}" action="{{url}}" class="queue-article__action-form" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
               {{#each fields}}<input type="hidden" name="{{name}}" value="{{value}}">{{/each}}
               <button class="{{buttonClass}}" type="submit" title="{{title}}" data-test-action="{{testAction}}">{{text}}</button>
             </form>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -293,14 +293,23 @@ describe("toQueueViewModel", () => {
 		expect(markUnreadAction?.fields).toEqual([{ name: "status", value: "unread" }]);
 	});
 
-	it("should use GET method and reader view URL for mark-read action", () => {
+	it("should use POST method and /status URL for mark-read action", () => {
 		const article = makeArticle({ status: "unread" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, { now: NOW });
 
 		const markReadAction = vm.articles[0].actions.find(a => a.testAction === "mark-read");
-		expect(markReadAction?.method).toBe("GET");
-		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/read`);
-		expect(markReadAction?.fields).toEqual([]);
+		expect(markReadAction?.method).toBe("POST");
+		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/status`);
+		expect(markReadAction?.fields).toEqual([{ name: "status", value: "read" }]);
+	});
+
+	it("should include return query in mark-read URL for non-default view", () => {
+		const article = makeArticle({ status: "unread" });
+		const filters = { order: "asc" as const, page: 1, status: "unread" as const };
+		const vm = toQueueViewModel(makeResult([article]), filters, { now: NOW });
+
+		const markReadAction = vm.articles[0].actions.find(a => a.testAction === "mark-read");
+		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/status?order=asc`);
 	});
 
 	it("should have no hidden fields in delete action", () => {
@@ -311,12 +320,12 @@ describe("toQueueViewModel", () => {
 		expect(deleteAction?.fields).toEqual([]);
 	});
 
-	it("should use GET for mark-read and POST for other actions", () => {
+	it("should use POST for all actions", () => {
 		const article = makeArticle({ status: "unread" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, { now: NOW });
 
 		const methods = vm.articles[0].actions.map(a => a.method);
-		expect(methods).toEqual(["GET", "POST"]);
+		expect(methods).toEqual(["POST", "POST"]);
 	});
 
 	it("should include unreadCount from options", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -16,7 +16,6 @@ export interface ArticleAction {
 	text: string;
 	title: string;
 	testAction: string;
-	pageReload: boolean;
 	fields: ArticleActionField[];
 }
 
@@ -85,7 +84,6 @@ function toArticleActions(
 			text: "Mark as read",
 			title: "Mark as read",
 			testAction: "mark-read",
-			pageReload: false,
 			fields: [{ name: "status", value: "read" }],
 		});
 	}
@@ -97,7 +95,6 @@ function toArticleActions(
 			text: "Unread",
 			title: "Mark as unread",
 			testAction: "mark-unread",
-			pageReload: false,
 			fields: [{ name: "status", value: "unread" }],
 		});
 	}
@@ -108,7 +105,6 @@ function toArticleActions(
 		text: "×",
 		title: "Delete",
 		testAction: "delete",
-		pageReload: false,
 		fields: [],
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -80,13 +80,13 @@ function toArticleActions(
 
 	if (article.status !== "read") {
 		actions.push({
-			method: "GET",
-			url: `/queue/${article.id}/read`,
-			text: "Read",
+			method: "POST",
+			url: `/queue/${article.id}/status${returnQuery}`,
+			text: "Mark as read",
 			title: "Mark as read",
 			testAction: "mark-read",
-			pageReload: true,
-			fields: [],
+			pageReload: false,
+			fields: [{ name: "status", value: "read" }],
 		});
 	}
 


### PR DESCRIPTION
## Summary
Changed the mark-read action from a GET request to a POST request, updating the endpoint and request format to be consistent with other article actions.

## Key Changes
- **HTTP Method**: Changed mark-read action from GET to POST
- **Endpoint**: Updated from `/queue/{id}/read` to `/queue/{id}/status`
- **Request Format**: Now sends status field in request body (`{ name: "status", value: "read" }`) instead of empty fields
- **Page Reload**: Disabled automatic page reload (`pageReload: false`) to allow HTMX to handle the response
- **HTMX Integration**: Enabled HTMX boost on mark-read form with proper targeting and swap configuration
- **UI Text**: Updated button text from "Read" to "Mark as read" for clarity
- **Return Query**: Added support for including filter parameters in the status URL for non-default views

## Implementation Details
- The mark-read action now uses the same POST-based pattern as the delete action
- HTMX boost is enabled with `hx-target="main"`, `hx-select="main"`, and `hx-swap="outerHTML show:none"` to properly update the page content
- Filter parameters (e.g., `order=asc`) are included in the URL when using non-default filters to maintain proper navigation context
- All article actions now consistently use POST method

https://claude.ai/code/session_01XhJyy3J5RB4NWKbSNdbpyt