### PR TITLE
Add bot defense mechanisms to signup form

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/auth-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/auth-actions.ts
@@ -40,6 +40,9 @@ export function createAuthActions(
         await page.locator('#email').fill(data.email)
         await page.locator('#password').fill(data.password)
         await page.locator('#confirmPassword').fill(data.password)
+        await page.locator('input[name="loadedAt"]').evaluate(
+          (el) => { (el as HTMLInputElement).value = String(Date.now() - 5000) },
+        )
         await clickAndWaitForPageReload(
           page,
           page.locator('[data-test-form="signup"] button[type="submit"]'),

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -56,6 +56,7 @@ import { initDynamoDbPendingSignup } from "./providers/pending-signup/dynamodb-p
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initLogParseError, type ParseErrorEvent } from "@packages/hutch-infra-components";
 import { createApp } from "./server";
+import type { BotDefenseEvent } from "./web/auth/auth.page";
 import { httpErrorMessageMapping } from "./web/pages/queue/queue.error";
 import { getEnv, requireEnv } from "./require-env";
 
@@ -349,6 +350,7 @@ export function createHutchApp(deps?: {
 		logParseError,
 		importSessionStore,
 		now: () => new Date(),
+		botDefenseLogger: HutchLogger.fromJSON<BotDefenseEvent>(),
 	});
 
 	return { app, auth, articleStore, oauthModel };

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -68,7 +68,9 @@ import type {
 	VerifyPasswordResetToken,
 } from "./providers/password-reset/password-reset.types";
 import type { OAuthModel } from "./providers/oauth/oauth-model";
+import type { HutchLogger } from "@packages/hutch-logger";
 import { initAuthRoutes } from "./web/auth/auth.page";
+import type { BotDefenseEvent } from "./web/auth/auth.page";
 import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { SESSION_COOKIE_NAME } from "./web/auth/session-cookie";
 import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
@@ -163,6 +165,7 @@ interface AppDependencies {
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
 }
 
 function requireAuth(req: Request, res: Response, next: NextFunction): void {
@@ -390,6 +393,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		baseUrl: deps.baseUrl,
 		staticBaseUrl,
 		logError: deps.logError,
+		now: deps.now,
+		botDefenseLogger: deps.botDefenseLogger,
 	});
 	app.use(authRouter);
 

--- a/projects/hutch/src/runtime/test-app-fakes.ts
+++ b/projects/hutch/src/runtime/test-app-fakes.ts
@@ -1,6 +1,8 @@
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import type { CrawlArticle } from "@packages/crawl-article";
+import type { HutchLogger } from "@packages/hutch-logger";
 import { noopLogger } from "@packages/hutch-logger";
+import type { BotDefenseEvent } from "./web/auth/auth.page";
 import { calculateReadTime } from "./domain/article/estimated-read-time";
 import type {
 	ParseArticle,
@@ -204,6 +206,18 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 	const stripe = initInMemoryStripeCheckout();
 	const pendingSignup = initInMemoryPendingSignup();
 
+	const botDefenseEvents: BotDefenseEvent[] = [];
+	/** Shared capture handler for every level — production code only ever calls
+	 * .info(), so the other levels collapse onto the same function. Avoids per-
+	 * level no-op closures that V8 reports as uncovered functions. */
+	const capture = (data: BotDefenseEvent) => { botDefenseEvents.push(data); };
+	const botDefenseLogger: HutchLogger.Typed<BotDefenseEvent> = {
+		info: capture,
+		error: capture,
+		warn: capture,
+		debug: capture,
+	};
+
 	return {
 		auth,
 		articleStore: {
@@ -269,5 +283,6 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		},
 		stripe,
 		pendingSignup,
+		botDefense: { logger: botDefenseLogger, events: botDefenseEvents },
 	};
 }

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -63,6 +63,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			shared: fixture.shared,
 			stripe: fixture.stripe,
 			pendingSignup: fixture.pendingSignup,
+			botDefense: fixture.botDefense,
 		});
 
 		expect(typeof result.app).toBe("function");

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -1,6 +1,8 @@
 import type { Express } from "express";
 import type { CrawlArticle } from "@packages/crawl-article";
