### PR TITLE
fix(crawl-article): add curl subprocess fallback for Cloudflare ALPN downgrade

### DIFF
--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -1,0 +1,53 @@
+import { parseCurlOutput } from "./curl-fetch";
+
+describe("parseCurlOutput", () => {
+	it("parses a simple 200 response with headers and body", () => {
+		const raw = Buffer.from(
+			"HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: nginx\r\n\r\n<html>hello</html>",
+		);
+		const { status, headers, body } = parseCurlOutput(raw);
+		expect(status).toBe(200);
+		expect(headers.get("content-type")).toBe("text/html");
+		expect(headers.get("server")).toBe("nginx");
+		expect(body.toString()).toBe("<html>hello</html>");
+	});
+
+	it("parses the final response after a redirect chain", () => {
+		const raw = Buffer.from(
+			[
+				"HTTP/1.1 301 Moved Permanently\r\nlocation: /new-path\r\n\r\n",
+				"HTTP/1.1 200 OK\r\ncontent-type: text/html\r\n\r\n<html>final</html>",
+			].join(""),
+		);
+		const { status, headers, body } = parseCurlOutput(raw);
+		expect(status).toBe(200);
+		expect(headers.get("content-type")).toBe("text/html");
+		expect(body.toString()).toBe("<html>final</html>");
+	});
+
+	it("parses a 403 response", () => {
+		const raw = Buffer.from(
+			"HTTP/2 403 \r\nserver: cloudflare\r\n\r\nForbidden",
+		);
+		const { status, headers, body } = parseCurlOutput(raw);
+		expect(status).toBe(403);
+		expect(headers.get("server")).toBe("cloudflare");
+		expect(body.toString()).toBe("Forbidden");
+	});
+
+	it("handles empty body", () => {
+		const raw = Buffer.from("HTTP/1.1 204 No Content\r\n\r\n");
+		const { status, body } = parseCurlOutput(raw);
+		expect(status).toBe(204);
+		expect(body.length).toBe(0);
+	});
+
+	it("handles binary body content", () => {
+		const headerPart = "HTTP/1.1 200 OK\r\ncontent-type: image/png\r\n\r\n";
+		const binaryBody = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+		const raw = Buffer.concat([Buffer.from(headerPart), binaryBody]);
+		const { status, body } = parseCurlOutput(raw);
+		expect(status).toBe(200);
+		expect(body).toEqual(binaryBody);
+	});
+});

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -1,0 +1,134 @@
+import { execFile } from "node:child_process";
+
+const MAX_REDIRECTS = 5;
+const DEFAULT_TIMEOUT_MS = 10000;
+
+type CurlFetchInit = {
+	headers?: Record<string, string>;
+	signal?: AbortSignal;
+};
+
+/**
+ * Fetch via curl subprocess. curl's TLS fingerprint (OpenSSL-based) differs
+ * from Node.js's (BoringSSL/undici), so Cloudflare's JA3/JA4 heuristics
+ * treat it as a trusted client. Used as a last-resort fallback when both
+ * Node's fetch and the HTTP/2 module are blocked by TLS fingerprinting.
+ */
+export function fetchCurl(url: string, init?: CurlFetchInit): Promise<Response> {
+	return new Promise((resolve, reject) => {
+		const args = buildCurlArgs({ url, headers: init?.headers });
+		const timeout = init?.signal ? undefined : DEFAULT_TIMEOUT_MS;
+		const child = execFile("curl", args, { encoding: "buffer", maxBuffer: 50 * 1024 * 1024, timeout }, (error, stdout) => {
+			if (error) {
+				reject(new Error(`fetchCurl failed for ${url}: ${error.message}`));
+				return;
+			}
+			const { status, headers, body } = parseCurlOutput(stdout);
+			resolve(new Response(body, { status, headers }));
+		});
+		const signal = init?.signal;
+		if (signal) {
+			if (signal.aborted) {
+				child.kill();
+				reject(signal.reason);
+				return;
+			}
+			const onAbort = () => {
+				child.kill();
+				reject(signal.reason);
+			};
+			signal.addEventListener("abort", onAbort, { once: true });
+			child.on("close", () => signal.removeEventListener("abort", onAbort));
+		}
+	});
+}
+
+function buildCurlArgs(params: { url: string; headers?: Record<string, string> }): string[] {
+	const args = [
+		"--http2",
+		"--silent",
+		"--show-error",
+		"--location",
+		"--max-redirs", String(MAX_REDIRECTS),
+		"--dump-header", "-",
+		"--output", "-",
+		"--compressed",
+	];
+	if (params.headers) {
+		for (const [key, value] of Object.entries(params.headers)) {
+			args.push("--header", `${toTitleCase(key)}: ${value}`);
+		}
+	}
+	args.push("--", params.url);
+	return args;
+}
+
+/**
+ * Cloudflare's JA3/JA4 heuristics factor in header name casing for HTTP/1.1.
+ * Real browsers send Title-Case headers; lowercase headers signal bot traffic.
+ */
+function toTitleCase(header: string): string {
+	return header.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+type ParsedCurlOutput = {
+	status: number;
+	headers: Headers;
+	body: Buffer;
+};
+
+/**
+ * curl --dump-header - --output - writes headers then a blank line then body.
+ * With --location, intermediate redirect headers appear before the final ones.
+ * We parse the LAST header block (after the last HTTP status line).
+ */
+export function parseCurlOutput(raw: Buffer): ParsedCurlOutput {
+	const crlfIndex = findLastHeaderBlock(raw);
+	const headerSection = raw.subarray(0, crlfIndex).toString("utf-8");
+	const body = raw.subarray(crlfIndex + 4);
+
+	const lines = headerSection.split("\r\n");
+	let status = 200;
+	const headers = new Headers();
+
+	for (const line of lines) {
+		if (line.startsWith("HTTP/")) {
+			const parts = line.split(" ");
+			status = Number(parts[1]);
+			continue;
+		}
+		const colonIdx = line.indexOf(":");
+		if (colonIdx > 0) {
+			headers.append(line.substring(0, colonIdx).trim(), line.substring(colonIdx + 1).trim());
+		}
+	}
+
+	return { status, headers, body };
+}
+
+/**
+ * Finds the end of the last header block (\r\n\r\n boundary).
+ * With --location, each redirect response has its own header block.
+ */
+function findLastHeaderBlock(raw: Buffer): number {
+	const separator = Buffer.from("\r\n\r\n");
+	let lastIdx = -1;
+	let searchFrom = 0;
+	while (true) {
+		const idx = raw.indexOf(separator, searchFrom);
+		if (idx === -1) break;
+		const afterSep = idx + 4;
+		const remaining = raw.subarray(afterSep);
+		if (remaining.length > 0 && remaining.toString("utf-8", 0, Math.min(5, remaining.length)).startsWith("HTTP/")) {
+			lastIdx = idx;
+			searchFrom = afterSep;
+			continue;
+		}
+		lastIdx = idx;
+		break;
+	}
+	if (lastIdx === -1) {
+		return raw.length;
+	}
+	return lastIdx;
+}

--- a/src/packages/crawl-article/src/h2-fetch.test.ts
+++ b/src/packages/crawl-article/src/h2-fetch.test.ts
@@ -271,4 +271,45 @@ describe("withH2Fallback", () => {
 		const wrapped = withH2Fallback(baseFetch);
 		expect(typeof wrapped).toBe("function");
 	});
+
+	it("falls back to curl when h2 throws a protocol error", async () => {
+		const baseFetch: typeof fetch = async () =>
+			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
+		const h2Impl = jest.fn(async () => {
+			throw new Error("ERR_HTTP2_ERROR: Protocol error");
+		});
+		const curlImpl = jest.fn(async () =>
+			new Response("<html>curl worked</html>", { status: 200, headers: { "content-type": "text/html" } }),
+		);
+		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2, curlImpl);
+
+		const response = await wrapped("https://example.com", {
+			headers: { "user-agent": "Test/1.0" },
+			signal: AbortSignal.timeout(5000),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<html>curl worked</html>");
+		expect(h2Impl).toHaveBeenCalledTimes(1);
+		expect(curlImpl).toHaveBeenCalledWith("https://example.com", {
+			headers: { "user-agent": "Test/1.0" },
+			signal: expect.any(AbortSignal),
+		});
+	});
+
+	it("does not invoke curl when h2 succeeds", async () => {
+		const baseFetch: typeof fetch = async () =>
+			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
+		const h2Impl = jest.fn(async () =>
+			new Response("<html>h2 ok</html>", { status: 200, headers: { "content-type": "text/html" } }),
+		);
+		const curlImpl = jest.fn();
+		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2, curlImpl);
+
+		const response = await wrapped("https://example.com");
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<html>h2 ok</html>");
+		expect(curlImpl).not.toHaveBeenCalled();
+	});
 });

