### PR TITLE
feat(save-link,hutch-infra-components): SQS partial batch failure reporting in stale-check handler

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -287,6 +287,7 @@ const staleCheckRequestedLambdaWithSQS = new HutchSQSBackedLambda("stale-check-r
 	lambda: staleCheckRequestedLambda,
 	queue: staleCheckRequestedQueue,
 	alertEmailDLQEntry: alertEmail,
+	reportBatchItemFailures: true,
 });
 
 eventBus.subscribe(StaleCheckRequestedEvent, staleCheckRequestedLambdaWithSQS);

--- a/projects/save-link/src/save-link/stale-check-handler.test.ts
+++ b/projects/save-link/src/save-link/stale-check-handler.test.ts
@@ -56,10 +56,15 @@ describe("initStaleCheckHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		const result = await handler(
+			createSqsEvent({ url: URL_UNDER_TEST }),
+			stubContext,
+			() => {},
+		);
 
 		expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
 		expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: URL_UNDER_TEST });
+		expect(result).toEqual({ batchItemFailures: [] });
 	});
 
 	it("re-publishes SaveAnonymousLinkCommand when refreshArticleIfStale returns 'new' (e.g. row was evicted between view and worker)", async () => {
@@ -181,15 +186,63 @@ describe("initStaleCheckHandler", () => {
 			],
 		};
 
-		await handler(batch, stubContext, () => {});
+		const result = await handler(batch, stubContext, () => {});
 
 		expect(refreshArticleIfStale).toHaveBeenCalledTimes(2);
 		expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(2);
 		expect(publishSaveAnonymousLink).toHaveBeenNthCalledWith(1, { url: "https://a.example.com/" });
 		expect(publishSaveAnonymousLink).toHaveBeenNthCalledWith(2, { url: "https://b.example.com/" });
+		expect(result).toEqual({ batchItemFailures: [] });
 	});
 
