### PR TITLE
Add master checkbox to toggle all import selections

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -68,6 +68,22 @@ const BUNDLES = [
 			"});",
 		].join("\n"),
 	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/pages/import/import.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "import.client.js"),
+		globalName: "ImportClient",
+		footer: [
+			"ImportClient.initIndeterminateCheckboxes({",
+			"  document: window.document,",
+			"  addSwapListener: function (listener) {",
+			"    window.document.body.addEventListener('htmx:afterSwap', listener);",
+			"  }",
+			"});",
+		].join("\n"),
+	},
 ];
 
 function buildOptions(bundle) {

--- a/projects/hutch/src/runtime/domain/import-session/import-session.schema.ts
+++ b/projects/hutch/src/runtime/domain/import-session/import-session.schema.ts
@@ -12,6 +12,10 @@ export const ImportToggleSchema = z.object({
 	checked: z.enum(["true", "false"]),
 });
 
+export const ImportToggleAllSchema = z.object({
+	checked: z.enum(["true", "false"]),
+});
+
 export const MAX_IMPORT_FILE_BYTES = 5 * 1024 * 1024;
 export const MAX_URLS_PER_IMPORT = 2_000;
 export const IMPORT_SESSION_TTL_SECONDS = 24 * 60 * 60;

--- a/projects/hutch/src/runtime/domain/import-session/import-session.types.ts
+++ b/projects/hutch/src/runtime/domain/import-session/import-session.types.ts
@@ -50,6 +50,12 @@ export type ToggleImportSelection = (params: {
 	checked: boolean;
 }) => Promise<void>;
 
+export type ToggleAllImportSelection = (params: {
+	id: ImportSessionId;
+	userId: UserId;
+	checked: boolean;
+}) => Promise<void>;
+
 export type DeleteImportSession = (params: {
 	id: ImportSessionId;
 	userId: UserId;
@@ -61,5 +67,6 @@ export interface ImportSessionStore {
 	loadImportSessionPage: LoadImportSessionPage;
 	loadAllImportSessionUrls: LoadAllImportSessionUrls;
 	toggleImportSelection: ToggleImportSelection;
+	toggleAllImportSelection: ToggleAllImportSelection;
 	deleteImportSession: DeleteImportSession;
 }

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -120,6 +120,22 @@ export function initDynamoDbImportSession(deps: {
 				},
 			});
 		},
+		toggleAllImportSelection: async ({ id, userId, checked }) => {
+			const row = await loadOwned(id, userId);
+			if (!row) return;
+			const next = checked
+				? []
+				: Array.from({ length: row.totalUrls }, (_v, i) => i);
+			await table.update({
+				Key: { sessionId: id },
+				ConditionExpression: "userId = :uid",
+				UpdateExpression: "SET deselected = :d",
+				ExpressionAttributeValues: {
+					":uid": userId,
+					":d": next,
+				},
+			});
+		},
 		deleteImportSession: async ({ id, userId }) => {
 			await table.delete({
 				Key: { sessionId: id },

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -26,9 +26,11 @@ const SessionRow = z.object({
 	truncated: z.boolean(),
 	urls: z.array(z.string()),
 	deselected: dynamoField(z.array(z.number().int())),
+	allDeselected: dynamoField(z.boolean()),
 });
 
 function toSession(row: z.infer<typeof SessionRow>): ImportSession {
+	const isAllDeselected = row.allDeselected ?? false;
 	return {
 		id: row.sessionId,
 		userId: row.userId,
@@ -37,7 +39,9 @@ function toSession(row: z.infer<typeof SessionRow>): ImportSession {
 		totalUrls: row.totalUrls,
 		totalFoundInFile: row.totalFoundInFile,
 		truncated: row.truncated,
-		deselected: new Set(row.deselected ?? []),
+		deselected: isAllDeselected
+			? new Set(Array.from({ length: row.totalUrls }, (_v, i) => i))
+			: new Set(row.deselected ?? []),
 	};
 }
 
@@ -76,6 +80,7 @@ export function initDynamoDbImportSession(deps: {
 					truncated,
 					urls: [...urls],
 					deselected: [],
+					allDeselected: false,
 				},
 			});
 			return {
@@ -107,32 +112,35 @@ export function initDynamoDbImportSession(deps: {
 		toggleImportSelection: async ({ id, userId, index, checked }) => {
 			const row = await loadOwned(id, userId);
 			if (!row) return;
-			const current = new Set<number>(row.deselected ?? []);
+			const isAllDeselected = row.allDeselected ?? false;
+			if (isAllDeselected && !checked) return;
+			const current = isAllDeselected
+				? new Set(Array.from({ length: row.totalUrls }, (_v, i) => i))
+				: new Set<number>(row.deselected ?? []);
 			if (checked) current.delete(index);
 			else current.add(index);
 			await table.update({
 				Key: { sessionId: id },
 				ConditionExpression: "userId = :uid",
-				UpdateExpression: "SET deselected = :d",
+				UpdateExpression: "SET deselected = :d, allDeselected = :a",
 				ExpressionAttributeValues: {
 					":uid": userId,
 					":d": Array.from(current),
+					":a": false,
 				},
 			});
 		},
 		toggleAllImportSelection: async ({ id, userId, checked }) => {
 			const row = await loadOwned(id, userId);
 			if (!row) return;
-			const next = checked
-				? []
-				: Array.from({ length: row.totalUrls }, (_v, i) => i);
 			await table.update({
 				Key: { sessionId: id },
 				ConditionExpression: "userId = :uid",
-				UpdateExpression: "SET deselected = :d",
+				UpdateExpression: "SET deselected = :d, allDeselected = :a",
 				ExpressionAttributeValues: {
 					":uid": userId,
-					":d": next,
+					":d": [],
+					":a": !checked,
 				},
 			});
 		},

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -26,11 +26,11 @@ const SessionRow = z.object({
 	truncated: z.boolean(),
 	urls: z.array(z.string()),
 	deselected: dynamoField(z.array(z.number().int())),
-	allDeselected: dynamoField(z.boolean()),
+	allSelected: dynamoField(z.boolean()),
 });
 
 function toSession(row: z.infer<typeof SessionRow>): ImportSession {
-	const isAllDeselected = row.allDeselected ?? false;
+	const allSelected = row.allSelected ?? true;
 	return {
 		id: row.sessionId,
 		userId: row.userId,
@@ -39,9 +39,9 @@ function toSession(row: z.infer<typeof SessionRow>): ImportSession {
 		totalUrls: row.totalUrls,
 		totalFoundInFile: row.totalFoundInFile,
 		truncated: row.truncated,
-		deselected: isAllDeselected
-			? new Set(Array.from({ length: row.totalUrls }, (_v, i) => i))
-			: new Set(row.deselected ?? []),
+		deselected: allSelected
+			? new Set(row.deselected ?? [])
+			: new Set(Array.from({ length: row.totalUrls }, (_v, i) => i)),
 	};
 }
 
@@ -80,7 +80,7 @@ export function initDynamoDbImportSession(deps: {
 					truncated,
 					urls: [...urls],
 					deselected: [],
-					allDeselected: false,
+					allSelected: true,
 				},
 			});
 			return {
@@ -112,21 +112,21 @@ export function initDynamoDbImportSession(deps: {
 		toggleImportSelection: async ({ id, userId, index, checked }) => {
 			const row = await loadOwned(id, userId);
 			if (!row) return;
-			const isAllDeselected = row.allDeselected ?? false;
-			if (isAllDeselected && !checked) return;
-			const current = isAllDeselected
-				? new Set(Array.from({ length: row.totalUrls }, (_v, i) => i))
-				: new Set<number>(row.deselected ?? []);
+			const allSelected = row.allSelected ?? true;
+			if (!allSelected && !checked) return;
+			const current = allSelected
+				? new Set<number>(row.deselected ?? [])
+				: new Set(Array.from({ length: row.totalUrls }, (_v, i) => i));
 			if (checked) current.delete(index);
 			else current.add(index);
 			await table.update({
 				Key: { sessionId: id },
 				ConditionExpression: "userId = :uid",
-				UpdateExpression: "SET deselected = :d, allDeselected = :a",
+				UpdateExpression: "SET deselected = :d, allSelected = :a",
 				ExpressionAttributeValues: {
 					":uid": userId,
 					":d": Array.from(current),
-					":a": false,
+					":a": true,
 				},
 			});
 		},
@@ -136,11 +136,11 @@ export function initDynamoDbImportSession(deps: {
 			await table.update({
 				Key: { sessionId: id },
 				ConditionExpression: "userId = :uid",
-				UpdateExpression: "SET deselected = :d, allDeselected = :a",
+				UpdateExpression: "SET deselected = :d, allSelected = :a",
 				ExpressionAttributeValues: {
 					":uid": userId,
 					":d": [],
-					":a": !checked,
+					":a": checked,
 				},
 			});
 		},

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
@@ -82,6 +82,56 @@ describe("initInMemoryImportSession", () => {
 		expect(reset.deselected.size).toBe(0);
 	});
 
+	it("deselects every row via toggleAllImportSelection({ checked: false })", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
+			truncated: false,
+			totalFoundInFile: 3,
+		});
+
+		await store.toggleAllImportSelection({ id: session.id, userId: owner, checked: false });
+
+		const after = await store.findImportSession({ id: session.id, userId: owner });
+		assert(after, "session must exist after bulk toggle");
+		expect([...after.deselected].sort()).toEqual([0, 1, 2]);
+	});
+
+	it("re-selects every row via toggleAllImportSelection({ checked: true })", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a", "https://example.com/b"],
+			truncated: false,
+			totalFoundInFile: 2,
+		});
+		await store.toggleImportSelection({ id: session.id, userId: owner, index: 0, checked: false });
+		await store.toggleImportSelection({ id: session.id, userId: owner, index: 1, checked: false });
+
+		await store.toggleAllImportSelection({ id: session.id, userId: owner, checked: true });
+
+		const after = await store.findImportSession({ id: session.id, userId: owner });
+		assert(after, "session must exist after bulk toggle");
+		expect(after.deselected.size).toBe(0);
+	});
+
+	it("ignores bulk toggles from a non-owner", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a", "https://example.com/b"],
+			truncated: false,
+			totalFoundInFile: 2,
+		});
+
+		await store.toggleAllImportSelection({ id: session.id, userId: otherUser, checked: false });
+
+		const after = await store.findImportSession({ id: session.id, userId: owner });
+		assert(after, "session must still exist");
+		expect(after.deselected.size).toBe(0);
+	});
+
 	it("ignores toggles from a non-owner", async () => {
 		const store = initInMemoryImportSession({ now: () => new Date() });
 		const session = await store.createImportSession({

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.test.ts
@@ -116,6 +116,23 @@ describe("initInMemoryImportSession", () => {
 		expect(after.deselected.size).toBe(0);
 	});
 
+	it("re-selects one row after bulk deselect", async () => {
+		const store = initInMemoryImportSession({ now: () => new Date() });
+		const session = await store.createImportSession({
+			userId: owner,
+			urls: ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
+			truncated: false,
+			totalFoundInFile: 3,
+		});
+
+		await store.toggleAllImportSelection({ id: session.id, userId: owner, checked: false });
+		await store.toggleImportSelection({ id: session.id, userId: owner, index: 1, checked: true });
+
+		const after = await store.findImportSession({ id: session.id, userId: owner });
+		assert(after, "session must exist");
+		expect([...after.deselected].sort()).toEqual([0, 2]);
+	});
+
 	it("ignores bulk toggles from a non-owner", async () => {
 		const store = initInMemoryImportSession({ now: () => new Date() });
 		const session = await store.createImportSession({

--- a/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/in-memory-import-session.ts
@@ -73,6 +73,15 @@ export function initInMemoryImportSession(deps: {
 				row.deselected.add(index);
 			}
 		},
+		toggleAllImportSelection: async ({ id, userId, checked }) => {
+			const row = load(id, userId);
+			if (!row) return;
+			if (checked) {
+				row.deselected.clear();
+			} else {
+				for (let i = 0; i < row.session.totalUrls; i++) row.deselected.add(i);
+			}
+		},
 		deleteImportSession: async ({ id, userId }) => {
 			const row = load(id, userId);
 			if (row) sessions.delete(id);

--- a/projects/hutch/src/runtime/web/pages/import/import.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.client.test.ts
@@ -1,0 +1,54 @@
+import { JSDOM } from "jsdom";
+import {
+	applyIndeterminate,
+	initIndeterminateCheckboxes,
+} from "./import.client";
+
+function makeDoc(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
+}
+
+describe("applyIndeterminate", () => {
+	it("sets the indeterminate property on every checkbox carrying the marker", () => {
+		const doc = makeDoc(
+			'<input type="checkbox" data-import-indeterminate id="a">' +
+				'<input type="checkbox" data-import-indeterminate id="b">' +
+				'<input type="checkbox" id="c">',
+		);
+
+		const matched = applyIndeterminate(doc);
+
+		expect(matched).toBe(2);
+		expect(doc.querySelector<HTMLInputElement>("#a")?.indeterminate).toBe(true);
+		expect(doc.querySelector<HTMLInputElement>("#b")?.indeterminate).toBe(true);
+		expect(doc.querySelector<HTMLInputElement>("#c")?.indeterminate).toBe(false);
+	});
+
+	it("returns 0 when no checkbox carries the marker", () => {
+		const doc = makeDoc('<input type="checkbox" id="a">');
+
+		expect(applyIndeterminate(doc)).toBe(0);
+	});
+});
+
+describe("initIndeterminateCheckboxes", () => {
+	it("applies indeterminate on initial run and on every swap notification", () => {
+		const doc = makeDoc('<input type="checkbox" data-import-indeterminate id="a">');
+		let registered: (() => void) | undefined;
+
+		initIndeterminateCheckboxes({
+			document: doc,
+			addSwapListener: (listener) => {
+				registered = listener;
+			},
+		});
+
+		const target = doc.querySelector<HTMLInputElement>("#a");
+		expect(target?.indeterminate).toBe(true);
+
+		// Reset to false then re-run via the swap listener and confirm it re-applies.
+		if (target) target.indeterminate = false;
+		registered?.();
+		expect(target?.indeterminate).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/import/import.client.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.client.ts
@@ -1,0 +1,39 @@
+/**
+ * The HTML `indeterminate` state cannot be set via attribute — it is a JS-only
+ * property on HTMLInputElement (see MDN: HTMLInputElement.indeterminate). The
+ * server marks the master checkbox with `data-import-indeterminate` whenever
+ * the import is partially selected; this module promotes that marker into the
+ * live `indeterminate` property on initial load and after every htmx swap of
+ * <main>, since the swapped-in DOM nodes don't carry runtime properties.
+ */
+
+interface IndeterminateCheckbox {
+	indeterminate: boolean;
+}
+
+interface IndeterminateRoot {
+	querySelectorAll(selector: string): ArrayLike<IndeterminateCheckbox>;
+}
+
+export function applyIndeterminate(root: IndeterminateRoot): number {
+	const matches = root.querySelectorAll(
+		'input[type="checkbox"][data-import-indeterminate]',
+	);
+	for (let i = 0; i < matches.length; i += 1) {
+		matches[i].indeterminate = true;
+	}
+	return matches.length;
+}
+
+interface IndeterminateDeps {
+	document: IndeterminateRoot;
+	addSwapListener: (listener: () => void) => void;
+}
+
+export function initIndeterminateCheckboxes(deps: IndeterminateDeps): void {
+	const run = (): void => {
+		applyIndeterminate(deps.document);
+	};
+	deps.addSwapListener(run);
+	run();
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -6,6 +6,7 @@ import { IMPORT_STYLES } from "./import.styles";
 import type { ImportViewModel } from "./import.viewmodel";
 
 const IMPORT_TEMPLATE = readFileSync(join(__dirname, "import.template.html"), "utf-8");
+const IMPORT_CLIENT_SCRIPT = `<script src="/client-dist/import.client.js" defer></script>`;
 
 export function ImportPage(vm: ImportViewModel): PageBody {
 	const content = render(IMPORT_TEMPLATE, {
@@ -25,5 +26,6 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 		styles: IMPORT_STYLES,
 		bodyClass: "page-import",
 		content,
+		scripts: IMPORT_CLIENT_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -6,6 +6,7 @@ import {
 	IMPORT_COMMIT_CONCURRENCY,
 	IMPORT_PAGE_SIZE,
 	ImportSessionIdSchema,
+	ImportToggleAllSchema,
 	ImportToggleSchema,
 	MAX_IMPORT_FILE_BYTES,
 } from "../../../domain/import-session/import-session.schema";
@@ -98,6 +99,25 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			id: parsedId.data,
 			userId: req.userId,
 			index: parsedBody.data.index,
+			checked: parsedBody.data.checked === "true",
+		});
+
+		const page = parseImportPage(req.query);
+		res.redirect(303, page > 1 ? `/import/${parsedId.data}?page=${page}` : `/import/${parsedId.data}`);
+	});
+
+	router.post("/:id/toggle-all", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
+		const parsedBody = ImportToggleAllSchema.safeParse(req.body);
+		if (!parsedId.success || !parsedBody.success) {
+			res.status(422).send("");
+			return;
+		}
+
+		await deps.importSessionStore.toggleAllImportSelection({
+			id: parsedId.data,
+			userId: req.userId,
 			checked: parsedBody.data.checked === "true",
 		});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -229,6 +229,178 @@ describe("Import routes", () => {
 		});
 	});
 
+	describe("GET /import/:id master checkbox", () => {
+		it("renders the master checkbox checked when every row is selected", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from("https://example.com/a https://example.com/b");
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+
+			const response = await agent.get(create.headers.location);
+
+			const doc = new JSDOM(response.text).window.document;
+			const master = doc.querySelector<HTMLInputElement>("[data-test-import-select-all]");
+			assert(master, "master checkbox must exist");
+			expect(master.hasAttribute("checked")).toBe(true);
+			expect(master.hasAttribute("data-import-indeterminate")).toBe(false);
+		});
+
+		it("renders the master checkbox unchecked-with-indeterminate when partially selected", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from("https://example.com/a https://example.com/b");
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+			await agent
+				.post(`${sessionPath}/toggle`)
+				.type("form")
+				.send({ index: 0, checked: "false" });
+
+			const response = await agent.get(sessionPath);
+
+			const doc = new JSDOM(response.text).window.document;
+			const master = doc.querySelector<HTMLInputElement>("[data-test-import-select-all]");
+			assert(master, "master checkbox must exist");
+			expect(master.hasAttribute("checked")).toBe(false);
+			expect(master.hasAttribute("data-import-indeterminate")).toBe(true);
+		});
+
+		it("renders the master checkbox unchecked with no indeterminate marker when all are deselected", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from("https://example.com/a https://example.com/b");
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+			await agent.post(`${sessionPath}/toggle-all`).type("form").send({ checked: "false" });
+
+			const response = await agent.get(sessionPath);
+
+			const doc = new JSDOM(response.text).window.document;
+			const master = doc.querySelector<HTMLInputElement>("[data-test-import-select-all]");
+			assert(master, "master checkbox must exist");
+			expect(master.hasAttribute("checked")).toBe(false);
+			expect(master.hasAttribute("data-import-indeterminate")).toBe(false);
+		});
+	});
+
+	describe("POST /import/:id/toggle-all", () => {
+		it("deselects every row and updates the summary to 0 of N", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from("https://example.com/a https://example.com/b https://example.com/c");
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+
+			const toggleResp = await agent
+				.post(`${sessionPath}/toggle-all`)
+				.type("form")
+				.send({ checked: "false" });
+			expect(toggleResp.status).toBe(303);
+
+			const review = await agent.get(sessionPath);
+			const doc = new JSDOM(review.text).window.document;
+			const checkboxes = doc.querySelectorAll<HTMLInputElement>("[data-test-import-checkbox]");
+			expect(checkboxes).toHaveLength(3);
+			for (const cb of checkboxes) {
+				expect(cb.hasAttribute("checked")).toBe(false);
+			}
+			expect(doc.querySelector("[data-test-import-summary]")?.textContent).toContain("0 of 3 selected");
+		});
+
+		it("re-selects every row from a partially-deselected state", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const file = Buffer.from("https://example.com/a https://example.com/b");
+			const { body, contentType } = multipartBody("urls.txt", file);
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+			await agent
+				.post(`${sessionPath}/toggle`)
+				.type("form")
+				.send({ index: 0, checked: "false" });
+
+			const toggleResp = await agent
+				.post(`${sessionPath}/toggle-all`)
+				.type("form")
+				.send({ checked: "true" });
+			expect(toggleResp.status).toBe(303);
+
+			const review = await agent.get(sessionPath);
+			const doc = new JSDOM(review.text).window.document;
+			const checkboxes = doc.querySelectorAll<HTMLInputElement>("[data-test-import-checkbox]");
+			for (const cb of checkboxes) {
+				expect(cb.hasAttribute("checked")).toBe(true);
+			}
+			expect(doc.querySelector("[data-test-import-summary]")?.textContent).toContain("2 of 2 selected");
+		});
+
+		it("deselects rows on pages the user is not currently viewing", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
+			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+
+			await agent.post(`${sessionPath}/toggle-all`).type("form").send({ checked: "false" });
+
+			const page2 = await agent.get(`${sessionPath}?page=2`);
+			const doc2 = new JSDOM(page2.text).window.document;
+			const page2Checkboxes = doc2.querySelectorAll<HTMLInputElement>("[data-test-import-checkbox]");
+			expect(page2Checkboxes).toHaveLength(10);
+			for (const cb of page2Checkboxes) {
+				expect(cb.hasAttribute("checked")).toBe(false);
+			}
+		});
+
+		it("preserves the current page in the redirect", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
+			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+
+			const toggleResp = await agent
+				.post(`${sessionPath}/toggle-all?page=2`)
+				.type("form")
+				.send({ checked: "false" });
+
+			expect(toggleResp.status).toBe(303);
+			expect(toggleResp.headers.location).toBe(`${sessionPath}?page=2`);
+		});
+
+		it("returns 422 for malformed body", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/a"));
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+
+			const response = await agent
+				.post(`${create.headers.location}/toggle-all`)
+				.type("form")
+				.send({ checked: "maybe" });
+
+			expect(response.status).toBe(422);
+		});
+
+		it("returns 422 for an invalid session id format", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent
+				.post("/import/not-an-id/toggle-all")
+				.type("form")
+				.send({ checked: "false" });
+
+			expect(response.status).toBe(422);
+		});
+	});
+
 	describe("POST /import/:id/commit", () => {
 		it("imports selected URLs into the user's queue and deletes the session", async () => {
 			const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.css
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.css
@@ -1,6 +1,8 @@
 .import { max-width: 800px; margin: 0 auto; padding: 1.5rem; }
 .import__title { font-size: 1.5rem; margin: 0 0 0.5rem; }
 .import__summary { color: var(--muted-foreground); margin: 0 0 1rem; }
+.import__select-all { margin: 0 0 1rem; }
+.import__select-all-label { display: flex; align-items: center; gap: 0.75rem; cursor: pointer; }
 .import__truncated-banner { background: var(--color-brand-light); border: 1px solid var(--color-warning); padding: 0.75rem 1rem; border-radius: var(--radius-sm); margin: 0 0 1rem; }
 .import__commit-form { margin: 1rem 0; }
 .import__commit-btn {

--- a/projects/hutch/src/runtime/web/pages/import/import.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.template.html
@@ -1,6 +1,20 @@
     <main class="import">
       <h1 class="import__title">Review imported links</h1>
-      <p class="import__summary" data-test-import-summary>{{totalSelected}} of {{totalUrls}} selected</p>
+      <form method="POST" action="{{toggleAllUrl}}" class="import__select-all"
+            hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none"
+            data-test-form="import-toggle-all">
+        <input type="hidden" name="checked" value="{{#if allSelected}}false{{else}}true{{/if}}">
+        <label class="import__select-all-label">
+          <input type="checkbox"
+                 name="confirm"
+                 {{#if allSelected}}checked{{/if}}
+                 {{#if someSelected}}data-import-indeterminate{{/if}}
+                 onclick="this.form.requestSubmit()"
+                 data-test-import-select-all>
+          <span class="import__summary" data-test-import-summary>{{totalSelected}} of {{totalUrls}} selected</span>
+        </label>
+        <noscript><button type="submit" class="import__row-toggle-btn">Toggle all</button></noscript>
+      </form>
       {{#if truncated}}
       <p class="import__truncated-banner" data-test-import-truncated>Your file contained {{totalFoundInFile}} links. We&rsquo;ve imported the first {{totalUrls}}.</p>
       {{/if}}

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -84,6 +84,46 @@ describe("toImportViewModel", () => {
 		expect(vm.rows.map((r) => r.index)).toEqual([50, 51]);
 	});
 
+	it("flags the master checkbox as fully selected when nothing is deselected", () => {
+		const session = makeSession({ totalUrls: 3 });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: [], page: 1, pageSize: 50 },
+			3,
+		);
+
+		expect(vm.allSelected).toBe(true);
+		expect(vm.noneSelected).toBe(false);
+		expect(vm.someSelected).toBe(false);
+		expect(vm.toggleAllUrl).toBe(`/import/${session.id}/toggle-all`);
+	});
+
+	it("flags the master checkbox as fully deselected when every row is deselected", () => {
+		const session = makeSession({ totalUrls: 2, deselected: new Set([0, 1]) });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: [], page: 1, pageSize: 50 },
+			0,
+		);
+
+		expect(vm.allSelected).toBe(false);
+		expect(vm.noneSelected).toBe(true);
+		expect(vm.someSelected).toBe(false);
+	});
+
+	it("flags the master checkbox as partially selected (indeterminate) when some are deselected", () => {
+		const session = makeSession({ totalUrls: 3, deselected: new Set([1]) });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: [], page: 1, pageSize: 50 },
+			2,
+		);
+
+		expect(vm.allSelected).toBe(false);
+		expect(vm.noneSelected).toBe(false);
+		expect(vm.someSelected).toBe(true);
+	});
+
 	it("propagates the truncated flag and totalFoundInFile from the session header", () => {
 		const session = makeSession({ totalUrls: 2_000, totalFoundInFile: 2_345, truncated: true });
 

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -20,6 +20,10 @@ export interface ImportViewModel {
 	readonly nextUrl?: string;
 	readonly commitUrl: string;
 	readonly toggleUrl: string;
+	readonly toggleAllUrl: string;
+	readonly allSelected: boolean;
+	readonly noneSelected: boolean;
+	readonly someSelected: boolean;
 }
 
 export function toImportViewModel(
@@ -30,6 +34,8 @@ export function toImportViewModel(
 	const totalPages = Math.max(1, Math.ceil(session.totalUrls / pageSize));
 	const start = (page - 1) * pageSize;
 	const sessionId = session.id;
+	const allSelected = totalSelected === session.totalUrls;
+	const noneSelected = totalSelected === 0;
 	return {
 		sessionId,
 		rows: pageUrls.map((url, i) => {
@@ -50,5 +56,9 @@ export function toImportViewModel(
 		nextUrl: page < totalPages ? buildImportUrl(sessionId, page + 1) : undefined,
 		commitUrl: `/import/${sessionId}/commit`,
 		toggleUrl: `/import/${sessionId}/toggle`,
+		toggleAllUrl: `/import/${sessionId}/toggle-all`,
+		allSelected,
+		noneSelected,
+		someSelected: !allSelected && !noneSelected,
 	};
 }


### PR DESCRIPTION
## Summary
This PR adds a "select all" master checkbox to the import review page that allows users to quickly select or deselect all imported URLs at once. The checkbox displays three states: fully selected, fully deselected, and partially selected (indeterminate).

## Key Changes

- **New Route**: Added `POST /import/:id/toggle-all` endpoint to handle bulk selection/deselection of all import rows
- **Store Implementation**: Implemented `toggleAllImportSelection` method in both in-memory and DynamoDB import session stores
- **UI Components**: 
  - Added master checkbox form in the import template with proper state indicators
  - Created client-side module (`import.client.ts`) to handle the HTML5 `indeterminate` property, which cannot be set via attributes
  - Updated view model to track selection states (`allSelected`, `noneSelected`, `someSelected`)
- **Styling**: Added CSS classes for the select-all form and label layout
- **Validation**: Added `ImportToggleAllSchema` for request body validation
- **Client Bundle**: Configured esbuild to bundle and auto-initialize the indeterminate checkbox handler

## Implementation Details

- The master checkbox state is determined by comparing total selected items against total URLs
- The indeterminate state is applied via JavaScript since HTML attributes cannot represent this state
- The client-side handler re-applies indeterminate state after htmx swaps to maintain the property on newly-inserted DOM nodes
- Bulk toggle operations preserve the current page number in redirects
- All operations include proper authorization checks (userId validation)
- Comprehensive test coverage for all three checkbox states and edge cases (pagination, malformed requests, etc.)

https://claude.ai/code/session_01LtAopXzBNVgMrZj1tPhQpB