--- a/src/packages/crawl-article/src/h2-fetch.ts
+++ b/src/packages/crawl-article/src/h2-fetch.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import http2 from "node:http2";
+import { fetchCurl } from "./curl-fetch";
 
 const MAX_REDIRECTS = 5;
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
@@ -110,20 +111,32 @@ function toFetchHeaders(incoming: http2.IncomingHttpHeaders): Headers {
  * challenge`) and plain "Attention Required!" interstitials (no cf-mitigated
  * header), since both are TLS-fingerprint blocks that real browsers bypass
  * via h2. Non-Cloudflare 403s and non-403 responses pass through unchanged.
+ *
+ * If the h2 fallback itself fails (e.g. Cloudflare refuses to negotiate h2
+ * via ALPN downgrade), a curl subprocess fallback kicks in. curl's OpenSSL-
+ * based TLS fingerprint differs from Node.js's and passes Cloudflare's
+ * JA3/JA4 heuristics.
  */
 export function withH2Fallback(
 	baseFetch: typeof fetch,
 	h2FetchImpl: typeof fetchH2 = fetchH2,
+	curlFetchImpl: typeof fetchCurl = fetchCurl,
 ): typeof fetch {
 	return async (input, init) => {
 		const response = await baseFetch(input, init);
 		if (response.status !== 403) return response;
 		if (response.headers.get("server")?.toLowerCase() !== "cloudflare") return response;
 		await response.text();
-		return h2FetchImpl(urlFromInput(input), {
+		const url = urlFromInput(input);
+		const fallbackInit = {
 			headers: toPlainHeaders(init?.headers),
 			signal: init?.signal ?? undefined,
-		});
+		};
+		try {
+			return await h2FetchImpl(url, fallbackInit);
+		} catch {
+			return curlFetchImpl(url, fallbackInit);
+		}
 	};
 }
 


### PR DESCRIPTION
Fixes #212

Cloudflare upgraded JA3/JA4 TLS fingerprinting for Stack Overflow, blocking both Node.js fetch (403 managed challenge) and the HTTP/2 fallback (ALPN downgrade → protocol error).

Adds a curl subprocess fallback as a third tier: fetch → H2 → curl. curl’s OpenSSL-based TLS fingerprint passes Cloudflare’s heuristics.