### PR TITLE
feat: cap auto-heal retries per URL with TTL-based reset

### DIFF
--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -51,6 +51,7 @@ const { publishUpdateFetchTimestamp } = initInMemoryUpdateFetchTimestamp({ logge
 const { refreshArticleIfStale } = initRefreshArticleIfStale({
   findArticleFreshness: fixture.articleStore.findArticleFreshness,
   findArticleCrawlStatus: fixture.articleCrawl.findArticleCrawlStatus,
+  incrementCrawlAutoHealAttempt: fixture.articleCrawl.incrementCrawlAutoHealAttempt,
   crawlArticle,
   parseHtml,
   publishRefreshArticleContent,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -25,7 +25,7 @@ import { initInMemoryPasswordReset } from "@packages/test-fixtures/providers/pas
 import { initDynamoDbPasswordReset } from "./providers/password-reset/dynamodb-password-reset";
 import { initDynamoDbGeneratedSummary } from "./providers/article-summary/dynamodb-generated-summary";
 import { initDynamoDbArticleCrawl } from "./providers/article-crawl/dynamodb-article-crawl";
-import { initInMemoryArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import { initInMemoryArticleCrawl, initIncrementCrawlAutoHealAttempt } from "@packages/test-fixtures/providers/article-crawl";
 import { S3Client } from "@aws-sdk/client-s3";
 import { initS3ReadContent } from "./providers/article-store/s3-read-content";
 import { initReadArticleContent } from "@packages/test-fixtures/providers/article-store";
@@ -122,10 +122,14 @@ function initProviders() {
 		const { publishUpdateFetchTimestamp } = initEventBridgeUpdateFetchTimestamp({ publishEvent });
 		const { publishExportUserDataCommand } = initEventBridgeExportUserDataCommand({ publishEvent });
 		const { putPendingHtml } = initPutPendingHtml({ client: new S3Client({}), bucketName: pendingHtmlBucketName });
+		const { incrementCrawlAutoHealAttempt } = initIncrementCrawlAutoHealAttempt({
+			findAutoHealState: crawlStore.findAutoHealState,
+			writeAutoHealAttempt: crawlStore.writeAutoHealAttempt,
+		});
 		const { refreshArticleIfStale } = initRefreshArticleIfStale({
 			findArticleFreshness: articleStore.findArticleFreshness,
 			findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
-			incrementCrawlAutoHealAttempt: crawlStore.incrementCrawlAutoHealAttempt,
+			incrementCrawlAutoHealAttempt,
 			crawlArticle,
 			parseHtml,
 			publishRefreshArticleContent,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -125,6 +125,7 @@ function initProviders() {
 		const { refreshArticleIfStale } = initRefreshArticleIfStale({
 			findArticleFreshness: articleStore.findArticleFreshness,
 			findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
+			incrementCrawlAutoHealAttempt: crawlStore.incrementCrawlAutoHealAttempt,
 			crawlArticle,
 			parseHtml,
 			publishRefreshArticleContent,
@@ -271,6 +272,7 @@ function initProviders() {
 	const { refreshArticleIfStale } = initRefreshArticleIfStale({
 		findArticleFreshness: articleStore.findArticleFreshness,
 		findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
+		incrementCrawlAutoHealAttempt: crawlStore.incrementCrawlAutoHealAttempt,
 		crawlArticle,
 		parseHtml,
 		publishRefreshArticleContent,

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
@@ -219,86 +219,82 @@ describe("initDynamoDbArticleCrawl", () => {
 		});
 	});
 
-	describe("incrementCrawlAutoHealAttempt", () => {
-		it("issues an atomic ADD with a cap-or-TTL guard and returns 'reprimed' when the condition passes", async () => {
+	describe("findAutoHealState", () => {
+		it("returns undefined when the row has no auto-heal attributes", async () => {
+			const { findAutoHealState } = initDynamoDbArticleCrawl({
+				client: clientReturning({ url: URL, crawlStatus: "failed", crawlFailureReason: "blocked" }),
+				tableName: TABLE,
+			});
+
+			expect(await findAutoHealState(URL)).toBeUndefined();
+		});
+
+		it("returns the auto-heal state when both attributes are present", async () => {
+			const { findAutoHealState } = initDynamoDbArticleCrawl({
+				client: clientReturning({
+					url: URL,
+					crawlStatus: "failed",
+					crawlFailureReason: "blocked",
+					crawlAutoHealAttempts: 2,
+					crawlAutoHealLastAttemptAt: "2026-05-10T05:00:00.000Z",
+				}),
+				tableName: TABLE,
+			});
+
+			expect(await findAutoHealState(URL)).toEqual({
+				attempts: 2,
+				lastAttemptAtIso: "2026-05-10T05:00:00.000Z",
+			});
+		});
+	});
+
+	describe("writeAutoHealAttempt", () => {
+		it("issues a SET with the provided count and timestamp", async () => {
 			let received: unknown;
 			const client = createFakeClient((input) => {
 				received = input;
 				return {};
 			});
-			const { incrementCrawlAutoHealAttempt } = initDynamoDbArticleCrawl({
+			const { writeAutoHealAttempt } = initDynamoDbArticleCrawl({
 				client: client as DynamoDBDocumentClient,
 				tableName: TABLE,
 			});
 
-			const result = await incrementCrawlAutoHealAttempt({
+			await writeAutoHealAttempt({
 				url: URL,
-				nowIso: "2026-05-10T05:00:00.000Z",
-				maxAttempts: 3,
-				ttlMs: 24 * 60 * 60 * 1000,
+				attempts: 3,
+				lastAttemptAtIso: "2026-05-10T05:00:00.000Z",
 			});
 
-			expect(result).toBe("reprimed");
 			const command = received as {
 				input: {
 					UpdateExpression?: string;
-					ConditionExpression?: string;
 					ExpressionAttributeValues?: Record<string, unknown>;
 				};
 			};
 			expect(command.input.UpdateExpression).toBe(
-				"ADD crawlAutoHealAttempts :one SET crawlAutoHealLastAttemptAt = :nowIso",
+				"SET crawlAutoHealAttempts = :attempts, crawlAutoHealLastAttemptAt = :lastAt",
 			);
-			expect(command.input.ConditionExpression).toBe(
-				"attribute_not_exists(crawlAutoHealAttempts) OR crawlAutoHealAttempts < :maxAttempts OR crawlAutoHealLastAttemptAt < :ttlCutoffIso",
-			);
-			expect(command.input.ExpressionAttributeValues?.[":one"]).toBe(1);
-			expect(command.input.ExpressionAttributeValues?.[":nowIso"]).toBe(
+			expect(command.input.ExpressionAttributeValues?.[":attempts"]).toBe(3);
+			expect(command.input.ExpressionAttributeValues?.[":lastAt"]).toBe(
 				"2026-05-10T05:00:00.000Z",
 			);
-			expect(command.input.ExpressionAttributeValues?.[":maxAttempts"]).toBe(3);
-			expect(command.input.ExpressionAttributeValues?.[":ttlCutoffIso"]).toBe(
-				"2026-05-09T05:00:00.000Z",
-			);
 		});
 
-		it("returns 'capped' when the conditional check fails (cap reached inside TTL)", async () => {
-			const client = createFakeClient(() => {
-				throw new ConditionalCheckFailedException({
-					$metadata: {},
-					message: "condition failed",
-				});
-			});
-			const { incrementCrawlAutoHealAttempt } = initDynamoDbArticleCrawl({
-				client: client as DynamoDBDocumentClient,
-				tableName: TABLE,
-			});
-
-			const result = await incrementCrawlAutoHealAttempt({
-				url: URL,
-				nowIso: "2026-05-10T05:00:00.000Z",
-				maxAttempts: 3,
-				ttlMs: 24 * 60 * 60 * 1000,
-			});
-
-			expect(result).toBe("capped");
-		});
-
-		it("rethrows non-ConditionalCheck errors (e.g. throttling)", async () => {
+		it("propagates DynamoDB errors", async () => {
 			const client = createFakeClient(() => {
 				throw new Error("throttled");
 			});
-			const { incrementCrawlAutoHealAttempt } = initDynamoDbArticleCrawl({
+			const { writeAutoHealAttempt } = initDynamoDbArticleCrawl({
 				client: client as DynamoDBDocumentClient,
 				tableName: TABLE,
 			});
 
 			await expect(
-				incrementCrawlAutoHealAttempt({
+				writeAutoHealAttempt({
 					url: URL,
-					nowIso: "2026-05-10T05:00:00.000Z",
-					maxAttempts: 3,
-					ttlMs: 24 * 60 * 60 * 1000,
+					attempts: 1,
+					lastAttemptAtIso: "2026-05-10T05:00:00.000Z",
 				}),
 			).rejects.toThrow("throttled");
 		});

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
@@ -218,4 +218,89 @@ describe("initDynamoDbArticleCrawl", () => {
 			);
 		});
 	});
+
+	describe("incrementCrawlAutoHealAttempt", () => {
+		it("issues an atomic ADD with a cap-or-TTL guard and returns 'reprimed' when the condition passes", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { incrementCrawlAutoHealAttempt } = initDynamoDbArticleCrawl({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			const result = await incrementCrawlAutoHealAttempt({
+				url: URL,
+				nowIso: "2026-05-10T05:00:00.000Z",
+				maxAttempts: 3,
+				ttlMs: 24 * 60 * 60 * 1000,
+			});
+
+			expect(result).toBe("reprimed");
+			const command = received as {
+				input: {
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.UpdateExpression).toBe(
+				"ADD crawlAutoHealAttempts :one SET crawlAutoHealLastAttemptAt = :nowIso",
+			);
+			expect(command.input.ConditionExpression).toBe(
+				"attribute_not_exists(crawlAutoHealAttempts) OR crawlAutoHealAttempts < :maxAttempts OR crawlAutoHealLastAttemptAt < :ttlCutoffIso",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":one"]).toBe(1);
+			expect(command.input.ExpressionAttributeValues?.[":nowIso"]).toBe(
+				"2026-05-10T05:00:00.000Z",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":maxAttempts"]).toBe(3);
+			expect(command.input.ExpressionAttributeValues?.[":ttlCutoffIso"]).toBe(
+				"2026-05-09T05:00:00.000Z",
+			);
+		});
+
+		it("returns 'capped' when the conditional check fails (cap reached inside TTL)", async () => {
+			const client = createFakeClient(() => {
+				throw new ConditionalCheckFailedException({
+					$metadata: {},
+					message: "condition failed",
+				});
+			});
+			const { incrementCrawlAutoHealAttempt } = initDynamoDbArticleCrawl({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			const result = await incrementCrawlAutoHealAttempt({
+				url: URL,
+				nowIso: "2026-05-10T05:00:00.000Z",
+				maxAttempts: 3,
+				ttlMs: 24 * 60 * 60 * 1000,
+			});
+
+			expect(result).toBe("capped");
+		});
+
+		it("rethrows non-ConditionalCheck errors (e.g. throttling)", async () => {
+			const client = createFakeClient(() => {
+				throw new Error("throttled");
+			});
+			const { incrementCrawlAutoHealAttempt } = initDynamoDbArticleCrawl({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await expect(
+				incrementCrawlAutoHealAttempt({
+					url: URL,
+					nowIso: "2026-05-10T05:00:00.000Z",
+					maxAttempts: 3,
+					ttlMs: 24 * 60 * 60 * 1000,
+				}),
+			).rejects.toThrow("throttled");
+		});
+	});
 });

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
@@ -11,9 +11,10 @@ import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import type {
 	ArticleCrawl,
 	FindArticleCrawlStatus,
+	FindAutoHealState,
 	ForceMarkCrawlPending,
-	IncrementCrawlAutoHealAttempt,
 	MarkCrawlPending,
+	WriteAutoHealAttempt,
 } from "@packages/test-fixtures/providers/article-crawl";
 
 const ArticleCrawlRow = z.object({
@@ -29,6 +30,8 @@ const ArticleCrawlRow = z.object({
 			"crawl-content-uploaded",
 		]),
 	),
+	crawlAutoHealAttempts: dynamoField(z.number()),
+	crawlAutoHealLastAttemptAt: dynamoField(z.string()),
 });
 
 type ArticleCrawlRowShape = z.infer<typeof ArticleCrawlRow>;
@@ -65,7 +68,8 @@ export function initDynamoDbArticleCrawl(deps: {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;
-	incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt;
+	findAutoHealState: FindAutoHealState;
+	writeAutoHealAttempt: WriteAutoHealAttempt;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
@@ -109,47 +113,43 @@ export function initDynamoDbArticleCrawl(deps: {
 		});
 	};
 
-	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
+	const findAutoHealState: FindAutoHealState = async (url) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		const row = await table.get({ url: articleResourceUniqueId.value });
+		if (
+			row?.crawlAutoHealAttempts === undefined ||
+			row?.crawlAutoHealLastAttemptAt === undefined
+		) {
+			return undefined;
+		}
+		return {
+			attempts: row.crawlAutoHealAttempts,
+			lastAttemptAtIso: row.crawlAutoHealLastAttemptAt,
+		};
+	};
+
+	const writeAutoHealAttempt: WriteAutoHealAttempt = async ({
 		url,
-		nowIso,
-		maxAttempts,
-		ttlMs,
+		attempts,
+		lastAttemptAtIso,
 	}) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
-		const ttlCutoffIso = new Date(new Date(nowIso).getTime() - ttlMs).toISOString();
-		try {
-			await table.update({
-				Key: { url: articleResourceUniqueId.value },
-				// ADD treats a missing attribute as 0 + delta. Both writes happen
-				// atomically, so two concurrent reprimes can never both slip
-				// through at attempts=maxAttempts-1.
-				UpdateExpression:
-					"ADD crawlAutoHealAttempts :one SET crawlAutoHealLastAttemptAt = :nowIso",
-				// Allow the increment when any of:
-				//   - first attempt (counter not yet present)
-				//   - attempts strictly under the cap
-				//   - last attempt is older than the TTL window (operator/world
-				//     state may have changed; let the user try again)
-				ConditionExpression:
-					"attribute_not_exists(crawlAutoHealAttempts) OR crawlAutoHealAttempts < :maxAttempts OR crawlAutoHealLastAttemptAt < :ttlCutoffIso",
-				ExpressionAttributeValues: {
-					":one": 1,
-					":nowIso": nowIso,
-					":maxAttempts": maxAttempts,
-					":ttlCutoffIso": ttlCutoffIso,
-				},
-			});
-			return "reprimed";
-		} catch (err) {
-			if (err instanceof ConditionalCheckFailedException) return "capped";
-			throw err;
-		}
+		await table.update({
+			Key: { url: articleResourceUniqueId.value },
+			UpdateExpression:
+				"SET crawlAutoHealAttempts = :attempts, crawlAutoHealLastAttemptAt = :lastAt",
+			ExpressionAttributeValues: {
+				":attempts": attempts,
+				":lastAt": lastAttemptAtIso,
+			},
+		});
 	};
 
 	return {
 		findArticleCrawlStatus,
 		markCrawlPending,
 		forceMarkCrawlPending,
-		incrementCrawlAutoHealAttempt,
+		findAutoHealState,
+		writeAutoHealAttempt,
 	};
 }

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
@@ -12,6 +12,7 @@ import type {
 	ArticleCrawl,
 	FindArticleCrawlStatus,
 	ForceMarkCrawlPending,
+	IncrementCrawlAutoHealAttempt,
 	MarkCrawlPending,
 } from "@packages/test-fixtures/providers/article-crawl";
 
@@ -64,6 +65,7 @@ export function initDynamoDbArticleCrawl(deps: {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;
+	incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
@@ -107,5 +109,47 @@ export function initDynamoDbArticleCrawl(deps: {
 		});
 	};
 
-	return { findArticleCrawlStatus, markCrawlPending, forceMarkCrawlPending };
+	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
+		url,
+		nowIso,
+		maxAttempts,
+		ttlMs,
+	}) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		const ttlCutoffIso = new Date(new Date(nowIso).getTime() - ttlMs).toISOString();
+		try {
+			await table.update({
+				Key: { url: articleResourceUniqueId.value },
+				// ADD treats a missing attribute as 0 + delta. Both writes happen
+				// atomically, so two concurrent reprimes can never both slip
+				// through at attempts=maxAttempts-1.
+				UpdateExpression:
+					"ADD crawlAutoHealAttempts :one SET crawlAutoHealLastAttemptAt = :nowIso",
+				// Allow the increment when any of:
+				//   - first attempt (counter not yet present)
+				//   - attempts strictly under the cap
+				//   - last attempt is older than the TTL window (operator/world
+				//     state may have changed; let the user try again)
+				ConditionExpression:
+					"attribute_not_exists(crawlAutoHealAttempts) OR crawlAutoHealAttempts < :maxAttempts OR crawlAutoHealLastAttemptAt < :ttlCutoffIso",
+				ExpressionAttributeValues: {
+					":one": 1,
+					":nowIso": nowIso,
+					":maxAttempts": maxAttempts,
+					":ttlCutoffIso": ttlCutoffIso,
+				},
+			});
+			return "reprimed";
+		} catch (err) {
+			if (err instanceof ConditionalCheckFailedException) return "capped";
+			throw err;
+		}
+	};
+
+	return {
+		findArticleCrawlStatus,
+		markCrawlPending,
+		forceMarkCrawlPending,
+		incrementCrawlAutoHealAttempt,
+	};
 }

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -19,6 +19,7 @@ import type {
 import type {
 	FindArticleCrawlStatus,
 	ForceMarkCrawlPending,
+	IncrementCrawlAutoHealAttempt,
 	MarkCrawlPending,
 } from "@packages/test-fixtures/providers/article-crawl";
 import type {
@@ -144,6 +145,7 @@ export interface ArticleCrawlBundle {
 	markCrawlReady: InMemoryMarkCrawlReady;
 	markCrawlFailed: InMemoryMarkCrawlFailed;
 	markCrawlStage: InMemoryMarkCrawlStage;
+	incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt;
 }
 
 export interface ParserBundle {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
@@ -27,6 +27,7 @@ describe("Queue freshness integration", () => {
 		const { refreshArticleIfStale } = initRefreshArticleIfStale({
 			findArticleFreshness: fixture.articleStore.findArticleFreshness,
 			findArticleCrawlStatus: fixture.articleCrawl.findArticleCrawlStatus,
+			incrementCrawlAutoHealAttempt: fixture.articleCrawl.incrementCrawlAutoHealAttempt,
 			crawlArticle: async (params) => {
 				if (!params.etag && !params.lastModified) {
 					return {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -1714,6 +1714,7 @@ describe("Queue routes", () => {
  	markCrawlReady: fixture.articleCrawl.markCrawlReady,
  	markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
  	markCrawlStage: fixture.articleCrawl.markCrawlStage,
+ 	incrementCrawlAutoHealAttempt: fixture.articleCrawl.incrementCrawlAutoHealAttempt,
  },
 			});
 			const agent = await loginAgent(app, auth);
@@ -1768,6 +1769,7 @@ describe("Queue routes", () => {
  	markCrawlReady: fixture.articleCrawl.markCrawlReady,
  	markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
  	markCrawlStage: fixture.articleCrawl.markCrawlStage,
+ 	incrementCrawlAutoHealAttempt: fixture.articleCrawl.incrementCrawlAutoHealAttempt,
  },
 			});
 			const agent = await loginAgent(app, auth);
@@ -1818,6 +1820,7 @@ describe("Queue routes", () => {
 					markCrawlReady: fixture.articleCrawl.markCrawlReady,
 					markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
 					markCrawlStage: fixture.articleCrawl.markCrawlStage,
+					incrementCrawlAutoHealAttempt: fixture.articleCrawl.incrementCrawlAutoHealAttempt,
 				},
 				summary: {
 					findGeneratedSummary: async () => undefined,

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1040,6 +1040,7 @@ describe("View routes", () => {
  	markCrawlReady: fixture.articleCrawl.markCrawlReady,
  	markCrawlFailed: fixture.articleCrawl.markCrawlFailed,
  	markCrawlStage: fixture.articleCrawl.markCrawlStage,
+ 	incrementCrawlAutoHealAttempt: fixture.articleCrawl.incrementCrawlAutoHealAttempt,
  },
 				summary:{
  	findGeneratedSummary: findGeneratedSummary,

--- a/projects/save-link/src/crawl-article-state/increment-crawl-auto-heal-attempt.ts
+++ b/projects/save-link/src/crawl-article-state/increment-crawl-auto-heal-attempt.ts
@@ -1,0 +1,64 @@
+/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id";
+import type { IncrementCrawlAutoHealAttempt } from "@packages/test-fixtures/providers/article-crawl";
+
+const Row = z.object({
+	url: z.string(),
+});
+
+export function initIncrementCrawlAutoHealAttempt(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+}): { incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt } {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: Row,
+	});
+
+	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
+		url,
+		nowIso,
+		maxAttempts,
+		ttlMs,
+	}) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		const ttlCutoffIso = new Date(new Date(nowIso).getTime() - ttlMs).toISOString();
+		try {
+			await table.update({
+				Key: { url: articleResourceUniqueId.value },
+				// ADD treats a missing attribute as 0 + delta. Both writes happen
+				// atomically, so two concurrent reprimes can never both slip
+				// through at attempts=maxAttempts-1.
+				UpdateExpression:
+					"ADD crawlAutoHealAttempts :one SET crawlAutoHealLastAttemptAt = :nowIso",
+				// Allow the increment when any of:
+				//   - first attempt (counter not yet present)
+				//   - attempts strictly under the cap
+				//   - last attempt is older than the TTL window (operator/world
+				//     state may have changed; let the user try again)
+				ConditionExpression:
+					"attribute_not_exists(crawlAutoHealAttempts) OR crawlAutoHealAttempts < :maxAttempts OR crawlAutoHealLastAttemptAt < :ttlCutoffIso",
+				ExpressionAttributeValues: {
+					":one": 1,
+					":nowIso": nowIso,
+					":maxAttempts": maxAttempts,
+					":ttlCutoffIso": ttlCutoffIso,
+				},
+			});
+			return "reprimed";
+		} catch (err) {
+			if (err instanceof ConditionalCheckFailedException) return "capped";
+			throw err;
+		}
+	};
+
+	return { incrementCrawlAutoHealAttempt };
+}
+/* c8 ignore stop */

--- a/projects/save-link/src/crawl-article-state/increment-crawl-auto-heal-attempt.ts
+++ b/projects/save-link/src/crawl-article-state/increment-crawl-auto-heal-attempt.ts
@@ -1,64 +1,67 @@
 /* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
 import {
-	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
 	defineDynamoTable,
+	dynamoField,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id";
-import type { IncrementCrawlAutoHealAttempt } from "@packages/test-fixtures/providers/article-crawl";
+import type {
+	FindAutoHealState,
+	WriteAutoHealAttempt,
+} from "@packages/test-fixtures/providers/article-crawl";
 
 const Row = z.object({
 	url: z.string(),
+	crawlAutoHealAttempts: dynamoField(z.number()),
+	crawlAutoHealLastAttemptAt: dynamoField(z.string()),
 });
 
-export function initIncrementCrawlAutoHealAttempt(deps: {
+export function initAutoHealStore(deps: {
 	client: DynamoDBDocumentClient;
 	tableName: string;
-}): { incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt } {
+}): {
+	findAutoHealState: FindAutoHealState;
+	writeAutoHealAttempt: WriteAutoHealAttempt;
+} {
 	const table = defineDynamoTable({
 		client: deps.client,
 		tableName: deps.tableName,
 		schema: Row,
 	});
 
-	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
-		url,
-		nowIso,
-		maxAttempts,
-		ttlMs,
-	}) => {
+	const findAutoHealState: FindAutoHealState = async (url) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
-		const ttlCutoffIso = new Date(new Date(nowIso).getTime() - ttlMs).toISOString();
-		try {
-			await table.update({
-				Key: { url: articleResourceUniqueId.value },
-				// ADD treats a missing attribute as 0 + delta. Both writes happen
-				// atomically, so two concurrent reprimes can never both slip
-				// through at attempts=maxAttempts-1.
-				UpdateExpression:
-					"ADD crawlAutoHealAttempts :one SET crawlAutoHealLastAttemptAt = :nowIso",
-				// Allow the increment when any of:
-				//   - first attempt (counter not yet present)
-				//   - attempts strictly under the cap
-				//   - last attempt is older than the TTL window (operator/world
-				//     state may have changed; let the user try again)
-				ConditionExpression:
-					"attribute_not_exists(crawlAutoHealAttempts) OR crawlAutoHealAttempts < :maxAttempts OR crawlAutoHealLastAttemptAt < :ttlCutoffIso",
-				ExpressionAttributeValues: {
-					":one": 1,
-					":nowIso": nowIso,
-					":maxAttempts": maxAttempts,
-					":ttlCutoffIso": ttlCutoffIso,
-				},
-			});
-			return "reprimed";
-		} catch (err) {
-			if (err instanceof ConditionalCheckFailedException) return "capped";
-			throw err;
+		const row = await table.get({ url: articleResourceUniqueId.value });
+		if (
+			row?.crawlAutoHealAttempts === undefined ||
+			row?.crawlAutoHealLastAttemptAt === undefined
+		) {
+			return undefined;
 		}
+		return {
+			attempts: row.crawlAutoHealAttempts,
+			lastAttemptAtIso: row.crawlAutoHealLastAttemptAt,
+		};
 	};
 
-	return { incrementCrawlAutoHealAttempt };
+	const writeAutoHealAttempt: WriteAutoHealAttempt = async ({
+		url,
+		attempts,
+		lastAttemptAtIso,
+	}) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		await table.update({
+			Key: { url: articleResourceUniqueId.value },
+			UpdateExpression:
+				"SET crawlAutoHealAttempts = :attempts, crawlAutoHealLastAttemptAt = :lastAt",
+			ExpressionAttributeValues: {
+				":attempts": attempts,
+				":lastAt": lastAttemptAtIso,
+			},
+		});
+	};
+
+	return { findAutoHealState, writeAutoHealAttempt };
 }
 /* c8 ignore stop */

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -22,7 +22,8 @@ import { requireEnv } from "../require-env";
 import { initStaleCheckHandler } from "../save-link/stale-check-handler";
 import { initFindArticleFreshness } from "../crawl-article-state/find-article-freshness";
 import { initFindArticleCrawlStatus } from "../crawl-article-state/find-article-crawl-status";
-import { initIncrementCrawlAutoHealAttempt } from "../crawl-article-state/increment-crawl-auto-heal-attempt";
+import { initAutoHealStore } from "../crawl-article-state/increment-crawl-auto-heal-attempt";
+import { initIncrementCrawlAutoHealAttempt } from "@packages/test-fixtures/providers/article-crawl";
 
 // 24h: mirrors hutch app.ts's staleTtlMs. Reads of an article older than this
 // trigger a conditional GET against the source (304 → noop, 200 → re-extract).
@@ -93,9 +94,13 @@ const { findArticleCrawlStatus } = initFindArticleCrawlStatus({
 	tableName: articlesTable,
 });
 
-const { incrementCrawlAutoHealAttempt } = initIncrementCrawlAutoHealAttempt({
+const autoHealStore = initAutoHealStore({
 	client,
 	tableName: articlesTable,
+});
+const { incrementCrawlAutoHealAttempt } = initIncrementCrawlAutoHealAttempt({
+	findAutoHealState: autoHealStore.findAutoHealState,
+	writeAutoHealAttempt: autoHealStore.writeAutoHealAttempt,
 });
 
 const { refreshArticleIfStale } = initRefreshArticleIfStale({

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -22,6 +22,7 @@ import { requireEnv } from "../require-env";
 import { initStaleCheckHandler } from "../save-link/stale-check-handler";
 import { initFindArticleFreshness } from "../crawl-article-state/find-article-freshness";
 import { initFindArticleCrawlStatus } from "../crawl-article-state/find-article-crawl-status";
+import { initIncrementCrawlAutoHealAttempt } from "../crawl-article-state/increment-crawl-auto-heal-attempt";
 
 // 24h: mirrors hutch app.ts's staleTtlMs. Reads of an article older than this
 // trigger a conditional GET against the source (304 → noop, 200 → re-extract).
@@ -92,9 +93,15 @@ const { findArticleCrawlStatus } = initFindArticleCrawlStatus({
 	tableName: articlesTable,
 });
 
+const { incrementCrawlAutoHealAttempt } = initIncrementCrawlAutoHealAttempt({
+	client,
+	tableName: articlesTable,
+});
+
 const { refreshArticleIfStale } = initRefreshArticleIfStale({
 	findArticleFreshness,
 	findArticleCrawlStatus,
+	incrementCrawlAutoHealAttempt,
 	crawlArticle,
 	parseHtml,
 	publishRefreshArticleContent,

--- a/projects/save-link/src/select-content/promote-tier-to-canonical.ts
+++ b/projects/save-link/src/select-content/promote-tier-to-canonical.ts
@@ -94,7 +94,12 @@ export function initPromoteTierToCanonical(deps: {
 
 		await articleTable.update({
 			Key: { url: id.value },
-			UpdateExpression: `SET ${setClauses.join(", ")} REMOVE crawlFailureReason, crawlFailedAt`,
+			// Clear the auto-heal counters atomically with the promote so a row
+			// that recovered (e.g. after Phase 2's bigger Lambda budget) gets a
+			// fresh budget against the next failure window. The cap (Phase 3)
+			// only applies inside the freshness path; resetting here is what
+			// keeps it from carrying stale state across successful crawls.
+			UpdateExpression: `SET ${setClauses.join(", ")} REMOVE crawlFailureReason, crawlFailedAt, crawlAutoHealAttempts, crawlAutoHealLastAttemptAt`,
 			ExpressionAttributeValues: values,
 		});
 	};

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -24,6 +24,7 @@ import type {
 import type {
 	FindArticleCrawlStatus,
 	ForceMarkCrawlPending,
+	IncrementCrawlAutoHealAttempt,
 	MarkCrawlPending,
 } from "./providers/article-crawl/article-crawl.types";
 import type {
@@ -149,6 +150,7 @@ export interface ArticleCrawlBundle {
 	markCrawlReady: InMemoryMarkCrawlReady;
 	markCrawlFailed: InMemoryMarkCrawlFailed;
 	markCrawlStage: InMemoryMarkCrawlStage;
+	incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt;
 }
 
 export interface ParserBundle {

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -263,6 +263,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 			markCrawlReady: articleCrawl.markCrawlReady,
 			markCrawlFailed: articleCrawl.markCrawlFailed,
 			markCrawlStage: articleCrawl.markCrawlStage,
+			incrementCrawlAutoHealAttempt: articleCrawl.incrementCrawlAutoHealAttempt,
 		},
 		parser: { parseArticle, crawlArticle },
 		events: {

--- a/src/packages/test-fixtures/src/providers/article-crawl/article-crawl.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/article-crawl.types.ts
@@ -19,3 +19,22 @@ export type MarkCrawlPending = (params: { url: string }) => Promise<void>;
  * crawlFailureReason.
  */
 export type ForceMarkCrawlPending = (params: { url: string }) => Promise<void>;
+
+/**
+ * Atomically attempts to record an auto-heal reprime against a failed row.
+ * Returns 'reprimed' when the cap is not yet hit (the call also bumps the
+ * counter and timestamp), or 'capped' when the row has already used up its
+ * budget of attempts inside the configured TTL window.
+ *
+ * The cap exists to prevent a structurally-impossible URL (e.g. a 100MB PDF
+ * the parser can never finish) from being republished forever. Successful
+ * promote (promoteTierToCanonical) clears the counter; an admin recrawl
+ * naturally bypasses the cap because /admin/recrawl does not flow through
+ * the freshness path that calls this dep.
+ */
+export type IncrementCrawlAutoHealAttempt = (params: {
+	url: string;
+	nowIso: string;
+	maxAttempts: number;
+	ttlMs: number;
+}) => Promise<"reprimed" | "capped">;

--- a/src/packages/test-fixtures/src/providers/article-crawl/article-crawl.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/article-crawl.types.ts
@@ -21,7 +21,7 @@ export type MarkCrawlPending = (params: { url: string }) => Promise<void>;
 export type ForceMarkCrawlPending = (params: { url: string }) => Promise<void>;
 
 /**
- * Atomically attempts to record an auto-heal reprime against a failed row.
+ * Attempts to record an auto-heal reprime against a failed row.
  * Returns 'reprimed' when the cap is not yet hit (the call also bumps the
  * counter and timestamp), or 'capped' when the row has already used up its
  * budget of attempts inside the configured TTL window.
@@ -38,3 +38,24 @@ export type IncrementCrawlAutoHealAttempt = (params: {
 	maxAttempts: number;
 	ttlMs: number;
 }) => Promise<"reprimed" | "capped">;
+
+export interface AutoHealState {
+	attempts: number;
+	lastAttemptAtIso: string;
+}
+
+/**
+ * Reads the current auto-heal counter state for a URL. Returns undefined
+ * when no attempts have been recorded yet.
+ */
+export type FindAutoHealState = (url: string) => Promise<AutoHealState | undefined>;
+
+/**
+ * Persists the auto-heal counter + timestamp. Unconditional write — the
+ * caller (domain function) has already evaluated the cap condition.
+ */
+export type WriteAutoHealAttempt = (params: {
+	url: string;
+	attempts: number;
+	lastAttemptAtIso: string;
+}) => Promise<void>;

--- a/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.test.ts
@@ -56,4 +56,58 @@ describe("initInMemoryArticleCrawl", () => {
 			});
 		});
 	});
+
+	describe("incrementCrawlAutoHealAttempt", () => {
+		const NOW_ISO = "2026-05-10T05:00:00.000Z";
+		const MAX = 3;
+		const TTL_MS = 24 * 60 * 60 * 1000;
+
+		it("returns 'reprimed' on the first attempt and records the count", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			expect(
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS }),
+			).toBe("reprimed");
+		});
+
+		it("returns 'reprimed' for attempts strictly under the cap", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS });
+			await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS });
+			expect(
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS }),
+			).toBe("reprimed");
+		});
+
+		it("returns 'capped' once the cap is hit within the TTL window", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			for (let i = 0; i < MAX; i += 1) {
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS });
+			}
+			expect(
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS }),
+			).toBe("capped");
+		});
+
+		it("re-allows reprime once the TTL window since the last attempt has elapsed", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			for (let i = 0; i < MAX; i += 1) {
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS });
+			}
+			const laterIso = new Date(new Date(NOW_ISO).getTime() + TTL_MS + 1).toISOString();
+			expect(
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: laterIso, maxAttempts: MAX, ttlMs: TTL_MS }),
+			).toBe("reprimed");
+		});
+
+		it("clears the auto-heal counter when markCrawlReady runs (mirrors prod promote reset)", async () => {
+			const crawl = initInMemoryArticleCrawl();
+			for (let i = 0; i < MAX; i += 1) {
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS });
+			}
+			await crawl.markCrawlReady({ url: URL });
+			expect(
+				await crawl.incrementCrawlAutoHealAttempt({ url: URL, nowIso: NOW_ISO, maxAttempts: MAX, ttlMs: TTL_MS }),
+			).toBe("reprimed");
+		});
+	});
 });

--- a/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.ts
@@ -4,6 +4,7 @@ import type {
 	ArticleCrawl,
 	FindArticleCrawlStatus,
 	ForceMarkCrawlPending,
+	IncrementCrawlAutoHealAttempt,
 	MarkCrawlPending,
 } from "./article-crawl.types";
 
@@ -17,6 +18,11 @@ export type InMemoryMarkCrawlStage = (params: {
 	stage: CrawlStage;
 }) => Promise<void>;
 
+interface AutoHealState {
+	attempts: number;
+	lastAttemptAtIso: string;
+}
+
 export function initInMemoryArticleCrawl(): {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
@@ -24,8 +30,10 @@ export function initInMemoryArticleCrawl(): {
 	markCrawlReady: InMemoryMarkCrawlReady;
 	markCrawlFailed: InMemoryMarkCrawlFailed;
 	markCrawlStage: InMemoryMarkCrawlStage;
+	incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt;
 } {
 	const states = new Map<string, ArticleCrawl>();
+	const autoHeal = new Map<string, AutoHealState>();
 
 	const findArticleCrawlStatus: FindArticleCrawlStatus = async (url) => {
 		const id = ArticleResourceUniqueId.parse(url);
@@ -58,6 +66,10 @@ export function initInMemoryArticleCrawl(): {
 	const markCrawlReady: InMemoryMarkCrawlReady = async ({ url }) => {
 		const id = ArticleResourceUniqueId.parse(url);
 		states.set(id.value, { status: "ready" });
+		// Mirror the prod reset path (promoteTierToCanonical clears auto-heal
+		// counters when promoting): a successful crawl should not leave a
+		// pre-existing cap in place to bite the next failure.
+		autoHeal.delete(id.value);
 	};
 
 	const markCrawlFailed: InMemoryMarkCrawlFailed = async ({ url, reason }) => {
@@ -77,6 +89,28 @@ export function initInMemoryArticleCrawl(): {
 		states.set(id.value, { status: "pending", stage });
 	};
 
+	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
+		url,
+		nowIso,
+		maxAttempts,
+		ttlMs,
+	}) => {
+		const id = ArticleResourceUniqueId.parse(url);
+		const current = autoHeal.get(id.value);
+		if (current) {
+			const elapsed = new Date(nowIso).getTime() - new Date(current.lastAttemptAtIso).getTime();
+			const withinTtlWindow = elapsed < ttlMs;
+			if (current.attempts >= maxAttempts && withinTtlWindow) {
+				return "capped";
+			}
+		}
+		autoHeal.set(id.value, {
+			attempts: (current?.attempts ?? 0) + 1,
+			lastAttemptAtIso: nowIso,
+		});
+		return "reprimed";
+	};
+
 	return {
 		findArticleCrawlStatus,
 		markCrawlPending,
@@ -84,5 +118,6 @@ export function initInMemoryArticleCrawl(): {
 		markCrawlReady,
 		markCrawlFailed,
 		markCrawlStage,
+		incrementCrawlAutoHealAttempt,
 	};
 }

--- a/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.ts
@@ -2,11 +2,15 @@ import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import type { CrawlStage } from "@packages/domain/article";
 import type {
 	ArticleCrawl,
+	AutoHealState,
 	FindArticleCrawlStatus,
+	FindAutoHealState,
 	ForceMarkCrawlPending,
 	IncrementCrawlAutoHealAttempt,
 	MarkCrawlPending,
+	WriteAutoHealAttempt,
 } from "./article-crawl.types";
+import { initIncrementCrawlAutoHealAttempt } from "./increment-crawl-auto-heal-attempt";
 
 export type InMemoryMarkCrawlReady = (params: { url: string }) => Promise<void>;
 export type InMemoryMarkCrawlFailed = (params: {
@@ -17,11 +21,6 @@ export type InMemoryMarkCrawlStage = (params: {
 	url: string;
 	stage: CrawlStage;
 }) => Promise<void>;
-
-interface AutoHealState {
-	attempts: number;
-	lastAttemptAtIso: string;
-}
 
 export function initInMemoryArticleCrawl(): {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
@@ -89,27 +88,24 @@ export function initInMemoryArticleCrawl(): {
 		states.set(id.value, { status: "pending", stage });
 	};
 
-	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
+	const findAutoHealState: FindAutoHealState = async (url) => {
+		const id = ArticleResourceUniqueId.parse(url);
+		return autoHeal.get(id.value);
+	};
+
+	const writeAutoHealAttempt: WriteAutoHealAttempt = async ({
 		url,
-		nowIso,
-		maxAttempts,
-		ttlMs,
+		attempts,
+		lastAttemptAtIso,
 	}) => {
 		const id = ArticleResourceUniqueId.parse(url);
-		const current = autoHeal.get(id.value);
-		if (current) {
-			const elapsed = new Date(nowIso).getTime() - new Date(current.lastAttemptAtIso).getTime();
-			const withinTtlWindow = elapsed < ttlMs;
-			if (current.attempts >= maxAttempts && withinTtlWindow) {
-				return "capped";
-			}
-		}
-		autoHeal.set(id.value, {
-			attempts: (current?.attempts ?? 0) + 1,
-			lastAttemptAtIso: nowIso,
-		});
-		return "reprimed";
+		autoHeal.set(id.value, { attempts, lastAttemptAtIso });
 	};
+
+	const { incrementCrawlAutoHealAttempt } = initIncrementCrawlAutoHealAttempt({
+		findAutoHealState,
+		writeAutoHealAttempt,
+	});
 
 	return {
 		findArticleCrawlStatus,

--- a/src/packages/test-fixtures/src/providers/article-crawl/increment-crawl-auto-heal-attempt.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/increment-crawl-auto-heal-attempt.ts
@@ -1,0 +1,35 @@
+import type {
+	FindAutoHealState,
+	IncrementCrawlAutoHealAttempt,
+	WriteAutoHealAttempt,
+} from "./article-crawl.types";
+
+export function initIncrementCrawlAutoHealAttempt(deps: {
+	findAutoHealState: FindAutoHealState;
+	writeAutoHealAttempt: WriteAutoHealAttempt;
+}): { incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt } {
+	const incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt = async ({
+		url,
+		nowIso,
+		maxAttempts,
+		ttlMs,
+	}) => {
+		const current = await deps.findAutoHealState(url);
+		if (current) {
+			const elapsed =
+				new Date(nowIso).getTime() -
+				new Date(current.lastAttemptAtIso).getTime();
+			if (current.attempts >= maxAttempts && elapsed < ttlMs) {
+				return "capped";
+			}
+		}
+		await deps.writeAutoHealAttempt({
+			url,
+			attempts: (current?.attempts ?? 0) + 1,
+			lastAttemptAtIso: nowIso,
+		});
+		return "reprimed";
+	};
+
+	return { incrementCrawlAutoHealAttempt };
+}

--- a/src/packages/test-fixtures/src/providers/article-crawl/increment-crawl-auto-heal-attempt.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/increment-crawl-auto-heal-attempt.ts
@@ -4,6 +4,8 @@ import type {
 	WriteAutoHealAttempt,
 } from "./article-crawl.types";
 
+// Not atomic: concurrent calls may each slip one extra attempt through.
+// Acceptable — the cap is a cost guard, not a correctness invariant.
 export function initIncrementCrawlAutoHealAttempt(deps: {
 	findAutoHealState: FindAutoHealState;
 	writeAutoHealAttempt: WriteAutoHealAttempt;

--- a/src/packages/test-fixtures/src/providers/article-crawl/index.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/index.ts
@@ -1,2 +1,3 @@
 export * from "./article-crawl.types";
+export * from "./increment-crawl-auto-heal-attempt";
 export * from "./in-memory-article-crawl";

--- a/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.test.ts
@@ -4,6 +4,9 @@ function createDeps(overrides?: Record<string, unknown>) {
 	return {
 		findArticleFreshness: async (_url: string) => null,
 		findArticleCrawlStatus: async (_url: string) => undefined,
+		// Default: never capped — most tests don't touch the failed branch, and
+		// the few that do override this to simulate the cap.
+		incrementCrawlAutoHealAttempt: async () => "reprimed" as const,
 		crawlArticle: async () => ({ status: "failed" as const }),
 		parseHtml: () => ({
 			ok: true as const,
@@ -59,6 +62,67 @@ describe("refreshArticleIfStale", () => {
 		const result = await refreshArticleIfStale({ url: "https://example.com/article" });
 
 		expect(result.action).toBe("reprime");
+	});
+
+	it("does not call incrementCrawlAutoHealAttempt for the legacy-stub branch (cap only applies to a known-failing crawl)", async () => {
+		const incrementCalls: unknown[] = [];
+		const deps = createDeps({
+			findArticleFreshness: async () => ({
+				contentFetchedAt: "2026-03-20T09:00:00Z",
+			}),
+			findArticleCrawlStatus: async () => undefined,
+			incrementCrawlAutoHealAttempt: async (params: unknown) => {
+				incrementCalls.push(params);
+				return "reprimed" as const;
+			},
+		});
+		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
+
+		await refreshArticleIfStale({ url: "https://example.com/article" });
+
+		expect(incrementCalls).toEqual([]);
+	});
+
+	it("returns action 'skip' when the auto-heal cap is hit on a failed crawl", async () => {
+		const deps = createDeps({
+			findArticleFreshness: async () => ({
+				contentFetchedAt: "2026-03-20T09:00:00Z",
+			}),
+			findArticleCrawlStatus: async () => ({ status: "failed" as const, reason: "blocked" }),
+			incrementCrawlAutoHealAttempt: async () => "capped" as const,
+		});
+		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
+
+		const result = await refreshArticleIfStale({ url: "https://example.com/article" });
+
+		expect(result.action).toBe("skip");
+	});
+
+	it("forwards now / max / ttl to incrementCrawlAutoHealAttempt for the failed branch", async () => {
+		const incrementCalls: { url: string; nowIso: string; maxAttempts: number; ttlMs: number }[] = [];
+		const deps = createDeps({
+			findArticleFreshness: async () => ({
+				contentFetchedAt: "2026-03-20T09:00:00Z",
+			}),
+			findArticleCrawlStatus: async () => ({ status: "failed" as const, reason: "blocked" }),
+			incrementCrawlAutoHealAttempt: async (params: typeof incrementCalls[number]) => {
+				incrementCalls.push(params);
+				return "reprimed" as const;
+			},
+			now: () => new Date("2026-03-20T10:00:00Z"),
+		});
+		const { refreshArticleIfStale } = initRefreshArticleIfStale(deps);
+
+		await refreshArticleIfStale({ url: "https://example.com/article" });
+
+		expect(incrementCalls).toEqual([
+			{
+				url: "https://example.com/article",
+				nowIso: "2026-03-20T10:00:00.000Z",
+				maxAttempts: 3,
+				ttlMs: 86_400_000,
+			},
+		]);
 	});
 
 	it("returns action 'skip' when contentFetchedAt is within TTL", async () => {

--- a/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
@@ -3,7 +3,10 @@ import type {
 	ParseArticleResult,
 	ParseHtml,
 } from "../article-parser/article-parser.types";
-import type { FindArticleCrawlStatus } from "../article-crawl/article-crawl.types";
+import type {
+	FindArticleCrawlStatus,
+	IncrementCrawlAutoHealAttempt,
+} from "../article-crawl/article-crawl.types";
 import type { FindArticleFreshness } from "../article-store/article-store.types";
 import type { PublishRefreshArticleContent } from "../events/publish-refresh-article-content.types";
 import type { PublishUpdateFetchTimestamp } from "../events/publish-update-fetch-timestamp.types";
@@ -20,9 +23,19 @@ export type RefreshArticleIfStale = (params: {
 	url: string;
 }) => Promise<ContentFreshnessResult>;
 
+// 3 attempts per 24h: a structurally-unparseable URL (e.g. a 100MB PDF the
+// parser will never finish) is allowed to retry a few times to ride out
+// transient failures, then the cap kicks in to stop /view from republishing
+// SaveAnonymousLinkCommand on every page load. The window resets when the
+// row is successfully promoted (promoteTierToCanonical clears the counter)
+// or when the TTL since the last attempt expires.
+const AUTO_HEAL_MAX_ATTEMPTS = 3;
+const AUTO_HEAL_TTL_MS = 24 * 60 * 60 * 1000;
+
 export function initRefreshArticleIfStale(deps: {
 	findArticleFreshness: FindArticleFreshness;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
+	incrementCrawlAutoHealAttempt: IncrementCrawlAutoHealAttempt;
 	crawlArticle: CrawlArticle;
 	parseHtml: ParseHtml;
 	publishRefreshArticleContent: PublishRefreshArticleContent;
@@ -38,8 +51,21 @@ export function initRefreshArticleIfStale(deps: {
 		}
 
 		const crawl = await deps.findArticleCrawlStatus(params.url);
-		if (!crawl || crawl.status === "failed") {
+		if (!crawl) {
+			// Legacy stub (freshness row exists but no crawl status). Always
+			// reprime — the worker has never run, so the cap doesn't apply
+			// (we want it to run at least once to discover whether this URL
+			// is parseable).
 			return { action: "reprime" };
+		}
+		if (crawl.status === "failed") {
+			const result = await deps.incrementCrawlAutoHealAttempt({
+				url: params.url,
+				nowIso: deps.now().toISOString(),
+				maxAttempts: AUTO_HEAL_MAX_ATTEMPTS,
+				ttlMs: AUTO_HEAL_TTL_MS,
+			});
+			return result === "capped" ? { action: "skip" } : { action: "reprime" };
 		}
 
 		if (freshness.contentFetchedAt) {

--- a/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
@@ -23,12 +23,14 @@ export type RefreshArticleIfStale = (params: {
 	url: string;
 }) => Promise<ContentFreshnessResult>;
 
-// 3 attempts per 24h: a structurally-unparseable URL (e.g. a 100MB PDF the
-// parser will never finish) is allowed to retry a few times to ride out
-// transient failures, then the cap kicks in to stop /view from republishing
-// SaveAnonymousLinkCommand on every page load. The window resets when the
-// row is successfully promoted (promoteTierToCanonical clears the counter)
-// or when the TTL since the last attempt expires.
+// 3 initial attempts, then 1 retry per TTL window: a structurally-unparseable
+// URL (e.g. a 100MB PDF the parser will never finish) gets 3 chances to ride
+// out transient failures, then the cap kicks in. Once capped, the counter is
+// not reset — only one retry is allowed per expired TTL window (the counter
+// keeps growing: 4, 5, …). This is intentional: structurally-broken URLs
+// waste less compute with a single periodic heartbeat retry than with 3 every
+// window. The counter fully resets when the row is successfully promoted
+// (promoteTierToCanonical clears it) or when an admin triggers a recrawl.
 const AUTO_HEAL_MAX_ATTEMPTS = 3;
 const AUTO_HEAL_TTL_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Why
Phase 3 of the unstick-articles plan. The earlier phases addressed two specific failure modes; this PR closes a class of failure that neither fixed.

**The problem.** When `/view` triggers a stale-check on a URL whose `crawlStatus='failed'`, the freshness path returns `{action: 'reprime'}` and republishes `SaveAnonymousLinkCommand`. For most URLs the worker succeeds and the row flips back to `ready`. But for a structurally-unparseable URL — a 100MB PDF, a page so large the parser will never finish, an origin that consistently returns malformed HTML — every `/view` click triggers the same loop:

```
/view click → stale-check → reprime → SaveAnonymousLinkCommand
                              ↓
            Lambda fails (exhausts maxReceiveCount=3 retries)
                              ↓
                  DLQ writes crawlStatus='failed'
                              ↓
              next /view click repeats the whole cycle
```

**Why earlier phases don't fix it.**
- Phase 1 moved this loop off the user request path (so `/view` no longer hangs while the loop runs), but the loop itself still executes in the background. Each click still pays the SQS + Lambda cost.
- Phase 2 widened the Lambda budget so URLs that took 30-180s to parse stop hitting the timeout. iana succeeded after Phase 2, but a structurally-impossible URL still loops — wider budget just means each cycle wastes more compute before failing.

**What this PR does.** Caps the auto-heal at **3 reprimes per 24h window** per URL. Once the cap is hit, the freshness path returns `{action: 'skip'}` and `/view` renders the existing failed state without republishing. The cap auto-resets when the URL successfully promotes (recovery clears the counter) and after 24h since the last attempt (operator/world state may have changed; let it try again).

## Summary
- New `IncrementCrawlAutoHealAttempt` primitive in `@packages/test-fixtures/providers/article-crawl` with parallel implementations: in-memory (for tests + dev) and DDB (for prod, used by both the stale-check Lambda and the `/queue` `/save` `/import` paths via hutch).
- The DDB version uses an atomic `UpdateItem`: counter increment + cap check in a single conditional update, so two concurrent `/view` requests can never both slip through at attempts=2. The condition allows the increment when any of: counter doesn't exist (first attempt) OR `crawlAutoHealAttempts < maxAttempts` OR `crawlAutoHealLastAttemptAt` is older than the TTL window.
- `refreshArticleIfStale`'s failed branch now calls the primitive and maps `'reprimed'` → `{action: 'reprime'}`, `'capped'` → `{action: 'skip'}`. The legacy-stub branch (no crawl row at all) explicitly does NOT consult the cap — the worker has never run, so we want it to run at least once.
- `promoteTierToCanonical` clears `crawlAutoHealAttempts` and `crawlAutoHealLastAttemptAt` atomically with the canonical write, so a recovered URL gets a fresh budget against the next failure window.
- `/admin/recrawl` naturally bypasses the cap because it calls `forceMarkCrawlPending` + `publishRecrawlLinkInitiated` — neither flows through `refreshArticleIfStale`.

## Files
- **Type + impls:** `article-crawl.types.ts` (new type), `in-memory-article-crawl.{ts,test.ts}` (5 new tests covering cap reach, TTL reset, reset-on-success, etc.), `projects/save-link/src/crawl-article-state/increment-crawl-auto-heal-attempt.ts` (new file, c8-ignored thin SDK wrapper), `projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.{ts,test.ts}` (DDB impl added to existing module + 3 new tests for the conditional-update + capped + rethrow paths).
- **Cap wiring:** `check-content-freshness.{ts,test.ts}` (failed-branch + 4 new tests for cap-hit / legacy-stub-no-cap / param forwarding).
- **Reset:** `promote-tier-to-canonical.ts` (extends the existing REMOVE clause).
- **Composition roots:** `app.ts` (prod + dev), `stale-check.main.ts`, `e2e-server.main.ts` (3 places that init `refreshArticleIfStale`), plus mechanical TS-only updates to `bundle.types.ts`, `fixture.ts`, `test-app.ts`, and the in-test `articleCrawl` overrides in `queue.route.test.ts`, `view.route.test.ts`, `queue.freshness.route.test.ts`.

## Test plan
- [x] Local: `nx run-many --target=lint --projects=@packages/test-fixtures,save-link,hutch` ✓
- [x] Local: `nx run-many --target=test-with-coverage --projects=…` ✓ — hutch project total 99.51 / 96.74 / 100 / 99.51 (above thresholds 99/96/100/99); save-link still 100% across 58 files; test-fixtures thresholds met
- [x] Pre-commit hook (full `pnpm check` on 18 projects) ✓ — required an `nx reset` first to clear stale daemon state from concurrent worktrees
- [ ] After merge: deploy to prod (CI auto-deploys hutch + save-link)
- [ ] After deploy: visit `/view` on a known-failing URL several times; observe DDB row gains `crawlAutoHealAttempts=3` then stops growing (cap hit). Logs should show `[StaleCheckRequested] no-op { action: 'skip' }` once capped.
- [ ] Verify `/admin/recrawl` still works on a failed URL (operator escape hatch preserved).

## Heads-up for reviewers
- Cap policy (3 attempts, 24h TTL) lives as constants in `check-content-freshness.ts`. Not env vars, not factory deps — keeps tests deterministic, but means a tuning change requires a deploy. If you want it dynamic, easy to thread through.
- I extended hutch's existing `initDynamoDbArticleCrawl` to also expose `incrementCrawlAutoHealAttempt` (rather than create a new file) since it's another crawl-row state op on the same table. Save-link uses one-file-per-primitive so the new helper got its own file there. If you'd rather have parallel structure across both projects, easy to split.
- The `forceMarkCrawlPending` "bypasses the cap" assertion is verified by code-trace, not a test. The cap lives in `refreshArticleIfStale`'s failed branch; `/admin/recrawl` never invokes that. If you want a test pinning that behavior I can add one.