### PR TITLE
refactor(@packages/crawl-article,save-link): dedupe extensionFromContentType helper

### DIFF
--- a/projects/save-link/src/save-link/download-media.ts
+++ b/projects/save-link/src/save-link/download-media.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto";
+import { extensionFromContentType } from "@packages/crawl-article";
+import type { HutchLogger } from "@packages/hutch-logger";
 import { parseHTML } from "linkedom";
 import parseSrcset from "parse-srcset";
 import type { CrawlFetch } from "@packages/crawl-article";
-import type { HutchLogger } from "@packages/hutch-logger";
 import type { ArticleResourceUniqueId } from "./article-resource-unique-id";
 import type { PutImageObject } from "./s3-put-image-object";
 
@@ -112,29 +113,3 @@ async function downloadImage(args: {
 
 	return { body, contentType };
 }
-
-function extensionFromContentType(params: { contentType: string; url: string }): string {
-	const { contentType, url } = params;
-	const mimeMap: Record<string, string> = {
-		"image/png": ".png",
-		"image/jpeg": ".jpg",
-		"image/gif": ".gif",
-		"image/webp": ".webp",
-		"image/svg+xml": ".svg",
-		"image/avif": ".avif",
-	};
-
-	const mimeBase = contentType.split(";")[0].trim().toLowerCase();
-	if (mimeMap[mimeBase]) return mimeMap[mimeBase];
-
-	try {
-		const pathname = new URL(url).pathname;
-		const match = pathname.match(/\.(\w{2,5})$/);
-		if (match) return `.${match[1]}`;
-	} catch {
-		// malformed URL
-	}
-
-	return ".bin";
-}
-

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -1,6 +1,7 @@
 import { parseHTML } from "linkedom";
 import type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";
 import type { CrawlFetch } from "./crawl-fetch";
+import { extensionFromContentType } from "./extension-from-content-type";
 import { headerOrUndefined } from "./header-utils";
 
 const FETCH_TIMEOUT_MS = 10000;
@@ -152,28 +153,6 @@ async function fetchViaOembed(
 		deps.logError(`[CrawlArticle] oembed error for ${params.url}`, error instanceof Error ? error : undefined);
 		return { status: "failed" } as const;
 	}
-}
-
-function extensionFromContentType(params: { contentType: string; url: string }): string {
-	const { contentType, url } = params;
-	const mimeMap: Record<string, string> = {
-		"image/png": ".png",
-		"image/jpeg": ".jpg",
-		"image/gif": ".gif",
-		"image/webp": ".webp",
-		"image/svg+xml": ".svg",
-		"image/avif": ".avif",
-	};
-	const mimeBase = contentType.split(";")[0].trim().toLowerCase();
-	if (mimeMap[mimeBase]) return mimeMap[mimeBase];
-	try {
-		const pathname = new URL(url).pathname;
-		const match = pathname.match(/\.(\w{2,5})$/);
-		if (match) return `.${match[1]}`;
-	} catch {
-		// malformed URL
-	}
-	return ".bin";
 }
 
 function extractThumbnailCandidates(params: {

--- a/src/packages/crawl-article/src/extension-from-content-type.test.ts
+++ b/src/packages/crawl-article/src/extension-from-content-type.test.ts
@@ -1,0 +1,38 @@
+import { extensionFromContentType } from "./extension-from-content-type";
+
+describe("extensionFromContentType", () => {
+	it("maps known image MIME types to their canonical extension", () => {
+		expect(extensionFromContentType({ contentType: "image/png", url: "https://example.com/x" })).toBe(".png");
+		expect(extensionFromContentType({ contentType: "image/jpeg", url: "https://example.com/x" })).toBe(".jpg");
+		expect(extensionFromContentType({ contentType: "image/gif", url: "https://example.com/x" })).toBe(".gif");
+		expect(extensionFromContentType({ contentType: "image/webp", url: "https://example.com/x" })).toBe(".webp");
+		expect(extensionFromContentType({ contentType: "image/svg+xml", url: "https://example.com/x" })).toBe(".svg");
+		expect(extensionFromContentType({ contentType: "image/avif", url: "https://example.com/x" })).toBe(".avif");
+	});
+
+	it("strips parameters from the content-type before looking up the MIME map", () => {
+		expect(
+			extensionFromContentType({ contentType: "image/jpeg; charset=binary", url: "https://example.com/x" }),
+		).toBe(".jpg");
+	});
+
+	it("normalizes the content-type to lowercase before MIME map lookup", () => {
+		expect(extensionFromContentType({ contentType: "IMAGE/PNG", url: "https://example.com/x" })).toBe(".png");
+	});
+
+	it("falls back to the URL pathname extension when the MIME type is unknown", () => {
+		expect(
+			extensionFromContentType({ contentType: "image/x-custom", url: "https://cdn.example.com/photo.tiff" }),
+		).toBe(".tiff");
+	});
+
+	it("returns .bin when the MIME type is unknown and the URL has no extension", () => {
+		expect(
+			extensionFromContentType({ contentType: "image/x-custom", url: "https://cdn.example.com/image" }),
+		).toBe(".bin");
+	});
+
+	it("returns .bin when the URL is malformed and cannot be parsed", () => {
+		expect(extensionFromContentType({ contentType: "image/x-custom", url: "not a url" })).toBe(".bin");
+	});
+});

--- a/src/packages/crawl-article/src/extension-from-content-type.ts
+++ b/src/packages/crawl-article/src/extension-from-content-type.ts
@@ -1,0 +1,21 @@
+export function extensionFromContentType(params: { contentType: string; url: string }): string {
+	const { contentType, url } = params;
+	const mimeMap: Record<string, string> = {
+		"image/png": ".png",
+		"image/jpeg": ".jpg",
+		"image/gif": ".gif",
+		"image/webp": ".webp",
+		"image/svg+xml": ".svg",
+		"image/avif": ".avif",
+	};
+	const mimeBase = contentType.split(";")[0].trim().toLowerCase();
+	if (mimeMap[mimeBase]) return mimeMap[mimeBase];
+	try {
+		const pathname = new URL(url).pathname;
+		const match = pathname.match(/\.(\w{2,5})$/);
+		if (match) return `.${match[1]}`;
+	} catch {
+		// malformed URL
+	}
+	return ".bin";
+}

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -1,4 +1,5 @@
 export { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "./crawl-article";
+export { extensionFromContentType } from "./extension-from-content-type";
 export type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";
 export { initCrawlFetch } from "./crawl-fetch";
 export type { CrawlFetch, CrawlFetchInit } from "./crawl-fetch";


### PR DESCRIPTION
## Summary

- Extracted `extensionFromContentType` into a new module `src/packages/crawl-article/src/extension-from-content-type.ts` and re-exported it from `@packages/crawl-article`.
- `crawl-article.ts` (thumbnail fetch) and `save-link/download-media.ts` (article image downloads) now both import the shared helper instead of carrying identical 21-line copies.
- Added a focused unit test (`extension-from-content-type.test.ts`) covering the MIME map, parameter stripping, lowercase normalization, URL-pathname fallback, the `.bin` default, and the malformed-URL `catch`. The new file hits 100% statements/branches/functions/lines.

`save-link` already declared `@packages/crawl-article` as a workspace dependency, so this change required no `package.json`, `project.json`, `tsconfig`, or coverage-config edits.

## Test plan

- [x] `pnpm nx run @packages/crawl-article:compile` succeeds
- [x] `pnpm nx run save-link:compile` succeeds
- [x] `pnpm test` in `@packages/crawl-article` (130/130 passing, including the new file's tests)
- [x] `pnpm test` in `save-link` (248/248 unit tests passing)
- [x] `pnpm lint` in `@packages/crawl-article` (clean — tsc, biome, knip)
- [x] `pnpm lint` in `save-link` (clean — tsc, biome, knip)
- [x] Coverage report shows `extension-from-content-type.ts` at 100% on all four metrics
- [x] `grep "function extensionFromContentType"` returns a single hit in the new module

https://claude.ai/code/session_01Wj7UvcdUHT2CQUsFWdUZww

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wj7UvcdUHT2CQUsFWdUZww)_