### PR TITLE
Add copy-to-clipboard button to share balloon

### DIFF
--- a/projects/hutch/src/runtime/web/shared/share-balloon/copy-icon.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/copy-icon.ts
@@ -1,0 +1,4 @@
+export const COPY_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+</svg>`;

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -13,7 +13,10 @@ const FIXTURE = `<!DOCTYPE html><html><body>
 <span data-share-balloon-status></span>
 <div data-share-balloon-wrap hidden>
   <button type="button" data-share-balloon-close></button>
-  <button type="button" data-share-balloon data-share-url="${ARTICLE_URL}" data-share-title="${ARTICLE_TITLE}"></button>
+  <div data-share-balloon-buttons>
+    <button type="button" data-share-balloon data-share-url="${ARTICLE_URL}" data-share-title="${ARTICLE_TITLE}"></button>
+    <button type="button" data-share-balloon-copy data-share-url="${ARTICLE_URL}"></button>
+  </div>
   <span data-share-balloon-copied>Link copied!</span>
 </div>
 </body></html>`;
@@ -338,6 +341,70 @@ describe("initShareBalloon — share click", () => {
 		fireEvent.click(element(document, "[data-share-balloon]"));
 
 		expect(share).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("initShareBalloon — copy click", () => {
+	it("copies the data-share-url to the clipboard and flashes the copied feedback", async () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		const copiedLabel = element(document, "[data-share-balloon-copied]");
+		const status = element(document, "[data-share-balloon-status]");
+		ctrl.attach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+		expect(writeText).toHaveBeenCalledWith(ARTICLE_URL);
+
+		await flushPromises();
+		expect(copiedLabel.classList.contains(COPIED_VISIBLE_CLASS)).toBe(true);
+		expect(status.textContent).toBe("Link copied to clipboard");
+	});
+
+	it("reports 'Unable to copy link' to the status region when writeText rejects", async () => {
+		const writeText = jest.fn(() => Promise.reject(new Error("denied")));
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		const status = element(document, "[data-share-balloon-status]");
+		ctrl.attach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+		await flushPromises();
+
+		expect(status.textContent).toBe("Unable to copy link");
+	});
+
+	it("does not call navigator.share when only the copy button is clicked", () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const share = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({
+			navigator: { clipboard: { writeText }, share },
+		});
+		ctrl.attach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+
+		expect(writeText).toHaveBeenCalledTimes(1);
+		expect(share).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when navigator.clipboard is unavailable (share-only environment)", () => {
+		const share = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { share } });
+		ctrl.attach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+
+		expect(share).not.toHaveBeenCalled();
+	});
+
+	it("removes the copy listener on detach so subsequent clicks do not fire", () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		ctrl.attach();
+		ctrl.detach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+
+		expect(writeText).not.toHaveBeenCalled();
 	});
 });
 

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -15,7 +15,7 @@ const FIXTURE = `<!DOCTYPE html><html><body>
   <button type="button" data-share-balloon-close></button>
   <div data-share-balloon-buttons>
     <button type="button" data-share-balloon data-share-url="${ARTICLE_URL}" data-share-title="${ARTICLE_TITLE}"></button>
-    <button type="button" data-share-balloon-copy data-share-url="${ARTICLE_URL}"></button>
+    <button type="button" data-share-balloon-copy></button>
   </div>
   <span data-share-balloon-copied>Link copied!</span>
 </div>

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -12,10 +12,10 @@ const ARTICLE_TITLE = "Hello World";
 const FIXTURE = `<!DOCTYPE html><html><body>
 <span data-share-balloon-status></span>
 <div data-share-balloon-wrap hidden>
-  <button type="button" data-share-balloon-close></button>
   <div data-share-balloon-buttons>
-    <button type="button" data-share-balloon data-share-url="${ARTICLE_URL}" data-share-title="${ARTICLE_TITLE}"></button>
     <button type="button" data-share-balloon-copy></button>
+    <button type="button" data-share-balloon data-share-url="${ARTICLE_URL}" data-share-title="${ARTICLE_TITLE}"></button>
+    <button type="button" data-share-balloon-close></button>
   </div>
   <span data-share-balloon-copied>Link copied!</span>
 </div>

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -13,10 +13,11 @@ const FIXTURE = `<!DOCTYPE html><html><body>
 <span data-share-balloon-status></span>
 <div data-share-balloon-wrap hidden>
   <div data-share-balloon-buttons>
+    <div data-share-balloon-chat></div>
     <button type="button" data-share-balloon-copy></button>
     <button type="button" data-share-balloon data-share-url="${ARTICLE_URL}" data-share-title="${ARTICLE_TITLE}"></button>
