### PR TITLE
feat(hutch): track top Medium posts driving readplace clicks

### DIFF
--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -540,6 +540,29 @@ new aws.cloudwatch.Dashboard("readplace-analytics", {
 						view: "table",
 					}),
 				),
+				/**
+				 * Top Medium Posts by Clicks — counts inbound pageviews where the
+				 * Medium `source=post_page-----<id>` parameter is present, grouped
+				 * by post id. The middleware extracts the id into `medium_post_id`;
+				 * this widget answers "which Medium post is sending readers to
+				 * Readplace?" at per-post fidelity (utm_source only gives per-author).
+				 * To resolve an id back to a post, open https://medium.com/p/<id>.
+				 */
+				logWidget({
+					title: "Top Medium Posts by Clicks",
+					logGroupNames: [hutchLogGroupName],
+					query: [
+						"fields @timestamp, medium_post_id",
+						"| filter stream = \"analytics\" and event = \"pageview\"",
+						"| filter ispresent(medium_post_id) and medium_post_id != \"\"",
+						...excludeVisitorHashesClause(),
+						"| stats count(*) as clicks by medium_post_id",
+						"| sort clicks desc",
+						"| limit 10",
+					].join(" "),
+					x: 0, y: 72, width: 12, height: 8,
+					view: "pie",
+				}),
 			],
 		}),
 	),

