### PR TITLE
fix(hutch): re-show onboarding when the extension is uninstalled

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/onboarding-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/onboarding-actions.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import {
-  COOKIE_NAME,
-  COOKIE_VALUE,
+  ALIVE_COOKIE_NAME,
+  ALIVE_COOKIE_VALUE,
   SAVE_COOKIE_NAME,
   SAVE_COOKIE_VALUE,
 } from '@packages/onboarding-extension-signal'
@@ -29,8 +29,8 @@ export function createOnboardingActions(
         await expect(step).toHaveAttribute('data-test-onboarding-complete', 'false')
 
         await page.context().addCookies([{
-          name: COOKIE_NAME,
-          value: COOKIE_VALUE,
+          name: ALIVE_COOKIE_NAME,
+          value: ALIVE_COOKIE_VALUE,
           path: '/',
           domain: new URL(page.url()).hostname,
         }])

--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -490,8 +490,8 @@ describe("POST /queue/:id/delete (Siren)", () => {
 	});
 });
 
-describe("extension-installed cookie middleware", () => {
-	it("sets the extension-installed cookie on the Siren entry point before login", async () => {
+describe("extension-alive cookie middleware", () => {
+	it("sets the alive cookie as httpOnly on the Siren entry point before login", async () => {
 		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const response = await request(testApp.app)
@@ -502,15 +502,18 @@ describe("extension-installed cookie middleware", () => {
 		expect(response.status).toBe(303);
 		const setCookie = response.headers["set-cookie"];
 		assert(Array.isArray(setCookie), "expected Set-Cookie header");
-		const cookie = setCookie.find((c: string) => c.startsWith("hutch_ext_installed="));
-		assert(cookie, "expected hutch_ext_installed cookie");
-		expect(cookie).toContain("hutch_ext_installed=1");
+		const cookie = setCookie.find((c: string) => c.startsWith("hutch_ext_alive="));
+		assert(cookie, "expected hutch_ext_alive cookie");
+		expect(cookie).toContain("hutch_ext_alive=1");
 		expect(cookie).toContain("Path=/");
 		expect(cookie).toContain("SameSite=Lax");
 		expect(cookie).toContain("Max-Age=");
+		// httpOnly is what blocks the extension content script (or any other JS)
+		// from forging or renewing this cookie via document.cookie.
+		expect(cookie).toContain("HttpOnly");
 	});
 
-	it("does not set the cookie on browser session requests", async () => {
+	it("does not set the alive cookie on browser session requests", async () => {
 		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
 		const agent = request.agent(testApp.app);
@@ -526,7 +529,41 @@ describe("extension-installed cookie middleware", () => {
 		expect(response.status).toBe(200);
 		const setCookie = response.headers["set-cookie"];
 		const cookies = Array.isArray(setCookie) ? setCookie : [];
-		const cookie = cookies.find((c: string) => c.startsWith("hutch_ext_installed="));
+		const cookie = cookies.find((c: string) => c.startsWith("hutch_ext_alive="));
+		expect(cookie).toBeUndefined();
+	});
+
+	it("renews the hutch_ext_saved cookie on a Siren request when it is already present", async () => {
+		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(testApp.app)
+			.get("/")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.set("Cookie", "hutch_ext_saved=1")
+			.redirects(0);
+
+		expect(response.status).toBe(303);
+		const setCookie = response.headers["set-cookie"];
+		assert(Array.isArray(setCookie), "expected Set-Cookie header");
+		const cookie = setCookie.find((c: string) => c.startsWith("hutch_ext_saved="));
+		assert(cookie, "expected hutch_ext_saved cookie to be renewed");
+		expect(cookie).toContain("hutch_ext_saved=1");
+		expect(cookie).toContain("Max-Age=");
+		expect(cookie).toContain("HttpOnly");
+	});
+
+	it("does not set hutch_ext_saved on a Siren request when the cookie is absent", async () => {
+		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(testApp.app)
+			.get("/")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.redirects(0);
+
+		expect(response.status).toBe(303);
+		const setCookie = response.headers["set-cookie"];
+		const cookies = Array.isArray(setCookie) ? setCookie : [];
+		const cookie = cookies.find((c: string) => c.startsWith("hutch_ext_saved="));
 		expect(cookie).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/mark-extension-installed.middleware.ts
+++ b/projects/hutch/src/runtime/web/mark-extension-installed.middleware.ts
@@ -1,24 +1,54 @@
 import type { Request, Response, NextFunction } from "express";
 import {
-	COOKIE_NAME,
-	COOKIE_VALUE,
+	ALIVE_COOKIE_NAME,
+	ALIVE_COOKIE_VALUE,
+	SAVE_COOKIE_NAME,
+	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
 import { wantsSiren } from "./content-negotiation";
 
-/** Sets the extension-installed cookie on every Siren response so
- * the onboarding UI can detect the extension is present. Browser
- * sessions never send Accept: application/vnd.siren+json, so
- * wantsSiren alone identifies extension requests — no auth check
- * needed, which means the cookie is set even on unauthenticated
- * requests (e.g. the first GET / before login). */
+/** 30 days. Refreshed on every Siren request the extension makes (popup
+ * opens, toolbar saves, the keyboard shortcut). Long enough that an active
+ * user with the extension installed but not opening the popup for a few
+ * weeks doesn't see the onboarding flicker; short enough that an uninstall
+ * surfaces within a month because no Siren requests arrive to renew. */
+const EXTENSION_LIVENESS_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Sets a server-only liveness cookie on every Siren response. Browser
+ * sessions never send Accept: application/vnd.siren+json, so wantsSiren
+ * alone identifies extension requests — no auth check needed, which means
+ * the cookie is set even on unauthenticated requests (e.g. the first GET /
+ * before login).
+ *
+ * The cookie is httpOnly so client-side scripts (including the extension's
+ * own content script) cannot forge or renew it. That's deliberate: the only
+ * way for `hutch_ext_alive` to stay set is for an installed extension to
+ * keep making Siren requests, so when the extension is uninstalled the
+ * cookie naturally lapses and the onboarding "install" step flips back to
+ * incomplete. The legacy `hutch_ext_installed` cookie (still written by the
+ * published extension's content script) is no longer used for onboarding.
+ *
+ * Also refreshes `hutch_ext_saved` if it's already present, so the
+ * "save your first article" milestone tracks extension liveness rather
+ * than sticking for a year past uninstall. We never *initialise* it here
+ * — only the save endpoints set it the first time. */
 export function initMarkExtensionInstalled() {
 	return (req: Request, res: Response, next: NextFunction) => {
 		if (wantsSiren(req)) {
-			res.cookie(COOKIE_NAME, COOKIE_VALUE, {
+			res.cookie(ALIVE_COOKIE_NAME, ALIVE_COOKIE_VALUE, {
 				path: "/",
-				maxAge: 365 * 24 * 60 * 60 * 1000,
+				maxAge: EXTENSION_LIVENESS_TTL_MS,
 				sameSite: "lax",
+				httpOnly: true,
 			});
+			if (req.cookies?.[SAVE_COOKIE_NAME] === SAVE_COOKIE_VALUE) {
+				res.cookie(SAVE_COOKIE_NAME, SAVE_COOKIE_VALUE, {
+					path: "/",
+					maxAge: EXTENSION_LIVENESS_TTL_MS,
+					sameSite: "lax",
+					httpOnly: true,
+				});
+			}
 		}
 		next();
 	};

--- a/projects/hutch/src/runtime/web/mark-extension-installed.middleware.ts
+++ b/projects/hutch/src/runtime/web/mark-extension-installed.middleware.ts
@@ -2,36 +2,15 @@ import type { Request, Response, NextFunction } from "express";
 import {
 	ALIVE_COOKIE_NAME,
 	ALIVE_COOKIE_VALUE,
+	EXTENSION_LIVENESS_TTL_MS,
 	SAVE_COOKIE_NAME,
 	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
 import { wantsSiren } from "./content-negotiation";
 
-/** 30 days. Refreshed on every Siren request the extension makes (popup
- * opens, toolbar saves, the keyboard shortcut). Long enough that an active
- * user with the extension installed but not opening the popup for a few
- * weeks doesn't see the onboarding flicker; short enough that an uninstall
- * surfaces within a month because no Siren requests arrive to renew. */
-const EXTENSION_LIVENESS_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-
-/** Sets a server-only liveness cookie on every Siren response. Browser
- * sessions never send Accept: application/vnd.siren+json, so wantsSiren
- * alone identifies extension requests — no auth check needed, which means
- * the cookie is set even on unauthenticated requests (e.g. the first GET /
- * before login).
- *
- * The cookie is httpOnly so client-side scripts (including the extension's
- * own content script) cannot forge or renew it. That's deliberate: the only
- * way for `hutch_ext_alive` to stay set is for an installed extension to
- * keep making Siren requests, so when the extension is uninstalled the
- * cookie naturally lapses and the onboarding "install" step flips back to
- * incomplete. The legacy `hutch_ext_installed` cookie (still written by the
- * published extension's content script) is no longer used for onboarding.
- *
- * Also refreshes `hutch_ext_saved` if it's already present, so the
- * "save your first article" milestone tracks extension liveness rather
- * than sticking for a year past uninstall. We never *initialise* it here
- * — only the save endpoints set it the first time. */
+/** Sets httpOnly liveness cookies on every Siren response (which only the
+ * extension makes). Also refreshes hutch_ext_saved while present so both
+ * cookies lapse together after uninstall. */
 export function initMarkExtensionInstalled() {
 	return (req: Request, res: Response, next: NextFunction) => {
 		if (wantsSiren(req)) {

--- a/projects/hutch/src/runtime/web/onboarding/extension-install.ts
+++ b/projects/hutch/src/runtime/web/onboarding/extension-install.ts
@@ -1,5 +1,5 @@
 import type { Request } from "express";
-import { COOKIE_NAME, COOKIE_VALUE, SAVE_COOKIE_NAME, SAVE_COOKIE_VALUE } from "@packages/onboarding-extension-signal";
+import { ALIVE_COOKIE_NAME, ALIVE_COOKIE_VALUE, SAVE_COOKIE_NAME, SAVE_COOKIE_VALUE } from "@packages/onboarding-extension-signal";
 import type { BrowserName } from "./onboarding.types";
 
 const INSTALL_URLS: Record<BrowserName, string> = {
@@ -8,8 +8,13 @@ const INSTALL_URLS: Record<BrowserName, string> = {
 	other: "/install",
 };
 
+/** Reads the server-only liveness cookie. The legacy hutch_ext_installed
+ * cookie (writable from the extension's content script) is intentionally
+ * ignored here — its presence does not prove the extension is currently
+ * installed, only that an extension was once installed in this browser
+ * within the last year. See mark-extension-installed.middleware.ts. */
 export function isExtensionInstalled(req: Request): boolean {
-	return req.cookies?.[COOKIE_NAME] === COOKIE_VALUE;
+	return req.cookies?.[ALIVE_COOKIE_NAME] === ALIVE_COOKIE_VALUE;
 }
 
 export function isExtensionSavedArticle(req: Request): boolean {

--- a/projects/hutch/src/runtime/web/onboarding/extension-install.ts
+++ b/projects/hutch/src/runtime/web/onboarding/extension-install.ts
@@ -8,11 +8,8 @@ const INSTALL_URLS: Record<BrowserName, string> = {
 	other: "/install",
 };
 
-/** Reads the server-only liveness cookie. The legacy hutch_ext_installed
- * cookie (writable from the extension's content script) is intentionally
- * ignored here — its presence does not prove the extension is currently
- * installed, only that an extension was once installed in this browser
- * within the last year. See mark-extension-installed.middleware.ts. */
+/** True when the extension is actively installed (server-only liveness
+ * cookie is present and not yet expired). */
 export function isExtensionInstalled(req: Request): boolean {
 	return req.cookies?.[ALIVE_COOKIE_NAME] === ALIVE_COOKIE_VALUE;
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import {
+	ALIVE_COOKIE_NAME,
+	ALIVE_COOKIE_VALUE,
 	COOKIE_NAME,
 	COOKIE_VALUE,
 	DISMISS_COOKIE_NAME,
@@ -81,7 +83,25 @@ describe("Queue onboarding", () => {
 		expect(step.getAttribute("data-test-onboarding-complete")).toBe("true");
 	});
 
-	it("marks install-extension complete when extension cookie is present", async () => {
+	it("marks install-extension complete when alive cookie is present", async () => {
+		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const agent = await loginAgent(app, auth);
+
+		const response = await agent
+			.get("/queue")
+			.set("Cookie", `${ALIVE_COOKIE_NAME}=${ALIVE_COOKIE_VALUE}`);
+
+		const doc = new JSDOM(response.text).window.document;
+		const step = doc.querySelector('[data-test-onboarding-step="install-extension"]');
+		assert(step, "install-extension step must be rendered");
+		expect(step.getAttribute("data-test-onboarding-complete")).toBe("true");
+	});
+
+	/** The legacy hutch_ext_installed cookie is writable from the extension's
+	 * content script and persists for a year, so its presence does not prove
+	 * the extension is currently installed. The server must ignore it for
+	 * onboarding purposes — only the httpOnly hutch_ext_alive cookie counts. */
+	it("does not mark install-extension complete when only the legacy hutch_ext_installed cookie is present", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const agent = await loginAgent(app, auth);
 
@@ -92,16 +112,16 @@ describe("Queue onboarding", () => {
 		const doc = new JSDOM(response.text).window.document;
 		const step = doc.querySelector('[data-test-onboarding-step="install-extension"]');
 		assert(step, "install-extension step must be rendered");
-		expect(step.getAttribute("data-test-onboarding-complete")).toBe("true");
+		expect(step.getAttribute("data-test-onboarding-complete")).toBe("false");
 	});
 
-	it("shows success message when both the install and extension-save cookies are present", async () => {
+	it("shows success message when both the alive and extension-save cookies are present", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const agent = await loginAgent(app, auth);
 
 		const response = await agent
 			.get("/queue")
-			.set("Cookie", `${COOKIE_NAME}=${COOKIE_VALUE}; ${SAVE_COOKIE_NAME}=${SAVE_COOKIE_VALUE}`);
+			.set("Cookie", `${ALIVE_COOKIE_NAME}=${ALIVE_COOKIE_VALUE}; ${SAVE_COOKIE_NAME}=${SAVE_COOKIE_VALUE}`);
 
 		const doc = new JSDOM(response.text).window.document;
 		const onboarding = doc.querySelector("[data-test-onboarding]");
@@ -161,7 +181,7 @@ describe("Queue onboarding", () => {
 
 		const response = await agent
 			.get("/queue?status=read")
-			.set("Cookie", `${COOKIE_NAME}=${COOKIE_VALUE}; ${SAVE_COOKIE_NAME}=${SAVE_COOKIE_VALUE}`);
+			.set("Cookie", `${ALIVE_COOKIE_NAME}=${ALIVE_COOKIE_VALUE}; ${SAVE_COOKIE_NAME}=${SAVE_COOKIE_VALUE}`);
 
 		const doc = new JSDOM(response.text).window.document;
 		const onboarding = doc.querySelector("[data-test-onboarding]");
@@ -175,39 +195,41 @@ describe("Queue onboarding", () => {
 	/** Dismissal hides the onboarding only when *both* cookies are present together.
 	 *
 	 * The dismiss button only appears in the success state, which requires the
-	 * install-extension step to be complete — meaning the install cookie was set in
+	 * install-extension step to be complete — meaning the alive cookie was set in
 	 * this browser at the moment of dismissal. So the only way to reach
-	 * "dismiss cookie present, install cookie absent" is if the user has moved to
-	 * a different context where the install cookie doesn't apply:
+	 * "dismiss cookie present, alive cookie absent" is if the user has moved to
+	 * a different context where the alive cookie doesn't apply:
 	 *
 	 *   - Same user, different browser. The user installed the extension in
 	 *     Browser A and dismissed there. Cookies are browser-scoped, so Browser B
 	 *     normally has neither cookie — but if the dismiss cookie is carried over
-	 *     (profile import, manual cookie copy, sync tooling) without the install
+	 *     (profile import, manual cookie copy, sync tooling) without the alive
 	 *     cookie, Browser B still needs the extension installed locally.
-	 *   - Same browser, install cookie lost. The user uninstalled the extension
-	 *     after dismissing, or cleared the install cookie selectively. The dismiss
-	 *     should not silently suppress the prompt to reinstall.
+	 *   - Same browser, extension uninstalled after dismissing. The alive cookie
+	 *     stops being renewed and lapses; the dismiss should not silently
+	 *     suppress the prompt to reinstall once that happens.
 	 *
-	 * The two tests below pin both directions of the rule:
+	 * The three tests below pin all directions of the rule:
 	 *   1. Both cookies present → onboarding stays hidden (the happy path).
 	 *   2. Dismiss cookie alone → onboarding re-renders with install-extension
 	 *      marked incomplete, so the user is prompted to install in this browser.
+	 *   3. Dismiss + legacy hutch_ext_installed without alive → onboarding
+	 *      re-renders, proving the legacy cookie does not satisfy dismissal.
 	 */
-	it("does not render onboarding when dismiss cookie matches current version and extension is installed", async () => {
+	it("does not render onboarding when dismiss cookie matches current version and extension is alive", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const agent = await loginAgent(app, auth);
 
 		const response = await agent
 			.get("/queue")
-			.set("Cookie", `${DISMISS_COOKIE_NAME}=${ONBOARDING_VERSION}; ${COOKIE_NAME}=${COOKIE_VALUE}`);
+			.set("Cookie", `${DISMISS_COOKIE_NAME}=${ONBOARDING_VERSION}; ${ALIVE_COOKIE_NAME}=${ALIVE_COOKIE_VALUE}`);
 
 		const doc = new JSDOM(response.text).window.document;
 		const onboarding = doc.querySelector("[data-test-onboarding]");
 		expect(onboarding).toBeNull();
 	});
 
-	it("re-renders onboarding when dismiss cookie is present but extension cookie is missing", async () => {
+	it("re-renders onboarding when dismiss cookie is present but alive cookie is missing", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const agent = await loginAgent(app, auth);
 
@@ -224,13 +246,35 @@ describe("Queue onboarding", () => {
 		expect(installStep.getAttribute("data-test-onboarding-complete")).toBe("false");
 	});
 
+	/** The exact bug this branch fixes: user installs the extension, completes
+	 * onboarding, dismisses it, then uninstalls the extension. The legacy
+	 * hutch_ext_installed cookie persists in the browser jar (1-year TTL,
+	 * written by the content script) but the httpOnly hutch_ext_alive lapses
+	 * once Siren requests stop. Onboarding must come back. */
+	it("re-renders onboarding after uninstall (dismiss + legacy cookie present, alive cookie missing)", async () => {
+		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const agent = await loginAgent(app, auth);
+
+		const response = await agent
+			.get("/queue")
+			.set("Cookie", `${DISMISS_COOKIE_NAME}=${ONBOARDING_VERSION}; ${COOKIE_NAME}=${COOKIE_VALUE}`);
+
+		const doc = new JSDOM(response.text).window.document;
+		const onboarding = doc.querySelector("[data-test-onboarding]");
+		assert(onboarding, "onboarding must re-render once the extension stops renewing the alive cookie");
+		expect(onboarding.classList.contains("onboarding--visible")).toBe(true);
+		const installStep = doc.querySelector('[data-test-onboarding-step="install-extension"]');
+		assert(installStep);
+		expect(installStep.getAttribute("data-test-onboarding-complete")).toBe("false");
+	});
+
 	it("re-renders onboarding when dismiss cookie has a stale version", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const agent = await loginAgent(app, auth);
 
 		const response = await agent
 			.get("/queue")
-			.set("Cookie", `${DISMISS_COOKIE_NAME}=stale-version; ${COOKIE_NAME}=${COOKIE_VALUE}`);
+			.set("Cookie", `${DISMISS_COOKIE_NAME}=stale-version; ${ALIVE_COOKIE_NAME}=${ALIVE_COOKIE_VALUE}`);
 
 		const doc = new JSDOM(response.text).window.document;
 		const onboarding = doc.querySelector("[data-test-onboarding]");

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -56,10 +56,11 @@ import {
 } from "../../onboarding/extension-install";
 
 function markExtensionSavedArticle(res: Response): void {
-	// Only Siren-only save endpoints call this; the form-based /queue/save path doesn't, so the onboarding step is gated on extension saves alone.
+	/** 1. Only Siren-only save endpoints call this; the form-based /queue/save path doesn't, so the onboarding step is gated on extension saves alone.
+	 *  2. 30 days. mark-extension-installed.middleware.ts refreshes this cookie on every Siren request while it's present, so an active extension keeps the step ticked and an uninstalled one lets it lapse — same liveness model as ALIVE_COOKIE_NAME. */
 	res.cookie(SAVE_COOKIE_NAME, SAVE_COOKIE_VALUE, {
 		path: "/",
-		maxAge: 365 * 24 * 60 * 60 * 1000,
+		maxAge: 30 * 24 * 60 * 60 * 1000, /* 2 */
 		sameSite: "lax",
 		httpOnly: true,
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import {
 	DISMISS_COOKIE_NAME,
+	EXTENSION_LIVENESS_TTL_MS,
 	SAVE_COOKIE_NAME,
 	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
@@ -56,11 +57,9 @@ import {
 } from "../../onboarding/extension-install";
 
 function markExtensionSavedArticle(res: Response): void {
-	/** 1. Only Siren-only save endpoints call this; the form-based /queue/save path doesn't, so the onboarding step is gated on extension saves alone.
-	 *  2. 30 days. mark-extension-installed.middleware.ts refreshes this cookie on every Siren request while it's present, so an active extension keeps the step ticked and an uninstalled one lets it lapse — same liveness model as ALIVE_COOKIE_NAME. */
 	res.cookie(SAVE_COOKIE_NAME, SAVE_COOKIE_VALUE, {
 		path: "/",
-		maxAge: 30 * 24 * 60 * 60 * 1000, /* 2 */
+		maxAge: EXTENSION_LIVENESS_TTL_MS,
 		sameSite: "lax",
 		httpOnly: true,
 	});

--- a/src/packages/onboarding-extension-signal/src/index.ts
+++ b/src/packages/onboarding-extension-signal/src/index.ts
@@ -1,16 +1,35 @@
+/** Legacy cookie. Still written by the published extension's content script
+ * via `markExtensionInstalled()` on every Readplace page load (the bundled
+ * copy of this package shipped with each extension version). The server no
+ * longer reads it for onboarding — that signal moved to ALIVE_COOKIE_NAME,
+ * which is httpOnly so a stale or forged client-side write can't keep the
+ * onboarding ticked after the extension is uninstalled. */
 export const COOKIE_NAME = "hutch_ext_installed";
 export const COOKIE_VALUE = "1";
+
+/** Set by the server on every Siren request (Accept: application/vnd.siren+json),
+ * which only the extension makes. httpOnly so the client cannot forge or
+ * renew it; ~30-day TTL so an uninstalled extension stops renewing the
+ * cookie and the onboarding "install" step flips back to incomplete within
+ * a month. */
+export const ALIVE_COOKIE_NAME = "hutch_ext_alive";
+export const ALIVE_COOKIE_VALUE = "1";
 
 /** Set by the server on successful saves through the extension's Siren save
  * endpoints (POST /queue, POST /queue/save-html). The onboarding "save your
  * first article" step uses this cookie so that only saves that came from the
- * browser extension count — saves through the web form on /queue do not. */
+ * browser extension count — saves through the web form on /queue do not.
+ * Renewed on every Siren request while present so it tracks extension
+ * liveness rather than persisting for a year past uninstall. */
 export const SAVE_COOKIE_NAME = "hutch_ext_saved";
 export const SAVE_COOKIE_VALUE = "1";
 
 export const DISMISS_COOKIE_NAME = "hutch_onboarding_dismissed";
 
-/** Called by the browser extension content script on Readplace pages. */
+/** Called by the browser extension content script on Readplace pages. The
+ * cookie it writes is no longer used by the server for onboarding (see
+ * ALIVE_COOKIE_NAME); kept for compatibility with deployed extension
+ * versions that bundle this function. */
 export function markExtensionInstalled(): void {
 	// biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API is unavailable in Firefox/Safari content scripts; document.cookie is the cross-browser path
 	document.cookie = `${COOKIE_NAME}=${COOKIE_VALUE}; path=/; max-age=31536000; SameSite=Lax`;

--- a/src/packages/onboarding-extension-signal/src/index.ts
+++ b/src/packages/onboarding-extension-signal/src/index.ts
@@ -1,35 +1,28 @@
-/** Legacy cookie. Still written by the published extension's content script
- * via `markExtensionInstalled()` on every Readplace page load (the bundled
- * copy of this package shipped with each extension version). The server no
- * longer reads it for onboarding — that signal moved to ALIVE_COOKIE_NAME,
- * which is httpOnly so a stale or forged client-side write can't keep the
- * onboarding ticked after the extension is uninstalled. */
+/** Legacy cookie written by deployed extension content scripts. The server
+ * ignores it for onboarding — see ALIVE_COOKIE_NAME. */
 export const COOKIE_NAME = "hutch_ext_installed";
 export const COOKIE_VALUE = "1";
 
-/** Set by the server on every Siren request (Accept: application/vnd.siren+json),
- * which only the extension makes. httpOnly so the client cannot forge or
- * renew it; ~30-day TTL so an uninstalled extension stops renewing the
- * cookie and the onboarding "install" step flips back to incomplete within
- * a month. */
+/** httpOnly cookie set by the server on every Siren request. Only the
+ * extension makes Siren requests, so when it's uninstalled the cookie
+ * lapses and the onboarding "install" step flips back to incomplete. */
 export const ALIVE_COOKIE_NAME = "hutch_ext_alive";
 export const ALIVE_COOKIE_VALUE = "1";
 
-/** Set by the server on successful saves through the extension's Siren save
- * endpoints (POST /queue, POST /queue/save-html). The onboarding "save your
- * first article" step uses this cookie so that only saves that came from the
- * browser extension count — saves through the web form on /queue do not.
- * Renewed on every Siren request while present so it tracks extension
- * liveness rather than persisting for a year past uninstall. */
+/** Shared TTL for all extension-liveness cookies (alive + saved). Long
+ * enough that an active user doesn't see onboarding flicker; short enough
+ * that an uninstall surfaces within a month. */
+export const EXTENSION_LIVENESS_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** httpOnly cookie set on extension saves only (not web-form saves).
+ * Renewed by the middleware while present so it tracks extension liveness. */
 export const SAVE_COOKIE_NAME = "hutch_ext_saved";
 export const SAVE_COOKIE_VALUE = "1";
 
 export const DISMISS_COOKIE_NAME = "hutch_onboarding_dismissed";
 
-/** Called by the browser extension content script on Readplace pages. The
- * cookie it writes is no longer used by the server for onboarding (see
- * ALIVE_COOKIE_NAME); kept for compatibility with deployed extension
- * versions that bundle this function. */
+/** Kept for compatibility with deployed extension versions that bundle
+ * this function. The cookie it writes is not used for onboarding. */
 export function markExtensionInstalled(): void {
 	// biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API is unavailable in Firefox/Safari content scripts; document.cookie is the cross-browser path
 	document.cookie = `${COOKIE_NAME}=${COOKIE_VALUE}; path=/; max-age=31536000; SameSite=Lax`;


### PR DESCRIPTION
## Summary

Once a user installed the extension, dismissed onboarding, then uninstalled (or wiped their profile / switched browser / cleared part of their cookie jar), the install + save-first-article checkboxes stayed ticked for up to a year and the onboarding banner stayed hidden. The product silently lied about what was actually installed.

## Why the bug existed

`hutch_ext_installed` had a 365-day TTL and was renewed by **two** independent paths:
- The extension's content script writing `document.cookie = "hutch_ext_installed=1; max-age=31536000"` on every Readplace page load (deployed code, not changeable without republishing the Chrome and Firefox extensions — weeks of store review).
- The hutch middleware setting it on every Siren request.

Neither path cleared the cookie when the extension was uninstalled. `hutch_ext_saved` had the same shape (365 days, no liveness check). The dismissal logic at `queue.page.ts:156` is gated on `extensionInstalled && dismiss === ONBOARDING_VERSION` — that branch was already correct, but `extensionInstalled` never flipped back to `false` in production.

## Fix (server-only, no extension republish)

1. **New `hutch_ext_alive` cookie** — `httpOnly`, **30-day TTL**, set by the existing `mark-extension-installed.middleware.ts` on every Siren request. Because it's `httpOnly`, the extension's content script (or any other JS) cannot forge or renew it via `document.cookie`. The only way it stays set is for an installed extension to keep making Siren requests.
2. `isExtensionInstalled(req)` now reads `hutch_ext_alive` instead of `hutch_ext_installed`. The legacy cookie is still written by deployed extensions but is intentionally ignored on the server.
3. **Cut `hutch_ext_saved` from 365d → 30d** and renew it from the same middleware while present, so the "save first article" milestone tracks extension liveness instead of persisting for a year past uninstall.
4. The dismiss cookie can stay 1-year — once `extensionInstalled` flips back to `false`, the dismissal is implicitly ignored and the onboarding re-renders.

## Behaviour change worth flagging

Users who install the extension but never open the popup (or use the Cmd/Ctrl+D shortcut) will see the install step show as **incomplete** until they actually use the extension once. Today the content-script's page-load write makes the step flip to complete just from loading any Readplace page — even if the user never touched the toolbar. Under this PR, the trigger is "the user actually invoked the extension" instead of "the extension was loaded by the browser". This is arguably more honest, and aligns the install step with the save-first-article step (which has always required a real extension action).

## Test plan

- [x] `pnpm nx run hutch:check` (lint + 100% coverage) — passes
- [x] `pnpm nx run hutch:test-integration` — passes
- [x] **New regression test**: `re-renders onboarding after uninstall (dismiss + legacy cookie present, alive cookie missing)` — pins the exact bug scenario
- [x] **New regression test**: `does not mark install-extension complete when only the legacy hutch_ext_installed cookie is present` — pins that the server stops trusting the content-script-written cookie
- [x] **New middleware tests**: `sets the alive cookie as httpOnly`, `renews the hutch_ext_saved cookie on a Siren request when it is already present`, `does not set hutch_ext_saved on a Siren request when the cookie is absent`
- [ ] Verified locally: install extension, dismiss onboarding, uninstall, return to `/queue` → onboarding visible with install step incomplete (within 30 days of last Siren call)

https://claude.ai/code/session_018razYuhVfZf5t8DtETBK8T

---
_Generated by [Claude Code](https://claude.ai/code/session_018razYuhVfZf5t8DtETBK8T)_