+import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
+import type { BotDefenseEvent } from "./web/auth/auth.page";
 import type { ParseArticle } from "./providers/article-parser/article-parser.types";
 import type { PublishLinkSaved } from "./providers/events/publish-link-saved.types";
 import type { PublishRecrawlLinkInitiated } from "./providers/events/publish-recrawl-link-initiated.types";
@@ -214,6 +216,11 @@ export interface ImportSessionBundle {
 	importSessionStore: ImportSessionStore;
 }
 
+export interface BotDefenseBundle {
+	logger: HutchLogger.Typed<BotDefenseEvent>;
+	events: BotDefenseEvent[];
+}
+
 export interface TestAppFixture {
 	auth: AuthBundle;
 	articleStore: ArticleStoreBundle;
@@ -233,6 +240,7 @@ export interface TestAppFixture {
 	shared: SharedBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
+	botDefense: BotDefenseBundle;
 }
 
 export interface TestAppResult {
@@ -247,6 +255,7 @@ export interface TestAppResult {
 	passwordReset: PasswordResetBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
+	botDefense: BotDefenseBundle;
 }
 
 function flattenFixtureToAppDependencies(
@@ -311,6 +320,7 @@ function flattenFixtureToAppDependencies(
 		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,
 		storePendingSignup: fixture.pendingSignup.storePendingSignup,
 		consumePendingSignup: fixture.pendingSignup.consumePendingSignup,
+		botDefenseLogger: fixture.botDefense.logger,
 	};
 }
 
@@ -328,5 +338,6 @@ export function createTestApp(fixture: TestAppFixture): TestAppResult {
 		passwordReset: fixture.passwordReset,
 		stripe: fixture.stripe,
 		pendingSignup: fixture.pendingSignup,
+		botDefense: fixture.botDefense,
 	};
 }

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -24,6 +24,10 @@ interface AuthFormData {
 	userCount: number;
 }
 
+interface SignupFormData extends AuthFormData {
+	loadedAt: number;
+}
+
 interface FieldViewModel {
 	errorClass: string;
 	error?: string;
@@ -82,7 +86,7 @@ export function VerifyEmailPage(data: { success: boolean; error?: string }): Pag
 	};
 }
 