-    <button type="button" data-share-balloon-close></button>
   </div>
+  <button type="button" data-share-balloon-close></button>
   <span data-share-balloon-copied>Link copied!</span>
 </div>
 </body></html>`;

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
@@ -77,6 +77,7 @@ export function initShareBalloon(
 
 	const wrap = pickElement(deps.document, "[data-share-balloon-wrap]");
 	const btn = pickElement(wrap, "[data-share-balloon]");
+	const copyBtn = pickElement(wrap, "[data-share-balloon-copy]");
 	const closeBtn = pickElement(wrap, "[data-share-balloon-close]");
 	const copiedLabel = pickElement(wrap, "[data-share-balloon-copied]");
 	const status = pickElement(deps.document, "[data-share-balloon-status]");
@@ -92,6 +93,7 @@ export function initShareBalloon(
 	let scrollListener: (() => void) | null = null;
 	let closeListener: ((event: Event) => void) | null = null;
 	let clickListener: (() => void) | null = null;
+	let copyListener: (() => void) | null = null;
 	let attached = false;
 
 	function openBalloon() {
@@ -145,6 +147,14 @@ export function initShareBalloon(
 		}
 	}
 
+	function onCopyClick() {
+		if (deps.navigator.clipboard !== undefined) {
+			deps.navigator.clipboard.writeText(url).then(flashCopied, () => {
+				status.textContent = "Unable to copy link";
+			});
+		}
+	}
+
 	function onCloseClick(event: Event) {
 		event.stopPropagation();
 		cancelPendingOpen();
@@ -172,6 +182,8 @@ export function initShareBalloon(
 		closeBtn.addEventListener("click", closeListener);
 		clickListener = onShareClick;
 		btn.addEventListener("click", clickListener);
+		copyListener = onCopyClick;
+		copyBtn.addEventListener("click", copyListener);
 	}
 
 	function detach(): void {
@@ -190,6 +202,10 @@ export function initShareBalloon(
 		if (clickListener !== null) {
 			btn.removeEventListener("click", clickListener);
 			clickListener = null;
+		}
+		if (copyListener !== null) {
+			copyBtn.removeEventListener("click", copyListener);
+			copyListener = null;
 		}
 	}
 

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { requireEnv } from "../../../require-env";
 import { render } from "../../render";
+import { COPY_ICON_SVG } from "./copy-icon";
 import { SHARE_ICON_SVG } from "./share-icon";
 
 const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
@@ -27,6 +28,7 @@ export function renderShareBalloon(input: ShareBalloonInput): string {
 		shareTitle: input.shareTitle,
 		shareHint: input.shareHint,
 		shareIconSvg: SHARE_ICON_SVG,
+		copyIconSvg: COPY_ICON_SVG,
 		founderAvatarUrl: FOUNDER_AVATAR_URL,
 	});
 }

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.styles.css
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.styles.css
@@ -36,6 +36,36 @@
   transition: opacity 2000ms ease 2200ms, transform 2400ms ease 2200ms, visibility 0s linear 2200ms;
 }
 
+.share-balloon__buttons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.share-balloon__copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0.5rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  transition: transform 120ms ease, filter 120ms ease;
+}
+
+.share-balloon__copy:hover {
+  filter: brightness(0.97);
+}
+
+.share-balloon__copy:active {
+  transform: scale(0.98);
+}
+
 .share-balloon {
   position: relative;
   display: inline-flex;
@@ -148,10 +178,12 @@
 @media (prefers-reduced-motion: reduce) {
   .share-balloon,
   .share-balloon__chat,
-  .share-balloon__close {
+  .share-balloon__close,
+  .share-balloon__copy {
     transition: none;
   }
-  .share-balloon:active {
+  .share-balloon:active,
+  .share-balloon__copy:active {
     transform: none;
   }
 }

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.styles.css
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.styles.css
@@ -6,7 +6,6 @@
 .share-balloon__buttons {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
   padding: 0.5rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);
@@ -22,44 +21,63 @@
 }
 
 .share-balloon__close {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  z-index: 2;
+  width: 22px;
+  height: 22px;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 0;
-  overflow: hidden;
-  padding: 0;
-  background: none;
-  border: none;
+  background: var(--color-surface-elevated);
   color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  box-shadow: var(--shadow-md);
   font-family: inherit;
   font-size: 14px;
   line-height: 1;
   cursor: pointer;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 180ms ease, width 240ms ease, visibility 0s linear 240ms;
+  transform: scale(0.7);
+  transition: opacity 180ms ease, transform 240ms ease, visibility 0s linear 240ms;
 }
 
+/**
+ * 1. Reveal the close button right after the chat open animation finishes
+ *    (~400ms) so users immediately see how to dismiss the bubble.
+ */
 .share-balloon__wrap--open .share-balloon__close {
-  width: 1.5rem;
   opacity: 1;
   visibility: visible;
-  transition: opacity 2000ms ease 2200ms, width 2400ms ease 2200ms, visibility 0s linear 2200ms;
+  transform: scale(1);
+  transition: opacity 250ms ease 500ms, transform 250ms ease 500ms, visibility 0s linear 500ms; /* 1 */
 }
 
+/**
+ * 1. Padding on every side gives a 38px tap target around the 18px icon.
+ * 2. The right margin keeps copy and share separated by a constant 0.625rem
+ *    so adjacent tap targets do not overlap on mobile.
+ */
 .share-balloon__copy {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  padding: 0.625rem; /* 1 */
+  margin-right: 0.625rem; /* 2 */
   background: none;
   color: inherit;
   border: none;
+  border-radius: 50%;
   cursor: pointer;
-  transition: transform 120ms ease, filter 120ms ease;
+  transition: transform 120ms ease, filter 120ms ease, background 120ms ease;
 }
 
 .share-balloon__copy:hover {
+  background: var(--color-surface);
   filter: brightness(0.97);
 }
 
@@ -71,18 +89,20 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  max-width: 100%;
-  padding: 0;
+  justify-content: center;
+  padding: 0.625rem;
   background: none;
   color: inherit;
   border: none;
+  border-radius: 50%;
   cursor: pointer;
   font: inherit;
   text-align: left;
-  transition: transform 120ms ease, filter 120ms ease;
+  transition: transform 120ms ease, filter 120ms ease, background 120ms ease;
 }
 
 .share-balloon:hover {
+  background: var(--color-surface);
   filter: brightness(0.97);
 }
 

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.styles.css
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.styles.css
@@ -3,57 +3,58 @@
   pointer-events: auto;
 }
 
-.share-balloon__close {
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  z-index: 2;
-  width: 22px;
-  height: 22px;
-  padding: 0;
+.share-balloon__buttons {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.5rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);
   border: 1px solid var(--color-border);
-  border-radius: 50%;
+  border-radius: 999px;
   box-shadow: var(--shadow-md);
+  transition: border-radius 300ms ease, padding 300ms ease;
+}
+
+.share-balloon__wrap--open .share-balloon__buttons {
+  border-radius: 18px;
+  padding: 0.5rem 0.75rem;
+}
+
+.share-balloon__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0;
+  overflow: hidden;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--color-text-primary);
   font-family: inherit;
   font-size: 14px;
   line-height: 1;
   cursor: pointer;
   opacity: 0;
   visibility: hidden;
-  transform: scale(0.7);
-  transition: opacity 180ms ease, transform 240ms ease, visibility 0s linear 240ms;
+  transition: opacity 180ms ease, width 240ms ease, visibility 0s linear 240ms;
 }
 
 .share-balloon__wrap--open .share-balloon__close {
+  width: 1.5rem;
   opacity: 1;
   visibility: visible;
-  transform: scale(1);
-  transition: opacity 2000ms ease 2200ms, transform 2400ms ease 2200ms, visibility 0s linear 2200ms;
-}
-
-.share-balloon__buttons {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
+  transition: opacity 2000ms ease 2200ms, width 2400ms ease 2200ms, visibility 0s linear 2200ms;
 }
 
 .share-balloon__copy {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0.5rem;
-  background: var(--color-surface-elevated);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-  border-radius: 50%;
-  box-shadow: var(--shadow-md);
+  padding: 0;
+  background: none;
+  color: inherit;
+  border: none;
   cursor: pointer;
   transition: transform 120ms ease, filter 120ms ease;
 }
@@ -71,21 +72,14 @@
   display: inline-flex;
   align-items: center;
   max-width: 100%;
-  padding: 0.5rem;
-  background: var(--color-surface-elevated);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-  border-radius: 50%;
-  box-shadow: var(--shadow-md);
+  padding: 0;
+  background: none;
+  color: inherit;
+  border: none;
   cursor: pointer;
   font: inherit;
   text-align: left;
-  transition: transform 120ms ease, filter 120ms ease, background 120ms ease, color 120ms ease, border-color 120ms ease, border-radius 300ms ease, padding 300ms ease;
-}
-
-.share-balloon__wrap--open .share-balloon {
-  border-radius: 18px;
-  padding: 0.5rem 0.75rem 0.5rem 0.5rem;
+  transition: transform 120ms ease, filter 120ms ease;
 }
 
 .share-balloon:hover {
@@ -177,6 +171,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .share-balloon,
+  .share-balloon__buttons,
   .share-balloon__chat,
   .share-balloon__close,
   .share-balloon__copy {

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
@@ -41,7 +41,6 @@
       type="button"
       class="share-balloon__copy"
       data-share-balloon-copy
-      data-share-url="{{shareUrl}}"
       aria-label="Copy link"
       data-test-share-balloon-copy
     >

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
@@ -9,32 +9,44 @@
   >
     <span aria-hidden="true">&times;</span>
   </button>
-  <button
-    type="button"
-    class="share-balloon"
-    data-share-balloon
-    data-share-url="{{shareUrl}}"
-    data-share-title="{{shareTitle}}"
-    aria-label="Share this article"
-    data-test-share-balloon
-  >
-    <div class="share-balloon__chat" data-share-balloon-chat>
-      <img
-        class="share-balloon__avatar"
-        src="{{founderAvatarUrl}}"
-        alt=""
-        width="32"
-        height="32"
-        aria-hidden="true"
-        data-test-share-balloon-avatar
-      />
-      <span class="share-balloon__text">
-        <span class="share-balloon__greeting" data-test-share-balloon-greeting>Hi, I'm Fayner Brack.</span>
-        <span class="share-balloon__hint" data-test-share-balloon-hint>Thanks for trying Readplace.</span>
-        <span class="share-balloon__hint" data-test-share-balloon-hint>{{shareHint}}</span>
-      </span>
-    </div>
-    <span class="share-balloon__icon" aria-hidden="true">{{{shareIconSvg}}}</span>
-  </button>
+  <div class="share-balloon__buttons" data-share-balloon-buttons>
+    <button
+      type="button"
+      class="share-balloon"
+      data-share-balloon
+      data-share-url="{{shareUrl}}"
+      data-share-title="{{shareTitle}}"
+      aria-label="Share this article"
+      data-test-share-balloon
+    >
+      <div class="share-balloon__chat" data-share-balloon-chat>
+        <img
+          class="share-balloon__avatar"
+          src="{{founderAvatarUrl}}"
+          alt=""
+          width="32"
+          height="32"
+          aria-hidden="true"
+          data-test-share-balloon-avatar
+        />
+        <span class="share-balloon__text">
+          <span class="share-balloon__greeting" data-test-share-balloon-greeting>Hi, I'm Fayner Brack.</span>
+          <span class="share-balloon__hint" data-test-share-balloon-hint>Thanks for trying Readplace.</span>
+          <span class="share-balloon__hint" data-test-share-balloon-hint>{{shareHint}}</span>
+        </span>
+      </div>
+      <span class="share-balloon__icon" aria-hidden="true">{{{shareIconSvg}}}</span>
+    </button>
+    <button
+      type="button"
+      class="share-balloon__copy"
+      data-share-balloon-copy
+      data-share-url="{{shareUrl}}"
+      aria-label="Copy link"
+      data-test-share-balloon-copy
+    >
+      <span class="share-balloon__icon" aria-hidden="true">{{{copyIconSvg}}}</span>
+    </button>
+  </div>
   <span class="share-balloon__copied" data-share-balloon-copied data-test-share-balloon-copied aria-hidden="true">Link copied!</span>
 </div>

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
@@ -1,6 +1,22 @@
 <span class="sr-only" role="status" aria-live="polite" data-share-balloon-status></span>
 <div class="share-balloon__wrap" data-share-balloon-wrap data-test-share-balloon-wrap hidden>
   <div class="share-balloon__buttons" data-share-balloon-buttons>
+    <div class="share-balloon__chat" data-share-balloon-chat>
+      <img
+        class="share-balloon__avatar"
+        src="{{founderAvatarUrl}}"
+        alt=""
+        width="32"
+        height="32"
+        aria-hidden="true"
+        data-test-share-balloon-avatar
+      />
+      <span class="share-balloon__text">
+        <span class="share-balloon__greeting" data-test-share-balloon-greeting>Hi, I'm Fayner Brack.</span>
+        <span class="share-balloon__hint" data-test-share-balloon-hint>Thanks for trying Readplace.</span>
+        <span class="share-balloon__hint" data-test-share-balloon-hint>{{shareHint}}</span>
+      </span>
+    </div>
     <button
       type="button"
       class="share-balloon__copy"
@@ -19,33 +35,17 @@
       aria-label="Share this article"
       data-test-share-balloon
     >
-      <div class="share-balloon__chat" data-share-balloon-chat>
-        <img
-          class="share-balloon__avatar"
-          src="{{founderAvatarUrl}}"
-          alt=""
-          width="32"
-          height="32"
-          aria-hidden="true"
-          data-test-share-balloon-avatar
-        />
-        <span class="share-balloon__text">
-          <span class="share-balloon__greeting" data-test-share-balloon-greeting>Hi, I'm Fayner Brack.</span>
-          <span class="share-balloon__hint" data-test-share-balloon-hint>Thanks for trying Readplace.</span>
-          <span class="share-balloon__hint" data-test-share-balloon-hint>{{shareHint}}</span>
-        </span>
-      </div>
       <span class="share-balloon__icon" aria-hidden="true">{{{shareIconSvg}}}</span>
     </button>
-    <button
-      type="button"
-      class="share-balloon__close"
-      data-share-balloon-close
-      data-test-share-balloon-close
-      aria-label="Dismiss message"
-    >
-      <span aria-hidden="true">&times;</span>
-    </button>
   </div>
+  <button
+    type="button"
+    class="share-balloon__close"
+    data-share-balloon-close
+    data-test-share-balloon-close
+    aria-label="Dismiss message"
+  >
+    <span aria-hidden="true">&times;</span>
+  </button>
   <span class="share-balloon__copied" data-share-balloon-copied data-test-share-balloon-copied aria-hidden="true">Link copied!</span>
 </div>

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
@@ -1,15 +1,15 @@
 <span class="sr-only" role="status" aria-live="polite" data-share-balloon-status></span>
 <div class="share-balloon__wrap" data-share-balloon-wrap data-test-share-balloon-wrap hidden>
-  <button
-    type="button"
-    class="share-balloon__close"
-    data-share-balloon-close
-    data-test-share-balloon-close
-    aria-label="Dismiss message"
-  >
-    <span aria-hidden="true">&times;</span>
-  </button>
   <div class="share-balloon__buttons" data-share-balloon-buttons>
+    <button
+      type="button"
+      class="share-balloon__copy"
+      data-share-balloon-copy
+      aria-label="Copy link"
+      data-test-share-balloon-copy
+    >
+      <span class="share-balloon__icon" aria-hidden="true">{{{copyIconSvg}}}</span>
+    </button>
     <button
       type="button"
       class="share-balloon"
@@ -39,12 +39,12 @@
     </button>
     <button
       type="button"
-      class="share-balloon__copy"
-      data-share-balloon-copy
-      aria-label="Copy link"
-      data-test-share-balloon-copy
+      class="share-balloon__close"
+      data-share-balloon-close
+      data-test-share-balloon-close
+      aria-label="Dismiss message"
     >
-      <span class="share-balloon__icon" aria-hidden="true">{{{copyIconSvg}}}</span>
+      <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <span class="share-balloon__copied" data-share-balloon-copied data-test-share-balloon-copied aria-hidden="true">Link copied!</span>


### PR DESCRIPTION
## Summary
This PR adds a new copy-to-clipboard button to the share balloon component, allowing users to quickly copy article links without using the native share dialog.

## Key Changes
- **New copy button UI**: Added a circular copy button next to the existing share button with a copy icon SVG
- **Clipboard functionality**: Implemented `onCopyClick()` handler that uses the Clipboard API (`navigator.clipboard.writeText()`) to copy the article URL
- **User feedback**: Shows "Link copied to clipboard" message in the status region on success, or "Unable to copy link" on failure
- **Graceful degradation**: Copy button is a no-op in environments without clipboard support (share-only environments)
- **Proper cleanup**: Copy listener is properly removed on component detach to prevent memory leaks
- **Styling**: Added `.share-balloon__buttons` container with flexbox layout and `.share-balloon__copy` button styles with hover and active states
- **Accessibility**: Included proper ARIA labels and test attributes for the new button
- **Icon asset**: Created new `copy-icon.ts` module with SVG icon definition

## Implementation Details
- The copy button is wrapped in a new `data-share-balloon-buttons` container alongside the existing share button
- Copy functionality gracefully handles missing clipboard API by checking `deps.navigator.clipboard !== undefined`
- The copied feedback uses the same visual feedback mechanism as the share button (flash animation)
- Respects `prefers-reduced-motion` media query for animations
- Comprehensive test coverage added for copy button interactions, error handling, and cleanup

https://claude.ai/code/session_01URU7UzmBVfQuXtaVs1pbGM