### PR TITLE
fix(crawl-article,save-link): pass Referer when downloading article images

### DIFF
--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -14,7 +14,7 @@ import {
 } from '@packages/test-fixtures'
 import { requireEnv } from '../runtime/require-env'
 import { initRefreshArticleIfStale } from '@packages/test-fixtures/providers/article-freshness'
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle } from '@packages/crawl-article'
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from '@packages/crawl-article'
 import { theInformationPreParser } from '@packages/test-fixtures/providers/article-parser'
 import { initInMemoryRefreshArticleContent } from '@packages/test-fixtures/providers/events'
 import { initInMemoryUpdateFetchTimestamp } from '@packages/test-fixtures/providers/events'
@@ -30,7 +30,8 @@ const origin = `http://127.0.0.1:${PORT}`
 const logger = HutchLogger.from(consoleLogger)
 
 const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }))
-const crawlArticle = initCrawlArticle({ fetch: globalThis.fetch, logError, headers: { ...DEFAULT_CRAWL_HEADERS } })
+const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } })
+const crawlArticle = initCrawlArticle({ crawlFetch, logError })
 const { parseArticle, parseHtml } = initReadabilityParser({ crawlArticle, sitePreParsers: [theInformationPreParser], logError })
 
 const fixture = createDefaultTestAppFixture(origin)

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -7,7 +7,7 @@ import { initInMemoryAuth } from "@packages/test-fixtures/providers/auth";
 import { initDynamoDbAuth } from "./providers/auth/dynamodb-auth";
 import { initInMemoryArticleStore } from "@packages/test-fixtures/providers/article-store";
 import { initDynamoDbArticleStore } from "./providers/article-store/dynamodb-article-store";
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle } from "@packages/crawl-article";
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "@packages/test-fixtures/providers/article-parser";
 import { theInformationPreParser } from "@packages/test-fixtures/providers/article-parser";
 import { initRefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
@@ -64,7 +64,8 @@ function initProviders() {
 	const persistence = requireEnv<"prod" | "development">("PERSISTENCE");
 	const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }));
 