-export function SignupPage(data: AuthFormData, options?: { statusCode?: number }): PageBody {
+export function SignupPage(data: SignupFormData, options?: { statusCode?: number }): PageBody {
 	const email = data.email ?? "";
 	const errors = data.errors;
 
@@ -90,6 +94,7 @@ export function SignupPage(data: AuthFormData, options?: { statusCode?: number }
 		email,
 		globalError: data.globalError,
 		returnUrl: data.returnUrl ? encodeURIComponent(data.returnUrl) : undefined,
+		loadedAt: data.loadedAt,
 		emailField: toFieldViewModel(errors, "email"),
 		passwordField: toFieldViewModel(errors, "password"),
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, Router } from "express";
 import express from "express";
 import { z } from "zod";
+import type { HutchLogger } from "@packages/hutch-logger";
 import type {
 	CountUsers,
 	CreateGoogleUser,
@@ -46,6 +47,24 @@ const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).p
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
 const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
 
+const SIGNUP_MIN_SUBMIT_MS = 2500;
+
+export type BotDefenseRejectReason =
+	| "honeypot"
+	| "submit_too_fast"
+	| "missing_timestamp"
+	| "invalid_timestamp";
+
+export interface BotDefenseEvent {
+	stream: "bot-defense";
+	event: "signup_rejected";
+	reason: BotDefenseRejectReason;
+	timestamp: string;
+	ip?: string;
+	email_domain?: string;
+	time_to_submit_ms?: number;
+}
+
 interface AuthDependencies {
 	createUserWithPasswordHash: CreateUserWithPasswordHash;
 	createGoogleUser: CreateGoogleUser;
@@ -67,6 +86,48 @@ interface AuthDependencies {
 	baseUrl: string;
 	staticBaseUrl: string;
 	logError: (message: string, error?: Error) => void;
+	now: () => Date;
+	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
+}
+
+type BotDefenseResult =
+	| { trip: false }
+	| { trip: true; reason: BotDefenseRejectReason; timeToSubmitMs?: number };
+
+function checkSignupBotDefense(
+	body: Record<string, unknown>,
+	nowMs: number,
+): BotDefenseResult {
+	const website = body.website;
+	if (typeof website === "string" && website.length > 0) {
+		return { trip: true, reason: "honeypot" };
+	}
+
+	const rawLoadedAt = body.loadedAt;
+	if (typeof rawLoadedAt !== "string" || rawLoadedAt.length === 0) {
+		return { trip: true, reason: "missing_timestamp" };
+	}
+
+	const loadedAt = Number.parseInt(rawLoadedAt, 10);
+	if (!Number.isFinite(loadedAt) || String(loadedAt) !== rawLoadedAt) {
+		return { trip: true, reason: "invalid_timestamp" };
+	}
+
+	const elapsed = nowMs - loadedAt;
+	if (elapsed < SIGNUP_MIN_SUBMIT_MS) {
+		return { trip: true, reason: "submit_too_fast", timeToSubmitMs: elapsed };
+	}
+
+	return { trip: false };
+}
+
+function extractEmailDomain(body: Record<string, unknown>): string | undefined {
+	const email = body.email;
+	if (typeof email !== "string") return undefined;
+	const at = email.indexOf("@");
+	if (at === -1) return undefined;
+	const domain = email.slice(at + 1).toLowerCase();
+	return domain.length > 0 ? domain : undefined;
 }
 
 export function initAuthRoutes(deps: AuthDependencies): Router {
@@ -185,11 +246,38 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 		const returnUrl = extractReturnUrl(req.query);
 		const userCount = await fetchUserCount();
-		sendComponent(res, renderPage(req, SignupPage({ returnUrl, userCount })));
+		sendComponent(
+			res,
+			renderPage(
+				req,
+				SignupPage({ returnUrl, userCount, loadedAt: deps.now().getTime() }),
+			),
+		);
 	});
 
 	router.post("/signup", async (req: Request, res: Response) => {
 		const returnUrl = extractReturnUrl(req.query);
+		const body = (req.body ?? {}) as Record<string, unknown>;
+
+		const botCheck = checkSignupBotDefense(body, deps.now().getTime());
+		if (botCheck.trip) {
+			const event: BotDefenseEvent = {
+				stream: "bot-defense",
+				event: "signup_rejected",
+				reason: botCheck.reason,
+				timestamp: deps.now().toISOString(),
+			};
+			if (req.ip) event.ip = req.ip;
+			const emailDomain = extractEmailDomain(body);
+			if (emailDomain) event.email_domain = emailDomain;
+			if (botCheck.timeToSubmitMs !== undefined) {
+				event.time_to_submit_ms = botCheck.timeToSubmitMs;
+			}
+			deps.botDefenseLogger.info(event);
+			res.redirect(303, "/?signup=pending");
+			return;
+		}
+
 		const parsed = SignupSchema.safeParse(req.body);
 
 		if (!parsed.success) {
@@ -200,6 +288,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					{
 						returnUrl,
 						userCount,
+						loadedAt: deps.now().getTime(),
 						email: req.body?.email,
 						errors: flattenZodErrors(parsed.error.issues),
 					},
@@ -220,6 +309,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					{
 						returnUrl,
 						userCount,
+						loadedAt: deps.now().getTime(),
 						email,
 						globalError: "An account with this email already exists",
 					},
@@ -259,6 +349,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				renderPage(req, SignupPage(
 					{
 						userCount,
+						loadedAt: deps.now().getTime(),
 						globalError: "Missing checkout session — please start again.",
 					},
 					{ statusCode: 400 },
@@ -274,7 +365,13 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				res,
-				renderPage(req, SignupPage({ userCount, globalError }, { statusCode })),
+				renderPage(
+					req,
+					SignupPage(
+						{ userCount, loadedAt: deps.now().getTime(), globalError },
+						{ statusCode },
+					),
+				),
 			);
 		};
 

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -463,6 +463,53 @@ describe("Auth routes", () => {
 			expect(botDefense.events[0]).toMatchObject({ reason: "missing_timestamp" });
 		});
 
+		it("logs 'missing_timestamp' when loadedAt is an empty string", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: "",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).toMatchObject({ reason: "missing_timestamp" });
+		});
+
+		it("omits email_domain from the event when the honeypot payload has no email", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				website: "https://spam.example",
+			});
+
+			expect(response.status).toBe(303);
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).not.toHaveProperty("email_domain");
+		});
+
+		it("omits email_domain when email has no @ sign", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "no-at-sign",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				website: "https://spam.example",
+			});
+
+			expect(response.status).toBe(303);
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).not.toHaveProperty("email_domain");
+		});
+
 		it("logs 'invalid_timestamp' and fakes success when loadedAt is not a parseable integer", async () => {
 			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
@@ -471,6 +518,22 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: "not-a-number",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).toMatchObject({ reason: "invalid_timestamp" });
+		});
+
+		it("logs 'invalid_timestamp' when loadedAt is a float string", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: "123.45",
 			});
 
 			expect(response.status).toBe(303);

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -3,6 +3,7 @@ import { JSDOM } from "jsdom";
 import request from "supertest";
 import { createTestApp } from "../../test-app";
 
