### PR TITLE
Add checkout recovery email script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,20 @@ const proxyUrl = getEnv('HTTPS_PROXY');
 
 **Exception:** Playwright config files (`playwright.config.*.ts`) must use `process.env` directly. Importing `getEnv`/`requireEnv` causes the playwright process to load `require-env.ts` outside V8 coverage instrumentation, creating uncovered function entries that break the 100% function coverage threshold.
 
+### Logging
+
+Use `HutchLogger` from `@packages/hutch-logger` for all logging. Never use raw `console.log`/`console.error` in application code. In composition roots, create the logger with `HutchLogger.from(consoleLogger)`.
+
+```typescript
+// BAD - Raw console
+console.log("[recovery] Starting…");
+
+// GOOD - HutchLogger
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+const logger = HutchLogger.from(consoleLogger);
+logger.info("[recovery] Starting…");
+```
+
 ### Comments Document Why, Not What
 
 Do not add comments that explain what code does. Only add comments to explain **why** when the reasoning isn't obvious.

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -44,6 +44,7 @@
     "dev:lambda": "tsx watch src/runtime/lambda.main.ts",
     "permalink": "tsx src/runtime/web/pages/save/save-permalink.cli.main.ts",
     "backfill-registered-at": "tsx src/runtime/providers/auth/backfill-registered-at.cli.main.ts",
+    "send-checkout-recovery-emails": "tsx src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test:sequential": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000 --runInBand",
     "test-integration": "jest --testMatch='**/dist/**/*.integration.js' --testTimeout=30000",

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -62,7 +62,7 @@ const applyParseResult = createFakeApplyParseResult({
 // E2E-specific Stripe checkout: generates local URLs so the browser can follow
 // the redirect chain (POST /signup → local checkout → /auth/checkout/success)
 // instead of hitting the unreachable https://checkout.stripe.test domain.
-const e2eStripe = initInMemoryStripeCheckout({ checkoutBaseUrl: `${origin}/e2e/stripe-checkout` })
+const e2eStripe = initInMemoryStripeCheckout({ checkoutBaseUrl: `${origin}/e2e/stripe-checkout`, now: () => new Date() })
 
 const { app: hutchApp, email } = createTestApp({
   ...fixture,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -185,7 +185,7 @@ function initProviders() {
 	const auth = initInMemoryAuth();
 	const articleStore = initInMemoryArticleStore();
 	const oauthModel = createOAuthModel(initInMemoryOAuthModel());
-	const devStripe = initInMemoryStripeCheckout();
+	const devStripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() });
 	const devPendingSignup = initInMemoryPendingSignup();
 	const devGoogleClientId = getEnv("GOOGLE_LOGIN_CLIENT_ID");
 	const devGoogleClientSecret = getEnv("GOOGLE_LOGIN_CLIENT_SECRET");

--- a/projects/hutch/src/runtime/checkout-recovery/select-recipients.test.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/select-recipients.test.ts
@@ -1,0 +1,165 @@
+import { CheckoutSessionIdSchema } from "../providers/stripe-checkout/stripe-checkout.schema";
+import type { RetrieveCheckoutSession } from "../providers/stripe-checkout/stripe-checkout.types";
+import { selectRecipients } from "./select-recipients";
+
+const NOW = new Date("2026-05-03T12:00:00Z");
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
+
+function createRetrieve(
+	overrides: Partial<{
+		paid: boolean;
+		customerEmail: string;
+		status: "open" | "complete" | "expired";
+		ageSeconds: number;
+	}>,
+): RetrieveCheckoutSession {
+	const ageSeconds = overrides.ageSeconds ?? 60 * 60 * 2;
+	return async () => ({
+		ok: true,
+		paid: overrides.paid ?? false,
+		customerEmail: overrides.customerEmail ?? "buyer@example.com",
+		status: overrides.status ?? "open",
+		created: NOW_SECONDS - ageSeconds,
+	});
+}
+
+describe("selectRecipients", () => {
+	it("includes a row whose session is unpaid, open, and older than one hour", async () => {
+		const id = CheckoutSessionIdSchema.parse("cs_test_eligible");
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [{ checkoutSessionId: id, email: "buyer@example.com", method: "email" }],
+			retrieveCheckoutSession: createRetrieve({}),
+		});
+
+		expect(result.recipients).toEqual([
+			{ checkoutSessionId: id, email: "buyer@example.com" },
+		]);
+		expect(result.skipped).toEqual([]);
+	});
+
+	it("includes a row whose session is expired and older than one hour", async () => {
+		const id = CheckoutSessionIdSchema.parse("cs_test_expired");
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [{ checkoutSessionId: id, email: "buyer@example.com", method: "email" }],
+			retrieveCheckoutSession: createRetrieve({ status: "expired", ageSeconds: 60 * 60 * 24 }),
+		});
+
+		expect(result.recipients).toHaveLength(1);
+		expect(result.skipped).toEqual([]);
+	});
+
+	it("skips a row that already has recoveryEmailSentAt set", async () => {
+		const id = CheckoutSessionIdSchema.parse("cs_test_already");
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [
+				{
+					checkoutSessionId: id,
+					email: "already@example.com",
+					method: "email",
+					recoveryEmailSentAt: 1234567890,
+				},
+			],
+			retrieveCheckoutSession: async () => {
+				throw new Error("Stripe should not be called for already-sent rows");
+			},
+		});
+
+		expect(result.recipients).toEqual([]);
+		expect(result.skipped).toEqual([
+			{ checkoutSessionId: id, email: "already@example.com", reason: "already-sent" },
+		]);
+	});
+
+	it("skips a row whose Stripe session is missing", async () => {
+		const id = CheckoutSessionIdSchema.parse("cs_test_missing");
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [{ checkoutSessionId: id, email: "missing@example.com", method: "email" }],
+			retrieveCheckoutSession: async () => ({ ok: false, reason: "not-found" }),
+		});
+
+		expect(result.recipients).toEqual([]);
+		expect(result.skipped).toEqual([
+			{ checkoutSessionId: id, email: "missing@example.com", reason: "session-not-found" },
+		]);
+	});
+
+	it("skips a row whose Stripe session has been paid", async () => {
+		const id = CheckoutSessionIdSchema.parse("cs_test_paid");
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [{ checkoutSessionId: id, email: "paid@example.com", method: "email" }],
+			retrieveCheckoutSession: createRetrieve({ paid: true, status: "complete" }),
+		});
+
+		expect(result.recipients).toEqual([]);
+		expect(result.skipped).toEqual([
+			{ checkoutSessionId: id, email: "paid@example.com", reason: "session-paid" },
+		]);
+	});
+
+	it("skips a row whose Stripe session was created less than one hour ago", async () => {
+		const id = CheckoutSessionIdSchema.parse("cs_test_recent");
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [{ checkoutSessionId: id, email: "recent@example.com", method: "email" }],
+			retrieveCheckoutSession: createRetrieve({ ageSeconds: 60 * 30 }),
+		});
+
+		expect(result.recipients).toEqual([]);
+		expect(result.skipped).toEqual([
+			{ checkoutSessionId: id, email: "recent@example.com", reason: "session-too-recent" },
+		]);
+	});
+
+	it("partitions a mixed batch into recipients and skipped rows", async () => {
+		const eligibleId = CheckoutSessionIdSchema.parse("cs_test_mixed_ok");
+		const recentId = CheckoutSessionIdSchema.parse("cs_test_mixed_recent");
+		const sentId = CheckoutSessionIdSchema.parse("cs_test_mixed_sent");
+		const sessionStates = new Map<string, { paid: boolean; ageSeconds: number }>([
+			[eligibleId, { paid: false, ageSeconds: 60 * 60 * 3 }],
+			[recentId, { paid: false, ageSeconds: 60 * 10 }],
+		]);
+		const retrieveCheckoutSession: RetrieveCheckoutSession = async (id) => {
+			const state = sessionStates.get(id);
+			if (!state) return { ok: false, reason: "not-found" };
+			return {
+				ok: true,
+				paid: state.paid,
+				customerEmail: "x@example.com",
+				status: "open",
+				created: NOW_SECONDS - state.ageSeconds,
+			};
+		};
+
+		const result = await selectRecipients({
+			now: NOW,
+			rows: [
+				{ checkoutSessionId: eligibleId, email: "ok@example.com", method: "email" },
+				{ checkoutSessionId: recentId, email: "recent@example.com", method: "google" },
+				{
+					checkoutSessionId: sentId,
+					email: "sent@example.com",
+					method: "email",
+					recoveryEmailSentAt: 1,
+				},
+			],
+			retrieveCheckoutSession,
+		});
+
+		expect(result.recipients).toEqual([
+			{ checkoutSessionId: eligibleId, email: "ok@example.com" },
+		]);
+		expect(result.skipped).toEqual([
+			{
+				checkoutSessionId: recentId,
+				email: "recent@example.com",
+				reason: "session-too-recent",
+			},
+			{ checkoutSessionId: sentId, email: "sent@example.com", reason: "already-sent" },
+		]);
+	});
+});

