### PR TITLE
feat(hutch): move import entry point from /queue into Import Links nav item

### DIFF
--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -3,16 +3,19 @@ import type { UserId } from "@packages/domain/user";
 export interface BannerStateSource {
 	userId?: UserId;
 	emailVerified?: boolean;
+	query?: Record<string, unknown>;
 }
 
 export interface BannerState {
 	isAuthenticated: boolean;
 	emailVerified: boolean | undefined;
+	featureImport: boolean;
 }
 
 export function bannerStateFromRequest(source: BannerStateSource): BannerState {
 	return {
 		isAuthenticated: Boolean(source.userId),
 		emailVerified: source.emailVerified,
+		featureImport: source.query?.feature === "import",
 	};
 }

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -17,7 +17,7 @@ function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
 	};
 }
 
-const GUEST_STATE: BannerState = { isAuthenticated: false, emailVerified: undefined };
+const GUEST_STATE: BannerState = { isAuthenticated: false, emailVerified: undefined, featureImport: false };
 
 describe("Base component", () => {
 	it("should render a complete HTML page with the provided title", () => {
@@ -77,12 +77,39 @@ describe("Base component", () => {
 
 	it("should render authenticated navigation when state is authenticated", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
+		const result = Base(page, { isAuthenticated: true, emailVerified: true, featureImport: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const nav = doc.querySelector("[data-test-nav-variant]");
 		assert(nav, "nav container must be rendered");
 		expect(nav.getAttribute("data-test-nav-variant")).toBe("authenticated");
+	});
+
+	it("renders the Import Links nav item when featureImport is on for an authenticated request", () => {
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: true, featureImport: true }).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const link = doc.querySelector('[data-test-nav-item="import"]');
+		assert(link, "Import Links nav item must be rendered when the feature flag is on");
+		expect(link.textContent).toBe("Import Links");
+		expect(link.getAttribute("href")).toBe("/import?feature=import");
+	});
+
+	it("hides the Import Links nav item when featureImport is off", () => {
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: true, featureImport: false }).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
+	});
+
+	it("hides the Import Links nav item for unauthenticated requests even when featureImport is on", () => {
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: false, emailVerified: undefined, featureImport: true }).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
 	});
 
 	it("should include the footer with copyright", () => {
@@ -163,7 +190,7 @@ describe("Base component", () => {
 
 	it("should show verification banner when authenticated and email not verified", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: true, emailVerified: false }).to("text/html");
+		const result = Base(page, { isAuthenticated: true, emailVerified: false, featureImport: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -174,7 +201,7 @@ describe("Base component", () => {
 
 	it("should hide verification banner when email is verified", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
+		const result = Base(page, { isAuthenticated: true, emailVerified: true, featureImport: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -184,7 +211,7 @@ describe("Base component", () => {
 
 	it("should hide verification banner when not authenticated", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: false, emailVerified: false }).to("text/html");
+		const result = Base(page, { isAuthenticated: false, emailVerified: false, featureImport: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");
@@ -194,7 +221,7 @@ describe("Base component", () => {
 
 	it("should hide verification banner when emailVerified is undefined", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: true, emailVerified: undefined }).to("text/html");
+		const result = Base(page, { isAuthenticated: true, emailVerified: undefined, featureImport: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const banner = doc.querySelector("[data-test-verify-banner]");

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -29,11 +29,12 @@ const BASE_TEMPLATE = readFileSync(join(__dirname, "base.template.html"), "utf-8
 
 function renderHeader(
 	variant: "default" | "transparent",
-	isAuthenticated: boolean,
+	options: { isAuthenticated: boolean; featureImport: boolean },
 ): string {
 	return render(HEADER_TEMPLATE, {
 		transparent: variant === "transparent",
-		isAuthenticated,
+		isAuthenticated: options.isAuthenticated,
+		featureImport: options.featureImport,
 	});
 }
 
@@ -197,7 +198,7 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		verifyBannerStyles: VERIFY_BANNER_STYLES,
 		showVerificationBanner: state.isAuthenticated && state.emailVerified === false,
 		bodyClass: body.bodyClass,
-		header: renderHeader(headerVariant, state.isAuthenticated),
+		header: renderHeader(headerVariant, { isAuthenticated: state.isAuthenticated, featureImport: state.featureImport }),
 		content: injectPageStylesIntoMain(body.content.html, body.styles),
 		footer: renderFooter(),
 		navScript: NAV_SCRIPT,

--- a/projects/hutch/src/runtime/web/header.template.html
+++ b/projects/hutch/src/runtime/web/header.template.html
@@ -11,6 +11,9 @@
           <ul class="nav__list" data-test-nav-variant="{{#if isAuthenticated}}authenticated{{else}}guest{{/if}}">
             {{#if isAuthenticated}}
             <li><a href="/queue" class="nav__link" data-test-nav-item="queue">Queue</a></li>
+            {{#if featureImport}}
+            <li><a href="/import?feature=import" class="nav__link" data-test-nav-item="import">Import Links</a></li>
+            {{/if}}
             <li><a href="/export" class="nav__link" data-test-nav-item="export">Export</a></li>
             <li>
               <form method="POST" action="/logout">

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -3,10 +3,32 @@ import { join } from "node:path";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { IMPORT_STYLES } from "./import.styles";
-import type { ImportViewModel } from "./import.viewmodel";
+import type { ImportUploadViewModel, ImportViewModel } from "./import.viewmodel";
 
 const IMPORT_TEMPLATE = readFileSync(join(__dirname, "import.template.html"), "utf-8");
+const IMPORT_UPLOAD_TEMPLATE = readFileSync(join(__dirname, "import.upload.template.html"), "utf-8");
 const IMPORT_CLIENT_SCRIPT = `<script src="/client-dist/import.client.js" defer></script>`;
+
+const UPLOAD_AUTO_SUBMIT_SCRIPT = `
+<script>
+	(function () {
+		function wire() {
+			var form = document.querySelector('form.import__upload-form');
+			if (!form) return;
+			var input = form.querySelector('input[type="file"]');
+			if (!input) return;
+			input.addEventListener('change', function () {
+				if (input.files && input.files.length > 0) form.requestSubmit();
+			});
+		}
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', wire, { once: true });
+		} else {
+			wire();
+		}
+	})();
+</script>
+`;
 
 export function ImportPage(vm: ImportViewModel): PageBody {
 	const content = render(IMPORT_TEMPLATE, {
@@ -27,5 +49,22 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 		bodyClass: "page-import",
 		content: { html: content },
 		scripts: IMPORT_CLIENT_SCRIPT,
+	};
+}
+
+export function ImportUploadPage(vm: ImportUploadViewModel): PageBody {
+	const content = render(IMPORT_UPLOAD_TEMPLATE, vm);
+
+	return {
+		seo: {
+			title: "Import Links — Readplace",
+			description: "Upload an export file and import the links into your queue.",
+			canonicalUrl: "/import",
+			robots: "noindex, nofollow",
+		},
+		styles: IMPORT_STYLES,
+		bodyClass: "page-import",
+		content: { html: content },
+		scripts: UPLOAD_AUTO_SUBMIT_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
@@ -1,0 +1,33 @@
+import { importErrorMessageMapping } from "./import.error";
+
+describe("importErrorMessageMapping", () => {
+	it("returns undefined when error_code is absent", () => {
+		expect(importErrorMessageMapping({})).toBeUndefined();
+	});
+
+	it("returns undefined when error_code is not a string", () => {
+		expect(importErrorMessageMapping({ error_code: 42 })).toBeUndefined();
+	});
+
+	it("returns undefined for an unknown error code", () => {
+		expect(importErrorMessageMapping({ error_code: "save_failed" })).toBeUndefined();
+	});
+
+	it("maps import_too_large to the 5 MiB / concierge fallback message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_too_large" })).toBe(
+			"That file is too large. The limit is 5 MiB — please email it to hutch+migrate@readplace.com instead.",
+		);
+	});
+
+	it("maps import_no_urls to the no-links message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_no_urls" })).toBe(
+			"We couldn't find any links in that file.",
+		);
+	});
+
+	it("maps import_session_not_found to the expired-session message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_session_not_found" })).toBe(
+			"That import session has expired. Please upload the file again.",
+		);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
@@ -13,9 +13,9 @@ describe("importErrorMessageMapping", () => {
 		expect(importErrorMessageMapping({ error_code: "save_failed" })).toBeUndefined();
 	});
 
-	it("maps import_too_large to the 5 MiB / concierge fallback message", () => {
+	it("maps import_too_large to the 5 MiB / contact fallback message", () => {
 		expect(importErrorMessageMapping({ error_code: "import_too_large" })).toBe(
-			"That file is too large. The limit is 5 MiB — please email it to hutch+migrate@readplace.com instead.",
+			"That file is too large. The limit is 5 MiB — please get in touch at fayner@readplace.com to increase the limit.",
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.error.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.ts
@@ -1,0 +1,12 @@
+const IMPORT_ERROR_MESSAGES: Record<string, string> = {
+	import_too_large: "That file is too large. The limit is 5 MiB — please email it to hutch+migrate@readplace.com instead.",
+	import_no_urls: "We couldn't find any links in that file.",
+	import_session_not_found: "That import session has expired. Please upload the file again.",
+};
+
+export type ImportErrorMessageMapping = (query: Record<string, unknown>) => string | undefined;
+
+export const importErrorMessageMapping: ImportErrorMessageMapping = (query) => {
+	const errorCode = typeof query.error_code === "string" ? query.error_code : undefined;
+	return errorCode ? IMPORT_ERROR_MESSAGES[errorCode] : undefined;
+};

--- a/projects/hutch/src/runtime/web/pages/import/import.error.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.ts
@@ -1,5 +1,5 @@
 const IMPORT_ERROR_MESSAGES: Record<string, string> = {
-	import_too_large: "That file is too large. The limit is 5 MiB — please email it to hutch+migrate@readplace.com instead.",
+	import_too_large: "That file is too large. The limit is 5 MiB — please get in touch at fayner@readplace.com to increase the limit.",
 	import_no_urls: "We couldn't find any links in that file.",
 	import_session_not_found: "That import session has expired. Please upload the file again.",
 };

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -14,8 +14,9 @@ import type { ImportSessionStore } from "@packages/domain/import-session";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { saveArticleFromUrl, type SaveArticleFromUrlDependencies } from "../../shared/save-article/save-article-from-url";
-import { ImportPage } from "./import.component";
-import { toImportViewModel } from "./import.viewmodel";
+import { ImportPage, ImportUploadPage } from "./import.component";
+import { importErrorMessageMapping } from "./import.error";
+import { toImportUploadViewModel, toImportViewModel } from "./import.viewmodel";
 import { initMultipartUpload } from "./multipart-upload";
 import { parseImportPage } from "./import.url";
 
@@ -24,29 +25,46 @@ interface ImportRouteDependencies extends SaveArticleFromUrlDependencies {
 	logError: (message: string, error?: Error) => void;
 }
 
+const UPLOAD_ERROR_REDIRECT = {
+	tooLarge: "/import?feature=import&error_code=import_too_large",
+	noUrls: "/import?feature=import&error_code=import_no_urls",
+	sessionNotFound: "/import?feature=import&error_code=import_session_not_found",
+} as const;
+
 export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 	const router = express.Router();
 	const { rawBodyParser, parseRequest } = initMultipartUpload({ maxBytes: MAX_IMPORT_FILE_BYTES });
 
 	const sizeLimitHandler: ErrorRequestHandler = (err, _req, res, next) => {
 		if (err && typeof err === "object" && "type" in err && err.type === "entity.too.large") {
-			res.redirect(303, "/queue?error_code=import_too_large");
+			res.redirect(303, UPLOAD_ERROR_REDIRECT.tooLarge);
 			return;
 		}
 		next(err);
 	};
 
+	router.get("/", (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		if (req.query.feature !== "import") {
+			res.redirect(303, "/queue");
+			return;
+		}
+		const errorMessage = importErrorMessageMapping(req.query);
+		const vm = toImportUploadViewModel({ errorMessage });
+		sendComponent(req, res, renderPage(req, ImportUploadPage(vm)));
+	});
+
 	router.post("/", rawBodyParser, sizeLimitHandler, async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const parsed = parseRequest(req);
 		if (!parsed.ok) {
-			res.redirect(303, "/queue?error_code=import_no_urls");
+			res.redirect(303, UPLOAD_ERROR_REDIRECT.noUrls);
 			return;
 		}
 
 		const { urls, truncated, totalFoundInFile } = extractUrls(parsed.file.content);
 		if (urls.length === 0) {
-			res.redirect(303, "/queue?error_code=import_no_urls");
+			res.redirect(303, UPLOAD_ERROR_REDIRECT.noUrls);
 			return;
 		}
 
@@ -76,7 +94,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		});
 
 		if (!pageResult) {
-			res.redirect(303, "/queue?error_code=import_session_not_found");
+			res.redirect(303, UPLOAD_ERROR_REDIRECT.sessionNotFound);
 			return;
 		}
 
@@ -130,7 +148,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		const userId = req.userId;
 		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
 		if (!parsedId.success) {
-			res.redirect(303, "/queue?error_code=import_session_not_found");
+			res.redirect(303, UPLOAD_ERROR_REDIRECT.sessionNotFound);
 			return;
 		}
 
@@ -139,7 +157,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			userId,
 		});
 		if (!session) {
-			res.redirect(303, "/queue?error_code=import_session_not_found");
+			res.redirect(303, UPLOAD_ERROR_REDIRECT.sessionNotFound);
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -30,6 +30,90 @@ function multipartBody(filename: string, content: Buffer): { body: Buffer; conte
 }
 
 describe("Import routes", () => {
+	describe("GET /import (unauthenticated)", () => {
+		it("redirects to /login", async () => {
+			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(app).get("/import?feature=import");
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/login");
+		});
+	});
+
+	describe("GET /import (authenticated)", () => {
+		it("renders the upload form when the feature flag is on", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import?feature=import");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const form = doc.querySelector('[data-test-form="import-file"]');
+			assert(form, "upload form must be rendered");
+			expect(form.getAttribute("action")).toBe("/import?feature=import");
+			const button = form.querySelector('[data-test-action="import-upload"]');
+			assert(button, "Upload button must remain in the DOM as the no-JS fallback");
+			expect(button.textContent).toBe("Upload");
+		});
+
+		it("redirects to /queue when the feature flag is missing", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+		});
+
+		it("renders the import_no_urls message when error_code=import_no_urls", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import?feature=import&error_code=import_no_urls");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const error = doc.querySelector("[data-test-import-error]");
+			assert(error, "error banner must be rendered when an error code is present");
+			expect(error.textContent).toBe("We couldn't find any links in that file.");
+		});
+
+		it("renders the import_too_large message when error_code=import_too_large", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import?feature=import&error_code=import_too_large");
+
+			const doc = new JSDOM(response.text).window.document;
+			const error = doc.querySelector("[data-test-import-error]");
+			assert(error, "error banner must be rendered");
+			expect(error.textContent).toContain("hutch+migrate@readplace.com");
+		});
+
+		it("renders the import_session_not_found message when error_code=import_session_not_found", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import?feature=import&error_code=import_session_not_found");
+
+			const doc = new JSDOM(response.text).window.document;
+			const error = doc.querySelector("[data-test-import-error]");
+			assert(error, "error banner must be rendered");
+			expect(error.textContent).toBe("That import session has expired. Please upload the file again.");
+		});
+
+		it("does not render the error banner when no error_code is present", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/import?feature=import");
+
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-import-error]")).toBeNull();
+		});
+	});
+
 	describe("POST /import (unauthenticated)", () => {
 		it("redirects to /login", async () => {
 			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -68,7 +152,7 @@ describe("Import routes", () => {
 				.send(body);
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue?error_code=import_no_urls");
+			expect(response.headers.location).toBe("/import?feature=import&error_code=import_no_urls");
 		});
 
 		it("redirects with import_too_large when the upload exceeds the size cap", async () => {
@@ -86,7 +170,7 @@ describe("Import routes", () => {
 				.send(body);
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue?error_code=import_too_large");
+			expect(response.headers.location).toBe("/import?feature=import&error_code=import_too_large");
 		});
 
 		it("redirects with import_no_urls for non-multipart bodies", async () => {
@@ -99,7 +183,7 @@ describe("Import routes", () => {
 				.send("https://example.com/x");
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue?error_code=import_no_urls");
+			expect(response.headers.location).toBe("/import?feature=import&error_code=import_no_urls");
 		});
 	});
 
@@ -156,7 +240,7 @@ describe("Import routes", () => {
 			const response = await intruder.get(sessionPath);
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue?error_code=import_session_not_found");
+			expect(response.headers.location).toBe("/import?feature=import&error_code=import_session_not_found");
 		});
 
 		it("paginates results across pages", async () => {
@@ -429,7 +513,7 @@ describe("Import routes", () => {
 
 			const reuse = await agent.get(sessionPath);
 			expect(reuse.status).toBe(303);
-			expect(reuse.headers.location).toBe("/queue?error_code=import_session_not_found");
+			expect(reuse.headers.location).toBe("/import?feature=import&error_code=import_session_not_found");
 		});
 
 		it("redirects when the session id is malformed", async () => {
@@ -439,7 +523,7 @@ describe("Import routes", () => {
 			const response = await agent.post("/import/not-an-id/commit");
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue?error_code=import_session_not_found");
+			expect(response.headers.location).toBe("/import?feature=import&error_code=import_session_not_found");
 		});
 
 		it("redirects when the session no longer exists", async () => {
@@ -449,7 +533,7 @@ describe("Import routes", () => {
 			const response = await agent.post("/import/00000000000000000000000000000000/commit");
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue?error_code=import_session_not_found");
+			expect(response.headers.location).toBe("/import?feature=import&error_code=import_session_not_found");
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -88,7 +88,7 @@ describe("Import routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			const error = doc.querySelector("[data-test-import-error]");
 			assert(error, "error banner must be rendered");
-			expect(error.textContent).toContain("hutch+migrate@readplace.com");
+			expect(error.textContent).toContain("fayner@readplace.com");
 		});
 
 		it("renders the import_session_not_found message when error_code=import_session_not_found", async () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.css
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.css
@@ -27,3 +27,36 @@
 .import__pagination { display: flex; gap: 1rem; align-items: center; margin: 1rem 0; }
 .import__pagination-info { color: var(--muted-foreground); }
 .import__row-toggle-btn { font-size: 0.85rem; padding: 0.2rem 0.5rem; cursor: pointer; }
+.import__intro { color: var(--muted-foreground); margin: 0 0 1rem; }
+.import__intro code { font-family: var(--font-mono, monospace); font-size: 0.875em; }
+.import__upload-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+  font-size: 0.875rem;
+  flex-wrap: wrap;
+}
+.import__upload-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--muted-foreground);
+}
+.import__upload-error {
+  color: var(--error);
+  font-size: 0.875rem;
+  margin: 0 0 1rem;
+}
+.import__upload-btn {
+  height: var(--input-height);
+  padding: 0 24px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.import__upload-btn:hover { opacity: 0.9; }

--- a/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
@@ -1,0 +1,21 @@
+    <main class="import">
+      <h1 class="import__title">Import Links</h1>
+      <p class="import__intro">
+        Upload any text-shaped export (HTML, JSON, plain text) and Readplace will
+        pull every <code>http(s)://</code> URL out for you to review before
+        saving. Files larger than 5&nbsp;MiB or imports above 2,000 links fall
+        back to emailing
+        <a href="mailto:hutch+migrate@readplace.com">hutch+migrate@readplace.com</a>
+        for the concierge path.
+      </p>
+      {{#if errorMessage}}
+      <p class="import__upload-error" data-test-import-error>{{errorMessage}}</p>
+      {{/if}}
+      <form class="import__upload-form" method="POST" action="{{uploadAction}}" enctype="multipart/form-data" data-test-form="import-file">
+        <label class="import__upload-label">
+          <span>Choose a file</span>
+          <input type="file" name="file" required data-test-import-file-input>
+        </label>
+        <button class="import__upload-btn" type="submit" data-test-action="import-upload">Upload</button>
+      </form>
+    </main>

--- a/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
@@ -3,10 +3,10 @@
       <p class="import__intro">
         Upload any text-shaped export (HTML, JSON, plain text) and Readplace will
         pull every <code>http(s)://</code> URL out for you to review before
-        saving. Files larger than 5&nbsp;MiB or imports above 2,000 links fall
-        back to emailing
-        <a href="mailto:hutch+migrate@readplace.com">hutch+migrate@readplace.com</a>
-        for the concierge path.
+        saving. Files larger than 5&nbsp;MiB or imports above 2,000 links?
+        Get in touch at
+        <a href="mailto:fayner@readplace.com">fayner@readplace.com</a>
+        to increase the limit.
       </p>
       {{#if errorMessage}}
       <p class="import__upload-error" data-test-import-error>{{errorMessage}}</p>

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -1,7 +1,7 @@
 import { ImportSessionIdSchema } from "@packages/domain/import-session";
 import type { ImportSession } from "@packages/domain/import-session";
 import { UserIdSchema } from "@packages/domain/user";
-import { toImportViewModel } from "./import.viewmodel";
+import { toImportUploadViewModel, toImportViewModel } from "./import.viewmodel";
 
 function makeSession(overrides: Partial<ImportSession> = {}): ImportSession {
 	return {
@@ -134,5 +134,22 @@ describe("toImportViewModel", () => {
 
 		expect(vm.truncated).toBe(true);
 		expect(vm.totalFoundInFile).toBe(2_345);
+	});
+});
+
+describe("toImportUploadViewModel", () => {
+	it("returns the upload action URL pre-baked with the feature flag so the form preserves the toggle", () => {
+		const vm = toImportUploadViewModel({});
+		expect(vm.uploadAction).toBe("/import?feature=import");
+	});
+
+	it("passes through an error message when provided", () => {
+		const vm = toImportUploadViewModel({ errorMessage: "We couldn't find any links in that file." });
+		expect(vm.errorMessage).toBe("We couldn't find any links in that file.");
+	});
+
+	it("leaves errorMessage undefined when no message is provided", () => {
+		const vm = toImportUploadViewModel({});
+		expect(vm.errorMessage).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -1,6 +1,18 @@
 import type { ImportSessionPage } from "@packages/domain/import-session";
 import { buildImportUrl } from "./import.url";
 
+export interface ImportUploadViewModel {
+	readonly errorMessage?: string;
+	readonly uploadAction: string;
+}
+
+export function toImportUploadViewModel(input: { errorMessage?: string }): ImportUploadViewModel {
+	return {
+		errorMessage: input.errorMessage,
+		uploadAction: "/import?feature=import",
+	};
+}
+
 export interface ImportRowViewModel {
 	readonly index: number;
 	readonly url: string;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -44,7 +44,6 @@ interface QueueDisplayModel {
 	pluralSuffix: string;
 	saveError?: string;
 	importFlash?: string;
-	showImportForm: boolean;
 	isEmpty: boolean;
 	hasArticles: boolean;
 	onboardingHtml: string;
@@ -73,7 +72,7 @@ export function formatUnreadLabel(count: number): string {
 	return count > 99 ? "To read (99+)" : `To read (${count})`;
 }
 
-function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; extensionSavedArticle: boolean; browser: BrowserName; onboardingDismissed: boolean; showImportForm: boolean }): QueueDisplayModel {
+function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; extensionSavedArticle: boolean; browser: BrowserName; onboardingDismissed: boolean }): QueueDisplayModel {
 	const activeTab = vm.filters.tab;
 	const effectiveOrder = vm.filters.order ?? tabQuery(activeTab).defaultOrder;
 	const nextOrder = effectiveOrder === "desc" ? "asc" : "desc";
@@ -93,7 +92,6 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		pluralSuffix: vm.total !== 1 ? "s" : "",
 		saveError: vm.saveError,
 		importFlash: vm.importFlash,
-		showImportForm: options.showImportForm,
 		isEmpty: vm.isEmpty,
 		hasArticles: !vm.isEmpty,
 		onboardingHtml,
@@ -131,34 +129,12 @@ const AUTO_SUBMIT_SCRIPT = `
 </script>
 `;
 
-const IMPORT_AUTO_SUBMIT_SCRIPT = `
-<script>
-	(function () {
-		function wire() {
-			var form = document.querySelector('form.queue__import-form');
-			if (!form) return;
-			var input = form.querySelector('input[type="file"]');
-			if (!input) return;
-			input.addEventListener('change', function () {
-				if (input.files && input.files.length > 0) form.requestSubmit();
-			});
-		}
-		if (document.readyState === 'loading') {
-			document.addEventListener('DOMContentLoaded', wire, { once: true });
-		} else {
-			wire();
-		}
-	})();
-</script>
-`;
-
-export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; extensionSavedArticle?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; showImportForm?: boolean; statusCode?: number }): PageBody {
+export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; extensionSavedArticle?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; statusCode?: number }): PageBody {
 	const saveUrl = options?.saveUrl;
-	const showImportForm = options?.showImportForm ?? false;
-	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, extensionSavedArticle: options?.extensionSavedArticle ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false, showImportForm });
+	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, extensionSavedArticle: options?.extensionSavedArticle ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false });
 	const content = render(QUEUE_TEMPLATE, { ...displayModel, saveUrl });
 
-	const scriptParts: string[] = [IMPORT_AUTO_SUBMIT_SCRIPT];
+	const scriptParts: string[] = [];
 	if (saveUrl) scriptParts.push(AUTO_SUBMIT_SCRIPT);
 
 	return {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
@@ -1,8 +1,5 @@
 const SAVE_ERROR_MESSAGES: Record<string, string> = {
 	save_failed: "Could not save article. Please try again.",
-	import_too_large: "That file is too large. The limit is 5 MiB — please email it to hutch+migrate@readplace.com instead.",
-	import_no_urls: "We couldn't find any links in that file.",
-	import_session_not_found: "That import session has expired. Please upload the file again.",
 };
 
 export type HttpErrorMessageMapping = (query: Record<string, unknown>) => string | undefined;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -155,10 +155,9 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		 * again so they can install the extension here. */
 		const onboardingDismissed = extensionInstalled && req.cookies?.[DISMISS_COOKIE_NAME] === ONBOARDING_VERSION;
 		const browser = detectBrowser(req);
-		const showImportForm = req.query.feature === "import";
 		sendComponent(
 			req, res,
-			renderPage(req, QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed, showImportForm })),
+			renderPage(req, QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed })),
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2576,7 +2576,7 @@ describe("Queue routes", () => {
 	});
 
 	describe("GET /queue?feature=import", () => {
-		it("should render the import form with the no-JS Upload button", async () => {
+		it("surfaces the Import Links nav item but no longer renders the upload form on /queue", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(app, auth);
 
@@ -2584,32 +2584,22 @@ describe("Queue routes", () => {
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
-			const form = doc.querySelector("form.queue__import-form");
-			assert(form, "import form must be rendered");
-			const button = form.querySelector("button.queue__import-btn");
-			assert(button, "Upload button must remain in the DOM as the no-JS fallback");
-			expect(button.textContent).toBe("Upload");
+			const navLink = doc.querySelector('[data-test-nav-item="import"]');
+			assert(navLink, "Import Links nav item must be rendered when the feature flag is on");
+			expect(navLink.getAttribute("href")).toBe("/import?feature=import");
+			expect(doc.querySelector("form.queue__import-form")).toBeNull();
+			expect(doc.querySelector('[data-test-form="import-file"]')).toBeNull();
 		});
 
-		it("should include the import auto-submit script", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
-
-			const response = await agent.get("/queue?feature=import");
-
-			expect(response.text).toContain("input.addEventListener");
-			expect(response.text).toContain("requestSubmit");
-		});
-
-		it("should include the import auto-submit script even when the import form is hidden", async () => {
+		it("does not surface the Import Links nav item when the feature flag is missing", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(app, auth);
 
 			const response = await agent.get("/queue");
 
 			expect(response.status).toBe(200);
-			expect(response.text).toContain("input.addEventListener");
-			expect(response.text).toContain("requestSubmit");
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -81,43 +81,11 @@
   margin-bottom: 16px;
 }
 
-.queue__import-form {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0 0 16px;
-  font-size: 0.875rem;
-}
-
-.queue__import-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--muted-foreground);
-}
-
 .queue__import-flash {
   color: var(--muted-foreground);
   font-size: 0.875rem;
   margin-top: -8px;
   margin-bottom: 16px;
-}
-
-.queue__import-btn {
-  padding: 8px 16px;
-  background: var(--secondary);
-  color: var(--secondary-foreground);
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 0.8125rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-
-.queue__import-btn:hover {
-  background: var(--primary);
-  color: var(--primary-foreground);
 }
 
 .queue__filters {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -8,15 +8,6 @@
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}">
         <button class="queue__save-btn" type="submit"><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
       </form>
-      {{#if showImportForm}}
-      <form class="queue__import-form" method="POST" action="/import" enctype="multipart/form-data" data-test-form="import-file">
-        <label class="queue__import-label">
-          <span>Import from a file</span>
-          <input type="file" name="file" required data-test-import-file-input>
-        </label>
-        <button class="queue__import-btn" type="submit" data-test-action="import-upload">Upload</button>
-      </form>
-      {{/if}}
       {{#if saveError}}<p class="queue__save-error" data-test-save-error>{{saveError}}</p>{{/if}}
       {{#if importFlash}}<p class="queue__import-flash" data-test-import-flash>{{importFlash}}</p>{{/if}}
       <nav class="queue__filters" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-filters>

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -26,7 +26,7 @@ const baseInput: ViewPageInput = {
 };
 
 function render(input = baseInput) {
-	const html = Base(ViewPage(input), { isAuthenticated: false, emailVerified: undefined }).to("text/html").body;
+	const html = Base(ViewPage(input), { isAuthenticated: false, emailVerified: undefined, featureImport: false }).to("text/html").body;
 	return new JSDOM(html).window.document;
 }
 

--- a/projects/hutch/src/runtime/web/render-page.test.ts
+++ b/projects/hutch/src/runtime/web/render-page.test.ts
@@ -89,4 +89,36 @@ describe("renderPage", () => {
 		assert(banner, "verify banner must be rendered");
 		expect(banner.classList.contains("verify-banner--hidden")).toBe(true);
 	});
+
+	it("renders the Import Links nav item when ?feature=import is set on an authenticated request", () => {
+		const result = renderPage(
+			createSource({ userId: USER_ID, query: { feature: "import" } }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const link = doc.querySelector('[data-test-nav-item="import"]');
+		assert(link, "Import Links nav item must be rendered when the feature flag is set");
+		expect(link.getAttribute("href")).toBe("/import?feature=import");
+	});
+
+	it("hides the Import Links nav item when the request has no feature flag", () => {
+		const result = renderPage(
+			createSource({ userId: USER_ID }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
+	});
+
+	it("hides the Import Links nav item when the feature query value is something else", () => {
+		const result = renderPage(
+			createSource({ userId: USER_ID, query: { feature: "something-else" } }),
+			createTestPageBody(),
+		).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
+	});
 });


### PR DESCRIPTION
## Summary

- Moves the file-import entry point off `/queue` (where it shared screen real estate with the daily save bar) and onto a dedicated **Import Links** nav item that lives in the top menu for authenticated users.
- Adds `GET /import` to render the upload form. The existing `?feature=import` toggle is preserved end-to-end: the nav item only renders when the flag is on, and `GET /import` redirects un-flagged users back to `/queue`.
- Upload errors (`import_no_urls`, `import_too_large`, `import_session_not_found`) now redirect to `/import?feature=import&error_code=...` so users stay in the gated flow. Post-commit redirect to `/queue?import_imported=N&import_total=M` is unchanged so users see their newly-imported cards in the queue.

## Why

Imports are a one-time migration event (Pocket / Instapaper / Omnivore), not a daily action. Bolting the upload form onto `/queue` next to the save bar made two unrelated affordances compete for the same eye region; users also had no way to discover the importer except by typing the magic `?feature=import` URL by hand. Lifting the entry point into a (still feature-gated) nav item finishes a separation that was already half-done — the rest of the import machinery (POST `/import`, GET `/:id`, toggle, commit) already lives under `/import`.

## Scope notes

- **Feature flag preserved.** Same `?feature=import` semantics as before: per-request query toggle. No new cookie or persistent state.
- **No landing-page regression.** The nav item is gated to authenticated users with the feature flag — the "do not restore the Import Your Data card" rule from CLAUDE.md still holds.
- **Blog posts not touched.** `pocket-migration.md`, `omnivore-alternative.md`, and `best-read-it-later-apps-2026.md` still tell users to "open your queue and use the picker." They assume general availability and are out of scope here; will update once the feature flag drops.

## Test plan

- [x] `pnpm nx run hutch:check` (tsc + biome + knip + check-unused-css + jest + 100% coverage thresholds) passes locally.
- [x] New `import.error.test.ts` covers the 3-code mapping.
- [x] `import.viewmodel.test.ts` covers `toImportUploadViewModel` (action URL preserves the flag, error message passthrough).
- [x] `import.route.test.ts` covers `GET /import?feature=import` (renders form), `GET /import` (redirects to /queue), all three `error_code=...` rendering paths, and the rerouted upload-error redirects.
- [x] `base.component.test.ts` + `render-page.test.ts` cover the new authenticated nav item: visible only when authenticated AND `featureImport` is on; href preserves the flag.
- [x] `queue.route.test.ts` covers the new behaviour on `/queue?feature=import` (nav item present, upload form absent) and `/queue` (nav item absent).

---
_Generated by [Claude Code](https://claude.ai/code/session_018cCFbTCTbUZHJEsUXDKWGc)_