### PR TITLE
Add markdown content negotiation support across the app

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,12 @@ importers:
       markdown-it:
         specifier: 14.1.1
         version: 14.1.1
+      node-html-markdown:
+        specifier: 2.0.0
+        version: 2.0.0
+      parse-srcset:
+        specifier: 1.0.2
+        version: 1.0.2
       resend:
         specifier: 6.9.3
         version: 6.9.3
@@ -3857,6 +3863,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   helmet@8.1.0:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
@@ -4670,6 +4680,13 @@ packages:
     resolution: {integrity: sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
+
+  node-html-markdown@2.0.0:
+    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
+    engines: {node: '>=20.0.0'}
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5722,10 +5739,12 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10066,6 +10085,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   helmet@8.1.0: {}
 
   hosted-git-info@7.0.2:
@@ -11120,6 +11141,15 @@ snapshots:
       which: 6.0.1
     transitivePeerDependencies:
       - supports-color
+
+  node-html-markdown@2.0.0:
+    dependencies:
+      node-html-parser: 6.1.13
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
 
   node-int64@0.4.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,9 +278,6 @@ importers:
       node-html-markdown:
         specifier: 2.0.0
         version: 2.0.0
-      parse-srcset:
-        specifier: 1.0.2
-        version: 1.0.2
       resend:
         specifier: 6.9.3
         version: 6.9.3

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -63,6 +63,8 @@
     "isbot": "5.1.39",
     "linkedom": "0.18.12",
     "markdown-it": "14.1.1",
+    "node-html-markdown": "2.0.0",
+    "parse-srcset": "1.0.2",
     "resend": "6.9.3",
     "save-link": "workspace:*",
     "serverless-http": "4.0.0",

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -64,7 +64,6 @@
     "linkedom": "0.18.12",
     "markdown-it": "14.1.1",
     "node-html-markdown": "2.0.0",
-    "parse-srcset": "1.0.2",
     "resend": "6.9.3",
     "save-link": "workspace:*",
     "serverless-http": "4.0.0",

--- a/projects/hutch/src/runtime/llms.txt
+++ b/projects/hutch/src/runtime/llms.txt
@@ -2,6 +2,8 @@
 
 > Readplace is a privacy-first read-it-later app and browser extension. A direct alternative to Pocket (shut down July 2025) and Omnivore (shut down late 2024). Built in Australia by Fayner Brack, creator of js-cookie (22 billion+ annual CDN downloads on jsDelivr).
 
+> Markdown of any page is also available via Accept: text/markdown.
+
 Readplace lets you save articles with one click using browser extensions for Firefox and Chrome, read them later in a distraction-free reader view, and get an AI-generated TL;DR summary for every article. User data is hosted in Sydney, Australia under the Australian Privacy Act. No third-party tracking, no ads, no analytics in the app. Source-available under AGPL on GitHub.
 
 ## Pricing

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -90,7 +90,8 @@ import { initMarkExtensionInstalled } from "./web/mark-extension-installed.middl
 import { initOAuthRoutes } from "./web/oauth/oauth.routes";
 import { renderPage } from "./web/render-page";
 import { sendComponent } from "./web/send-component";
-import { wantsSiren } from "./web/content-negotiation";
+import { wantsMarkdown, wantsSiren } from "./web/content-negotiation";
+import { contentSignalMiddleware } from "./web/content-signal.middleware";
 import { HomePage } from "./web/pages/home";
 import { PrivacyPage } from "./web/pages/privacy";
 import { TermsPage } from "./web/pages/terms";
@@ -197,6 +198,8 @@ export function createApp(dependencies: AppDependencies): Express {
 			fallthrough: false,
 		}),
 	);
+
+	app.use(contentSignalMiddleware);
 
 	app.use(async (req: Request, _res: Response, next: NextFunction) => {
 		const sessionId = req.cookies?.[SESSION_COOKIE_NAME];
@@ -317,7 +320,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	/** Firefox extensions enforce CORS preflight for fetches with non-simple headers (Accept: application/vnd.siren+json, Authorization). Register OPTIONS so the preflight succeeds; without this it returns 404 and firefox aborts the fetch with NetworkError. */
 	app.options("/", extensionCors);
 	app.get("/", extensionCors, async (req: Request, res: Response) => {
-		if (wantsSiren(req)) {
+		if (wantsSiren(req) && !wantsMarkdown(req)) {
 			res.redirect(303, "/queue");
 			return;
 		}
@@ -328,15 +331,15 @@ export function createApp(dependencies: AppDependencies): Express {
 			: ua.includes("Chrome/") ? "chrome"
 			: "other";
 		const userCount = await countUsers().catch(() => 0);
-		sendComponent(res, renderPage(req, HomePage({ userCount, staticBaseUrl, browser })));
+		sendComponent(req, res, renderPage(req, HomePage({ userCount, staticBaseUrl, browser })));
 	});
 
 	app.get("/privacy", (req: Request, res: Response) => {
-		sendComponent(res, renderPage(req, PrivacyPage()));
+		sendComponent(req, res, renderPage(req, PrivacyPage()));
 	});
 
 	app.get("/terms", (req: Request, res: Response) => {
-		sendComponent(res, renderPage(req, TermsPage()));
+		sendComponent(req, res, renderPage(req, TermsPage()));
 	});
 
 	// Path-uniqued article fixture for staging e2e tests. The :id segment is
@@ -348,7 +351,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	// both expose it.
 	if (getEnv("NODE_ENV") !== "production") {
 		app.get("/e2e/article/:id", (req: Request, res: Response) => {
-			sendComponent(res, renderPage(req, E2EFixturePage()));
+			sendComponent(req, res, renderPage(req, E2EFixturePage()));
 		});
 	}
 
@@ -358,7 +361,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			fetchFirefoxDownloadUrl(),
 			fetchChromeDownloadUrl(),
 		]);
-		sendComponent(res, renderPage(req, InstallPage({ firefox, chrome, browser })));
+		sendComponent(req, res, renderPage(req, InstallPage({ firefox, chrome, browser })));
 	});
 
 	const blogRouter = initBlogRoutes();
@@ -520,7 +523,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	app.use("/oauth", oauthRouter);
 
 	app.use((req: Request, res: Response) => {
-		sendComponent(res, renderPage(req, NotFoundPage()));
+		sendComponent(req, res, renderPage(req, NotFoundPage()));
 	});
 
 	return app;

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -66,7 +66,7 @@ export function LoginPage(data: AuthFormData, options?: { statusCode?: number })
 		},
 		styles: AUTH_STYLES,
 		bodyClass: "page-login",
-		content,
+		content: { html: content },
 		statusCode: options?.statusCode,
 	};
 }
@@ -83,7 +83,7 @@ export function VerifyEmailPage(data: { success: boolean; error?: string }): Pag
 		},
 		styles: AUTH_STYLES,
 		bodyClass: "page-verify-email",
-		content,
+		content: { html: content },
 		statusCode: data.success ? 200 : 400,
 	};
 }
@@ -120,7 +120,7 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		},
 		styles: AUTH_STYLES,
 		bodyClass: "page-signup",
-		content,
+		content: { html: content },
 		statusCode: options?.statusCode,
 	};
 }
@@ -148,7 +148,7 @@ export function ForgotPasswordPage(
 		},
 		styles: AUTH_STYLES,
 		bodyClass: "page-forgot-password",
-		content,
+		content: { html: content },
 		statusCode: options?.statusCode,
 	};
 }
@@ -177,7 +177,7 @@ export function ResetPasswordPage(
 		},
 		styles: AUTH_STYLES,
 		bodyClass: "page-reset-password",
-		content,
+		content: { html: content },
 		statusCode: options?.statusCode,
 	};
 }

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -171,7 +171,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 		const returnUrl = extractReturnUrl(req.query);
 		const userCount = await fetchUserCount();