--- a/projects/hutch/src/runtime/analytics.test.ts
+++ b/projects/hutch/src/runtime/analytics.test.ts
@@ -69,6 +69,7 @@ describe("createAnalyticsMiddleware", () => {
 		expect(serialized).not.toContain("utm_campaign");
 		expect(serialized).not.toContain("utm_content");
 		expect(serialized).not.toContain("referrer_host");
+		expect(serialized).not.toContain("medium_post_id");
 		expect(event).toEqual({
 			stream: "analytics",
 			event: "pageview",
@@ -124,6 +125,26 @@ describe("createAnalyticsMiddleware", () => {
 		const req = createReq({ query: { utm_source: "" } });
 		const [event] = runMiddleware(req, createRes(200));
 		expect(JSON.stringify(event)).not.toContain("utm_source");
+	});
+
+	it("extracts the Medium post id from source=post_page-----<id>--- — Medium attaches this to every outbound link from a post and the alnum segment is the canonical post id (same one used at https://medium.com/p/<id>)", () => {
+		const req = createReq({
+			path: "/view",
+			query: { source: "post_page-----b07aa10a0d93---------------------------------------" },
+		});
+		const [event] = runMiddleware(req, createRes(200));
+		expect(event).toMatchObject({ medium_post_id: "b07aa10a0d93" });
+	});
+
+	it("omits medium_post_id from the emitted JSON when the source param does not match Medium's post_page-----<id> shape (some Medium URLs carry source=user_profile_page or empty)", () => {
+		const req = createReq({ query: { source: "user_profile_page" } });
+		const [event] = runMiddleware(req, createRes(200));
+		expect(JSON.stringify(event)).not.toContain("medium_post_id");
+	});
+
+	it("omits medium_post_id from the emitted JSON when the source param is absent", () => {
+		const [event] = runMiddleware(createReq({ query: {} }), createRes(200));
+		expect(JSON.stringify(event)).not.toContain("medium_post_id");
 	});
 });
 

--- a/projects/hutch/src/runtime/analytics.ts
+++ b/projects/hutch/src/runtime/analytics.ts
@@ -13,6 +13,7 @@ export interface AnalyticsPageview {
 	utm_campaign?: string;
 	utm_content?: string;
 	referrer_host?: string;
+	medium_post_id?: string;
 	visitor_hash: string | null;
 	is_authenticated: 0 | 1;
 }
@@ -53,6 +54,20 @@ function extractReferrerHost(req: Request): string | undefined {
 	}
 }
 
+/**
+ * Medium attaches `source=post_page-----<id>---------------------------------------`
+ * to every outbound link from a post. The 12-char alnum segment after
+ * `post_page-----` is the post's canonical Medium identifier — same one Medium
+ * uses for `https://medium.com/p/<id>`. We capture only the ID (not the
+ * trailing dashes) so the dashboard's group-by key is the post itself.
+ */
+function extractMediumPostId(req: Request): string | undefined {
+	const source = req.query.source;
+	if (typeof source !== "string") return undefined;
+	const match = source.match(/^post_page-----([A-Za-z0-9]+)/);
+	return match ? match[1] : undefined;
+}
+
 export function hashIp(deps: { ip: string | undefined; salt: string }): string | null {
 	if (!deps.ip) return null;
 	return createHash("sha256")
@@ -79,6 +94,7 @@ export function createAnalyticsMiddleware(deps: {
 				utm_campaign: extractQueryString(req, "utm_campaign"),
 				utm_content: extractQueryString(req, "utm_content"),
 				referrer_host: extractReferrerHost(req),
+				medium_post_id: extractMediumPostId(req),
 				visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
 				is_authenticated: req.userId ? 1 : 0,
 			});


### PR DESCRIPTION
## Why

Today the analytics dashboard groups inbound traffic by `utm_source` (the Medium subdomain — e.g. `fagnerbrack.com`) and `utm_content` (link position). That tells us *which author/publication* sends traffic but merges every post by the same author into a single bucket. If one of an author's 30 posts is a viral hit driving 90% of clicks, the dashboard hides it inside one slice.

Medium attaches a unique post ID to every outbound link via the `source` query parameter, e.g. `source=post_page-----b07aa10a0d93---------------------------------------`. The `b07aa10a0d93` segment is Medium's canonical post ID — the same one used at `https://medium.com/p/<id>`. Our analytics middleware previously captured `utm_*` params but discarded `source`, so no CloudWatch query — however clever — could show per-post breakdowns.

This PR captures that ID into the analytics stream and adds a "Top Medium Posts by Clicks" pie widget to the existing `readplace-analytics` CloudWatch dashboard.

## What changed

- **`projects/hutch/src/runtime/analytics.ts`** — `AnalyticsPageview` gains an optional `medium_post_id` field. A new `extractMediumPostId(req)` helper reads `req.query.source`, matches `^post_page-----([A-Za-z0-9]+)`, and emits the captured ID. Returns `undefined` for non-Medium / absent values so `JSON.stringify` drops the key (consistent with `extractQueryString`'s shape).
- **`projects/hutch/src/runtime/analytics.test.ts`** — three new cases covering all three branches: a valid Medium source param yields the ID; a non-matching source param drops the key from the JSON; an absent source param drops the key. The negative-case test in the existing `absent UTM/referrer keys` block is also extended to assert `medium_post_id` is absent.
- **`projects/hutch/src/infra/index.ts`** — appends one `logWidget(...)` to the `readplace-analytics` dashboard's `widgets` array. Pie view, half-width, top-10 by `count(*)`, includes `excludeVisitorHashesClause()` to keep operator self-clicks out of the chart.

## Trade-offs

- **No backfill.** Pageviews logged before this deploys lack `medium_post_id`. The widget will be sparse for the first day or two until traffic accumulates. The alternative — `parse @message` against historical raw log lines — was rejected as fragile.
- **Post ID is opaque.** The chart shows `b07aa10a0d93`, not the post title. To resolve, paste `https://medium.com/p/<id>` into a browser. Not solving title-resolution in this PR; future enhancement if the basic widget proves valuable.
- **Pattern lock-in.** If Medium changes the `post_page-----<id>` format the regex stops matching and the widget silently empties. Mitigation: the unit test pins the documented example URL from the original request.

## Test plan

- [x] `pnpm nx run hutch:compile` succeeds
- [x] `pnpm test-with-coverage` passes (16/16 analytics tests including the 3 new ones; 100% coverage thresholds met)
- [x] `pnpm lint` passes (tsc, biome, knip, css-unused)
- [x] Pre-commit hook (`pnpm check` across all projects) passes
- [ ] After deploy, load `/view/<some-url>?source=post_page-----testpost123-----` in a non-excluded browser and confirm the new widget renders the test ID after a minute or two of CloudWatch indexing latency

https://claude.ai/code/session_01BbUyBkL5sPMox7t1hizuJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbUyBkL5sPMox7t1hizuJH)_