### PR TITLE
fix: accept application/xhtml+xml content-type in article crawler

### DIFF
--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -104,6 +104,24 @@ describe("initCrawlArticle — regular first-save fetch", () => {
 		});
 	});
 
+	it("returns status 'fetched' when content-type is application/xhtml+xml", async () => {
+		const fakeFetch: typeof fetch = async () =>
+			new Response("<html>XHTML content</html>", {
+				status: 200,
+				headers: { "content-type": "application/xhtml+xml; charset=utf-8" },
+			});
+		const crawlArticle = initCrawl({ fetch: fakeFetch });
+
+		const result = await crawlArticle({ url: "https://example.com" });
+
+		expect(result).toEqual({
+			status: "fetched",
+			html: "<html>XHTML content</html>",
+			etag: undefined,
+			lastModified: undefined,
+		});
+	});
+
 	it("passes the URL through to the fetch function unchanged", async () => {
 		let capturedInput: unknown;
 		const fakeFetch: typeof fetch = async (input) => {

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -56,7 +56,7 @@ export function initCrawlArticle(deps: {
 				return { status: "failed" };
 			}
 			const contentType = response.headers.get("content-type") ?? "";
-			if (!contentType.includes("text/html")) {
+			if (!isHtmlContentType(contentType)) {
 				deps.logError(`[CrawlArticle] Unexpected Content-Type "${contentType}" for ${params.url}`);
 				return { status: "failed" };
 			}
@@ -229,4 +229,9 @@ function isValidHttpUrl(url: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+/** Accept text/html and application/xhtml+xml — both are HTML-parseable by linkedom. */
+function isHtmlContentType(contentType: string): boolean {
+	return contentType.includes("text/html") || contentType.includes("application/xhtml+xml");
 }


### PR DESCRIPTION
Closes #247

**Summary**
- The crawler’s Accept header already requests `application/xhtml+xml` but the content-type validation only accepted `text/html`. Extract the check into `isHtmlContentType()` and accept both.
- See issue for full root-cause analysis and data-fix instructions.

Generated with [Claude Code](https://claude.ai/code)