### PR TITLE
Add structured data (Schema.org) markup to blog, install, and blog post pages

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/blog-index.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-index.component.ts
@@ -15,6 +15,47 @@ export function BlogIndexPage(params: { posts: BlogPost[] }): PageBody {
 				"Articles about reading, building software, and the tools behind Readplace.",
 			canonicalUrl: "https://readplace.com/blog",
 			ogType: "website",
+			structuredData: [
+				{
+					"@context": "https://schema.org",
+					"@type": "Blog",
+					name: "Readplace Blog",
+					url: "https://readplace.com/blog",
+					description:
+						"Articles about reading, building software, and the tools behind Readplace.",
+					publisher: {
+						"@type": "Organization",
+						name: "Readplace",
+						url: "https://readplace.com",
+					},
+					blogPost: params.posts.map((post) => ({
+						"@type": "BlogPosting",
+						headline: post.title,
+						description: post.description,
+						datePublished: post.date,
+						url: `https://readplace.com/blog/${post.slug}`,
+						author: { "@type": "Person", name: post.author },
+					})),
+				},
+				{
+					"@context": "https://schema.org",
+					"@type": "BreadcrumbList",
+					itemListElement: [
+						{
+							"@type": "ListItem",
+							position: 1,
+							name: "Home",
+							item: "https://readplace.com/",
+						},
+						{
+							"@type": "ListItem",
+							position: 2,
+							name: "Blog",
+							item: "https://readplace.com/blog",
+						},
+					],
+				},
+			],
 		},
 		styles: BLOG_STYLES,
 		bodyClass: "page-blog",

--- a/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
@@ -42,6 +42,30 @@ export function BlogPostPage(params: { post: BlogPost }): PageBody {
 						url: "https://readplace.com",
 					},
 				},
+				{
+					"@context": "https://schema.org",
+					"@type": "BreadcrumbList",
+					itemListElement: [
+						{
+							"@type": "ListItem",
+							position: 1,
+							name: "Home",
+							item: "https://readplace.com/",
+						},
+						{
+							"@type": "ListItem",
+							position: 2,
+							name: "Blog",
+							item: "https://readplace.com/blog",
+						},
+						{
+							"@type": "ListItem",
+							position: 3,
+							name: post.title,
+							item: `https://readplace.com/blog/${post.slug}`,
+						},
+					],
+				},
 			],
 		},
 		styles: BLOG_STYLES,

--- a/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
@@ -69,6 +69,44 @@ describe("GET /blog", () => {
 
 		expect(doc.body.classList.contains("page-blog")).toBe(true);
 	});
