### PR TITLE
ci: use pnpm nx instead of npx nx in extension workflows

### DIFF
--- a/.github/workflows/publish-chrome-extension.yml
+++ b/.github/workflows/publish-chrome-extension.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build and package extension
         env:
           EXTENSION_VERSION: ${{ steps.version.outputs.version }}
-        run: npx nx run-many --target=compile --projects=browser-extension-core,chrome-extension
+        run: pnpm nx run-many --target=compile --projects=browser-extension-core,chrome-extension
 
       - name: Submit to Chrome Web Store
         run: node projects/extensions/chrome-extension/scripts/submit-to-chrome-web-store.js

--- a/.github/workflows/submit-ff-extension-for-signing.yml
+++ b/.github/workflows/submit-ff-extension-for-signing.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build and package extension
         env:
           EXTENSION_VERSION: ${{ steps.version.outputs.version }}
-        run: npx nx run-many --target=compile --projects=browser-extension-core,firefox-extension
+        run: pnpm nx run-many --target=compile --projects=browser-extension-core,firefox-extension
 
       - name: Create source code archive for AMO review
         run: |

--- a/.github/workflows/sync-signed-extension.yml
+++ b/.github/workflows/sync-signed-extension.yml
@@ -30,7 +30,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: npx nx compile browser-extension-core
+      - run: pnpm nx compile browser-extension-core
 
       - name: Sync signed extension from AMO to S3
         run: node projects/extensions/firefox-extension/scripts/sync-signed-extension.js


### PR DESCRIPTION
## Summary

- Replace `npx nx` with `pnpm nx` in three GitHub Actions workflows that build/package the browser extensions.
- Aligns with the [CLAUDE.md guideline](../blob/main/CLAUDE.md): "Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) — avoids using globally installed CLI."
- Consistent with the rest of the workflows in `.github/workflows/` (`ci.yml`, `project-deployment.yaml`, `tier-1-plus-crawl-pipeline-health.yml`, `stuck-articles-canary.yml`), which already use `pnpm nx`.

## Files changed

| Workflow | Line | Command |
|---|---|---|
| `publish-chrome-extension.yml` | 40 | `nx run-many --target=compile --projects=browser-extension-core,chrome-extension` |
| `submit-ff-extension-for-signing.yml` | 38 | `nx run-many --target=compile --projects=browser-extension-core,firefox-extension` |
| `sync-signed-extension.yml` | 33 | `nx compile browser-extension-core` |

## Test plan

- [ ] CI passes on this branch
- [ ] Next Chrome extension publish run uses the workspace-pinned Nx
- [ ] Next Firefox extension submit/sync runs use the workspace-pinned Nx

https://claude.ai/code/session_01GRtR9sqB9qBUvsPWanC6JD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRtR9sqB9qBUvsPWanC6JD)_