### PR TITLE
Remove outdated Chrome release note from install page

### DIFF
--- a/projects/hutch/src/runtime/web/pages/install/install.template.html
+++ b/projects/hutch/src/runtime/web/pages/install/install.template.html
@@ -31,9 +31,6 @@
       <section class="install-page__panel" data-test-section="chrome">
         {{#if chromeDownloadUrl}}
         <a href="{{chromeDownloadUrl}}" class="install-page__download" data-test-cta="download-chrome">Install Readplace for Chrome</a>
-        <p>
-          Note: Google Chrome team is taking weeks to release the last version of Readplace. You might still see it as "Hutch" and the checkbox from the onboarding message won't be ticked until they release the new version.
-        </p>
         {{else}}
         <p class="install-page__unavailable" data-test-section="chrome-unavailable">The Chrome extension is not available for download yet. Please check back soon.</p>
         {{/if}}


### PR DESCRIPTION
## Summary
Removed an outdated notice from the Chrome extension installation section that referenced delays in Google Chrome's release process for Readplace.

## Changes
- Removed the deprecation notice that mentioned Google Chrome team delays and the extension appearing as "Hutch" instead of "Readplace"
- The note is no longer relevant as the Chrome Web Store release has been completed

## Details
The removed message was a temporary notice informing users about potential naming inconsistencies and delayed Chrome Web Store approval. Since this situation has been resolved, the notice is no longer necessary and has been cleaned up from the install page.

https://claude.ai/code/session_01MduLqK2v15UgV5Vij6DXhi