+
+	it("should have Blog and BreadcrumbList structured data", async () => {
+		const response = await request(app).get("/blog");
+		const doc = new JSDOM(response.text).window.document;
+
+		const scripts = doc.querySelectorAll(
+			'script[type="application/ld+json"]',
+		);
+		const schemas = Array.from(scripts).map((s) =>
+			JSON.parse(s.textContent ?? "{}"),
+		);
+		const blog = schemas.find(
+			(s: { "@type": string }) => s["@type"] === "Blog",
+		);
+		expect(blog).toBeDefined();
+		expect(blog.url).toBe("https://readplace.com/blog");
+		expect(Array.isArray(blog.blogPost)).toBe(true);
+		expect(blog.blogPost.length).toBeGreaterThan(0);
+
+		const breadcrumb = schemas.find(
+			(s: { "@type": string }) => s["@type"] === "BreadcrumbList",
+		);
+		expect(breadcrumb).toBeDefined();
+		expect(breadcrumb.itemListElement).toEqual([
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: "https://readplace.com/",
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Blog",
+				item: "https://readplace.com/blog",
+			},
+		]);
+	});
 });
 
 describe("GET /blog/:slug", () => {
@@ -138,6 +176,44 @@ describe("GET /blog/:slug", () => {
 		const data = JSON.parse(ldJson?.textContent ?? "{}");
 		expect(data["@type"]).toBe("BlogPosting");
 		expect(data.headline).toBe(firstPost.title);
+	});
+
+	it("should have BreadcrumbList structured data", async () => {
+		const response = await request(app).get(
+			`/blog/${firstPost.slug}`,
+		);
+		const doc = new JSDOM(response.text).window.document;
+
+		const scripts = doc.querySelectorAll(
+			'script[type="application/ld+json"]',
+		);
+		const schemas = Array.from(scripts).map((s) =>
+			JSON.parse(s.textContent ?? "{}"),
+		);
+		const breadcrumb = schemas.find(
+			(s: { "@type": string }) => s["@type"] === "BreadcrumbList",
+		);
+		expect(breadcrumb).toBeDefined();
+		expect(breadcrumb.itemListElement).toEqual([
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: "https://readplace.com/",
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Blog",
+				item: "https://readplace.com/blog",
+			},
+			{
+				"@type": "ListItem",
+				position: 3,
+				name: firstPost.title,
+				item: `https://readplace.com/blog/${firstPost.slug}`,
+			},
+		]);
 	});
 
 	it("should have correct canonical URL", async () => {

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -35,6 +35,47 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 			description:
 				"Where reading still matters. Download the Readplace browser extension for Firefox or Chrome and save articles with one click.",
 			canonicalUrl: "https://readplace.com/install",
+			structuredData: [
+				{
+					"@context": "https://schema.org",
+					"@type": "SoftwareApplication",
+					name: "Readplace Browser Extension",
+					description:
+						"Save any article to your Readplace reading list with one click from Firefox or Chrome.",
+					applicationCategory: "BrowserApplication",
+					operatingSystem: "Windows, macOS, Linux, ChromeOS",
+					url: "https://readplace.com/install",
+					downloadUrl: "https://readplace.com/install",
+					offers: {
+						"@type": "Offer",
+						price: "0",
+						priceCurrency: "AUD",
+					},
+					publisher: {
+						"@type": "Organization",
+						name: "Readplace",
+						url: "https://readplace.com",
+					},
+				},
+				{
+					"@context": "https://schema.org",
+					"@type": "BreadcrumbList",
+					itemListElement: [
+						{
+							"@type": "ListItem",
+							position: 1,
+							name: "Home",
+							item: "https://readplace.com/",
+						},
+						{
+							"@type": "ListItem",
+							position: 2,
+							name: "Install",
+							item: "https://readplace.com/install",
+						},
+					],
+				},
+			],
 		},
 		styles: INSTALL_PAGE_STYLES,
 		bodyClass: "page-install",

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -49,7 +49,7 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 					offers: {
 						"@type": "Offer",
 						price: "0",
-						priceCurrency: "AUD",
+						priceCurrency: "USD",
 					},
 					publisher: {
 						"@type": "Organization",

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -126,6 +126,43 @@ describe("GET /install", () => {
 		expect(description?.getAttribute("content")).toContain("extension");
 	});
 
+	it("should have SoftwareApplication and BreadcrumbList structured data", async () => {
+		const response = await request(app).get("/install");
+		const doc = new JSDOM(response.text).window.document;
+
+		const scripts = doc.querySelectorAll(
+			'script[type="application/ld+json"]',
+		);
+		const schemas = Array.from(scripts).map((s) =>
+			JSON.parse(s.textContent ?? "{}"),
+		);
+		const software = schemas.find(
+			(s: { "@type": string }) => s["@type"] === "SoftwareApplication",
+		);
+		expect(software).toBeDefined();
+		expect(software.applicationCategory).toBe("BrowserApplication");
+		expect(software.offers.price).toBe("0");
+
+		const breadcrumb = schemas.find(
+			(s: { "@type": string }) => s["@type"] === "BreadcrumbList",
+		);
+		expect(breadcrumb).toBeDefined();
+		expect(breadcrumb.itemListElement).toEqual([
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: "https://readplace.com/",
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Install",
+				item: "https://readplace.com/install",
+			},
+		]);
+	});
+
 	it("should show Firefox unavailable message when Firefox latest.txt returns 404", async () => {
 		jest.restoreAllMocks();
 		jest.spyOn(globalThis, "fetch").mockImplementation(async () => {


### PR DESCRIPTION
## Summary
This PR adds Schema.org structured data markup to improve SEO and enable rich snippets for the blog index, blog post detail, and install pages. The changes include both implementation of the structured data in components and comprehensive test coverage.

## Key Changes
- **Blog Index Page**: Added `Blog` schema with blog post listings and `BreadcrumbList` schema
- **Blog Post Page**: Added `BreadcrumbList` schema for the post detail page
- **Install Page**: Added `SoftwareApplication` schema describing the browser extension and `BreadcrumbList` schema
- **Test Coverage**: Added comprehensive tests for all new structured data schemas on each page, validating:
  - Correct schema types are present
  - Required properties are populated correctly
  - Breadcrumb navigation structure is accurate

## Implementation Details
- Structured data is added via the `structuredData` property in page metadata, which gets rendered as `<script type="application/ld+json">` tags
- All schemas include proper `@context` and `@type` fields following Schema.org specifications
- Blog posts are included as `BlogPosting` items within the main `Blog` schema
- Breadcrumb lists follow a consistent pattern across all pages, starting with Home and ending with the current page
- The install page includes offer information (free software) and operating system compatibility details

https://claude.ai/code/session_01Pw68pygJ6uV5sXePDn31QB