### PR TITLE
Implement founding member free tier with 100-user limit

### DIFF
--- a/projects/hutch/src/runtime/providers/auth/in-memory-auth.ts
+++ b/projects/hutch/src/runtime/providers/auth/in-memory-auth.ts
@@ -49,6 +49,7 @@ export function initInMemoryAuth(): {
 	userExistsByEmail: UserExistsByEmail;
 	updatePassword: UpdatePassword;
 	findEmailByUserId: FindEmailByUserId;
+	deleteUser: (email: string) => Promise<void>;
 } {
 	const users = new Map<string, StoredUser>();
 	const sessions = new Map<string, StoredSession>();
@@ -190,6 +191,10 @@ export function initInMemoryAuth(): {
 		user.passwordHash = await hashPassword(password);
 	};
 
+	const deleteUser = async (email: string): Promise<void> => {
+		users.delete(normalizeEmail(email));
+	};
+
 	return {
 		createUser,
 		createUserWithPasswordHash,
@@ -205,5 +210,6 @@ export function initInMemoryAuth(): {
 		userExistsByEmail,
 		updatePassword,
 		findEmailByUserId,
+		deleteUser,
 	};
 }

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -1,6 +1,7 @@
 /* c8 ignore start -- thin Stripe API wrapper, tested via integration */
 import { z } from "zod";
 import { CheckoutSessionIdSchema } from "./stripe-checkout.schema";
+import { STRIPE_TRIAL_PERIOD_DAYS } from "./stripe-trial-config";
 import type {
 	CreateCheckoutSession,
 	RetrieveCheckoutSession,
@@ -46,7 +47,7 @@ export function initStripeCheckout(deps: {
 			mode: "subscription",
 			"line_items[0][price]": deps.priceId,
 			"line_items[0][quantity]": "1",
-			"subscription_data[trial_period_days]": "14",
+			"subscription_data[trial_period_days]": String(STRIPE_TRIAL_PERIOD_DAYS),
 			customer_email: customerEmail,
 			success_url: successUrl,
 			cancel_url: cancelUrl,

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-trial-config.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-trial-config.ts
@@ -1,0 +1,1 @@
+export const STRIPE_TRIAL_PERIOD_DAYS = 14;

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -403,13 +403,17 @@ export function createApp(dependencies: AppDependencies): Express {
 			googleClientId: deps.googleAuth.clientId,
 			googleClientSecret: deps.googleAuth.clientSecret,
 			appOrigin,
+			baseUrl: deps.baseUrl,
+			staticBaseUrl,
 			createSession: deps.createSession,
+			createGoogleUser: deps.createGoogleUser,
 			findUserByEmail: deps.findUserByEmail,
 			countUsers,
 			markEmailVerified: deps.markEmailVerified,
 			exchangeGoogleCode: deps.googleAuth.exchangeGoogleCode,
 			createCheckoutSession: deps.createCheckoutSession,
 			storePendingSignup: deps.storePendingSignup,
+			sendEmail: deps.sendEmail,
 			logError: deps.logError,
 		});
 		app.use(googleAuthRouter);

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -101,6 +101,7 @@ export interface AuthBundle {
 	userExistsByEmail: UserExistsByEmail;
 	updatePassword: UpdatePassword;
 	findEmailByUserId: FindEmailByUserId;
+	deleteUser: (email: string) => Promise<void>;
 }
 
 export interface StripeCheckoutBundle {

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import type { PageBody } from "../page-body.types";
 import { render } from "../render";
 import { renderFoundingProgress } from "../shared/founding-progress/founding-progress.component";
+import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
+import { STRIPE_TRIAL_PERIOD_DAYS } from "../../providers/stripe-checkout/stripe-trial-config";
 import { AUTH_STYLES } from "./auth.styles";
 
 const LOGIN_TEMPLATE = readFileSync(join(__dirname, "login.template.html"), "utf-8");
@@ -89,6 +91,9 @@ export function VerifyEmailPage(data: { success: boolean; error?: string }): Pag
 export function SignupPage(data: SignupFormData, options?: { statusCode?: number }): PageBody {
 	const email = data.email ?? "";
 	const errors = data.errors;
+	const trialSuffix = isFoundingAllocationExhausted(data.userCount)
+		? ` (${STRIPE_TRIAL_PERIOD_DAYS} days free)`
+		: "";
 
 	const content = render(SIGNUP_TEMPLATE, {
 		email,
@@ -98,6 +103,8 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		emailField: toFieldViewModel(errors, "email"),
 		passwordField: toFieldViewModel(errors, "password"),
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
+		submitLabel: `Join Readplace${trialSuffix}`,
+		googleLabel: `Sign up with Google${trialSuffix}`,
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
 		}),

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -40,6 +40,7 @@ import { buildVerificationEmailHtml } from "./verification-email";
 import { buildWelcomeEmailHtml } from "./welcome-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
+import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
@@ -320,6 +321,34 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 
 		const passwordHash = await hashPassword(password);
+
+		const userCount = await fetchUserCount();
+		if (!isFoundingAllocationExhausted(userCount)) {
+			const created = await deps.createUserWithPasswordHash({ email, passwordHash });
+			if (!created.ok) {
+				const refreshedCount = await fetchUserCount();
+				sendComponent(
+					res,
+					renderPage(req, SignupPage(
+						{
+							returnUrl,
+							userCount: refreshedCount,
+							loadedAt: deps.now().getTime(),
+							email,
+							globalError: "An account with this email already exists",
+						},
+						{ statusCode: 422 },
+					)),
+				);
+				return;
+			}
+
+			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
+			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			sendVerificationEmail(created.userId, email);
+			res.redirect(303, parseReturnUrl({ return: returnUrl }));
+			return;
+		}
 
 		const checkout = await deps.createCheckoutSession({
 			customerEmail: email,

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -37,16 +37,15 @@ import { LoginPage, SignupPage, VerifyEmailPage } from "./auth.component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
 import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "./session-cookie";
 import { buildVerificationEmailHtml } from "./verification-email";
-import { buildWelcomeEmailHtml } from "./welcome-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
+import { initSendWelcomeEmail } from "./send-welcome-email";
 import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
-const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
 
 const SIGNUP_MIN_SUBMIT_MS = 2500;
 
@@ -152,19 +151,12 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		return `${deps.appOrigin}${path}${suffix}`;
 	};
 
-	const sendWelcomeEmail = (email: string): void => {
-		const installUrl = `${deps.baseUrl}/install`;
-		const avatarUrl = `${deps.staticBaseUrl}/fayner-brack.jpg`;
-		deps.sendEmail({
-			from: WELCOME_EMAIL_FROM,
-			to: email,
-			bcc: "readplace+welcome@readplace.com",
-			subject: "Welcome to Readplace",
-			html: buildWelcomeEmailHtml({ installUrl, avatarUrl }),
-		}).catch((err) => {
-			deps.logError("[Email] Welcome email failed", err instanceof Error ? err : new Error(String(err)));
-		});
-	};
+	const sendWelcomeEmail = initSendWelcomeEmail({
+		sendEmail: deps.sendEmail,
+		baseUrl: deps.baseUrl,
+		staticBaseUrl: deps.staticBaseUrl,
+		logError: deps.logError,
+	});
 
 	const sendVerificationEmail = (userId: UserId, email: string): void => {
 		deps.createVerificationToken({ userId, email })

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -259,8 +259,91 @@ describe("Auth routes", () => {
 	});
 
 	describe("POST /signup", () => {
-		it("should redirect new visitors to a Stripe checkout URL", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		it("should create the account directly and redirect to /queue when at or below the founding limit", async () => {
+			const { app, auth, pendingSignup } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			for (let i = 0; i < 100; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "free@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+			expect(response.headers["set-cookie"].length).toBeGreaterThan(0);
+
+			const lookup = await auth.findUserByEmail("free@example.com");
+			assert(lookup, "free signup must persist a user");
+			expect(lookup.emailVerified).toBe(false);
+
+			const consumed = await pendingSignup.consumePendingSignup(
+				CheckoutSessionIdSchema.parse("cs_test_never_created"),
+			);
+			expect(consumed).toBeNull();
+		}, 30000);
+
+		it("should redirect to Stripe checkout when over the founding limit", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			for (let i = 0; i < 101; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "paid@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
+		}, 30000);
+
+		it("should fall back to free signup after a manual deletion drops the count back to the limit", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			for (let i = 0; i < 102; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+			await auth.deleteUser("seed0@test.com");
+			await auth.deleteUser("seed1@test.com");
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "after-delete@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+		}, 30000);
+
+		it("should send the email verification email on free signup", async () => {
+			const { app, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "verify-free@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(303);
+			const sent = email.getSentEmails();
+			const verification = sent.find((m) => m.to === "verify-free@example.com");
+			assert(verification, "verification email must be sent on free signup");
+			expect(verification.subject).toBe("Verify your email — Readplace");
+		});
+
+		it("should redirect new visitors to a Stripe checkout URL when over the founding limit", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			for (let i = 0; i < 101; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
 
 			const response = await request(app).post("/signup").type("form").send({
 				email: "new@example.com",
@@ -271,13 +354,14 @@ describe("Auth routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
-		});
+		}, 30000);
 
 		it("should create the account on successful Stripe checkout and redirect to /queue", async () => {
-			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "new@example.com",
 				password: "password123",
@@ -286,13 +370,14 @@ describe("Auth routes", () => {
 			expect(successResponse.status).toBe(303);
 			expect(successResponse.headers.location).toBe("/queue");
 			expect(successResponse.headers["set-cookie"].length).toBeGreaterThan(0);
-		});
+		}, 30000);
 
 		it("should redirect to return URL after successful Stripe checkout", async () => {
-			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "new@example.com",
 				password: "password123",
@@ -301,13 +386,14 @@ describe("Auth routes", () => {
 
 			expect(successResponse.status).toBe(303);
 			expect(successResponse.headers.location).toBe("/oauth/authorize?client_id=test");
-		});
+		}, 30000);
 
 		it("should ignore protocol-relative return URLs on signup", async () => {
-			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "new@example.com",
 				password: "password123",
@@ -316,13 +402,14 @@ describe("Auth routes", () => {
 
 			expect(successResponse.status).toBe(303);
 			expect(successResponse.headers.location).toBe("/queue");
-		});
+		}, 30000);
 
 		it("should ignore non-relative return URLs on signup", async () => {
-			const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "new@example.com",
 				password: "password123",
@@ -331,7 +418,7 @@ describe("Auth routes", () => {
 
 			expect(successResponse.status).toBe(303);
 			expect(successResponse.headers.location).toBe("/queue");
-		});
+		}, 30000);
 
 		it("should show error for duplicate email", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -585,8 +672,11 @@ describe("Auth routes", () => {
 			expect(consumed).toBeNull();
 		});
 
-		it("falls through to the existing happy path (303 to Stripe) when the honeypot is empty and loadedAt is older than 2.5s", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		it("falls through to the existing happy path (303 to Stripe) when the honeypot is empty, loadedAt is older than 2.5s, and the founding allocation is exhausted", async () => {
+			const { app, auth, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			for (let i = 0; i < 101; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
 
 			const response = await request(app).post("/signup").type("form").send({
 				email: "real@example.com",
@@ -599,7 +689,7 @@ describe("Auth routes", () => {
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
 			expect(botDefense.events).toEqual([]);
-		});
+		}, 30000);
 	});
 
 	describe("GET /verify-email", () => {

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -259,9 +259,9 @@ describe("Auth routes", () => {
 	});
 
 	describe("POST /signup", () => {
-		it("should create the account directly and redirect to /queue when at or below the founding limit", async () => {
+		it("should create the account directly and redirect to /queue when below the founding limit", async () => {
 			const { app, auth, pendingSignup } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < 100; i++) {
+			for (let i = 0; i < 99; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -286,9 +286,9 @@ describe("Auth routes", () => {
 			expect(consumed).toBeNull();
 		}, 30000);
 
-		it("should redirect to Stripe checkout when over the founding limit", async () => {
+		it("should redirect to Stripe checkout when at the founding limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -303,9 +303,9 @@ describe("Auth routes", () => {
 			expect(response.headers.location).toMatch(/^https:\/\/checkout\.stripe\.test\//);
 		}, 30000);
 
-		it("should fall back to free signup after a manual deletion drops the count back to the limit", async () => {
+		it("should fall back to free signup after a manual deletion drops the count below the limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < 102; i++) {
+			for (let i = 0; i < 101; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			await auth.deleteUser("seed0@test.com");
@@ -369,9 +369,9 @@ describe("Auth routes", () => {
 			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("already exists");
 		});
 
-		it("should redirect new visitors to a Stripe checkout URL when over the founding limit", async () => {
+		it("should redirect new visitors to a Stripe checkout URL when at the founding limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -704,7 +704,7 @@ describe("Auth routes", () => {
 
 		it("falls through to the existing happy path (303 to Stripe) when the honeypot is empty, loadedAt is older than 2.5s, and the founding allocation is exhausted", async () => {
 			const { app, auth, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -878,9 +878,9 @@ describe("Auth routes", () => {
 	});
 
 	describe("Founding members progress — exhausted allocation", () => {
-		it("should render the exhausted message on /signup when over the limit", async () => {
+		it("should render the exhausted message on /signup when at the limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 			}
 

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -339,6 +339,36 @@ describe("Auth routes", () => {
 			expect(verification.subject).toBe("Verify your email — Readplace");
 		});
 
+		it("should show duplicate-email error when a race condition causes createUserWithPasswordHash to fail during free signup", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			let raceFindCount = 0;
+			const { app } = createTestApp({
+				...fixture,
+				auth: {
+					...fixture.auth,
+					findUserByEmail: async (email) => {
+						if (email === "race@example.com") {
+							raceFindCount++;
+							if (raceFindCount === 1) return null;
+						}
+						return fixture.auth.findUserByEmail(email);
+					},
+				},
+			});
+			await fixture.auth.createUser({ email: "race@example.com", password: "existing" });
+
+			const response = await request(app).post("/signup").type("form").send({
+				email: "race@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(422);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("already exists");
+		});
+
 		it("should redirect new visitors to a Stripe checkout URL when over the founding limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			for (let i = 0; i < 101; i++) {

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -8,7 +8,7 @@ import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 import { FOUNDING_MEMBER_LIMIT } from "../shared/founding-progress/founding-allocation";
 
 async function seedAboveFoundingLimit(auth: { createUser: (params: { email: string; password: string }) => Promise<{ ok: boolean }> }) {
-	for (let i = 0; i < FOUNDING_MEMBER_LIMIT + 1; i++) {
+	for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
 		await auth.createUser({ email: `gate-${i}@test.invalid`, password: "password123" });
 	}
 }

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -5,6 +5,13 @@ import { createTestApp } from "../../test-app";
 import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "../../test-app-fakes";
 import { CheckoutSessionIdSchema } from "../../providers/stripe-checkout/stripe-checkout.schema";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
+import { FOUNDING_MEMBER_LIMIT } from "../shared/founding-progress/founding-allocation";
+
+async function seedAboveFoundingLimit(auth: { createUser: (params: { email: string; password: string }) => Promise<{ ok: boolean }> }) {
+	for (let i = 0; i < FOUNDING_MEMBER_LIMIT + 1; i++) {
+		await auth.createUser({ email: `gate-${i}@test.invalid`, password: "password123" });
+	}
+}
 
 describe("GET /auth/checkout/success", () => {
 	it("renders an error and 400 when the session_id query param is missing", async () => {
@@ -28,7 +35,8 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("renders 402 when the checkout has not been paid yet", async () => {
-		const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		await seedAboveFoundingLimit(auth);
 
 		const signup = await request(app).post("/signup").type("form").send({
 			email: "unpaid@example.com",
@@ -52,10 +60,11 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("renders 409 when the checkout has been paid but the pending signup was already consumed", async () => {
-		const { app, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const { checkoutSessionId } = await completeStripeSignup({
 			app,
+			auth,
 			stripe,
 			email: "double@example.com",
 			password: "password123",
@@ -75,6 +84,7 @@ describe("GET /auth/checkout/success", () => {
 
 		const { successResponse } = await completeStripeSignup({
 			app,
+			auth,
 			stripe,
 			email: "buyer@example.com",
 			password: "password123",
@@ -97,6 +107,7 @@ describe("GET /auth/checkout/success", () => {
 
 	it("renders 409 when the email has been claimed since the Stripe redirect started", async () => {
 		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		await seedAboveFoundingLimit(auth);
 
 		const signup = await request(app).post("/signup").type("form").send({
 			email: "race@example.com",

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -24,10 +24,11 @@ import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 describe("Email verification", () => {
 	describe("POST /signup → Stripe → success", () => {
 		it("should send a verification email after successful Stripe checkout", async () => {
-			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "new@example.com",
 				password: "password123",
@@ -97,6 +98,7 @@ describe("Email verification", () => {
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "fail-email@example.com",
 				password: "password123",
@@ -123,10 +125,11 @@ describe("Email verification", () => {
 
 	describe("GET /verify-email", () => {
 		it("should verify email with a valid token", async () => {
-			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "verify@example.com",
 				password: "password123",
@@ -165,10 +168,11 @@ describe("Email verification", () => {
 		});
 
 		it("should reject a token that has already been used", async () => {
-			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "once@example.com",
 				password: "password123",
@@ -192,6 +196,7 @@ describe("Email verification", () => {
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "flag@example.com",
 				password: "password123",
@@ -224,6 +229,7 @@ describe("Email verification", () => {
 
 			const { successResponse } = await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "noverify@example.com",
 				password: "password123",
@@ -243,10 +249,11 @@ describe("Email verification", () => {
 		});
 
 		it("should send a welcome email after successful verification", async () => {
-			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "welcome@example.com",
 				password: "password123",
@@ -271,10 +278,11 @@ describe("Email verification", () => {
 		});
 
 		it("should not send a welcome email when the verification token is invalid", async () => {
-			const { app, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			await completeStripeSignup({
 				app,
+				auth,
 				stripe,
 				email: "nowelcome@example.com",
 				password: "password123",

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -5,13 +5,17 @@ import { z } from "zod";
 import { UserIdSchema } from "../../domain/user/user.schema";
 import type {
 	CountUsers,
+	CreateGoogleUser,
 	CreateSession,
 	FindUserByEmail,
 	MarkEmailVerified,
 } from "../../providers/auth/auth.types";
+import type { SendEmail } from "../../providers/email/email.types";
 import type { ExchangeGoogleCode } from "../../providers/google-auth/google-token.types";
 import type { StorePendingSignup } from "../../providers/pending-signup/pending-signup.types";
 import type { CreateCheckoutSession } from "../../providers/stripe-checkout/stripe-checkout.types";
+import { buildWelcomeEmailHtml } from "./welcome-email";
+import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
 import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
@@ -37,15 +41,21 @@ interface GoogleAuthDependencies {
 	googleClientId: string;
 	googleClientSecret: string;
 	appOrigin: string;
+	baseUrl: string;
+	staticBaseUrl: string;
 	createSession: CreateSession;
+	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
 	countUsers: CountUsers;
 	markEmailVerified: MarkEmailVerified;
 	exchangeGoogleCode: ExchangeGoogleCode;
 	createCheckoutSession: CreateCheckoutSession;
 	storePendingSignup: StorePendingSignup;
+	sendEmail: SendEmail;
 	logError: (message: string, error?: Error) => void;
 }
+
+const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
 
 const signState = (payload: string, secret: string): string => {
 	const mac = createHmac("sha256", secret).update(payload).digest("base64url");
@@ -151,6 +161,46 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 
 		const newUserId = UserIdSchema.parse(randomBytes(16).toString("hex"));
 		const safeReturnUrl = extractReturnUrl({ return: stateData.returnUrl });
+
+		const userCount = await fetchUserCount();
+		if (!isFoundingAllocationExhausted(userCount)) {
+			const created = await deps.createGoogleUser({
+				email: tokenResult.email,
+				userId: newUserId,
+			});
+			if (!created.ok) {
+				const lookup = await deps.findUserByEmail(tokenResult.email);
+				if (lookup) {
+					if (!lookup.emailVerified) {
+						await deps.markEmailVerified(tokenResult.email);
+					}
+					const sessionId = await deps.createSession({ userId: lookup.userId, emailVerified: true });
+					res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+					res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
+					return;
+				}
+				await renderError("Account creation failed. Please try again.");
+				return;
+			}
+
+			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
+			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			deps.sendEmail({
+				from: WELCOME_EMAIL_FROM,
+				to: tokenResult.email,
+				bcc: "readplace+welcome@readplace.com",
+				subject: "Welcome to Readplace",
+				html: buildWelcomeEmailHtml({
+					installUrl: `${deps.baseUrl}/install`,
+					avatarUrl: `${deps.staticBaseUrl}/fayner-brack.jpg`,
+				}),
+			}).catch((err) => {
+				deps.logError("[Email] Welcome email failed", err instanceof Error ? err : new Error(String(err)));
+			});
+			res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
+			return;
+		}
+
 		const returnSuffix = safeReturnUrl
 			? `&return=${encodeURIComponent(safeReturnUrl)}`
 			: "";

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -14,8 +14,8 @@ import type { SendEmail } from "../../providers/email/email.types";
 import type { ExchangeGoogleCode } from "../../providers/google-auth/google-token.types";
 import type { StorePendingSignup } from "../../providers/pending-signup/pending-signup.types";
 import type { CreateCheckoutSession } from "../../providers/stripe-checkout/stripe-checkout.types";
-import { buildWelcomeEmailHtml } from "./welcome-email";
 import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
+import { initSendWelcomeEmail } from "./send-welcome-email";
 import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
@@ -55,8 +55,6 @@ interface GoogleAuthDependencies {
 	logError: (message: string, error?: Error) => void;
 }
 
-const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
-
 const signState = (payload: string, secret: string): string => {
 	const mac = createHmac("sha256", secret).update(payload).digest("base64url");
 	return `${payload}.${mac}`;
@@ -80,6 +78,12 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 		countUsers: deps.countUsers,
 		logError: deps.logError,
 		logPrefix: "[Google Auth]",
+	});
+	const sendWelcomeEmail = initSendWelcomeEmail({
+		sendEmail: deps.sendEmail,
+		baseUrl: deps.baseUrl,
+		staticBaseUrl: deps.staticBaseUrl,
+		logError: deps.logError,
 	});
 
 	router.get("/auth/google", (req: Request, res: Response) => {
@@ -185,18 +189,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
-			deps.sendEmail({
-				from: WELCOME_EMAIL_FROM,
-				to: tokenResult.email,
-				bcc: "readplace+welcome@readplace.com",
-				subject: "Welcome to Readplace",
-				html: buildWelcomeEmailHtml({
-					installUrl: `${deps.baseUrl}/install`,
-					avatarUrl: `${deps.staticBaseUrl}/fayner-brack.jpg`,
-				}),
-			}).catch((err) => {
-				deps.logError("[Email] Welcome email failed", err instanceof Error ? err : new Error(String(err)));
-			});
+			sendWelcomeEmail(tokenResult.email);
 			res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
 			return;
 		}

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -205,7 +205,39 @@ describe("Google auth routes", () => {
 			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not verified");
 		});
 
-		it("should redirect a brand-new user to a Stripe checkout URL", async () => {
+		it("creates the user directly and skips Stripe when at or below the founding limit", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { app, auth, pendingSignup } = createTestApp({
+				...fixture,
+				google: {
+					exchangeGoogleCode: stubExchange({ email: "free-google@example.com" }),
+					clientId: "test-google-client-id",
+					clientSecret: "test-google-client-secret",
+				},
+			});
+			for (let i = 0; i < 100; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+			const state = signState(freshState());
+
+			const response = await request(app)
+				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
+				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+			expect(cookiesFrom(response).join(";")).toContain("hutch_sid=");
+
+			const lookup = await auth.findUserByEmail("free-google@example.com");
+			expect(lookup?.emailVerified).toBe(true);
+
+			const consumed = await pendingSignup.consumePendingSignup(
+				CheckoutSessionIdSchema.parse("cs_test_never_created"),
+			);
+			expect(consumed).toBeNull();
+		}, 30000);
+
+		it("redirects a brand-new user through Stripe when over the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth } = createTestApp({
 				...fixture,
@@ -215,6 +247,9 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			for (let i = 0; i < 101; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
 			const state = signState(freshState());
 
 			const response = await request(app)
@@ -226,9 +261,9 @@ describe("Google auth routes", () => {
 
 			const lookup = await auth.findUserByEmail("brand-new@example.com");
 			expect(lookup).toBeNull();
-		});
+		}, 30000);
 
-		it("should create the Google user only after successful Stripe checkout", async () => {
+		it("should create the Google user only after successful Stripe checkout when over the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth, stripe } = createTestApp({
 				...fixture,
@@ -238,6 +273,9 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			for (let i = 0; i < 101; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
 			const state = signState(freshState());
 			const agent = request.agent(app);
 			const callbackResponse = await agent
@@ -259,11 +297,11 @@ describe("Google auth routes", () => {
 
 			const lookup = await auth.findUserByEmail("brand-new@example.com");
 			expect(lookup?.emailVerified).toBe(true);
-		});
+		}, 30000);
 
-		it("should preserve the return URL through the Stripe checkout boundary", async () => {
+		it("should preserve the return URL through the Stripe checkout boundary when over the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, stripe } = createTestApp({
+			const { app, auth, stripe } = createTestApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "return@example.com" }),
@@ -271,6 +309,9 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			for (let i = 0; i < 101; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
 			const state = signState(freshState({ returnUrl: "/save?url=https%3A%2F%2Fexample.com" }));
 			const agent = request.agent(app);
 			const callbackResponse = await agent
@@ -287,7 +328,7 @@ describe("Google auth routes", () => {
 
 			expect(successResponse.status).toBe(303);
 			expect(successResponse.headers.location).toBe("/save?url=https%3A%2F%2Fexample.com");
-		});
+		}, 30000);
 
 		it("should reuse an existing verified email/password account and keep the password working", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -205,7 +205,7 @@ describe("Google auth routes", () => {
 			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not verified");
 		});
 
-		it("creates the user directly and skips Stripe when at or below the founding limit", async () => {
+		it("creates the user directly and skips Stripe when below the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth, pendingSignup } = createTestApp({
 				...fixture,
@@ -215,7 +215,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < 100; i++) {
+			for (let i = 0; i < 99; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
@@ -337,7 +337,7 @@ describe("Google auth routes", () => {
 			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("Account creation failed");
 		});
 
-		it("redirects a brand-new user through Stripe when over the founding limit", async () => {
+		it("redirects a brand-new user through Stripe when at the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth } = createTestApp({
 				...fixture,
@@ -347,7 +347,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
@@ -363,7 +363,7 @@ describe("Google auth routes", () => {
 			expect(lookup).toBeNull();
 		}, 30000);
 
-		it("should create the Google user only after successful Stripe checkout when over the founding limit", async () => {
+		it("should create the Google user only after successful Stripe checkout when at the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth, stripe } = createTestApp({
 				...fixture,
@@ -373,7 +373,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
@@ -399,7 +399,7 @@ describe("Google auth routes", () => {
 			expect(lookup?.emailVerified).toBe(true);
 		}, 30000);
 
-		it("should preserve the return URL through the Stripe checkout boundary when over the founding limit", async () => {
+		it("should preserve the return URL through the Stripe checkout boundary when at the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth, stripe } = createTestApp({
 				...fixture,
@@ -409,7 +409,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < 101; i++) {
+			for (let i = 0; i < 100; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState({ returnUrl: "/save?url=https%3A%2F%2Fexample.com" }));

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -237,6 +237,106 @@ describe("Google auth routes", () => {
 			expect(consumed).toBeNull();
 		}, 30000);
 
+		it("logs in the existing user when a race condition causes createGoogleUser to fail during free signup", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			let raceFindCount = 0;
+			const { app } = createTestApp({
+				...fixture,
+				auth: {
+					...fixture.auth,
+					findUserByEmail: async (email) => {
+						if (email === "race-google@example.com") {
+							raceFindCount++;
+							if (raceFindCount === 1) return null;
+						}
+						return fixture.auth.findUserByEmail(email);
+					},
+				},
+				google: {
+					exchangeGoogleCode: stubExchange({ email: "race-google@example.com" }),
+					clientId: "test-google-client-id",
+					clientSecret: "test-google-client-secret",
+				},
+			});
+			await fixture.auth.createUser({ email: "race-google@example.com", password: "existing" });
+			const state = signState(freshState());
+
+			const response = await request(app)
+				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
+				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+			expect(cookiesFrom(response).join(";")).toContain("hutch_sid=");
+
+			const lookup = await fixture.auth.findUserByEmail("race-google@example.com");
+			expect(lookup?.emailVerified).toBe(true);
+		});
+
+		it("marks email verified during race condition when existing user is unverified", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			let raceFindCount = 0;
+			const { app } = createTestApp({
+				...fixture,
+				auth: {
+					...fixture.auth,
+					findUserByEmail: async (email) => {
+						if (email === "unverified-race@example.com") {
+							raceFindCount++;
+							if (raceFindCount === 1) return null;
+						}
+						return fixture.auth.findUserByEmail(email);
+					},
+				},
+				google: {
+					exchangeGoogleCode: stubExchange({ email: "unverified-race@example.com" }),
+					clientId: "test-google-client-id",
+					clientSecret: "test-google-client-secret",
+				},
+			});
+			await fixture.auth.createUser({ email: "unverified-race@example.com", password: "existing" });
+			const beforeLookup = await fixture.auth.findUserByEmail("unverified-race@example.com");
+			expect(beforeLookup?.emailVerified).toBe(false);
+			const state = signState(freshState());
+
+			const response = await request(app)
+				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
+				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
+
+			expect(response.status).toBe(303);
+			const afterLookup = await fixture.auth.findUserByEmail("unverified-race@example.com");
+			expect(afterLookup?.emailVerified).toBe(true);
+		});
+
+		it("renders error when race condition causes createGoogleUser to fail and user cannot be found", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { app } = createTestApp({
+				...fixture,
+				auth: {
+					...fixture.auth,
+					findUserByEmail: async (email) => {
+						if (email === "vanished@example.com") return null;
+						return fixture.auth.findUserByEmail(email);
+					},
+					createGoogleUser: async () => ({ ok: false, reason: "email-already-exists" }),
+				},
+				google: {
+					exchangeGoogleCode: stubExchange({ email: "vanished@example.com" }),
+					clientId: "test-google-client-id",
+					clientSecret: "test-google-client-secret",
+				},
+			});
+			const state = signState(freshState());
+
+			const response = await request(app)
+				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
+				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
+
+			expect(response.status).toBe(400);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("Account creation failed");
+		});
+
 		it("redirects a brand-new user through Stripe when over the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const { app, auth } = createTestApp({

--- a/projects/hutch/src/runtime/web/auth/send-welcome-email.ts
+++ b/projects/hutch/src/runtime/web/auth/send-welcome-email.ts
@@ -1,0 +1,29 @@
+import type { SendEmail } from "../../providers/email/email.types";
+import { buildWelcomeEmailHtml } from "./welcome-email";
+
+const WELCOME_EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
+
+interface SendWelcomeEmailDeps {
+	sendEmail: SendEmail;
+	baseUrl: string;
+	staticBaseUrl: string;
+	logError: (message: string, error?: Error) => void;
+}
+
+export type SendWelcomeEmail = (email: string) => void;
+
+export function initSendWelcomeEmail(deps: SendWelcomeEmailDeps): SendWelcomeEmail {
+	return (email: string): void => {
+		const installUrl = `${deps.baseUrl}/install`;
+		const avatarUrl = `${deps.staticBaseUrl}/fayner-brack.jpg`;
+		deps.sendEmail({
+			from: WELCOME_EMAIL_FROM,
+			to: email,
+			bcc: "readplace+welcome@readplace.com",
+			subject: "Welcome to Readplace",
+			html: buildWelcomeEmailHtml({ installUrl, avatarUrl }),
+		}).catch((err) => {
+			deps.logError("[Email] Welcome email failed", err instanceof Error ? err : new Error(String(err)));
+		});
+	};
+}

--- a/projects/hutch/src/runtime/web/auth/signup.template.html
+++ b/projects/hutch/src/runtime/web/auth/signup.template.html
@@ -25,13 +25,13 @@
             <input class="auth-form__input{{confirmPasswordField.errorClass}}" type="password" id="confirmPassword" name="confirmPassword" required autocomplete="new-password">
             {{#if confirmPasswordField.error}}<p class="auth-form__error" data-test-error="confirmPassword">{{confirmPasswordField.error}}</p>{{/if}}
           </div>
-          <button class="auth-form__submit" type="submit">Join Readplace (14 days free)</button>
+          <button class="auth-form__submit" type="submit">{{submitLabel}}</button>
         </form>
         <div class="auth-google-section" data-test-google-section>
           <div class="auth-divider">or</div>
           <a class="auth-google-button" href="/auth/google{{#if returnUrl}}?return={{returnUrl}}{{/if}}">
             <svg class="auth-google-button__logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18" aria-hidden="true" focusable="false"><path fill="#4285F4" d="M17.64 9.2045c0-.6381-.0573-1.2518-.1636-1.8409H9v3.4814h4.8436c-.2086 1.125-.8427 2.0782-1.7959 2.7164v2.2581h2.9087c1.7018-1.5668 2.6836-3.874 2.6836-6.615z"/><path fill="#34A853" d="M9 18c2.43 0 4.4673-.806 5.9564-2.1805l-2.9087-2.2581c-.806.54-1.8368.8595-3.0477.8595-2.344 0-4.3282-1.5831-5.0364-3.7104H.9573v2.3318C2.4382 15.9831 5.4818 18 9 18z"/><path fill="#FBBC05" d="M3.9636 10.71c-.18-.54-.2823-1.1168-.2823-1.71s.1023-1.17.2823-1.71V4.9582H.9573A8.9965 8.9965 0 0 0 0 9c0 1.4523.3477 2.8268.9573 4.0418L3.9636 10.71z"/><path fill="#EA4335" d="M9 3.5795c1.3214 0 2.5077.4541 3.4405 1.346l2.5813-2.5814C13.4632.8918 11.426 0 9 0 5.4818 0 2.4382 2.0168.9573 4.9582L3.9636 7.29C4.6718 5.1627 6.6559 3.5795 9 3.5795z"/></svg>
-            <span class="auth-google-button__label">Sign up with Google (14 days free)</span>
+            <span class="auth-google-button__label">{{googleLabel}}</span>
           </a>
         </div>
         <p class="auth-card__footer">

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -17,8 +17,8 @@ interface StripeBundle {
  * the shared agent so the session cookie persists.
  *
  * Stripe checkout is gated behind the founding-member allocation: signups only
- * route through Stripe once the user count exceeds FOUNDING_MEMBER_LIMIT. This
- * helper seeds enough fake users to push past that boundary so callers can
+ * route through Stripe once the user count reaches FOUNDING_MEMBER_LIMIT. This
+ * helper seeds enough fake users to meet that boundary so callers can
  * exercise the paid path without needing to know about it. */
 export async function completeStripeSignup(params: {
 	app: Express;
@@ -33,7 +33,7 @@ export async function completeStripeSignup(params: {
 	successResponse: import("supertest").Response;
 	checkoutSessionId: CheckoutSessionId;
 }> {
-	for (let i = 0; i < FOUNDING_MEMBER_LIMIT + 1; i++) {
+	for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
 		const seedEmail = `stripe-seed-${i}@test.invalid`;
 		const existing = await params.auth.findUserByEmail(seedEmail);
 		if (!existing) {

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -4,6 +4,8 @@ import request from "supertest";
 import type { Express } from "express";
 import { CheckoutSessionIdSchema } from "../../../providers/stripe-checkout/stripe-checkout.schema";
 import type { CheckoutSessionId } from "../../../providers/stripe-checkout/stripe-checkout.types";
+import type { AuthBundle } from "../../../test-app";
+import { FOUNDING_MEMBER_LIMIT } from "../../shared/founding-progress/founding-allocation";
 
 interface StripeBundle {
 	markPaid: (id: CheckoutSessionId) => void;
@@ -12,9 +14,15 @@ interface StripeBundle {
 /** Drives an email-signup flow through the Stripe checkout boundary in a single
  * step: posts to /signup, asserts the redirect to the Stripe URL, marks the
  * session paid via the in-memory Stripe fake, then GETs the success URL using
- * the shared agent so the session cookie persists. */
+ * the shared agent so the session cookie persists.
+ *
+ * Stripe checkout is gated behind the founding-member allocation: signups only
+ * route through Stripe once the user count exceeds FOUNDING_MEMBER_LIMIT. This
+ * helper seeds enough fake users to push past that boundary so callers can
+ * exercise the paid path without needing to know about it. */
 export async function completeStripeSignup(params: {
 	app: Express;
+	auth: AuthBundle;
 	stripe: StripeBundle;
 	email: string;
 	password: string;
@@ -25,6 +33,14 @@ export async function completeStripeSignup(params: {
 	successResponse: import("supertest").Response;
 	checkoutSessionId: CheckoutSessionId;
 }> {
+	for (let i = 0; i < FOUNDING_MEMBER_LIMIT + 1; i++) {
+		const seedEmail = `stripe-seed-${i}@test.invalid`;
+		const existing = await params.auth.findUserByEmail(seedEmail);
+		if (!existing) {
+			await params.auth.createUser({ email: seedEmail, password: "password123" });
+		}
+	}
+
 	const agent = params.agent ?? request.agent(params.app);
 	const signupPath = params.returnUrl
 		? `/signup?return=${encodeURIComponent(params.returnUrl)}`

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -4,6 +4,7 @@ import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { switchHelpers } from "../../handlebars-switch";
 import { renderFoundingProgress } from "../../shared/founding-progress/founding-progress.component";
+import { isFoundingAllocationExhausted } from "../../shared/founding-progress/founding-allocation";
 import { HOME_PAGE_STYLES } from "./home.styles";
 
 const HOME_TEMPLATE = readFileSync(join(__dirname, "home.template.html"), "utf-8");
@@ -102,6 +103,13 @@ const HOME_SCROLL_HINT_SCRIPT = `<script>
 export function HomePage(params: { userCount: number; staticBaseUrl: string; browser: "firefox" | "chrome" | "other" }): PageBody {
 	const { userCount, staticBaseUrl, browser } = params;
 	const foundingProgressHtml = renderFoundingProgress({ userCount });
+	const foundingAllocationAvailable = !isFoundingAllocationExhausted(userCount);
+	const pricingGridStateClass = foundingAllocationAvailable
+		? "pricing-grid--visible"
+		: "pricing-grid--hidden";
+	const fallbackCtaStateClass = foundingAllocationAvailable
+		? "home-pricing__fallback-cta--hidden"
+		: "home-pricing__fallback-cta--visible";
 	return {
 		seo: {
 			title: "Readplace — Read-It-Later App | Save Articles, Read Them Later",
@@ -277,6 +285,8 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 			browserName: browser,
 			founderAvatarUrl: `${staticBaseUrl}/fayner-brack.jpg`,
 			foundingProgressHtml,
+			pricingGridStateClass,
+			fallbackCtaStateClass,
 			featuredFeatures: [
 				{
 					name: "Reader View",

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -182,16 +182,23 @@ describe("GET /", () => {
 		expect(backstory).not.toBeNull();
 	});
 
-	// it("should render one pricing plan for founding members", async () => {
-	// 	const response = await request(app).get("/");
-	// 	const doc = new JSDOM(response.text).window.document;
+	it("should render the founding pricing card and hide the fallback CTA when under the limit", async () => {
+		const response = await request(app).get("/");
+		const doc = new JSDOM(response.text).window.document;
 
-	// 	const pricingSection = doc.querySelector('[data-test-section="pricing"]');
-	// 	const plans = pricingSection?.querySelectorAll(".pricing-card");
-	// 	expect(plans?.length).toBe(1);
-	// 	expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__name')?.textContent).toBe("Founding Member");
-	// 	expect(doc.querySelector('[data-test-plan="founding"] .pricing-card__price')?.textContent).toContain("$0");
-	// });
+		const founding = doc.querySelector('[data-test-plan="founding"]');
+		assert(founding, "founding pricing card must be rendered");
+		expect(founding.querySelector(".pricing-card__name")?.textContent).toBe("Founding Member");
+		expect(founding.querySelector(".pricing-card__price")?.textContent).toContain("$0");
+
+		const grid = founding.closest(".pricing-grid");
+		assert(grid, "pricing-grid wrapper must be rendered");
+		expect(grid.classList.contains("pricing-grid--visible")).toBe(true);
+
+		const fallback = doc.querySelector(".home-pricing__fallback-cta");
+		assert(fallback, "fallback CTA wrapper must be rendered");
+		expect(fallback.classList.contains("home-pricing__fallback-cta--hidden")).toBe(true);
+	});
 
 	it("should render the founding members progress bar with zero users", async () => {
 		const response = await request(app).get("/");
@@ -344,7 +351,28 @@ describe("GET / with exhausted founding allocation", () => {
 
 		const label = doc.querySelector(".founding-progress__label");
 		expect(label?.textContent).toBe("101 / 100 founding members");
-	});
+	}, 30000);
+
+	it("should hide the founding pricing card and show the fallback CTA when over the limit", async () => {
+		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		for (let i = 0; i < 102; i++) {
+			await auth.createUser({ email: `over${i}@test.com`, password: "password123" });
+		}
+
+		const response = await request(app).get("/");
+		const doc = new JSDOM(response.text).window.document;
+
+		const founding = doc.querySelector('[data-test-plan="founding"]');
+		assert(founding, "founding pricing card must be rendered");
+		const grid = founding.closest(".pricing-grid");
+		assert(grid, "pricing-grid wrapper must be rendered");
+		expect(grid.classList.contains("pricing-grid--hidden")).toBe(true);
+
+		const fallback = doc.querySelector(".home-pricing__fallback-cta");
+		assert(fallback, "fallback CTA wrapper must be rendered");
+		expect(fallback.classList.contains("home-pricing__fallback-cta--visible")).toBe(true);
+	}, 30000);
 });
 
 describe("GET /robots.txt", () => {

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -334,7 +334,7 @@ describe("GET / with exhausted founding allocation", () => {
 	it("should render the exhausted message and cap progress at 100% when users exceed the limit", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		for (let i = 0; i < 101; i++) {
+		for (let i = 0; i < 100; i++) {
 			await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 		}
 
@@ -350,13 +350,13 @@ describe("GET / with exhausted founding allocation", () => {
 		expect(fill?.getAttribute("style")).toBe("width: 100%");
 
 		const label = doc.querySelector(".founding-progress__label");
-		expect(label?.textContent).toBe("101 / 100 founding members");
+		expect(label?.textContent).toBe("100 / 100 founding members");
 	}, 30000);
 
 	it("should hide the founding pricing card and show the fallback CTA when over the limit", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		for (let i = 0; i < 102; i++) {
+		for (let i = 0; i < 100; i++) {
 			await auth.createUser({ email: `over${i}@test.com`, password: "password123" });
 		}
 

--- a/projects/hutch/src/runtime/web/pages/home/home.styles.css
+++ b/projects/hutch/src/runtime/web/pages/home/home.styles.css
@@ -689,6 +689,22 @@
   align-items: start;
 }
 
+.pricing-grid--visible {
+  display: grid;
+}
+
+.pricing-grid--hidden {
+  display: none;
+}
+
+.home-pricing__fallback-cta--visible {
+  display: block;
+}
+
+.home-pricing__fallback-cta--hidden {
+  display: none;
+}
+
 .pricing-card {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);

--- a/projects/hutch/src/runtime/web/pages/home/home.styles.css
+++ b/projects/hutch/src/runtime/web/pages/home/home.styles.css
@@ -683,7 +683,6 @@
 }
 
 .pricing-grid {
-  display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 24px;
   align-items: start;

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -232,7 +232,7 @@
           <h2 class="section-header__title">Free for the first 100 members.</h2>
         </div>
         {{{foundingProgressHtml}}}
-        <!-- <div class="pricing-grid">
+        <div class="pricing-grid {{pricingGridStateClass}}">
           <div class="pricing-card pricing-card--featured" data-test-plan="founding">
             <span class="pricing-card__badge">First 100 Users</span>
             <h3 class="pricing-card__name">Founding Member</h3>
@@ -245,11 +245,11 @@
               <li class="pricing-card__feature">All features as they ship</li>
               <li class="pricing-card__feature">Direct access to the developer</li>
             </ul>
-            <a href="/signup" class="btn btn--brand pricing-card__cta" data-test-cta="founding">Signup</a>
+            <a href="/signup?utm_source=homepage&utm_medium=internal&utm_content=founding-card" class="btn btn--brand pricing-card__cta" data-test-cta="founding">Signup</a>
           </div>
-        </div> -->
-        <div>
-          <a href="/signup?utm_source=homepage&utm_medium=internal&utm_content=signup-body" class="btn btn--brand pricing-card__cta">Become a Member</a>
+        </div>
+        <div class="home-pricing__fallback-cta {{fallbackCtaStateClass}}">
+          <a href="/signup?utm_source=homepage&utm_medium=internal&utm_content=signup-body" class="btn btn--brand pricing-card__cta" data-test-cta="become-member">Become a Member</a>
         </div>
       </div>
     </section>

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
@@ -1,0 +1,5 @@
+export const FOUNDING_MEMBER_LIMIT = 100;
+
+export function isFoundingAllocationExhausted(userCount: number): boolean {
+	return userCount > FOUNDING_MEMBER_LIMIT;
+}

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
@@ -1,5 +1,5 @@
 export const FOUNDING_MEMBER_LIMIT = 100;
 
 export function isFoundingAllocationExhausted(userCount: number): boolean {
-	return userCount > FOUNDING_MEMBER_LIMIT;
+	return userCount >= FOUNDING_MEMBER_LIMIT;
 }

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.component.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.component.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { render } from "../../render";
-
-const FOUNDING_MEMBER_LIMIT = 100;
+import {
+	FOUNDING_MEMBER_LIMIT,
+	isFoundingAllocationExhausted,
+} from "./founding-allocation";
 
 const FOUNDING_PROGRESS_TEMPLATE = readFileSync(
 	join(__dirname, "founding-progress.template.html"),
@@ -15,7 +17,7 @@ export function renderFoundingProgress(input: { userCount: number }): string {
 		Math.round((userCount / FOUNDING_MEMBER_LIMIT) * 100),
 		100,
 	);
-	const allocationExhausted = userCount >= FOUNDING_MEMBER_LIMIT;
+	const allocationExhausted = isFoundingAllocationExhausted(userCount);
 	const exhaustedStateClass = allocationExhausted
 		? "founding-progress__exhausted--visible"
 		: "founding-progress__exhausted--hidden";


### PR DESCRIPTION
## Summary
This PR implements a founding member program that allows the first 100 users to sign up for free, while subsequent users are directed through Stripe checkout. The feature includes UI updates to show/hide pricing cards based on allocation status and email verification for free signups.

## Key Changes

- **Founding allocation logic**: Created `founding-allocation.ts` with `FOUNDING_MEMBER_LIMIT` (100) and `isFoundingAllocationExhausted()` helper to determine if the free tier is exhausted
- **Free signup path**: Modified `/signup` endpoint to create accounts directly and skip Stripe when under the 100-user limit, with email verification sent automatically
- **Google auth integration**: Updated Google OAuth callback to create users directly when under the limit, with welcome email sent and email marked as verified
- **UI state management**: Added CSS classes and template logic to show the founding pricing card when allocation is available and hide it when exhausted, with a fallback CTA displayed instead
- **Test infrastructure**: 
  - Updated `completeStripeSignup()` helper to seed users above the founding limit automatically
  - Added `deleteUser()` method to in-memory auth for testing user count scenarios
  - Expanded test coverage with separate test cases for free vs. paid signup paths
  - Added 30-second timeouts to tests that seed large numbers of users
- **Email notifications**: Integrated welcome email sending for free Google signups using existing email infrastructure
- **Home page updates**: Modified home component to conditionally render pricing grid and fallback CTA based on founding allocation status

## Implementation Details

- The founding allocation check happens early in both email and Google signup flows, allowing free users to bypass Stripe entirely
- Free email signups create unverified accounts and send verification emails; Google signups mark email as verified immediately
- The `completeStripeSignup()` test helper now handles the founding limit automatically, ensuring all Stripe checkout tests exercise the paid path
- Pricing card visibility is controlled via CSS classes (`pricing-grid--visible`/`pricing-grid--hidden`) and template variables
- User count is fetched fresh during signup to ensure accurate allocation checks

https://claude.ai/code/session_013s4JkdLwJ68CSHrhPFNmCN