### PR TITLE
Add readAt sorting for read articles in queue

### DIFF
--- a/projects/hutch/src/infra/hutch-storage.ts
+++ b/projects/hutch/src/infra/hutch-storage.ts
@@ -53,12 +53,19 @@ export class HutchStorage extends pulumi.ComponentResource {
 				{ name: "userId", type: "S" },
 				{ name: "url", type: "S" },
 				{ name: "savedAt", type: "S" },
+				{ name: "readAt", type: "S" },
 			],
 			globalSecondaryIndexes: [
 				{
 					name: "userId-savedAt-index",
 					hashKey: "userId",
 					rangeKey: "savedAt",
+					projectionType: "ALL",
+				},
+				{
+					name: "userId-readAt-index",
+					hashKey: "userId",
+					rangeKey: "readAt",
 					projectionType: "ALL",
 				},
 			],

--- a/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
+++ b/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
@@ -12,7 +12,7 @@ export interface SaveArticleParams {
 	estimatedReadTime: SavedArticle["estimatedReadTime"];
 }
 
-type SortField = "savedAt" | "readAt";
+export type SortField = "savedAt" | "readAt";
 export type SortOrder = "asc" | "desc";
 
 export interface FindArticlesQuery {

--- a/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
+++ b/projects/hutch/src/runtime/providers/article-store/article-store.types.ts
@@ -12,7 +12,7 @@ export interface SaveArticleParams {
 	estimatedReadTime: SavedArticle["estimatedReadTime"];
 }
 
-type SortField = "savedAt";
+type SortField = "savedAt" | "readAt";
 export type SortOrder = "asc" | "desc";
 
 export interface FindArticlesQuery {

--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -199,6 +199,8 @@ export function initDynamoDbArticleStore(deps: {
 		const page = query.page ?? 1;
 		const pageSize = query.pageSize ?? 20;
 		const order = query.order ?? "desc";
+		const sort = query.sort ?? "savedAt";
+		const indexName = sort === "readAt" ? "userId-readAt-index" : "userId-savedAt-index";
 
 		const expressionValues: Record<string, unknown> = {
 			":userId": query.userId,
@@ -216,7 +218,7 @@ export function initDynamoDbArticleStore(deps: {
 		let countStartKey: Record<string, unknown> | undefined;
 		do {
 			const { count, lastEvaluatedKey } = await userArticles.query({
-				IndexName: "userId-savedAt-index",
+				IndexName: indexName,
 				KeyConditionExpression: "userId = :userId",
 				FilterExpression: filterExpression,
 				ExpressionAttributeValues: expressionValues,
@@ -235,7 +237,7 @@ export function initDynamoDbArticleStore(deps: {
 
 		do {
 			const { items, lastEvaluatedKey } = await userArticles.query({
-				IndexName: "userId-savedAt-index",
+				IndexName: indexName,
 				KeyConditionExpression: "userId = :userId",
 				FilterExpression: filterExpression,
 				ExpressionAttributeValues: expressionValues,

--- a/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.test.ts
+++ b/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.test.ts
@@ -215,6 +215,71 @@ describe("initInMemoryArticleStore", () => {
 			expect(result.articles[1].id.value).toBe(a2.id.value);
 		});
 
+		it("should sort by readAt descending when sort=readAt", async () => {
+			const store = initInMemoryArticleStore();
+			const a1 = await store.saveArticle(
+				makeArticleParams({ url: "https://example.com/first" }),
+			);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			const a2 = await store.saveArticle(
+				makeArticleParams({ url: "https://example.com/second" }),
+			);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			const a3 = await store.saveArticle(
+				makeArticleParams({ url: "https://example.com/third" }),
+			);
+
+			await store.updateArticleStatus(a2.id, USER_A, "read");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await store.updateArticleStatus(a1.id, USER_A, "read");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await store.updateArticleStatus(a3.id, USER_A, "read");
+
+			const result = await store.findArticlesByUser({
+				userId: USER_A,
+				status: "read",
+				sort: "readAt",
+			});
+
+			expect(result.articles.map((a) => a.id.value)).toEqual([
+				a3.id.value,
+				a1.id.value,
+				a2.id.value,
+			]);
+		});
+
+		it("should sort by readAt ascending when sort=readAt and order=asc", async () => {
+			const store = initInMemoryArticleStore();
+			const a1 = await store.saveArticle(
+				makeArticleParams({ url: "https://example.com/first" }),
+			);
+			const a2 = await store.saveArticle(
+				makeArticleParams({ url: "https://example.com/second" }),
+			);
+			const a3 = await store.saveArticle(
+				makeArticleParams({ url: "https://example.com/third" }),
+			);
+
+			await store.updateArticleStatus(a2.id, USER_A, "read");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await store.updateArticleStatus(a1.id, USER_A, "read");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await store.updateArticleStatus(a3.id, USER_A, "read");
+
+			const result = await store.findArticlesByUser({
+				userId: USER_A,
+				status: "read",
+				sort: "readAt",
+				order: "asc",
+			});
+
+			expect(result.articles.map((a) => a.id.value)).toEqual([
+				a2.id.value,
+				a1.id.value,
+				a3.id.value,
+			]);
+		});
+
 		it("should paginate results", async () => {
 			const store = initInMemoryArticleStore();
 			for (let i = 0; i < 5; i++) {

--- a/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/in-memory-article-store.ts
@@ -157,6 +157,7 @@ export function initInMemoryArticleStore(): {
 		const page = query.page ?? 1;
 		const pageSize = query.pageSize ?? 20;
 		const order = query.order ?? "desc";
+		const sort = query.sort ?? "savedAt";
 
 		let userArts = Array.from(userArticles.values()).filter(
 			(ua) => ua.userId === query.userId,
@@ -167,7 +168,11 @@ export function initInMemoryArticleStore(): {
 		}
 
 		userArts.sort((a, b) => {
-			const diff = a.savedAt.getTime() - b.savedAt.getTime();
+			const aValue = sort === "readAt" ? a.readAt : a.savedAt;
+			const bValue = sort === "readAt" ? b.readAt : b.savedAt;
+			assert(aValue, "sort field must be set on every row matching this query");
+			assert(bValue, "sort field must be set on every row matching this query");
+			const diff = aValue.getTime() - bValue.getTime();
 			return order === "asc" ? diff : -diff;
 		});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -71,10 +71,10 @@ export function formatUnreadLabel(count: number): string {
 }
 
 function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; browser: BrowserName; onboardingDismissed: boolean }): QueueDisplayModel {
-	const activeStatus = vm.filters.status;
+	const activeTab = vm.filters.tab;
 	const nextOrder = vm.filters.order === "desc" ? "asc" : "desc";
 	const sortLabel = vm.filters.order === "desc" ? "Newest first ↓" : "Oldest first ↑";
-	const sortUrl = buildQueueUrl({ status: activeStatus, order: nextOrder });
+	const sortUrl = buildQueueUrl({ tab: activeTab, order: nextOrder });
 
 	const onboardingHtml = options.onboardingDismissed
 		? ""
@@ -92,9 +92,9 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		hasArticles: !vm.isEmpty,
 		onboardingHtml,
 		articles: vm.articles.map(toArticleDisplayModel),
-		filterUnreadClass: filterLinkClass(activeStatus === "unread"),
+		filterUnreadClass: filterLinkClass(activeTab === "queue"),
 		filterUnreadLabel: formatUnreadLabel(vm.unreadCount),
-		filterReadClass: filterLinkClass(activeStatus === "read"),
+		filterReadClass: filterLinkClass(activeTab === "done"),
 		filterUnreadUrl: vm.filterUrls.unread,
 		filterReadUrl: vm.filterUrls.read,
 		sortUrl,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -7,6 +7,7 @@ import { render } from "../../render";
 import { QUEUE_STYLES } from "./queue.styles";
 import type { ArticleAction, QueueArticleViewModel, QueueViewModel } from "./queue.viewmodel";
 import { buildQueueUrl } from "./queue.url";
+import { tabQuery } from "./queue.tabs";
 
 const QUEUE_TEMPLATE = readFileSync(join(__dirname, "queue.template.html"), "utf-8");
 
@@ -72,8 +73,9 @@ export function formatUnreadLabel(count: number): string {
 
 function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; browser: BrowserName; onboardingDismissed: boolean }): QueueDisplayModel {
 	const activeTab = vm.filters.tab;
-	const nextOrder = vm.filters.order === "desc" ? "asc" : "desc";
-	const sortLabel = vm.filters.order === "desc" ? "Newest first ↓" : "Oldest first ↑";
+	const effectiveOrder = vm.filters.order ?? tabQuery(activeTab).defaultOrder;
+	const nextOrder = effectiveOrder === "desc" ? "asc" : "desc";
+	const sortLabel = effectiveOrder === "desc" ? "Newest first ↓" : "Oldest first ↑";
 	const sortUrl = buildQueueUrl({ tab: activeTab, order: nextOrder });
 
 	const onboardingHtml = options.onboardingDismissed

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -38,6 +38,7 @@ import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
 import { toArticleEntity } from "../../api/article-siren";
 import { parseQueueUrl, buildQueueUrl } from "./queue.url";
+import { tabQuery } from "./queue.tabs";
 import type { HttpErrorMessageMapping } from "./queue.error";
 import { toQueueViewModel } from "./queue.viewmodel";
 import { QueuePage } from "./queue.component";
@@ -173,12 +174,13 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
 		const urlState = parseQueueUrl(req.query);
+		const tab = tabQuery(urlState.tab);
 		const filterUrl = typeof req.query.url === "string" ? req.query.url : undefined;
 
 		const result = await deps.findArticlesByUser({
 			userId,
-			status: urlState.status,
-			sort: urlState.status === "read" ? "readAt" : "savedAt",
+			status: tab.status,
+			sort: tab.sort,
 			order: urlState.order,
 			page: urlState.page,
 		});
@@ -193,7 +195,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 			res.type(SIREN_MEDIA_TYPE).json(
 				toArticleCollectionEntity(filtered, {
-					status: urlState.status,
+					status: tab.status,
 					order: urlState.order,
 					page: urlState.page,
 					pageSize: result.pageSize,
@@ -203,7 +205,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			return;
 		}
 
-		const unreadCount = urlState.status === "unread"
+		const unreadCount = urlState.tab === "queue"
 			? result.total
 			: (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
 		const totalArticles = (await deps.findArticlesByUser({ userId, page: 1, pageSize: 1 })).total;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -178,6 +178,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const result = await deps.findArticlesByUser({
 			userId,
 			status: urlState.status,
+			sort: urlState.status === "read" ? "readAt" : "savedAt",
 			order: urlState.order,
 			page: urlState.page,
 		});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -177,11 +177,12 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const tab = tabQuery(urlState.tab);
 		const filterUrl = typeof req.query.url === "string" ? req.query.url : undefined;
 
+		const order = urlState.order ?? tab.defaultOrder;
 		const result = await deps.findArticlesByUser({
 			userId,
 			status: tab.status,
 			sort: tab.sort,
-			order: urlState.order,
+			order,
 			page: urlState.page,
 		});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2219,6 +2219,82 @@ describe("Queue routes", () => {
 			expect(sortLink?.getAttribute("href")).toBe("/queue");
 			expect(sortLink?.textContent).toContain("Oldest first");
 		});
+
+		it("should order Done tab by readAt descending (most recently read first)", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/a" });
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/b" });
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/c" });
+
+			const queueResponse = await agent.get("/queue");
+			const queueDoc = new JSDOM(queueResponse.text).window.document;
+			const cards = queueDoc.querySelectorAll("[data-test-article-list] .queue-article");
+			const idByUrl = new Map<string, string>();
+			for (const card of cards) {
+				const url = card.querySelector("[data-test-article-url]")?.getAttribute("href");
+				const id = card.getAttribute("data-test-article");
+				assert(url && id, "article card must expose url and id");
+				idByUrl.set(url, id);
+			}
+
+			const idA = idByUrl.get("https://example.com/a");
+			const idB = idByUrl.get("https://example.com/b");
+			const idC = idByUrl.get("https://example.com/c");
+			assert(idA && idB && idC, "all three articles must be in the saved list");
+
+			await agent.post(`/queue/${idB}/status`).type("form").send({ status: "read" });
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await agent.post(`/queue/${idA}/status`).type("form").send({ status: "read" });
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await agent.post(`/queue/${idC}/status`).type("form").send({ status: "read" });
+
+			const readResponse = await agent.get("/queue?status=read");
+			const readDoc = new JSDOM(readResponse.text).window.document;
+			const readIds = Array.from(
+				readDoc.querySelectorAll("[data-test-article-list] .queue-article"),
+			).map((el) => el.getAttribute("data-test-article"));
+
+			expect(readIds).toEqual([idC, idA, idB]);
+		});
+
+		it("should order Done tab by readAt ascending when order=asc", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/a" });
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/b" });
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/c" });
+
+			const queueResponse = await agent.get("/queue");
+			const queueDoc = new JSDOM(queueResponse.text).window.document;
+			const idByUrl = new Map<string, string>();
+			for (const card of queueDoc.querySelectorAll("[data-test-article-list] .queue-article")) {
+				const url = card.querySelector("[data-test-article-url]")?.getAttribute("href");
+				const id = card.getAttribute("data-test-article");
+				assert(url && id, "article card must expose url and id");
+				idByUrl.set(url, id);
+			}
+			const idA = idByUrl.get("https://example.com/a");
+			const idB = idByUrl.get("https://example.com/b");
+			const idC = idByUrl.get("https://example.com/c");
+			assert(idA && idB && idC, "all three articles must be in the saved list");
+
+			await agent.post(`/queue/${idB}/status`).type("form").send({ status: "read" });
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await agent.post(`/queue/${idA}/status`).type("form").send({ status: "read" });
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			await agent.post(`/queue/${idC}/status`).type("form").send({ status: "read" });
+
+			const readResponse = await agent.get("/queue?status=read&order=asc");
+			const readDoc = new JSDOM(readResponse.text).window.document;
+			const readIds = Array.from(
+				readDoc.querySelectorAll("[data-test-article-list] .queue-article"),
+			).map((el) => el.getAttribute("data-test-article"));
+
+			expect(readIds).toEqual([idB, idA, idC]);
+		});
 	});
 
 	describe("Re-saving a read article marks it unread", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2188,14 +2188,14 @@ describe("Queue routes", () => {
 			expect(doc.querySelector("[data-test-sort]")?.textContent).toContain("first");
 		});
 
-		it("should include status in sort toggle URL when on read tab", async () => {
+		it("should include tab in sort toggle URL when on done tab", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(app, auth);
 
-			const response = await agent.get("/queue?status=read");
+			const response = await agent.get("/queue?tab=done");
 			const doc = new JSDOM(response.text).window.document;
 			const sortLink = doc.querySelector("[data-test-sort]");
-			expect(sortLink?.getAttribute("href")).toContain("status=read");
+			expect(sortLink?.getAttribute("href")).toContain("tab=done");
 		});
 
 		it("should toggle sort order from desc to asc", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.tabs.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.tabs.ts
@@ -1,0 +1,19 @@
+import type { ArticleStatus } from "../../../domain/article/article.types";
+import type { SortField, SortOrder } from "../../../providers/article-store/article-store.types";
+
+export type TabId = "queue" | "done";
+
+interface TabQuery {
+	status: ArticleStatus;
+	sort: SortField;
+	defaultOrder: SortOrder;
+}
+
+const tabs: Record<TabId, TabQuery> = {
+	queue: { status: "unread", sort: "savedAt", defaultOrder: "desc" },
+	done: { status: "read", sort: "readAt", defaultOrder: "desc" },
+};
+
+export function tabQuery(tab: TabId): TabQuery {
+	return tabs[tab];
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
@@ -65,12 +65,14 @@ describe("buildQueueUrl", () => {
 		expect(buildQueueUrl({ tab: "done" })).toBe("/queue?tab=done");
 	});
 
-	it("should omit default order (desc)", () => {
+	it("should omit order matching tab defaultOrder", () => {
 		expect(buildQueueUrl({ order: "desc" })).toBe("/queue");
+		expect(buildQueueUrl({ tab: "done", order: "desc" })).toBe("/queue?tab=done");
 	});
 
-	it("should include non-default order", () => {
+	it("should include order differing from tab defaultOrder", () => {
 		expect(buildQueueUrl({ order: "asc" })).toBe("/queue?order=asc");
+		expect(buildQueueUrl({ tab: "done", order: "asc" })).toBe("/queue?tab=done&order=asc");
 	});
 
 	it("should omit page 1", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
@@ -3,7 +3,7 @@ import { buildQueueUrl, parseQueueUrl } from "./queue.url";
 describe("parseQueueUrl", () => {
 	it("should default to queue tab for empty query", () => {
 		const state = parseQueueUrl({});
-		expect(state).toEqual({ tab: "queue", order: "desc", page: 1 });
+		expect(state).toEqual({ tab: "queue", order: undefined, page: 1 });
 	});
 
 	it("should parse tab parameter", () => {
@@ -36,8 +36,8 @@ describe("parseQueueUrl", () => {
 		expect(parseQueueUrl({ order: "desc" }).order).toBe("desc");
 	});
 
-	it("should default to desc for invalid order", () => {
-		expect(parseQueueUrl({ order: "invalid" }).order).toBe("desc");
+	it("should return undefined for invalid order", () => {
+		expect(parseQueueUrl({ order: "invalid" }).order).toBeUndefined();
 	});
 
 	it("should parse page number", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
@@ -1,18 +1,34 @@
 import { buildQueueUrl, parseQueueUrl } from "./queue.url";
 
 describe("parseQueueUrl", () => {
-	it("should default to unread status for empty query", () => {
+	it("should default to queue tab for empty query", () => {
 		const state = parseQueueUrl({});
-		expect(state).toEqual({ status: "unread", order: "desc", page: 1 });
+		expect(state).toEqual({ tab: "queue", order: "desc", page: 1 });
 	});
 
-	it("should parse valid status", () => {
-		expect(parseQueueUrl({ status: "read" }).status).toBe("read");
-		expect(parseQueueUrl({ status: "unread" }).status).toBe("unread");
+	it("should parse tab parameter", () => {
+		expect(parseQueueUrl({ tab: "done" }).tab).toBe("done");
+		expect(parseQueueUrl({ tab: "queue" }).tab).toBe("queue");
 	});
 
-	it("should default to unread for invalid status", () => {
-		expect(parseQueueUrl({ status: "invalid" }).status).toBe("unread");
+	it("should default to queue tab for invalid tab", () => {
+		expect(parseQueueUrl({ tab: "invalid" }).tab).toBe("queue");
+	});
+
+	it("should map legacy status=read to done tab", () => {
+		expect(parseQueueUrl({ status: "read" }).tab).toBe("done");
+	});
+
+	it("should map legacy status=unread to queue tab", () => {
+		expect(parseQueueUrl({ status: "unread" }).tab).toBe("queue");
+	});
+
+	it("should prefer tab over legacy status when both present", () => {
+		expect(parseQueueUrl({ tab: "queue", status: "read" }).tab).toBe("queue");
+	});
+
+	it("should default to queue tab for invalid legacy status", () => {
+		expect(parseQueueUrl({ status: "invalid" }).tab).toBe("queue");
 	});
 
 	it("should parse order", () => {
@@ -41,12 +57,12 @@ describe("buildQueueUrl", () => {
 		expect(buildQueueUrl({})).toBe("/queue");
 	});
 
-	it("should omit default status (unread)", () => {
-		expect(buildQueueUrl({ status: "unread" })).toBe("/queue");
+	it("should omit default tab (queue)", () => {
+		expect(buildQueueUrl({ tab: "queue" })).toBe("/queue");
 	});
 
-	it("should include non-default status", () => {
-		expect(buildQueueUrl({ status: "read" })).toBe("/queue?status=read");
+	it("should include non-default tab", () => {
+		expect(buildQueueUrl({ tab: "done" })).toBe("/queue?tab=done");
 	});
 
 	it("should omit default order (desc)", () => {
@@ -66,8 +82,8 @@ describe("buildQueueUrl", () => {
 	});
 
 	it("should combine multiple params", () => {
-		const url = buildQueueUrl({ status: "read", order: "asc", page: 3 });
-		expect(url).toContain("status=read");
+		const url = buildQueueUrl({ tab: "done", order: "asc", page: 3 });
+		expect(url).toContain("tab=done");
 		expect(url).toContain("order=asc");
 		expect(url).toContain("page=3");
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { SortOrder } from "../../../providers/article-store/article-store.types";
-import type { TabId } from "./queue.tabs";
+import { type TabId, tabQuery } from "./queue.tabs";
 
 export interface QueueUrlState {
 	tab: TabId;
@@ -27,11 +27,13 @@ export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 
 export function buildQueueUrl(state: Partial<QueueUrlState>): string {
 	const params = new URLSearchParams();
+	const tab = state.tab ?? "queue";
+	const { defaultOrder } = tabQuery(tab);
 
-	if (state.tab && state.tab !== "queue") {
-		params.set("tab", state.tab);
+	if (tab !== "queue") {
+		params.set("tab", tab);
 	}
-	if (state.order && state.order !== "desc") {
+	if (state.order && state.order !== defaultOrder) {
 		params.set("order", state.order);
 	}
 	if (state.page && state.page > 1) {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -1,14 +1,15 @@
 import { z } from "zod";
-import type { ArticleStatus } from "../../../domain/article/article.types";
 import type { SortOrder } from "../../../providers/article-store/article-store.types";
+import type { TabId } from "./queue.tabs";
 
 export interface QueueUrlState {
-	status: ArticleStatus;
+	tab: TabId;
 	order: SortOrder;
 	page: number;
 }
 
 const QueueQuerySchema = z.object({
+	tab: z.enum(["queue", "done"]).optional().catch(undefined),
 	status: z.enum(["unread", "read"]).optional().catch(undefined),
 	order: z.enum(["asc", "desc"]).optional().catch(undefined),
 	page: z.coerce.number().int().min(1).optional().catch(undefined),
@@ -16,8 +17,9 @@ const QueueQuerySchema = z.object({
 
 export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 	const parsed = QueueQuerySchema.parse(query);
+	const tab = parsed.tab ?? (parsed.status === "read" ? "done" : "queue");
 	return {
-		status: parsed.status ?? "unread",
+		tab,
 		order: parsed.order ?? "desc",
 		page: parsed.page ?? 1,
 	};
@@ -26,8 +28,8 @@ export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 export function buildQueueUrl(state: Partial<QueueUrlState>): string {
 	const params = new URLSearchParams();
 
-	if (state.status && state.status !== "unread") {
-		params.set("status", state.status);
+	if (state.tab && state.tab !== "queue") {
+		params.set("tab", state.tab);
 	}
 	if (state.order && state.order !== "desc") {
 		params.set("order", state.order);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -4,7 +4,7 @@ import type { TabId } from "./queue.tabs";
 
 export interface QueueUrlState {
 	tab: TabId;
-	order: SortOrder;
+	order?: SortOrder;
 	page: number;
 }
 
@@ -20,7 +20,7 @@ export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 	const tab = parsed.tab ?? (parsed.status === "read" ? "done" : "queue");
 	return {
 		tab,
-		order: parsed.order ?? "desc",
+		order: parsed.order,
 		page: parsed.page ?? 1,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -42,7 +42,7 @@ function makeResult(
 }
 
 const NOW = new Date("2025-06-01T13:00:00Z");
-const DEFAULT_FILTERS = { status: "unread" as const, order: "desc" as const, page: 1 };
+const DEFAULT_FILTERS = { tab: "queue" as const, order: "desc" as const, page: 1 };
 
 describe("toQueueViewModel", () => {
 	it("should map article fields to view model", () => {
@@ -106,7 +106,7 @@ describe("toQueueViewModel", () => {
 		const vm = toQueueViewModel(makeResult([]), DEFAULT_FILTERS, { now: NOW });
 
 		expect(vm.filterUrls.unread).toBe("/queue");
-		expect(vm.filterUrls.read).toBe("/queue?status=read");
+		expect(vm.filterUrls.read).toBe("/queue?tab=done");
 	});
 
 	it("should set isUnread to true for unread articles", () => {
@@ -268,11 +268,11 @@ describe("toQueueViewModel", () => {
 
 	it("should include return query in action URLs for non-default view", () => {
 		const article = makeArticle({ status: "read" });
-		const filters = { order: "asc" as const, page: 1, status: "read" as const };
+		const filters = { order: "asc" as const, page: 1, tab: "done" as const };
 		const vm = toQueueViewModel(makeResult([article]), filters, { now: NOW });
 
 		const deleteAction = vm.articles[0].actions.find(a => a.testAction === "delete");
-		expect(deleteAction?.url).toBe(`/queue/${ARTICLE_ID}/delete?status=read&order=asc`);
+		expect(deleteAction?.url).toBe(`/queue/${ARTICLE_ID}/delete?tab=done&order=asc`);
 	});
 
 	it("should not include query string in action URLs for default view", () => {
@@ -305,7 +305,7 @@ describe("toQueueViewModel", () => {
 
 	it("should include return query in mark-read URL for non-default view", () => {
 		const article = makeArticle({ status: "unread" });
-		const filters = { order: "asc" as const, page: 1, status: "unread" as const };
+		const filters = { order: "asc" as const, page: 1, tab: "queue" as const };
 		const vm = toQueueViewModel(makeResult([article]), filters, { now: NOW });
 
 		const markReadAction = vm.articles[0].actions.find(a => a.testAction === "mark-read");

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -165,8 +165,8 @@ export function toQueueViewModel(
 		totalArticles: options?.totalArticles ?? result.total,
 		unreadCount: options?.unreadCount ?? result.total,
 		filterUrls: {
-			unread: buildQueueUrl({ ...baseFilters, status: "unread" }),
-			read: buildQueueUrl({ ...baseFilters, status: "read" }),
+			unread: buildQueueUrl({ ...baseFilters, tab: "queue" }),
+			read: buildQueueUrl({ ...baseFilters, tab: "done" }),
 		},
 		paginationUrls: {
 			prev:


### PR DESCRIPTION
## Summary
This PR adds support for sorting read articles by their `readAt` timestamp, allowing users to view recently read articles first (or oldest first with ascending order).

## Key Changes
- **Database Schema**: Added `readAt` attribute and `userId-readAt-index` global secondary index to DynamoDB table for efficient querying
- **Article Store Types**: Extended `SortField` type to include `"readAt"` in addition to `"savedAt"`
- **In-Memory Store**: Updated sorting logic to support sorting by `readAt` field with configurable order (ascending/descending)
- **DynamoDB Store**: Modified query logic to dynamically select the appropriate index based on sort field
- **Queue Page**: Updated to automatically sort read articles by `readAt` in descending order (most recently read first)
- **Tests**: Added comprehensive test coverage for both ascending and descending sort orders on the read articles tab

## Implementation Details
- The queue page now passes `sort: "readAt"` when querying articles with `status: "read"`
- Both in-memory and DynamoDB implementations support the new sort parameter
- Default sort order for read articles is descending (most recent first), with ascending available via `order=asc` query parameter
- The implementation maintains backward compatibility by defaulting to `"savedAt"` sort when not specified

https://claude.ai/code/session_013AwWtqMz3B43wJyXTU5GK9