### PR TITLE
feat: bump saveLinkWork Lambda budget 30→180s + matching SQS visibility

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -70,16 +70,19 @@ const linkSavedQueue = new HutchSQS("link-saved", {
 	visibilityTimeoutSeconds: 60,
 });
 
+// saveLinkWork-bearing queues use 360s visibility = 2× the 180s Lambda
+// timeout (AWS guidance) so a long-running invocation never has the message
+// re-delivered to a second worker before the first finishes.
 const saveLinkCommandQueue = new HutchSQS("save-link-command", {
-	visibilityTimeoutSeconds: 60,
+	visibilityTimeoutSeconds: 360,
 });
 
 const saveAnonymousLinkCommandQueue = new HutchSQS("save-anonymous-link-command", {
-	visibilityTimeoutSeconds: 60,
+	visibilityTimeoutSeconds: 360,
 });
 
 const saveLinkRawHtmlCommandQueue = new HutchSQS("save-link-raw-html-command", {
-	visibilityTimeoutSeconds: 60,
+	visibilityTimeoutSeconds: 360,
 });
 
 const anonymousLinkSavedQueue = new HutchSQS("anonymous-link-saved", {
@@ -95,7 +98,7 @@ const summaryGenerationFailedQueue = new HutchSQS("summary-generation-failed", {
 });
 
 const recrawlLinkInitiatedQueue = new HutchSQS("recrawl-link-initiated", {
-	visibilityTimeoutSeconds: 60,
+	visibilityTimeoutSeconds: 360,
 });
 
 const staleCheckRequestedQueue = new HutchSQS("stale-check-requested", {
@@ -118,7 +121,11 @@ const saveLinkCommandLambda = new HutchLambda("save-link-command", {
 	outputDir: ".lib/save-link-command",
 	assetDir: "./src",
 	memorySize: 256,
-	timeout: 30,
+	// 180s budget for saveLinkWork: large XHTML/HTML pages (e.g. iana media-types)
+	// take >30s to fetch + parse end-to-end. Paired with 360s SQS visibility
+	// (≥2× Lambda timeout per AWS guidance) so the message stays held for the
+	// full execution. Phase 2 of the unstick-articles plan.
+	timeout: 180,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
@@ -166,7 +173,7 @@ const saveLinkRawHtmlCommandLambda = new HutchLambda("save-link-raw-html-command
 	outputDir: ".lib/save-link-raw-html-command",
 	assetDir: "./src",
 	memorySize: 256,
-	timeout: 30,
+	timeout: 180,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
@@ -219,7 +226,7 @@ const saveAnonymousLinkCommandLambda = new HutchLambda("save-anonymous-link-comm
 	outputDir: ".lib/save-anonymous-link-command",
 	assetDir: "./src",
 	memorySize: 256,
-	timeout: 30,
+	timeout: 180,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
@@ -473,7 +480,7 @@ const recrawlLinkInitiatedLambda = new HutchLambda("recrawl-link-initiated", {
 	outputDir: ".lib/recrawl-link-initiated",
 	assetDir: "./src",
 	memorySize: 256,
-	timeout: 30,
+	timeout: 180,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,

--- a/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
+++ b/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
@@ -36,14 +36,17 @@ function requireEnv(name: string): string {
 const ORIGIN = process.env.READPLACE_ORIGIN ?? "https://readplace.com";
 const SERVICE_TOKEN = requireEnv("RECRAWL_SERVICE_TOKEN");
 
-// 3s poll interval × 60 polls = 180s budget per source. A successful
-// Lambda cold start + crawl + parse + write lands well inside that.
-// The upper bound also covers save-link's SQS retry → DLQ → terminal
-// markCrawlFailed path, which takes ~90s on an origin that blocks the
-// Lambda egress or a parser crash — both of which this canary MUST
+// 3s poll interval × 440 polls = 1320s (22 min) budget per source. A
+// successful Lambda cold start + crawl + parse + write still lands in a
+// few seconds; the budget exists to cover save-link's SQS retry → DLQ →
+// terminal markCrawlFailed path. Phase 2 of the unstick-articles plan
+// raised saveLinkWork's Lambda timeout 30→180s and matched SQS visibility
+// 60→360s, so worst-case wall clock to DLQ is now visibility × maxReceiveCount
+// = 360s × 3 = 1080s (~18 min). 22 min adds 4 min slack for cold starts
+// and the DLQ handler's terminal write — both of which this canary MUST
 // surface as a failing test, not a timeout.
 const POLL_INTERVAL_MS = 3000;
-const POLL_TIMEOUT_MS = 180_000;
+const POLL_TIMEOUT_MS = 1_320_000;
 
 type TerminalReaderStatus = Exclude<ReaderStatus, "pending">;
 


### PR DESCRIPTION
## Summary
- Raises Lambda timeout 30s → 180s on the four handlers that run `saveLinkWork`: `save-link-command`, `save-anonymous-link-command`, `save-link-raw-html-command`, `recrawl-link-initiated`.
- Matches SQS visibility 60s → 360s on the four corresponding queues per AWS guidance (≥2× Lambda timeout).
- Bumps the Tier 1+ canary's poll budget 180s → 1320s (22 min) so the "row went terminal failed" path stays inside the SLO under the new retry-chain wall clock.
- Phase 2 of 4 in the unstick-articles plan. **This is the bet-on phase for iana** (the failure mode is purely a 30s budget overflow — `crawlStage='crawl-fetched'` consistently, with `Status: timeout / Duration: 30000.00 ms` REPORT lines in CloudWatch).

## Why
Mode A in the RCA: large XHTML/HTML pages (e.g. `iana.org/.../media-types.xhtml`) take >30s to fetch + parse end-to-end. Every retry timed out, the message landed in the DLQ, and the DLQ handler flipped `crawlStatus='failed'`. With Phase 1 in place (`/view` no longer republishes via the auto-heal loop), bumping the budget is the actual fix.

The skill (`crawl-pipeline-rca`, rule 4) explicitly warns against bumping Lambda timeout in isolation: it would push failure-surfacing past the canary's SLO. So this PR moves all three knobs (Lambda timeout, SQS visibility, canary poll budget) together.

### Math
| Knob | Before | After | Why |
|---|---|---|---|
| Lambda timeout | 30s | **180s** | iana parse takes ≈45s; 180s gives 4× headroom |
| SQS visibility | 60s | **360s** | 2× Lambda timeout — AWS guidance, prevents the same message being delivered to a second worker mid-execution |
| `maxReceiveCount` | 3 (default) | 3 (unchanged) | Phase 4 will drop save-anonymous-link to 1; not in scope here |
| Worst-case wall clock to DLQ | 60s × 3 = 180s | **360s × 3 = 1080s (~18 min)** | Fold-out of visibility × maxReceiveCount |
| Canary poll budget | 180s | **1320s (22 min)** | >18 min so the canary still surfaces "row went terminal failed" within its SLO; +4 min slack for cold starts and the DLQ handler's terminal write |

## What does NOT change here
- `select-most-complete-content` and `generate-summary` Lambdas keep their existing dedicated timeout files (`SELECT_CONTENT_TIMEOUTS`, `GENERATE_SUMMARY_TIMEOUTS`) — they aren't the binding constraint for Mode A.
- `stale-check-requested` Lambda timeout stays at 30s — it's the freshness path (304-conditional GET), not the parse path.
- `maxReceiveCount` stays at 3 across all queues (Phase 4 lowers it for save-anonymous-link only).

## Test plan
- [x] Local: `nx run save-link:lint` ✓ · `nx run @packages/crawl-article:lint` ✓
- [x] Local: `nx run save-link:test-with-coverage` 100/100/100/100 across 57 files
- [x] Pre-commit hook (full `pnpm check` on 18 projects + 18 dependent tasks) ✓
- [ ] After merge: deploy to prod (CI auto-deploys hutch + save-link)
- [ ] After deploy: trigger `/admin/recrawl` on the four target URLs
- [ ] **iana DDB row should flip `crawlStatus: pending → ready`** (the bet)
- [ ] CloudWatch `recrawl-link-initiated-handler` REPORT lines for iana — confirm Duration <180000ms (no more `Status: timeout`)
- [ ] If iana still times out at 180s, the page is genuinely too big for any reasonable Lambda — flag before Phase 3

## Heads-up for reviewers
- `crawl-article:test-with-coverage` is currently red on main due to a pre-existing gap in `src/aia-fetch.ts` (71% statement coverage). My change is in `scripts/tier-1-plus-pipeline-health.ts` which isn't covered by the `src/**` include pattern, so this is unrelated. The project's `check` target only runs `lint`, which is why CI hasn't surfaced it.
- Pre-commit hook flaked once on `@packages/test-fixtures:check` (cache-related); cleared by re-running. Nx itself flagged it: `NX detected a flaky task`.