+import { CheckoutSessionIdSchema } from "../../providers/stripe-checkout/stripe-checkout.schema";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -516,7 +517,7 @@ describe("Auth routes", () => {
 			 * never invoked by attempting to consume any plausible session id and
 			 * receiving null. */
 			const consumed = await pendingSignup.consumePendingSignup(
-				"cs_test_never_created" as unknown as Parameters<typeof pendingSignup.consumePendingSignup>[0],
+				CheckoutSessionIdSchema.parse("cs_test_never_created"),
 			);
 			expect(consumed).toBeNull();
 		});

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -9,6 +9,12 @@ import {
 } from "../../test-app-fakes";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 
+/** A loadedAt value safely older than the bot-defense minimum submit window
+ * (2.5s), so the form submission passes the timing gate. */
+function freshLoadedAt(): string {
+	return String(Date.now() - 5000);
+}
+
 describe("Auth routes", () => {
 	describe("GET /login", () => {
 		it("should render the login form", async () => {
@@ -183,6 +189,38 @@ describe("Auth routes", () => {
 			expect(doc.querySelector('input[name="confirmPassword"]')?.getAttribute("type")).toBe("password");
 		});
 
+		it("should render a visually-hidden honeypot input named 'website' inside the signup form", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(app).get("/signup");
+
+			const doc = new JSDOM(response.text).window.document;
+			const form = doc.querySelector('[data-test-form="signup"]');
+			assert(form, "signup form must be rendered");
+			const honeypotContainer = form.querySelector(".auth-form__visually-hidden");
+			assert(honeypotContainer, "honeypot container must be rendered inside the signup form");
+			expect(honeypotContainer.getAttribute("aria-hidden")).toBe("true");
+			const honeypot = honeypotContainer.querySelector('input[name="website"]');
+			assert(honeypot, "honeypot input[name=website] must be rendered");
+			expect(honeypot.getAttribute("type")).toBe("text");
+			expect(honeypot.getAttribute("tabindex")).toBe("-1");
+			expect(honeypot.getAttribute("autocomplete")).toBe("off");
+		});
+
+		it("should render a hidden loadedAt input with the current server-side ms timestamp", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const before = Date.now();
+			const response = await request(app).get("/signup");
+			const after = Date.now();
+
+			const doc = new JSDOM(response.text).window.document;
+			const loadedAtInput = doc.querySelector('input[name="loadedAt"]');
+			assert(loadedAtInput, "loadedAt input must be rendered");
+			expect(loadedAtInput.getAttribute("type")).toBe("hidden");
+			const loadedAt = Number.parseInt(loadedAtInput.getAttribute("value") ?? "", 10);
+			expect(loadedAt).toBeGreaterThanOrEqual(before);
+			expect(loadedAt).toBeLessThanOrEqual(after);
+		});
+
 		it("should redirect authenticated user to /queue", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			await auth.createUser({ email: "test@example.com", password: "password123" });
@@ -227,6 +265,7 @@ describe("Auth routes", () => {
 				email: "new@example.com",
 				password: "password123",
 				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
 			});
 
 			expect(response.status).toBe(303);
@@ -301,6 +340,7 @@ describe("Auth routes", () => {
 				email: "existing@example.com",
 				password: "password123",
 				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
 			});
 
 			expect(response.status).toBe(422);
@@ -317,6 +357,7 @@ describe("Auth routes", () => {
 				email: "new@example.com",
 				password: "password123",
 				confirmPassword: "differentpassword",
+				loadedAt: freshLoadedAt(),
 			});
 
 			expect(response.status).toBe(422);
@@ -336,6 +377,7 @@ describe("Auth routes", () => {
 					email: "new@example.com",
 					password: "password123",
 					confirmPassword: "differentpassword",
+					loadedAt: freshLoadedAt(),
 				});
 
 			expect(response.status).toBe(422);
@@ -356,6 +398,7 @@ describe("Auth routes", () => {
 					email: "existing@example.com",
 					password: "password123",
 					confirmPassword: "password123",
+					loadedAt: freshLoadedAt(),
 				});
 
 			expect(response.status).toBe(422);
@@ -372,11 +415,126 @@ describe("Auth routes", () => {
 				email: "new@example.com",
 				password: "short",
 				confirmPassword: "short",
+				loadedAt: freshLoadedAt(),
 			});
 
 			expect(response.status).toBe(422);
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector('[data-test-error="password"]')?.textContent).toBe("Password must be at least 8 characters");
+		});
+	});
+
+	describe("POST /signup — bot defense", () => {
+		it("returns a fake-success 303 to /?signup=pending and logs a 'honeypot' rejection when the hidden website field is filled", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				website: "https://spam.example",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).toMatchObject({
+				stream: "bot-defense",
+				event: "signup_rejected",
+				reason: "honeypot",
+				email_domain: "example.com",
+			});
+		});
+
+		it("logs 'missing_timestamp' and fakes success when loadedAt is absent from the form payload", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).toMatchObject({ reason: "missing_timestamp" });
+		});
+
+		it("logs 'invalid_timestamp' and fakes success when loadedAt is not a parseable integer", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: "not-a-number",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			expect(botDefense.events[0]).toMatchObject({ reason: "invalid_timestamp" });
+		});
+
+		it("logs 'submit_too_fast' with the elapsed time when the form is submitted within the 2.5s window", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: String(Date.now() - 1000),
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			const event = botDefense.events[0];
+			assert(event, "expected a captured bot-defense event");
+			expect(event.reason).toBe("submit_too_fast");
+			expect(event.time_to_submit_ms).toBeGreaterThanOrEqual(1000);
+			expect(event.time_to_submit_ms).toBeLessThan(2500);
+		});
+
+		it("does not create a Stripe checkout session or store a pending signup when the honeypot is tripped", async () => {
+			const { app, pendingSignup, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "bot@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				website: "https://spam.example",
+			});
+
+			expect(response.headers.location).toBe("/?signup=pending");
+			expect(botDefense.events).toHaveLength(1);
+			/** No Stripe session was created — if one had been, the redirect would
+			 * be to checkout.stripe.test/. We also confirm storePendingSignup was
+			 * never invoked by attempting to consume any plausible session id and
+			 * receiving null. */
+			const consumed = await pendingSignup.consumePendingSignup(
+				"cs_test_never_created" as unknown as Parameters<typeof pendingSignup.consumePendingSignup>[0],
+			);
+			expect(consumed).toBeNull();
+		});
+
+		it("falls through to the existing happy path (303 to Stripe) when the honeypot is empty and loadedAt is older than 2.5s", async () => {
+			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "real@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: String(Date.now() - 5000),
+				website: "",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
+			expect(botDefense.events).toEqual([]);
 		});
 	});
 