--- a/projects/hutch/src/runtime/checkout-recovery/select-recipients.test.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/select-recipients.test.ts
@@ -28,7 +28,7 @@ describe("selectRecipients", () => {
 		const id = CheckoutSessionIdSchema.parse("cs_test_eligible");
 		const result = await selectRecipients({
 			now: NOW,
-			rows: [{ checkoutSessionId: id, email: "buyer@example.com", method: "email" }],
+			rows: [{ checkoutSessionId: id, email: "buyer@example.com" }],
 			retrieveCheckoutSession: createRetrieve({}),
 		});
 
@@ -42,7 +42,7 @@ describe("selectRecipients", () => {
 		const id = CheckoutSessionIdSchema.parse("cs_test_expired");
 		const result = await selectRecipients({
 			now: NOW,
-			rows: [{ checkoutSessionId: id, email: "buyer@example.com", method: "email" }],
+			rows: [{ checkoutSessionId: id, email: "buyer@example.com" }],
 			retrieveCheckoutSession: createRetrieve({ status: "expired", ageSeconds: 60 * 60 * 24 }),
 		});
 
@@ -50,7 +50,7 @@ describe("selectRecipients", () => {
 		expect(result.skipped).toEqual([]);
 	});
 
-	it("skips a row that already has recoveryEmailSentAt set", async () => {
+	it("skips a row that already has checkoutRecoveryEmailSentAt set", async () => {
 		const id = CheckoutSessionIdSchema.parse("cs_test_already");
 		const result = await selectRecipients({
 			now: NOW,
@@ -58,8 +58,7 @@ describe("selectRecipients", () => {
 				{
 					checkoutSessionId: id,
 					email: "already@example.com",
-					method: "email",
-					recoveryEmailSentAt: 1234567890,
+					checkoutRecoveryEmailSentAt: 1234567890,
 				},
 			],
 			retrieveCheckoutSession: async () => {
@@ -77,7 +76,7 @@ describe("selectRecipients", () => {
 		const id = CheckoutSessionIdSchema.parse("cs_test_missing");
 		const result = await selectRecipients({
 			now: NOW,
-			rows: [{ checkoutSessionId: id, email: "missing@example.com", method: "email" }],
+			rows: [{ checkoutSessionId: id, email: "missing@example.com" }],
 			retrieveCheckoutSession: async () => ({ ok: false, reason: "not-found" }),
 		});
 
@@ -87,17 +86,17 @@ describe("selectRecipients", () => {
 		]);
 	});
 
-	it("skips a row whose Stripe session has been paid", async () => {
+	it("skips a row whose Stripe session has been paid (already a founding member)", async () => {
 		const id = CheckoutSessionIdSchema.parse("cs_test_paid");
 		const result = await selectRecipients({
 			now: NOW,
-			rows: [{ checkoutSessionId: id, email: "paid@example.com", method: "email" }],
+			rows: [{ checkoutSessionId: id, email: "paid@example.com" }],
 			retrieveCheckoutSession: createRetrieve({ paid: true, status: "complete" }),
 		});
 
 		expect(result.recipients).toEqual([]);
 		expect(result.skipped).toEqual([
-			{ checkoutSessionId: id, email: "paid@example.com", reason: "session-paid" },
+			{ checkoutSessionId: id, email: "paid@example.com", reason: "already-founding-member" },
 		]);
 	});
 
@@ -105,7 +104,7 @@ describe("selectRecipients", () => {
 		const id = CheckoutSessionIdSchema.parse("cs_test_recent");
 		const result = await selectRecipients({
 			now: NOW,
-			rows: [{ checkoutSessionId: id, email: "recent@example.com", method: "email" }],
+			rows: [{ checkoutSessionId: id, email: "recent@example.com" }],
 			retrieveCheckoutSession: createRetrieve({ ageSeconds: 60 * 30 }),
 		});
 
@@ -138,13 +137,12 @@ describe("selectRecipients", () => {
 		const result = await selectRecipients({
 			now: NOW,
 			rows: [
-				{ checkoutSessionId: eligibleId, email: "ok@example.com", method: "email" },
-				{ checkoutSessionId: recentId, email: "recent@example.com", method: "google" },
+				{ checkoutSessionId: eligibleId, email: "ok@example.com" },
+				{ checkoutSessionId: recentId, email: "recent@example.com" },
 				{
 					checkoutSessionId: sentId,
 					email: "sent@example.com",
-					method: "email",
-					recoveryEmailSentAt: 1,
+					checkoutRecoveryEmailSentAt: 1,
 				},
 			],
 			retrieveCheckoutSession,

--- a/projects/hutch/src/runtime/checkout-recovery/select-recipients.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/select-recipients.ts
@@ -1,0 +1,85 @@
+import type {
+	CheckoutSessionId,
+	RetrieveCheckoutSession,
+} from "../providers/stripe-checkout/stripe-checkout.types";
+import type { PendingSignupSummary } from "../providers/pending-signup/pending-signup.types";
+
+const ONE_HOUR_SECONDS = 60 * 60;
+
+export interface RecoveryCandidate {
+	checkoutSessionId: CheckoutSessionId;
+	email: string;
+}
+
+export type SkipReason =
+	| "already-sent"
+	| "session-not-found"
+	| "session-paid"
+	| "session-too-recent";
+
+export interface SkippedRow {
+	checkoutSessionId: CheckoutSessionId;
+	email: string;
+	reason: SkipReason;
+}
+
+export interface SelectRecipientsResult {
+	recipients: RecoveryCandidate[];
+	skipped: SkippedRow[];
+}
+
+export async function selectRecipients(params: {
+	now: Date;
+	rows: PendingSignupSummary[];
+	retrieveCheckoutSession: RetrieveCheckoutSession;
+}): Promise<SelectRecipientsResult> {
+	const nowSeconds = Math.floor(params.now.getTime() / 1000);
+	const recipients: RecoveryCandidate[] = [];
+	const skipped: SkippedRow[] = [];
+
+	for (const row of params.rows) {
+		if (row.recoveryEmailSentAt !== undefined) {
+			skipped.push({
+				checkoutSessionId: row.checkoutSessionId,
+				email: row.email,
+				reason: "already-sent",
+			});
+			continue;
+		}
+
+		const session = await params.retrieveCheckoutSession(row.checkoutSessionId);
+		if (!session.ok) {
+			skipped.push({
+				checkoutSessionId: row.checkoutSessionId,
+				email: row.email,
+				reason: "session-not-found",
+			});
+			continue;
+		}
+
+		if (session.paid) {
+			skipped.push({
+				checkoutSessionId: row.checkoutSessionId,
+				email: row.email,
+				reason: "session-paid",
+			});
+			continue;
+		}
+
+		if (nowSeconds - session.created < ONE_HOUR_SECONDS) {
+			skipped.push({
+				checkoutSessionId: row.checkoutSessionId,
+				email: row.email,
+				reason: "session-too-recent",
+			});
+			continue;
+		}
+
+		recipients.push({
+			checkoutSessionId: row.checkoutSessionId,
+			email: row.email,
+		});
+	}
+
+	return { recipients, skipped };
+}

--- a/projects/hutch/src/runtime/checkout-recovery/select-recipients.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/select-recipients.ts
@@ -14,7 +14,7 @@ export interface RecoveryCandidate {
 export type SkipReason =
 	| "already-sent"
 	| "session-not-found"
-	| "session-paid"
+	| "already-founding-member"
 	| "session-too-recent";
 
 export interface SkippedRow {
@@ -38,7 +38,7 @@ export async function selectRecipients(params: {
 	const skipped: SkippedRow[] = [];
 
 	for (const row of params.rows) {
-		if (row.recoveryEmailSentAt !== undefined) {
+		if (row.checkoutRecoveryEmailSentAt !== undefined) {
 			skipped.push({
 				checkoutSessionId: row.checkoutSessionId,
 				email: row.email,
@@ -61,7 +61,7 @@ export async function selectRecipients(params: {
 			skipped.push({
 				checkoutSessionId: row.checkoutSessionId,
 				email: row.email,
-				reason: "session-paid",
+				reason: "already-founding-member",
 			});
 			continue;
 		}

--- a/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
@@ -1,0 +1,115 @@
+/* c8 ignore start -- composition root, no logic to test */
+import { writeFile } from "node:fs/promises";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbPendingSignup } from "../providers/pending-signup/dynamodb-pending-signup";
+import { initResendEmail } from "../providers/email/resend-email";
+import { initStripeCheckout } from "../providers/stripe-checkout/stripe-checkout";
+import { buildCheckoutRecoveryEmail } from "../web/auth/checkout-recovery-email";
+import { getEnv, requireEnv } from "../require-env";
+import { selectRecipients } from "./select-recipients";
+
+async function main(): Promise<void> {
+	const tableName = requireEnv("DYNAMODB_PENDING_SIGNUPS_TABLE");
+	const stripeApiKey = requireEnv("STRIPE_SECRET_KEY");
+	const stripePriceId = requireEnv("STRIPE_PRICE_ID");
+	const resendApiKey = requireEnv("RESEND_API_KEY");
+	const origin = requireEnv("READPLACE_ORIGIN");
+	const from = requireEnv("RECOVERY_EMAIL_FROM");
+	const replyTo = requireEnv("RECOVERY_EMAIL_REPLY_TO");
+	const bcc = requireEnv("RECOVERY_EMAIL_BCC");
+	const dryRun = getEnv("RECOVERY_EMAIL_DRY_RUN") === "true";
+	const reportPath = getEnv("RECOVERY_REPORT_PATH");
+
+	const dynamoClient = createDynamoDocumentClient();
+	const pendingSignup = initDynamoDbPendingSignup({ client: dynamoClient, tableName });
+	const stripe = initStripeCheckout({
+		apiKey: stripeApiKey,
+		priceId: stripePriceId,
+		fetch: globalThis.fetch,
+	});
+	const { sendEmail } = initResendEmail(resendApiKey);
+
+	const founderAvatarUrl = `${origin}/fayner-brack.jpg`;
+
+	console.log(`[recovery] Scanning ${tableName} for pending signups…`);
+	const rows = await pendingSignup.listAllPendingSignups();
+	console.log(`[recovery] Found ${rows.length} pending signup row(s).`);
+
+	const { recipients, skipped } = await selectRecipients({
+		now: new Date(),
+		rows,
+		retrieveCheckoutSession: stripe.retrieveCheckoutSession,
+	});
+
+	console.log(
+		`[recovery] ${recipients.length} candidate(s), ${skipped.length} skipped.`,
+	);
+	for (const skip of skipped) {
+		console.log(`[recovery]   skip ${skip.email} (${skip.reason})`);
+	}
+
+	let sent = 0;
+	const errors: { email: string; error: string }[] = [];
+
+	for (const recipient of recipients) {
+		const resumeUrl = `${origin}/signup?email=${encodeURIComponent(recipient.email)}&utm_source=recovery`;
+		const { html, text } = buildCheckoutRecoveryEmail({ founderAvatarUrl, resumeUrl });
+		const message = {
+			from,
+			to: recipient.email,
+			bcc,
+			replyTo,
+			subject: "Did something stop you?",
+			html,
+			text,
+		};
+
+		if (dryRun) {
+			console.log(`[recovery] DRY RUN → would send to ${recipient.email}`);
+			console.log(`[recovery]   resumeUrl=${resumeUrl}`);
+			continue;
+		}
+
+		try {
+			await sendEmail(message);
+			await pendingSignup.markPendingSignupRecoveryEmailSent({
+				checkoutSessionId: recipient.checkoutSessionId,
+				sentAt: Math.floor(Date.now() / 1000),
+			});
+			sent++;
+			console.log(`[recovery] sent → ${recipient.email}`);
+		} catch (err) {
+			const error = err instanceof Error ? err.message : String(err);
+			errors.push({ email: recipient.email, error });
+			console.error(`[recovery] FAILED → ${recipient.email}: ${error}`);
+		}
+	}
+
+	if (reportPath !== undefined) {
+		await writeFile(
+			reportPath,
+			`${JSON.stringify(
+				{
+					candidates: recipients.length,
+					skipped,
+					sent,
+					errors,
+					dryRun,
+				},
+				null,
+				2,
+			)}\n`,
+			"utf8",
+		);
+	}
+
+	console.log(
+		`[recovery] Done. ${recipients.length} candidate(s), ${skipped.length} skipped, ${sent} sent, ${errors.length} error(s).`,
+	);
+}
+
+main().catch((err) => {
+	console.error("[recovery] Fatal:", err);
+	process.exit(1);
+});
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
@@ -53,7 +53,12 @@ async function main(): Promise<void> {
 
 	for (const recipient of recipients) {
 		const resumeUrl = `${origin}/signup?email=${encodeURIComponent(recipient.email)}&utm_source=recovery`;
-		const { html, text } = buildCheckoutRecoveryEmail({ founderAvatarUrl, resumeUrl });
+		const { html, text } = buildCheckoutRecoveryEmail({
+			founderAvatarUrl,
+			resumeUrl,
+			monthlyPrice: "$3.99",
+			yearlyDiscount: "20%",
+		});
 		const message = {
 			from,
 			to: recipient.email,

--- a/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
 	const from = requireEnv("RECOVERY_EMAIL_FROM");
 	const replyTo = requireEnv("RECOVERY_EMAIL_REPLY_TO");
 	const bcc = requireEnv("RECOVERY_EMAIL_BCC");
-	const dryRun = getEnv("RECOVERY_EMAIL_DRY_RUN") === "true";
+	const dryRun = requireEnv<"true" | "false">("RECOVERY_EMAIL_DRY_RUN") === "true";
 	const reportPath = getEnv("RECOVERY_REPORT_PATH");
 
 	const dynamoClient = createDynamoDocumentClient();

--- a/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
@@ -1,11 +1,12 @@
 /* c8 ignore start -- composition root, no logic to test */
-import { writeFile } from "node:fs/promises";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initDynamoDbPendingSignup } from "../providers/pending-signup/dynamodb-pending-signup";
 import { initResendEmail } from "../providers/email/resend-email";
 import { initStripeCheckout } from "../providers/stripe-checkout/stripe-checkout";
-import { buildCheckoutRecoveryEmail } from "../web/auth/checkout-recovery-email";
-import { getEnv, requireEnv } from "../require-env";
+import { CheckoutRecoveryEmail } from "../web/auth/checkout-recovery-email";
+import { buildSignupResumeUrl } from "../web/auth/signup-resume-url";
+import { requireEnv } from "../require-env";
 import { selectRecipients } from "./select-recipients";
 
 async function main(): Promise<void> {
@@ -17,8 +18,8 @@ async function main(): Promise<void> {
 	const from = requireEnv("RECOVERY_EMAIL_FROM");
 	const replyTo = requireEnv("RECOVERY_EMAIL_REPLY_TO");
 	const bcc = requireEnv("RECOVERY_EMAIL_BCC");
-	const dryRun = requireEnv<"true" | "false">("RECOVERY_EMAIL_DRY_RUN") === "true";
-	const reportPath = getEnv("RECOVERY_REPORT_PATH");
+
+	const logger = HutchLogger.from(consoleLogger);
 
 	const dynamoClient = createDynamoDocumentClient();
 	const pendingSignup = initDynamoDbPendingSignup({ client: dynamoClient, tableName });
@@ -31,9 +32,9 @@ async function main(): Promise<void> {
 
 	const founderAvatarUrl = `${origin}/fayner-brack.jpg`;
 
-	console.log(`[recovery] Scanning ${tableName} for pending signups…`);
+	logger.info(`[recovery] Scanning ${tableName} for pending signups…`);
 	const rows = await pendingSignup.listAllPendingSignups();
-	console.log(`[recovery] Found ${rows.length} pending signup row(s).`);
+	logger.info(`[recovery] Found ${rows.length} pending signup row(s).`);
 
 	const { recipients, skipped } = await selectRecipients({
 		now: new Date(),
@@ -41,19 +42,19 @@ async function main(): Promise<void> {
 		retrieveCheckoutSession: stripe.retrieveCheckoutSession,
 	});
 
-	console.log(
+	logger.info(
 		`[recovery] ${recipients.length} candidate(s), ${skipped.length} skipped.`,
 	);
 	for (const skip of skipped) {
-		console.log(`[recovery]   skip ${skip.email} (${skip.reason})`);
+		logger.info(`[recovery]   skip ${skip.email} (${skip.reason})`);
 	}
 
 	let sent = 0;
 	const errors: { email: string; error: string }[] = [];
 
 	for (const recipient of recipients) {
-		const resumeUrl = `${origin}/signup?email=${encodeURIComponent(recipient.email)}&utm_source=recovery`;
-		const { html, text } = buildCheckoutRecoveryEmail({
+		const resumeUrl = buildSignupResumeUrl({ origin, email: recipient.email });
+		const email = CheckoutRecoveryEmail({
 			founderAvatarUrl,
 			resumeUrl,
 			monthlyPrice: "$3.99",
@@ -65,50 +66,26 @@ async function main(): Promise<void> {
 			bcc,
 			replyTo,
 			subject: "Did something stop you?",
-			html,
-			text,
+			html: email.to("text/html"),
+			text: email.to("text/plain"),
 		};
-
-		if (dryRun) {
-			console.log(`[recovery] DRY RUN → would send to ${recipient.email}`);
-			console.log(`[recovery]   resumeUrl=${resumeUrl}`);
-			continue;
-		}
 
 		try {
 			await sendEmail(message);
-			await pendingSignup.markPendingSignupRecoveryEmailSent({
+			await pendingSignup.markCheckoutRecoveryEmailSent({
 				checkoutSessionId: recipient.checkoutSessionId,
 				sentAt: Math.floor(Date.now() / 1000),
 			});
 			sent++;
-			console.log(`[recovery] sent → ${recipient.email}`);
+			logger.info(`[recovery] sent → ${recipient.email}`);
 		} catch (err) {
 			const error = err instanceof Error ? err.message : String(err);
 			errors.push({ email: recipient.email, error });
-			console.error(`[recovery] FAILED → ${recipient.email}: ${error}`);
+			logger.error(`[recovery] FAILED → ${recipient.email}: ${error}`);
 		}
 	}
 
-	if (reportPath !== undefined) {
-		await writeFile(
-			reportPath,
-			`${JSON.stringify(
-				{
-					candidates: recipients.length,
-					skipped,
-					sent,
-					errors,
-					dryRun,
-				},
-				null,
-				2,
-			)}\n`,
-			"utf8",
-		);
-	}
-
-	console.log(
+	logger.info(
 		`[recovery] Done. ${recipients.length} candidate(s), ${skipped.length} skipped, ${sent} sent, ${errors.length} error(s).`,
 	);
 }

--- a/projects/hutch/src/runtime/providers/email/email.types.ts
+++ b/projects/hutch/src/runtime/providers/email/email.types.ts
@@ -2,8 +2,10 @@ export interface EmailMessage {
 	from: string;
 	to: string;
 	bcc?: string;
+	replyTo?: string;
 	subject: string;
 	html: string;
+	text?: string;
 }
 
 export type SendEmail = (message: EmailMessage) => Promise<void>;

--- a/projects/hutch/src/runtime/providers/email/log-email.test.ts
+++ b/projects/hutch/src/runtime/providers/email/log-email.test.ts
@@ -16,8 +16,10 @@ describe("initLogEmail", () => {
 			from: "sender@example.com",
 			to: "recipient@example.com",
 			bcc: undefined,
+			replyTo: undefined,
 			subject: "Test Subject",
 			html: "<p>Test</p>",
+			text: undefined,
 		});
 
 		consoleSpy.mockRestore();

--- a/projects/hutch/src/runtime/providers/email/log-email.ts
+++ b/projects/hutch/src/runtime/providers/email/log-email.ts
@@ -6,8 +6,10 @@ export function initLogEmail(): { sendEmail: SendEmail } {
 			from: message.from,
 			to: message.to,
 			bcc: message.bcc,
+			replyTo: message.replyTo,
 			subject: message.subject,
 			html: message.html,
+			text: message.text,
 		});
 	};
 

--- a/projects/hutch/src/runtime/providers/email/resend-email.ts
+++ b/projects/hutch/src/runtime/providers/email/resend-email.ts
@@ -11,7 +11,9 @@ export function initResendEmail(apiKey: string): { sendEmail: SendEmail } {
 			to: message.to,
 			subject: message.subject,
 			html: message.html,
+			...(message.text && { text: message.text }),
 			...(message.bcc && { bcc: message.bcc }),
+			...(message.replyTo && { replyTo: message.replyTo }),
 		});
 		if (result.error) {
 			throw new Error(`Resend ${result.error.name}: ${result.error.message}`);

--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
@@ -9,6 +9,8 @@ import { UserIdSchema } from "../../domain/user/user.schema";
 import { CheckoutSessionIdSchema } from "../stripe-checkout/stripe-checkout.schema";
 import type {
 	ConsumePendingSignup,
+	ListAllPendingSignups,
+	MarkPendingSignupRecoveryEmailSent,
 	PendingSignup,
 	StorePendingSignup,
 } from "./pending-signup.types";
@@ -20,6 +22,14 @@ const PendingSignupRow = z.object({
 	passwordHash: dynamoField(z.string()),
 	userId: dynamoField(UserIdSchema),
 	returnUrl: dynamoField(z.string()),
+	recoveryEmailSentAt: dynamoField(z.number()),
+});
+
+const PendingSignupSummaryRow = z.object({
+	checkoutSessionId: CheckoutSessionIdSchema,
+	method: z.enum(["email", "google"]),
+	email: z.string(),
+	recoveryEmailSentAt: dynamoField(z.number()),
 });
 
 export function initDynamoDbPendingSignup(deps: {
@@ -28,11 +38,19 @@ export function initDynamoDbPendingSignup(deps: {
 }): {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+	listAllPendingSignups: ListAllPendingSignups;
+	markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
 		tableName: deps.tableName,
 		schema: PendingSignupRow,
+	});
+
+	const summaryTable = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: PendingSignupSummaryRow,
 	});
 
 	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup }) => {
@@ -79,6 +97,47 @@ export function initDynamoDbPendingSignup(deps: {
 		return signup;
 	};
 
-	return { storePendingSignup, consumePendingSignup };
+	const listAllPendingSignups: ListAllPendingSignups = async () => {
+		const summaries = [];
+		let lastEvaluatedKey: Record<string, unknown> | undefined;
+		do {
+			const page = await summaryTable.scan({
+				ProjectionExpression:
+					"checkoutSessionId, email, #method, recoveryEmailSentAt",
+				ExpressionAttributeNames: { "#method": "method" },
+				ExclusiveStartKey: lastEvaluatedKey,
+			});
+			for (const row of page.items) {
+				summaries.push({
+					checkoutSessionId: row.checkoutSessionId,
+					email: row.email,
+					method: row.method,
+					...(row.recoveryEmailSentAt !== undefined
+						? { recoveryEmailSentAt: row.recoveryEmailSentAt }
+						: {}),
+				});
+			}
+			lastEvaluatedKey = page.lastEvaluatedKey;
+		} while (lastEvaluatedKey !== undefined);
+		return summaries;
+	};
+
+	const markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent = async ({
+		checkoutSessionId,
+		sentAt,
+	}) => {
+		await table.update({
+			Key: { checkoutSessionId },
+			UpdateExpression: "SET recoveryEmailSentAt = :sentAt",
+			ExpressionAttributeValues: { ":sentAt": sentAt },
+		});
+	};
+
+	return {
+		storePendingSignup,
+		consumePendingSignup,
+		listAllPendingSignups,
+		markPendingSignupRecoveryEmailSent,
+	};
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
@@ -10,7 +10,7 @@ import { CheckoutSessionIdSchema } from "../stripe-checkout/stripe-checkout.sche
 import type {
 	ConsumePendingSignup,
 	ListAllPendingSignups,
-	MarkPendingSignupRecoveryEmailSent,
+	MarkCheckoutRecoveryEmailSent,
 	PendingSignup,
 	StorePendingSignup,
 } from "./pending-signup.types";
@@ -22,14 +22,13 @@ const PendingSignupRow = z.object({
 	passwordHash: dynamoField(z.string()),
 	userId: dynamoField(UserIdSchema),
 	returnUrl: dynamoField(z.string()),
-	recoveryEmailSentAt: dynamoField(z.number()),
+	checkoutRecoveryEmailSentAt: dynamoField(z.number()),
 });
 
 const PendingSignupSummaryRow = z.object({
 	checkoutSessionId: CheckoutSessionIdSchema,
-	method: z.enum(["email", "google"]),
 	email: z.string(),
-	recoveryEmailSentAt: dynamoField(z.number()),
+	checkoutRecoveryEmailSentAt: dynamoField(z.number()),
 });
 
 export function initDynamoDbPendingSignup(deps: {
@@ -39,7 +38,7 @@ export function initDynamoDbPendingSignup(deps: {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
 	listAllPendingSignups: ListAllPendingSignups;
-	markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent;
+	markCheckoutRecoveryEmailSent: MarkCheckoutRecoveryEmailSent;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
@@ -103,17 +102,15 @@ export function initDynamoDbPendingSignup(deps: {
 		do {
 			const page = await summaryTable.scan({
 				ProjectionExpression:
-					"checkoutSessionId, email, #method, recoveryEmailSentAt",
-				ExpressionAttributeNames: { "#method": "method" },
+					"checkoutSessionId, email, checkoutRecoveryEmailSentAt",
 				ExclusiveStartKey: lastEvaluatedKey,
 			});
 			for (const row of page.items) {
 				summaries.push({
 					checkoutSessionId: row.checkoutSessionId,
 					email: row.email,
-					method: row.method,
-					...(row.recoveryEmailSentAt !== undefined
-						? { recoveryEmailSentAt: row.recoveryEmailSentAt }
+					...(row.checkoutRecoveryEmailSentAt !== undefined
+						? { checkoutRecoveryEmailSentAt: row.checkoutRecoveryEmailSentAt }
 						: {}),
 				});
 			}
@@ -122,13 +119,13 @@ export function initDynamoDbPendingSignup(deps: {
 		return summaries;
 	};
 
-	const markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent = async ({
+	const markCheckoutRecoveryEmailSent: MarkCheckoutRecoveryEmailSent = async ({
 		checkoutSessionId,
 		sentAt,
 	}) => {
 		await table.update({
 			Key: { checkoutSessionId },
-			UpdateExpression: "SET recoveryEmailSentAt = :sentAt",
+			UpdateExpression: "SET checkoutRecoveryEmailSentAt = :sentAt",
 			ExpressionAttributeValues: { ":sentAt": sentAt },
 		});
 	};
@@ -137,7 +134,7 @@ export function initDynamoDbPendingSignup(deps: {
 		storePendingSignup,
 		consumePendingSignup,
 		listAllPendingSignups,
-		markPendingSignupRecoveryEmailSent,
+		markCheckoutRecoveryEmailSent,
 	};
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.test.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.test.ts
@@ -51,4 +51,54 @@ describe("initInMemoryPendingSignup", () => {
 		const second = await consumePendingSignup(checkoutSessionId);
 		expect(second).toBeNull();
 	});
+
+	it("lists all stored signups and reflects markPendingSignupRecoveryEmailSent", async () => {
+		const {
+			storePendingSignup,
+			listAllPendingSignups,
+			markPendingSignupRecoveryEmailSent,
+		} = initInMemoryPendingSignup();
+		const emailId = CheckoutSessionIdSchema.parse("cs_test_list_email");
+		const googleId = CheckoutSessionIdSchema.parse("cs_test_list_google");
+		const userId = UserIdSchema.parse("u-list-1");
+		await storePendingSignup({
+			checkoutSessionId: emailId,
+			signup: { method: "email", email: "a@example.com", passwordHash: "hash" },
+		});
+		await storePendingSignup({
+			checkoutSessionId: googleId,
+			signup: { method: "google", email: "b@example.com", userId },
+		});
+
+		const before = await listAllPendingSignups();
+		expect(before).toHaveLength(2);
+		const emailRow = before.find((r) => r.checkoutSessionId === emailId);
+		assert(emailRow, "email row must be present");
+		expect(emailRow.email).toBe("a@example.com");
+		expect(emailRow.method).toBe("email");
+		expect(emailRow.recoveryEmailSentAt).toBeUndefined();
+
+		await markPendingSignupRecoveryEmailSent({
+			checkoutSessionId: emailId,
+			sentAt: 1735000000,
+		});
+
+		const after = await listAllPendingSignups();
+		const emailRowAfter = after.find((r) => r.checkoutSessionId === emailId);
+		assert(emailRowAfter, "email row must still be present");
+		expect(emailRowAfter.recoveryEmailSentAt).toBe(1735000000);
+		const googleRowAfter = after.find((r) => r.checkoutSessionId === googleId);
+		assert(googleRowAfter, "google row must still be present");
+		expect(googleRowAfter.recoveryEmailSentAt).toBeUndefined();
+	});
+
+	it("throws when marking an unknown checkout session as recovery-email sent", async () => {
+		const { markPendingSignupRecoveryEmailSent } = initInMemoryPendingSignup();
+		await expect(
+			markPendingSignupRecoveryEmailSent({
+				checkoutSessionId: CheckoutSessionIdSchema.parse("cs_test_missing"),
+				sentAt: 1,
+			}),
+		).rejects.toThrow(/No pending signup/);
+	});
 });

--- a/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.test.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.test.ts
@@ -52,11 +52,11 @@ describe("initInMemoryPendingSignup", () => {
 		expect(second).toBeNull();
 	});
 
-	it("lists all stored signups and reflects markPendingSignupRecoveryEmailSent", async () => {
+	it("lists all stored signups and reflects markCheckoutRecoveryEmailSent", async () => {
 		const {
 			storePendingSignup,
 			listAllPendingSignups,
-			markPendingSignupRecoveryEmailSent,
+			markCheckoutRecoveryEmailSent,
 		} = initInMemoryPendingSignup();
 		const emailId = CheckoutSessionIdSchema.parse("cs_test_list_email");
 		const googleId = CheckoutSessionIdSchema.parse("cs_test_list_google");
@@ -75,10 +75,9 @@ describe("initInMemoryPendingSignup", () => {
 		const emailRow = before.find((r) => r.checkoutSessionId === emailId);
 		assert(emailRow, "email row must be present");
 		expect(emailRow.email).toBe("a@example.com");
-		expect(emailRow.method).toBe("email");
-		expect(emailRow.recoveryEmailSentAt).toBeUndefined();
+		expect(emailRow.checkoutRecoveryEmailSentAt).toBeUndefined();
 
-		await markPendingSignupRecoveryEmailSent({
+		await markCheckoutRecoveryEmailSent({
 			checkoutSessionId: emailId,
 			sentAt: 1735000000,
 		});
@@ -86,16 +85,16 @@ describe("initInMemoryPendingSignup", () => {
 		const after = await listAllPendingSignups();
 		const emailRowAfter = after.find((r) => r.checkoutSessionId === emailId);
 		assert(emailRowAfter, "email row must still be present");
-		expect(emailRowAfter.recoveryEmailSentAt).toBe(1735000000);
+		expect(emailRowAfter.checkoutRecoveryEmailSentAt).toBe(1735000000);
 		const googleRowAfter = after.find((r) => r.checkoutSessionId === googleId);
 		assert(googleRowAfter, "google row must still be present");
-		expect(googleRowAfter.recoveryEmailSentAt).toBeUndefined();
+		expect(googleRowAfter.checkoutRecoveryEmailSentAt).toBeUndefined();
 	});
 
-	it("throws when marking an unknown checkout session as recovery-email sent", async () => {
-		const { markPendingSignupRecoveryEmailSent } = initInMemoryPendingSignup();
+	it("throws when marking an unknown checkout session as checkout-recovery-email sent", async () => {
+		const { markCheckoutRecoveryEmailSent } = initInMemoryPendingSignup();
 		await expect(
-			markPendingSignupRecoveryEmailSent({
+			markCheckoutRecoveryEmailSent({
 				checkoutSessionId: CheckoutSessionIdSchema.parse("cs_test_missing"),
 				sentAt: 1,
 			}),

--- a/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.ts
@@ -1,26 +1,59 @@
 import type { CheckoutSessionId } from "../stripe-checkout/stripe-checkout.types";
 import type {
 	ConsumePendingSignup,
+	ListAllPendingSignups,
+	MarkPendingSignupRecoveryEmailSent,
 	PendingSignup,
 	StorePendingSignup,
 } from "./pending-signup.types";
 
+interface StoredEntry {
+	signup: PendingSignup;
+	recoveryEmailSentAt?: number;
+}
+
 export function initInMemoryPendingSignup(): {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+	listAllPendingSignups: ListAllPendingSignups;
+	markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent;
 } {
-	const store = new Map<CheckoutSessionId, PendingSignup>();
+	const store = new Map<CheckoutSessionId, StoredEntry>();
 
 	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup }) => {
-		store.set(checkoutSessionId, signup);
+		store.set(checkoutSessionId, { signup });
 	};
 
 	const consumePendingSignup: ConsumePendingSignup = async (checkoutSessionId) => {
-		const signup = store.get(checkoutSessionId);
-		if (!signup) return null;
+		const entry = store.get(checkoutSessionId);
+		if (!entry) return null;
 		store.delete(checkoutSessionId);
-		return signup;
+		return entry.signup;
 	};
 
-	return { storePendingSignup, consumePendingSignup };
+	const listAllPendingSignups: ListAllPendingSignups = async () =>
+		Array.from(store.entries()).map(([checkoutSessionId, entry]) => ({
+			checkoutSessionId,
+			email: entry.signup.email,
+			method: entry.signup.method,
+			...(entry.recoveryEmailSentAt !== undefined
+				? { recoveryEmailSentAt: entry.recoveryEmailSentAt }
+				: {}),
+		}));
+
+	const markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent = async ({
+		checkoutSessionId,
+		sentAt,
+	}) => {
+		const entry = store.get(checkoutSessionId);
+		if (!entry) throw new Error(`No pending signup: ${checkoutSessionId}`);
+		entry.recoveryEmailSentAt = sentAt;
+	};
+
+	return {
+		storePendingSignup,
+		consumePendingSignup,
+		listAllPendingSignups,
+		markPendingSignupRecoveryEmailSent,
+	};
 }

--- a/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/in-memory-pending-signup.ts
@@ -2,21 +2,21 @@ import type { CheckoutSessionId } from "../stripe-checkout/stripe-checkout.types
 import type {
 	ConsumePendingSignup,
 	ListAllPendingSignups,
-	MarkPendingSignupRecoveryEmailSent,
+	MarkCheckoutRecoveryEmailSent,
 	PendingSignup,
 	StorePendingSignup,
 } from "./pending-signup.types";
 
 interface StoredEntry {
 	signup: PendingSignup;
-	recoveryEmailSentAt?: number;
+	checkoutRecoveryEmailSentAt?: number;
 }
 
 export function initInMemoryPendingSignup(): {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
 	listAllPendingSignups: ListAllPendingSignups;
-	markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent;
+	markCheckoutRecoveryEmailSent: MarkCheckoutRecoveryEmailSent;
 } {
 	const store = new Map<CheckoutSessionId, StoredEntry>();
 
@@ -35,25 +35,24 @@ export function initInMemoryPendingSignup(): {
 		Array.from(store.entries()).map(([checkoutSessionId, entry]) => ({
 			checkoutSessionId,
 			email: entry.signup.email,
-			method: entry.signup.method,
-			...(entry.recoveryEmailSentAt !== undefined
-				? { recoveryEmailSentAt: entry.recoveryEmailSentAt }
+			...(entry.checkoutRecoveryEmailSentAt !== undefined
+				? { checkoutRecoveryEmailSentAt: entry.checkoutRecoveryEmailSentAt }
 				: {}),
 		}));
 
-	const markPendingSignupRecoveryEmailSent: MarkPendingSignupRecoveryEmailSent = async ({
+	const markCheckoutRecoveryEmailSent: MarkCheckoutRecoveryEmailSent = async ({
 		checkoutSessionId,
 		sentAt,
 	}) => {
 		const entry = store.get(checkoutSessionId);
 		if (!entry) throw new Error(`No pending signup: ${checkoutSessionId}`);
-		entry.recoveryEmailSentAt = sentAt;
+		entry.checkoutRecoveryEmailSentAt = sentAt;
 	};
 
 	return {
 		storePendingSignup,
 		consumePendingSignup,
 		listAllPendingSignups,
-		markPendingSignupRecoveryEmailSent,
+		markCheckoutRecoveryEmailSent,
 	};
 }

--- a/projects/hutch/src/runtime/providers/pending-signup/pending-signup.types.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/pending-signup.types.ts
@@ -6,6 +6,13 @@ export type PendingSignup =
 	| { method: "email"; email: string; passwordHash: string; returnUrl?: string }
 	| { method: "google"; email: string; userId: UserId; returnUrl?: string };
 
+export interface PendingSignupSummary {
+	checkoutSessionId: CheckoutSessionId;
+	email: string;
+	method: "email" | "google";
+	recoveryEmailSentAt?: number;
+}
+
 export type StorePendingSignup = (params: {
 	checkoutSessionId: CheckoutSessionId;
 	signup: PendingSignup;
@@ -14,4 +21,11 @@ export type StorePendingSignup = (params: {
 export type ConsumePendingSignup = (
 	checkoutSessionId: CheckoutSessionId,
 ) => Promise<PendingSignup | null>;
+
+export type ListAllPendingSignups = () => Promise<PendingSignupSummary[]>;
+
+export type MarkPendingSignupRecoveryEmailSent = (params: {
+	checkoutSessionId: CheckoutSessionId;
+	sentAt: number;
+}) => Promise<void>;
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/pending-signup/pending-signup.types.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/pending-signup.types.ts
@@ -9,8 +9,7 @@ export type PendingSignup =
 export interface PendingSignupSummary {
 	checkoutSessionId: CheckoutSessionId;
 	email: string;
-	method: "email" | "google";
-	recoveryEmailSentAt?: number;
+	checkoutRecoveryEmailSentAt?: number;
 }
 
 export type StorePendingSignup = (params: {
@@ -24,7 +23,7 @@ export type ConsumePendingSignup = (
 
 export type ListAllPendingSignups = () => Promise<PendingSignupSummary[]>;
 
-export type MarkPendingSignupRecoveryEmailSent = (params: {
+export type MarkCheckoutRecoveryEmailSent = (params: {
 	checkoutSessionId: CheckoutSessionId;
 	sentAt: number;
 }) => Promise<void>;

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
@@ -31,8 +31,8 @@ describe("initInMemoryStripeCheckout", () => {
 		expect(session.url).not.toContain("checkout.stripe.test");
 	});
 
-	it("returns unpaid status until markPaid is called", async () => {
-		const stripe = initInMemoryStripeCheckout();
+	it("returns unpaid open status until markPaid is called", async () => {
+		const stripe = initInMemoryStripeCheckout({ now: () => new Date("2026-01-01T00:00:00Z") });
 		const session = await stripe.createCheckoutSession({
 			customerEmail: "buyer@example.com",
 			successUrl: "https://app.test/ok",
@@ -44,13 +44,51 @@ describe("initInMemoryStripeCheckout", () => {
 		if (before.ok) {
 			expect(before.paid).toBe(false);
 			expect(before.customerEmail).toBe("buyer@example.com");
+			expect(before.status).toBe("open");
+			expect(before.created).toBe(Math.floor(new Date("2026-01-01T00:00:00Z").getTime() / 1000));
 		}
 
 		stripe.markPaid(session.id);
 
 		const after = await stripe.retrieveCheckoutSession(session.id);
 		assert.equal(after.ok, true);
-		if (after.ok) expect(after.paid).toBe(true);
+		if (after.ok) {
+			expect(after.paid).toBe(true);
+			expect(after.status).toBe("complete");
+		}
+	});
+
+	it("uses the system clock for created when no clock is injected", async () => {
+		const stripe = initInMemoryStripeCheckout();
+		const before = Math.floor(Date.now() / 1000);
+		const session = await stripe.createCheckoutSession({
+			customerEmail: "buyer@example.com",
+			successUrl: "https://app.test/ok",
+			cancelUrl: "https://app.test/cancel",
+		});
+		const after = Math.floor(Date.now() / 1000);
+
+		const retrieved = await stripe.retrieveCheckoutSession(session.id);
+		assert.equal(retrieved.ok, true);
+		if (retrieved.ok) {
+			expect(retrieved.created).toBeGreaterThanOrEqual(before);
+			expect(retrieved.created).toBeLessThanOrEqual(after);
+		}
+	});
+
+	it("marks a session expired", async () => {
+		const stripe = initInMemoryStripeCheckout();
+		const session = await stripe.createCheckoutSession({
+			customerEmail: "buyer@example.com",
+			successUrl: "https://app.test/ok",
+			cancelUrl: "https://app.test/cancel",
+		});
+
+		stripe.markExpired(session.id);
+
+		const retrieved = await stripe.retrieveCheckoutSession(session.id);
+		assert.equal(retrieved.ok, true);
+		if (retrieved.ok) expect(retrieved.status).toBe("expired");
 	});
 
 	it("returns not-found when retrieving an unknown session", async () => {
@@ -64,6 +102,13 @@ describe("initInMemoryStripeCheckout", () => {
 	it("throws when marking an unknown session as paid", () => {
 		const stripe = initInMemoryStripeCheckout();
 		expect(() => stripe.markPaid(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
+			/No checkout session/,
+		);
+	});
+
+	it("throws when marking an unknown session as expired", () => {
+		const stripe = initInMemoryStripeCheckout();
+		expect(() => stripe.markExpired(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
 			/No checkout session/,
 		);
 	});

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { initInMemoryStripeCheckout } from "./in-memory-stripe-checkout";
 import { CheckoutSessionIdSchema } from "./stripe-checkout.schema";
 
+const DEFAULT_OPTS = { checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() };
+
 describe("initInMemoryStripeCheckout", () => {
 	it("returns a checkout URL containing the success URL", async () => {
-		const stripe = initInMemoryStripeCheckout();
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
 
 		const session = await stripe.createCheckoutSession({
 			customerEmail: "test@example.com",
@@ -19,7 +21,7 @@ describe("initInMemoryStripeCheckout", () => {
 	});
 
 	it("uses custom checkoutBaseUrl when provided", async () => {
-		const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "http://localhost:9999/e2e/stripe-checkout" });
+		const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "http://localhost:9999/e2e/stripe-checkout", now: () => new Date() });
 
 		const session = await stripe.createCheckoutSession({
 			customerEmail: "test@example.com",
@@ -32,7 +34,7 @@ describe("initInMemoryStripeCheckout", () => {
 	});
 
 	it("returns unpaid open status until markPaid is called", async () => {
-		const stripe = initInMemoryStripeCheckout({ now: () => new Date("2026-01-01T00:00:00Z") });
+		const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date("2026-01-01T00:00:00Z") });
 		const session = await stripe.createCheckoutSession({
 			customerEmail: "buyer@example.com",
 			successUrl: "https://app.test/ok",
@@ -58,26 +60,24 @@ describe("initInMemoryStripeCheckout", () => {
 		}
 	});
 
-	it("uses the system clock for created when no clock is injected", async () => {
-		const stripe = initInMemoryStripeCheckout();
-		const before = Math.floor(Date.now() / 1000);
+	it("uses the injected clock for created timestamp", async () => {
+		const fixedDate = new Date("2026-06-15T10:00:00Z");
+		const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => fixedDate });
 		const session = await stripe.createCheckoutSession({
 			customerEmail: "buyer@example.com",
 			successUrl: "https://app.test/ok",
 			cancelUrl: "https://app.test/cancel",
 		});
-		const after = Math.floor(Date.now() / 1000);
 
 		const retrieved = await stripe.retrieveCheckoutSession(session.id);
 		assert.equal(retrieved.ok, true);
 		if (retrieved.ok) {
-			expect(retrieved.created).toBeGreaterThanOrEqual(before);
-			expect(retrieved.created).toBeLessThanOrEqual(after);
+			expect(retrieved.created).toBe(Math.floor(fixedDate.getTime() / 1000));
 		}
 	});
 
 	it("marks a session expired", async () => {
-		const stripe = initInMemoryStripeCheckout();
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
 		const session = await stripe.createCheckoutSession({
 			customerEmail: "buyer@example.com",
 			successUrl: "https://app.test/ok",
@@ -92,7 +92,7 @@ describe("initInMemoryStripeCheckout", () => {
 	});
 
 	it("returns not-found when retrieving an unknown session", async () => {
-		const stripe = initInMemoryStripeCheckout();
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
 		const result = await stripe.retrieveCheckoutSession(
 			CheckoutSessionIdSchema.parse("cs_test_unknown"),
 		);
@@ -100,21 +100,21 @@ describe("initInMemoryStripeCheckout", () => {
 	});
 
 	it("throws when marking an unknown session as paid", () => {
-		const stripe = initInMemoryStripeCheckout();
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
 		expect(() => stripe.markPaid(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
 			/No checkout session/,
 		);
 	});
 
 	it("throws when marking an unknown session as expired", () => {
-		const stripe = initInMemoryStripeCheckout();
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
 		expect(() => stripe.markExpired(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
 			/No checkout session/,
 		);
 	});
 
 	it("throws when looking up the URL of an unknown session", () => {
-		const stripe = initInMemoryStripeCheckout();
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
 		expect(() => stripe.getCheckoutUrl(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
 			/No checkout URL/,
 		);

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { CheckoutSessionIdSchema } from "./stripe-checkout.schema";
 import type {
 	CheckoutSessionId,
+	CheckoutSessionStatus,
 	CreateCheckoutSession,
 	RetrieveCheckoutSession,
 } from "./stripe-checkout.types";
@@ -9,21 +10,33 @@ import type {
 interface StoredSession {
 	customerEmail: string;
 	paid: boolean;
+	status: CheckoutSessionStatus;
+	created: number;
 }
 
-export function initInMemoryStripeCheckout(opts?: { checkoutBaseUrl?: string }): {
+export function initInMemoryStripeCheckout(opts?: {
+	checkoutBaseUrl?: string;
+	now?: () => Date;
+}): {
 	createCheckoutSession: CreateCheckoutSession;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	markPaid: (id: CheckoutSessionId) => void;
+	markExpired: (id: CheckoutSessionId) => void;
 	getCheckoutUrl: (id: CheckoutSessionId) => string;
 } {
 	const sessions = new Map<CheckoutSessionId, StoredSession>();
 	const urls = new Map<CheckoutSessionId, string>();
 	const baseUrl = opts?.checkoutBaseUrl ?? "https://checkout.stripe.test";
+	const now = opts?.now ?? (() => new Date());
 
 	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl }) => {
 		const id = CheckoutSessionIdSchema.parse(`cs_test_${randomBytes(12).toString("hex")}`);
-		sessions.set(id, { customerEmail, paid: false });
+		sessions.set(id, {
+			customerEmail,
+			paid: false,
+			status: "open",
+			created: Math.floor(now().getTime() / 1000),
+		});
 		const url = `${baseUrl}/${id}?next=${encodeURIComponent(successUrl)}`;
 		urls.set(id, url);
 		return { id, url };
@@ -32,13 +45,26 @@ export function initInMemoryStripeCheckout(opts?: { checkoutBaseUrl?: string }):
 	const retrieveCheckoutSession: RetrieveCheckoutSession = async (id) => {
 		const session = sessions.get(id);
 		if (!session) return { ok: false, reason: "not-found" };
-		return { ok: true, paid: session.paid, customerEmail: session.customerEmail };
+		return {
+			ok: true,
+			paid: session.paid,
+			customerEmail: session.customerEmail,
+			status: session.status,
+			created: session.created,
+		};
 	};
 
 	const markPaid = (id: CheckoutSessionId) => {
 		const session = sessions.get(id);
 		if (!session) throw new Error(`No checkout session: ${id}`);
 		session.paid = true;
+		session.status = "complete";
+	};
+
+	const markExpired = (id: CheckoutSessionId) => {
+		const session = sessions.get(id);
+		if (!session) throw new Error(`No checkout session: ${id}`);
+		session.status = "expired";
 	};
 
 	const getCheckoutUrl = (id: CheckoutSessionId): string => {
@@ -47,5 +73,5 @@ export function initInMemoryStripeCheckout(opts?: { checkoutBaseUrl?: string }):
 		return url;
 	};
 
-	return { createCheckoutSession, retrieveCheckoutSession, markPaid, getCheckoutUrl };
+	return { createCheckoutSession, retrieveCheckoutSession, markPaid, markExpired, getCheckoutUrl };
 }

--- a/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/in-memory-stripe-checkout.ts
@@ -14,9 +14,9 @@ interface StoredSession {
 	created: number;
 }
 
-export function initInMemoryStripeCheckout(opts?: {
-	checkoutBaseUrl?: string;
-	now?: () => Date;
+export function initInMemoryStripeCheckout(opts: {
+	checkoutBaseUrl: string;
+	now: () => Date;
 }): {
 	createCheckoutSession: CreateCheckoutSession;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
@@ -26,8 +26,6 @@ export function initInMemoryStripeCheckout(opts?: {
 } {
 	const sessions = new Map<CheckoutSessionId, StoredSession>();
 	const urls = new Map<CheckoutSessionId, string>();
-	const baseUrl = opts?.checkoutBaseUrl ?? "https://checkout.stripe.test";
-	const now = opts?.now ?? (() => new Date());
 
 	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl }) => {
 		const id = CheckoutSessionIdSchema.parse(`cs_test_${randomBytes(12).toString("hex")}`);
@@ -35,9 +33,9 @@ export function initInMemoryStripeCheckout(opts?: {
 			customerEmail,
 			paid: false,
 			status: "open",
-			created: Math.floor(now().getTime() / 1000),
+			created: Math.floor(opts.now().getTime() / 1000),
 		});
-		const url = `${baseUrl}/${id}?next=${encodeURIComponent(successUrl)}`;
+		const url = `${opts.checkoutBaseUrl}/${id}?next=${encodeURIComponent(successUrl)}`;
 		urls.set(id, url);
 		return { id, url };
 	};

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -17,6 +17,8 @@ const RetrieveSessionResponse = z.object({
 	customer_email: z.string().nullish(),
 	customer_details: z.object({ email: z.string().nullish() }).nullish(),
 	payment_status: z.enum(["paid", "unpaid", "no_payment_required"]),
+	status: z.enum(["open", "complete", "expired"]),
+	created: z.number(),
 });
 
 const StripeErrorResponse = z.object({
@@ -102,6 +104,8 @@ export function initStripeCheckout(deps: {
 			ok: true,
 			paid: parsed.payment_status === "paid" || parsed.payment_status === "no_payment_required",
 			customerEmail,
+			status: parsed.status,
+			created: parsed.created,
 		};
 	};
 

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.types.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.types.ts
@@ -12,8 +12,16 @@ export type CreateCheckoutSession = (params: {
 	cancelUrl: string;
 }) => Promise<CheckoutSession>;
 
+export type CheckoutSessionStatus = "open" | "complete" | "expired";
+
 export type RetrieveCheckoutSession = (id: CheckoutSessionId) => Promise<
-	| { ok: true; paid: boolean; customerEmail: string }
+	| {
+			ok: true;
+			paid: boolean;
+			customerEmail: string;
+			status: CheckoutSessionStatus;
+			created: number;
+	  }
 	| { ok: false; reason: "not-found" }
 >;
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/test-app-fakes.ts
+++ b/projects/hutch/src/runtime/test-app-fakes.ts
@@ -203,7 +203,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		logger: noopLogger,
 	});
 	const oauthModel = createOAuthModel(initInMemoryOAuthModel(), { appOrigin });
-	const stripe = initInMemoryStripeCheckout();
+	const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() });
 	const pendingSignup = initInMemoryPendingSignup();
 
 	const botDefenseEvents: BotDefenseEvent[] = [];

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -43,6 +43,7 @@ import { initFetchUserCount } from "./fetch-user-count";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
+const SignupQuerySchema = z.object({ email: z.string().email() }).passthrough();
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
 const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
@@ -246,11 +247,13 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 		const returnUrl = extractReturnUrl(req.query);
 		const userCount = await fetchUserCount();
+		const parsed = SignupQuerySchema.safeParse(req.query);
+		const email = parsed.success ? parsed.data.email : undefined;
 		sendComponent(
 			res,
 			renderPage(
 				req,
-				SignupPage({ returnUrl, userCount, loadedAt: deps.now().getTime() }),
+				SignupPage({ returnUrl, userCount, loadedAt: deps.now().getTime(), email }),
 			),
 		);
 	});

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -256,6 +256,30 @@ describe("Auth routes", () => {
 			expect(loginLink).toContain("/login");
 			expect(loginLink).toContain("return=");
 		});
+
+		it("should pre-fill the email field when a valid email is provided in the query string", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(app).get(
+				"/signup?email=jane%40example.com&utm_source=recovery",
+			);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const emailInput = doc.querySelector('input[name="email"]');
+			assert(emailInput, "email input must be rendered");
+			expect(emailInput.getAttribute("value")).toBe("jane@example.com");
+		});
+
+		it("should leave the email field empty when the query email is invalid", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(app).get("/signup?email=not-an-email");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const emailInput = doc.querySelector('input[name="email"]');
+			assert(emailInput, "email input must be rendered");
+			expect(emailInput.getAttribute("value")).toBe("");
+		});
 	});
 
 	describe("POST /signup", () => {

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.template.html
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.template.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Did something stop you?</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:{{colors.background}};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:{{colors.background}};padding:40px 20px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:{{colors.surface}};border-radius:8px;padding:40px;">
+            <tr>
+              <td align="center" style="padding-bottom:16px;">
+                <img src="{{founderAvatarUrl}}" width="64" height="64" alt="Fayner Brack" style="border-radius:50%;display:block;">
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">Hi there,</p>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">I'm Fayner — I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?</p>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">I genuinely want to know. A two-line reply would help me more than any analytics dashboard.</p>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">The reason I'm pushing for a paid plan at all is that the {{monthlyPrice}} a month is what pays for the AI summaries on every article you save — and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this — every subscription literally keeps Readplace running for one more month.</p>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">If you want, I can offer you a yearly plan with {{yearlyDiscount}} off — just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.</p>
+                <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:{{colors.body}};">Either way, your 14-day free trial is still waiting if you want to try it without paying first.</p>
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td style="border-radius:6px;background-color:{{colors.brand}};">
+                      <a href="{{resumeUrl}}" style="display:inline-block;padding:12px 24px;font-size:16px;color:{{colors.brandText}};text-decoration:none;border-radius:6px;">Resume your trial</a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:32px 0 0;font-size:14px;line-height:1.6;color:{{colors.muted}};">— Fayner<br>readplace.com</p>
+                <p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:{{colors.muted}};">If you'd rather not hear from me, just reply STOP.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.test.ts
@@ -1,0 +1,58 @@
+import { buildCheckoutRecoveryEmail } from "./checkout-recovery-email";
+
+describe("buildCheckoutRecoveryEmail", () => {
+	const baseParams = {
+		founderAvatarUrl: "https://readplace.com/fayner-brack.jpg",
+		resumeUrl: "https://readplace.com/signup?email=jane%40example.com&utm_source=recovery",
+	};
+
+	it("includes the resume URL on the CTA anchor", () => {
+		const { html } = buildCheckoutRecoveryEmail(baseParams);
+
+		expect(html).toContain(
+			'href="https://readplace.com/signup?email=jane%40example.com&amp;utm_source=recovery"',
+		);
+		expect(html).toContain(">Resume your trial</a>");
+	});
+
+	it("renders the founder avatar with the absolute URL", () => {
+		const { html } = buildCheckoutRecoveryEmail(baseParams);
+
+		expect(html).toContain('src="https://readplace.com/fayner-brack.jpg"');
+		expect(html).toContain('alt="Fayner Brack"');
+		expect(html).toContain("border-radius:50%");
+	});
+
+	it("escapes HTML entities in the avatar and resume URLs", () => {
+		const { html } = buildCheckoutRecoveryEmail({
+			founderAvatarUrl: 'https://readplace.com/avatar.jpg?"<>&',
+			resumeUrl: 'https://readplace.com/signup?email=a&b="<>',
+		});
+
+		expect(html).toContain('src="https://readplace.com/avatar.jpg?&quot;&lt;&gt;&amp;"');
+		expect(html).toContain(
+			'href="https://readplace.com/signup?email=a&amp;b=&quot;&lt;&gt;"',
+		);
+	});
+
+	it("produces a complete HTML document with the subject heading content", () => {
+		const { html } = buildCheckoutRecoveryEmail(baseParams);
+
+		expect(html).toContain("<!DOCTYPE html>");
+		expect(html).toContain("</html>");
+		expect(html).toContain("Did something stop you?");
+	});
+
+	it("returns a plain-text body containing the resume URL on its own line", () => {
+		const { text } = buildCheckoutRecoveryEmail(baseParams);
+
+		const lines = text.split("\n");
+		expect(lines).toContain(
+			"https://readplace.com/signup?email=jane%40example.com&utm_source=recovery",
+		);
+		expect(text).toContain("Hi there,");
+		expect(text).toContain("— Fayner");
+		expect(text).toContain("readplace.com");
+		expect(text).toContain("If you'd rather not hear from me, just reply STOP.");
+	});
+});

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.test.ts
@@ -4,13 +4,15 @@ describe("buildCheckoutRecoveryEmail", () => {
 	const baseParams = {
 		founderAvatarUrl: "https://readplace.com/fayner-brack.jpg",
 		resumeUrl: "https://readplace.com/signup?email=jane%40example.com&utm_source=recovery",
+		monthlyPrice: "$3.99",
+		yearlyDiscount: "20%",
 	};
 
 	it("includes the resume URL on the CTA anchor", () => {
 		const { html } = buildCheckoutRecoveryEmail(baseParams);
 
 		expect(html).toContain(
-			'href="https://readplace.com/signup?email=jane%40example.com&amp;utm_source=recovery"',
+			'href="https://readplace.com/signup?email&#x3D;jane%40example.com&amp;utm_source&#x3D;recovery"',
 		);
 		expect(html).toContain(">Resume your trial</a>");
 	});
@@ -25,13 +27,14 @@ describe("buildCheckoutRecoveryEmail", () => {
 
 	it("escapes HTML entities in the avatar and resume URLs", () => {
 		const { html } = buildCheckoutRecoveryEmail({
-			founderAvatarUrl: 'https://readplace.com/avatar.jpg?"<>&',
-			resumeUrl: 'https://readplace.com/signup?email=a&b="<>',
+			...baseParams,
+			founderAvatarUrl: "https://readplace.com/avatar.jpg?\"'<>&",
+			resumeUrl: "https://readplace.com/signup?email=a&b=\"'<>",
 		});
 
-		expect(html).toContain('src="https://readplace.com/avatar.jpg?&quot;&lt;&gt;&amp;"');
+		expect(html).toContain("src=\"https://readplace.com/avatar.jpg?&quot;&#x27;&lt;&gt;&amp;\"");
 		expect(html).toContain(
-			'href="https://readplace.com/signup?email=a&amp;b=&quot;&lt;&gt;"',
+			"href=\"https://readplace.com/signup?email&#x3D;a&amp;b&#x3D;&quot;&#x27;&lt;&gt;\"",
 		);
 	});
 
@@ -43,6 +46,15 @@ describe("buildCheckoutRecoveryEmail", () => {
 		expect(html).toContain("Did something stop you?");
 	});
 
+	it("renders pricing from params in both HTML and text", () => {
+		const { html, text } = buildCheckoutRecoveryEmail(baseParams);
+
+		expect(html).toContain("$3.99 a month");
+		expect(html).toContain("20% off");
+		expect(text).toContain("$3.99 a month");
+		expect(text).toContain("20% off");
+	});
+
 	it("returns a plain-text body containing the resume URL on its own line", () => {
 		const { text } = buildCheckoutRecoveryEmail(baseParams);
 
@@ -51,7 +63,7 @@ describe("buildCheckoutRecoveryEmail", () => {
 			"https://readplace.com/signup?email=jane%40example.com&utm_source=recovery",
 		);
 		expect(text).toContain("Hi there,");
-		expect(text).toContain("— Fayner");
+		expect(text).toContain("\u2014 Fayner");
 		expect(text).toContain("readplace.com");
 		expect(text).toContain("If you'd rather not hear from me, just reply STOP.");
 	});

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.test.ts
@@ -1,6 +1,6 @@
-import { buildCheckoutRecoveryEmail } from "./checkout-recovery-email";
+import { CheckoutRecoveryEmail } from "./checkout-recovery-email";
 
-describe("buildCheckoutRecoveryEmail", () => {
+describe("CheckoutRecoveryEmail", () => {
 	const baseParams = {
 		founderAvatarUrl: "https://readplace.com/fayner-brack.jpg",
 		resumeUrl: "https://readplace.com/signup?email=jane%40example.com&utm_source=recovery",
@@ -9,7 +9,7 @@ describe("buildCheckoutRecoveryEmail", () => {
 	};
 
 	it("includes the resume URL on the CTA anchor", () => {
-		const { html } = buildCheckoutRecoveryEmail(baseParams);
+		const html = CheckoutRecoveryEmail(baseParams).to("text/html");
 
 		expect(html).toContain(
 			'href="https://readplace.com/signup?email&#x3D;jane%40example.com&amp;utm_source&#x3D;recovery"',
@@ -18,7 +18,7 @@ describe("buildCheckoutRecoveryEmail", () => {
 	});
 
 	it("renders the founder avatar with the absolute URL", () => {
-		const { html } = buildCheckoutRecoveryEmail(baseParams);
+		const html = CheckoutRecoveryEmail(baseParams).to("text/html");
 
 		expect(html).toContain('src="https://readplace.com/fayner-brack.jpg"');
 		expect(html).toContain('alt="Fayner Brack"');
@@ -26,11 +26,11 @@ describe("buildCheckoutRecoveryEmail", () => {
 	});
 
 	it("escapes HTML entities in the avatar and resume URLs", () => {
-		const { html } = buildCheckoutRecoveryEmail({
+		const html = CheckoutRecoveryEmail({
 			...baseParams,
 			founderAvatarUrl: "https://readplace.com/avatar.jpg?\"'<>&",
 			resumeUrl: "https://readplace.com/signup?email=a&b=\"'<>",
-		});
+		}).to("text/html");
 
 		expect(html).toContain("src=\"https://readplace.com/avatar.jpg?&quot;&#x27;&lt;&gt;&amp;\"");
 		expect(html).toContain(
@@ -39,7 +39,7 @@ describe("buildCheckoutRecoveryEmail", () => {
 	});
 
 	it("produces a complete HTML document with the subject heading content", () => {
-		const { html } = buildCheckoutRecoveryEmail(baseParams);
+		const html = CheckoutRecoveryEmail(baseParams).to("text/html");
 
 		expect(html).toContain("<!DOCTYPE html>");
 		expect(html).toContain("</html>");
@@ -47,7 +47,9 @@ describe("buildCheckoutRecoveryEmail", () => {
 	});
 
 	it("renders pricing from params in both HTML and text", () => {
-		const { html, text } = buildCheckoutRecoveryEmail(baseParams);
+		const email = CheckoutRecoveryEmail(baseParams);
+		const html = email.to("text/html");
+		const text = email.to("text/plain");
 
 		expect(html).toContain("$3.99 a month");
 		expect(html).toContain("20% off");
@@ -56,7 +58,7 @@ describe("buildCheckoutRecoveryEmail", () => {
 	});
 
 	it("returns a plain-text body containing the resume URL on its own line", () => {
-		const { text } = buildCheckoutRecoveryEmail(baseParams);
+		const text = CheckoutRecoveryEmail(baseParams).to("text/plain");
 
 		const lines = text.split("\n");
 		expect(lines).toContain(

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.ts
@@ -1,0 +1,91 @@
+const EMAIL_COLORS = {
+	background: "#F7F8FA",
+	surface: "#FFFFFF",
+	heading: "#1A202C",
+	body: "#5A6170",
+	muted: "#8C919D",
+	brand: "#C8702A",
+	brandText: "#FFFFFF",
+} as const;
+
+interface BuildCheckoutRecoveryEmailParams {
+	founderAvatarUrl: string;
+	resumeUrl: string;
+}
+
+interface CheckoutRecoveryEmail {
+	html: string;
+	text: string;
+}
+
+export function buildCheckoutRecoveryEmail(
+	params: BuildCheckoutRecoveryEmailParams,
+): CheckoutRecoveryEmail {
+	const { founderAvatarUrl, resumeUrl } = params;
+
+	const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Did something stop you?</title>
+</head>
+<body style="margin:0;padding:0;background-color:${EMAIL_COLORS.background};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.background};padding:40px 20px;">
+<tr><td align="center">
+<table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.surface};border-radius:8px;padding:40px;">
+<tr><td align="center" style="padding-bottom:16px;">
+<img src="${escapeHtml(founderAvatarUrl)}" width="64" height="64" alt="Fayner Brack" style="border-radius:50%;display:block;">
+</td></tr>
+<tr><td>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Hi there,</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I'm Fayner — I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I genuinely want to know. A two-line reply would help me more than any analytics dashboard.</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The reason I'm pushing for a paid plan at all is that the $3.99 a month is what pays for the AI summaries on every article you save — and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this — every subscription literally keeps Readplace running for one more month.</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If you want, I can offer you a yearly plan with 20% off — just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.</p>
+<p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Either way, your 14-day free trial is still waiting if you want to try it without paying first.</p>
+<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
+<a href="${escapeHtml(resumeUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Resume your trial</a>
+</td></tr></table>
+<p style="margin:32px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">— Fayner<br>readplace.com</p>
+<p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:${EMAIL_COLORS.muted};">If you'd rather not hear from me, just reply STOP.</p>
+</td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+	const text = [
+		"Hi there,",
+		"",
+		"I'm Fayner — I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?",
+		"",
+		"I genuinely want to know. A two-line reply would help me more than any analytics dashboard.",
+		"",
+		"The reason I'm pushing for a paid plan at all is that the $3.99 a month is what pays for the AI summaries on every article you save — and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this — every subscription literally keeps Readplace running for one more month.",
+		"",
+		"If you want, I can offer you a yearly plan with 20% off — just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.",
+		"",
+		"Either way, your 14-day free trial is still waiting if you want to try it without paying first.",
+		"",
+		"Resume your trial:",
+		resumeUrl,
+		"",
+		"— Fayner",
+		"readplace.com",
+		"",
+		"If you'd rather not hear from me, just reply STOP.",
+		"",
+	].join("\n");
+
+	return { html, text };
+}
+
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/"/g, "&quot;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.ts
@@ -1,3 +1,5 @@
+import Handlebars from "handlebars";
+
 const EMAIL_COLORS = {
 	background: "#F7F8FA",
 	surface: "#FFFFFF",
@@ -11,6 +13,8 @@ const EMAIL_COLORS = {
 interface BuildCheckoutRecoveryEmailParams {
 	founderAvatarUrl: string;
 	resumeUrl: string;
+	monthlyPrice: string;
+	yearlyDiscount: string;
 }
 
 interface CheckoutRecoveryEmail {
@@ -18,12 +22,7 @@ interface CheckoutRecoveryEmail {
 	text: string;
 }
 
-export function buildCheckoutRecoveryEmail(
-	params: BuildCheckoutRecoveryEmailParams,
-): CheckoutRecoveryEmail {
-	const { founderAvatarUrl, resumeUrl } = params;
-
-	const html = `<!DOCTYPE html>
+const htmlTemplate = Handlebars.compile(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -35,44 +34,51 @@ export function buildCheckoutRecoveryEmail(
 <tr><td align="center">
 <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.surface};border-radius:8px;padding:40px;">
 <tr><td align="center" style="padding-bottom:16px;">
-<img src="${escapeHtml(founderAvatarUrl)}" width="64" height="64" alt="Fayner Brack" style="border-radius:50%;display:block;">
+<img src="{{founderAvatarUrl}}" width="64" height="64" alt="Fayner Brack" style="border-radius:50%;display:block;">
 </td></tr>
 <tr><td>
 <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Hi there,</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I'm Fayner — I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I'm Fayner \u2014 I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?</p>
 <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I genuinely want to know. A two-line reply would help me more than any analytics dashboard.</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The reason I'm pushing for a paid plan at all is that the $3.99 a month is what pays for the AI summaries on every article you save — and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this — every subscription literally keeps Readplace running for one more month.</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If you want, I can offer you a yearly plan with 20% off — just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The reason I'm pushing for a paid plan at all is that the {{monthlyPrice}} a month is what pays for the AI summaries on every article you save \u2014 and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this \u2014 every subscription literally keeps Readplace running for one more month.</p>
+<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If you want, I can offer you a yearly plan with {{yearlyDiscount}} off \u2014 just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.</p>
 <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Either way, your 14-day free trial is still waiting if you want to try it without paying first.</p>
 <table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="${escapeHtml(resumeUrl)}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Resume your trial</a>
+<a href="{{resumeUrl}}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Resume your trial</a>
 </td></tr></table>
-<p style="margin:32px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">— Fayner<br>readplace.com</p>
+<p style="margin:32px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">\u2014 Fayner<br>readplace.com</p>
 <p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:${EMAIL_COLORS.muted};">If you'd rather not hear from me, just reply STOP.</p>
 </td></tr>
 </table>
 </td></tr>
 </table>
 </body>
-</html>`;
+</html>`);
+
+export function buildCheckoutRecoveryEmail(
+	params: BuildCheckoutRecoveryEmailParams,
+): CheckoutRecoveryEmail {
+	const { resumeUrl, monthlyPrice, yearlyDiscount } = params;
+
+	const html = htmlTemplate(params);
 
 	const text = [
 		"Hi there,",
 		"",
-		"I'm Fayner — I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?",
+		"I'm Fayner \u2014 I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?",
 		"",
 		"I genuinely want to know. A two-line reply would help me more than any analytics dashboard.",
 		"",
-		"The reason I'm pushing for a paid plan at all is that the $3.99 a month is what pays for the AI summaries on every article you save — and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this — every subscription literally keeps Readplace running for one more month.",
+		`The reason I'm pushing for a paid plan at all is that the ${monthlyPrice} a month is what pays for the AI summaries on every article you save \u2014 and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this \u2014 every subscription literally keeps Readplace running for one more month.`,
 		"",
-		"If you want, I can offer you a yearly plan with 20% off — just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.",
+		`If you want, I can offer you a yearly plan with ${yearlyDiscount} off \u2014 just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.`,
 		"",
 		"Either way, your 14-day free trial is still waiting if you want to try it without paying first.",
 		"",
 		"Resume your trial:",
 		resumeUrl,
 		"",
-		"— Fayner",
+		"\u2014 Fayner",
 		"readplace.com",
 		"",
 		"If you'd rather not hear from me, just reply STOP.",
@@ -80,12 +86,4 @@ export function buildCheckoutRecoveryEmail(
 	].join("\n");
 
 	return { html, text };
-}
-
-function escapeHtml(str: string): string {
-	return str
-		.replace(/&/g, "&amp;")
-		.replace(/"/g, "&quot;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;");
 }

--- a/projects/hutch/src/runtime/web/auth/checkout-recovery-email.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-recovery-email.ts
@@ -1,89 +1,53 @@
-import Handlebars from "handlebars";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { EMAIL_COLORS } from "../email-colors";
+import { render } from "../render";
 
-const EMAIL_COLORS = {
-	background: "#F7F8FA",
-	surface: "#FFFFFF",
-	heading: "#1A202C",
-	body: "#5A6170",
-	muted: "#8C919D",
-	brand: "#C8702A",
-	brandText: "#FFFFFF",
-} as const;
+const TEMPLATE = readFileSync(join(__dirname, "checkout-recovery-email.template.html"), "utf-8");
 
-interface BuildCheckoutRecoveryEmailParams {
+interface CheckoutRecoveryEmailParams {
 	founderAvatarUrl: string;
 	resumeUrl: string;
 	monthlyPrice: string;
 	yearlyDiscount: string;
 }
 
-interface CheckoutRecoveryEmail {
-	html: string;
-	text: string;
+interface CheckoutRecoveryEmailComponent {
+	to: (mediaType: "text/html" | "text/plain") => string;
 }
 
-const htmlTemplate = Handlebars.compile(`<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Did something stop you?</title>
-</head>
-<body style="margin:0;padding:0;background-color:${EMAIL_COLORS.background};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.background};padding:40px 20px;">
-<tr><td align="center">
-<table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:${EMAIL_COLORS.surface};border-radius:8px;padding:40px;">
-<tr><td align="center" style="padding-bottom:16px;">
-<img src="{{founderAvatarUrl}}" width="64" height="64" alt="Fayner Brack" style="border-radius:50%;display:block;">
-</td></tr>
-<tr><td>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Hi there,</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I'm Fayner \u2014 I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">I genuinely want to know. A two-line reply would help me more than any analytics dashboard.</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">The reason I'm pushing for a paid plan at all is that the {{monthlyPrice}} a month is what pays for the AI summaries on every article you save \u2014 and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this \u2014 every subscription literally keeps Readplace running for one more month.</p>
-<p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">If you want, I can offer you a yearly plan with {{yearlyDiscount}} off \u2014 just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.</p>
-<p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:${EMAIL_COLORS.body};">Either way, your 14-day free trial is still waiting if you want to try it without paying first.</p>
-<table role="presentation" cellpadding="0" cellspacing="0"><tr><td style="border-radius:6px;background-color:${EMAIL_COLORS.brand};">
-<a href="{{resumeUrl}}" style="display:inline-block;padding:12px 24px;font-size:16px;color:${EMAIL_COLORS.brandText};text-decoration:none;border-radius:6px;">Resume your trial</a>
-</td></tr></table>
-<p style="margin:32px 0 0;font-size:14px;line-height:1.6;color:${EMAIL_COLORS.muted};">\u2014 Fayner<br>readplace.com</p>
-<p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:${EMAIL_COLORS.muted};">If you'd rather not hear from me, just reply STOP.</p>
-</td></tr>
-</table>
-</td></tr>
-</table>
-</body>
-</html>`);
+export function CheckoutRecoveryEmail(
+	params: CheckoutRecoveryEmailParams,
+): CheckoutRecoveryEmailComponent {
+	return {
+		to(mediaType) {
+			if (mediaType === "text/html") {
+				return render(TEMPLATE, { ...params, colors: EMAIL_COLORS });
+			}
 
-export function buildCheckoutRecoveryEmail(
-	params: BuildCheckoutRecoveryEmailParams,
-): CheckoutRecoveryEmail {
-	const { resumeUrl, monthlyPrice, yearlyDiscount } = params;
-
-	const html = htmlTemplate(params);
-
-	const text = [
-		"Hi there,",
-		"",
-		"I'm Fayner \u2014 I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?",
-		"",
-		"I genuinely want to know. A two-line reply would help me more than any analytics dashboard.",
-		"",
-		`The reason I'm pushing for a paid plan at all is that the ${monthlyPrice} a month is what pays for the AI summaries on every article you save \u2014 and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this \u2014 every subscription literally keeps Readplace running for one more month.`,
-		"",
-		`If you want, I can offer you a yearly plan with ${yearlyDiscount} off \u2014 just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.`,
-		"",
-		"Either way, your 14-day free trial is still waiting if you want to try it without paying first.",
-		"",
-		"Resume your trial:",
-		resumeUrl,
-		"",
-		"\u2014 Fayner",
-		"readplace.com",
-		"",
-		"If you'd rather not hear from me, just reply STOP.",
-		"",
-	].join("\n");
-
-	return { html, text };
+			const { resumeUrl, monthlyPrice, yearlyDiscount } = params;
+			return [
+				"Hi there,",
+				"",
+				"I'm Fayner \u2014 I built Readplace alone, and I noticed you signed up but didn't make it through checkout. I wanted to ask, gently: was it the price, the flow, or something else?",
+				"",
+				"I genuinely want to know. A two-line reply would help me more than any analytics dashboard.",
+				"",
+				`The reason I'm pushing for a paid plan at all is that the ${monthlyPrice} a month is what pays for the AI summaries on every article you save \u2014 and once it lands, the manual Pocket and Instapaper import I'm running by hand for the first members. It's less than a single cup of coffee a month, and there's no investor money behind this \u2014 every subscription literally keeps Readplace running for one more month.`,
+				"",
+				`If you want, I can offer you a yearly plan with ${yearlyDiscount} off \u2014 just reply to this email and I'll set it up for you. That's the founder discount, it's not on the website.`,
+				"",
+				"Either way, your 14-day free trial is still waiting if you want to try it without paying first.",
+				"",
+				"Resume your trial:",
+				resumeUrl,
+				"",
+				"\u2014 Fayner",
+				"readplace.com",
+				"",
+				"If you'd rather not hear from me, just reply STOP.",
+				"",
+			].join("\n");
+		},
+	};
 }

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -47,7 +47,7 @@ describe("Email verification", () => {
 			const oauthModel = createOAuthModel(initInMemoryOAuthModel());
 			const emailVerification = initInMemoryEmailVerification();
 			const passwordReset = initInMemoryPasswordReset();
-			const stripe = initInMemoryStripeCheckout();
+			const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() });
 			const pendingSignup = initInMemoryPendingSignup();
 
 			let resolveErrorLogged: () => void;

--- a/projects/hutch/src/runtime/web/auth/signup-resume-url.test.ts
+++ b/projects/hutch/src/runtime/web/auth/signup-resume-url.test.ts
@@ -1,0 +1,25 @@
+import { buildSignupResumeUrl } from "./signup-resume-url";
+
+describe("buildSignupResumeUrl", () => {
+	it("encodes the email and appends utm_source=recovery", () => {
+		const url = buildSignupResumeUrl({
+			origin: "https://readplace.com",
+			email: "jane@example.com",
+		});
+
+		expect(url).toBe(
+			"https://readplace.com/signup?email=jane%40example.com&utm_source=recovery",
+		);
+	});
+
+	it("encodes special characters in the email", () => {
+		const url = buildSignupResumeUrl({
+			origin: "https://readplace.com",
+			email: "user+tag@example.com",
+		});
+
+		expect(url).toBe(
+			"https://readplace.com/signup?email=user%2Btag%40example.com&utm_source=recovery",
+		);
+	});
+});

--- a/projects/hutch/src/runtime/web/auth/signup-resume-url.ts
+++ b/projects/hutch/src/runtime/web/auth/signup-resume-url.ts
@@ -1,0 +1,6 @@
+export function buildSignupResumeUrl(params: {
+	origin: string;
+	email: string;
+}): string {
+	return `${params.origin}/signup?email=${encodeURIComponent(params.email)}&utm_source=recovery`;
+}


### PR DESCRIPTION
Founders-voiced one-off CLI that emails users who reached the Stripe
checkout screen but didn't complete payment. Idempotent via a new
recoveryEmailSentAt attribute on the pending signups table; respects
a one-hour grace window so active checkouts are not interrupted.

- Extends EmailMessage with replyTo and text for plain-text deliverability
- Extends Stripe retrieveCheckoutSession to expose status and created
- Extends PendingSignup provider with listAll and markRecoveryEmailSent
- Adds buildCheckoutRecoveryEmail HTML+text template
- Pre-fills the email field on GET /signup from the resume URL
- New tsx CLI: pnpm send-checkout-recovery-emails (DRY_RUN by default)