### PR TITLE
feat(queue): auto-refresh pending cards via per-row htmx polling

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/is-card-terminal.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/is-card-terminal.test.ts
@@ -1,0 +1,59 @@
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import { isCardTerminal } from "./is-card-terminal";
+
+describe("isCardTerminal", () => {
+	it("is non-terminal while the crawl is pending", () => {
+		const crawl: ArticleCrawl = { status: "pending" };
+		const summary: GeneratedSummary = { status: "pending" };
+		expect(isCardTerminal(crawl, summary)).toBe(false);
+	});
+
+	it("is non-terminal while crawl ready but summary pending", () => {
+		const crawl: ArticleCrawl = { status: "ready" };
+		const summary: GeneratedSummary = { status: "pending" };
+		expect(isCardTerminal(crawl, summary)).toBe(false);
+	});
+
+	it("is terminal when crawl ready and summary ready", () => {
+		const crawl: ArticleCrawl = { status: "ready" };
+		const summary: GeneratedSummary = {
+			status: "ready",
+			summary: "TL;DR.",
+		};
+		expect(isCardTerminal(crawl, summary)).toBe(true);
+	});
+
+	it("is terminal when crawl ready and summary skipped", () => {
+		const crawl: ArticleCrawl = { status: "ready" };
+		const summary: GeneratedSummary = {
+			status: "skipped",
+			reason: "content-too-short",
+		};
+		expect(isCardTerminal(crawl, summary)).toBe(true);
+	});
+
+	it("is terminal when crawl ready and summary failed", () => {
+		const crawl: ArticleCrawl = { status: "ready" };
+		const summary: GeneratedSummary = {
+			status: "failed",
+			reason: "deepseek timeout",
+		};
+		expect(isCardTerminal(crawl, summary)).toBe(true);
+	});
+
+	it("is terminal as soon as the crawl fails, regardless of summary state", () => {
+		const crawl: ArticleCrawl = { status: "failed", reason: "blocked" };
+		const summary: GeneratedSummary = { status: "pending" };
+		expect(isCardTerminal(crawl, summary)).toBe(true);
+	});
+
+	it("is non-terminal when both crawl and summary are missing (legacy heal)", () => {
+		expect(isCardTerminal(undefined, undefined)).toBe(false);
+	});
+
+	it("is non-terminal when crawl ready but summary row not yet written", () => {
+		const crawl: ArticleCrawl = { status: "ready" };
+		expect(isCardTerminal(crawl, undefined)).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/is-card-terminal.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/is-card-terminal.ts
@@ -1,0 +1,30 @@
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+
+/**
+ * Polls `/queue/:id/card` stop ticking once both pipelines reach a terminal
+ * state. Mirrors `shouldKeepPollingReader` in article-reader.ts but for the
+ * queue-list card surface, where the only visible fields that change are
+ * title / siteName / excerpt / imageUrl / wordCount — i.e. the side effects of
+ * crawl and summary completion.
+ *
+ * 1. Failed crawl wins immediately: the pipeline gave up so nothing else will
+ *    arrive. The card stays on its hostname-derived stub.
+ * 2. Pending crawl: title / imageUrl / wordCount may still land.
+ * 3. Crawl ready, summary pending: excerpt may still mature.
+ * 4. crawl === undefined && summary === undefined: legacy stub before either
+ *    state machine has a row. Same heal as article-reader.ts:38-40 — keep
+ *    polling, the next save-link-work tick will mark them pending.
+ */
+export function isCardTerminal(
+	crawl: ArticleCrawl | undefined,
+	summary: GeneratedSummary | undefined,
+): boolean {
+	if (crawl?.status === "failed") return true; /* 1 */
+	if (crawl?.status === "pending") return false; /* 2 */
+	const summaryStatus = summary?.status;
+	if (crawl?.status === "ready" && summaryStatus === "pending") return false; /* 3 */
+	if (crawl === undefined && summary === undefined) return false; /* 4 */
+	if (crawl?.status === "ready" && summaryStatus === undefined) return false;
+	return true;
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card-poll-url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card-poll-url.test.ts
@@ -1,0 +1,48 @@
+import { buildCardPollUrl } from "./queue-card-poll-url";
+
+describe("buildCardPollUrl", () => {
+	it("encodes only the poll counter when filters are at their defaults", () => {
+		const url = buildCardPollUrl({
+			articleId: "abc123",
+			pollCount: 1,
+			filters: { tab: "queue", page: 1 },
+		});
+		expect(url).toBe("/queue/abc123/card?poll=1");
+	});
+
+	it("preserves the done tab so the card's action redirects stay on the done view", () => {
+		const url = buildCardPollUrl({
+			articleId: "abc123",
+			pollCount: 4,
+			filters: { tab: "done", page: 1 },
+		});
+		expect(url).toBe("/queue/abc123/card?poll=4&tab=done");
+	});
+
+	it("omits order when it equals the tab's default order", () => {
+		const url = buildCardPollUrl({
+			articleId: "abc123",
+			pollCount: 1,
+			filters: { tab: "queue", order: "desc", page: 1 },
+		});
+		expect(url).toBe("/queue/abc123/card?poll=1");
+	});
+
+	it("includes order when it diverges from the tab default", () => {
+		const url = buildCardPollUrl({
+			articleId: "abc123",
+			pollCount: 2,
+			filters: { tab: "queue", order: "asc", page: 1 },
+		});
+		expect(url).toBe("/queue/abc123/card?poll=2&order=asc");
+	});
+
+	it("includes page when the user is past page 1", () => {
+		const url = buildCardPollUrl({
+			articleId: "abc123",
+			pollCount: 1,
+			filters: { tab: "queue", page: 3 },
+		});
+		expect(url).toBe("/queue/abc123/card?poll=1&page=3");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card-poll-url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card-poll-url.ts
@@ -1,0 +1,31 @@
+import type { QueueUrlState } from "../queue.url";
+import { tabQuery } from "../queue.tabs";
+
+/**
+ * Polling URL for one card. The path takes the article id; the query
+ * preserves the filter context (tab/order/page) of the parent /queue page so
+ * that action forms inside the refreshed card still post back with the
+ * filter-aware redirect query the user expects.
+ *
+ * Mirrors `buildQueueUrl` in queue.url.ts in two ways: the `tab=queue` and
+ * default-order parameters are omitted because they are the implicit default,
+ * keeping the polled URLs clean and stable across consecutive ticks.
+ */
+export function buildCardPollUrl(params: {
+	articleId: string;
+	pollCount: number;
+	filters: Partial<QueueUrlState>;
+}): string {
+	const search = new URLSearchParams();
+	search.set("poll", String(params.pollCount));
+	const tab = params.filters.tab ?? "queue";
+	if (tab !== "queue") search.set("tab", tab);
+	const { defaultOrder } = tabQuery(tab);
+	if (params.filters.order && params.filters.order !== defaultOrder) {
+		search.set("order", params.filters.order);
+	}
+	if (params.filters.page && params.filters.page > 1) {
+		search.set("page", String(params.filters.page));
+	}
+	return `/queue/${params.articleId}/card?${search.toString()}`;
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	renderQueueCard,
+	toQueueCardDisplayModel,
+} from "./queue-card.component";
+import type { QueueArticleViewModel } from "../queue.viewmodel";
+
+function makeViewModel(
+	overrides?: Partial<QueueArticleViewModel>,
+): QueueArticleViewModel {
+	return {
+		id: "abc123",
+		title: "Article Title",
+		siteName: "example.com",
+		excerpt: "An excerpt.",
+		url: "https://example.com/article",
+		readTimeLabel: "3 min read",
+		status: "unread",
+		isUnread: true,
+		savedAgo: "10m ago",
+		hasContent: false,
+		actions: [],
+		...overrides,
+	};
+}
+
+function parse(html: string): Document {
+	return new JSDOM(html).window.document;
+}
+
+describe("renderQueueCard", () => {
+	it("renders the article title and excerpt", () => {
+		const html = renderQueueCard(
+			toQueueCardDisplayModel(makeViewModel(), { isFirst: false }),
+		);
+		const doc = parse(html);
+		const card = doc.querySelector(".queue-article");
+		assert(card, "card root must be present");
+		expect(doc.querySelector("[data-test-article-title]")?.textContent).toBe(
+			"Article Title",
+		);
+		expect(doc.querySelector(".queue-article__excerpt")?.textContent).toBe(
+			"An excerpt.",
+		);
+	});
+
+	it("emits the polling htmx attributes when cardPollUrl is set", () => {
+		const html = renderQueueCard(
+			toQueueCardDisplayModel(
+				makeViewModel({ cardPollUrl: "/queue/abc123/card?poll=2" }),
+				{ isFirst: false },
+			),
+		);
+		const card = parse(html).querySelector(".queue-article");
+		assert(card, "card root must be present");
+		expect(card.getAttribute("hx-get")).toBe("/queue/abc123/card?poll=2");
+		expect(card.getAttribute("hx-trigger")).toBe("every 3s");
+		expect(card.getAttribute("hx-target")).toBe("this");
+		expect(card.getAttribute("hx-swap")).toBe("outerHTML");
+		expect(card.getAttribute("data-card-status")).toBe("pending");
+	});
+
+	it("does not emit polling attributes when cardPollUrl is undefined", () => {
+		const html = renderQueueCard(
+			toQueueCardDisplayModel(makeViewModel({ cardPollUrl: undefined }), {
+				isFirst: false,
+			}),
+		);
+		const card = parse(html).querySelector(".queue-article");
+		assert(card, "card root must be present");
+		expect(card.hasAttribute("hx-get")).toBe(false);
+		expect(card.hasAttribute("hx-trigger")).toBe(false);
+		expect(card.getAttribute("data-card-status")).toBe("terminal");
+	});
+
+	it("marks the first card with id=latest-saved so anchor jumps still work", () => {
+		const html = renderQueueCard(
+			toQueueCardDisplayModel(makeViewModel(), { isFirst: true }),
+		);
+		const card = parse(html).querySelector(".queue-article");
+		assert(card);
+		expect(card.getAttribute("id")).toBe("latest-saved");
+	});
+
+	it("does not mark non-first cards with id=latest-saved", () => {
+		const html = renderQueueCard(
+			toQueueCardDisplayModel(makeViewModel(), { isFirst: false }),
+		);
+		const card = parse(html).querySelector(".queue-article");
+		assert(card);
+		expect(card.hasAttribute("id")).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render } from "../../../render";
+import type {
+	ArticleAction,
+	QueueArticleViewModel,
+} from "../queue.viewmodel";
+
+const TEMPLATE = readFileSync(join(__dirname, "queue-card.template.html"), "utf-8");
+
+export interface ActionDisplayModel extends ArticleAction {
+	buttonClass: string;
+}
+
+export interface QueueCardDisplayModel extends QueueArticleViewModel {
+	linkUrl: string;
+	unreadClass: string;
+	isFirst: boolean;
+	cardStatus: "pending" | "terminal";
+	actions: ActionDisplayModel[];
+}
+
+export function toActionDisplayModel(action: ArticleAction): ActionDisplayModel {
+	return {
+		...action,
+		buttonClass:
+			action.testAction === "delete"
+				? "queue-article__action-btn queue-article__action-btn--delete"
+				: "queue-article__action-btn",
+	};
+}
+
+export function toQueueCardDisplayModel(
+	article: QueueArticleViewModel,
+	options: { isFirst: boolean },
+): QueueCardDisplayModel {
+	return {
+		...article,
+		linkUrl: `/queue/${article.id}/read`,
+		unreadClass: article.isUnread ? " queue-article--unread" : "",
+		isFirst: options.isFirst,
+		cardStatus: article.cardPollUrl ? "pending" : "terminal",
+		actions: article.actions.map(toActionDisplayModel),
+	};
+}
+
+export function renderQueueCard(displayModel: QueueCardDisplayModel): string {
+	return render(TEMPLATE, displayModel);
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.etag.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.etag.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import type { Minutes, SavedArticle } from "@packages/domain/article";
+import { ReaderArticleHashId } from "@packages/domain/article";
+import type { UserId } from "@packages/domain/user";
+import { computeQueueCardEtag, etagMatches } from "./queue-card.etag";
+
+const ARTICLE_URL = "https://example.com/post";
+
+function makeArticle(overrides?: Partial<SavedArticle>): SavedArticle {
+	return {
+		id: ReaderArticleHashId.from(ARTICLE_URL),
+		userId: "user-1" as UserId,
+		url: ARTICLE_URL,
+		metadata: {
+			title: "Test Article",
+			siteName: "example.com",
+			excerpt: "An excerpt",
+			wordCount: 500,
+		},
+		estimatedReadTime: 3 as Minutes,
+		status: "unread",
+		savedAt: new Date("2025-06-01T12:00:00Z"),
+		...overrides,
+	};
+}
+
+describe("computeQueueCardEtag", () => {
+	it("returns a weak ETag", () => {
+		const etag = computeQueueCardEtag({
+			article: makeArticle(),
+			crawl: { status: "ready" },
+			summary: { status: "ready", summary: "TL;DR" },
+		});
+		assert(etag.startsWith('W/"'));
+		assert(etag.endsWith('"'));
+	});
+
+	it("is stable across calls with the same input", () => {
+		const input = {
+			article: makeArticle(),
+			crawl: { status: "ready" as const },
+			summary: { status: "ready" as const, summary: "TL;DR" },
+		};
+		expect(computeQueueCardEtag(input)).toBe(computeQueueCardEtag(input));
+	});
+
+	it("changes when crawlStatus changes", () => {
+		const article = makeArticle();
+		const a = computeQueueCardEtag({ article, crawl: { status: "pending" }, summary: undefined });
+		const b = computeQueueCardEtag({ article, crawl: { status: "ready" }, summary: undefined });
+		expect(a).not.toBe(b);
+	});
+
+	it("changes when summaryStatus changes", () => {
+		const article = makeArticle();
+		const a = computeQueueCardEtag({ article, crawl: { status: "ready" }, summary: { status: "pending" } });
+		const b = computeQueueCardEtag({ article, crawl: { status: "ready" }, summary: { status: "ready", summary: "TL;DR" } });
+		expect(a).not.toBe(b);
+	});
+
+	it("changes when wordCount changes", () => {
+		const a = computeQueueCardEtag({
+			article: makeArticle({ metadata: { title: "T", siteName: "s.com", excerpt: "e", wordCount: 0 } }),
+			crawl: { status: "pending" },
+			summary: { status: "pending" },
+		});
+		const b = computeQueueCardEtag({
+			article: makeArticle({ metadata: { title: "T", siteName: "s.com", excerpt: "e", wordCount: 750 } }),
+			crawl: { status: "pending" },
+			summary: { status: "pending" },
+		});
+		expect(a).not.toBe(b);
+	});
+
+	it("changes when imageUrl is filled in late by the S3 thumbnail copy", () => {
+		const without = computeQueueCardEtag({
+			article: makeArticle({ metadata: { title: "T", siteName: "s.com", excerpt: "e", wordCount: 500 } }),
+			crawl: { status: "ready" },
+			summary: { status: "ready", summary: "TL;DR" },
+		});
+		const withImage = computeQueueCardEtag({
+			article: makeArticle({
+				metadata: { title: "T", siteName: "s.com", excerpt: "e", wordCount: 500, imageUrl: "https://cdn.example.com/img.jpg" },
+			}),
+			crawl: { status: "ready" },
+			summary: { status: "ready", summary: "TL;DR" },
+		});
+		expect(without).not.toBe(withImage);
+	});
+
+	it("changes when the user-visible status flips between read and unread", () => {
+		const unread = computeQueueCardEtag({
+			article: makeArticle({ status: "unread" }),
+			crawl: { status: "ready" },
+			summary: { status: "ready", summary: "TL;DR" },
+		});
+		const read = computeQueueCardEtag({
+			article: makeArticle({ status: "read", readAt: new Date("2025-06-02T00:00:00Z") }),
+			crawl: { status: "ready" },
+			summary: { status: "ready", summary: "TL;DR" },
+		});
+		expect(unread).not.toBe(read);
+	});
+});
+
+describe("etagMatches", () => {
+	it("returns false for an undefined If-None-Match header", () => {
+		expect(etagMatches(undefined, 'W/"abc"')).toBe(false);
+	});
+
+	it("matches an exact single ETag", () => {
+		expect(etagMatches('W/"abc"', 'W/"abc"')).toBe(true);
+	});
+
+	it("matches when the header carries multiple ETags", () => {
+		expect(etagMatches('W/"abc", W/"def"', 'W/"def"')).toBe(true);
+	});
+
+	it("does not match when no entry equals the ETag", () => {
+		expect(etagMatches('W/"abc"', 'W/"xyz"')).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.etag.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.etag.ts
@@ -1,0 +1,59 @@
+import { createHash } from "node:crypto";
+import type { SavedArticle } from "@packages/domain/article";
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+
+export interface QueueCardEtagInput {
+	article: SavedArticle;
+	crawl: ArticleCrawl | undefined;
+	summary: GeneratedSummary | undefined;
+}
+
+function hashFields(parts: readonly string[]): string {
+	const hash = createHash("sha256");
+	for (const part of parts) {
+		hash.update(part);
+		hash.update("|");
+	}
+	return hash.digest("hex").slice(0, 16);
+}
+
+/**
+ * Weak ETag composed of the row identity + every field that can mutate while
+ * the card sits on screen. Crawl and summary status drive the obvious
+ * transitions; wordCount goes 0 → real number when the crawl writes back; the
+ * title/excerpt/imageUrl hash catches in-place re-summary regenerations and
+ * the late-arriving S3 thumbnail copy that flips imageUrl after crawlStatus
+ * is already "ready".
+ *
+ * `W/` prefix marks this weak — semantically equivalent representations may
+ * share the tag (acceptable here since htmx never byte-compares responses).
+ */
+export function computeQueueCardEtag(input: QueueCardEtagInput): string {
+	const { article, crawl, summary } = input;
+	const summaryStatus = summary?.status ?? "absent";
+	const crawlStatus = crawl?.status ?? "absent";
+	const summaryReason =
+		summary?.status === "failed" || summary?.status === "skipped"
+			? (summary.reason ?? "")
+			: "";
+	const crawlReason = crawl?.status === "failed" ? crawl.reason : "";
+	const contentHash = hashFields([
+		article.metadata.title,
+		article.metadata.excerpt,
+		article.metadata.imageUrl ?? "",
+		article.metadata.siteName,
+	]);
+	return `W/"${article.id.value}:${article.status}:${crawlStatus}:${summaryStatus}:${article.metadata.wordCount}:${contentHash}:${hashFields([crawlReason, summaryReason])}"`;
+}
+
+export function etagMatches(
+	ifNoneMatchHeader: string | undefined,
+	etag: string,
+): boolean {
+	if (!ifNoneMatchHeader) return false;
+	return ifNoneMatchHeader
+		.split(",")
+		.map((part) => part.trim())
+		.includes(etag);
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
@@ -1,0 +1,24 @@
+<div class="queue-article{{unreadClass}}" data-test-article="{{id}}"{{#if isFirst}} id="latest-saved"{{/if}}{{#if cardPollUrl}} hx-get="{{cardPollUrl}}" hx-trigger="every 3s" hx-target="this" hx-swap="outerHTML"{{/if}} data-card-status="{{cardStatus}}">
+	{{!-- onerror is a vestigial safety net for legacy DynamoDB rows whose imageUrl still points at an external host that can 404 over time. New saves go through the S3-only thumbnail path in @packages/crawl-article, so once a backfill migration rewrites every legacy row to a CDN URL, this onerror (and the paired onload) can be deleted. --}}
+	{{#if imageUrl}}<a href="{{linkUrl}}" class="queue-article__thumbnail-link" tabindex="-1" aria-hidden="true"><img class="queue-article__thumbnail" src="{{imageUrl}}" alt="" onload="this.parentElement.classList.add('queue-article__thumbnail-link--loaded')" onerror="this.parentElement.remove()"></a>{{/if}}
+	<div class="queue-article__content">
+		<div class="queue-article__title-row">
+			{{#if isUnread}}<span class="queue-article__unread-dot" aria-label="Unread"></span>{{/if}}
+			<a class="queue-article__title" href="{{linkUrl}}" data-test-article-title>{{title}}</a>
+		</div>
+		<div class="queue-article__meta">
+			{{#if siteName}}<a class="queue-article__url" href="{{url}}" target="_blank" rel="noopener" data-test-article-url>{{siteName}}</a>{{/if}}
+			<span>{{readTimeLabel}}</span>
+			<span>{{savedAgo}}</span>
+		</div>
+		<p class="queue-article__excerpt">{{excerpt}}</p>
+	</div>
+	<div class="queue-article__actions">
+		{{#each actions}}
+		<form method="{{method}}" action="{{url}}" class="queue-article__action-form" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
+			{{#each fields}}<input type="hidden" name="{{name}}" value="{{value}}">{{/each}}
+			<button class="{{buttonClass}}" type="submit" title="{{title}}" data-test-action="{{testAction}}">{{text}}</button>
+		</form>
+		{{/each}}
+	</div>
+</div>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -5,39 +5,12 @@ import type { BrowserName } from "../../onboarding/onboarding.types";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { QUEUE_STYLES } from "./queue.styles";
-import type { ArticleAction, QueueArticleViewModel, QueueViewModel } from "./queue.viewmodel";
+import { renderQueueCard, toQueueCardDisplayModel } from "./queue-card/queue-card.component";
+import type { QueueViewModel } from "./queue.viewmodel";
 import { buildQueueUrl } from "./queue.url";
 import { tabQuery } from "./queue.tabs";
 
 const QUEUE_TEMPLATE = readFileSync(join(__dirname, "queue.template.html"), "utf-8");
-
-interface ActionDisplayModel extends ArticleAction {
-	buttonClass: string;
-}
-
-interface ArticleDisplayModel extends QueueArticleViewModel {
-	linkUrl: string;
-	unreadClass: string;
-	actions: ActionDisplayModel[];
-}
-
-function toActionDisplayModel(action: ArticleAction): ActionDisplayModel {
-	return {
-		...action,
-		buttonClass: action.testAction === "delete"
-			? "queue-article__action-btn queue-article__action-btn--delete"
-			: "queue-article__action-btn",
-	};
-}
-
-function toArticleDisplayModel(article: QueueArticleViewModel): ArticleDisplayModel {
-	return {
-		...article,
-		linkUrl: `/queue/${article.id}/read`,
-		unreadClass: article.isUnread ? " queue-article--unread" : "",
-		actions: article.actions.map(toActionDisplayModel),
-	};
-}
 
 interface QueueDisplayModel {
 	total: number;
@@ -48,7 +21,7 @@ interface QueueDisplayModel {
 	isEmpty: boolean;
 	hasArticles: boolean;
 	onboardingHtml: string;
-	articles: ArticleDisplayModel[];
+	articleHtmls: string[];
 	filterUnreadClass: string;
 	filterUnreadLabel: string;
 	filterReadClass: string;
@@ -97,7 +70,9 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		isEmpty: vm.isEmpty,
 		hasArticles: !vm.isEmpty,
 		onboardingHtml,
-		articles: vm.articles.map(toArticleDisplayModel),
+		articleHtmls: vm.articles.map((article, index) =>
+			renderQueueCard(toQueueCardDisplayModel(article, { isFirst: index === 0 })),
+		),
 		filterUnreadClass: filterLinkClass(activeTab === "queue"),
 		filterUnreadLabel: formatUnreadLabel(vm.unreadCount),
 		filterReadClass: filterLinkClass(activeTab === "done"),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -20,6 +20,7 @@ import type {
 import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/providers/events";
 import type { ReadArticleContent } from "@packages/test-fixtures/providers/article-store";
 import type {
+	ArticleCrawl,
 	FindArticleCrawlStatus,
 	MarkCrawlPending,
 } from "@packages/test-fixtures/providers/article-crawl";
@@ -44,8 +45,13 @@ import { parseQueueUrl, buildQueueUrl } from "./queue.url";
 import { tabQuery } from "./queue.tabs";
 import type { HttpErrorMessageMapping } from "./queue.error";
 import { importFlashMapping } from "./queue.error";
-import { toQueueViewModel } from "./queue.viewmodel";
+import { MAX_CARD_POLLS, toQueueArticleViewModel, toQueueViewModel } from "./queue.viewmodel";
 import { QueuePage } from "./queue.component";
+import {
+	renderQueueCard,
+	toQueueCardDisplayModel,
+} from "./queue-card/queue-card.component";
+import { computeQueueCardEtag, etagMatches } from "./queue-card/queue-card.etag";
 import { ReaderPage } from "../reader/reader.component";
 import { ONBOARDING_VERSION } from "../../onboarding/onboarding.steps";
 import {
@@ -100,6 +106,17 @@ async function loadSummaries(
 	}));
 }
 
+async function loadCrawls(
+	findArticleCrawlStatus: FindArticleCrawlStatus,
+	articles: readonly SavedArticle[],
+): Promise<Map<string, ArticleCrawl | undefined>> {
+	const results = await Promise.allSettled(articles.map((a) => findArticleCrawlStatus(a.url)));
+	return new Map(articles.map((a, i) => {
+		const r = results[i];
+		return [a.url, r.status === "fulfilled" ? r.value : undefined] as const;
+	}));
+}
+
 export function initQueueRoutes(deps: QueueDependencies): Router {
 	const router = express.Router();
 
@@ -144,8 +161,17 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			: (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
 		const saveError = deps.httpErrorMessageMapping(req.query);
 		const importFlash = importFlashMapping(req.query);
-		const summaryByUrl = await loadSummaries(deps.findGeneratedSummary, result.articles);
-		const vm = toQueueViewModel(result, urlState, { unreadCount, saveError, importFlash, summaryByUrl });
+		const [summaryByUrl, crawlByUrl] = await Promise.all([
+			loadSummaries(deps.findGeneratedSummary, result.articles),
+			loadCrawls(deps.findArticleCrawlStatus, result.articles),
+		]);
+		const vm = toQueueViewModel(result, urlState, {
+			unreadCount,
+			saveError,
+			importFlash,
+			summaryByUrl,
+			crawlByUrl,
+		});
 		const extensionInstalled = isExtensionInstalled(req);
 		const extensionSavedArticle = isExtensionSavedArticle(req);
 		/** Dismissal only counts when the extension is also installed in *this* browser.
@@ -321,11 +347,15 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const urlState = parseQueueUrl({});
 			const result = await deps.findArticlesByUser({ userId });
 			const unreadCount = (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
-			const summaryByUrl = await loadSummaries(deps.findGeneratedSummary, result.articles);
+			const [summaryByUrl, crawlByUrl] = await Promise.all([
+				loadSummaries(deps.findGeneratedSummary, result.articles),
+				loadCrawls(deps.findArticleCrawlStatus, result.articles),
+			]);
 			const vm = toQueueViewModel(result, urlState, {
 				saveError: "Please enter a valid URL",
 				unreadCount,
 				summaryByUrl,
+				crawlByUrl,
 			});
 			sendComponent(req, res, renderPage(req, QueuePage(vm, { statusCode: 422 })));
 			return;
@@ -434,6 +464,59 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
 		sendComponent(req, res, component);
+	});
+
+	router.get("/:id/card", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const userId = req.userId;
+		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
+		const article = parsedId.success
+			? await deps.findArticleById(parsedId.data, userId)
+			: null;
+
+		if (!article) {
+			res.status(404).type("html").send("");
+			return;
+		}
+
+		const [crawl, summary] = await Promise.all([
+			deps.findArticleCrawlStatus(article.url),
+			deps.findGeneratedSummary(article.url),
+		]);
+
+		const etag = computeQueueCardEtag({ article, crawl, summary });
+		/** Per-user data — never share across CDN edges or between users on a
+		 * shared cache. `no-cache` requires revalidation on every request, which
+		 * is exactly what we want: the browser always asks, the server cheaply
+		 * returns 304 when the row hasn't changed during the wait window. */
+		res.set("Cache-Control", "private, no-cache");
+		res.set("Vary", "Cookie");
+		res.set("ETag", etag);
+
+		if (etagMatches(req.get("If-None-Match"), etag)) {
+			res.status(304).end();
+			return;
+		}
+
+		const filters = parseQueueUrl(req.query);
+		const queueUrl = buildQueueUrl(filters);
+		const queryIndex = queueUrl.indexOf("?");
+		const returnQuery = queryIndex !== -1 ? queueUrl.slice(queryIndex) : "";
+		const requestedPoll = Number(req.query.poll ?? "0");
+		const articleVm = toQueueArticleViewModel({
+			article,
+			now: deps.now(),
+			returnQuery,
+			summary,
+			crawl,
+			filters,
+			pollCount: requestedPoll + 1,
+			maxPolls: MAX_CARD_POLLS,
+		});
+		const html = renderQueueCard(
+			toQueueCardDisplayModel(articleVm, { isFirst: false }),
+		);
+		res.status(200).type("html").send(html);
 	});
 
 	router.post("/:id/status", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2612,4 +2612,264 @@ describe("Queue routes", () => {
 			expect(response.text).toContain("requestSubmit");
 		});
 	});
+
+	describe("Queue list auto-refresh (per-card polling)", () => {
+		async function getFirstArticleId(agent: ReturnType<typeof request.agent>): Promise<string> {
+			const queueResponse = await agent.get("/queue");
+			const queueDoc = new JSDOM(queueResponse.text).window.document;
+			const id = queueDoc
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert(id, "first article must be rendered with data-test-article id");
+			return id;
+		}
+
+		it("renders hx-get polling on the queue list card while crawl is pending", async () => {
+			// Default fixture leaves crawl in pending state — no fake publish wiring.
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/list-pending" });
+
+			const queueResponse = await agent.get("/queue");
+			const doc = new JSDOM(queueResponse.text).window.document;
+			const card = doc.querySelector("[data-test-article-list] .queue-article");
+			assert(card, "card must be rendered");
+			expect(card.getAttribute("hx-get")).toMatch(/^\/queue\/.+\/card\?poll=1$/);
+			expect(card.getAttribute("hx-trigger")).toBe("every 3s");
+			expect(card.getAttribute("hx-target")).toBe("this");
+			expect(card.getAttribute("hx-swap")).toBe("outerHTML");
+			expect(card.getAttribute("data-card-status")).toBe("pending");
+		});
+
+		it("does not render hx-get on the queue list card once both pipelines terminate", async () => {
+			const articleHtml = `<html><head><title>Done Post</title></head><body><article><h1>Done Post</h1><p>Body.</p></article></body></html>`;
+			const crawlArticle = async () => ({ status: "fetched" as const, html: articleHtml });
+			const findGeneratedSummary = async () => ({
+				status: "ready" as const,
+				summary: "Ready summary.",
+			});
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { parseArticle } = initReadabilityParser({ crawlArticle, sitePreParsers: [], logError: createNoopLogError() });
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const { app, auth } = createTestApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+				summary: {
+					findGeneratedSummary,
+					markSummaryPending: fixture.summary.markSummaryPending,
+					forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
+				},
+			});
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/list-done" });
+
+			const queueResponse = await agent.get("/queue");
+			const doc = new JSDOM(queueResponse.text).window.document;
+			const card = doc.querySelector("[data-test-article-list] .queue-article");
+			assert(card, "card must be rendered");
+			expect(card.hasAttribute("hx-get")).toBe(false);
+			expect(card.hasAttribute("hx-trigger")).toBe(false);
+			expect(card.getAttribute("data-card-status")).toBe("terminal");
+		});
+
+		it("GET /queue/:id/card returns a single card fragment with the next-poll URL when pending", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-fragment-pending" });
+
+			const articleId = await getFirstArticleId(agent);
+			const response = await agent.get(`/queue/${articleId}/card?poll=3`);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const card = doc.querySelector(".queue-article");
+			assert(card, "card fragment must be rendered");
+			expect(card.getAttribute("data-test-article")).toBe(articleId);
+			expect(card.getAttribute("hx-get")).toMatch(/poll=4(?:&|$)/);
+			expect(card.getAttribute("hx-trigger")).toBe("every 3s");
+		});
+
+		it("GET /queue/:id/card stops polling once both pipelines terminate", async () => {
+			const articleHtml = `<html><head><title>Terminal Post</title></head><body><article><h1>Terminal Post</h1><p>Body.</p></article></body></html>`;
+			const crawlArticle = async () => ({ status: "fetched" as const, html: articleHtml });
+			const findGeneratedSummary = async () => ({
+				status: "ready" as const,
+				summary: "Ready summary.",
+			});
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { parseArticle } = initReadabilityParser({ crawlArticle, sitePreParsers: [], logError: createNoopLogError() });
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const { app, auth } = createTestApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+				summary: {
+					findGeneratedSummary,
+					markSummaryPending: fixture.summary.markSummaryPending,
+					forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
+				},
+			});
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-fragment-done" });
+
+			const articleId = await getFirstArticleId(agent);
+			const response = await agent.get(`/queue/${articleId}/card?poll=3`);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const card = doc.querySelector(".queue-article");
+			assert(card, "card fragment must be rendered");
+			expect(card.hasAttribute("hx-get")).toBe(false);
+			expect(card.getAttribute("data-card-status")).toBe("terminal");
+		});
+
+		it("GET /queue/:id/card stops polling at MAX_CARD_POLLS even while still pending", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-fragment-cap" });
+
+			const articleId = await getFirstArticleId(agent);
+			const response = await agent.get(`/queue/${articleId}/card?poll=40`);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const card = doc.querySelector(".queue-article");
+			assert(card, "card fragment must be rendered");
+			expect(card.hasAttribute("hx-get")).toBe(false);
+		});
+
+		it("GET /queue/:id/card returns 404 for an unknown article", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			const response = await agent.get("/queue/00000000000000000000000000000000/card");
+			expect(response.status).toBe(404);
+		});
+
+		it("GET /queue/:id/card sets ETag and revalidation cache directives", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-etag" });
+			const articleId = await getFirstArticleId(agent);
+
+			const response = await agent.get(`/queue/${articleId}/card?poll=1`);
+			expect(response.status).toBe(200);
+			const etag = response.headers.etag;
+			assert(etag, "ETag header must be set");
+			expect(etag.startsWith('W/"')).toBe(true);
+			expect(response.headers["cache-control"]).toBe("private, no-cache");
+			expect(response.headers.vary).toContain("Cookie");
+		});
+
+		it("GET /queue/:id/card returns 304 when If-None-Match matches the current ETag", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-etag-304" });
+			const articleId = await getFirstArticleId(agent);
+
+			const first = await agent.get(`/queue/${articleId}/card?poll=1`);
+			const etag = first.headers.etag;
+			assert(etag, "first response must carry an ETag");
+
+			const revalidate = await agent
+				.get(`/queue/${articleId}/card?poll=2`)
+				.set("If-None-Match", etag);
+			expect(revalidate.status).toBe(304);
+			expect(revalidate.text).toBe("");
+			expect(revalidate.headers.etag).toBe(etag);
+		});
+
+		it("GET /queue/:id/card returns 200 with a new ETag when If-None-Match does not match", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-etag-200" });
+			const articleId = await getFirstArticleId(agent);
+
+			const response = await agent
+				.get(`/queue/${articleId}/card?poll=1`)
+				.set("If-None-Match", 'W/"stale-tag"');
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const card = doc.querySelector(".queue-article");
+			assert(card, "card fragment must be rendered when ETag does not match");
+		});
+
+		it("GET /queue/:id/card preserves filter context (tab/order/page) on the next-poll URL", async () => {
+			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/card-filter" });
+			const articleId = await getFirstArticleId(agent);
+
+			const response = await agent.get(`/queue/${articleId}/card?poll=2&tab=done&order=asc`);
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const card = doc.querySelector(".queue-article");
+			assert(card, "card must be rendered");
+			const next = card.getAttribute("hx-get");
+			assert(next, "non-terminal card must carry an hx-get");
+			expect(next).toContain("poll=3");
+			expect(next).toContain("tab=done");
+		});
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2624,6 +2624,40 @@ describe("Queue routes", () => {
 			return id;
 		}
 
+		function createTerminalPipelineFixture() {
+			const articleHtml = `<html><head><title>Terminal Post</title></head><body><article><h1>Terminal Post</h1><p>Body.</p></article></body></html>`;
+			const crawlArticle = async () => ({ status: "fetched" as const, html: articleHtml });
+			const findGeneratedSummary = async () => ({
+				status: "ready" as const,
+				summary: "Ready summary.",
+			});
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { parseArticle } = initReadabilityParser({ crawlArticle, sitePreParsers: [], logError: createNoopLogError() });
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			return createTestApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+				summary: {
+					findGeneratedSummary,
+					markSummaryPending: fixture.summary.markSummaryPending,
+					forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
+				},
+			});
+		}
+
 		it("renders hx-get polling on the queue list card while crawl is pending", async () => {
 			// Default fixture leaves crawl in pending state — no fake publish wiring.
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -2646,37 +2680,7 @@ describe("Queue routes", () => {
 		});
 
 		it("does not render hx-get on the queue list card once both pipelines terminate", async () => {
-			const articleHtml = `<html><head><title>Done Post</title></head><body><article><h1>Done Post</h1><p>Body.</p></article></body></html>`;
-			const crawlArticle = async () => ({ status: "fetched" as const, html: articleHtml });
-			const findGeneratedSummary = async () => ({
-				status: "ready" as const,
-				summary: "Ready summary.",
-			});
-			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { parseArticle } = initReadabilityParser({ crawlArticle, sitePreParsers: [], logError: createNoopLogError() });
-			const applyParseResult = createFakeApplyParseResult({
-				articleStore: fixture.articleStore,
-				articleCrawl: fixture.articleCrawl,
-				parseArticle,
-			});
-			const { app, auth } = createTestApp({
-				...fixture,
-				parser: { parseArticle, crawlArticle },
-				events: {
-					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
-					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
-					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
-					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
-					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
-					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
-					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
-				},
-				summary: {
-					findGeneratedSummary,
-					markSummaryPending: fixture.summary.markSummaryPending,
-					forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
-				},
-			});
+			const { app, auth } = createTerminalPipelineFixture();
 			const agent = await loginAgent(app, auth);
 
 			await agent
@@ -2715,37 +2719,7 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card stops polling once both pipelines terminate", async () => {
-			const articleHtml = `<html><head><title>Terminal Post</title></head><body><article><h1>Terminal Post</h1><p>Body.</p></article></body></html>`;
-			const crawlArticle = async () => ({ status: "fetched" as const, html: articleHtml });
-			const findGeneratedSummary = async () => ({
-				status: "ready" as const,
-				summary: "Ready summary.",
-			});
-			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { parseArticle } = initReadabilityParser({ crawlArticle, sitePreParsers: [], logError: createNoopLogError() });
-			const applyParseResult = createFakeApplyParseResult({
-				articleStore: fixture.articleStore,
-				articleCrawl: fixture.articleCrawl,
-				parseArticle,
-			});
-			const { app, auth } = createTestApp({
-				...fixture,
-				parser: { parseArticle, crawlArticle },
-				events: {
-					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
-					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
-					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
-					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
-					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
-					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
-					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
-				},
-				summary: {
-					findGeneratedSummary,
-					markSummaryPending: fixture.summary.markSummaryPending,
-					forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
-				},
-			});
+			const { app, auth } = createTerminalPipelineFixture();
 			const agent = await loginAgent(app, auth);
 
 			await agent

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -34,32 +34,7 @@
       {{/if}}
       {{#if hasArticles}}
       <div class="queue__list" data-test-article-list>
-        {{#each articles}}
-        <div class="queue-article{{unreadClass}}" data-test-article="{{id}}"{{#if @first}} id="latest-saved"{{/if}}>
-          {{!-- onerror is a vestigial safety net for legacy DynamoDB rows whose imageUrl still points at an external host that can 404 over time. New saves go through the S3-only thumbnail path in @packages/crawl-article, so once a backfill migration rewrites every legacy row to a CDN URL, this onerror (and the paired onload) can be deleted. --}}
-          {{#if imageUrl}}<a href="{{linkUrl}}" class="queue-article__thumbnail-link" tabindex="-1" aria-hidden="true"><img class="queue-article__thumbnail" src="{{imageUrl}}" alt="" onload="this.parentElement.classList.add('queue-article__thumbnail-link--loaded')" onerror="this.parentElement.remove()"></a>{{/if}}
-          <div class="queue-article__content">
-            <div class="queue-article__title-row">
-              {{#if isUnread}}<span class="queue-article__unread-dot" aria-label="Unread"></span>{{/if}}
-              <a class="queue-article__title" href="{{linkUrl}}" data-test-article-title>{{title}}</a>
-            </div>
-            <div class="queue-article__meta">
-              {{#if siteName}}<a class="queue-article__url" href="{{url}}" target="_blank" rel="noopener" data-test-article-url>{{siteName}}</a>{{/if}}
-              <span>{{readTimeLabel}}</span>
-              <span>{{savedAgo}}</span>
-            </div>
-            <p class="queue-article__excerpt">{{excerpt}}</p>
-          </div>
-          <div class="queue-article__actions">
-            {{#each actions}}
-            <form method="{{method}}" action="{{url}}" class="queue-article__action-form" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
-              {{#each fields}}<input type="hidden" name="{{name}}" value="{{value}}">{{/each}}
-              <button class="{{buttonClass}}" type="submit" title="{{title}}" data-test-action="{{testAction}}">{{text}}</button>
-            </form>
-            {{/each}}
-          </div>
-        </div>
-        {{/each}}
+        {{#each articleHtmls}}{{{this}}}{{/each}}
       </div>
       {{/if}}
       {{#if showPagination}}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -1,7 +1,10 @@
 import type { SavedArticle } from "@packages/domain/article";
 import type { FindArticlesResult } from "@packages/test-fixtures/providers/article-store";
 import { pickExcerpt } from "../../../providers/article-summary/article-summary.helpers";
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
 import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import { buildCardPollUrl } from "./queue-card/queue-card-poll-url";
+import { isCardTerminal } from "./queue-card/is-card-terminal";
 import type { QueueUrlState } from "./queue.url";
 import { buildQueueUrl } from "./queue.url";
 
@@ -32,6 +35,13 @@ export interface QueueArticleViewModel {
 	imageUrl?: string;
 	hasContent: boolean;
 	actions: ArticleAction[];
+	/**
+	 * Set when the row's crawl/summary state machines are still in flight.
+	 * The card renders an htmx poll against this URL every 3s; once both
+	 * pipelines reach a terminal state the field is undefined and the card
+	 * stops ticking. See isCardTerminal for the rules.
+	 */
+	cardPollUrl?: string;
 }
 
 export interface QueueViewModel {
@@ -53,6 +63,14 @@ export interface QueueViewModel {
 	saveError?: string;
 	importFlash?: string;
 }
+
+/**
+ * Hard cap on how many `every 3s` ticks a single card emits before stopping.
+ * 40 ticks ≈ 2 minutes — long enough that ordinary crawl + summary completion
+ * lands inside the window, short enough that a hung row doesn't poll forever
+ * on a backgrounded tab. Mirrors the reader-poll cap in article-reader.ts.
+ */
+export const MAX_CARD_POLLS = 40;
 
 function formatRelativeDate(date: Date, now: Date): string {
 	const diffMs = now.getTime() - date.getTime();
@@ -111,14 +129,24 @@ function toArticleActions(
 	return actions;
 }
 
-function toArticleViewModel(
-	article: SavedArticle,
-	now: Date,
-	returnQuery: string,
-	summary: GeneratedSummary | undefined,
-): QueueArticleViewModel {
+export function toQueueArticleViewModel(params: {
+	article: SavedArticle;
+	now: Date;
+	returnQuery: string;
+	summary: GeneratedSummary | undefined;
+	crawl: ArticleCrawl | undefined;
+	filters: QueueUrlState;
+	pollCount?: number;
+	maxPolls: number;
+}): QueueArticleViewModel {
+	const { article, now, returnQuery, summary, crawl, filters, maxPolls } = params;
+	const pollCount = params.pollCount ?? 1;
 	const readTime = article.estimatedReadTime;
 	const id = article.id.value;
+	const cardPollUrl =
+		isCardTerminal(crawl, summary) || pollCount > maxPolls
+			? undefined
+			: buildCardPollUrl({ articleId: id, pollCount, filters });
 	return {
 		id,
 		title: article.metadata.title,
@@ -132,6 +160,7 @@ function toArticleViewModel(
 		imageUrl: article.metadata.imageUrl,
 		hasContent: Boolean(article.content),
 		actions: toArticleActions({ id, status: article.status }, returnQuery),
+		cardPollUrl,
 	};
 }
 
@@ -144,6 +173,7 @@ export function toQueueViewModel(
 		importFlash?: string;
 		unreadCount?: number;
 		summaryByUrl?: ReadonlyMap<string, GeneratedSummary | undefined>;
+		crawlByUrl?: ReadonlyMap<string, ArticleCrawl | undefined>;
 	},
 ): QueueViewModel {
 	const now = options?.now ?? new Date();
@@ -155,7 +185,15 @@ export function toQueueViewModel(
 
 	return {
 		articles: result.articles.map((a) =>
-			toArticleViewModel(a, now, returnQuery, options?.summaryByUrl?.get(a.url)),
+			toQueueArticleViewModel({
+				article: a,
+				now,
+				returnQuery,
+				summary: options?.summaryByUrl?.get(a.url),
+				crawl: options?.crawlByUrl?.get(a.url),
+				filters,
+				maxPolls: MAX_CARD_POLLS,
+			}),
 		),
 		filters,
 		isEmpty: result.total === 0,


### PR DESCRIPTION
## Why

After a save (or import), `/queue` shows a row immediately with hostname-only stub metadata (`title: "Article from {hostname}"`, `excerpt: "Saved from {hostname}."`, `wordCount: 0`) — see `save-article-from-url.ts:38-58`. The async `LinkSaved → crawl → summary` pipeline lands real metadata seconds-to-minutes later, but the open `/queue` tab never finds out: `queue.template.html` was a static list with no polling. The user had to ⌘R to see real titles and AI excerpts.

The pain is most visible after a bulk import: 50 stubs sit on screen reading "Article from x.com" and the page looks broken. The contract advertised in `pocket-migration.md` ("cards appear immediately and progressively populate") only delivered the first half.

## How

This mirrors the existing reader-poll pattern (`article-reader.ts:127-167`) onto the queue list — same htmx idiom (`hx-get` + `hx-trigger="every 3s"`), same termination logic, same `MAX_POLLS=40` (~2 min) hard cap.

- **Per-card polling**: each non-terminal `.queue-article` div carries `hx-get="/queue/:id/card?poll=N" hx-trigger="every 3s" hx-target="this" hx-swap="outerHTML"`. The card's own GET response replaces the card in place — no scroll loss, no focus loss, no fan-out beyond the visible page.
- **`isCardTerminal(crawl, summary)`** centralises the stop rule:
  - `crawlStatus === "failed"` → terminal (pipeline gave up).
  - `crawlStatus === "ready" && summaryStatus ∈ {ready, failed, skipped}` → terminal.
  - Anything else (including legacy stubs with both attrs missing) → keep polling.
- **`GET /queue/:id/card`** returns one card fragment with the next-poll URL embedded. When `pollCount >= 40` or both pipelines terminal, no `hx-get` is emitted and polling stops.
- **ETag + 304 revalidation**: weak ETag covers `(articleId, status, crawlStatus, summaryStatus, wordCount, sha256(title|excerpt|imageUrl|siteName))` so an unchanged row returns a 14-byte 304. Cache-Control is `private, no-cache` with `Vary: Cookie` so caches always revalidate and never share rows across users.
- **Filter context preservation**: `buildCardPollUrl` echoes `tab/order/page` into the polled URL so action forms inside the refreshed card still redirect back to the user's filter view.
- **Visible-page-only**: the existing `/queue` pagination already caps polling fan-out — only the 20 rows of the current page emit `hx-get`. Pages 2-N revalidate when boost-navigated to.

### Considered and rejected (or layered)

| Option | Why rejected (or layered) |
|---|---|
| Whole-page htmx polling | Drops focus/scroll, refetches every row even when one changed. |
| SSE / WebSocket push | Lambda's request/response model can't hold long-lived streams without a substantial migration. |
| ETag + Cache-Control alone | Browser still has to ask — without polling, nothing triggers refresh. ETag is layered *on top* here. |
| Service Worker offline cache | Different problem (offline UX); auth/invalidation is non-trivial. Out of scope. |

## Test plan

- [x] Unit tests: `is-card-terminal.test.ts` covers every cell of the termination matrix.
- [x] Unit tests: `queue-card.etag.test.ts` covers ETag stability + every input that should bust it (status, summary, wordCount, imageUrl, read/unread).
- [x] Unit tests: `queue-card-poll-url.test.ts` covers tab/order/page round-tripping with default-elision rules matching `buildQueueUrl`.
- [x] Unit tests: `queue-card.component.test.ts` asserts presence/absence of htmx attributes based on `cardPollUrl`.
- [x] Route tests (`queue.route.test.ts` — 10 new cases):
  - List card carries `hx-get` while pending.
  - List card has no `hx-get` once pipelines terminate.
  - `GET /queue/:id/card` returns a fragment with `poll=N+1`.
  - `GET /queue/:id/card` stops polling when terminal.
  - `GET /queue/:id/card` stops at `MAX_CARD_POLLS=40`.
  - `GET /queue/:id/card` returns 404 for unknown article.
  - Sets ETag, `Cache-Control: private, no-cache`, `Vary: Cookie`.
  - Returns 304 when `If-None-Match` matches; 200 with new ETag when it doesn't.
  - Preserves `tab=done` filter context across polls.
- [x] Full `nx run hutch:check` clean: lint + 1088 tests + coverage thresholds (99% statements / 96% branches / 100% functions / 99% lines) all pass.

## Out of scope (good follow-ups)

- Cross-tab / cross-device updates (e.g., delete on phone → see disappear on laptop). Needs pubsub or SSE.
- SW + offline cache for `/queue`. Worth a dedicated design.
- Coalescing 20 per-card polls into a single batched `/queue/cards?ids=…` request. Per-card is simpler; measure first.

https://claude.ai/code/session_01NTZE3dEvfD6HWXwxTTPMmK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTZE3dEvfD6HWXwxTTPMmK)_