### PR TITLE
fix(hutch): trigger copy from copy icon, not share icon

### DIFF
--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -322,6 +322,21 @@ describe("initShareBalloon — copy click", () => {
 		expect(status.textContent).toBe("Link copied to clipboard");
 	});
 
+	it("fades the copied feedback out after COPIED_FADE_MS", async () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		const copiedLabel = element(document, "[data-share-balloon-copied]");
+		const status = element(document, "[data-share-balloon-status]");
+		ctrl.attach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+		await flushPromises();
+		jest.advanceTimersByTime(3000);
+
+		expect(copiedLabel.classList.contains(COPIED_VISIBLE_CLASS)).toBe(false);
+		expect(status.textContent).toBe("");
+	});
+
 	it("reports 'Unable to copy link' to the status region when writeText rejects", async () => {
 		const writeText = jest.fn(() => Promise.reject(new Error("denied")));
 		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -248,48 +248,6 @@ describe("initShareBalloon — close button", () => {
 });
 
 describe("initShareBalloon — share click", () => {
-	it("copies the data-share-url to the clipboard and flashes the copied feedback", async () => {
-		const writeText = jest.fn(() => Promise.resolve());
-		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
-		const copiedLabel = element(document, "[data-share-balloon-copied]");
-		const status = element(document, "[data-share-balloon-status]");
-		ctrl.attach();
-
-		fireEvent.click(element(document, "[data-share-balloon]"));
-		expect(writeText).toHaveBeenCalledWith(ARTICLE_URL);
-
-		await flushPromises();
-		expect(copiedLabel.classList.contains(COPIED_VISIBLE_CLASS)).toBe(true);
-		expect(status.textContent).toBe("Link copied to clipboard");
-	});
-
-	it("fades the copied feedback out after COPIED_FADE_MS", async () => {
-		const writeText = jest.fn(() => Promise.resolve());
-		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
-		const copiedLabel = element(document, "[data-share-balloon-copied]");
-		const status = element(document, "[data-share-balloon-status]");
-		ctrl.attach();
-
-		fireEvent.click(element(document, "[data-share-balloon]"));
-		await flushPromises();
-		jest.advanceTimersByTime(3000);
-
-		expect(copiedLabel.classList.contains(COPIED_VISIBLE_CLASS)).toBe(false);
-		expect(status.textContent).toBe("");
-	});
-
-	it("reports 'Unable to copy link' to the status region when writeText rejects", async () => {
-		const writeText = jest.fn(() => Promise.reject(new Error("denied")));
-		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
-		const status = element(document, "[data-share-balloon-status]");
-		ctrl.attach();
-
-		fireEvent.click(element(document, "[data-share-balloon]"));
-		await flushPromises();
-
-		expect(status.textContent).toBe("Unable to copy link");
-	});
-
 	it("calls navigator.share with the title and url from the data attributes", () => {
 		const share = jest.fn(() => Promise.resolve());
 		const { document, ctrl } = setup({ navigator: { share } });
@@ -324,24 +282,27 @@ describe("initShareBalloon — share click", () => {
 		await expect(flushPromises()).resolves.toBeUndefined();
 	});
 
-	it("only uses navigator.share when the API is available (clipboard-only fallback)", () => {
+	it("does not copy to the clipboard when only the share button is clicked", () => {
 		const writeText = jest.fn(() => Promise.resolve());
-		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
-		ctrl.attach();
-
-		fireEvent.click(element(document, "[data-share-balloon]"));
-
-		expect(writeText).toHaveBeenCalledTimes(1);
-	});
-
-	it("only uses clipboard.writeText when the API is available (share-only fallback)", () => {
 		const share = jest.fn(() => Promise.resolve());
-		const { document, ctrl } = setup({ navigator: { share } });
+		const { document, ctrl } = setup({
+			navigator: { clipboard: { writeText }, share },
+		});
 		ctrl.attach();
 
 		fireEvent.click(element(document, "[data-share-balloon]"));
 
 		expect(share).toHaveBeenCalledTimes(1);
+		expect(writeText).not.toHaveBeenCalled();
+	});
+
+	it("hides the share button when navigator.share is unavailable", () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		ctrl.attach();
+
+		const btn = element(document, "[data-share-balloon]");
+		expect(btn.hasAttribute("hidden")).toBe(true);
 	});
 });
 
@@ -479,13 +440,13 @@ describe("initShareBalloon — detach()", () => {
 		expect(() => ctrl.detach()).not.toThrow();
 	});
 
-	it("cancels a pending fade timer after a share click", async () => {
+	it("cancels a pending fade timer after a copy click", async () => {
 		const writeText = jest.fn(() => Promise.resolve());
 		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
 		const copiedLabel = element(document, "[data-share-balloon-copied]");
 		ctrl.attach();
 
-		fireEvent.click(element(document, "[data-share-balloon]"));
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
 		await flushPromises();
 		expect(copiedLabel.classList.contains(COPIED_VISIBLE_CLASS)).toBe(true);
 
@@ -495,13 +456,13 @@ describe("initShareBalloon — detach()", () => {
 	});
 
 	it("prevents subsequent share clicks from firing handlers", () => {
-		const writeText = jest.fn(() => Promise.resolve());
-		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		const share = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { share } });
 		ctrl.attach();
 		ctrl.detach();
 
 		fireEvent.click(element(document, "[data-share-balloon]"));
 
-		expect(writeText).not.toHaveBeenCalled();
+		expect(share).not.toHaveBeenCalled();
 	});
 });

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
@@ -135,11 +135,6 @@ export function initShareBalloon(
 	}
 
 	function onShareClick() {
-		if (deps.navigator.clipboard !== undefined) {
-			deps.navigator.clipboard.writeText(url).then(flashCopied, () => {
-				status.textContent = "Unable to copy link";
-			});
-		}
 		if (deps.navigator.share !== undefined) {
 			deps.navigator.share({ title, url }).catch((err) => {
 				if (err && err.name === "AbortError") return;
@@ -171,6 +166,8 @@ export function initShareBalloon(
 		if (!canShare && !canCopy) return;
 		attached = true;
 		wrap.hidden = false;
+		btn.hidden = !canShare;
+		copyBtn.hidden = !canCopy;
 
 		if (!readDismissed()) {
 			scrollListener = onScroll;


### PR DESCRIPTION
## Summary
- Remove the implicit clipboard copy from the share balloon's share button so only the copy icon triggers `navigator.clipboard.writeText`.
- Hide each balloon button when its underlying capability is unavailable (`navigator.share` for the share icon, `navigator.clipboard` for the copy icon) to avoid dead controls on browsers that lack one of the two APIs.
- Update unit tests to assert the new responsibilities (share icon → share only; copy icon → copy only) and that buttons hide when their capability is missing.

Applies to all reader views (public `/view/...` and private `/queue/.../reader`) since both surfaces include the shared `share-balloon` component.

## Test plan
- [x] `pnpm exec nx test hutch -- --testPathPattern=share-balloon.client` (28 passed)
- [x] `pnpm exec nx test hutch -- --testPathPattern=view.route` (47 passed)
- [x] `pnpm exec nx test hutch -- --testPathPattern=reader` (43 passed)
- [x] `pnpm exec nx test hutch -- --testPathPattern=queue.route` (87 passed)
- [ ] Manual: open a public `/view/...` URL on mobile + desktop and confirm the share icon invokes the OS share sheet (mobile) / is hidden (desktop), and the copy icon copies the URL with the "Link copied!" feedback.

https://claude.ai/code/session_01UC5x82GJk2h6uqYcUa5gBN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UC5x82GJk2h6uqYcUa5gBN)_