@@ -526,7 +684,7 @@ describe("Auth routes", () => {
 			const response = await request(app)
 				.post("/signup")
 				.type("form")
-				.send({ email: "", password: "short", confirmPassword: "short" });
+				.send({ email: "", password: "short", confirmPassword: "short", loadedAt: freshLoadedAt() });
 
 			expect(response.status).toBe(422);
 			const doc = new JSDOM(response.text).window.document;

--- a/projects/hutch/src/runtime/web/auth/auth.styles.css
+++ b/projects/hutch/src/runtime/web/auth/auth.styles.css
@@ -43,6 +43,23 @@
   gap: 6px;
 }
 
+/**
+ * WAI-ARIA visually-hidden pattern. Used for the honeypot field on /signup —
+ * the input must remain in the DOM and form payload (so bots fill it) but be
+ * invisible and unfocusable for sighted, keyboard, and screen-reader users.
+ */
+.auth-form__visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .auth-form__label {
   font-size: 0.875rem;
   font-weight: 500;

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -34,6 +34,7 @@ describe("GET /auth/checkout/success", () => {
 			email: "unpaid@example.com",
 			password: "password123",
 			confirmPassword: "password123",
+			loadedAt: String(Date.now() - 5000),
 		});
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),
@@ -101,6 +102,7 @@ describe("GET /auth/checkout/success", () => {
 			email: "race@example.com",
 			password: "password123",
 			confirmPassword: "password123",
+			loadedAt: String(Date.now() - 5000),
 		});
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -92,6 +92,7 @@ describe("Email verification", () => {
 				logParseError: () => {},
 				importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
 				now: () => new Date(),
+				botDefenseLogger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
 			});
 
 			const { successResponse } = await completeStripeSignup({
@@ -113,6 +114,7 @@ describe("Email verification", () => {
 				email: "existing@example.com",
 				password: "password123",
 				confirmPassword: "password123",
+				loadedAt: String(Date.now() - 5000),
 			});
 
 			expect(email.getSentEmails()).toHaveLength(0);

--- a/projects/hutch/src/runtime/web/auth/signup.template.html
+++ b/projects/hutch/src/runtime/web/auth/signup.template.html
@@ -5,6 +5,11 @@
         {{{foundingProgressHtml}}}
         {{#if globalError}}<div class="auth-form__global-error" data-test-global-error>{{globalError}}</div>{{/if}}
         <form class="auth-form" method="POST" action="/signup{{#if returnUrl}}?return={{returnUrl}}{{/if}}" data-test-form="signup">
+          <div class="auth-form__visually-hidden" aria-hidden="true">
+            <label for="website">Website (do not fill)</label>
+            <input type="text" id="website" name="website" tabindex="-1" autocomplete="off">
+          </div>
+          <input type="hidden" name="loadedAt" value="{{loadedAt}}">
           <div class="auth-form__field">
             <label class="auth-form__label" for="email">Email</label>
             <input class="auth-form__input{{emailField.errorClass}}" type="email" id="email" name="email" value="{{email}}" required autocomplete="email">

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -36,6 +36,7 @@ export async function completeStripeSignup(params: {
 			email: params.email,
 			password: params.password,
 			confirmPassword: params.password,
+			loadedAt: String(Date.now() - 5000),
 		});
 
 	assert.equal(signupResponse.status, 303, "signup should redirect to Stripe");


### PR DESCRIPTION
## Summary
Implements bot defense measures for the signup form by adding a honeypot field, form submission timing validation, and bot defense event logging.

## Key Changes

- **Honeypot field**: Added a visually-hidden "website" input field that legitimate users won't fill but bots typically will. Uses WAI-ARIA patterns to hide from sighted, keyboard, and screen-reader users.

- **Submission timing validation**: Added a `loadedAt` hidden input field that captures the server-side timestamp when the signup form is rendered. On submission, the elapsed time is validated to ensure it's at least 2.5 seconds (configurable via `SIGNUP_MIN_SUBMIT_MS`).

- **Bot defense event logging**: Implemented `checkSignupBotDefense()` function that validates form submissions and logs rejection events with reasons:
  - `honeypot`: Website field was filled
  - `missing_timestamp`: loadedAt field absent
  - `invalid_timestamp`: loadedAt is not a valid integer
  - `submit_too_fast`: Form submitted within 2.5s window

- **Fake success responses**: When bot defense is triggered, the endpoint returns a 303 redirect to `/?signup=pending` (same as legitimate flow) to avoid revealing detection to attackers, while logging the rejection event with email domain and IP information.

- **Test coverage**: Added comprehensive test suite covering all bot defense scenarios, including honeypot tripping, missing/invalid timestamps, fast submissions, and verification that no Stripe session is created for rejected submissions.

## Implementation Details

- Bot defense checks occur before form validation, preventing unnecessary processing of suspicious requests
- Email domain is extracted from the submission for logging purposes
- The `now()` dependency is used consistently for timestamp generation and validation
- All bot defense events are logged via a typed `HutchLogger` for structured event tracking
- Existing signup tests updated to include `loadedAt` parameter to pass bot defense checks

https://claude.ai/code/session_01QYG9oKavPar7Cxt3xbn8T6