### PR TITLE
fix(save-link): mark summary failed when recrawl DLQ fires

### DIFF
--- a/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.test.ts
@@ -1,6 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initRecrawlLinkInitiatedDlqHandler } from "./recrawl-link-initiated-dlq-handler";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -50,10 +51,12 @@ function createSqsEvent(
 describe("initRecrawlLinkInitiatedDlqHandler", () => {
 	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initRecrawlLinkInitiatedDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -68,6 +71,10 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 			url: "https://example.com/failed",
 			reason: "exceeded SQS maxReceiveCount",
 		});
+		expect(markSummaryFailed).toHaveBeenCalledWith({
+			url: "https://example.com/failed",
+			reason: "crawl failed",
+		});
 		expect(publishEvent).toHaveBeenCalledWith({
 			source: "hutch.save-link",
 			detailType: "CrawlArticleFailed",
@@ -81,10 +88,12 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 
 	it("throws on an invalid event envelope", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn();
+		const markSummaryFailed: MarkSummaryFailed = jest.fn();
 		const publishEvent: PublishEvent = jest.fn();
 
 		const handler = initRecrawlLinkInitiatedDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -105,6 +114,7 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 
 		await expect(handler(invalidEvent, stubContext, () => {})).rejects.toThrow();
 		expect(markCrawlFailed).not.toHaveBeenCalled();
+		expect(markSummaryFailed).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 });

--- a/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.ts
@@ -6,9 +6,11 @@ import {
 	RecrawlLinkInitiatedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlFailed } from "./article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 
 interface RecrawlLinkInitiatedDlqHandlerDeps {
 	markCrawlFailed: MarkCrawlFailed;
+	markSummaryFailed: MarkSummaryFailed;
 	publishEvent: PublishEvent;
 	logger: HutchLogger;
 }
@@ -17,7 +19,7 @@ interface RecrawlLinkInitiatedDlqHandlerDeps {
 export function initRecrawlLinkInitiatedDlqHandler(
 	deps: RecrawlLinkInitiatedDlqHandlerDeps,
 ): SQSHandler {
-	const { markCrawlFailed, publishEvent, logger } = deps;
+	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -32,6 +34,7 @@ export function initRecrawlLinkInitiatedDlqHandler(
 			});
 
 			await markCrawlFailed({ url: detail.url, reason });
+			await markSummaryFailed({ url: detail.url, reason: "crawl failed" });
 
 			await publishEvent({
 				source: CrawlArticleFailedEvent.source,

--- a/projects/save-link/src/runtime/recrawl-content-extracted-dlq.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted-dlq.main.ts
@@ -3,6 +3,7 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { requireEnv } from "../require-env";
 import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initRecrawlContentExtractedDlqHandler } from "../select-content/recrawl-content-extracted-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
@@ -15,6 +16,11 @@ const crawlStore = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
+const summaryStore = initDynamoDbGeneratedSummary({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
@@ -22,6 +28,7 @@ const { publishEvent } = initEventBridgePublisher({
 
 export const handler = initRecrawlContentExtractedDlqHandler({
 	markCrawlFailed: crawlStore.markCrawlFailed,
+	markSummaryFailed: summaryStore.markSummaryFailed,
 	publishEvent,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/recrawl-link-initiated-dlq.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated-dlq.main.ts
@@ -3,6 +3,7 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { requireEnv } from "../require-env";
 import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initRecrawlLinkInitiatedDlqHandler } from "../crawl-article-state/recrawl-link-initiated-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
@@ -15,6 +16,11 @@ const crawlStore = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
+const summaryStore = initDynamoDbGeneratedSummary({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
@@ -22,6 +28,7 @@ const { publishEvent } = initEventBridgePublisher({
 
 export const handler = initRecrawlLinkInitiatedDlqHandler({
 	markCrawlFailed: crawlStore.markCrawlFailed,
+	markSummaryFailed: summaryStore.markSummaryFailed,
 	publishEvent,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.test.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.test.ts
@@ -1,6 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initRecrawlContentExtractedDlqHandler } from "./recrawl-content-extracted-dlq-handler";
 import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -50,10 +51,12 @@ function createSqsEvent(
 describe("initRecrawlContentExtractedDlqHandler", () => {
 	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
 		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initRecrawlContentExtractedDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -68,6 +71,10 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 			url: "https://example.com/failed",
 			reason: "exceeded SQS maxReceiveCount",
 		});
+		expect(markSummaryFailed).toHaveBeenCalledWith({
+			url: "https://example.com/failed",
+			reason: "crawl failed",
+		});
 		expect(publishEvent).toHaveBeenCalledWith({
 			source: "hutch.save-link",
 			detailType: "CrawlArticleFailed",
@@ -81,10 +88,12 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 
 	it("throws on an invalid event envelope", async () => {
 		const markCrawlFailed: MarkCrawlFailed = jest.fn();
+		const markSummaryFailed: MarkSummaryFailed = jest.fn();
 		const publishEvent: PublishEvent = jest.fn();
 
 		const handler = initRecrawlContentExtractedDlqHandler({
 			markCrawlFailed,
+			markSummaryFailed,
 			publishEvent,
 			logger: noopLogger,
 		});
@@ -105,6 +114,7 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 
 		await expect(handler(invalidEvent, stubContext, () => {})).rejects.toThrow();
 		expect(markCrawlFailed).not.toHaveBeenCalled();
+		expect(markSummaryFailed).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.ts
@@ -6,9 +6,11 @@ import {
 	RecrawlContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
+import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
 
 interface RecrawlContentExtractedDlqHandlerDeps {
 	markCrawlFailed: MarkCrawlFailed;
+	markSummaryFailed: MarkSummaryFailed;
 	publishEvent: PublishEvent;
 	logger: HutchLogger;
 }
@@ -17,7 +19,7 @@ interface RecrawlContentExtractedDlqHandlerDeps {
 export function initRecrawlContentExtractedDlqHandler(
 	deps: RecrawlContentExtractedDlqHandlerDeps,
 ): SQSHandler {
-	const { markCrawlFailed, publishEvent, logger } = deps;
+	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -32,6 +34,7 @@ export function initRecrawlContentExtractedDlqHandler(
 			});
 
 			await markCrawlFailed({ url: detail.url, reason });
+			await markSummaryFailed({ url: detail.url, reason: "crawl failed" });
 
 			await publishEvent({
 				source: CrawlArticleFailedEvent.source,


### PR DESCRIPTION
The recrawl DLQ handlers only marked crawlStatus as failed, leaving summaryStatus stuck as "pending". The admin recrawl page resets both statuses to pending before publishing the command, so a failed recrawl must also fail both.

Closes #211