### PR TITLE
Send welcome email after email verification and Google signup

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/password-reset-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/password-reset-actions.ts
@@ -69,7 +69,7 @@ export function createPasswordResetActions(
         const response = await page.request.get(`${data.baseUrl}/e2e/sent-emails`)
         const emails = await response.json()
         const resetEmail = emails.find((e: { subject: string }) => e.subject.includes('Reset your password'))
-        const tokenMatch = resetEmail.html.match(/token=([a-f0-9]+)/)
+        const tokenMatch = resetEmail.html.match(/token&#x3D;([a-f0-9]+)/)
         const token = tokenMatch[1]
 
         await page.goto(`${data.baseUrl}/reset-password?token=${token}`)

--- a/projects/hutch/src/runtime/providers/email/resend-email.ts
+++ b/projects/hutch/src/runtime/providers/email/resend-email.ts
@@ -6,13 +6,16 @@ export function initResendEmail(apiKey: string): { sendEmail: SendEmail } {
 	const resend = new Resend(apiKey);
 
 	const sendEmail: SendEmail = async (message) => {
-		await resend.emails.send({
+		const result = await resend.emails.send({
 			from: message.from,
 			to: message.to,
 			subject: message.subject,
 			html: message.html,
 			...(message.bcc && { bcc: message.bcc }),
 		});
+		if (result.error) {
+			throw new Error(`Resend ${result.error.name}: ${result.error.message}`);
+		}
 	};
 
 	return { sendEmail };

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -381,6 +381,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		consumePendingSignup: deps.consumePendingSignup,
 		appOrigin,
 		baseUrl: deps.baseUrl,
+		staticBaseUrl,
 		logError: deps.logError,
 	});
 	app.use(authRouter);

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -65,6 +65,7 @@ interface AuthDependencies {
 	consumePendingSignup: ConsumePendingSignup;
 	appOrigin: string;
 	baseUrl: string;
+	staticBaseUrl: string;
 	logError: (message: string, error?: Error) => void;
 }
 
@@ -91,12 +92,13 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 
 	const sendWelcomeEmail = (email: string): void => {
 		const installUrl = `${deps.baseUrl}/install`;
+		const avatarUrl = `${deps.staticBaseUrl}/fayner-brack.jpg`;
 		deps.sendEmail({
 			from: WELCOME_EMAIL_FROM,
 			to: email,
 			bcc: "readplace+welcome@readplace.com",
 			subject: "Welcome to Readplace",
-			html: buildWelcomeEmailHtml({ installUrl }),
+			html: buildWelcomeEmailHtml({ installUrl, avatarUrl }),
 		}).catch((err) => {
 			deps.logError("[Email] Welcome email failed", err instanceof Error ? err : new Error(String(err)));
 		});

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -36,6 +36,7 @@ import { LoginPage, SignupPage, VerifyEmailPage } from "./auth.component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
 import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "./session-cookie";
 import { buildVerificationEmailHtml } from "./verification-email";
+import { buildWelcomeEmailHtml } from "./welcome-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
 
@@ -43,6 +44,7 @@ const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough(
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
+const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
 
 interface AuthDependencies {
 	createUserWithPasswordHash: CreateUserWithPasswordHash;
@@ -85,6 +87,19 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 	const buildCancelUrl = (path: "/signup", returnUrl: string | undefined): string => {
 		const suffix = returnUrl ? `?return=${encodeURIComponent(returnUrl)}` : "";
 		return `${deps.appOrigin}${path}${suffix}`;
+	};
+
+	const sendWelcomeEmail = (email: string): void => {
+		const installUrl = `${deps.baseUrl}/install`;
+		deps.sendEmail({
+			from: WELCOME_EMAIL_FROM,
+			to: email,
+			bcc: "readplace+welcome@readplace.com",
+			subject: "Welcome to Readplace",
+			html: buildWelcomeEmailHtml({ installUrl }),
+		}).catch((err) => {
+			deps.logError("[Email] Welcome email failed", err instanceof Error ? err : new Error(String(err)));
+		});
 	};
 
 	const sendVerificationEmail = (userId: UserId, email: string): void => {
@@ -317,6 +332,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
 		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+		sendWelcomeEmail(pending.email);
 		res.redirect(303, returnPath);
 	});
 
@@ -349,6 +365,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 
 		await deps.markEmailVerified(verifyResult.email);
+		sendWelcomeEmail(verifyResult.email);
 
 		const sessionId = req.cookies?.[SESSION_COOKIE_NAME];
 		if (sessionId) {

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -150,6 +150,39 @@ describe("GET /auth/checkout/success", () => {
 		expect(lookup.userId).toBe("u-google-checkout-1");
 	});
 
+	it("sends a welcome email after a new Google user completes Stripe checkout", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const { app, email, stripe, pendingSignup } = createTestApp(fixture);
+		const { UserIdSchema } = await import("../../domain/user/user.schema");
+
+		const checkout = await stripe.createCheckoutSession({
+			customerEmail: "google-welcome@example.com",
+			successUrl: "http://localhost:3000/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "http://localhost:3000/login",
+		});
+		await pendingSignup.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "google",
+				email: "google-welcome@example.com",
+				userId: UserIdSchema.parse("u-google-welcome-1"),
+			},
+		});
+		stripe.markPaid(checkout.id);
+
+		await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
+		);
+
+		const sent = email.getSentEmails();
+		expect(sent).toHaveLength(1);
+		expect(sent[0].to).toBe("google-welcome@example.com");
+		expect(sent[0].from).toContain("fayner@readplace.com");
+		expect(sent[0].bcc).toBe("readplace+welcome@readplace.com");
+		expect(sent[0].subject).toBe("Welcome to Readplace");
+		expect(sent[0].html).toContain("/install");
+	});
+
 	it("logs the existing user in when a Google sign-up arrives for an email that already exists", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const { app, auth, stripe, pendingSignup } = createTestApp(fixture);
@@ -186,5 +219,38 @@ describe("GET /auth/checkout/success", () => {
 		assert(lookup, "user should still exist");
 		expect(lookup.userId).toBe(existing.userId);
 		expect(lookup.emailVerified).toBe(true);
+	});
+
+	it("does not send a welcome email when a Google sign-up falls back to an existing email/password account", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const { app, auth, email, stripe, pendingSignup } = createTestApp(fixture);
+		const { UserIdSchema } = await import("../../domain/user/user.schema");
+
+		const existing = await auth.createUser({
+			email: "existing-welcome@example.com",
+			password: "password123",
+		});
+		assert(existing.ok, "setup");
+
+		const checkout = await stripe.createCheckoutSession({
+			customerEmail: "existing-welcome@example.com",
+			successUrl: "http://localhost:3000/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "http://localhost:3000/login",
+		});
+		await pendingSignup.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "google",
+				email: "existing-welcome@example.com",
+				userId: UserIdSchema.parse("u-google-existing-welcome"),
+			},
+		});
+		stripe.markPaid(checkout.id);
+
+		await request(app).get(
+			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
+		);
+
+		expect(email.getSentEmails()).toHaveLength(0);
 	});
 });

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -37,7 +37,7 @@ describe("Email verification", () => {
 			expect(sent[0].to).toBe("new@example.com");
 			expect(sent[0].from).toContain("readplace@readplace.com");
 			expect(sent[0].subject).toContain("Verify");
-			expect(sent[0].html).toContain("verify-email?token=");
+			expect(sent[0].html).toContain("verify-email?token&#x3D;");
 		});
 
 		it("should complete signup even when email sending fails", async () => {
@@ -129,7 +129,7 @@ describe("Email verification", () => {
 			});
 
 			const sent = email.getSentEmails();
-			const tokenMatch = sent[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sent[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
@@ -171,7 +171,7 @@ describe("Email verification", () => {
 			});
 
 			const sent = email.getSentEmails();
-			const tokenMatch = sent[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sent[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
@@ -204,7 +204,7 @@ describe("Email verification", () => {
 			expect(session.emailVerified).toBe(false);
 
 			const sent = email.getSentEmails();
-			const tokenMatch = sent[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sent[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
@@ -250,7 +250,7 @@ describe("Email verification", () => {
 
 			const sentBeforeVerify = email.getSentEmails();
 			expect(sentBeforeVerify).toHaveLength(1);
-			const tokenMatch = sentBeforeVerify[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sentBeforeVerify[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -237,5 +237,50 @@ describe("Email verification", () => {
 			assert(session, "Expected session to exist");
 			expect(session.emailVerified).toBe(false);
 		});
+
+		it("should send a welcome email after successful verification", async () => {
+			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await completeStripeSignup({
+				app,
+				stripe,
+				email: "welcome@example.com",
+				password: "password123",
+			});
+
+			const sentBeforeVerify = email.getSentEmails();
+			expect(sentBeforeVerify).toHaveLength(1);
+			const tokenMatch = sentBeforeVerify[0].html.match(/token=([a-f0-9]+)/);
+			assert(tokenMatch, "Expected token in verification email");
+			const token = tokenMatch[1];
+
+			await request(app).get(`/verify-email?token=${token}`);
+
+			const sent = email.getSentEmails();
+			expect(sent).toHaveLength(2);
+			const welcome = sent[1];
+			expect(welcome.to).toBe("welcome@example.com");
+			expect(welcome.from).toContain("fayner@readplace.com");
+			expect(welcome.bcc).toBe("readplace+welcome@readplace.com");
+			expect(welcome.subject).toBe("Welcome to Readplace");
+			expect(welcome.html).toContain("/install");
+		});
+
+		it("should not send a welcome email when the verification token is invalid", async () => {
+			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await completeStripeSignup({
+				app,
+				stripe,
+				email: "nowelcome@example.com",
+				password: "password123",
+			});
+
+			await request(app).get("/verify-email?token=invalidtoken");
+
+			const sent = email.getSentEmails();
+			expect(sent).toHaveLength(1);
+			expect(sent[0].subject).toContain("Verify");
+		});
 	});
 });

--- a/projects/hutch/src/runtime/web/auth/forgot-password.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.route.test.ts
@@ -63,7 +63,7 @@ describe("Forgot password", () => {
 			expect(sent[0].to).toBe("user@example.com");
 			expect(sent[0].from).toContain("Readplace Password Reset <readplace@readplace.com>");
 			expect(sent[0].subject).toContain("Reset your password");
-			expect(sent[0].html).toContain("reset-password?token=");
+			expect(sent[0].html).toContain("reset-password?token&#x3D;");
 		});
 
 		it("should not send email for non-existing user", async () => {
@@ -124,7 +124,7 @@ describe("Forgot password", () => {
 				.send({ email: "user@example.com" });
 
 			const sent = email.getSentEmails();
-			const tokenMatch = sent[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sent[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in password reset email");
 			const token = tokenMatch[1];
 
@@ -167,7 +167,7 @@ describe("Forgot password", () => {
 				.send({ email: "user@example.com" });
 
 			const sent = email.getSentEmails();
-			const tokenMatch = sent[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sent[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in password reset email");
 			const token = tokenMatch[1];
 
@@ -235,7 +235,7 @@ describe("Forgot password", () => {
 				.send({ email: "user@example.com" });
 
 			const sent = email.getSentEmails();
-			const tokenMatch = sent[0].html.match(/token=([a-f0-9]+)/);
+			const tokenMatch = sent[0].html.match(/token&#x3D;([a-f0-9]+)/);
 			assert(tokenMatch, "Expected token in password reset email");
 			const token = tokenMatch[1];
 

--- a/projects/hutch/src/runtime/web/auth/password-reset-email.ts
+++ b/projects/hutch/src/runtime/web/auth/password-reset-email.ts
@@ -1,14 +1,8 @@
-const EMAIL_COLORS = {
-	background: "#F7F8FA",
-	surface: "#FFFFFF",
-	heading: "#1A202C",
-	body: "#5A6170",
-	muted: "#8C919D",
-	brand: "#C8702A",
-	brandText: "#FFFFFF",
-} as const;
+import Handlebars from "handlebars";
+import { EMAIL_COLORS } from "../email-colors";
 
 export function buildPasswordResetEmailHtml(resetUrl: string): string {
+	const safeResetUrl = Handlebars.Utils.escapeExpression(resetUrl);
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -24,7 +18,7 @@ export function buildPasswordResetEmailHtml(resetUrl: string): string {
 <h1 style="margin:0 0 16px;font-size:24px;color:${EMAIL_COLORS.heading};">Reset your password</h1>
 <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Click the button below to set a new password for your Readplace account. This link expires in one hour.</p>
 <table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="${escapeHtml(resetUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Reset password</a>
+<a href="${safeResetUrl}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Reset password</a>
 </td></tr></table>
 <p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">If you didn't request a password reset, you can ignore this email.</p>
 </td></tr>
@@ -33,13 +27,4 @@ export function buildPasswordResetEmailHtml(resetUrl: string): string {
 </table>
 </body>
 </html>`;
-}
-
-function escapeHtml(str: string): string {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#39;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;");
 }

--- a/projects/hutch/src/runtime/web/auth/verification-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/verification-email.test.ts
@@ -4,13 +4,13 @@ describe("buildVerificationEmailHtml", () => {
 	it("includes the verify URL in the email link", () => {
 		const html = buildVerificationEmailHtml("https://readplace.com/verify?token=abc123");
 
-		expect(html).toContain('href="https://readplace.com/verify?token=abc123"');
+		expect(html).toContain('href="https://readplace.com/verify?token&#x3D;abc123"');
 	});
 
 	it("escapes HTML entities in the URL to prevent injection", () => {
 		const html = buildVerificationEmailHtml('https://example.com/verify?a=1&b=2"<>');
 
-		expect(html).toContain('href="https://example.com/verify?a=1&amp;b=2&quot;&lt;&gt;"');
+		expect(html).toContain('href="https://example.com/verify?a&#x3D;1&amp;b&#x3D;2&quot;&lt;&gt;"');
 	});
 
 	it("renders the email subject heading", () => {

--- a/projects/hutch/src/runtime/web/auth/verification-email.ts
+++ b/projects/hutch/src/runtime/web/auth/verification-email.ts
@@ -1,14 +1,8 @@
-const EMAIL_COLORS = {
-	background: "#F7F8FA",
-	surface: "#FFFFFF",
-	heading: "#1A202C",
-	body: "#5A6170",
-	muted: "#8C919D",
-	brand: "#C8702A",
-	brandText: "#FFFFFF",
-} as const;
+import Handlebars from "handlebars";
+import { EMAIL_COLORS } from "../email-colors";
 
 export function buildVerificationEmailHtml(verifyUrl: string): string {
+	const safeVerifyUrl = Handlebars.Utils.escapeExpression(verifyUrl);
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -24,7 +18,7 @@ export function buildVerificationEmailHtml(verifyUrl: string): string {
 <h1 style="margin:0 0 16px;font-size:24px;color:${EMAIL_COLORS.heading};">Verify your email</h1>
 <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Click the button below to verify your email address and activate your Readplace account.</p>
 <table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="${escapeHtml(verifyUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Verify email</a>
+<a href="${safeVerifyUrl}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Verify email</a>
 </td></tr></table>
 <p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">If you didn't create a Readplace account, you can ignore this email.</p>
 </td></tr>
@@ -33,12 +27,4 @@ export function buildVerificationEmailHtml(verifyUrl: string): string {
 </table>
 </body>
 </html>`;
-}
-
-function escapeHtml(str: string): string {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;");
 }

--- a/projects/hutch/src/runtime/web/auth/welcome-email.template.html
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.template.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to Readplace</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:{{colors.background}};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:{{colors.background}};padding:40px 20px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:{{colors.surface}};border-radius:8px;padding:40px;">
+            <tr>
+              <td>
+                <img src="{{avatarUrl}}" alt="Fayner Brack" width="80" height="80" style="display:block;border-radius:50%;margin:0 0 16px;">
+                <h1 style="margin:0 0 16px;font-size:24px;color:{{colors.heading}};">Welcome to Readplace</h1>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">Thanks for joining — really glad you're here.</p>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">I built Readplace because I wanted a quiet place to keep the things I want to read later, without the noise of a feed or the rot of bookmarks. It's still just me working on it, so every signup matters.</p>
+                <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:{{colors.body}};">The fastest way to start saving is to install the browser extension:</p>
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td style="border-radius:6px;background-color:{{colors.brand}};">
+                      <a href="{{installUrl}}" style="display:inline-block;padding:12px 24px;font-size:16px;color:{{colors.brandText}};text-decoration:none;border-radius:6px;">Get the extension</a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:24px 0 0;font-size:16px;line-height:1.6;color:{{colors.body}};">If anything breaks or feels off, just reply to this email — it comes straight to me, and I read everything.</p>
+                <p style="margin:16px 0 0;font-size:16px;line-height:1.6;color:{{colors.body}};">— Fayner</p>
+                <p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:{{colors.muted}};">Readplace is solo-built. Your feedback shapes what I work on next.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/projects/hutch/src/runtime/web/auth/welcome-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.test.ts
@@ -2,7 +2,7 @@ import { buildWelcomeEmailHtml } from "./welcome-email";
 
 describe("buildWelcomeEmailHtml", () => {
 	it("includes the install URL in the call-to-action link", () => {
-		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install", avatarUrl: "https://static.readplace.com/fayner-brack.jpg" });
 
 		expect(html).toContain('href="https://readplace.com/install"');
 	});
@@ -10,25 +10,45 @@ describe("buildWelcomeEmailHtml", () => {
 	it("escapes HTML entities in the install URL to prevent injection", () => {
 		const html = buildWelcomeEmailHtml({
 			installUrl: 'https://example.com/install?a=1&b=2"<>',
+			avatarUrl: "https://static.readplace.com/fayner-brack.jpg",
 		});
 
 		expect(html).toContain('href="https://example.com/install?a&#x3D;1&amp;b&#x3D;2&quot;&lt;&gt;"');
 	});
 
+	it("renders the avatar image at the top of the body", () => {
+		const html = buildWelcomeEmailHtml({
+			installUrl: "https://readplace.com/install",
+			avatarUrl: "https://static.readplace.com/fayner-brack.jpg",
+		});
+
+		expect(html).toContain('src="https://static.readplace.com/fayner-brack.jpg"');
+		expect(html).toContain('alt="Fayner Brack"');
+	});
+
+	it("escapes HTML entities in the avatar URL to prevent injection", () => {
+		const html = buildWelcomeEmailHtml({
+			installUrl: "https://readplace.com/install",
+			avatarUrl: 'https://example.com/avatar.jpg?a=1&b=2"<>',
+		});
+
+		expect(html).toContain('src="https://example.com/avatar.jpg?a&#x3D;1&amp;b&#x3D;2&quot;&lt;&gt;"');
+	});
+
 	it("renders the welcome heading", () => {
-		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install", avatarUrl: "https://static.readplace.com/fayner-brack.jpg" });
 
 		expect(html).toContain("Welcome to Readplace");
 	});
 
 	it("invites the recipient to reply directly with feedback", () => {
-		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install", avatarUrl: "https://static.readplace.com/fayner-brack.jpg" });
 
 		expect(html).toContain("reply to this email");
 	});
 
 	it("produces a complete HTML document", () => {
-		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install", avatarUrl: "https://static.readplace.com/fayner-brack.jpg" });
 
 		expect(html).toContain("<!DOCTYPE html>");
 		expect(html).toContain("</html>");

--- a/projects/hutch/src/runtime/web/auth/welcome-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.test.ts
@@ -1,0 +1,36 @@
+import { buildWelcomeEmailHtml } from "./welcome-email";
+
+describe("buildWelcomeEmailHtml", () => {
+	it("includes the install URL in the call-to-action link", () => {
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+
+		expect(html).toContain('href="https://readplace.com/install"');
+	});
+
+	it("escapes HTML entities in the install URL to prevent injection", () => {
+		const html = buildWelcomeEmailHtml({
+			installUrl: 'https://example.com/install?a=1&b=2"<>',
+		});
+
+		expect(html).toContain('href="https://example.com/install?a=1&amp;b=2&quot;&lt;&gt;"');
+	});
+
+	it("renders the welcome heading", () => {
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+
+		expect(html).toContain("Welcome to Readplace");
+	});
+
+	it("invites the recipient to reply directly with feedback", () => {
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+
+		expect(html).toContain("reply to this email");
+	});
+
+	it("produces a complete HTML document", () => {
+		const html = buildWelcomeEmailHtml({ installUrl: "https://readplace.com/install" });
+
+		expect(html).toContain("<!DOCTYPE html>");
+		expect(html).toContain("</html>");
+	});
+});

--- a/projects/hutch/src/runtime/web/auth/welcome-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.test.ts
@@ -12,7 +12,7 @@ describe("buildWelcomeEmailHtml", () => {
 			installUrl: 'https://example.com/install?a=1&b=2"<>',
 		});
 
-		expect(html).toContain('href="https://example.com/install?a=1&amp;b=2&quot;&lt;&gt;"');
+		expect(html).toContain('href="https://example.com/install?a&#x3D;1&amp;b&#x3D;2&quot;&lt;&gt;"');
 	});
 
 	it("renders the welcome heading", () => {

--- a/projects/hutch/src/runtime/web/auth/welcome-email.ts
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.ts
@@ -1,34 +1,20 @@
-import Handlebars from "handlebars";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { EMAIL_COLORS } from "../email-colors";
+import { render } from "../render";
 
-export function buildWelcomeEmailHtml({ installUrl }: { installUrl: string }): string {
-	const safeInstallUrl = Handlebars.Utils.escapeExpression(installUrl);
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Welcome to Readplace</title>
-</head>
-<body style="margin:0;padding:0;background-color:${EMAIL_COLORS.background};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.background};padding:40px 20px;">
-<tr><td align="center">
-<table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.surface};border-radius:8px;padding:40px;">
-<tr><td>
-<h1 style="margin:0 0 16px;font-size:24px;color:${EMAIL_COLORS.heading};">Welcome to Readplace</h1>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Thanks for joining — really glad you're here.</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I built Readplace because I wanted a quiet place to keep the things I want to read later, without the noise of a feed or the rot of bookmarks. It's still just me working on it, so every signup matters.</p>
-<p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The fastest way to start saving is to install the browser extension:</p>
-<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="${safeInstallUrl}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Get the extension</a>
-</td></tr></table>
-<p style="margin:24px 0 0;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If anything breaks or feels off, just reply to this email — it comes straight to me, and I read everything.</p>
-<p style="margin:16px 0 0;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">— Fayner</p>
-<p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">Readplace is solo-built. Your feedback shapes what I work on next.</p>
-</td></tr>
-</table>
-</td></tr>
-</table>
-</body>
-</html>`;
+const WELCOME_EMAIL_TEMPLATE = readFileSync(join(__dirname, "welcome-email.template.html"), "utf-8");
+
+export function buildWelcomeEmailHtml({
+	installUrl,
+	avatarUrl,
+}: {
+	installUrl: string;
+	avatarUrl: string;
+}): string {
+	return render(WELCOME_EMAIL_TEMPLATE, {
+		installUrl,
+		avatarUrl,
+		colors: EMAIL_COLORS,
+	});
 }

--- a/projects/hutch/src/runtime/web/auth/welcome-email.ts
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.ts
@@ -1,14 +1,8 @@
-const EMAIL_COLORS = {
-	background: "#F7F8FA",
-	surface: "#FFFFFF",
-	heading: "#1A202C",
-	body: "#5A6170",
-	muted: "#8C919D",
-	brand: "#C8702A",
-	brandText: "#FFFFFF",
-} as const;
+import Handlebars from "handlebars";
+import { EMAIL_COLORS } from "../email-colors";
 
 export function buildWelcomeEmailHtml({ installUrl }: { installUrl: string }): string {
+	const safeInstallUrl = Handlebars.Utils.escapeExpression(installUrl);
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -26,7 +20,7 @@ export function buildWelcomeEmailHtml({ installUrl }: { installUrl: string }): s
 <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I built Readplace because I wanted a quiet place to keep the things I want to read later, without the noise of a feed or the rot of bookmarks. It's still just me working on it, so every signup matters.</p>
 <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The fastest way to start saving is to install the browser extension:</p>
 <table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="${escapeHtml(installUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Get the extension</a>
+<a href="${safeInstallUrl}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Get the extension</a>
 </td></tr></table>
 <p style="margin:24px 0 0;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If anything breaks or feels off, just reply to this email — it comes straight to me, and I read everything.</p>
 <p style="margin:16px 0 0;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">— Fayner</p>
@@ -37,12 +31,4 @@ export function buildWelcomeEmailHtml({ installUrl }: { installUrl: string }): s
 </table>
 </body>
 </html>`;
-}
-
-function escapeHtml(str: string): string {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;");
 }

--- a/projects/hutch/src/runtime/web/auth/welcome-email.ts
+++ b/projects/hutch/src/runtime/web/auth/welcome-email.ts
@@ -1,0 +1,48 @@
+const EMAIL_COLORS = {
+	background: "#F7F8FA",
+	surface: "#FFFFFF",
+	heading: "#1A202C",
+	body: "#5A6170",
+	muted: "#8C919D",
+	brand: "#C8702A",
+	brandText: "#FFFFFF",
+} as const;
+
+export function buildWelcomeEmailHtml({ installUrl }: { installUrl: string }): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Welcome to Readplace</title>
+</head>
+<body style="margin:0;padding:0;background-color:${EMAIL_COLORS.background};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.background};padding:40px 20px;">
+<tr><td align="center">
+<table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.surface};border-radius:8px;padding:40px;">
+<tr><td>
+<h1 style="margin:0 0 16px;font-size:24px;color:${EMAIL_COLORS.heading};">Welcome to Readplace</h1>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Thanks for joining — really glad you're here.</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I built Readplace because I wanted a quiet place to keep the things I want to read later, without the noise of a feed or the rot of bookmarks. It's still just me working on it, so every signup matters.</p>
+<p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The fastest way to start saving is to install the browser extension:</p>
+<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
+<a href="${escapeHtml(installUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Get the extension</a>
+</td></tr></table>
+<p style="margin:24px 0 0;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If anything breaks or feels off, just reply to this email — it comes straight to me, and I read everything.</p>
+<p style="margin:16px 0 0;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">— Fayner</p>
+<p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">Readplace is solo-built. Your feedback shapes what I work on next.</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/"/g, "&quot;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}

--- a/projects/hutch/src/runtime/web/email-colors.ts
+++ b/projects/hutch/src/runtime/web/email-colors.ts
@@ -1,0 +1,9 @@
+export const EMAIL_COLORS = {
+	background: "#F7F8FA",
+	surface: "#FFFFFF",
+	heading: "#1A202C",
+	body: "#5A6170",
+	muted: "#8C919D",
+	brand: "#C8702A",
+	brandText: "#FFFFFF",
+} as const;

--- a/projects/hutch/src/runtime/web/pages/export/user-data-export-email.ts
+++ b/projects/hutch/src/runtime/web/pages/export/user-data-export-email.ts
@@ -1,12 +1,5 @@
-const EMAIL_COLORS = {
-	background: "#F7F8FA",
-	surface: "#FFFFFF",
-	heading: "#1A202C",
-	body: "#5A6170",
-	muted: "#8C919D",
-	brand: "#C8702A",
-	brandText: "#FFFFFF",
-} as const;
+import Handlebars from "handlebars";
+import { EMAIL_COLORS } from "../../email-colors";
 
 export function buildUserDataExportEmailHtml(params: {
 	downloadUrl: string;
@@ -14,6 +7,7 @@ export function buildUserDataExportEmailHtml(params: {
 	ttlDays: number;
 }): string {
 	const { downloadUrl, articleCount, ttlDays } = params;
+	const safeDownloadUrl = Handlebars.Utils.escapeExpression(downloadUrl);
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -29,22 +23,13 @@ export function buildUserDataExportEmailHtml(params: {
 <h1 style="margin:0 0 16px;font-size:24px;color:${EMAIL_COLORS.heading};">Your export is ready</h1>
 <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">We've packaged ${articleCount} article${articleCount === 1 ? "" : "s"} as a single JSON file. Click the button below to download it. The link expires in ${ttlDays} days.</p>
 <table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="${escapeHtml(downloadUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Download my data</a>
+<a href="${safeDownloadUrl}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Download my data</a>
 </td></tr></table>
-<p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">If the button above doesn't work, copy and paste this URL into your browser:<br><span style="word-break:break-all;">${escapeHtml(downloadUrl)}</span></p>
+<p style="margin:24px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">If the button above doesn't work, copy and paste this URL into your browser:<br><span style="word-break:break-all;">${safeDownloadUrl}</span></p>
 </td></tr>
 </table>
 </td></tr>
 </table>
 </body>
 </html>`;
-}
-
-function escapeHtml(str: string): string {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#39;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;");
 }


### PR DESCRIPTION
Once a customer completes both join (Stripe checkout) and email
verification, send a personal welcome email from
email that points them to the install page and
invites a direct reply. Triggered after markEmailVerified for
email/password users and after createGoogleUser succeeds for new
Google OAuth users; not sent on the duplicate-account fallback.