-		sendComponent(res, renderPage(req, LoginPage({ returnUrl, userCount })));
+		sendComponent(req, res, renderPage(req, LoginPage({ returnUrl, userCount })));
 	});
 
 	router.post("/login", async (req: Request, res: Response) => {
@@ -181,7 +181,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!parsed.success) {
 			const userCount = await fetchUserCount();
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, LoginPage(
 					{
 						returnUrl,
@@ -201,7 +201,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!credentials.ok) {
 			const userCount = await fetchUserCount();
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, LoginPage(
 					{
 						returnUrl,
@@ -229,13 +229,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const userCount = await fetchUserCount();
 		const parsed = SignupQuerySchema.safeParse(req.query);
 		const email = parsed.success ? parsed.data.email : undefined;
-		sendComponent(
-			res,
-			renderPage(
-				req,
-				SignupPage({ returnUrl, userCount, loadedAt: deps.now().getTime(), email }),
-			),
-		);
+		sendComponent(req, res, renderPage(req, SignupPage({ returnUrl, userCount, loadedAt: deps.now().getTime(), email })));
 	});
 
 	router.post("/signup", async (req: Request, res: Response) => {
@@ -266,7 +260,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!parsed.success) {
 			const userCount = await fetchUserCount();
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, SignupPage(
 					{
 						returnUrl,
@@ -287,7 +281,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (existing) {
 			const userCount = await fetchUserCount();
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, SignupPage(
 					{
 						returnUrl,
@@ -356,7 +350,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!parsedQuery.success) {
 			const userCount = await fetchUserCount();
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, SignupPage(
 					{
 						userCount,
@@ -375,14 +369,8 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const renderFailure = async (statusCode: number, globalError: string) => {
 			const userCount = await fetchUserCount();
 			sendComponent(
-				res,
-				renderPage(
-					req,
-					SignupPage(
-						{ userCount, loadedAt: deps.now().getTime(), globalError },
-						{ statusCode },
-					),
-				),
+				req, res,
+				renderPage(req, SignupPage({ userCount, loadedAt: deps.now().getTime(), globalError }, { statusCode })),
 			);
 		};
 
@@ -452,7 +440,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 
 		if (!token) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, VerifyEmailPage({
 					success: false,
 					error: "No verification token provided.",
@@ -465,7 +453,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 
 		if (!verifyResult.ok) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, VerifyEmailPage({
 					success: false,
 					error: "This verification link is invalid or has already been used.",
@@ -482,7 +470,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			await deps.markSessionEmailVerified(sessionId);
 		}
 
-		sendComponent(res, renderPage(req, VerifyEmailPage({ success: true })));
+		sendComponent(req, res, renderPage(req, VerifyEmailPage({ success: true })));
 	});
 
 	router.post("/logout", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -304,6 +304,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			if (!created.ok) {
 				const refreshedCount = await fetchUserCount();
 				sendComponent(
+					req,
 					res,
 					renderPage(req, SignupPage(
 						{

--- a/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
@@ -33,7 +33,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 	const router = express.Router();
 
 	router.get("/forgot-password", (req: Request, res: Response) => {
-		sendComponent(res, renderPage(req, ForgotPasswordPage()));
+		sendComponent(req, res, renderPage(req, ForgotPasswordPage()));
 	});
 
 	router.post("/forgot-password", async (req: Request, res: Response) => {
@@ -41,7 +41,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		if (!parsed.success) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, ForgotPasswordPage(
 					{
 						email: req.body?.email,
@@ -55,7 +55,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		const { email } = parsed.data;
 
-		sendComponent(res, renderPage(req, ForgotPasswordPage({ sent: true })));
+		sendComponent(req, res, renderPage(req, ForgotPasswordPage({ sent: true })));
 
 		deps.userExistsByEmail(email)
 			.then(async (exists) => {
@@ -82,13 +82,13 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		if (!token) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, ResetPasswordPage({ error: "No reset token provided." }, { statusCode: 400 })),
 			);
 			return;
 		}
 
-		sendComponent(res, renderPage(req, ResetPasswordPage({ token })));
+		sendComponent(req, res, renderPage(req, ResetPasswordPage({ token })));
 	});
 
 	router.post("/reset-password", async (req: Request, res: Response) => {
@@ -97,7 +97,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		if (!token) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, ResetPasswordPage({ error: "No reset token provided." }, { statusCode: 400 })),
 			);
 			return;
@@ -107,7 +107,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		if (!parsed.success) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, ResetPasswordPage(
 					{
 						token,
@@ -123,7 +123,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		if (!verifyResult.ok) {
 			sendComponent(
-				res,
+				req, res,
 				renderPage(req, ResetPasswordPage(
 					{ error: "This reset link is invalid or has already been used." },
 					{ statusCode: 400 },
@@ -134,7 +134,7 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 
 		await deps.updatePassword({ email: verifyResult.email, password: parsed.data.password });
 
-		sendComponent(res, renderPage(req, ResetPasswordPage({ success: true })));
+		sendComponent(req, res, renderPage(req, ResetPasswordPage({ success: true })));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -117,7 +117,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 
 		const renderError = async (globalError: string) => {
 			const userCount = await fetchUserCount();
-			sendComponent(res, renderPage(req, LoginPage({ userCount, globalError }, { statusCode: 400 })));
+			sendComponent(req, res, renderPage(req, LoginPage({ userCount, globalError }, { statusCode: 400 })));
 		};
 
 		if (!parsedQuery.success || !stateCookie || parsedQuery.data.state !== stateCookie) {

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { Base } from "./base.component";
 import type { BannerState } from "./banner-state";
-import type { SupportedMediaType } from "./component.types";
 import type { PageBody } from "./page-body.types";
 
 function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
@@ -113,12 +112,37 @@ describe("Base component", () => {
 		expect(meta?.getAttribute("content")).toBe("My desc");
 	});
 
-	it("should return 415 for unsupported media type", () => {
-		const page = createTestPageBody();
-		const result = Base(page, GUEST_STATE).to("application/vnd.siren+json" as SupportedMediaType);
+	it("renders markdown when text/markdown is requested, prefixing the title and description", () => {
+		const page = createTestPageBody({
+			seo: {
+				title: "My Markdown Title",
+				description: "Markdown description.",
+				canonicalUrl: "https://readplace.com/test",
+			},
+			content: "<main><h2>Section</h2><p>Body copy.</p></main>",
+		});
 
-		expect(result.statusCode).toBe(415);
-		expect(result.body).toBe("");
+		const result = Base(page, GUEST_STATE).to("text/markdown");
+
+		expect(result.statusCode).toBe(200);
+		expect(result.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(result.body.startsWith("# My Markdown Title")).toBe(true);
+		expect(result.body).toContain("Markdown description.");
+		expect(result.body).toContain("Body copy.");
+		expect(result.body).not.toContain("<main>");
+	});
+
+	it("uses markdownContent verbatim when provided, skipping HTML conversion", () => {
+		const page = createTestPageBody({
+			content: "<main><p>HTML body.</p></main>",
+			markdownContent: "## Article\n\nClean prose.",
+		});
+
+		const result = Base(page, GUEST_STATE).to("text/markdown");
+
+		expect(result.body).toContain("## Article");
+		expect(result.body).toContain("Clean prose.");
+		expect(result.body).not.toContain("HTML body.");
 	});
 
 	it("should render structured data when provided", () => {

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -12,7 +12,7 @@ function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
 			canonicalUrl: "https://readplace.com/test",
 		},
 		styles: "",
-		content: "<main><p>Test content</p></main>",
+		content: { html: "<main><p>Test content</p></main>" },
 		...overrides,
 	};
 }
@@ -40,7 +40,7 @@ describe("Base component", () => {
 	});
 
 	it("should include page content in the body", () => {
-		const page = createTestPageBody({ content: "<main><h1>Hello World</h1></main>" });
+		const page = createTestPageBody({ content: { html: "<main><h1>Hello World</h1></main>" } });
 		const result = Base(page, GUEST_STATE).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
@@ -119,7 +119,7 @@ describe("Base component", () => {
 				description: "Markdown description.",
 				canonicalUrl: "https://readplace.com/test",
 			},
-			content: "<main><h2>Section</h2><p>Body copy.</p></main>",
+			content: { html: "<main><h2>Section</h2><p>Body copy.</p></main>" },
 		});
 
 		const result = Base(page, GUEST_STATE).to("text/markdown");
@@ -132,10 +132,9 @@ describe("Base component", () => {
 		expect(result.body).not.toContain("<main>");
 	});
 
-	it("uses markdownContent verbatim when provided, skipping HTML conversion", () => {
+	it("uses markdown content verbatim when provided, skipping HTML conversion", () => {
 		const page = createTestPageBody({
-			content: "<main><p>HTML body.</p></main>",
-			markdownContent: "## Article\n\nClean prose.",
+			content: { html: "<main><p>HTML body.</p></main>", markdown: "## Article\n\nClean prose." },
 		});
 
 		const result = Base(page, GUEST_STATE).to("text/markdown");

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -14,8 +14,11 @@ import {
 	UTILITY_STYLES,
 } from "./base.styles";
 import type { BannerState } from "./banner-state";
-import type { Component } from "./component.types";
+import type { Component, ParsedComponent } from "./component.types";
 import { HtmlPage } from "./html-page";
+import { htmlToMarkdown } from "./html-to-markdown";
+import { MarkdownPage } from "./markdown-page";
+import { buildMarkdownFrontmatter } from "./markdown-frontmatter";
 import type { PageBody, SeoMetadata } from "./page-body.types";
 import { render } from "./render";
 import { getEnv, requireEnv } from "../require-env";
@@ -203,6 +206,21 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 	});
 }
 
+function renderMarkdown(body: PageBody): string {
+	const frontmatter = buildMarkdownFrontmatter(body.seo, {
+		formattedDate: body.markdownFormattedDate,
+	});
+	const content = body.markdownContent ?? htmlToMarkdown(body.content);
+	return `${frontmatter}\n\n${content}`;
+}
+
 export function Base(body: PageBody, state: BannerState): Component {
-	return HtmlPage(renderBaseTemplate(body, state), body.statusCode);
+	return {
+		to: (mediaType): ParsedComponent => {
+			if (mediaType === "text/markdown") {
+				return MarkdownPage(renderMarkdown(body), body.statusCode).to(mediaType);
+			}
+			return HtmlPage(renderBaseTemplate(body, state), body.statusCode).to(mediaType);
+		},
+	};
 }

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -198,7 +198,7 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		showVerificationBanner: state.isAuthenticated && state.emailVerified === false,
 		bodyClass: body.bodyClass,
 		header: renderHeader(headerVariant, state.isAuthenticated),
-		content: injectPageStylesIntoMain(body.content, body.styles),
+		content: injectPageStylesIntoMain(body.content.html, body.styles),
 		footer: renderFooter(),
 		navScript: NAV_SCRIPT,
 		offlineScript: OFFLINE_INDICATOR_SCRIPT,
@@ -210,7 +210,7 @@ function renderMarkdown(body: PageBody): string {
 	const frontmatter = buildMarkdownFrontmatter(body.seo, {
 		formattedDate: body.markdownFormattedDate,
 	});
-	const content = body.markdownContent ?? htmlToMarkdown(body.content);
+	const content = body.content.markdown ?? htmlToMarkdown(body.content.html);
 	return `${frontmatter}\n\n${content}`;
 }
 

--- a/projects/hutch/src/runtime/web/component.types.ts
+++ b/projects/hutch/src/runtime/web/component.types.ts
@@ -4,7 +4,7 @@ export interface ParsedComponent {
   body: string;
 }
 
-export type SupportedMediaType = 'text/html' | 'application/vnd.siren+json';
+export type SupportedMediaType = 'text/html' | 'text/markdown';
 
 export type Component = {
   to: (mediaType: SupportedMediaType) => ParsedComponent;

--- a/projects/hutch/src/runtime/web/content-negotiation.test.ts
+++ b/projects/hutch/src/runtime/web/content-negotiation.test.ts
@@ -1,5 +1,5 @@
 import type { Request } from "express";
-import { wantsSiren } from "./content-negotiation";
+import { wantsMarkdown, wantsSiren } from "./content-negotiation";
 
 function requestWithAccept(accept: string): Request {
 	return { get: (header: string) => header === "Accept" ? accept : undefined } as unknown as Request;
@@ -28,5 +28,31 @@ describe("wantsSiren", () => {
 		const req = { get: () => undefined } as unknown as Request;
 
 		expect(wantsSiren(req)).toBe(false);
+	});
+});
+
+describe("wantsMarkdown", () => {
+	it("returns true when Accept header is text/markdown", () => {
+		const req = requestWithAccept("text/markdown");
+
+		expect(wantsMarkdown(req)).toBe(true);
+	});
+
+	it("returns true when text/markdown is among multiple accepted types", () => {
+		const req = requestWithAccept("text/markdown, text/html;q=0.5");
+
+		expect(wantsMarkdown(req)).toBe(true);
+	});
+
+	it("returns false for a plain HTML accept header", () => {
+		const req = requestWithAccept("text/html");
+
+		expect(wantsMarkdown(req)).toBe(false);
+	});
+
+	it("returns false when no Accept header is present", () => {
+		const req = { get: () => undefined } as unknown as Request;
+
+		expect(wantsMarkdown(req)).toBe(false);
 	});
 });

--- a/projects/hutch/src/runtime/web/content-negotiation.test.ts
+++ b/projects/hutch/src/runtime/web/content-negotiation.test.ts
@@ -2,7 +2,22 @@ import type { Request } from "express";
 import { wantsMarkdown, wantsSiren } from "./content-negotiation";
 
 function requestWithAccept(accept: string): Request {
-	return { get: (header: string) => header === "Accept" ? accept : undefined } as unknown as Request;
+	const types = accept.split(",").map(entry => {
+		const [type, ...params] = entry.trim().split(";");
+		const qParam = params.find(p => p.trim().startsWith("q="));
+		const q = qParam ? Number.parseFloat(qParam.trim().slice(2)) : 1;
+		return { type: type.trim(), q };
+	});
+	return {
+		get: (header: string) => header === "Accept" ? accept : undefined,
+		accepts: (...args: string[]) => {
+			for (const candidate of args.flat()) {
+				const match = types.find(t => t.type === candidate);
+				if (match && match.q > 0) return candidate;
+			}
+			return false;
+		},
+	} as unknown as Request;
 }
 
 describe("wantsSiren", () => {
@@ -50,8 +65,14 @@ describe("wantsMarkdown", () => {
 		expect(wantsMarkdown(req)).toBe(false);
 	});
 
+	it("returns false when text/markdown has quality 0", () => {
+		const req = requestWithAccept("text/markdown;q=0, text/html");
+
+		expect(wantsMarkdown(req)).toBe(false);
+	});
+
 	it("returns false when no Accept header is present", () => {
-		const req = { get: () => undefined } as unknown as Request;
+		const req = { get: () => undefined, accepts: () => false } as unknown as Request;
 
 		expect(wantsMarkdown(req)).toBe(false);
 	});

--- a/projects/hutch/src/runtime/web/content-negotiation.test.ts
+++ b/projects/hutch/src/runtime/web/content-negotiation.test.ts
@@ -39,8 +39,14 @@ describe("wantsSiren", () => {
 		expect(wantsSiren(req)).toBe(false);
 	});
 
+	it("returns false when Siren has quality 0", () => {
+		const req = requestWithAccept("application/vnd.siren+json;q=0, text/html");
+
+		expect(wantsSiren(req)).toBe(false);
+	});
+
 	it("returns false when no Accept header is present", () => {
-		const req = { get: () => undefined } as unknown as Request;
+		const req = { get: () => undefined, accepts: () => false } as unknown as Request;
 
 		expect(wantsSiren(req)).toBe(false);
 	});

--- a/projects/hutch/src/runtime/web/content-negotiation.ts
+++ b/projects/hutch/src/runtime/web/content-negotiation.ts
@@ -1,7 +1,14 @@
 import type { Request } from "express";
 import { SIREN_MEDIA_TYPE } from "./api/siren";
 
+export const MARKDOWN_MEDIA_TYPE = "text/markdown";
+
 export function wantsSiren(req: Request): boolean {
 	const acceptHeader = req.get("Accept") || "";
 	return acceptHeader.includes(SIREN_MEDIA_TYPE);
+}
+
+export function wantsMarkdown(req: Request): boolean {
+	const acceptHeader = req.get("Accept") || "";
+	return acceptHeader.includes(MARKDOWN_MEDIA_TYPE);
 }

--- a/projects/hutch/src/runtime/web/content-negotiation.ts
+++ b/projects/hutch/src/runtime/web/content-negotiation.ts
@@ -10,5 +10,6 @@ export function wantsSiren(req: Request): boolean {
 
 export function wantsMarkdown(req: Request): boolean {
 	const acceptHeader = req.get("Accept") || "";
-	return acceptHeader.includes(MARKDOWN_MEDIA_TYPE);
+	if (!acceptHeader.includes(MARKDOWN_MEDIA_TYPE)) return false;
+	return req.accepts(MARKDOWN_MEDIA_TYPE) === MARKDOWN_MEDIA_TYPE;
 }

--- a/projects/hutch/src/runtime/web/content-negotiation.ts
+++ b/projects/hutch/src/runtime/web/content-negotiation.ts
@@ -5,7 +5,8 @@ export const MARKDOWN_MEDIA_TYPE = "text/markdown";
 
 export function wantsSiren(req: Request): boolean {
 	const acceptHeader = req.get("Accept") || "";
-	return acceptHeader.includes(SIREN_MEDIA_TYPE);
+	if (!acceptHeader.includes(SIREN_MEDIA_TYPE)) return false;
+	return req.accepts(SIREN_MEDIA_TYPE) === SIREN_MEDIA_TYPE;
 }
 
 export function wantsMarkdown(req: Request): boolean {

--- a/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
@@ -1,0 +1,59 @@
+import type { NextFunction, Request, Response } from "express";
+import {
+	CONTENT_SIGNAL_VALUE,
+	contentSignalMiddleware,
+} from "./content-signal.middleware";
+
+interface FakeRes {
+	headers: Record<string, string>;
+	varied: string[];
+	res: Response;
+}
+
+function createFakeRes(): FakeRes {
+	const headers: Record<string, string> = {};
+	const varied: string[] = [];
+	const res = {
+		set(name: string, value: string) {
+			headers[name] = value;
+			return res;
+		},
+		vary(field: string) {
+			varied.push(field);
+			return res;
+		},
+	} as unknown as Response;
+	return { headers, varied, res };
+}
+
+describe("contentSignalMiddleware", () => {
+	it("sets the site-wide Content-Signal policy on GET responses", () => {
+		const { headers, res } = createFakeRes();
+		const next = jest.fn() as unknown as NextFunction;
+
+		contentSignalMiddleware({ method: "GET" } as Request, res, next);
+
+		expect(headers["Content-Signal"]).toBe(CONTENT_SIGNAL_VALUE);
+		expect(next).toHaveBeenCalled();
+	});
+
+	it("varies on Accept so a CDN keys HTML and markdown separately", () => {
+		const { varied, res } = createFakeRes();
+		const next = jest.fn() as unknown as NextFunction;
+
+		contentSignalMiddleware({ method: "GET" } as Request, res, next);
+
+		expect(varied).toEqual(["Accept"]);
+	});
+
+	it("does not set the Content-Signal header on non-GET requests", () => {
+		const { headers, varied, res } = createFakeRes();
+		const next = jest.fn() as unknown as NextFunction;
+
+		contentSignalMiddleware({ method: "POST" } as Request, res, next);
+
+		expect(headers["Content-Signal"]).toBeUndefined();
+		expect(varied).toEqual([]);
+		expect(next).toHaveBeenCalled();
+	});
+});

--- a/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
@@ -31,7 +31,7 @@ describe("contentSignalMiddleware", () => {
 		const { headers, res } = createFakeRes();
 		const next = jest.fn() as unknown as NextFunction;
 
-		contentSignalMiddleware({ method: "GET" } as Request, res, next);
+		contentSignalMiddleware({ method: "GET", path: "/" } as Request, res, next);
 
 		expect(headers["Content-Signal"]).toBe(CONTENT_SIGNAL_VALUE);
 		expect(next).toHaveBeenCalled();
@@ -41,7 +41,7 @@ describe("contentSignalMiddleware", () => {
 		const { varied, res } = createFakeRes();
 		const next = jest.fn() as unknown as NextFunction;
 
-		contentSignalMiddleware({ method: "GET" } as Request, res, next);
+		contentSignalMiddleware({ method: "GET", path: "/" } as Request, res, next);
 
 		expect(varied).toEqual(["Accept"]);
 	});
@@ -56,4 +56,18 @@ describe("contentSignalMiddleware", () => {
 		expect(varied).toEqual([]);
 		expect(next).toHaveBeenCalled();
 	});
+
+	it.each(["/robots.txt", "/llms.txt", "/llms-full.txt", "/sitemap.xml", "/health"])(
+		"skips Content-Signal and Vary on non-page GET %s",
+		(path) => {
+			const { headers, varied, res } = createFakeRes();
+			const next = jest.fn() as unknown as NextFunction;
+
+			contentSignalMiddleware({ method: "GET", path } as Request, res, next);
+
+			expect(headers["Content-Signal"]).toBeUndefined();
+			expect(varied).toEqual([]);
+			expect(next).toHaveBeenCalled();
+		},
+	);
 });

--- a/projects/hutch/src/runtime/web/content-signal.middleware.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.ts
@@ -1,0 +1,15 @@
+import type { NextFunction, Request, Response } from "express";
+
+export const CONTENT_SIGNAL_VALUE = "search=yes, ai-input=yes, ai-train=no";
+
+export function contentSignalMiddleware(
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void {
+	if (req.method === "GET") {
+		res.set("Content-Signal", CONTENT_SIGNAL_VALUE);
+		res.vary("Accept");
+	}
+	next();
+}

--- a/projects/hutch/src/runtime/web/content-signal.middleware.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.ts
@@ -2,12 +2,14 @@ import type { NextFunction, Request, Response } from "express";
 
 export const CONTENT_SIGNAL_VALUE = "search=yes, ai-input=yes, ai-train=no";
 
+const NON_PAGE_PREFIXES = ["/robots.txt", "/llms.txt", "/llms-full.txt", "/sitemap.xml", "/health"];
+
 export function contentSignalMiddleware(
 	req: Request,
 	res: Response,
 	next: NextFunction,
 ): void {
-	if (req.method === "GET") {
+	if (req.method === "GET" && !NON_PAGE_PREFIXES.some(p => req.path === p)) {
 		res.set("Content-Signal", CONTENT_SIGNAL_VALUE);
 		res.vary("Accept");
 	}

--- a/projects/hutch/src/runtime/web/html-page.test.ts
+++ b/projects/hutch/src/runtime/web/html-page.test.ts
@@ -17,10 +17,10 @@ describe("HtmlPage", () => {
 		expect(result.body).toBe("<p>Not found</p>");
 	});
 
-	it("returns 415 with empty body and no headers for unsupported media types", () => {
-		const result = HtmlPage("<p>Hello</p>").to("application/vnd.siren+json");
+	it("returns 406 with empty body and no headers when text/markdown is requested", () => {
+		const result = HtmlPage("<p>Hello</p>").to("text/markdown");
 
-		expect(result.statusCode).toBe(415);
+		expect(result.statusCode).toBe(406);
 		expect(result.headers).toEqual({});
 		expect(result.body).toBe("");
 	});

--- a/projects/hutch/src/runtime/web/html-page.ts
+++ b/projects/hutch/src/runtime/web/html-page.ts
@@ -6,7 +6,7 @@ export function HtmlPage(body: string, statusCode: number = 200): Component {
   return {
     to: (mediaType): ParsedComponent => {
       if (mediaType !== 'text/html') {
-        return { statusCode: 415, headers: {}, body: '' };
+        return { statusCode: 406, headers: {}, body: '' };
       }
       return {
         statusCode,

--- a/projects/hutch/src/runtime/web/html-to-markdown.test.ts
+++ b/projects/hutch/src/runtime/web/html-to-markdown.test.ts
@@ -1,0 +1,74 @@
+import { htmlToMarkdown } from "./html-to-markdown";
+
+describe("htmlToMarkdown", () => {
+	it("converts headings, paragraphs, and inline links to markdown", () => {
+		const html = `<h1>Hello</h1><p>World <a href="https://example.com">link</a>.</p>`;
+
+		const md = htmlToMarkdown(html);
+
+		expect(md).toContain("# Hello");
+		expect(md).toContain("World [link](https://example.com).");
+	});
+
+	it("converts tables to GFM table syntax", () => {
+		const html = `
+			<table>
+				<thead><tr><th>Name</th><th>Price</th></tr></thead>
+				<tbody>
+					<tr><td>Readplace</td><td>$3.99</td></tr>
+					<tr><td>Readwise</td><td>$9.99</td></tr>
+				</tbody>
+			</table>
+		`;
+
+		const md = htmlToMarkdown(html);
+
+		expect(md).toMatch(/\|\s+Name\s+\|\s+Price\s+\|/);
+		expect(md).toMatch(/\|\s+-+\s+\|\s+-+\s+\|/);
+		expect(md).toContain("Readplace");
+		expect(md).toContain("$3.99");
+	});
+
+	it("drops <script> blocks (including JSON-LD) entirely", () => {
+		const html = `
+			<p>Visible.</p>
+			<script type="application/ld+json">{"@type":"WebSite"}</script>
+			<script>console.log('hi')</script>
+		`;
+
+		const md = htmlToMarkdown(html);
+
+		expect(md).toContain("Visible.");
+		expect(md).not.toContain("WebSite");
+		expect(md).not.toContain("console.log");
+	});
+
+	it("drops <style> and <noscript> blocks", () => {
+		const html = `
+			<style>.a { color: red; }</style>
+			<noscript>Enable JS</noscript>
+			<p>Body.</p>
+		`;
+
+		const md = htmlToMarkdown(html);
+
+		expect(md).toContain("Body.");
+		expect(md).not.toContain("color: red");
+		expect(md).not.toContain("Enable JS");
+	});
+
+	it("does not retain htmx or data-test attributes from container elements", () => {
+		const html = `
+			<form hx-boost="true" hx-target="main" data-test-form="save">
+				<button data-test-cta="save">Save</button>
+			</form>
+		`;
+
+		const md = htmlToMarkdown(html);
+
+		expect(md).not.toContain("hx-boost");
+		expect(md).not.toContain("hx-target");
+		expect(md).not.toContain("data-test-");
+		expect(md).toContain("Save");
+	});
+});

--- a/projects/hutch/src/runtime/web/html-to-markdown.ts
+++ b/projects/hutch/src/runtime/web/html-to-markdown.ts
@@ -1,0 +1,12 @@
+import { NodeHtmlMarkdown } from "node-html-markdown";
+
+const converter = new NodeHtmlMarkdown({
+	ignore: ["script", "style", "noscript", "template"],
+	useInlineLinks: false,
+	useLinkReferenceDefinitions: false,
+	keepDataImages: false,
+});
+
+export function htmlToMarkdown(html: string): string {
+	return converter.translate(html);
+}

--- a/projects/hutch/src/runtime/web/markdown-frontmatter.test.ts
+++ b/projects/hutch/src/runtime/web/markdown-frontmatter.test.ts
@@ -1,0 +1,47 @@
+import { buildMarkdownFrontmatter } from "./markdown-frontmatter";
+
+describe("buildMarkdownFrontmatter", () => {
+	it("renders title as h1, description as a paragraph, and canonical URL", () => {
+		const result = buildMarkdownFrontmatter({
+			title: "Hello world",
+			description: "An article about hellos.",
+			canonicalUrl: "https://readplace.com/hello",
+		});
+
+		expect(result).toBe(
+			[
+				"# Hello world",
+				"",
+				"An article about hellos.",
+				"",
+				"Canonical: https://readplace.com/hello",
+			].join("\n"),
+		);
+	});
+
+	it("includes author and formattedDate when provided", () => {
+		const result = buildMarkdownFrontmatter(
+			{
+				title: "Post title",
+				description: "Post description.",
+				canonicalUrl: "https://readplace.com/blog/post",
+				author: "Fayner Brack",
+			},
+			{ formattedDate: "1 May 2026" },
+		);
+
+		expect(result).toContain("Author: Fayner Brack");
+		expect(result).toContain("Date: 1 May 2026");
+		expect(result).toContain("Canonical: https://readplace.com/blog/post");
+	});
+
+	it("omits the metadata block entirely when no author, date, or canonical URL", () => {
+		const result = buildMarkdownFrontmatter({
+			title: "Stub",
+			description: "Stub description.",
+			canonicalUrl: "",
+		});
+
+		expect(result).toBe("# Stub\n\nStub description.");
+	});
+});

--- a/projects/hutch/src/runtime/web/markdown-frontmatter.ts
+++ b/projects/hutch/src/runtime/web/markdown-frontmatter.ts
@@ -1,0 +1,20 @@
+import type { SeoMetadata } from "./page-body.types";
+
+export interface MarkdownFrontmatterOpts {
+	formattedDate?: string;
+}
+
+export function buildMarkdownFrontmatter(
+	seo: SeoMetadata,
+	opts: MarkdownFrontmatterOpts = {},
+): string {
+	const lines: string[] = [`# ${seo.title}`, "", seo.description];
+	const meta: string[] = [];
+	if (seo.author) meta.push(`Author: ${seo.author}`);
+	if (opts.formattedDate) meta.push(`Date: ${opts.formattedDate}`);
+	if (seo.canonicalUrl) meta.push(`Canonical: ${seo.canonicalUrl}`);
+	if (meta.length > 0) {
+		lines.push("", meta.join("  \n"));
+	}
+	return lines.join("\n");
+}

--- a/projects/hutch/src/runtime/web/markdown-page.test.ts
+++ b/projects/hutch/src/runtime/web/markdown-page.test.ts
@@ -1,0 +1,35 @@
+import { MarkdownPage } from "./markdown-page";
+
+describe("MarkdownPage", () => {
+	it("returns 200 with text/markdown content-type and a token estimate header", () => {
+		const result = MarkdownPage("# Hello\n\nWorld").to("text/markdown");
+
+		expect(result.statusCode).toBe(200);
+		expect(result.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(result.body).toBe("# Hello\n\nWorld");
+		expect(Number(result.headers["x-markdown-tokens"])).toBeGreaterThan(0);
+	});
+
+	it("estimates tokens at roughly one per four characters", () => {
+		const body = "x".repeat(400);
+
+		const result = MarkdownPage(body).to("text/markdown");
+
+		expect(result.headers["x-markdown-tokens"]).toBe("100");
+	});
+
+	it("uses the provided statusCode", () => {
+		const result = MarkdownPage("# Not found", 404).to("text/markdown");
+
+		expect(result.statusCode).toBe(404);
+		expect(result.body).toBe("# Not found");
+	});
+
+	it("returns 406 with empty body and no headers when text/html is requested", () => {
+		const result = MarkdownPage("# Hello").to("text/html");
+
+		expect(result.statusCode).toBe(406);
+		expect(result.headers).toEqual({});
+		expect(result.body).toBe("");
+	});
+});

--- a/projects/hutch/src/runtime/web/markdown-page.ts
+++ b/projects/hutch/src/runtime/web/markdown-page.ts
@@ -1,0 +1,30 @@
+import type { Component, ParsedComponent } from "./component.types";
+
+const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+
+/** Heuristic: ~4 chars per token for English prose. Cloudflare's
+ * x-markdown-tokens header is itself documented as an estimate; bundling a
+ * real tokenizer (gpt-tokenizer ≈ 2 MB) would bloat the Lambda for marginal
+ * accuracy. Swap behind this function if agents start treating the count
+ * as authoritative. */
+function estimateTokens(body: string): number {
+	return Math.ceil(body.length / 4);
+}
+
+export function MarkdownPage(body: string, statusCode: number = 200): Component {
+	return {
+		to: (mediaType): ParsedComponent => {
+			if (mediaType !== "text/markdown") {
+				return { statusCode: 406, headers: {}, body: "" };
+			}
+			return {
+				statusCode,
+				headers: {
+					"content-type": MARKDOWN_CONTENT_TYPE,
+					"x-markdown-tokens": String(estimateTokens(body)),
+				},
+				body,
+			};
+		},
+	};
+}

--- a/projects/hutch/src/runtime/web/oauth/oauth.component.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.component.ts
@@ -97,7 +97,7 @@ export function OAuthAuthorizePage(params: AuthorizePageParams): PageBody {
 		},
 		styles: OAUTH_AUTHORIZE_STYLES,
 		bodyClass: "page-oauth-authorize",
-		content,
+		content: { html: content },
 	};
 }
 
@@ -111,6 +111,6 @@ export function OAuthCallbackPage(): PageBody {
 		},
 		styles: OAUTH_CALLBACK_STYLES,
 		bodyClass: "page-oauth-callback",
-		content: render(OAUTH_CALLBACK_TEMPLATE, {}),
+		content: { html: render(OAUTH_CALLBACK_TEMPLATE, {}) },
 	};
 }

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -75,7 +75,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 		}
 
 		sendComponent(
-			res,
+			req, res,
 			renderPage(req, OAuthAuthorizePage({
 				clientName: client.name,
 				clientId: client_id,
@@ -163,7 +163,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 	});
 
 	router.get("/callback", (req: Request, res: Response) => {
-		sendComponent(res, renderPage(req, OAuthCallbackPage()));
+		sendComponent(req, res, renderPage(req, OAuthCallbackPage()));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/page-body.types.ts
+++ b/projects/hutch/src/runtime/web/page-body.types.ts
@@ -20,6 +20,12 @@ export interface PageBody {
 	headerVariant?: "default" | "transparent";
 	bodyClass?: string;
 	content: string;
+	/** When set, the markdown branch of `Base()` serves this verbatim instead
+	 * of converting `content` from HTML. Used by routes that want to ship a
+	 * subset of the page (e.g., /view returns only the article body, not the
+	 * surrounding share/save UI). */
+	markdownContent?: string;
+	markdownFormattedDate?: string;
 	scripts?: string;
 	statusCode?: number;
 }

--- a/projects/hutch/src/runtime/web/page-body.types.ts
+++ b/projects/hutch/src/runtime/web/page-body.types.ts
@@ -19,12 +19,7 @@ export interface PageBody {
 	styles: string;
 	headerVariant?: "default" | "transparent";
 	bodyClass?: string;
-	content: string;
-	/** When set, the markdown branch of `Base()` serves this verbatim instead
-	 * of converting `content` from HTML. Used by routes that want to ship a
-	 * subset of the page (e.g., /view returns only the article body, not the
-	 * surrounding share/save UI). */
-	markdownContent?: string;
+	content: { html: string; markdown?: string };
 	markdownFormattedDate?: string;
 	scripts?: string;
 	statusCode?: number;

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl-landing.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl-landing.component.ts
@@ -32,6 +32,6 @@ export function AdminRecrawlLandingPage(): PageBody {
 		},
 		styles: RECRAWL_STYLES,
 		bodyClass: "page-admin-recrawl",
-		content,
+		content: { html: content },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
@@ -66,7 +66,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 		},
 		styles: RECRAWL_STYLES,
 		bodyClass: "page-admin-recrawl",
-		content,
+		content: { html: content },
 		scripts: PROGRESS_BAR_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog-index.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-index.component.ts
@@ -59,6 +59,6 @@ export function BlogIndexPage(params: { posts: BlogPost[] }): PageBody {
 		},
 		styles: BLOG_STYLES,
 		bodyClass: "page-blog",
-		content: render(BLOG_INDEX_TEMPLATE, { posts: params.posts }),
+		content: { html: render(BLOG_INDEX_TEMPLATE, { posts: params.posts }) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
@@ -77,5 +77,7 @@ export function BlogPostPage(params: { post: BlogPost }): PageBody {
 			author: post.author,
 			htmlContent: post.htmlContent,
 		}),
+		markdownContent: post.markdownContent,
+		markdownFormattedDate: post.formattedDate,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog-post.component.ts
@@ -70,14 +70,16 @@ export function BlogPostPage(params: { post: BlogPost }): PageBody {
 		},
 		styles: BLOG_STYLES,
 		bodyClass: "page-blog-post",
-		content: render(BLOG_POST_TEMPLATE, {
-			title: post.title,
-			date: post.date,
-			formattedDate: post.formattedDate,
-			author: post.author,
-			htmlContent: post.htmlContent,
-		}),
-		markdownContent: post.markdownContent,
+		content: {
+			html: render(BLOG_POST_TEMPLATE, {
+				title: post.title,
+				date: post.date,
+				formattedDate: post.formattedDate,
+				author: post.author,
+				htmlContent: post.htmlContent,
+			}),
+			markdown: post.markdownContent,
+		},
 		markdownFormattedDate: post.formattedDate,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
@@ -18,7 +18,7 @@ export function initBlogRoutes(): Router {
 
 	router.get("/", (req: Request, res: Response) => {
 		const posts = getAllPosts();
-		sendComponent(res, renderPage(req, BlogIndexPage({ posts })));
+		sendComponent(req, res, renderPage(req, BlogIndexPage({ posts })));
 	});
 
 	router.get("/:slug", (req: Request, res: Response) => {
@@ -29,10 +29,10 @@ export function initBlogRoutes(): Router {
 		}
 		const post = findPostBySlug(req.params.slug);
 		if (!post) {
-			sendComponent(res, renderPage(req, NotFoundPage()));
+			sendComponent(req, res, renderPage(req, NotFoundPage()));
 			return;
 		}
-		sendComponent(res, renderPage(req, BlogPostPage({ post })));
+		sendComponent(req, res, renderPage(req, BlogPostPage({ post })));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/blog/blog.posts.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.posts.test.ts
@@ -29,6 +29,14 @@ describe("blog posts", () => {
 		}
 	});
 
+	it("should retain the raw markdown body for every post", () => {
+		for (const post of posts) {
+			expect(typeof post.markdownContent).toBe("string");
+			expect(post.markdownContent.length).toBeGreaterThan(0);
+			expect(post.markdownContent).not.toContain("---\ntitle:");
+		}
+	});
+
 	it("should have formatted dates for every post", () => {
 		for (const post of posts) {
 			expect(post.formattedDate).toMatch(/\d{1,2} \w+ \d{4}/);

--- a/projects/hutch/src/runtime/web/pages/blog/blog.posts.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.posts.ts
@@ -18,6 +18,7 @@ const BlogFrontmatter = z.object({
 
 export type BlogPost = z.infer<typeof BlogFrontmatter> & {
 	htmlContent: string;
+	markdownContent: string;
 	formattedDate: string;
 };
 
@@ -50,6 +51,7 @@ const posts: BlogPost[] = files
 		return {
 			...frontmatter,
 			htmlContent: md.render(content),
+			markdownContent: content,
 			formattedDate: formatDate(frontmatter.date),
 		};
 	})

--- a/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
@@ -306,3 +306,76 @@ describe("GET /sitemap.xml", () => {
 		);
 	});
 });
+
+describe("GET /blog with Accept: text/markdown", () => {
+	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+	it("returns 200 with text/markdown content-type and an x-markdown-tokens header", async () => {
+		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(Number(response.headers["x-markdown-tokens"])).toBeGreaterThan(0);
+	});
+
+	it("emits the site-wide Content-Signal policy and Vary: Accept", async () => {
+		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+
+		expect(response.headers["content-signal"]).toBe(
+			"search=yes, ai-input=yes, ai-train=no",
+		);
+		expect(response.headers.vary).toMatch(/\bAccept\b/);
+	});
+
+	it("renders the page heading as the markdown h1 and lists the first post title", async () => {
+		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+
+		expect(response.text.startsWith("# Blog")).toBe(true);
+		expect(response.text).toContain(firstPost.title);
+	});
+
+	it("does not include the rendered HTML chrome (no <script>, no htmx, no data-test-*)", async () => {
+		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+
+		expect(response.text).not.toContain("<script");
+		expect(response.text).not.toContain("hx-boost");
+		expect(response.text).not.toContain("data-test-");
+	});
+});
+
+describe("GET /blog/:slug with Accept: text/markdown", () => {
+	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+	it("returns 200 with text/markdown content-type and the canonical URL header in frontmatter", async () => {
+		const response = await request(app)
+			.get(`/blog/${firstPost.slug}`)
+			.set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(response.text.startsWith(`# ${firstPost.title}`)).toBe(true);
+		expect(response.text).toContain(`Canonical: https://readplace.com/blog/${firstPost.slug}`);
+		expect(response.text).toContain(`Author: ${firstPost.author}`);
+	});
+
+	it("serves the raw markdown source verbatim, without going through HTML conversion", async () => {
+		const response = await request(app)
+			.get(`/blog/${firstPost.slug}`)
+			.set("Accept", "text/markdown");
+
+		expect(response.text).toContain(firstPost.markdownContent.trim().split("\n")[0]);
+	});
+});
+
+describe("HTML responses now carry the Content-Signal header", () => {
+	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+	it("sets Content-Signal: search=yes, ai-input=yes, ai-train=no on a plain HTML GET", async () => {
+		const response = await request(app).get(`/blog/${firstPost.slug}`);
+
+		expect(response.headers["content-signal"]).toBe(
+			"search=yes, ai-input=yes, ai-train=no",
+		);
+		expect(response.headers.vary).toMatch(/\bAccept\b/);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/e2e-fixture/e2e-fixture.component.ts
+++ b/projects/hutch/src/runtime/web/pages/e2e-fixture/e2e-fixture.component.ts
@@ -14,6 +14,6 @@ export function E2EFixturePage(): PageBody {
 			robots: "noindex, nofollow",
 		},
 		styles: "",
-		content: render(TEMPLATE, {}),
+		content: { html: render(TEMPLATE, {}) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/embed/embed.page.ts
+++ b/projects/hutch/src/runtime/web/pages/embed/embed.page.ts
@@ -17,12 +17,12 @@ export function initEmbedRoutes(deps: { appOrigin: string }): Router {
 		}),
 	);
 
-	router.get("/", (_req, res) => {
-		sendComponent(res, EmbedPage({ appOrigin: deps.appOrigin, embedOrigin }));
+	router.get("/", (req, res) => {
+		sendComponent(req, res, EmbedPage({ appOrigin: deps.appOrigin, embedOrigin }));
 	});
 
-	router.get("/preview", (_req, res) => {
-		sendComponent(res, PreviewPage({ appOrigin: deps.appOrigin, embedOrigin }));
+	router.get("/preview", (req, res) => {
+		sendComponent(req, res, PreviewPage({ appOrigin: deps.appOrigin, embedOrigin }));
 	});
 
 	router.get("/icon.svg", (_req, res) => {

--- a/projects/hutch/src/runtime/web/pages/export/export.component.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.component.ts
@@ -30,6 +30,6 @@ export function ExportPage(params: { status: "idle" | "preparing" }): PageBody {
 		},
 		styles: EXPORT_STYLES,
 		bodyClass: "page-export",
-		content,
+		content: { html: content },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/export/export.page.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.page.ts
@@ -19,7 +19,7 @@ export function initExportRoutes(deps: ExportDependencies): Router {
 
 	router.get("/", (req: Request, res: Response) => {
 		const status = req.query.status === "preparing" ? "preparing" : "idle";
-		sendComponent(res, renderPage(req, ExportPage({ status })));
+		sendComponent(req, res, renderPage(req, ExportPage({ status })));
 	});
 
 	router.post("/start", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -280,7 +280,7 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 		styles: HOME_PAGE_STYLES,
 		scripts: HOME_HEADLINE_SCRIPT + HOME_SCROLL_HINT_SCRIPT,
 		bodyClass: "page-home",
-		content: render(HOME_TEMPLATE, {
+		content: { html: render(HOME_TEMPLATE, {
 			staticBaseUrl,
 			browserName: browser,
 			founderAvatarUrl: `${staticBaseUrl}/fayner-brack.jpg`,
@@ -375,6 +375,6 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 						"Export everything, anytime. Your data is yours. Cancel and your saved articles stay available for export.",
 				},
 			],
-		}, { helpers: switchHelpers }),
+		}, { helpers: switchHelpers }) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -383,6 +383,51 @@ describe("GET /llms.txt", () => {
 		expect(response.text).toContain("read-it-later");
 		expect(response.text).toContain("## Pages");
 	});
+
+	it("advertises the markdown content-negotiation capability", async () => {
+		const response = await request(app).get("/llms.txt");
+		expect(response.text).toContain("Accept: text/markdown");
+	});
+});
+
+describe("GET / with Accept: text/markdown", () => {
+	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+	it("returns 200 with text/markdown content-type instead of redirecting to /queue", async () => {
+		const response = await request(app).get("/").set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(response.headers.location).toBeUndefined();
+	});
+
+	it("converts the comparison table into markdown table syntax", async () => {
+		const response = await request(app).get("/").set("Accept", "text/markdown");
+
+		expect(response.text).toMatch(/\|\s+-+\s+\|/);
+	});
+
+	it("emits the Content-Signal policy and Vary: Accept", async () => {
+		const response = await request(app).get("/").set("Accept", "text/markdown");
+
+		expect(response.headers["content-signal"]).toBe(
+			"search=yes, ai-input=yes, ai-train=no",
+		);
+		expect(response.headers.vary).toMatch(/\bAccept\b/);
+	});
+});
+
+describe("GET / HTML response gains the Content-Signal header", () => {
+	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+	it("sets the site-wide Content-Signal policy on plain HTML GETs", async () => {
+		const response = await request(app).get("/");
+
+		expect(response.headers["content-signal"]).toBe(
+			"search=yes, ai-input=yes, ai-train=no",
+		);
+		expect(response.headers.vary).toMatch(/\bAccept\b/);
+	});
 });
 
 describe("GET /llms-full.txt", () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -25,7 +25,7 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 		},
 		styles: IMPORT_STYLES,
 		bodyClass: "page-import",
-		content,
+		content: { html: content },
 		scripts: IMPORT_CLIENT_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -83,7 +83,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		const totalSelected =
 			pageResult.session.totalUrls - pageResult.session.deselected.size;
 		const vm = toImportViewModel(pageResult, totalSelected);
-		sendComponent(res, renderPage(req, ImportPage(vm)));
+		sendComponent(req, res, renderPage(req, ImportPage(vm)));
 	});
 
 	router.post("/:id/toggle", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -79,10 +79,10 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 		},
 		styles: INSTALL_PAGE_STYLES,
 		bodyClass: "page-install",
-		content: render(INSTALL_TEMPLATE, {
+		content: { html: render(INSTALL_TEMPLATE, {
 			browser: params.browser,
 			firefoxDownloadUrl: params.firefox,
 			chromeDownloadUrl: params.chrome,
-		}, { helpers: switchHelpers }),
+		}, { helpers: switchHelpers }) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -205,4 +205,15 @@ describe("GET /install", () => {
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
 		expect(chromeTab?.getAttribute("href")).toBe("/install?browser=chrome");
 	});
+
+	it("returns markdown when Accept: text/markdown is sent", async () => {
+		const response = await request(app)
+			.get("/install")
+			.set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(response.text).toMatch(/^# /);
+		expect(response.text).not.toContain("<script");
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/not-found/not-found.component.ts
+++ b/projects/hutch/src/runtime/web/pages/not-found/not-found.component.ts
@@ -16,7 +16,7 @@ export function NotFoundPage(): PageBody {
 		},
 		styles: NOT_FOUND_STYLES,
 		bodyClass: "page-not-found",
-		content: render(NOT_FOUND_TEMPLATE, {}),
+		content: { html: render(NOT_FOUND_TEMPLATE, {}) },
 		statusCode: 404,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/privacy/privacy.component.ts
+++ b/projects/hutch/src/runtime/web/pages/privacy/privacy.component.ts
@@ -17,6 +17,6 @@ export function PrivacyPage(): PageBody {
 		},
 		styles: LEGAL_PAGE_STYLES,
 		bodyClass: "page-privacy",
-		content: render(PRIVACY_TEMPLATE, {}),
+		content: { html: render(PRIVACY_TEMPLATE, {}) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/privacy/privacy.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/privacy/privacy.route.test.ts
@@ -13,4 +13,14 @@ describe("GET /privacy", () => {
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
+
+	it("returns markdown when Accept: text/markdown is sent", async () => {
+		const response = await request(app)
+			.get("/privacy")
+			.set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(response.text).toMatch(/^# /);
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -170,7 +170,7 @@ export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; exte
 		},
 		styles: `${QUEUE_STYLES}\n${ONBOARDING_STYLES}`,
 		bodyClass: "page-queue",
-		content,
+		content: { html: content },
 		scripts: scriptParts.join("\n"),
 		statusCode: options?.statusCode,
 	};

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -157,7 +157,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const browser = detectBrowser(req);
 		const showImportForm = req.query.feature === "import";
 		sendComponent(
-			res,
+			req, res,
 			renderPage(req, QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed, showImportForm })),
 		);
 	});
@@ -327,7 +327,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				unreadCount,
 				summaryByUrl,
 			});
-			sendComponent(res, renderPage(req, QueuePage(vm, { statusCode: 422 })));
+			sendComponent(req, res, renderPage(req, QueuePage(vm, { statusCode: 422 })));
 			return;
 		}
 
@@ -378,7 +378,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		});
 
 		sendComponent(
-			res,
+			req, res,
 			renderPage(req, ReaderPage({ ...article, content: state.content }, {
 				summary: state.summary,
 				summaryPollUrl: state.summaryPollUrl,
@@ -410,7 +410,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			pollCount,
 			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
 		});
-		sendComponent(res, component);
+		sendComponent(req, res, component);
 	});
 
 	router.get("/:id/reader", async (req: Request, res: Response) => {
@@ -433,7 +433,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
-		sendComponent(res, component);
+		sendComponent(req, res, component);
 	});
 
 	router.post("/:id/status", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -63,7 +63,7 @@ export function ReaderPage(
 		},
 		styles: READER_STYLES,
 		bodyClass: "page-reader",
-		content,
+		content: { html: content },
 		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/save/save-error.component.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-error.component.ts
@@ -31,12 +31,12 @@ export function SaveErrorPage(input: { redirectUrl: string; linkLabel: string })
 		},
 		styles: SAVE_ERROR_STYLES,
 		bodyClass: "page-save-error",
-		content: render(SAVE_ERROR_TEMPLATE, {
+		content: { html: render(SAVE_ERROR_TEMPLATE, {
 			refreshDelay: COUNTDOWN_SECONDS,
 			seconds: COUNTDOWN_SECONDS,
 			redirectUrl: input.redirectUrl,
 			linkLabel: input.linkLabel,
-		}),
+		}) },
 		scripts: COUNTDOWN_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/save/save.page.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.page.ts
@@ -23,7 +23,7 @@ export function initSaveRoutes(): Router {
 		if (!url) {
 			const redirectUrl = req.userId ? "/queue" : "/";
 			const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
-			sendComponent(res, renderPage(req, SaveErrorPage({ redirectUrl, linkLabel })));
+			sendComponent(req, res, renderPage(req, SaveErrorPage({ redirectUrl, linkLabel })));
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/terms/terms.component.ts
+++ b/projects/hutch/src/runtime/web/pages/terms/terms.component.ts
@@ -17,6 +17,6 @@ export function TermsPage(): PageBody {
 		},
 		styles: LEGAL_PAGE_STYLES,
 		bodyClass: "page-terms",
-		content: render(TERMS_TEMPLATE, {}),
+		content: { html: render(TERMS_TEMPLATE, {}) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/terms/terms.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/terms/terms.route.test.ts
@@ -13,4 +13,14 @@ describe("GET /terms", () => {
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
+
+	it("returns markdown when Accept: text/markdown is sent", async () => {
+		const response = await request(app)
+			.get("/terms")
+			.set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(response.text).toMatch(/^# /);
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-landing.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-landing.component.ts
@@ -21,6 +21,6 @@ export function ViewLandingPage(): PageBody {
 		},
 		styles: VIEW_LANDING_STYLES,
 		bodyClass: "page-view-landing",
-		content: render(VIEW_LANDING_TEMPLATE, {}),
+		content: { html: render(VIEW_LANDING_TEMPLATE, {}) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -117,7 +117,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		},
 		styles: VIEW_STYLES,
 		bodyClass: "page-view",
-		content,
+		content: { html: content },
 		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -22,6 +22,10 @@ import type {
 	MarkSummaryPending,
 } from "@packages/test-fixtures/providers/article-summary";
 import type { PublishSaveAnonymousLink } from "@packages/test-fixtures/providers/events";
+import { wantsMarkdown } from "../../content-negotiation";
+import { htmlToMarkdown } from "../../html-to-markdown";
+import { buildMarkdownFrontmatter } from "../../markdown-frontmatter";
+import { MarkdownPage } from "../../markdown-page";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { extensionInstallUrlIfMissing } from "../../onboarding/extension-install";
@@ -50,7 +54,7 @@ interface ViewDependencies {
 function renderError(req: Request, res: Response) {
 	const redirectUrl = req.userId ? "/queue" : "/";
 	const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
-	sendComponent(res, renderPage(req, SaveErrorPage({ redirectUrl, linkLabel })));
+	sendComponent(req, res, renderPage(req, SaveErrorPage({ redirectUrl, linkLabel })));
 }
 
 function hostnameFrom(validatedUrl: string): string {
@@ -68,7 +72,7 @@ function handleViewLanding(req: Request, res: Response) {
 	const submittedUrl =
 		typeof req.query.url === "string" ? req.query.url : undefined;
 	if (submittedUrl === undefined) {
-		sendComponent(res, renderPage(req, ViewLandingPage()));
+		sendComponent(req, res, renderPage(req, ViewLandingPage()));
 		return;
 	}
 	const parsed = ViewUrlSchema.safeParse(submittedUrl);
@@ -137,6 +141,17 @@ function handleViewArticle(deps: ViewDependencies) {
 			pollUrlBuilder,
 		});
 
+		if (wantsMarkdown(req)) {
+			const frontmatter = buildMarkdownFrontmatter({
+				title: metadata.title,
+				description: metadata.excerpt,
+				canonicalUrl: articleUrl,
+			});
+			const articleMarkdown = state.content ? htmlToMarkdown(state.content) : "";
+			sendComponent(req, res, MarkdownPage(`${frontmatter}\n\n${articleMarkdown}`));
+			return;
+		}
+
 		const utmParams = collectUtmParams(req.query);
 
 		const actions: ViewAction[] = [
@@ -153,7 +168,7 @@ function handleViewArticle(deps: ViewDependencies) {
 		];
 
 		sendComponent(
-			res,
+			req, res,
 			renderPage(req, ViewPage({
 				articleUrl,
 				metadata,
@@ -186,7 +201,7 @@ function handleViewSummary(deps: ViewDependencies) {
 			pollCount,
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 		});
-		sendComponent(res, component);
+		sendComponent(req, res, component);
 	};
 }
 
@@ -206,7 +221,7 @@ function handleViewReader(deps: ViewDependencies) {
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
-		sendComponent(res, component);
+		sendComponent(req, res, component);
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1711,4 +1711,62 @@ describe("View routes", () => {
 			expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: ARTICLE_URL });
 		});
 	});
+
+	describe("GET /view/<encoded-url> with Accept: text/markdown", () => {
+		it("returns the article body as markdown without the share/save UI", async () => {
+			const parseArticle: ParseArticle = async () =>
+				buildParseResult({
+					title: "Hello Markdown",
+					excerpt: "An article rendered as markdown.",
+					content: "<p>The article body.</p>",
+				});
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const { app } = createTestApp({
+				...fixture,
+				parser: {
+					parseArticle,
+					crawlArticle: fixture.parser.crawlArticle,
+				},
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+			});
+
+			const response = await request(app)
+				.get(`/view/${ENCODED}`)
+				.set("Accept", "text/markdown");
+
+			expect(response.status).toBe(200);
+			expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+			expect(response.text.startsWith("# Hello Markdown")).toBe(true);
+			expect(response.text).toContain("An article rendered as markdown.");
+			expect(response.text).toContain(`Canonical: ${ARTICLE_URL}`);
+			expect(response.text).toContain("The article body.");
+			expect(response.text).not.toContain("<script");
+			expect(response.text).not.toContain("data-test-");
+			expect(response.text).not.toContain("hx-boost");
+		});
+
+		it("renders the landing page as markdown when /view is requested without a URL", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app)
+				.get("/view")
+				.set("Accept", "text/markdown");
+
+			expect(response.status).toBe(200);
+			expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+			expect(response.text).toMatch(/^# /);
+		});
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1757,6 +1757,26 @@ describe("View routes", () => {
 			expect(response.text).not.toContain("hx-boost");
 		});
 
+		it("returns markdown with empty body when article content is not yet available", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { app } = createTestApp({
+				...fixture,
+				events: {
+					...fixture.events,
+					publishSaveAnonymousLink: async () => {},
+				},
+			});
+
+			const response = await request(app)
+				.get(`/view/${ENCODED}`)
+				.set("Accept", "text/markdown");
+
+			expect(response.status).toBe(200);
+			expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
+			expect(response.text).toContain(`Canonical: ${ARTICLE_URL}`);
+			expect(response.text).not.toContain("<p>");
+		});
+
 		it("renders the landing page as markdown when /view is requested without a URL", async () => {
 			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 

--- a/projects/hutch/src/runtime/web/render-page.test.ts
+++ b/projects/hutch/src/runtime/web/render-page.test.ts
@@ -13,7 +13,7 @@ function createTestPageBody(): PageBody {
 			canonicalUrl: "https://readplace.com/test",
 		},
 		styles: "",
-		content: "<main><p>Test content</p></main>",
+		content: { html: "<main><p>Test content</p></main>" },
 	};
 }
 

--- a/projects/hutch/src/runtime/web/send-component.test.ts
+++ b/projects/hutch/src/runtime/web/send-component.test.ts
@@ -1,6 +1,7 @@
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import type { Component } from "./component.types";
 import { HtmlPage } from "./html-page";
+import { MarkdownPage } from "./markdown-page";
 import { sendComponent } from "./send-component";
 
 interface FakeResponse {
@@ -27,11 +28,15 @@ function createFakeResponse(): FakeResponse {
 	return { calls, res };
 }
 
+function requestWithAccept(accept?: string): Request {
+	return { get: (header: string) => header === "Accept" ? accept : undefined } as unknown as Request;
+}
+
 describe("sendComponent", () => {
 	it("passes the component's statusCode, headers, and body through to the response", () => {
 		const { calls, res } = createFakeResponse();
 
-		sendComponent(res, HtmlPage("<p>Hello</p>"));
+		sendComponent(requestWithAccept(), res, HtmlPage("<p>Hello</p>"));
 
 		expect(calls.status).toEqual([200]);
 		expect(calls.set).toEqual([{ "content-type": "text/html; charset=utf-8" }]);
@@ -41,7 +46,7 @@ describe("sendComponent", () => {
 	it("uses the statusCode that the component carries", () => {
 		const { calls, res } = createFakeResponse();
 
-		sendComponent(res, HtmlPage("<p>Not found</p>", 404));
+		sendComponent(requestWithAccept(), res, HtmlPage("<p>Not found</p>", 404));
 
 		expect(calls.status).toEqual([404]);
 		expect(calls.set).toEqual([{ "content-type": "text/html; charset=utf-8" }]);
@@ -58,10 +63,30 @@ describe("sendComponent", () => {
 			}),
 		};
 
-		sendComponent(res, siren);
+		sendComponent(requestWithAccept(), res, siren);
 
 		expect(calls.status).toEqual([201]);
 		expect(calls.set).toEqual([{ "content-type": "application/vnd.siren+json" }]);
 		expect(calls.send).toEqual(['{"class":["article"]}']);
+	});
+
+	it("returns the markdown branch when Accept is text/markdown and the component supports it", () => {
+		const { calls, res } = createFakeResponse();
+
+		sendComponent(requestWithAccept("text/markdown"), res, MarkdownPage("# Hi"));
+
+		expect(calls.status).toEqual([200]);
+		expect(calls.set[0]["content-type"]).toBe("text/markdown; charset=utf-8");
+		expect(calls.send).toEqual(["# Hi"]);
+	});
+
+	it("falls back to text/html when the component returns 406 for the markdown branch", () => {
+		const { calls, res } = createFakeResponse();
+
+		sendComponent(requestWithAccept("text/markdown"), res, HtmlPage("<p>Hi</p>"));
+
+		expect(calls.status).toEqual([200]);
+		expect(calls.set[0]["content-type"]).toBe("text/html; charset=utf-8");
+		expect(calls.send).toEqual(["<p>Hi</p>"]);
 	});
 });

--- a/projects/hutch/src/runtime/web/send-component.test.ts
+++ b/projects/hutch/src/runtime/web/send-component.test.ts
@@ -29,7 +29,22 @@ function createFakeResponse(): FakeResponse {
 }
 
 function requestWithAccept(accept?: string): Request {
-	return { get: (header: string) => header === "Accept" ? accept : undefined } as unknown as Request;
+	const types = (accept || "").split(",").map(entry => {
+		const [type, ...params] = entry.trim().split(";");
+		const qParam = params.find(p => p.trim().startsWith("q="));
+		const q = qParam ? Number.parseFloat(qParam.trim().slice(2)) : 1;
+		return { type: type.trim(), q };
+	});
+	return {
+		get: (header: string) => header === "Accept" ? accept : undefined,
+		accepts: (...args: string[]) => {
+			for (const candidate of args.flat()) {
+				const match = types.find(t => t.type === candidate);
+				if (match && match.q > 0) return candidate;
+			}
+			return false;
+		},
+	} as unknown as Request;
 }
 
 describe("sendComponent", () => {

--- a/projects/hutch/src/runtime/web/send-component.ts
+++ b/projects/hutch/src/runtime/web/send-component.ts
@@ -1,7 +1,15 @@
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import type { Component } from "./component.types";
+import { wantsMarkdown } from "./content-negotiation";
 
-export function sendComponent(res: Response, component: Component): void {
+export function sendComponent(req: Request, res: Response, component: Component): void {
+	if (wantsMarkdown(req)) {
+		const md = component.to("text/markdown");
+		if (md.statusCode !== 406) {
+			res.status(md.statusCode).set(md.headers).send(md.body);
+			return;
+		}
+	}
 	const parsed = component.to("text/html");
 	res.status(parsed.statusCode).set(parsed.headers).send(parsed.body);
 }


### PR DESCRIPTION
## Summary
This PR adds support for content negotiation via the `Accept: text/markdown` header, allowing clients to request markdown versions of pages instead of HTML. This enables better integration with AI/LLM tools and provides a cleaner content format for programmatic consumption.

## Key Changes

- **Content Negotiation**: Added `wantsMarkdown()` function to detect `Accept: text/markdown` requests and route them appropriately
- **HTML to Markdown Conversion**: Implemented `htmlToMarkdown()` utility using `node-html-markdown` library to convert HTML content to markdown, with proper handling of tables, links, and filtering of script/style/noscript tags
- **Markdown Page Component**: Created `MarkdownPage()` component that returns markdown responses with proper content-type headers and token count estimates via `x-markdown-tokens` header
- **Markdown Frontmatter**: Added `buildMarkdownFrontmatter()` to generate markdown headers with title, description, author, date, and canonical URL metadata
- **Content-Signal Middleware**: Implemented `contentSignalMiddleware` to emit `Content-Signal: search=yes, ai-input=yes, ai-train=no` header on all GET requests and vary on Accept header for proper CDN caching
- **Request Parameter Addition**: Updated `sendComponent()` to accept `Request` parameter for content negotiation logic
- **Blog Post Markdown Support**: Added `markdownContent` field to blog posts to serve raw markdown verbatim instead of converting from HTML
- **Page Body Enhancement**: Extended `PageBody` type with optional `markdownContent` and `markdownFormattedDate` fields
- **Route Updates**: Updated all route handlers to pass `req` to `sendComponent()` for markdown support across:
  - Home page (`/`)
  - Blog index and posts (`/blog`, `/blog/:slug`)
  - View/article pages (`/view`, `/view/:url`)
  - Auth pages (login, signup, forgot password)
  - Static pages (privacy, terms, install)
  - Other routes (queue, embed, export, save, OAuth)

## Implementation Details

- Token estimation uses a heuristic of ~4 characters per token for English prose
- Markdown responses return 406 (Not Acceptable) when markdown is requested but not supported by a component
- HTML responses now include `Vary: Accept` header to ensure CDN caches HTML and markdown separately
- Blog posts retain raw markdown source for clean markdown output without HTML conversion
- The `llms.txt` file was updated to advertise markdown content-negotiation capability

https://claude.ai/code/session_0165a4N2RQdLuWYPE57imErz