-	it("throws on invalid event detail (zod parse failure)", async () => {
+	it("reports the failed record (and only that record) when refreshArticleIfStale throws mid-batch", async () => {
+		const refreshArticleIfStale = jest
+			.fn<ReturnType<RefreshArticleIfStale>, Parameters<RefreshArticleIfStale>>()
+			.mockResolvedValueOnce({ action: "reprime" })
+			.mockRejectedValueOnce(new Error("upstream failure"));
+		const publishSaveAnonymousLink = jest.fn().mockResolvedValue(undefined);
+
+		const handler = initStaleCheckHandler({
+			refreshArticleIfStale,
+			publishSaveAnonymousLink,
+			logger: noopLogger,
+		});
+
+		const batch: SQSEvent = {
+			Records: [
+				{
+					messageId: "msg-1",
+					receiptHandle: "receipt-1",
+					body: JSON.stringify({ detail: { url: "https://a.example.com/" } }),
+					attributes: stubAttributes,
+					messageAttributes: {},
+					md5OfBody: "",
+					eventSource: "aws:sqs",
+					eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:StaleCheckRequested",
+					awsRegion: "ap-southeast-2",
+				},
+				{
+					messageId: "msg-2",
+					receiptHandle: "receipt-2",
+					body: JSON.stringify({ detail: { url: "https://b.example.com/" } }),
+					attributes: stubAttributes,
+					messageAttributes: {},
+					md5OfBody: "",
+					eventSource: "aws:sqs",
+					eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:StaleCheckRequested",
+					awsRegion: "ap-southeast-2",
+				},
+			],
+		};
+
+		const result = await handler(batch, stubContext, () => {});
+
+		expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
+		expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: "https://a.example.com/" });
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-2" }] });
+	});
+
+	it("reports the record as a batch failure when the event detail fails zod validation", async () => {
 		const handler = initStaleCheckHandler({
 			refreshArticleIfStale: jest.fn(),
 			publishSaveAnonymousLink: jest.fn(),
@@ -210,8 +263,8 @@ describe("initStaleCheckHandler", () => {
 			}],
 		};
 
-		await expect(
-			handler(invalidEvent, stubContext, () => {}),
-		).rejects.toThrow();
+		const result = await handler(invalidEvent, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/save-link/stale-check-handler.ts
+++ b/projects/save-link/src/save-link/stale-check-handler.ts
@@ -1,4 +1,4 @@
-import type { SQSHandler } from "aws-lambda";
+import type { SQSBatchItemFailure, SQSBatchResponse, SQSHandler } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { StaleCheckRequestedEvent } from "@packages/hutch-infra-components";
 import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
@@ -11,27 +11,39 @@ export function initStaleCheckHandler(deps: {
 }): SQSHandler {
 	const { refreshArticleIfStale, publishSaveAnonymousLink, logger } = deps;
 
-	return async (event) => {
+	return async (event): Promise<SQSBatchResponse> => {
+		const batchItemFailures: SQSBatchItemFailure[] = [];
+
 		for (const record of event.Records) {
-			const envelope = JSON.parse(record.body);
-			const detail = StaleCheckRequestedEvent.detailSchema.parse(envelope.detail);
+			try {
+				const envelope = JSON.parse(record.body);
+				const detail = StaleCheckRequestedEvent.detailSchema.parse(envelope.detail);
 
-			logger.info("[StaleCheckRequested] processing", { url: detail.url });
+				logger.info("[StaleCheckRequested] processing", { url: detail.url });
 
-			const result = await refreshArticleIfStale({ url: detail.url });
+				const result = await refreshArticleIfStale({ url: detail.url });
 
-			if (result.action === "reprime" || result.action === "new") {
-				await publishSaveAnonymousLink({ url: detail.url });
-				logger.info("[StaleCheckRequested] re-published SaveAnonymousLinkCommand", {
-					url: detail.url,
-					action: result.action,
+				if (result.action === "reprime" || result.action === "new") {
+					await publishSaveAnonymousLink({ url: detail.url });
+					logger.info("[StaleCheckRequested] re-published SaveAnonymousLinkCommand", {
+						url: detail.url,
+						action: result.action,
+					});
+				} else {
+					logger.info("[StaleCheckRequested] no-op", {
+						url: detail.url,
+						action: result.action,
+					});
+				}
+			} catch (error) {
+				logger.error("[StaleCheckRequested] record failed", {
+					messageId: record.messageId,
+					error,
 				});
-			} else {
-				logger.info("[StaleCheckRequested] no-op", {
-					url: detail.url,
-					action: result.action,
-				});
+				batchItemFailures.push({ itemIdentifier: record.messageId });
 			}
 		}
+
+		return { batchItemFailures };
 	};
 }

--- a/src/packages/hutch-infra-components/src/infra/hutch-sqs-backed-lambda.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-sqs-backed-lambda.ts
@@ -13,6 +13,7 @@ export class HutchSQSBackedLambda extends pulumi.ComponentResource {
 			lambda: HutchLambda;
 			queue: HutchSQS;
 			alertEmailDLQEntry: string;
+			reportBatchItemFailures?: boolean;
 		},
 		opts?: pulumi.ComponentResourceOptions,
 	) {
@@ -39,6 +40,9 @@ export class HutchSQSBackedLambda extends pulumi.ComponentResource {
 			eventSourceArn: args.queue.queueArn,
 			functionName: args.lambda.arn,
 			batchSize: 1,
+			...(args.reportBatchItemFailures
+				? { functionResponseTypes: ["ReportBatchItemFailures"] }
+				: {}),
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
 
 		const topic = new aws.sns.Topic(`${name}-dlq-topic`, {


### PR DESCRIPTION
## Summary

Addresses the low-priority follow-up flagged on the merged stale-check Lambda PR (#253):

> Consider SQS partial batch failure reporting in stale-check handler — `projects/save-link/src/save-link/stale-check-handler.ts:15-35`

The handler now returns `SQSBatchResponse` with `batchItemFailures`, so when one record in a batch errors the others are still settled and only the failed record is retried. Previously the whole batch was retried on a single failure (safe, given upstream idempotency, but redundant).

## What changed

- **`projects/save-link/src/save-link/stale-check-handler.ts`** — wraps the per-record processing in a `try/catch`, pushes failed `messageId`s into `batchItemFailures`, and returns `{ batchItemFailures }` instead of throwing on the first failure.
- **`src/packages/hutch-infra-components/src/infra/hutch-sqs-backed-lambda.ts`** — adds an opt-in `reportBatchItemFailures?: boolean` flag that wires `functionResponseTypes: ["ReportBatchItemFailures"]` on the `EventSourceMapping`. Without this flag set, AWS would silently treat the response as a successful invocation and skip the DLQ entirely — so the handler change and the infra change must land together.
- **`projects/save-link/src/infra/index.ts`** — passes `reportBatchItemFailures: true` to the stale-check `HutchSQSBackedLambda`. All other SQS-backed Lambdas keep their existing throw-to-redrive semantics (unchanged).
- **`projects/save-link/src/save-link/stale-check-handler.test.ts`** — updates the existing batch test + the zod-validation test to assert the response shape, and adds a new spec that exercises the partial-failure path: two records, the second one rejects from `refreshArticleIfStale`, and the response reports only `msg-2`.

## Why both layers

`batchSize: 1` is hardcoded today on `HutchSQSBackedLambda`, so the runtime impact for the stale-check Lambda is currently nil. The handler change is correctness-preserving for the for-loop pattern (so a future `batchSize > 1` does not regress) and the EventSourceMapping config is what actually instructs AWS to honor the response — without `functionResponseTypes` set, returning `{ batchItemFailures: [...] }` is treated as success and the failed record would be silently dropped before the DLQ alarm fires.

## Test plan

- [x] `pnpm nx run save-link:test --testPathPattern=stale-check-handler` → 8 specs pass (5 existing + 1 updated batch + 2 new failure-reporting specs)
- [x] `npx jest --coverage --collectCoverageFrom='dist/save-link/stale-check-handler.js'` → 100% statements/branches/functions/lines on the handler
- [x] `pnpm nx run save-link:lint` and `pnpm nx run @packages/hutch-infra-components:lint` → clean
- [x] Pre-commit `pnpm check` (run-many across 18 projects) → green
- [ ] After merge: confirm the deployed `stale-check-requested` EventSourceMapping has `FunctionResponseTypes: ["ReportBatchItemFailures"]` (`aws lambda list-event-source-mappings --function-name stale-check-requested-handler`)
- [ ] After merge: force a handler error (e.g. transient DDB throttle) and verify only the failing message is retried + DLQ alarm still fires after `maxReceiveCount`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hc9GFNQBHbfHFhdRCbZ6wz)_