### PR TITLE
fix(save-link): break selector tie when one tier carries CDN-rewritten image URLs

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -527,6 +527,7 @@ const recrawlContentExtractedLambda = new HutchLambda("recrawl-content-extracted
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		DEEPSEEK_API_KEY: deepseekApiKey,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 	},
 	policies: [
 		...recrawlContentExtractedDynamodb.policies,

--- a/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
@@ -20,6 +20,7 @@ const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const deepseekApiKey = requireEnv("DEEPSEEK_API_KEY");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
+const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 
 const s3Client = new S3Client({});
 const dynamoClient = createDynamoDocumentClient();
@@ -80,5 +81,6 @@ export const handler = initRecrawlContentExtractedHandler({
 	markCrawlReady,
 	dispatchGenerateSummary,
 	publishEvent,
+	imagesCdnBaseUrl,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
@@ -171,6 +171,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
+		expect(findContentSourceTier).not.toHaveBeenCalled();
 		expect(promoteTierToCanonical).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
@@ -74,6 +74,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		markCrawlReady: jest.fn().mockResolvedValue(undefined),
 		dispatchGenerateSummary: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
+		imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
 		logger: noopLogger,
 		...overrides,
 	};
@@ -147,6 +148,34 @@ describe("initRecrawlContentExtractedHandler", () => {
 		expect(publishEvent).toHaveBeenCalledWith(
 			expect.objectContaining({ detailType: "RecrawlCompleted" }),
 		);
+	});
+
+	it("on a tie, breaks in favour of the candidate with more CDN-host URLs even when canonical exists", async () => {
+		// Regression: pre-Referer-fix canonical (tier-0, raw origin URLs) tied
+		// with post-fix tier-1 (CDN URLs) — LLM said "only image URLs differ",
+		// which left readers stuck on the broken hotlink-protected origin.
+		const tier0 = tierSource("tier-0", { html: '<p>same body</p><img src="https://origin.example/a.png">' });
+		const tier1 = tierSource("tier-1", {
+			html: '<p>same body</p><img src="https://cdn.example.cloudfront.net/a.png"><img src="https://cdn.example.cloudfront.net/b.png">',
+		});
+		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
+		const findContentSourceTier = jest.fn().mockResolvedValue("tier-0");
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "only image URLs differ" }),
+			findContentSourceTier,
+			promoteTierToCanonical,
+			imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(promoteTierToCanonical).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-1",
+			metadata: tier1.metadata,
+		});
 	});
 
 	it("on a tie with no canonical (recovering a stuck row), defaults to tier-1 and promotes so summary generation can find content", async () => {

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
@@ -22,6 +22,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 	markCrawlReady: MarkCrawlReady;
 	dispatchGenerateSummary: DispatchCommand<typeof GenerateSummaryCommand>;
 	publishEvent: PublishEvent;
+	imagesCdnBaseUrl: string;
 	logger: HutchLogger;
 }): SQSHandler {
 	const {
@@ -32,8 +33,10 @@ export function initRecrawlContentExtractedHandler(deps: {
 		markCrawlReady,
 		dispatchGenerateSummary,
 		publishEvent,
+		imagesCdnBaseUrl,
 		logger,
 	} = deps;
+	const cdnHost = new URL(imagesCdnBaseUrl).host;
 
 	return async (event) => {
 		for (const record of event.Records) {
@@ -74,8 +77,20 @@ export function initRecrawlContentExtractedHandler(deps: {
 					reason: decision.reason,
 				});
 				if (decision.winner === "tie") {
-					const existingTier = await findContentSourceTier(detail.url);
-					if (existingTier) {
+					/* The LLM treats "only image URLs differ" as a tie, but a
+					 * recrawl after the Referer fix migrates <img src> from the
+					 * origin to our CDN — never a wash. Hotlink-protected
+					 * origins 403 the reader's browser
+					 * without our server-side Referer trick, so any net-positive
+					 * shift toward the CDN host is unambiguously an improvement.
+					 * Override the tie when one candidate has more occurrences
+					 * of the CDN host than the others. */
+					const cdnTie = breakTieByCdnRewriteCount(sources, cdnHost);
+					const existingTier = cdnTie ? undefined : await findContentSourceTier(detail.url);
+					if (cdnTie) {
+						winnerTier = cdnTie.tier;
+						reason = cdnTie.reason;
+					} else if (existingTier) {
 						/* Recrawl tie + canonical already set: keep canonical
 						 * exactly as-is; the operator still gets a fresh summary
 						 * via the unconditional dispatchGenerateSummary below. */
@@ -142,4 +157,23 @@ export function initRecrawlContentExtractedHandler(deps: {
 			});
 		}
 	};
+}
+
+function breakTieByCdnRewriteCount(
+	sources: readonly TierSource[],
+	cdnHost: string,
+): { tier: TierSource["tier"]; reason: string } | undefined {
+	const counts = sources
+		.map((source) => ({ tier: source.tier, count: countOccurrences(source.html, cdnHost) }))
+		.sort((a, b) => b.count - a.count);
+	const [top, second] = counts;
+	if (!top || !second || top.count <= second.count) return undefined;
+	return {
+		tier: top.tier,
+		reason: `tie broken: ${top.tier} has ${top.count} CDN-rewritten URLs vs ${second.count} in next candidate`,
+	};
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+	return haystack.split(needle).length - 1;
 }


### PR DESCRIPTION
## Summary

- Follow-up to #254. The Referer fix correctly downloads images to the CDN, but the LLM-based selector in `recrawl-content-extracted-handler` was returning `tie — only image URLs differ` and keeping the pre-fix canonical, so readers still saw broken hotlink-403'd images even after a successful recrawl. Reproduced on https://readplace.com/view/https%3A%2F%2Ffabiensanglard.net%2Fquake_asm_optimizations%2Findex.html (the same article that motivated #254).
- Override the tie when one candidate has strictly more occurrences of the configured CDN host than the next. Migrating images off the origin is never a wash, so the selector should treat that asymmetry as a deterministic improvement, not a quality call.
- Wires `IMAGES_CDN_BASE_URL` into the `recrawl-content-extracted` Lambda from the existing `contentMediaCdn.baseUrl` Pulumi output — no new GitHub Actions secrets needed.

## Test plan

- [x] New regression test in `recrawl-content-extracted-handler.test.ts` covering the exact failure shape from production: `tier-0` (raw origin URLs) tied with `tier-1` (CDN URLs), `findContentSourceTier` returns `tier-0`, expect `promoteTierToCanonical` called for `tier-1`.
- [x] `pnpm nx run save-link:test` — 250/250 (one new test, no existing test modifications).
- [x] `pnpm nx run save-link:lint` — clean.
- [x] `pulumi preview` shows the only environment diff is on `recrawl-content-extracted-handler` adding `IMAGES_CDN_BASE_URL`.