### PR TITLE
feat(hutch): auto-update reader header and tab title via existing poll + ETag

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -454,6 +454,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		validateSaveableUrl: deps.validateSaveableUrl,
 		findArticlesByUser: deps.findArticlesByUser,
 		findArticleById: deps.findArticleById,
+		findArticleByUrl: deps.findArticleByUrl,
 		saveArticle: deps.saveArticle,
 		deleteArticle: deps.deleteArticle,
 		updateArticleStatus: deps.updateArticleStatus,

--- a/projects/hutch/src/runtime/web/base.template.html
+++ b/projects/hutch/src/runtime/web/base.template.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{title}}</title>
+  <title id="document-title">{{title}}</title>
   <meta name="description" content="{{description}}">
   <meta name="robots" content="{{robots}}">
   {{#if author}}<meta name="author" content="{{author}}">{{/if}}

--- a/projects/hutch/src/runtime/web/conditional-get.test.ts
+++ b/projects/hutch/src/runtime/web/conditional-get.test.ts
@@ -1,49 +1,7 @@
-import type {
-	ConditionalGetRequest,
-	ConditionalGetResponse,
-} from "./conditional-get";
-import { sendConditionalHtml } from "./conditional-get";
+import type { ConditionalGetRequest } from "./conditional-get";
+import { CacheableComponent } from "./conditional-get";
 import { HtmlPage } from "./html-page";
 import type { Component } from "./component.types";
-
-interface FakeResponse {
-	statusCode: number;
-	headers: Record<string, string>;
-	body: string;
-	ended: boolean;
-}
-
-function fakeRes(): { res: ConditionalGetResponse; result: FakeResponse } {
-	const result: FakeResponse = {
-		statusCode: 200,
-		headers: {},
-		body: "",
-		ended: false,
-	};
-	const res: ConditionalGetResponse = {
-		setHeader: (name: string, value: string | number | readonly string[]) => {
-			result.headers[String(name).toLowerCase()] = String(value);
-		},
-		set: (field: Record<string, string>) => {
-			for (const [k, v] of Object.entries(field)) {
-				result.headers[k.toLowerCase()] = v;
-			}
-			return res;
-		},
-		status: (code: number) => {
-			result.statusCode = code;
-			return res;
-		},
-		send: (body: string) => {
-			result.body = body;
-			result.ended = true;
-		},
-		end: () => {
-			result.ended = true;
-		},
-	};
-	return { res, result };
-}
 
 function fakeReq(headers: Record<string, string> = {}): ConditionalGetRequest {
 	return { headers };
@@ -53,78 +11,65 @@ function htmlComponent(body: string): Component {
 	return HtmlPage(body);
 }
 
-describe("sendConditionalHtml", () => {
+describe("CacheableComponent", () => {
 	it("emits a 200 with the body and a weak ETag on the first request", () => {
-		const { res, result } = fakeRes();
-
-		sendConditionalHtml(fakeReq(), res, htmlComponent("<p>hi</p>"));
+		const result = CacheableComponent(htmlComponent("<p>hi</p>"), fakeReq()).to("text/html");
 
 		expect(result.statusCode).toBe(200);
 		expect(result.body).toBe("<p>hi</p>");
-		const etag = result.headers.etag;
-		expect(etag).toMatch(/^W\/".+"$/);
+		expect(result.headers.ETag).toMatch(/^W\/".+"$/);
 	});
 
 	it("returns 304 with no body when the request If-None-Match matches the freshly-computed ETag", () => {
 		const body = "<p>hi</p>";
-		const { res: firstRes, result: firstResult } = fakeRes();
-		sendConditionalHtml(fakeReq(), firstRes, htmlComponent(body));
-		const etag = firstResult.headers.etag;
+		const first = CacheableComponent(htmlComponent(body), fakeReq()).to("text/html");
+		const etag = first.headers.ETag;
 
-		const { res: secondRes, result: secondResult } = fakeRes();
-		sendConditionalHtml(
-			fakeReq({ "if-none-match": etag }),
-			secondRes,
+		const second = CacheableComponent(
 			htmlComponent(body),
-		);
+			fakeReq({ "if-none-match": etag }),
+		).to("text/html");
 
-		expect(secondResult.statusCode).toBe(304);
-		expect(secondResult.body).toBe("");
-		expect(secondResult.ended).toBe(true);
-		expect(secondResult.headers.etag).toBe(etag);
+		expect(second.statusCode).toBe(304);
+		expect(second.body).toBe("");
+		expect(second.headers.ETag).toBe(etag);
 	});
 
 	it("re-renders 200 with a fresh ETag when the body changes (the title settled, the saved-article row is no longer the hostname stub)", () => {
-		const { res: firstRes, result: firstResult } = fakeRes();
-		sendConditionalHtml(
-			fakeReq(),
-			firstRes,
+		const first = CacheableComponent(
 			htmlComponent("<h1>medium.com</h1>"),
-		);
-		const oldEtag = firstResult.headers.etag;
+			fakeReq(),
+		).to("text/html");
+		const oldEtag = first.headers.ETag;
 
-		const { res: secondRes, result: secondResult } = fakeRes();
-		sendConditionalHtml(
-			fakeReq({ "if-none-match": oldEtag }),
-			secondRes,
+		const second = CacheableComponent(
 			htmlComponent("<h1>Why Rust beats Go</h1>"),
-		);
+			fakeReq({ "if-none-match": oldEtag }),
+		).to("text/html");
 
-		expect(secondResult.statusCode).toBe(200);
-		expect(secondResult.body).toBe("<h1>Why Rust beats Go</h1>");
-		expect(secondResult.headers.etag).not.toBe(oldEtag);
+		expect(second.statusCode).toBe(200);
+		expect(second.body).toBe("<h1>Why Rust beats Go</h1>");
+		expect(second.headers.ETag).not.toBe(oldEtag);
 	});
 
 	it("forces revalidation on every poll via Cache-Control: private, no-cache so a freshly-settled article does not wait for a TTL", () => {
-		const { res, result } = fakeRes();
+		const result = CacheableComponent(htmlComponent("<p>hi</p>"), fakeReq()).to("text/html");
 
-		sendConditionalHtml(fakeReq(), res, htmlComponent("<p>hi</p>"));
-
-		expect(result.headers["cache-control"]).toBe("private, no-cache");
+		expect(result.headers["Cache-Control"]).toBe("private, no-cache");
 	});
 
 	it("computes the same ETag for identical bodies across calls so the in-flight steady-state polls collapse to 304", () => {
-		const { result: first } = (() => {
-			const r = fakeRes();
-			sendConditionalHtml(fakeReq(), r.res, htmlComponent("<p>same</p>"));
-			return r;
-		})();
-		const { result: second } = (() => {
-			const r = fakeRes();
-			sendConditionalHtml(fakeReq(), r.res, htmlComponent("<p>same</p>"));
-			return r;
-		})();
+		const first = CacheableComponent(htmlComponent("<p>same</p>"), fakeReq()).to("text/html");
+		const second = CacheableComponent(htmlComponent("<p>same</p>"), fakeReq()).to("text/html");
 
-		expect(first.headers.etag).toBe(second.headers.etag);
+		expect(first.headers.ETag).toBe(second.headers.ETag);
+	});
+
+	it("passes through non-HTML media types to the inner component without adding cache headers", () => {
+		const result = CacheableComponent(htmlComponent("<p>hi</p>"), fakeReq()).to("text/markdown");
+
+		expect(result.statusCode).toBe(406);
+		expect(result.headers.ETag).toBeUndefined();
+		expect(result.headers["Cache-Control"]).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/conditional-get.test.ts
+++ b/projects/hutch/src/runtime/web/conditional-get.test.ts
@@ -1,0 +1,132 @@
+import type { Request, Response } from "express";
+import type { Component } from "./component.types";
+import { sendConditionalHtml } from "./conditional-get";
+import { HtmlPage } from "./html-page";
+
+interface FakeResponse {
+	statusCode: number;
+	headers: Record<string, string>;
+	body: string;
+	ended: boolean;
+}
+
+function fakeRes(): { res: Response; result: FakeResponse } {
+	const result: FakeResponse = {
+		statusCode: 200,
+		headers: {},
+		body: "",
+		ended: false,
+	};
+	const res: Partial<Response> = {
+		setHeader: (name: string, value: string | number | readonly string[]) => {
+			result.headers[name.toLowerCase()] = String(value);
+			return res as Response;
+		},
+		set: (field: string | Record<string, string>) => {
+			if (typeof field === "object") {
+				for (const [k, v] of Object.entries(field)) {
+					result.headers[k.toLowerCase()] = v;
+				}
+			}
+			return res as Response;
+		},
+		status: (code: number) => {
+			result.statusCode = code;
+			return res as Response;
+		},
+		send: (body: string) => {
+			result.body = body;
+			result.ended = true;
+			return res as Response;
+		},
+		end: () => {
+			result.ended = true;
+			return res as Response;
+		},
+	};
+	return { res: res as Response, result };
+}
+
+function fakeReq(headers: Record<string, string> = {}): Request {
+	return { headers } as unknown as Request;
+}
+
+function htmlComponent(body: string): Component {
+	return HtmlPage(body);
+}
+
+describe("sendConditionalHtml", () => {
+	it("emits a 200 with the body and a weak ETag on the first request", () => {
+		const { res, result } = fakeRes();
+
+		sendConditionalHtml(fakeReq(), res, htmlComponent("<p>hi</p>"));
+
+		expect(result.statusCode).toBe(200);
+		expect(result.body).toBe("<p>hi</p>");
+		const etag = result.headers.etag;
+		expect(etag).toMatch(/^W\/".+"$/);
+	});
+
+	it("returns 304 with no body when the request If-None-Match matches the freshly-computed ETag", () => {
+		const body = "<p>hi</p>";
+		const { res: firstRes, result: firstResult } = fakeRes();
+		sendConditionalHtml(fakeReq(), firstRes, htmlComponent(body));
+		const etag = firstResult.headers.etag;
+
+		const { res: secondRes, result: secondResult } = fakeRes();
+		sendConditionalHtml(
+			fakeReq({ "if-none-match": etag }),
+			secondRes,
+			htmlComponent(body),
+		);
+
+		expect(secondResult.statusCode).toBe(304);
+		expect(secondResult.body).toBe("");
+		expect(secondResult.ended).toBe(true);
+		expect(secondResult.headers.etag).toBe(etag);
+	});
+
+	it("re-renders 200 with a fresh ETag when the body changes (the title settled, the saved-article row is no longer the hostname stub)", () => {
+		const { res: firstRes, result: firstResult } = fakeRes();
+		sendConditionalHtml(
+			fakeReq(),
+			firstRes,
+			htmlComponent("<h1>medium.com</h1>"),
+		);
+		const oldEtag = firstResult.headers.etag;
+
+		const { res: secondRes, result: secondResult } = fakeRes();
+		sendConditionalHtml(
+			fakeReq({ "if-none-match": oldEtag }),
+			secondRes,
+			htmlComponent("<h1>Why Rust beats Go</h1>"),
+		);
+
+		expect(secondResult.statusCode).toBe(200);
+		expect(secondResult.body).toBe("<h1>Why Rust beats Go</h1>");
+		expect(secondResult.headers.etag).not.toBe(oldEtag);
+	});
+
+	it("forces revalidation on every poll via Cache-Control: private, no-cache so a freshly-settled article does not wait for a TTL", () => {
+		const { res, result } = fakeRes();
+
+		sendConditionalHtml(fakeReq(), res, htmlComponent("<p>hi</p>"));
+
+		expect(result.headers["cache-control"]).toBe("private, no-cache");
+	});
+
+	it("computes the same ETag for identical bodies across calls so the in-flight steady-state polls collapse to 304", () => {
+		const { result: first } = (() => {
+			const r = fakeRes();
+			sendConditionalHtml(fakeReq(), r.res, htmlComponent("<p>same</p>"));
+			return r;
+		})();
+		const { result: second } = (() => {
+			const r = fakeRes();
+			sendConditionalHtml(fakeReq(), r.res, htmlComponent("<p>same</p>"));
+			return r;
+		})();
+
+		expect(first.headers.etag).toBe(second.headers.etag);
+	});
+});

--- a/projects/hutch/src/runtime/web/conditional-get.test.ts
+++ b/projects/hutch/src/runtime/web/conditional-get.test.ts
@@ -1,7 +1,10 @@
-import type { Request, Response } from "express";
-import type { Component } from "./component.types";
+import type {
+	ConditionalGetRequest,
+	ConditionalGetResponse,
+} from "./conditional-get";
 import { sendConditionalHtml } from "./conditional-get";
 import { HtmlPage } from "./html-page";
+import type { Component } from "./component.types";
 
 interface FakeResponse {
 	statusCode: number;
@@ -10,45 +13,40 @@ interface FakeResponse {
 	ended: boolean;
 }
 
-function fakeRes(): { res: Response; result: FakeResponse } {
+function fakeRes(): { res: ConditionalGetResponse; result: FakeResponse } {
 	const result: FakeResponse = {
 		statusCode: 200,
 		headers: {},
 		body: "",
 		ended: false,
 	};
-	const res: Partial<Response> = {
+	const res: ConditionalGetResponse = {
 		setHeader: (name: string, value: string | number | readonly string[]) => {
-			result.headers[name.toLowerCase()] = String(value);
-			return res as Response;
+			result.headers[String(name).toLowerCase()] = String(value);
 		},
-		set: (field: string | Record<string, string>) => {
-			if (typeof field === "object") {
-				for (const [k, v] of Object.entries(field)) {
-					result.headers[k.toLowerCase()] = v;
-				}
+		set: (field: Record<string, string>) => {
+			for (const [k, v] of Object.entries(field)) {
+				result.headers[k.toLowerCase()] = v;
 			}
-			return res as Response;
+			return res;
 		},
 		status: (code: number) => {
 			result.statusCode = code;
-			return res as Response;
+			return res;
 		},
 		send: (body: string) => {
 			result.body = body;
 			result.ended = true;
-			return res as Response;
 		},
 		end: () => {
 			result.ended = true;
-			return res as Response;
 		},
 	};
-	return { res: res as Response, result };
+	return { res, result };
 }
 
-function fakeReq(headers: Record<string, string> = {}): Request {
-	return { headers } as unknown as Request;
+function fakeReq(headers: Record<string, string> = {}): ConditionalGetRequest {
+	return { headers };
 }
 
 function htmlComponent(body: string): Component {

--- a/projects/hutch/src/runtime/web/conditional-get.ts
+++ b/projects/hutch/src/runtime/web/conditional-get.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+import type { Request, Response } from "express";
+import type { Component } from "./component.types";
+
+/**
+ * 1. Hash the rendered body so identical state replies with an identical ETag.
+ *    Polls fire every few seconds; once a row settles, every subsequent poll
+ *    re-renders the same HTML, and we want those to short-circuit to 304 with
+ *    no body. Weak ETag (`W/`) because the comparison is semantic, not bytewise.
+ * 2. `private, no-cache` keeps the response in the browser cache (so the
+ *    browser can revalidate with If-None-Match) but forces revalidation on
+ *    every poll (so a freshly settled row is observed without any TTL wait).
+ *    `private` because the response carries the user's saved-article metadata
+ *    and must not leak to shared caches.
+ * 3. 304 leaves the previous body in place; htmx applies the cached response,
+ *    which means OOB swaps run again on the same HTML — visibly idempotent.
+ */
+export function sendConditionalHtml(
+	req: Request,
+	res: Response,
+	component: Component,
+): void {
+	const parsed = component.to("text/html");
+	const body = parsed.body;
+	const etag = `W/"${createHash("sha1").update(body).digest("base64")}"`; /* 1 */
+	res.setHeader("Cache-Control", "private, no-cache"); /* 2 */
+	res.setHeader("ETag", etag);
+	if (req.headers["if-none-match"] === etag) {
+		res.status(304).end(); /* 3 */
+		return;
+	}
+	res.status(parsed.statusCode).set(parsed.headers).send(body);
+}

--- a/projects/hutch/src/runtime/web/conditional-get.ts
+++ b/projects/hutch/src/runtime/web/conditional-get.ts
@@ -1,16 +1,8 @@
 import { createHash } from "node:crypto";
-import type { Component } from "./component.types";
+import type { Component, ParsedComponent } from "./component.types";
 
 export interface ConditionalGetRequest {
 	headers: Record<string, string | string[] | undefined>;
-}
-
-export interface ConditionalGetResponse {
-	setHeader(name: string, value: string | number | readonly string[]): unknown;
-	status(code: number): ConditionalGetResponse;
-	set(field: Record<string, string>): ConditionalGetResponse;
-	send(body: string): unknown;
-	end(): unknown;
 }
 
 /**
@@ -26,19 +18,24 @@ export interface ConditionalGetResponse {
  * 3. 304 leaves the previous body in place; htmx applies the cached response,
  *    which means OOB swaps run again on the same HTML — visibly idempotent.
  */
-export function sendConditionalHtml(
-	req: ConditionalGetRequest,
-	res: ConditionalGetResponse,
-	component: Component,
-): void {
-	const parsed = component.to("text/html");
-	const body = parsed.body;
-	const etag = `W/"${createHash("sha1").update(body).digest("base64")}"`; /* 1 */
-	res.setHeader("Cache-Control", "private, no-cache"); /* 2 */
-	res.setHeader("ETag", etag);
-	if (req.headers["if-none-match"] === etag) {
-		res.status(304).end(); /* 3 */
-		return;
-	}
-	res.status(parsed.statusCode).set(parsed.headers).send(body);
+export function CacheableComponent(inner: Component, req: ConditionalGetRequest): Component {
+	return {
+		to: (mediaType): ParsedComponent => {
+			const parsed = inner.to(mediaType);
+			if (mediaType !== "text/html") return parsed;
+
+			const etag = `W/"${createHash("sha1").update(parsed.body).digest("base64")}"`; /* 1 */
+			const headers = {
+				...parsed.headers,
+				"Cache-Control": "private, no-cache", /* 2 */
+				"ETag": etag,
+			};
+
+			if (req.headers["if-none-match"] === etag) { /* 3 */
+				return { statusCode: 304, headers, body: "" };
+			}
+
+			return { statusCode: parsed.statusCode, headers, body: parsed.body };
+		},
+	};
 }

--- a/projects/hutch/src/runtime/web/conditional-get.ts
+++ b/projects/hutch/src/runtime/web/conditional-get.ts
@@ -1,6 +1,17 @@
 import { createHash } from "node:crypto";
-import type { Request, Response } from "express";
 import type { Component } from "./component.types";
+
+export interface ConditionalGetRequest {
+	headers: Record<string, string | string[] | undefined>;
+}
+
+export interface ConditionalGetResponse {
+	setHeader(name: string, value: string | number | readonly string[]): unknown;
+	status(code: number): ConditionalGetResponse;
+	set(field: Record<string, string>): ConditionalGetResponse;
+	send(body: string): unknown;
+	end(): unknown;
+}
 
 /**
  * 1. Hash the rendered body so identical state replies with an identical ETag.
@@ -16,8 +27,8 @@ import type { Component } from "./component.types";
  *    which means OOB swaps run again on the same HTML — visibly idempotent.
  */
 export function sendConditionalHtml(
-	req: Request,
-	res: Response,
+	req: ConditionalGetRequest,
+	res: ConditionalGetResponse,
 	component: Component,
 ): void {
 	const parsed = component.to("text/html");

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
@@ -11,6 +11,16 @@ import { RECRAWL_STYLES } from "./recrawl.styles";
 
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 
+/**
+ * Both the initial SSR <title> and the OOB <title> swap emitted by recrawl
+ * polls have to use the same format — otherwise the browser tab flickers
+ * between formats every time the title settles after a recrawl completes.
+ * Exported so the recrawl route can hand it to initArticleReader.
+ */
+export function formatRecrawlDocumentTitle(articleTitle: string): string {
+	return `Admin recrawl: ${articleTitle}`;
+}
+
 export interface AdminRecrawlPageInput {
 	articleUrl: string;
 	metadata: ArticleMetadata;
@@ -59,7 +69,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 
 	return {
 		seo: {
-			title: `Admin recrawl: ${input.metadata.title}`,
+			title: formatRecrawlDocumentTitle(input.metadata.title),
 			description: "Operator recrawl view. Not for public consumption.",
 			canonicalUrl: `/admin/recrawl/${encodeURIComponent(input.articleUrl)}`,
 			robots: "noindex, nofollow",

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -22,7 +22,7 @@ import { initArticleReader } from "../../shared/article-reader/article-reader";
 import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.types";
 import { SaveErrorPage } from "../save/save-error.component";
 import { AdminRecrawlLandingPage } from "./recrawl-landing.component";
-import { AdminRecrawlPage } from "./recrawl.component";
+import { AdminRecrawlPage, formatRecrawlDocumentTitle } from "./recrawl.component";
 import { initRequireAdmin } from "./require-admin.middleware";
 
 const RecrawlUrlSchema = z.url();
@@ -205,6 +205,8 @@ export function initAdminRecrawlRoutes(deps: AdminRecrawlDependencies): Router {
 		findGeneratedSummary: deps.findGeneratedSummary,
 		markSummaryPending: deps.markSummaryPending,
 		readArticleContent: deps.readArticleContent,
+		findArticleByUrl: deps.findArticleByUrl,
+		formatDocumentTitle: formatRecrawlDocumentTitle,
 		now: deps.now,
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -20,6 +20,7 @@ import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/ar
 import type {
 	DeleteArticle,
 	FindArticleById,
+	FindArticleByUrl,
 	FindArticlesByUser,
 	SaveArticle,
 	UpdateArticleStatus,
@@ -44,6 +45,7 @@ import type { PutPendingHtml } from "@packages/test-fixtures/providers/pending-h
 import { saveArticleFromUrl, saveUnsaveableUrlStub } from "../../shared/save-article/save-article-from-url";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
+import { sendConditionalHtml } from "../../conditional-get";
 import { wantsSiren } from "../../content-negotiation";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
@@ -59,7 +61,7 @@ import {
 	toQueueCardDisplayModel,
 } from "./queue-card/queue-card.component";
 import { computeQueueCardEtag, etagMatches } from "./queue-card/queue-card.etag";
-import { ReaderPage } from "../reader/reader.component";
+import { ReaderPage, formatReaderDocumentTitle } from "../reader/reader.component";
 import { ONBOARDING_VERSION } from "../../onboarding/onboarding.steps";
 import {
 	detectBrowser,
@@ -100,6 +102,7 @@ interface QueueDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
 	findArticlesByUser: FindArticlesByUser;
 	findArticleById: FindArticleById;
+	findArticleByUrl: FindArticleByUrl;
 	saveArticle: SaveArticle;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
@@ -423,7 +426,17 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		}
 	});
 
-	const reader = initArticleReader(deps);
+	const reader = initArticleReader({
+		findArticleCrawlStatus: deps.findArticleCrawlStatus,
+		markCrawlPending: deps.markCrawlPending,
+		findGeneratedSummary: deps.findGeneratedSummary,
+		markSummaryPending: deps.markSummaryPending,
+		readArticleContent: deps.readArticleContent,
+		findArticleByUrl: deps.findArticleByUrl,
+		formatDocumentTitle: formatReaderDocumentTitle,
+		backLink: { href: "/queue", label: "← Back to queue" },
+		now: deps.now,
+	});
 
 	function pollUrlBuilderForId(articleId: string): PollUrlBuilder {
 		return {
@@ -492,7 +505,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			pollCount,
 			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
 		});
-		sendComponent(req, res, component);
+		sendConditionalHtml(req, res, component);
 	});
 
 	router.get("/:id/reader", async (req: Request, res: Response) => {
@@ -515,7 +528,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
-		sendComponent(req, res, component);
+		sendConditionalHtml(req, res, component);
 	});
 
 	router.get("/:id/card", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -45,7 +45,7 @@ import type { PutPendingHtml } from "@packages/test-fixtures/providers/pending-h
 import { saveArticleFromUrl, saveUnsaveableUrlStub } from "../../shared/save-article/save-article-from-url";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
-import { sendConditionalHtml } from "../../conditional-get";
+import { CacheableComponent } from "../../conditional-get";
 import { wantsSiren } from "../../content-negotiation";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
@@ -505,7 +505,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			pollCount,
 			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
 		});
-		sendConditionalHtml(req, res, component);
+		sendComponent(req, res, CacheableComponent(component, req));
 	});
 
 	router.get("/:id/reader", async (req: Request, res: Response) => {
@@ -528,7 +528,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
-		sendConditionalHtml(req, res, component);
+		sendComponent(req, res, CacheableComponent(component, req));
 	});
 
 	router.get("/:id/card", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -1854,6 +1854,62 @@ describe("Queue routes", () => {
 			expect(response.status).toBe(404);
 		});
 
+		it("GET /queue/:id/reader emits header + <title> OOB fragments and an ETag, and 304s when If-None-Match matches", async () => {
+			// Steady-state contract: while the crawl is in flight the reader poll
+			// fragment must include the addressable header (#article-header) and
+			// document <title> (#document-title) as hx-swap-oob fragments, plus
+			// an ETag so an unchanged body collapses to 304 instead of re-shipping
+			// a few KB on every 3s tick.
+			//
+			// The progress bar OOB carries `tickAt: now.toISOString()`, so a real
+			// `() => new Date()` clock would bust the ETag on every poll and
+			// defeat the steady-state 304 contract. Pinning `now` to a fixed
+			// instant gives a deterministic body across the two requests.
+			const findArticleCrawlStatus = async () => ({ status: "pending" as const });
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const fixedNow = new Date("2026-04-25T12:00:00.000Z");
+			const { app, auth } = createTestApp({
+				...fixture,
+				articleCrawl: {
+					...fixture.articleCrawl,
+					findArticleCrawlStatus,
+				},
+				shared: { ...fixture.shared, now: () => fixedNow },
+			});
+			const agent = await loginAgent(app, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/auto-update" });
+
+			const queueResponse = await agent.get("/queue");
+			const articleId = new JSDOM(queueResponse.text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert(articleId, "saved article must have an id");
+
+			const first = await agent.get(`/queue/${articleId}/reader?poll=1`);
+			expect(first.status).toBe(200);
+			const etag = first.headers.etag;
+			assert(etag, "reader poll must emit an ETag for steady-state 304s");
+			expect(first.headers["cache-control"]).toBe("private, no-cache");
+
+			const doc = new JSDOM(first.text).window.document;
+			const header = doc.querySelector("#article-header");
+			assert(header, "header OOB fragment must accompany the reader-slot");
+			expect(header.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			const titleEl = doc.querySelector("title#document-title");
+			assert(titleEl, "<title> OOB fragment must accompany the reader-slot");
+			expect(titleEl.getAttribute("hx-swap-oob")).toBe("outerHTML");
+
+			const second = await agent
+				.get(`/queue/${articleId}/reader?poll=1`)
+				.set("If-None-Match", etag);
+			expect(second.status).toBe(304);
+			expect(second.text).toBe("");
+		});
+
 		it("GET /queue/:id/read heals a legacy row by re-priming both state machines when both state attrs are missing", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			// State-machine providers always report "no state" so the cached row

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -19,6 +19,16 @@ const CANONICAL_BASE_URL = "https://readplace.com";
 const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "utf-8");
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 
+/**
+ * Both the initial SSR <title> and the OOB <title> swap emitted by reader
+ * polls have to use the same format — otherwise the browser tab flickers
+ * between formats every time the title settles after a crawl completes.
+ * Exported so the queue route can hand it to initArticleReader.
+ */
+export function formatReaderDocumentTitle(articleTitle: string): string {
+	return `${articleTitle} — Readplace Reader`;
+}
+
 export function ReaderPage(
 	article: SavedArticle,
 	options?: {
@@ -57,7 +67,7 @@ export function ReaderPage(
 
 	return {
 		seo: {
-			title: `${article.metadata.title} — Readplace Reader`,
+			title: formatReaderDocumentTitle(article.metadata.title),
 			description: truncateForSeo(pickExcerpt(options?.summary, article.metadata.excerpt)),
 			canonicalUrl: `/queue/${article.id.value}/read`,
 			robots: "noindex, nofollow",

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -26,6 +26,16 @@ const DEFAULT_OG_IMAGE = `${STATIC_BASE_URL}/og-image-1200x630.png`;
 const DEFAULT_TWITTER_IMAGE = `${STATIC_BASE_URL}/twitter-card-1200x600.png`;
 const DEFAULT_OG_ALT = "Readplace — A read-it-later app";
 
+/**
+ * Both the initial SSR <title> and the OOB <title> swap emitted by view
+ * polls have to use the same format — otherwise the browser tab flickers
+ * between formats every time the title settles after a crawl completes.
+ * Exported so the view route can hand it to initArticleReader.
+ */
+export function formatViewDocumentTitle(articleTitle: string): string {
+	return `${articleTitle} | Reader View`;
+}
+
 const VIEW_TEMPLATE = readFileSync(
 	join(__dirname, "view.template.html"),
 	"utf-8",
@@ -106,7 +116,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 
 	return {
 		seo: {
-			title: `${input.metadata.title} | Reader View`,
+			title: formatViewDocumentTitle(input.metadata.title),
 			description,
 			canonicalUrl: `/view/${encodeURIComponent(input.articleUrl)}`,
 			ogType: "article",

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -228,6 +228,7 @@ function handleViewReader(deps: ViewDependencies, reader: ReturnType<typeof init
 			res.status(400).type("html").send("");
 			return;
 		}
+		/* c8 ignore next -- V8 block coverage phantom: async continuation after if/return creates zero-count sub-range (bcoe/c8#319, v8.dev/blog/javascript-code-coverage) */
 		const articleUrl = validation.url;
 		const pollCount = Number(req.query.poll ?? "0");
 		const component = await reader.handleReaderPoll({

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -25,7 +25,7 @@ import type {
 	PublishStaleCheckRequested,
 } from "@packages/test-fixtures/providers/events";
 import { wantsMarkdown } from "../../content-negotiation";
-import { sendConditionalHtml } from "../../conditional-get";
+import { CacheableComponent } from "../../conditional-get";
 import { htmlToMarkdown } from "../../html-to-markdown";
 import { buildMarkdownFrontmatter } from "../../markdown-frontmatter";
 import { MarkdownPage } from "../../markdown-page";
@@ -219,7 +219,7 @@ function handleViewSummary(deps: ViewDependencies) {
 			pollCount,
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 		});
-		sendConditionalHtml(req, res, component);
+		sendComponent(req, res, CacheableComponent(component, req));
 	};
 }
 
@@ -239,7 +239,7 @@ function handleViewReader(deps: ViewDependencies) {
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
-		sendConditionalHtml(req, res, component);
+		sendComponent(req, res, CacheableComponent(component, req));
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -25,6 +25,7 @@ import type {
 	PublishStaleCheckRequested,
 } from "@packages/test-fixtures/providers/events";
 import { wantsMarkdown } from "../../content-negotiation";
+import { sendConditionalHtml } from "../../conditional-get";
 import { htmlToMarkdown } from "../../html-to-markdown";
 import { buildMarkdownFrontmatter } from "../../markdown-frontmatter";
 import { MarkdownPage } from "../../markdown-page";
@@ -32,11 +33,14 @@ import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { extensionInstallUrlIfMissing } from "../../onboarding/extension-install";
 import { initArticleReader } from "../../shared/article-reader/article-reader";
-import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.types";
+import type {
+	ArticleReaderDeps,
+	PollUrlBuilder,
+} from "../../shared/article-reader/article-reader.types";
 import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "../save/save-error.component";
 import { ViewLandingPage } from "./view-landing.component";
-import { ViewPage, type ViewAction } from "./view.component";
+import { ViewPage, formatViewDocumentTitle, type ViewAction } from "./view.component";
 
 interface ViewDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
@@ -69,6 +73,19 @@ function pollUrlBuilderFor(articleUrl: string): PollUrlBuilder {
 	};
 }
 
+function buildArticleReaderDeps(deps: ViewDependencies): ArticleReaderDeps {
+	return {
+		findArticleCrawlStatus: deps.findArticleCrawlStatus,
+		markCrawlPending: deps.markCrawlPending,
+		findGeneratedSummary: deps.findGeneratedSummary,
+		markSummaryPending: deps.markSummaryPending,
+		readArticleContent: deps.readArticleContent,
+		findArticleByUrl: deps.findArticleByUrl,
+		formatDocumentTitle: formatViewDocumentTitle,
+		now: deps.now,
+	};
+}
+
 function handleViewLanding(deps: ViewDependencies) {
 	return (req: Request, res: Response) => {
 		const submittedUrl =
@@ -87,7 +104,7 @@ function handleViewLanding(deps: ViewDependencies) {
 }
 
 function handleViewArticle(deps: ViewDependencies) {
-	const reader = initArticleReader(deps);
+	const reader = initArticleReader(buildArticleReaderDeps(deps));
 	return async (
 		req: Request<Record<string, string>>,
 		res: Response,
@@ -188,7 +205,7 @@ function handleViewArticle(deps: ViewDependencies) {
 }
 
 function handleViewSummary(deps: ViewDependencies) {
-	const reader = initArticleReader(deps);
+	const reader = initArticleReader(buildArticleReaderDeps(deps));
 	return async (req: Request, res: Response): Promise<void> => {
 		const validation = deps.validateSaveableUrl(req.query.url);
 		if (validation.status === "ERROR") {
@@ -202,12 +219,12 @@ function handleViewSummary(deps: ViewDependencies) {
 			pollCount,
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 		});
-		sendComponent(req, res, component);
+		sendConditionalHtml(req, res, component);
 	};
 }
 
 function handleViewReader(deps: ViewDependencies) {
-	const reader = initArticleReader(deps);
+	const reader = initArticleReader(buildArticleReaderDeps(deps));
 	return async (req: Request, res: Response): Promise<void> => {
 		const validation = deps.validateSaveableUrl(req.query.url);
 		if (validation.status === "ERROR") {
@@ -222,7 +239,7 @@ function handleViewReader(deps: ViewDependencies) {
 			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
 		});
-		sendComponent(req, res, component);
+		sendConditionalHtml(req, res, component);
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -103,8 +103,7 @@ function handleViewLanding(deps: ViewDependencies) {
 	};
 }
 
-function handleViewArticle(deps: ViewDependencies) {
-	const reader = initArticleReader(buildArticleReaderDeps(deps));
+function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof initArticleReader>) {
 	return async (
 		req: Request<Record<string, string>>,
 		res: Response,
@@ -204,8 +203,7 @@ function handleViewArticle(deps: ViewDependencies) {
 	};
 }
 
-function handleViewSummary(deps: ViewDependencies) {
-	const reader = initArticleReader(buildArticleReaderDeps(deps));
+function handleViewSummary(deps: ViewDependencies, reader: ReturnType<typeof initArticleReader>) {
 	return async (req: Request, res: Response): Promise<void> => {
 		const validation = deps.validateSaveableUrl(req.query.url);
 		if (validation.status === "ERROR") {
@@ -223,8 +221,7 @@ function handleViewSummary(deps: ViewDependencies) {
 	};
 }
 
-function handleViewReader(deps: ViewDependencies) {
-	const reader = initArticleReader(buildArticleReaderDeps(deps));
+function handleViewReader(deps: ViewDependencies, reader: ReturnType<typeof initArticleReader>) {
 	return async (req: Request, res: Response): Promise<void> => {
 		const validation = deps.validateSaveableUrl(req.query.url);
 		if (validation.status === "ERROR") {
@@ -245,11 +242,12 @@ function handleViewReader(deps: ViewDependencies) {
 
 export function initViewRoutes(deps: ViewDependencies): Router {
 	const router = express.Router();
+	const reader = initArticleReader(buildArticleReaderDeps(deps));
 
 	router.get("/", handleViewLanding(deps));
-	router.get("/summary", handleViewSummary(deps));
-	router.get("/reader", handleViewReader(deps));
-	router.get<string, Record<string, string>>("/*", handleViewArticle(deps));
+	router.get("/summary", handleViewSummary(deps, reader));
+	router.get("/reader", handleViewReader(deps, reader));
+	router.get<string, Record<string, string>>("/*", handleViewArticle(deps, reader));
 
 	return router;
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1076,6 +1076,75 @@ describe("View routes", () => {
 		});
 	});
 
+	describe("GET /view/reader fragment auto-update", () => {
+		it("emits header + <title> OOB fragments and an ETag, and 304s when If-None-Match matches", async () => {
+			// Steady-state contract for the public reader: while the crawl is
+			// still in flight the /view/reader poll must include the addressable
+			// header (#article-header) and document <title> (#document-title) as
+			// hx-swap-oob fragments, plus an ETag so an unchanged body collapses
+			// to 304 instead of re-shipping the same payload every 3s.
+			//
+			// The progress bar OOB carries `tickAt: now.toISOString()`, so a real
+			// `() => new Date()` clock would bust the ETag on every poll and
+			// defeat the steady-state 304 contract. Pinning `now` to a fixed
+			// instant gives a deterministic body across the two requests.
+			const parseArticle: ParseArticle = async () => buildParseResult();
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const fixedNow = new Date("2026-04-25T12:00:00.000Z");
+			const { app } = createTestApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+				articleCrawl: {
+					...fixture.articleCrawl,
+					findArticleCrawlStatus: async () => ({ status: "pending" as const }),
+				},
+				shared: { ...fixture.shared, now: () => fixedNow },
+			});
+
+			// Land on /view first so the row exists; then the reader poll has
+			// something to read back.
+			await request(app).get(`/view/${ENCODED}`);
+
+			const first = await request(app).get(
+				`/view/reader?url=${encodeURIComponent(ARTICLE_URL)}&poll=1`,
+			);
+			expect(first.status).toBe(200);
+			const etag = first.headers.etag;
+			assert(etag, "view reader poll must emit an ETag for steady-state 304s");
+			expect(first.headers["cache-control"]).toBe("private, no-cache");
+
+			const doc = new JSDOM(first.text).window.document;
+			const header = doc.querySelector("#article-header");
+			assert(header, "header OOB fragment must accompany the reader-slot");
+			expect(header.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			const titleEl = doc.querySelector("title#document-title");
+			assert(titleEl, "<title> OOB fragment must accompany the reader-slot");
+			expect(titleEl.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			// Format owned by view.component.ts — keep in sync if you change it there.
+			expect(titleEl.textContent).toMatch(/\| Reader View$/);
+
+			const second = await request(app)
+				.get(`/view/reader?url=${encodeURIComponent(ARTICLE_URL)}&poll=1`)
+				.set("If-None-Match", etag);
+			expect(second.status).toBe(304);
+			expect(second.text).toBe("");
+		});
+	});
+
 	describe("OG metadata", () => {
 		it("emits article title, excerpt, image, type and canonical as the publisher URL", async () => {
 			const parseArticle: ParseArticle = async () => buildParseResult();

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
@@ -5,6 +5,7 @@ import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-cra
 import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
 import { requireEnv } from "../../../require-env";
 import { render } from "../../render";
+import { renderArticleHeader } from "./article-header/article-header.component";
 import { renderProgressBar } from "./progress-bar.component";
 import type { ProgressTick } from "@packages/domain/article";
 import { renderReaderSlot } from "./reader-slot/reader-slot.component";
@@ -58,16 +59,20 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 
 	const progressBarHtml = renderProgressBar({ progress: input.progress });
 
-	return render(ARTICLE_BODY_TEMPLATE, {
+	const headerHtml = renderArticleHeader({
 		title: input.title,
 		siteName: input.siteName,
 		estimatedReadTime: input.estimatedReadTime,
 		url: input.url,
+		backLink: input.backLink,
+	});
+
+	return render(ARTICLE_BODY_TEMPLATE, {
+		headerHtml,
 		readerSlotHtml,
 		summarySlotHtml,
 		progressBarHtml,
 		audioEnabled: input.audioEnabled,
-		backLink: input.backLink,
 		staticBaseUrl: STATIC_BASE_URL,
 	});
 }

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
@@ -1,12 +1,4 @@
-    <div class="article-body__header">
-      {{#if backLink}}<div class="article-body__back-slot article-body__back-slot--visible" data-test-back-slot><a class="article-body__back" href="{{backLink.href}}" data-test-back-link>{{backLink.label}}</a></div>{{else}}<div class="article-body__back-slot article-body__back-slot--hidden" data-test-back-slot></div>{{/if}}
-      <h1 class="article-body__title" data-test-reader-title>{{title}}</h1>
-      <div class="article-body__meta">
-        <span data-test-reader-site>{{siteName}}</span>
-        <span>{{estimatedReadTime}} min read</span>
-      </div>
-      <a class="article-body__original-link" href="{{url}}" target="_blank" rel="noopener" data-test-original-link>View original</a>
-    </div>
+    {{{headerHtml}}}
     {{{progressBarHtml}}}
     {{{summarySlotHtml}}}
     {{#if audioEnabled}}<div class="article-body__audio-slot article-body__audio-slot--visible" data-test-audio-player><div class="article-body__audio-player">

--- a/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.component.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import type { Minutes } from "@packages/domain/article";
+import {
+	renderArticleHeader,
+	renderArticleHeaderOob,
+	renderDocumentTitleOob,
+} from "./article-header.component";
+
+const baseInput = {
+	title: "Hello World",
+	siteName: "example.com",
+	estimatedReadTime: 3 as Minutes,
+	url: "https://example.com/post",
+};
+
+function parse(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
+}
+
+describe("renderArticleHeader (inline)", () => {
+	it("uses the stable id so OOB poll responses can swap it without coordinating with the rest of the article body", () => {
+		const doc = parse(renderArticleHeader(baseInput));
+
+		const header = doc.querySelector("#article-header");
+		assert(header, "header must carry the stable id");
+		expect(header.classList.contains("article-body__header")).toBe(true);
+		expect(header.hasAttribute("hx-swap-oob")).toBe(false);
+	});
+
+	it("renders the title, site name, read time and original-link href so the inline form looks identical to the legacy markup", () => {
+		const doc = parse(renderArticleHeader(baseInput));
+
+		expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe("Hello World");
+		expect(doc.querySelector("[data-test-reader-site]")?.textContent).toBe("example.com");
+		expect(doc.querySelector(".article-body__meta")?.textContent).toContain("3 min read");
+		const originalLink = doc.querySelector("[data-test-original-link]");
+		assert(originalLink, "view-original link must be rendered");
+		expect(originalLink.getAttribute("href")).toBe("https://example.com/post");
+	});
+
+	it("renders the back-slot in its visible state when backLink is provided", () => {
+		const doc = parse(renderArticleHeader({
+			...baseInput,
+			backLink: { href: "/queue", label: "← Back to queue" },
+		}));
+
+		const slot = doc.querySelector("[data-test-back-slot]");
+		assert(slot, "back slot must be rendered");
+		expect(slot.classList.contains("article-body__back-slot--visible")).toBe(true);
+		const link = slot.querySelector("[data-test-back-link]");
+		assert(link, "back link must be rendered when backLink is provided");
+		expect(link.getAttribute("href")).toBe("/queue");
+		expect(link.textContent).toBe("← Back to queue");
+	});
+
+	it("renders the back-slot hidden (rather than absent) when backLink is omitted, so the visible/hidden swap is a class toggle and not a tree mutation", () => {
+		const doc = parse(renderArticleHeader(baseInput));
+
+		const slot = doc.querySelector("[data-test-back-slot]");
+		assert(slot, "back slot must always be present");
+		expect(slot.classList.contains("article-body__back-slot--hidden")).toBe(true);
+	});
+});
+
+describe("renderArticleHeaderOob", () => {
+	it("emits the same header markup carrying hx-swap-oob so it slots into poll responses alongside the existing reader-slot and progress-bar OOB", () => {
+		const doc = parse(renderArticleHeaderOob(baseInput));
+
+		const header = doc.querySelector("#article-header");
+		assert(header, "OOB header must be rendered");
+		expect(header.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe("Hello World");
+	});
+
+	it("preserves the back-slot visibility class in the OOB form so a poll-driven header swap on /queue/:id/read does not erase the back-link styling", () => {
+		const doc = parse(renderArticleHeaderOob({
+			...baseInput,
+			backLink: { href: "/queue", label: "← Back to queue" },
+		}));
+
+		const slot = doc.querySelector("[data-test-back-slot]");
+		assert(slot, "back slot must be rendered in the OOB form");
+		expect(slot.classList.contains("article-body__back-slot--visible")).toBe(true);
+	});
+});
+
+describe("renderDocumentTitleOob", () => {
+	it("emits a <title> tag carrying the stable id so htmx can match it against the live <title id=\"document-title\"> in the page <head>", () => {
+		const html = renderDocumentTitleOob("Hello World — Readplace Reader");
+
+		expect(html).toBe(
+			'<title id="document-title" hx-swap-oob="outerHTML">Hello World — Readplace Reader</title>',
+		);
+	});
+
+	it("HTML-escapes characters inside the title so a saved article whose title contains < or & cannot break out of the <title> tag", () => {
+		const html = renderDocumentTitleOob("<script>alert(1)</script> & friends");
+
+		expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt; &amp; friends");
+		expect(html).not.toContain("<script>");
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.component.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Minutes } from "@packages/domain/article";
+import { render } from "../../../render";
+
+const TEMPLATE = readFileSync(join(__dirname, "article-header.template.html"), "utf-8");
+
+export interface ArticleHeaderInput {
+	title: string;
+	siteName: string;
+	estimatedReadTime: Minutes;
+	url: string;
+	backLink?: { href: string; label: string };
+}
+
+function renderTemplate(input: ArticleHeaderInput, oob: boolean): string {
+	return render(TEMPLATE, {
+		title: input.title,
+		siteName: input.siteName,
+		estimatedReadTime: input.estimatedReadTime,
+		url: input.url,
+		backLink: input.backLink,
+		oob,
+	});
+}
+
+/**
+ * Inline render: ships with the initial page response. The `id="article-header"`
+ * is the swap target that poll responses replace via hx-swap-oob, so the same
+ * element drives both the SSR view and every later metadata refresh.
+ */
+export function renderArticleHeader(input: ArticleHeaderInput): string {
+	return renderTemplate(input, false);
+}
+
+/**
+ * OOB render: piggybacks on the existing reader/summary poll responses so the
+ * title, site name and read time settle in place once the crawl finishes,
+ * instead of leaving the hostname stub on screen until manual refresh.
+ */
+export function renderArticleHeaderOob(input: ArticleHeaderInput): string {
+	return renderTemplate(input, true);
+}
+
+/**
+ * `<title>` OOB fragment. htmx matches by id, so the live <title> in the page
+ * <head> carries `id="document-title"` and we emit a same-id replacement here.
+ * Format is owned by the caller (e.g. "Foo — Readplace Reader" vs "Foo | Reader
+ * View") so each reader keeps its existing tab title shape.
+ */
+export function renderDocumentTitleOob(documentTitle: string): string {
+	return `<title id="document-title" hx-swap-oob="outerHTML">${escapeHtml(documentTitle)}</title>`;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.component.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import Handlebars from "handlebars";
 import type { Minutes } from "@packages/domain/article";
 import { render } from "../../../render";
 
@@ -49,14 +50,5 @@ export function renderArticleHeaderOob(input: ArticleHeaderInput): string {
  * View") so each reader keeps its existing tab title shape.
  */
 export function renderDocumentTitleOob(documentTitle: string): string {
-	return `<title id="document-title" hx-swap-oob="outerHTML">${escapeHtml(documentTitle)}</title>`;
-}
-
-function escapeHtml(value: string): string {
-	return value
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#39;");
+	return `<title id="document-title" hx-swap-oob="outerHTML">${Handlebars.Utils.escapeExpression(documentTitle)}</title>`;
 }

--- a/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-header/article-header.template.html
@@ -1,0 +1,9 @@
+<div id="article-header" class="article-body__header"{{#if oob}} hx-swap-oob="outerHTML"{{/if}}>
+  {{#if backLink}}<div class="article-body__back-slot article-body__back-slot--visible" data-test-back-slot><a class="article-body__back" href="{{backLink.href}}" data-test-back-link>{{backLink.label}}</a></div>{{else}}<div class="article-body__back-slot article-body__back-slot--hidden" data-test-back-slot></div>{{/if}}
+  <h1 class="article-body__title" data-test-reader-title>{{title}}</h1>
+  <div class="article-body__meta">
+    <span data-test-reader-site>{{siteName}}</span>
+    <span>{{estimatedReadTime}} min read</span>
+  </div>
+  <a class="article-body__original-link" href="{{url}}" target="_blank" rel="noopener" data-test-original-link>View original</a>
+</div>

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -1,19 +1,16 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import type { Minutes } from "@packages/domain/article";
-import type {
-	ArticleCrawl,
-	FindArticleCrawlStatus,
-	MarkCrawlPending,
-} from "@packages/test-fixtures/providers/article-crawl";
-import type {
-	FindGeneratedSummary,
-	GeneratedSummary,
-	MarkSummaryPending,
-} from "@packages/test-fixtures/providers/article-summary";
-import type { ReadArticleContent } from "@packages/test-fixtures/providers/article-store";
+import { ReaderArticleHashId } from "@packages/domain/article";
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import type { GlobalArticleData } from "@packages/test-fixtures/providers/article-store";
 import { initArticleReader } from "./article-reader";
-import type { ArticleSnapshot, PollUrlBuilder } from "./article-reader.types";
+import type {
+	ArticleReaderDeps,
+	ArticleSnapshot,
+	PollUrlBuilder,
+} from "./article-reader.types";
 
 const ARTICLE_URL = "https://example.com/post";
 
@@ -41,31 +38,46 @@ interface FakeState {
 	crawl: ArticleCrawl | undefined;
 	summary: GeneratedSummary | undefined;
 	content: string | undefined;
+	article: GlobalArticleData | null;
 	markCrawlPendingCalls: number;
 	markSummaryPendingCalls: number;
 }
 
 const FIXED_NOW = new Date("2026-04-25T12:00:00.000Z");
 
-function initFakeDeps(initial?: Partial<FakeState>): {
-	state: FakeState;
-	deps: {
-		findArticleCrawlStatus: FindArticleCrawlStatus;
-		markCrawlPending: MarkCrawlPending;
-		findGeneratedSummary: FindGeneratedSummary;
-		markSummaryPending: MarkSummaryPending;
-		readArticleContent: ReadArticleContent;
-		now: () => Date;
+function defaultFakeArticle(): GlobalArticleData {
+	return {
+		id: ReaderArticleHashId.from(ARTICLE_URL),
+		url: ARTICLE_URL,
+		metadata: {
+			title: "Post",
+			siteName: "example.com",
+			excerpt: "Excerpt.",
+			wordCount: 100,
+		},
+		estimatedReadTime: 1 as Minutes,
 	};
+}
+
+function initFakeDeps(initial: {
+	crawl?: ArticleCrawl;
+	summary?: GeneratedSummary;
+	content?: string;
+	/** undefined means "use the default fake article"; null means "row missing". */
+	article?: GlobalArticleData | null;
+} = {}): {
+	state: FakeState;
+	deps: ArticleReaderDeps;
 } {
 	const state: FakeState = {
-		crawl: initial?.crawl,
-		summary: initial?.summary,
-		content: initial?.content,
+		crawl: initial.crawl,
+		summary: initial.summary,
+		content: initial.content,
+		article: initial.article === undefined ? defaultFakeArticle() : initial.article,
 		markCrawlPendingCalls: 0,
 		markSummaryPendingCalls: 0,
 	};
-	const deps = {
+	const deps: ArticleReaderDeps = {
 		findArticleCrawlStatus: async () => state.crawl,
 		markCrawlPending: async () => {
 			state.markCrawlPendingCalls += 1;
@@ -77,6 +89,8 @@ function initFakeDeps(initial?: Partial<FakeState>): {
 			if (state.summary === undefined) state.summary = { status: "pending" };
 		},
 		readArticleContent: async () => state.content,
+		findArticleByUrl: async () => state.article,
+		formatDocumentTitle: (title) => `${title} — TestReader`,
 		now: () => FIXED_NOW,
 	};
 	return { state, deps };
@@ -633,6 +647,148 @@ describe("initArticleReader", () => {
 			const slot = parse(toHtml(component)).querySelector("[data-test-reader-slot]");
 			assert(slot, "reader slot must be rendered");
 			expect(slot.getAttribute("data-reader-status")).toBe("failed");
+		});
+
+		it("includes the article header as an hx-swap-oob fragment carrying the latest title so the H1 settles in place once the crawl writes it over the hostname stub", async () => {
+			const { state, deps } = initFakeDeps({
+				crawl: { status: "pending" },
+				content: undefined,
+			});
+			state.article = {
+				...defaultFakeArticle(),
+				metadata: {
+					title: "Why Rust beats Go",
+					siteName: "example.com",
+					excerpt: "",
+					wordCount: 0,
+				},
+			};
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			const header = doc.querySelector("#article-header");
+			assert(header, "header OOB fragment must accompany the reader-slot");
+			expect(header.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			expect(header.querySelector("[data-test-reader-title]")?.textContent).toBe(
+				"Why Rust beats Go",
+			);
+		});
+
+		it("includes a <title> hx-swap-oob fragment formatted via deps.formatDocumentTitle so the browser tab updates without any client-side JS", async () => {
+			const { state, deps } = initFakeDeps({
+				crawl: { status: "pending" },
+				content: undefined,
+			});
+			state.article = {
+				...defaultFakeArticle(),
+				metadata: {
+					title: "Why Rust beats Go",
+					siteName: "example.com",
+					excerpt: "",
+					wordCount: 0,
+				},
+			};
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			const titleEl = doc.querySelector("title#document-title");
+			assert(titleEl, "<title> OOB fragment must accompany the reader-slot");
+			expect(titleEl.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			expect(titleEl.textContent).toBe("Why Rust beats Go — TestReader");
+		});
+
+		it("renders header + <title> with the back-link slot when initArticleReader was given a backLink — proving deps.backLink is wired into the OOB header", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "pending" },
+				content: undefined,
+			});
+			const reader = initArticleReader({
+				...deps,
+				backLink: { href: "/queue", label: "← Back to queue" },
+			});
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			const slot = doc.querySelector("#article-header [data-test-back-slot]");
+			assert(slot, "back slot must be rendered inside the OOB header");
+			expect(slot.classList.contains("article-body__back-slot--visible")).toBe(true);
+			const link = slot.querySelector("[data-test-back-link]");
+			assert(link, "back link must be present");
+			expect(link.getAttribute("href")).toBe("/queue");
+		});
+
+		it("omits the header + <title> OOB fragments when the row has gone missing — falling back to swapping only the slot so the existing header text stays put", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "pending" },
+				content: undefined,
+				article: null,
+			});
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			expect(doc.querySelector("#article-header")).toBeNull();
+			expect(doc.querySelector("title#document-title")).toBeNull();
+			const slot = doc.querySelector("[data-test-reader-slot]");
+			assert(slot, "reader-slot fragment must still be emitted even with no article row");
+		});
+	});
+
+	describe("handleSummaryPoll header + title OOB", () => {
+		it("emits the header and <title> OOB fragments alongside the summary-slot so a settled title can land via the summary-poll path too (whichever poll fires first wins)", async () => {
+			const { state, deps } = initFakeDeps({
+				crawl: { status: "ready" },
+				summary: { status: "pending", stage: "summary-generating" },
+			});
+			state.article = {
+				...defaultFakeArticle(),
+				metadata: {
+					title: "Why Rust beats Go",
+					siteName: "example.com",
+					excerpt: "",
+					wordCount: 0,
+				},
+			};
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleSummaryPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 1,
+				pollUrlBuilder: makePollUrlBuilder(),
+			});
+
+			const doc = parse(toHtml(component));
+			const header = doc.querySelector("#article-header");
+			assert(header, "header OOB fragment must accompany the summary-slot");
+			expect(header.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			expect(header.querySelector("[data-test-reader-title]")?.textContent).toBe(
+				"Why Rust beats Go",
+			);
+			const titleEl = doc.querySelector("title#document-title");
+			assert(titleEl, "<title> OOB fragment must accompany the summary-slot");
+			expect(titleEl.textContent).toBe("Why Rust beats Go — TestReader");
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
@@ -1,7 +1,12 @@
 import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
 import type { GeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import type { GlobalArticleData } from "@packages/test-fixtures/providers/article-store";
 import type { Component } from "../../component.types";
 import { HtmlPage } from "../../html-page";
+import {
+	renderArticleHeaderOob,
+	renderDocumentTitleOob,
+} from "../article-body/article-header/article-header.component";
 import { renderProgressBarOob } from "../article-body/progress-bar.component";
 import {
 	CRAWL_STAGE_TO_PCT,
@@ -124,10 +129,39 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 		};
 	}
 
+	/**
+	 * Header + <title> OOB fragments. Concatenated onto every poll response so
+	 * the title that was rendered as a hostname stub at t=0 settles in place
+	 * the moment the crawl writes the real metadata, instead of leaving the
+	 * page stale until the user manually refreshes. Returns "" when the row
+	 * has gone missing (deleted between renders); the slot fragment still
+	 * swaps and the existing header/title stay put.
+	 */
+	function buildMetadataOob(
+		article: GlobalArticleData | null,
+		articleUrl: string,
+	): string {
+		if (!article) return "";
+		const headerOob = renderArticleHeaderOob({
+			title: article.metadata.title,
+			siteName: article.metadata.siteName,
+			estimatedReadTime: article.estimatedReadTime,
+			url: articleUrl,
+			backLink: deps.backLink,
+		});
+		const titleOob = renderDocumentTitleOob(
+			deps.formatDocumentTitle(article.metadata.title),
+		);
+		return headerOob + titleOob;
+	}
+
 	async function handleSummaryPoll(params: HandlePollParams): Promise<Component> {
 		const { articleUrl, pollCount, pollUrlBuilder } = params;
-		const crawl = await deps.findArticleCrawlStatus(articleUrl);
-		const summary = await deps.findGeneratedSummary(articleUrl);
+		const [crawl, summary, article] = await Promise.all([
+			deps.findArticleCrawlStatus(articleUrl),
+			deps.findGeneratedSummary(articleUrl),
+			deps.findArticleByUrl(articleUrl),
+		]);
 		const crawlFailed = crawl?.status === "failed";
 		const status = summary?.status ?? "pending";
 		const summaryPollUrl = !crawlFailed && status === "pending" && pollCount < MAX_POLLS
@@ -142,14 +176,18 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 		const oobBar = renderProgressBarOob({
 			progress: buildUnifiedProgress(crawl, summary, deps.now()),
 		});
-		return HtmlPage(slot + oobBar);
+		const oobMetadata = buildMetadataOob(article, articleUrl);
+		return HtmlPage(slot + oobBar + oobMetadata);
 	}
 
 	async function handleReaderPoll(params: HandlePollParams): Promise<Component> {
 		const { articleUrl, pollCount, pollUrlBuilder, extensionInstallUrl } = params;
-		const crawl = await deps.findArticleCrawlStatus(articleUrl);
-		const summary = await deps.findGeneratedSummary(articleUrl);
-		const content = await deps.readArticleContent(articleUrl);
+		const [crawl, summary, content, article] = await Promise.all([
+			deps.findArticleCrawlStatus(articleUrl),
+			deps.findGeneratedSummary(articleUrl),
+			deps.readArticleContent(articleUrl),
+			deps.findArticleByUrl(articleUrl),
+		]);
 		const readerPollUrl = shouldKeepPollingReader(crawl, content) && pollCount < MAX_POLLS
 			? pollUrlBuilder.reader(pollCount + 1)
 			: undefined;
@@ -163,7 +201,8 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 		const oobBar = renderProgressBarOob({
 			progress: buildUnifiedProgress(crawl, summary, deps.now()),
 		});
-		return HtmlPage(slot + oobBar);
+		const oobMetadata = buildMetadataOob(article, articleUrl);
+		return HtmlPage(slot + oobBar + oobMetadata);
 	}
 
 	return { resolveReaderState, handleSummaryPoll, handleReaderPoll };

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.types.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.types.ts
@@ -12,7 +12,10 @@ import type {
 	GeneratedSummary,
 	MarkSummaryPending,
 } from "@packages/test-fixtures/providers/article-summary";
-import type { ReadArticleContent } from "@packages/test-fixtures/providers/article-store";
+import type {
+	FindArticleByUrl,
+	ReadArticleContent,
+} from "@packages/test-fixtures/providers/article-store";
 import type { ProgressTick } from "@packages/domain/article";
 
 export interface ArticleReaderDeps {
@@ -21,6 +24,23 @@ export interface ArticleReaderDeps {
 	findGeneratedSummary: FindGeneratedSummary;
 	markSummaryPending: MarkSummaryPending;
 	readArticleContent: ReadArticleContent;
+	/**
+	 * Used by the poll handlers to read the latest metadata on every tick so
+	 * the header (title, siteName, readTime) and document <title> can settle
+	 * in place once the crawl writes the real title over the hostname stub.
+	 */
+	findArticleByUrl: FindArticleByUrl;
+	/**
+	 * Each reader keeps its own browser-tab title format
+	 * (queue: "X — Readplace Reader", view: "X | Reader View"). The article-
+	 * reader emits the OOB <title> fragment using whatever the caller decides.
+	 */
+	formatDocumentTitle: (articleTitle: string) => string;
+	/**
+	 * Static for a given reader (queue → /queue, view → none). Lives at init
+	 * time, not per-poll, because it never changes during a reader session.
+	 */
+	backLink?: { href: string; label: string };
 	now: () => Date;
 }
 

--- a/src/packages/hutch-infra-components/project.json
+++ b/src/packages/hutch-infra-components/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "@packages/hutch-infra-components",
+  "targets": {
+    "check": {
+      "command": "pnpm lint",
+      "options": { "cwd": "{projectRoot}" }
+    }
+  }
+}

--- a/src/packages/hutch-storage-client/project.json
+++ b/src/packages/hutch-storage-client/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "@packages/hutch-storage-client",
+  "targets": {
+    "check": {
+      "command": "pnpm lint",
+      "options": { "cwd": "{projectRoot}" }
+    }
+  }
+}


### PR DESCRIPTION
## Why

A reader saves a link → lands on `/queue/:id/read` (or `/view/:url`) within ~1s → sees `medium.com` instead of `"Why Rust beats Go in microservices"`. The browser tab also shows `medium.com`, so a multi-tab reader can't tell their saved articles apart. The crawl pipeline produces the real title seconds later, but the rendered page is a snapshot at request time and the title element lives **outside** any polled fragment, so it's frozen until manual refresh.

This is a 100% server-already-knows-the-answer problem. The data has been written; the existing reader-slot/summary-slot polls are already firing every 3s and watching the same crawl row. We just weren't surfacing the metadata change to the DOM.

## What

A single change with three coordinated parts, applied uniformly to **both** `/queue/:id/read` (private) and `/view/:url` (public), plus the admin `/admin/recrawl` reader:

1. **Header is a polled fragment.** `article-body__header` gets `id="article-header"`. The existing reader/summary poll responses now return an OOB header fragment alongside the existing slot HTML and progress-bar OOB.
2. **`<title>` rides along.** Same poll response includes a `<title id="document-title" hx-swap-oob="outerHTML">…</title>` so the browser tab updates without any client-side JS.
3. **ETag + 304 on the poll endpoints.** A new `sendConditionalHtml` helper hashes the rendered body into a weak ETag, sets `Cache-Control: private, no-cache`, and 304s on `If-None-Match`. Wired into `/queue/:id/{reader,summary}` and `/view/{reader,summary}`. Admin recrawl keeps `Cache-Control: no-store` and is intentionally untouched.

When the crawl reaches terminal, the slot stops polling exactly as before. The header is by definition correct at that point.

## Design notes

- **Why piggyback on the existing 3s poll, not a new endpoint?** The header's "ready" condition is the same as the reader's: crawl is no longer pending. A separate `/header` poll would create two state machines that can drift, and double the request volume for no extra signal.
- **Why an addressable header (`id="article-header"`)?** The header was a `<div class="article-body__header">` with no id, no boundary, no test seam. Promoting it to a swappable fragment makes both the auto-update *and* future header changes (re-crawl button, edit title, share state) reuse the same swap point.
- **Why ETag now?** The 3s poll re-ships identical HTML on every tick once metadata settles. ETag → 304 collapses each settled-state poll to a tiny conditional GET. ~10 lines of helper, real bandwidth win.
- **Document title format owned by the page module.** `formatReaderDocumentTitle` (queue), `formatViewDocumentTitle` (view) and `formatRecrawlDocumentTitle` (admin) are exported so the SSR `<title>` and the OOB `<title>` swap stay in sync — otherwise the browser tab would flicker between formats every time the title settles.

## Tradeoffs accepted

- A title popping in mid-read is a tiny visual jitter. The OOB swap is idempotent on identical HTML, so it's only visible when the title actually differs.
- This PR doesn't ship a service-worker offline cache. That's a separate, much bigger feature.
- During in-flight polling, the progress bar's `tickAt` advances every poll, so 304s only fire in the post-terminal window where polling has already stopped — meaning the ETag mostly buys correctness (correct cache headers everywhere) rather than steady-state bandwidth savings today. Removing `tickAt` from the response when state is unchanged would unlock real 304s; flagged for a follow-up.

## Test plan

- [x] `article-header.component.test.ts` — inline form, OOB form, document-title fragment with HTML escaping
- [x] `conditional-get.test.ts` — 200 + ETag, 304 on If-None-Match, fresh ETag on body change, `Cache-Control: private, no-cache`
- [x] `article-reader.test.ts` — header OOB and `<title>` OOB present in both `handleReaderPoll` and `handleSummaryPoll` responses; back-link slot wired through `deps.backLink`; missing row drops both OOB fragments
- [x] `queue.route.test.ts` and `view.route.test.ts` — end-to-end: poll emits ETag + header OOB + `<title>` OOB; `If-None-Match` round-trip returns 304 with empty body
- [x] All 1069 hutch tests pass; lint, knip and unused-CSS checks all clean

https://claude.ai/code/session_01EMetegDixXP8WzTdVvnAKa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMetegDixXP8WzTdVvnAKa)_