-	const crawlArticle = initCrawlArticle({ fetch: globalThis.fetch, logError, headers: { ...DEFAULT_CRAWL_HEADERS } });
+	const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
+	const crawlArticle = initCrawlArticle({ crawlFetch, logError });
 	const { parseHtml } = initReadabilityParser({
 		crawlArticle,
 		sitePreParsers: [theInformationPreParser],

--- a/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
@@ -4,7 +4,7 @@ import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
 import { requireEnv } from "../require-env";
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle } from "@packages/crawl-article";
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../article-parser/readability-parser";
 import { theInformationPreParser } from "../article-parser/the-information-pre-parser";
 import { initS3PutImageObject } from "../save-link/s3-put-image-object";
@@ -29,7 +29,8 @@ const client = createDynamoDocumentClient();
 const s3Client = new S3Client({});
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 
-const crawlArticle = initCrawlArticle({ fetch: globalThis.fetch, logError, headers: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlArticle = initCrawlArticle({ crawlFetch, logError });
 
 const { parseHtml } = initReadabilityParser({
 	crawlArticle,
@@ -60,7 +61,7 @@ const { markCrawlFailed, markCrawlStage } = initDynamoDbArticleCrawl({
 const downloadMedia = initDownloadMedia({
 	putImageObject,
 	logger: consoleLogger,
-	fetch: globalThis.fetch,
+	crawlFetch,
 	imagesCdnBaseUrl,
 });
 

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -4,7 +4,7 @@ import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
 import { requireEnv } from "../require-env";
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle } from "@packages/crawl-article";
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../article-parser/readability-parser";
 import { theInformationPreParser } from "../article-parser/the-information-pre-parser";
 import { initS3PutImageObject } from "../save-link/s3-put-image-object";
@@ -29,7 +29,8 @@ const client = createDynamoDocumentClient();
 const s3Client = new S3Client({});
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 
-const crawlArticle = initCrawlArticle({ fetch: globalThis.fetch, logError, headers: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlArticle = initCrawlArticle({ crawlFetch, logError });
 
 const { parseHtml } = initReadabilityParser({
 	crawlArticle,
@@ -60,7 +61,7 @@ const { markCrawlFailed, markCrawlStage } = initDynamoDbArticleCrawl({
 const downloadMedia = initDownloadMedia({
 	putImageObject,
 	logger: consoleLogger,
-	fetch: globalThis.fetch,
+	crawlFetch,
 	imagesCdnBaseUrl,
 });
 

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -4,7 +4,7 @@ import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
 import { requireEnv } from "../require-env";
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle } from "@packages/crawl-article";
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../article-parser/readability-parser";
 import { theInformationPreParser } from "../article-parser/the-information-pre-parser";
 import { initS3PutImageObject } from "../save-link/s3-put-image-object";
@@ -29,7 +29,8 @@ const client = createDynamoDocumentClient();
 const s3Client = new S3Client({});
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 
-const crawlArticle = initCrawlArticle({ fetch: globalThis.fetch, logError, headers: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlArticle = initCrawlArticle({ crawlFetch, logError });
 
 const { parseHtml } = initReadabilityParser({
 	crawlArticle,
@@ -60,7 +61,7 @@ const { markCrawlFailed, markCrawlStage } = initDynamoDbArticleCrawl({
 const downloadMedia = initDownloadMedia({
 	putImageObject,
 	logger: consoleLogger,
-	fetch: globalThis.fetch,
+	crawlFetch,
 	imagesCdnBaseUrl,
 });
 

--- a/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
@@ -1,6 +1,6 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
-import { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "@packages/crawl-article";
+import { initCrawlArticle, initCrawlFetch, DEFAULT_CRAWL_HEADERS } from "@packages/crawl-article";
 import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
@@ -29,7 +29,8 @@ const eventBusName = requireEnv("EVENT_BUS_NAME");
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 const s3Client = new S3Client({});
 const dynamoClient = createDynamoDocumentClient();
-const crawlArticle = initCrawlArticle({ fetch: globalThis.fetch, logError, headers: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
+const crawlArticle = initCrawlArticle({ crawlFetch, logError });
 
 const { parseHtml } = initReadabilityParser({
 	crawlArticle,
@@ -50,7 +51,7 @@ const { putImageObject } = initS3PutImageObject({
 const downloadMedia = initDownloadMedia({
 	putImageObject,
 	logger: consoleLogger,
-	fetch: globalThis.fetch,
+	crawlFetch,
 	imagesCdnBaseUrl,
 });
 

--- a/projects/save-link/src/save-link-raw-html/save-link-raw-html-command-handler.ts
+++ b/projects/save-link/src/save-link-raw-html/save-link-raw-html-command-handler.ts
@@ -77,6 +77,7 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 			const articleResourceUniqueId = ArticleResourceUniqueId.parse(detail.url);
 			const media = await downloadMedia({
 				html: parseResult.article.content,
+				articleUrl: detail.url,
 				articleResourceUniqueId,
 			});
 			const processedHtml = await processContent({ html: parseResult.article.content, media });

--- a/projects/save-link/src/save-link/download-media.test.ts
+++ b/projects/save-link/src/save-link/download-media.test.ts
@@ -1,9 +1,11 @@
 import { noopLogger } from "@packages/hutch-logger";
+import type { CrawlFetch } from "@packages/crawl-article";
 import { initDownloadMedia } from "./download-media";
 import type { PutImageObject } from "./s3-put-image-object";
 import { ArticleResourceUniqueId } from "./article-resource-unique-id";
 
-const articleResourceUniqueId = ArticleResourceUniqueId.parse("https://example.com/article");
+const ARTICLE_URL = "https://example.com/article";
+const articleResourceUniqueId = ArticleResourceUniqueId.parse(ARTICLE_URL);
 
 function createPngResponse(): Response {
 	const pixel = Buffer.from(
@@ -26,11 +28,12 @@ function createOversizedResponse(): Response {
 function createDownloadMedia(overrides?: { putImageObject?: PutImageObject; fetch?: jest.Mock }) {
 	const putImageObject: PutImageObject = overrides?.putImageObject ?? jest.fn().mockResolvedValue(undefined);
 	const fakeFetch = overrides?.fetch ?? jest.fn().mockImplementation(() => Promise.resolve(createPngResponse()));
+	const crawlFetch: CrawlFetch = (url, init) => fakeFetch(url, init);
 
 	const downloadMedia = initDownloadMedia({
 		putImageObject,
 		logger: noopLogger,
-		fetch: fakeFetch,
+		crawlFetch,
 		imagesCdnBaseUrl: "https://d123.cloudfront.net",
 	});
 
@@ -38,11 +41,26 @@ function createDownloadMedia(overrides?: { putImageObject?: PutImageObject; fetc
 }
 
 describe("initDownloadMedia", () => {
+	it("sends the article URL as Referer so hotlink-protected origins serve the image", async () => {
+		const { downloadMedia, fakeFetch } = createDownloadMedia();
+
+		await downloadMedia({
+			html: '<img src="https://hotlinkprotected.example/photo.png">',
+			articleUrl: "https://hotlinkprotected.example/post",
+			articleResourceUniqueId,
+		});
+
+		expect(fakeFetch).toHaveBeenCalledTimes(1);
+		const init = fakeFetch.mock.calls[0][1];
+		expect(init.referer).toBe("https://hotlinkprotected.example/post");
+	});
+
 	it("downloads image and returns mapping with CDN URL", async () => {
 		const { downloadMedia, putImageObject } = createDownloadMedia();
 
 		const media = await downloadMedia({
 			html: '<p><img src="https://example.com/photo.png"></p>',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -64,6 +82,7 @@ describe("initDownloadMedia", () => {
 
 		await downloadMedia({
 			html: '<img src="https://example.com/photo.png">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId: nestedArticle,
 		});
 
@@ -80,6 +99,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/photo.png">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId: nestedArticle,
 		});
 
@@ -91,6 +111,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img srcset="https://example.com/small.png 300w, https://example.com/large.png 600w">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -104,6 +125,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img srcset="https://cdn.example.com/image/fetch/w_424,c_limit,f_webp,q_auto:good/photo.png 424w, https://cdn.example.com/image/fetch/w_848,c_limit,f_webp,q_auto:good/photo.png 848w">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -126,6 +148,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/photo.png"><img srcset="https://example.com/p/w_424 424w">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -138,6 +161,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/photo.png" srcset="https://example.com/photo.png 1x">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -151,6 +175,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<p><img src="https://example.com/broken.png"></p>',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -164,6 +189,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<p><img src="https://example.com/huge.jpg"></p>',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -176,6 +202,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/photo.png"><img src="https://example.com/photo.png">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -193,6 +220,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: imgs,
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -205,6 +233,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="data:image/png;base64,iVBORw0KGgo=">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -217,6 +246,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: "<p>Plain text article</p>",
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -230,6 +260,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/photo.png">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -247,6 +278,7 @@ describe("initDownloadMedia", () => {
 
 		await downloadMedia({
 			html: '<img src="https://example.com/unknown">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -266,6 +298,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/huge-no-header.jpg">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -281,6 +314,7 @@ describe("initDownloadMedia", () => {
 
 		const media = await downloadMedia({
 			html: '<img src="https://example.com/missing.png">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -299,6 +333,7 @@ describe("initDownloadMedia", () => {
 
 		await downloadMedia({
 			html: '<img src="https://example.com/photo.tiff">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 
@@ -318,6 +353,7 @@ describe("initDownloadMedia", () => {
 
 		await downloadMedia({
 			html: '<img src="https://example.com/image">',
+			articleUrl: ARTICLE_URL,
 			articleResourceUniqueId,
 		});
 

--- a/projects/save-link/src/save-link/download-media.ts
+++ b/projects/save-link/src/save-link/download-media.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { parseHTML } from "linkedom";
 import parseSrcset from "parse-srcset";
+import type { CrawlFetch } from "@packages/crawl-article";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { ArticleResourceUniqueId } from "./article-resource-unique-id";
 import type { PutImageObject } from "./s3-put-image-object";
@@ -14,18 +15,19 @@ export type DownloadedMedia = { originalUrl: string; cdnUrl: string };
 
 export type DownloadMedia = (params: {
 	html: string;
+	articleUrl: string;
 	articleResourceUniqueId: ArticleResourceUniqueId;
 }) => Promise<DownloadedMedia[]>;
 
 export function initDownloadMedia(deps: {
 	putImageObject: PutImageObject;
 	logger: HutchLogger;
-	fetch: typeof globalThis.fetch;
+	crawlFetch: CrawlFetch;
 	imagesCdnBaseUrl: string;
 }): DownloadMedia {
-	const { putImageObject, logger, fetch: fetchFn, imagesCdnBaseUrl } = deps;
+	const { putImageObject, logger, crawlFetch, imagesCdnBaseUrl } = deps;
 
-	return async ({ html, articleResourceUniqueId }) => {
+	return async ({ html, articleUrl, articleResourceUniqueId }) => {
 		const results: DownloadedMedia[] = [];
 
 		const imageUrls = extractImageUrls(html);
@@ -36,7 +38,7 @@ export function initDownloadMedia(deps: {
 			const batch = uniqueUrls.slice(i, i + CONCURRENCY);
 			await Promise.all(batch.map(async (originalUrl) => {
 				try {
-					const downloaded = await downloadImage(fetchFn, originalUrl);
+					const downloaded = await downloadImage({ crawlFetch, url: originalUrl, referer: articleUrl });
 					if (!downloaded) return;
 
 					const hash = createHash("sha256").update(originalUrl).digest("hex").slice(0, 16);
@@ -80,12 +82,16 @@ function extractImageUrls(html: string): string[] {
 	return urls;
 }
 
-async function downloadImage(
-	fetchFn: typeof globalThis.fetch,
-	url: string,
-): Promise<{ body: Buffer; contentType: string } | undefined> {
-	const response = await fetchFn(url, {
+async function downloadImage(args: {
+	crawlFetch: CrawlFetch;
+	url: string;
+	referer: string;
+}): Promise<{ body: Buffer; contentType: string } | undefined> {
+	const { crawlFetch, url, referer } = args;
+	const response = await crawlFetch(url, {
 		signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+		headers: { accept: "image/*,*/*;q=0.8" },
+		referer,
 	});
 
 	if (!response.ok) return undefined;

--- a/projects/save-link/src/save-link/save-link-work.ts
+++ b/projects/save-link/src/save-link/save-link-work.ts
@@ -96,6 +96,7 @@ export function initSaveLinkWork(deps: {
 
 		const media = await downloadMedia({
 			html: article.content,
+			articleUrl: url,
 			articleResourceUniqueId,
 		});
 

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "./crawl-article";
 import type { CrawlArticleResult } from "./crawl-article.types";
+import { initCrawlFetch } from "./crawl-fetch";
 import type { fetchCurl } from "./curl-fetch";
 
 const noopLogError = () => {};
@@ -21,11 +22,14 @@ function initCrawl(overrides?: {
 			status: 200,
 			headers: { "content-type": "text/html" },
 		});
-	return initCrawlArticle({
+	const crawlFetch = initCrawlFetch({
 		fetch: overrides?.fetch ?? defaultFetch,
-		logError: overrides?.logError ?? noopLogError,
-		headers: { ...DEFAULT_CRAWL_HEADERS },
+		defaultHeaders: { ...DEFAULT_CRAWL_HEADERS },
 		fetchCurl: overrides?.fetchCurl ?? stubFetchCurl,
+	});
+	return initCrawlArticle({
+		crawlFetch,
+		logError: overrides?.logError ?? noopLogError,
 	});
 }
 
@@ -268,13 +272,15 @@ describe("initCrawlArticle — X/Twitter oembed fallback", () => {
 	it("returns 'failed' when oembed API throws a network error", async () => {
 		const networkError = new Error("timeout");
 		const fakeFetch: typeof fetch = async () => { throw networkError; };
+		const curlError = new Error("curl also failed");
+		const stubCurl: typeof fetchCurl = async () => { throw curlError; };
 		const logError = jest.fn();
-		const crawlArticle = initCrawl({ fetch: fakeFetch, logError });
+		const crawlArticle = initCrawl({ fetch: fakeFetch, fetchCurl: stubCurl, logError });
 
 		const result = await crawlArticle({ url: "https://x.com/user/status/123" });
 
 		expect(result).toEqual({ status: "failed" });
-		expect(logError).toHaveBeenCalledWith("[CrawlArticle] oembed error for https://x.com/user/status/123", networkError);
+		expect(logError).toHaveBeenCalledWith("[CrawlArticle] oembed error for https://x.com/user/status/123", curlError);
 	});
 
 	it("encodes the tweet URL in the oembed request", async () => {

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -1,8 +1,6 @@
 import { parseHTML } from "linkedom";
-import { withAiaChasing } from "./aia-fetch";
 import type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";
-import type { fetchCurl } from "./curl-fetch";
-import { type fetchH2, withH2Fallback } from "./h2-fetch";
+import type { CrawlFetch } from "./crawl-fetch";
 import { headerOrUndefined } from "./header-utils";
 
 const FETCH_TIMEOUT_MS = 10000;
@@ -23,28 +21,21 @@ export const DEFAULT_CRAWL_HEADERS = {
 const X_TWITTER_PATTERN = /^https?:\/\/(x\.com|twitter\.com)\//;
 
 export function initCrawlArticle(deps: {
-	fetch: typeof globalThis.fetch;
+	crawlFetch: CrawlFetch;
 	logError: (message: string, error?: Error) => void;
-	headers: Record<string, string>;
-	fetchH2?: typeof fetchH2;
-	fetchCurl?: typeof fetchCurl;
 }): CrawlArticle {
-	const fetchWithFallback = withH2Fallback(
-		withAiaChasing(deps.fetch),
-		deps.fetchH2,
-		deps.fetchCurl,
-	);
+	const { crawlFetch, logError } = deps;
 	return async (params) => {
 		if (X_TWITTER_PATTERN.test(params.url)) {
-			return fetchViaOembed(deps, params);
+			return fetchViaOembed({ crawlFetch, logError }, params);
 		}
 
-		const headers: Record<string, string> = { ...deps.headers };
+		const headers: Record<string, string> = {};
 		if (params.etag) headers["if-none-match"] = params.etag;
 		if (params.lastModified) headers["if-modified-since"] = params.lastModified;
 
 		try {
-			const response = await fetchWithFallback(params.url, {
+			const response = await crawlFetch(params.url, {
 				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 				headers,
 			});
@@ -64,7 +55,7 @@ export function initCrawlArticle(deps: {
 			const candidates = extractThumbnailCandidates({ html, baseUrl: params.url });
 			const thumbnailUrl = candidates[0];
 			const thumbnailImage = params.fetchThumbnail
-				? await fetchThumbnailImage({ fetchWithFallback, logError: deps.logError, candidates })
+				? await fetchThumbnailImage({ crawlFetch, logError, candidates, referer: params.url })
 				: undefined;
 			const result: CrawlArticleResult & { status: "fetched" } = {
 				status: "fetched",
@@ -83,14 +74,15 @@ export function initCrawlArticle(deps: {
 }
 
 async function fetchThumbnailImage(args: {
-	fetchWithFallback: typeof globalThis.fetch;
+	crawlFetch: CrawlFetch;
 	logError: (message: string, error?: Error) => void;
 	candidates: string[];
+	referer: string;
 }): Promise<ThumbnailImage | undefined> {
-	const { fetchWithFallback, logError, candidates } = args;
+	const { crawlFetch, logError, candidates, referer } = args;
 
 	for (const candidateUrl of candidates) {
-		const result = await tryFetchImage({ fetchWithFallback, logError, url: candidateUrl });
+		const result = await tryFetchImage({ crawlFetch, logError, url: candidateUrl, referer });
 		if (result) return result;
 	}
 
@@ -98,15 +90,17 @@ async function fetchThumbnailImage(args: {
 }
 
 async function tryFetchImage(args: {
-	fetchWithFallback: typeof globalThis.fetch;
+	crawlFetch: CrawlFetch;
 	logError: (message: string, error?: Error) => void;
 	url: string;
+	referer: string;
 }): Promise<ThumbnailImage | undefined> {
-	const { fetchWithFallback, logError, url } = args;
+	const { crawlFetch, logError, url, referer } = args;
 	try {
-		const response = await fetchWithFallback(url, {
+		const response = await crawlFetch(url, {
 			signal: AbortSignal.timeout(THUMBNAIL_FETCH_TIMEOUT_MS),
 			headers: { accept: "image/*,*/*;q=0.8" },
+			referer,
 		});
 		if (!response.ok) {
 			logError(`[CrawlArticle] Thumbnail HTTP ${response.status} for ${url}`);
@@ -137,12 +131,12 @@ async function tryFetchImage(args: {
 
 /** X/Twitter returns a JS app shell with no content. The oembed API returns the actual tweet text. */
 async function fetchViaOembed(
-	deps: { fetch: typeof globalThis.fetch; logError: (message: string, error?: Error) => void },
+	deps: { crawlFetch: CrawlFetch; logError: (message: string, error?: Error) => void },
 	params: { url: string },
 ) {
 	const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(params.url)}`;
 	try {
-		const response = await deps.fetch(oembedUrl, {
+		const response = await deps.crawlFetch(oembedUrl, {
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
 		if (!response.ok) {

--- a/src/packages/crawl-article/src/crawl-fetch.test.ts
+++ b/src/packages/crawl-article/src/crawl-fetch.test.ts
@@ -11,9 +11,9 @@ function createCrawlFetch() {
 }
 
 describe("initCrawlFetch", () => {
-	it("throws when referer is passed in both `referer` field and `headers`", () => {
+	it("throws when referer is passed in both `referer` field and `headers`", async () => {
 		const crawlFetch = createCrawlFetch();
-		assert.rejects(
+		await assert.rejects(
 			() =>
 				crawlFetch("https://example.com", {
 					referer: "https://article.com",

--- a/src/packages/crawl-article/src/crawl-fetch.test.ts
+++ b/src/packages/crawl-article/src/crawl-fetch.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert";
+import { initCrawlFetch } from "./crawl-fetch";
+
+const stubFetch: typeof fetch = async () => new Response("ok");
+
+function createCrawlFetch() {
+	return initCrawlFetch({
+		fetch: stubFetch,
+		defaultHeaders: { "user-agent": "test" },
+	});
+}
+
+describe("initCrawlFetch", () => {
+	it("throws when referer is passed in both `referer` field and `headers`", () => {
+		const crawlFetch = createCrawlFetch();
+		assert.rejects(
+			() =>
+				crawlFetch("https://example.com", {
+					referer: "https://article.com",
+					headers: { referer: "https://other.com" },
+				}),
+			{
+				message:
+					"Pass referer via the `referer` field or `headers.referer`, not both",
+			},
+		);
+	});
+});

--- a/src/packages/crawl-article/src/crawl-fetch.ts
+++ b/src/packages/crawl-article/src/crawl-fetch.ts
@@ -1,0 +1,37 @@
+import { withAiaChasing } from "./aia-fetch";
+import type { fetchCurl } from "./curl-fetch";
+import { type fetchH2, withH2Fallback } from "./h2-fetch";
+
+export type CrawlFetchInit = {
+	headers?: Record<string, string>;
+	signal?: AbortSignal;
+	/** Sent as `Referer`. Required by hotlink-protected origins. */
+	referer?: string;
+};
+
+/**
+ * Universal browser-like fetcher used for every external resource (HTML,
+ * images, oembed JSON). Composes the same fallback chain as `crawlArticle`:
+ * AIA chasing → HTTP/2 fallback for Cloudflare TLS challenges → curl
+ * fallback for JA3/JA4 + transient TLS errors. Default headers impersonate a
+ * real browser; per-call headers (and `referer`) are merged on top.
+ */
+export type CrawlFetch = (url: string, init?: CrawlFetchInit) => Promise<Response>;
+
+export function initCrawlFetch(deps: {
+	fetch: typeof globalThis.fetch;
+	defaultHeaders: Record<string, string>;
+	fetchH2?: typeof fetchH2;
+	fetchCurl?: typeof fetchCurl;
+}): CrawlFetch {
+	const fetchWithFallback = withH2Fallback(
+		withAiaChasing(deps.fetch),
+		deps.fetchH2,
+		deps.fetchCurl,
+	);
+	return async (url, init) => {
+		const headers: Record<string, string> = { ...deps.defaultHeaders, ...init?.headers };
+		if (init?.referer) headers.referer = init.referer;
+		return fetchWithFallback(url, { headers, signal: init?.signal });
+	};
+}

--- a/src/packages/crawl-article/src/crawl-fetch.ts
+++ b/src/packages/crawl-article/src/crawl-fetch.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { withAiaChasing } from "./aia-fetch";
 import type { fetchCurl } from "./curl-fetch";
 import { type fetchH2, withH2Fallback } from "./h2-fetch";
@@ -30,6 +31,10 @@ export function initCrawlFetch(deps: {
 		deps.fetchCurl,
 	);
 	return async (url, init) => {
+		assert(
+			!(init?.referer && init.headers?.referer),
+			"Pass referer via the `referer` field or `headers.referer`, not both",
+		);
 		const headers: Record<string, string> = { ...deps.defaultHeaders, ...init?.headers };
 		if (init?.referer) headers.referer = init.referer;
 		return fetchWithFallback(url, { headers, signal: init?.signal });

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -1,3 +1,5 @@
 export { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "./crawl-article";
 export type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";
+export { initCrawlFetch } from "./crawl-fetch";
+export type { CrawlFetch, CrawlFetchInit } from "./crawl-fetch";
 


### PR DESCRIPTION
## Summary

- Fixes broken images on saved articles whose origins (e.g. `fabiensanglard.net`) reject image fetches without a `Referer` header. Reproduced on https://readplace.com/view/https%3A%2F%2Ffabiensanglard.net%2Fquake_asm_optimizations%2Findex.html, where the article rendered with raw origin URLs and the PNGs 403'd in the reader's browser.
- Extracts a single `initCrawlFetch` primitive in `@packages/crawl-article` that owns browser-like default headers, the AIA → h2 → curl fallback chain, and an optional `referer`. Every external resource fetch (article HTML, images, thumbnails, oembed) now flows through this primitive instead of touching `globalThis.fetch` directly.
- `downloadMedia` now takes the article URL and sends it as `Referer` per image, so hotlink-protected origins serve the bytes; the CDN then caches them and serves them without referrer requirements.

## Test plan

- [x] `pnpm nx run @packages/crawl-article:test` — 124/124
- [x] `pnpm nx run save-link:test` — 249/249 (new test asserts Referer is sent)
- [x] `pnpm nx run hutch:test` — 1049/1049
- [x] `pnpm check` — all 18 projects green
- [x] Live verification: `crawlFetch` against `https://fabiensanglard.net/quake_asm_optimizations/42.3.png` returns `200 image/png 77045 bytes` with the article URL as Referer; `downloadMedia` against the article HTML uploads all three referenced images (42.3.png, 42.2.png, chart.svg) to the CDN.