### PR TITLE
Refactor curl fetch to injectable architecture with comprehensive tests

### DIFF
--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -201,8 +201,9 @@ describe("fetchCurl abort signal handling", () => {
 });
 
 describe("createCurlFetch defaults", () => {
-	it("returns a callable function when no execCurl override is provided", () => {
-		const fetchCurl = createCurlFetch();
+	it("returns a callable function with an explicit execCurl", () => {
+		const fake = makeFakeExec();
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
 		expect(typeof fetchCurl).toBe("function");
 	});
 });

--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -1,53 +1,208 @@
-import { parseCurlOutput } from "./curl-fetch";
+import { type ExecCurl, createCurlFetch } from "./curl-fetch";
 
-describe("parseCurlOutput", () => {
-	it("parses a simple 200 response with headers and body", () => {
-		const raw = Buffer.from(
-			"HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: nginx\r\n\r\n<html>hello</html>",
-		);
-		const { status, headers, body } = parseCurlOutput(raw);
-		expect(status).toBe(200);
-		expect(headers.get("content-type")).toBe("text/html");
-		expect(headers.get("server")).toBe("nginx");
-		expect(body.toString()).toBe("<html>hello</html>");
+type ExecCall = {
+	args: readonly string[];
+	options: { timeoutMs: number | undefined };
+};
+
+type FakeExec = {
+	execCurl: ExecCurl;
+	calls: ExecCall[];
+	kill: jest.Mock;
+	pendingClose: () => void;
+};
+
+function makeFakeExec(opts: { stdout?: Buffer | string; error?: Error; deferCallback?: boolean } = {}): FakeExec {
+	const calls: ExecCall[] = [];
+	const kill = jest.fn();
+	let closeListener: (() => void) | undefined;
+	let pendingCallback: (() => void) | undefined;
+	const execCurl: ExecCurl = (args, options, callback) => {
+		calls.push({ args, options });
+		const buf = typeof opts.stdout === "string" ? Buffer.from(opts.stdout) : opts.stdout ?? Buffer.alloc(0);
+		const fire = () => {
+			callback(opts.error ?? null, buf);
+			closeListener?.();
+		};
+		if (opts.deferCallback) {
+			pendingCallback = fire;
+		} else {
+			setImmediate(fire);
+		}
+		return {
+			kill: () => {
+				kill();
+				closeListener?.();
+			},
+			onClose: (listener) => {
+				closeListener = listener;
+			},
+		};
+	};
+	return {
+		execCurl,
+		calls,
+		kill,
+		pendingClose: () => pendingCallback?.(),
+	};
+}
+
+describe("fetchCurl response parsing", () => {
+	it("parses a simple 200 response with headers and body", async () => {
+		const fake = makeFakeExec({
+			stdout: "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: nginx\r\n\r\n<html>hello</html>",
+		});
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const response = await fetchCurl("https://example.com");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("text/html");
+		expect(response.headers.get("server")).toBe("nginx");
+		expect(await response.text()).toBe("<html>hello</html>");
 	});
 
-	it("parses the final response after a redirect chain", () => {
-		const raw = Buffer.from(
-			[
+	it("parses the final response after a redirect chain", async () => {
+		const fake = makeFakeExec({
+			stdout: [
 				"HTTP/1.1 301 Moved Permanently\r\nlocation: /new-path\r\n\r\n",
 				"HTTP/1.1 200 OK\r\ncontent-type: text/html\r\n\r\n<html>final</html>",
 			].join(""),
-		);
-		const { status, headers, body } = parseCurlOutput(raw);
-		expect(status).toBe(200);
-		expect(headers.get("content-type")).toBe("text/html");
-		expect(body.toString()).toBe("<html>final</html>");
+		});
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const response = await fetchCurl("https://example.com");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toBe("text/html");
+		expect(await response.text()).toBe("<html>final</html>");
 	});
 
-	it("parses a 403 response", () => {
-		const raw = Buffer.from(
-			"HTTP/2 403 \r\nserver: cloudflare\r\n\r\nForbidden",
-		);
-		const { status, headers, body } = parseCurlOutput(raw);
-		expect(status).toBe(403);
-		expect(headers.get("server")).toBe("cloudflare");
-		expect(body.toString()).toBe("Forbidden");
+	it("parses a 403 response", async () => {
+		const fake = makeFakeExec({
+			stdout: "HTTP/2 403 \r\nserver: cloudflare\r\n\r\nForbidden",
+		});
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const response = await fetchCurl("https://example.com");
+		expect(response.status).toBe(403);
+		expect(response.headers.get("server")).toBe("cloudflare");
+		expect(await response.text()).toBe("Forbidden");
 	});
 
-	it("handles empty body", () => {
-		const raw = Buffer.from("HTTP/1.1 204 No Content\r\n\r\n");
-		const { status, body } = parseCurlOutput(raw);
-		expect(status).toBe(204);
-		expect(body.length).toBe(0);
+	it("handles an empty body", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 204 No Content\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const response = await fetchCurl("https://example.com");
+		expect(response.status).toBe(204);
+		expect(await response.text()).toBe("");
 	});
 
-	it("handles binary body content", () => {
+	it("preserves binary body content", async () => {
 		const headerPart = "HTTP/1.1 200 OK\r\ncontent-type: image/png\r\n\r\n";
 		const binaryBody = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
-		const raw = Buffer.concat([Buffer.from(headerPart), binaryBody]);
-		const { status, body } = parseCurlOutput(raw);
-		expect(status).toBe(200);
-		expect(body).toEqual(binaryBody);
+		const fake = makeFakeExec({ stdout: Buffer.concat([Buffer.from(headerPart), binaryBody]) });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const response = await fetchCurl("https://example.com");
+		expect(response.status).toBe(200);
+		expect(Buffer.from(await response.arrayBuffer())).toEqual(binaryBody);
+	});
+
+	it("treats output without a header separator as headers-only with empty body", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 502 Bad Gateway\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const response = await fetchCurl("https://example.com");
+		expect(response.status).toBe(502);
+		expect(await response.text()).toBe("");
+	});
+});
+
+describe("fetchCurl argument construction", () => {
+	it("invokes curl with --http2 and the URL after a -- separator", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await fetchCurl("https://example.com/page?q=1");
+		const args = fake.calls[0].args;
+		expect(args).toContain("--http2");
+		expect(args).toContain("--compressed");
+		expect(args).toContain("--location");
+		const sepIdx = args.indexOf("--");
+		expect(sepIdx).toBeGreaterThan(0);
+		expect(args[sepIdx + 1]).toBe("https://example.com/page?q=1");
+	});
+
+	it("title-cases header names per Cloudflare JA3 fingerprinting", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await fetchCurl("https://example.com", {
+			headers: {
+				"user-agent": "Test/1.0",
+				"accept-language": "en-US",
+				accept: "text/html",
+			},
+		});
+		const args = fake.calls[0].args;
+		expect(args).toContain("User-Agent: Test/1.0");
+		expect(args).toContain("Accept-Language: en-US");
+		expect(args).toContain("Accept: text/html");
+	});
+
+	it("uses the default 10s timeout when no signal is provided", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await fetchCurl("https://example.com");
+		expect(fake.calls[0].options.timeoutMs).toBe(10000);
+	});
+
+	it("disables the internal timeout when a signal is provided so the caller controls timing", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await fetchCurl("https://example.com", { signal: new AbortController().signal });
+		expect(fake.calls[0].options.timeoutMs).toBeUndefined();
+	});
+});
+
+describe("fetchCurl error handling", () => {
+	it("rejects with the URL embedded in the message when curl fails", async () => {
+		const fake = makeFakeExec({ error: new Error("spawn ENOENT") });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await expect(fetchCurl("https://example.com/path")).rejects.toThrow(
+			/fetchCurl failed for https:\/\/example\.com\/path: spawn ENOENT/,
+		);
+	});
+});
+
+describe("fetchCurl abort signal handling", () => {
+	it("rejects immediately and kills the child if the signal is already aborted", async () => {
+		const fake = makeFakeExec({ deferCallback: true });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const controller = new AbortController();
+		controller.abort(new Error("already aborted"));
+		await expect(fetchCurl("https://example.com", { signal: controller.signal })).rejects.toThrow(
+			"already aborted",
+		);
+		expect(fake.kill).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects and kills the child when the signal aborts mid-flight", async () => {
+		const fake = makeFakeExec({ deferCallback: true });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const controller = new AbortController();
+		const promise = fetchCurl("https://example.com", { signal: controller.signal });
+		setImmediate(() => controller.abort(new Error("mid-flight abort")));
+		await expect(promise).rejects.toThrow("mid-flight abort");
+		expect(fake.kill).toHaveBeenCalledTimes(1);
+	});
+
+	it("removes the abort listener once the child closes so a later abort is a no-op", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\nbody" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		const controller = new AbortController();
+		const response = await fetchCurl("https://example.com", { signal: controller.signal });
+		expect(response.status).toBe(200);
+		controller.abort(new Error("late abort"));
+		expect(fake.kill).not.toHaveBeenCalled();
+	});
+});
+
+describe("createCurlFetch defaults", () => {
+	it("returns a callable function when no execCurl override is provided", () => {
+		const fetchCurl = createCurlFetch();
+		expect(typeof fetchCurl).toBe("function");
 	});
 });

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -8,40 +8,79 @@ type CurlFetchInit = {
 	signal?: AbortSignal;
 };
 
+type CurlChild = {
+	kill: () => void;
+	onClose: (listener: () => void) => void;
+};
+
+export type ExecCurl = (
+	args: readonly string[],
+	options: { timeoutMs: number | undefined },
+	callback: (error: Error | null, stdout: Buffer) => void,
+) => CurlChild;
+
+type CurlFetch = (url: string, init?: CurlFetchInit) => Promise<Response>;
+
+const defaultExecCurl: ExecCurl = (args, options, callback) => {
+	const child = execFile(
+		"curl",
+		args,
+		{ encoding: "buffer", maxBuffer: 50 * 1024 * 1024, timeout: options.timeoutMs },
+		callback,
+	);
+	return {
+		kill: () => {
+			child.kill();
+		},
+		onClose: (listener) => {
+			child.on("close", listener);
+		},
+	};
+};
+
 /**
  * Fetch via curl subprocess. curl's TLS fingerprint (OpenSSL-based) differs
  * from Node.js's (BoringSSL/undici), so Cloudflare's JA3/JA4 heuristics
  * treat it as a trusted client. Used as a last-resort fallback when both
  * Node's fetch and the HTTP/2 module are blocked by TLS fingerprinting.
+ *
+ * The execCurl dependency is injectable so tests can drive the full function
+ * (argument construction, header title-casing, abort handling, error mapping,
+ * response parsing) without spawning a real curl process.
  */
-export function fetchCurl(url: string, init?: CurlFetchInit): Promise<Response> {
-	return new Promise((resolve, reject) => {
-		const args = buildCurlArgs({ url, headers: init?.headers });
-		const timeout = init?.signal ? undefined : DEFAULT_TIMEOUT_MS;
-		const child = execFile("curl", args, { encoding: "buffer", maxBuffer: 50 * 1024 * 1024, timeout }, (error, stdout) => {
-			if (error) {
-				reject(new Error(`fetchCurl failed for ${url}: ${error.message}`));
-				return;
+export function createCurlFetch(deps: { execCurl?: ExecCurl } = {}): CurlFetch {
+	const execCurl = deps.execCurl ?? defaultExecCurl;
+	return function fetchCurl(url, init) {
+		return new Promise((resolve, reject) => {
+			const args = buildCurlArgs({ url, headers: init?.headers });
+			const timeoutMs = init?.signal ? undefined : DEFAULT_TIMEOUT_MS;
+			const child = execCurl(args, { timeoutMs }, (error, stdout) => {
+				if (error) {
+					reject(new Error(`fetchCurl failed for ${url}: ${error.message}`));
+					return;
+				}
+				const { status, headers, body } = parseCurlOutput(stdout);
+				resolve(new Response(body.length === 0 ? null : body, { status, headers }));
+			});
+			const signal = init?.signal;
+			if (signal) {
+				if (signal.aborted) {
+					child.kill();
+					reject(signal.reason);
+					return;
+				}
+				const onAbort = () => {
+					child.kill();
+					reject(signal.reason);
+				};
+				signal.addEventListener("abort", onAbort, { once: true });
+				child.onClose(() => signal.removeEventListener("abort", onAbort));
 			}
-			const { status, headers, body } = parseCurlOutput(stdout);
-			resolve(new Response(body, { status, headers }));
 		});
-		const signal = init?.signal;
-		if (signal) {
-			if (signal.aborted) {
-				child.kill();
-				reject(signal.reason);
-				return;
-			}
-			const onAbort = () => {
-				child.kill();
-				reject(signal.reason);
-			};
-			signal.addEventListener("abort", onAbort, { once: true });
-			child.on("close", () => signal.removeEventListener("abort", onAbort));
-		}
-	});
+	};
 }
+
+export const fetchCurl: CurlFetch = createCurlFetch();
 
 function buildCurlArgs(params: { url: string; headers?: Record<string, string> }): string[] {
 	const args = [
@@ -49,9 +88,12 @@ function buildCurlArgs(params: { url: string; headers?: Record<string, string> }
 		"--silent",
 		"--show-error",
 		"--location",
-		"--max-redirs", String(MAX_REDIRECTS),
-		"--dump-header", "-",
-		"--output", "-",
+		"--max-redirs",
+		String(MAX_REDIRECTS),
+		"--dump-header",
+		"-",
+		"--output",
+		"-",
 		"--compressed",
 	];
 	if (params.headers) {
@@ -82,7 +124,7 @@ type ParsedCurlOutput = {
  * With --location, intermediate redirect headers appear before the final ones.
  * We parse the LAST header block (after the last HTTP status line).
  */
-export function parseCurlOutput(raw: Buffer): ParsedCurlOutput {
+function parseCurlOutput(raw: Buffer): ParsedCurlOutput {
 	const crlfIndex = findLastHeaderBlock(raw);
 	const headerSection = raw.subarray(0, crlfIndex).toString("utf-8");
 	const body = raw.subarray(crlfIndex + 4);

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -48,8 +48,8 @@ const defaultExecCurl: ExecCurl = (args, options, callback) => {
  * (argument construction, header title-casing, abort handling, error mapping,
  * response parsing) without spawning a real curl process.
  */
-export function createCurlFetch(deps: { execCurl?: ExecCurl } = {}): CurlFetch {
-	const execCurl = deps.execCurl ?? defaultExecCurl;
+export function createCurlFetch(deps: { execCurl: ExecCurl }): CurlFetch {
+	const { execCurl } = deps;
 	return function fetchCurl(url, init) {
 		return new Promise((resolve, reject) => {
 			const args = buildCurlArgs({ url, headers: init?.headers });
@@ -80,7 +80,7 @@ export function createCurlFetch(deps: { execCurl?: ExecCurl } = {}): CurlFetch {
 	};
 }
 
-export const fetchCurl: CurlFetch = createCurlFetch();
+export const fetchCurl: CurlFetch = createCurlFetch({ execCurl: defaultExecCurl });
 
 function buildCurlArgs(params: { url: string; headers?: Record<string, string> }): string[] {
 	const args = [

--- a/src/packages/crawl-article/src/h2-fetch.test.ts
+++ b/src/packages/crawl-article/src/h2-fetch.test.ts
@@ -1,5 +1,6 @@
 import http2 from "node:http2";
 import type { AddressInfo } from "node:net";
+import type { fetchCurl } from "./curl-fetch";
 import { fetchH2, withH2Fallback } from "./h2-fetch";
 
 type StreamHandler = (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => void;
@@ -114,8 +115,8 @@ describe("withH2Fallback", () => {
 	it("passes through non-403 responses unchanged", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } });
-		const h2Impl = jest.fn();
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>();
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const response = await wrapped("https://example.com");
 
@@ -127,8 +128,8 @@ describe("withH2Fallback", () => {
 	it("passes through 403 when server header is not 'cloudflare'", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("Forbidden", { status: 403, headers: { server: "nginx" } });
-		const h2Impl = jest.fn();
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>();
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const response = await wrapped("https://example.com");
 
@@ -142,10 +143,10 @@ describe("withH2Fallback", () => {
 				status: 403,
 				headers: { server: "cloudflare", "cf-mitigated": "challenge" },
 			});
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html>real</html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const signal = AbortSignal.timeout(5000);
 		const response = await wrapped("https://example.com", {
@@ -167,10 +168,10 @@ describe("withH2Fallback", () => {
 				status: 403,
 				headers: { server: "cloudflare" },
 			});
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html>real</html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const response = await wrapped("https://example.com");
 
@@ -182,10 +183,10 @@ describe("withH2Fallback", () => {
 	it("matches the server header case-insensitively", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("blocked", { status: 403, headers: { server: "Cloudflare" } });
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html>ok</html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const response = await wrapped("https://example.com");
 
@@ -196,8 +197,8 @@ describe("withH2Fallback", () => {
 	it("passes through 403 when the server header is missing", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("Forbidden", { status: 403 });
-		const h2Impl = jest.fn();
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>();
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const response = await wrapped("https://example.com");
 
@@ -208,10 +209,10 @@ describe("withH2Fallback", () => {
 	it("extracts the URL string from a URL object input", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		await wrapped(new URL("https://example.com/page?q=1"));
 
@@ -221,10 +222,10 @@ describe("withH2Fallback", () => {
 	it("extracts the URL from a Request input", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		await wrapped(new Request("https://example.com/other"));
 
@@ -234,10 +235,10 @@ describe("withH2Fallback", () => {
 	it("normalizes a Headers instance in init.headers to a plain object before passing to h2", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		const headers = new Headers();
 		headers.set("user-agent", "Test/1.0");
@@ -253,10 +254,10 @@ describe("withH2Fallback", () => {
 	it("passes undefined headers to h2 when init is omitted", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html></html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2);
+		const wrapped = withH2Fallback(baseFetch, h2Impl);
 
 		await wrapped("https://example.com");
 
@@ -275,13 +276,13 @@ describe("withH2Fallback", () => {
 	it("falls back to curl when h2 throws a protocol error", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
-		const h2Impl = jest.fn(async () => {
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () => {
 			throw new Error("ERR_HTTP2_ERROR: Protocol error");
 		});
-		const curlImpl = jest.fn(async () =>
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
 			new Response("<html>curl worked</html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2, curlImpl);
+		const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
 
 		const response = await wrapped("https://example.com", {
 			headers: { "user-agent": "Test/1.0" },
@@ -300,16 +301,65 @@ describe("withH2Fallback", () => {
 	it("does not invoke curl when h2 succeeds", async () => {
 		const baseFetch: typeof fetch = async () =>
 			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
-		const h2Impl = jest.fn(async () =>
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () =>
 			new Response("<html>h2 ok</html>", { status: 200, headers: { "content-type": "text/html" } }),
 		);
-		const curlImpl = jest.fn();
-		const wrapped = withH2Fallback(baseFetch, h2Impl as unknown as typeof fetchH2, curlImpl);
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+		const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
 
 		const response = await wrapped("https://example.com");
 
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("<html>h2 ok</html>");
 		expect(curlImpl).not.toHaveBeenCalled();
+	});
+
+	it.each(["ENOTFOUND", "ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH"])(
+		"propagates %s without falling back to curl since the network is unreachable",
+		async (code) => {
+			const baseFetch: typeof fetch = async () =>
+				new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
+			const networkError = Object.assign(new Error(`getaddrinfo ${code} example.com`), { code });
+			const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () => {
+				throw networkError;
+			});
+			const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+			const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
+
+			await expect(wrapped("https://example.com")).rejects.toBe(networkError);
+			expect(curlImpl).not.toHaveBeenCalled();
+		},
+	);
+
+	it("propagates an abort without falling back to curl", async () => {
+		const baseFetch: typeof fetch = async () =>
+			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
+		const controller = new AbortController();
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () => {
+			controller.abort(new Error("aborted"));
+			throw new Error("aborted");
+		});
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+		const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
+
+		await expect(wrapped("https://example.com", { signal: controller.signal })).rejects.toThrow("aborted");
+		expect(curlImpl).not.toHaveBeenCalled();
+	});
+
+	it("falls back to curl when h2 throws a non-Error value", async () => {
+		const baseFetch: typeof fetch = async () =>
+			new Response("challenge", { status: 403, headers: { server: "cloudflare" } });
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>(async () => {
+			throw "string-error";
+		});
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
+			new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
+		);
+		const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
+
+		const response = await wrapped("https://example.com");
+
+		expect(response.status).toBe(200);
+		expect(curlImpl).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/packages/crawl-article/src/h2-fetch.ts
+++ b/src/packages/crawl-article/src/h2-fetch.ts
@@ -112,10 +112,12 @@ function toFetchHeaders(incoming: http2.IncomingHttpHeaders): Headers {
  * header), since both are TLS-fingerprint blocks that real browsers bypass
  * via h2. Non-Cloudflare 403s and non-403 responses pass through unchanged.
  *
- * If the h2 fallback itself fails (e.g. Cloudflare refuses to negotiate h2
- * via ALPN downgrade), a curl subprocess fallback kicks in. curl's OpenSSL-
- * based TLS fingerprint differs from Node.js's and passes Cloudflare's
- * JA3/JA4 heuristics.
+ * If the h2 fallback itself fails with a TLS- or protocol-level error (e.g.
+ * Cloudflare refuses to negotiate h2 via ALPN downgrade), a curl subprocess
+ * fallback kicks in. curl's OpenSSL-based TLS fingerprint differs from
+ * Node.js's and passes Cloudflare's JA3/JA4 heuristics. Clear network
+ * failures (DNS, connection refused) and aborts skip curl since they would
+ * fail the same way and only add latency.
  */
 export function withH2Fallback(
 	baseFetch: typeof fetch,
@@ -134,10 +136,27 @@ export function withH2Fallback(
 		};
 		try {
 			return await h2FetchImpl(url, fallbackInit);
-		} catch {
+		} catch (error) {
+			if (!shouldFallbackToCurl(error, fallbackInit.signal)) throw error;
 			return curlFetchImpl(url, fallbackInit);
 		}
 	};
+}
+
+const NETWORK_ERROR_CODES = new Set([
+	"ENOTFOUND",
+	"ECONNREFUSED",
+	"EHOSTUNREACH",
+	"ENETUNREACH",
+]);
+
+function shouldFallbackToCurl(error: unknown, signal: AbortSignal | undefined): boolean {
+	if (signal?.aborted) return false;
+	if (!(error instanceof Error)) return true;
+	if ("code" in error && typeof error.code === "string" && NETWORK_ERROR_CODES.has(error.code)) {
+		return false;
+	}
+	return true;
 }
 
 type FetchInput = Parameters<typeof fetch>[0];


### PR DESCRIPTION
## Summary
Refactored the curl-based fetch implementation to use dependency injection for the underlying process execution, enabling comprehensive testing without spawning real curl processes. Added extensive test coverage for argument construction, response parsing, error handling, and abort signal behavior.

## Key Changes

- **Dependency Injection**: Introduced `ExecCurl` type and `createCurlFetch()` factory function that accepts an injectable `execCurl` dependency, allowing tests to mock process execution while maintaining the same public API through a default export
- **Test Infrastructure**: Created `makeFakeExec()` helper that simulates curl subprocess behavior with configurable stdout, errors, and callback timing for comprehensive testing scenarios
- **Expanded Test Coverage**: 
  - Response parsing: simple 200, redirect chains, error codes, empty bodies, binary content
  - Argument construction: HTTP/2 flags, header title-casing for JA3 fingerprinting, URL handling
  - Timeout behavior: default 10s timeout vs. signal-controlled timing
  - Error handling: curl failures with URL context in error messages
  - Abort signal handling: pre-aborted signals, mid-flight aborts, cleanup after completion
- **H2 Fallback Improvements**: Enhanced `withH2Fallback()` to intelligently skip curl fallback for network-level errors (DNS, connection refused) and aborts, since they would fail identically and only add latency. Added proper type annotations for jest mocks
- **Response Handling**: Fixed Response body handling to pass `null` instead of empty buffer for empty responses, matching standard fetch behavior
- **Code Organization**: Made `parseCurlOutput()` private (internal implementation detail) and exported only the public `fetchCurl` function and `createCurlFetch` factory

## Notable Implementation Details

- The `ExecCurl` interface abstracts the child process lifecycle with `kill()` and `onClose()` methods, enabling proper cleanup and abort handling
- Abort signal listeners are properly removed after process completion to prevent memory leaks
- Header title-casing is preserved for Cloudflare JA3 fingerprinting compatibility
- The fallback logic distinguishes between TLS/protocol errors (fallback to curl) and network errors (propagate immediately)

https://claude.ai/code/session_01Uonh7RiFQVW6yeKm37qnrp