### PR TITLE
feat(extensions): show "Saving…" progress bar in popup

### DIFF
--- a/projects/browser-extension-core/src/e2e/extension-views.ts
+++ b/projects/browser-extension-core/src/e2e/extension-views.ts
@@ -4,7 +4,7 @@ export const EXTENSION_VIEW_IDS = [
 	"already-saved-view",
 	"removed-view",
 	"list-view",
-	"loading-view",
+	"saving-view",
 ] as const;
 
 export type ExtensionViewId = (typeof EXTENSION_VIEW_IDS)[number];

--- a/projects/browser-extension-core/src/e2e/flow-runner.test.ts
+++ b/projects/browser-extension-core/src/e2e/flow-runner.test.ts
@@ -44,7 +44,7 @@ describe("FlowRunner", () => {
 		const driver = createTestDriver();
 		const stateHandler: FlowStateHandler = {
 			detectCurrentState: async () => ({
-				activeView: "loading-view",
+				activeView: "saving-view",
 				availableActions: [],
 			}),
 			executeAction: async () => {},

--- a/projects/browser-extension-core/src/popup/popup.styles.css
+++ b/projects/browser-extension-core/src/popup/popup.styles.css
@@ -183,6 +183,54 @@ body {
   color: var(--popup-brand-text);
 }
 
+/* --- Saving view --- */
+
+.saving-view {
+  align-items: center;
+  text-align: center;
+  padding: 32px 24px 24px;
+  gap: 16px;
+}
+
+.saving-view__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--popup-text);
+  margin: 0;
+}
+
+.saving-view__progress {
+  width: 100%;
+  height: 4px;
+  background: var(--popup-surface);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+/**
+ * 1. Asymptotic ease toward 90% over 3s — the bar moves quickly at first then
+ *    slows, so the popup feels responsive even when the save is fast and stays
+ *    plausible when the save is slow. State classes interrupt the transition.
+ */
+.saving-view__progress-fill {
+  width: 0%;
+  height: 100%;
+  background: var(--popup-brand);
+  border-radius: 2px;
+  transition: width 3s cubic-bezier(0, 0.7, 0.3, 1); /* 1 */
+}
+
+/* purgecss-ignore-start: applied dynamically in popup.browser.ts when starting/finishing the save progress bar */
+.saving-view__progress-fill--starting {
+  width: 90%;
+}
+
+.saving-view__progress-fill--complete {
+  width: 100%;
+  transition: width 0.2s ease-out;
+}
+/* purgecss-ignore-end */
+
 /* --- Shortcut hint --- */
 
 .shortcut-hint {
@@ -536,19 +584,6 @@ body {
   font-size: 13px;
   text-align: center;
   margin: 0;
-}
-
-/* --- Loading view --- */
-
-.view--loading {
-  padding: 32px 16px;
-  align-items: center;
-}
-
-.view--loading > p {
-  margin: 0;
-  font-size: 13px;
-  color: var(--popup-label);
 }
 
 /* --- Spinner overlay --- */

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -297,6 +297,11 @@ async function saveAndShowList() {
 		return;
 	}
 
+	const savingTitle = document.querySelector(".saving-view__title");
+	if (savingTitle) savingTitle.textContent = "Saving\u2026";
+	const progressBar = document.querySelector(".saving-view__progress");
+	if (progressBar) progressBar.setAttribute("aria-label", "Saving article");
+
 	const saveResult = (await send({
 		type: "save-current-tab",
 		url: activeTab.url,

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -22,6 +22,32 @@ function showView(id: string) {
 	if (target) target.hidden = false;
 }
 
+/**
+ * 1. Defer one frame so the browser has committed the initial 0% width
+ *    before we set the target. Without this the transition collapses into a
+ *    single computed-style read and the bar jumps to 90% with no animation.
+ */
+function startSavingProgress() {
+	const fill = document.querySelector(".saving-view__progress-fill");
+	if (!fill) return;
+	requestAnimationFrame(() => {
+		fill.classList.add("saving-view__progress-fill--starting");
+	});
+}
+
+function finishSavingProgress(): Promise<void> {
+	return new Promise((resolve) => {
+		const fill = document.querySelector(".saving-view__progress-fill");
+		if (!fill) {
+			resolve();
+			return;
+		}
+		fill.classList.remove("saving-view__progress-fill--starting");
+		fill.classList.add("saving-view__progress-fill--complete");
+		setTimeout(resolve, 350); // 200ms snap to 100% + 150ms hold
+	});
+}
+
 function send(message: PopupMessage): Promise<unknown> {
 	return browser.runtime.sendMessage(message);
 }
@@ -283,6 +309,7 @@ async function saveAndShowList() {
 	}
 
 	if (saveResult.ok && saveResult.value.ok) {
+		await finishSavingProgress();
 		showView("saved-view");
 		return;
 	}
@@ -319,7 +346,8 @@ document.getElementById("login-button")?.addEventListener("click", async () => {
 		return;
 	}
 
-	showView("loading-view");
+	showView("saving-view");
+	startSavingProgress();
 	await saveAndShowList();
 });
 
@@ -359,6 +387,7 @@ if (shortcutHint) {
 	}
 }
 
+startSavingProgress();
 saveAndShowList().catch((error) => {
 	logger.error("Failed to initialize popup:", error);
 	showView("list-view");

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.template.html
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.template.html
@@ -61,12 +61,12 @@
   </div>
 
   <div id="saving-view" class="view saving-view">
-    <p class="saving-view__title">Saving&hellip;</p>
+    <p class="saving-view__title">Loading&hellip;</p>
     <div
       class="saving-view__progress"
       role="progressbar"
       aria-busy="true"
-      aria-label="Saving article"
+      aria-label="Loading"
       aria-valuemin="0"
       aria-valuemax="100"
     >

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.template.html
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.template.html
@@ -60,8 +60,18 @@
     <p id="list-error" class="list-view__error" hidden>Failed to load links</p>
   </div>
 
-  <div id="loading-view" class="view view--loading">
-    <p>Loading...</p>
+  <div id="saving-view" class="view saving-view">
+    <p class="saving-view__title">Saving&hellip;</p>
+    <div
+      class="saving-view__progress"
+      role="progressbar"
+      aria-busy="true"
+      aria-label="Saving article"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
+      <div class="saving-view__progress-fill"></div>
+    </div>
   </div>
 
   <div id="spinner-overlay" class="spinner-overlay" hidden>

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -296,6 +296,11 @@ async function saveAndShowList() {
 		return;
 	}
 
+	const savingTitle = document.querySelector(".saving-view__title");
+	if (savingTitle) savingTitle.textContent = "Saving\u2026";
+	const progressBar = document.querySelector(".saving-view__progress");
+	if (progressBar) progressBar.setAttribute("aria-label", "Saving article");
+
 	const saveResult = (await send({
 		type: "save-current-tab",
 		url: activeTab.url,

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -21,6 +21,32 @@ function showView(id: string) {
 	if (target) target.hidden = false;
 }
 
+/**
+ * 1. Defer one frame so the browser has committed the initial 0% width
+ *    before we set the target. Without this the transition collapses into a
+ *    single computed-style read and the bar jumps to 90% with no animation.
+ */
+function startSavingProgress() {
+	const fill = document.querySelector(".saving-view__progress-fill");
+	if (!fill) return;
+	requestAnimationFrame(() => {
+		fill.classList.add("saving-view__progress-fill--starting");
+	});
+}
+
+function finishSavingProgress(): Promise<void> {
+	return new Promise((resolve) => {
+		const fill = document.querySelector(".saving-view__progress-fill");
+		if (!fill) {
+			resolve();
+			return;
+		}
+		fill.classList.remove("saving-view__progress-fill--starting");
+		fill.classList.add("saving-view__progress-fill--complete");
+		setTimeout(resolve, 350); // 200ms snap to 100% + 150ms hold
+	});
+}
+
 function send(message: PopupMessage): Promise<unknown> {
 	return browser.runtime.sendMessage(message);
 }
@@ -282,6 +308,7 @@ async function saveAndShowList() {
 	}
 
 	if (saveResult.ok && saveResult.value.ok) {
+		await finishSavingProgress();
 		showView("saved-view");
 		return;
 	}
@@ -318,7 +345,8 @@ document.getElementById("login-button")?.addEventListener("click", async () => {
 		return;
 	}
 
-	showView("loading-view");
+	showView("saving-view");
+	startSavingProgress();
 	await saveAndShowList();
 });
 
@@ -355,6 +383,7 @@ if (shortcutHint) {
 	}
 }
 
+startSavingProgress();
 saveAndShowList().catch((error) => {
 	logger.error("Failed to initialize popup:", error);
 	showView("list-view");

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.template.html
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.template.html
@@ -61,12 +61,12 @@
   </div>
 
   <div id="saving-view" class="view saving-view">
-    <p class="saving-view__title">Saving&hellip;</p>
+    <p class="saving-view__title">Loading&hellip;</p>
     <div
       class="saving-view__progress"
       role="progressbar"
       aria-busy="true"
-      aria-label="Saving article"
+      aria-label="Loading"
       aria-valuemin="0"
       aria-valuemax="100"
     >

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.template.html
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.template.html
@@ -60,8 +60,18 @@
     <p id="list-error" class="list-view__error" hidden>Failed to load links</p>
   </div>
 
-  <div id="loading-view" class="view view--loading">
-    <p>Loading...</p>
+  <div id="saving-view" class="view saving-view">
+    <p class="saving-view__title">Saving&hellip;</p>
+    <div
+      class="saving-view__progress"
+      role="progressbar"
+      aria-busy="true"
+      aria-label="Saving article"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    >
+      <div class="saving-view__progress-fill"></div>
+    </div>
   </div>
 
   <div id="spinner-overlay" class="spinner-overlay" hidden>


### PR DESCRIPTION
## Summary

- Replaces the static `Loading…` placeholder in the Chrome and Firefox popups with a `Saving…` view whose progress bar eases asymptotically toward 90% and snaps to 100% on completion.
- Adds `.saving-view` styles (with `purgecss-ignore` around the JS-toggled `--starting` / `--complete` modifier classes) and renames the `loading-view` registry entry to `saving-view`.
- Wires `startSavingProgress()` / `finishSavingProgress()` in both popup entry points so the bar starts on popup open and the success view only appears after the snap-to-100% finishes.

## Why

When the user clicks the extension icon on a saveable page, the popup may sit for up to ~5 s while the background script captures the active tab's HTML and the server stub-saves the article. A static `Loading…` text gives no signal of progress, so slow saves feel broken and the abrupt swap to the green "Article saved" view feels jumpy. A simulated asymptotic bar (no real progress data exists — the server stub-saves synchronously and the async crawl pipeline is opaque to the extension) provides immediate visual feedback and a continuous handoff into the success view.

## Test plan

- [x] `pnpm nx run browser-extension-core:lint` — `check-unused-css` confirms purgecss keeps the `--starting` / `--complete` classes.
- [x] `pnpm nx run browser-extension-core:test-with-coverage` — 100% statements/branches/functions/lines.
- [x] `pnpm nx run chrome-extension:lint` and `pnpm nx run firefox-extension:lint`.
- [x] `pnpm nx run-many --target=compile --projects=browser-extension-core,chrome-extension,firefox-extension`.
- [x] `pnpm check` (all 18 projects) — pre-commit hook verified end-to-end.
- [ ] Manual smoke (Chrome): load unpacked extension, click icon on a saveable URL → bar moves smoothly, snaps to 100%, transitions to "Article saved".
- [ ] Manual smoke (Firefox): same sequence.
- [ ] Manual smoke: click icon on `https://readplace.com/...` (app URL) → brief "Saving…" flash then list view (accepted).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MLjbicd3ciwu8E86Ytfdhz)_