### PR TITLE
fix(crawl-article): fall back to curl when primary fetch times out

### DIFF
--- a/src/packages/crawl-article/src/h2-fetch.test.ts
+++ b/src/packages/crawl-article/src/h2-fetch.test.ts
@@ -362,4 +362,89 @@ describe("withH2Fallback", () => {
 		expect(response.status).toBe(200);
 		expect(curlImpl).toHaveBeenCalledTimes(1);
 	});
+
+	it("falls back to curl when baseFetch throws due to a timed-out signal", async () => {
+		const controller = new AbortController();
+		const reason = Object.assign(new Error("The operation timed out"), { name: "TimeoutError" });
+		controller.abort(reason);
+		const baseFetch: typeof fetch = async () => {
+			throw reason;
+		};
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>();
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
+			new Response("<html>curl fallback</html>", { status: 200, headers: { "content-type": "text/html" } }),
+		);
+		const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
+
+		const response = await wrapped("https://hex.ooo/page.html", {
+			headers: { "user-agent": "Test/1.0" },
+			signal: controller.signal,
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<html>curl fallback</html>");
+		expect(h2Impl).not.toHaveBeenCalled();
+		expect(curlImpl).toHaveBeenCalledWith("https://hex.ooo/page.html", {
+			headers: { "user-agent": "Test/1.0" },
+		});
+	});
+
+	it("does not pass the exhausted signal to curl on timeout fallback", async () => {
+		const controller = new AbortController();
+		const reason = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+		controller.abort(reason);
+		const baseFetch: typeof fetch = async () => {
+			throw reason;
+		};
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
+			new Response("ok", { status: 200 }),
+		);
+		const wrapped = withH2Fallback(baseFetch, jest.fn(), curlImpl);
+
+		await wrapped("https://example.com", { signal: controller.signal });
+
+		expect(curlImpl).toHaveBeenCalledWith("https://example.com", {
+			headers: undefined,
+		});
+	});
+
+	it("propagates baseFetch error when signal is explicitly aborted (not timeout)", async () => {
+		const controller = new AbortController();
+		controller.abort(new Error("user cancelled"));
+		const baseFetch: typeof fetch = async () => {
+			throw new Error("user cancelled");
+		};
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+		const wrapped = withH2Fallback(baseFetch, jest.fn(), curlImpl);
+
+		await expect(wrapped("https://example.com", { signal: controller.signal })).rejects.toThrow("user cancelled");
+		expect(curlImpl).not.toHaveBeenCalled();
+	});
+
+	it.each(["ENOTFOUND", "ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH"])(
+		"propagates baseFetch %s error without falling back to curl",
+		async (code) => {
+			const networkError = Object.assign(new Error(`connect ${code}`), { code });
+			const baseFetch: typeof fetch = async () => {
+				throw networkError;
+			};
+			const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+			const wrapped = withH2Fallback(baseFetch, jest.fn(), curlImpl);
+
+			await expect(wrapped("https://example.com")).rejects.toBe(networkError);
+			expect(curlImpl).not.toHaveBeenCalled();
+		},
+	);
+
+	it("propagates baseFetch error when there is no signal (no timeout to detect)", async () => {
+		const socketError = new Error("socket hang up");
+		const baseFetch: typeof fetch = async () => {
+			throw socketError;
+		};
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>();
+		const wrapped = withH2Fallback(baseFetch, jest.fn(), curlImpl);
+
+		await expect(wrapped("https://example.com")).rejects.toBe(socketError);
+		expect(curlImpl).not.toHaveBeenCalled();
+	});
 });

--- a/src/packages/crawl-article/src/h2-fetch.ts
+++ b/src/packages/crawl-article/src/h2-fetch.ts
@@ -125,7 +125,15 @@ export function withH2Fallback(
 	curlFetchImpl: typeof fetchCurl = fetchCurl,
 ): typeof fetch {
 	return async (input, init) => {
-		const response = await baseFetch(input, init);
+		let response: Response;
+		try {
+			response = await baseFetch(input, init);
+		} catch (error) {
+			const signal = init?.signal ?? undefined;
+			if (!signal?.aborted || !isTimeoutError(signal.reason)) throw error;
+			const url = urlFromInput(input);
+			return curlFetchImpl(url, { headers: toPlainHeaders(init?.headers) });
+		}
 		if (response.status !== 403) return response;
 		if (response.headers.get("server")?.toLowerCase() !== "cloudflare") return response;
 		await response.text();
@@ -141,6 +149,10 @@ export function withH2Fallback(
 			return curlFetchImpl(url, fallbackInit);
 		}
 	};
+}
+
+function isTimeoutError(reason: unknown): boolean {
+	return reason instanceof Error && reason.name === "TimeoutError";
 }
 
 const NETWORK_ERROR_CODES = new Set([


### PR DESCRIPTION
When the primary Node.js fetch times out (AbortSignal.timeout fires), try the curl subprocess as a last resort before propagating the error. This handles non-Cloudflare sites (like hex.ooo) where the server is transiently unreachable from Lambda but curl's fresh connection might succeed.

Closes #224

Generated with [Claude Code](https://claude.ai/code)