### PR TITLE
fix(save-link,hutch): regenerate summary after content refresh

### DIFF
--- a/.github/workflows/stuck-articles-canary.yml
+++ b/.github/workflows/stuck-articles-canary.yml
@@ -96,7 +96,7 @@ jobs:
               stuckCount = report.stuck.length;
               if (stuckCount > 0) {
                 stuckList = report.stuck
-                  .map((row) => `- [${row.reasons.join(',')}] ${row.originalUrl} — fetched: ${row.contentFetchedAt ?? '-'}; failure: ${row.failureReason ?? '-'}; recrawl: ${row.recrawlUrl}`)
+                  .map((row) => `- [${row.reasons.join(',')}] ${row.originalUrl} — ${row.terminalCheckMessage}; fetched: ${row.contentFetchedAt ?? '-'}; failure: ${row.failureReason ?? '-'}; recrawl: ${row.recrawlUrl}`)
                   .join('\n');
               }
             }

--- a/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.test.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.test.ts
@@ -67,6 +67,31 @@ describe("initDynamoDbGeneratedSummary", () => {
 		expect(result).toEqual({ status: "ready", summary: "Fresh summary" });
 	});
 
+	it("throws when summaryStatus=ready is persisted without summary text (data inconsistency)", async () => {
+		// Why this matters: this is the exact state the
+		// fagnerbrack.com/why-developers-become-frustrated-… row was left in
+		// after the 2026-05-10 freshness refresh ran an UpdateExpression that
+		// REMOVEd `summary` without resetting `summaryStatus`. With the previous
+		// code path the mapper silently returned undefined, the reader UI
+		// rendered "Generating summary…" and polled `/view/summary` every 3s
+		// forever. The explicit assert turns that silent stuck-pending state
+		// into a loud 500 the moment any future writer reintroduces the same
+		// inconsistency, and keeps the consumer honest about the writer
+		// contract: status=ready ⇒ summary text MUST be present.
+		const client = createFakeClient({
+			url: "https://example.com/article",
+			summaryStatus: "ready",
+		});
+		const { findGeneratedSummary } = initDynamoDbGeneratedSummary({
+			client: client as typeof client & DynamoDBDocumentClient,
+			tableName: "test-table",
+		});
+
+		await expect(findGeneratedSummary("https://example.com/article")).rejects.toThrow(
+			"summaryStatus=ready row must carry a summary",
+		);
+	});
+
 	it("returns ready with both summary and excerpt when summaryExcerpt is present", async () => {
 		const client = createFakeClient({
 			url: "https://example.com/article",

--- a/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.ts
@@ -32,6 +32,18 @@ const ArticleSummaryRow = z.object({
 
 type ArticleSummaryRowShape = z.infer<typeof ArticleSummaryRow>;
 
+function readyFromRow(
+	summary: string,
+	excerpt: string | undefined,
+): { status: "ready"; summary: string; excerpt?: string } {
+	const ready: { status: "ready"; summary: string; excerpt?: string } = {
+		status: "ready",
+		summary,
+	};
+	if (excerpt) ready.excerpt = excerpt;
+	return ready;
+}
+
 function rowToGeneratedSummary(
 	row: ArticleSummaryRowShape | undefined,
 ): GeneratedSummary | undefined {
@@ -50,17 +62,20 @@ function rowToGeneratedSummary(
 			? { status: "pending", stage: row.summaryStage }
 			: { status: "pending" };
 	}
+	if (row.summaryStatus === "ready") {
+		// Status and text must move together. A row with status=ready and no
+		// summary text means a writer dropped the text without resetting the
+		// status (or vice versa) — fail loud here so the inconsistency surfaces
+		// instead of degrading silently to a forever-polling reader UI.
+		assert(row.summary, "summaryStatus=ready row must carry a summary");
+		return readyFromRow(row.summary, row.summaryExcerpt);
+	}
 	// Legacy row (summaryStatus absent). A backfilled `summary` column means the
 	// row pre-dates the state machine but carried a pre-computed summary — expose
 	// as ready. Otherwise return undefined so the caller can re-prime the pipeline
 	// rather than rendering a stuck pending row that polls forever.
 	if (!row.summary) return undefined;
-	const ready: { status: "ready"; summary: string; excerpt?: string } = {
-		status: "ready",
-		summary: row.summary,
-	};
-	if (row.summaryExcerpt) ready.excerpt = row.summaryExcerpt;
-	return ready;
+	return readyFromRow(row.summary, row.summaryExcerpt);
 }
 
 export function initDynamoDbGeneratedSummary(deps: {

--- a/projects/save-link/src/generate-summary/dynamodb-generated-summary.test.ts
+++ b/projects/save-link/src/generate-summary/dynamodb-generated-summary.test.ts
@@ -45,7 +45,14 @@ describe("initDynamoDbGeneratedSummary (unit)", () => {
 			expect(await findGeneratedSummary(URL)).toEqual({ status: "ready", summary: "done" });
 		});
 
-		it("returns ready with both summary and excerpt when summaryExcerpt is present", async () => {
+		it("returns ready with both summary and excerpt when summaryStatus is set and excerpt is present", async () => {
+			// Why this matters: covers the explicit summaryStatus="ready"
+			// branch with the excerpt-truthy sub-branch — the path the
+			// production summariser hits on every fresh save once
+			// `saveGeneratedSummary` writes summary, summaryExcerpt and
+			// summaryStatus together. Without this test the new ready branch's
+			// `if (row.summaryExcerpt)` true side stays uncovered and the
+			// 100% branch threshold trips.
 			const { findGeneratedSummary } = initDynamoDbGeneratedSummary({
 				client: clientForGet({
 					summaryStatus: "ready",
@@ -59,6 +66,24 @@ describe("initDynamoDbGeneratedSummary (unit)", () => {
 				summary: "done",
 				excerpt: "blurb",
 			});
+		});
+
+		it("throws when summaryStatus=ready is persisted without summary text (data inconsistency)", async () => {
+			// Why this matters: this is the exact state the
+			// fagnerbrack.com/why-developers-become-frustrated-… row was left in
+			// after the 2026-05-10 freshness refresh ran an UpdateExpression that
+			// REMOVEd `summary` without resetting `summaryStatus`. With the
+			// previous code path the mapper silently returned undefined and the
+			// reader UI rendered "Generating summary…" forever. The explicit
+			// assert turns that silent stuck-pending state into a loud error
+			// the moment any future writer reintroduces the same inconsistency.
+			const { findGeneratedSummary } = initDynamoDbGeneratedSummary({
+				client: clientForGet({ summaryStatus: "ready" }) as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+			await expect(findGeneratedSummary(URL)).rejects.toThrow(
+				"summaryStatus=ready row must carry a summary",
+			);
 		});
 
 		it("returns failed with reason when status=failed", async () => {

--- a/projects/save-link/src/generate-summary/dynamodb-generated-summary.ts
+++ b/projects/save-link/src/generate-summary/dynamodb-generated-summary.ts
@@ -30,6 +30,18 @@ const GeneratedSummaryRow = z.object({
 
 type GeneratedSummaryRowShape = z.infer<typeof GeneratedSummaryRow>;
 
+function readyFromRow(
+	summary: string,
+	excerpt: string | undefined,
+): { status: "ready"; summary: string; excerpt?: string } {
+	const ready: { status: "ready"; summary: string; excerpt?: string } = {
+		status: "ready",
+		summary,
+	};
+	if (excerpt) ready.excerpt = excerpt;
+	return ready;
+}
+
 function rowToGeneratedSummary(
 	row: GeneratedSummaryRowShape | undefined,
 ): GeneratedSummary | undefined {
@@ -44,17 +56,20 @@ function rowToGeneratedSummary(
 			: { status: "skipped" };
 	}
 	if (row.summaryStatus === "pending") return { status: "pending" };
+	if (row.summaryStatus === "ready") {
+		// Status and text must move together. A row with status=ready and no
+		// summary text means a writer dropped the text without resetting the
+		// status (or vice versa) — fail loud here so the inconsistency surfaces
+		// instead of degrading silently.
+		assert(row.summary, "summaryStatus=ready row must carry a summary");
+		return readyFromRow(row.summary, row.summaryExcerpt);
+	}
 	// Legacy row (summaryStatus absent). A backfilled `summary` column means the
 	// row pre-dates the state machine but carried a pre-computed summary — expose
 	// as ready. Otherwise return undefined so the caller can re-prime the pipeline
 	// instead of treating the row as actively pending.
 	if (!row.summary) return undefined;
-	const ready: { status: "ready"; summary: string; excerpt?: string } = {
-		status: "ready",
-		summary: row.summary,
-	};
-	if (row.summaryExcerpt) ready.excerpt = row.summaryExcerpt;
-	return ready;
+	return readyFromRow(row.summary, row.summaryExcerpt);
 }
 
 async function swallowConditionalCheckFailure(action: () => Promise<void>): Promise<void> {

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -640,9 +640,11 @@ const refreshArticleContentLambda = new HutchLambda("refresh-article-content", {
 	timeout: 30,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...refreshArticleContentDynamodb.policies,
+		...generateSummaryQueue.policies.map((p) => ({ ...p, name: `refresh-${p.name}` })),
 	],
 });
 

--- a/projects/save-link/src/runtime/refresh-article-content.main.ts
+++ b/projects/save-link/src/runtime/refresh-article-content.main.ts
@@ -1,19 +1,31 @@
+import { SQSClient } from "@aws-sdk/client-sqs";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { consoleLogger } from "@packages/hutch-logger";
+import { initSqsCommandDispatcher } from "@packages/hutch-infra-components/runtime";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
 import { requireEnv } from "../require-env";
 import { initRefreshArticleContent } from "../save-link/refresh-article-content";
 import { initRefreshArticleContentHandler } from "../save-link/refresh-article-content-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const client = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
 const { refreshArticleContent } = initRefreshArticleContent({
 	client,
 	tableName: articlesTable,
 });
 
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
+});
+
 export const handler = initRefreshArticleContentHandler({
 	refreshArticleContent,
+	dispatchGenerateSummary,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/save-link/refresh-article-content-handler.test.ts
+++ b/projects/save-link/src/save-link/refresh-article-content-handler.test.ts
@@ -48,11 +48,21 @@ function createSqsEvent(detail: {
 }
 
 describe("initRefreshArticleContentHandler", () => {
-	it("calls refreshArticleContent with parsed detail", async () => {
+	it("calls refreshArticleContent with parsed detail and dispatches GenerateSummaryCommand", async () => {
+		// Why this matters: refreshArticleContent invalidates the cached summary
+		// (clears summary text + flips status back to pending). If the handler
+		// did not also dispatch GenerateSummaryCommand the row would sit in the
+		// pending state forever — no worker would ever pick it up — and the
+		// reader would render "Generating summary…" indefinitely. This is
+		// exactly the regression that left
+		// fagnerbrack.com/why-developers-become-frustrated-… stuck after the
+		// 2026-05-10 freshness refresh.
 		const refreshArticleContent = jest.fn().mockResolvedValue(undefined);
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
 
 		const handler = initRefreshArticleContentHandler({
 			refreshArticleContent,
+			dispatchGenerateSummary,
 			logger: noopLogger,
 		});
 
@@ -74,11 +84,46 @@ describe("initRefreshArticleContentHandler", () => {
 			lastModified: "Thu, 10 Apr 2026 12:00:00 GMT",
 			contentFetchedAt: "2026-04-10T12:00:00Z",
 		});
+		expect(dispatchGenerateSummary).toHaveBeenCalledTimes(1);
+		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
+	});
+
+	it("dispatches AFTER refreshArticleContent so the worker never reads a status=ready cache hit", async () => {
+		// Why this matters: summarizeArticle short-circuits when the cached
+		// summaryStatus is "ready" or "skipped" (link-summariser.ts:52). If we
+		// dispatched the command before refreshArticleContent flipped the row
+		// out of "ready", a fast-running worker could read the stale cache,
+		// log "already summarized", and return — leaving the row with the
+		// new content but no regenerated summary. Locking the order eliminates
+		// that race.
+		const order: string[] = [];
+		const refreshArticleContent = jest.fn().mockImplementation(async () => {
+			order.push("refresh");
+		});
+		const dispatchGenerateSummary = jest.fn().mockImplementation(async () => {
+			order.push("dispatch");
+		});
+
+		const handler = initRefreshArticleContentHandler({
+			refreshArticleContent,
+			dispatchGenerateSummary,
+			logger: noopLogger,
+		});
+
+		await handler(createSqsEvent({
+			url: "https://example.com/article",
+			metadata: { title: "Test", siteName: "example.com", excerpt: "Excerpt", wordCount: 100 },
+			estimatedReadTime: 1,
+			contentFetchedAt: "2026-04-10T12:00:00Z",
+		}), stubContext, () => {});
+
+		expect(order).toEqual(["refresh", "dispatch"]);
 	});
 
 	it("reports the record as a batch failure on invalid event detail (Zod failure)", async () => {
 		const handler = initRefreshArticleContentHandler({
 			refreshArticleContent: jest.fn(),
+			dispatchGenerateSummary: jest.fn(),
 			logger: noopLogger,
 		});
 
@@ -97,6 +142,31 @@ describe("initRefreshArticleContentHandler", () => {
 		};
 
 		const result = await handler(invalidEvent, stubContext, () => {});
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+	});
+
+	it("does not dispatch when refreshArticleContent throws", async () => {
+		// Why this matters: dispatching a regen command for an URL whose row
+		// the DDB update could not write would summarise stale content (or
+		// stamp a row that does not exist) — the handler must let the SQS
+		// retry replay the whole transaction.
+		const refreshArticleContent = jest.fn().mockRejectedValue(new Error("DDB throttled"));
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+
+		const handler = initRefreshArticleContentHandler({
+			refreshArticleContent,
+			dispatchGenerateSummary,
+			logger: noopLogger,
+		});
+
+		const result = await handler(createSqsEvent({
+			url: "https://example.com/article",
+			metadata: { title: "Test", siteName: "example.com", excerpt: "Excerpt", wordCount: 100 },
+			estimatedReadTime: 1,
+			contentFetchedAt: "2026-04-10T12:00:00Z",
+		}), stubContext, () => {});
+
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/save-link/refresh-article-content-handler.ts
+++ b/projects/save-link/src/save-link/refresh-article-content-handler.ts
@@ -1,5 +1,7 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
+import type { DispatchCommand } from "@packages/hutch-infra-components/runtime";
+import type { GenerateSummaryCommand } from "@packages/hutch-infra-components";
 import { RefreshArticleContentCommand } from "./index";
 
 export type RefreshArticleContent = (params: {
@@ -19,9 +21,10 @@ export type RefreshArticleContent = (params: {
 
 export function initRefreshArticleContentHandler(deps: {
 	refreshArticleContent: RefreshArticleContent;
+	dispatchGenerateSummary: DispatchCommand<typeof GenerateSummaryCommand>;
 	logger: HutchLogger;
 }): Handler<SQSEvent, SQSBatchResponse> {
-	const { refreshArticleContent, logger } = deps;
+	const { refreshArticleContent, dispatchGenerateSummary, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -34,6 +37,12 @@ export function initRefreshArticleContentHandler(deps: {
 				logger.info("[RefreshArticleContent] processing", { url: detail.url });
 
 				await refreshArticleContent(detail);
+
+				// refreshArticleContent has already reset summaryStatus to pending and
+				// cleared the cached summary text, so the worker won't short-circuit
+				// on the cache-hit branch in summarizeArticle. Mirrors the
+				// recrawl-content-extracted handler's unconditional dispatch.
+				await dispatchGenerateSummary({ url: detail.url });
 
 				logger.info("[RefreshArticleContent] completed", { url: detail.url });
 			} catch (error) {

--- a/projects/save-link/src/save-link/refresh-article-content.ts
+++ b/projects/save-link/src/save-link/refresh-article-content.ts
@@ -33,10 +33,16 @@ export function initRefreshArticleContent(deps: {
 
 	const refreshArticleContent: RefreshArticleContent = async (params) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
+		// Refreshing content invalidates the cached summary. Atomically (a) clear
+		// every summary-derived attribute and (b) flip summaryStatus back to
+		// pending so the row never sits in the inconsistent (status=ready,
+		// summary=missing) state that the reader UI maps to a forever-polling
+		// "Generating summary…". Caller dispatches GenerateSummaryCommand
+		// immediately after this resolves so the worker picks the row up.
 		await table.update({
 			Key: { url: articleResourceUniqueId.value },
 			UpdateExpression:
-				"SET title = :title, siteName = :siteName, excerpt = :excerpt, wordCount = :wordCount, estimatedReadTime = :ert, contentFetchedAt = :cfa, etag = :etag, lastModified = :lm, imageUrl = :img REMOVE summary, summaryInputTokens, summaryOutputTokens",
+				"SET title = :title, siteName = :siteName, excerpt = :excerpt, wordCount = :wordCount, estimatedReadTime = :ert, contentFetchedAt = :cfa, etag = :etag, lastModified = :lm, imageUrl = :img, summaryStatus = :pending REMOVE summary, summaryExcerpt, summaryInputTokens, summaryOutputTokens, summaryStage, summaryFailureReason, summarySkippedReason",
 			ExpressionAttributeValues: {
 				":title": params.metadata.title,
 				":siteName": params.metadata.siteName,
@@ -47,6 +53,7 @@ export function initRefreshArticleContent(deps: {
 				":etag": params.etag ?? null,
 				":lm": params.lastModified ?? null,
 				":img": params.metadata.imageUrl ?? null,
+				":pending": "pending",
 			},
 		});
 	};

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "compile": "tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint scripts\" \"knip\"",
-    "test": "node --test dist/scripts/classify-row.test.js dist/scripts/check-reachable.test.js",
+    "test": "node --test dist/scripts/classify-row.test.js dist/scripts/check-reachable.test.js dist/scripts/check-terminal-state.test.js",
     "check": "pnpm lint && pnpm test",
     "check-infra": "echo 'No infrastructure — canary script'"
   },

--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -119,14 +119,20 @@ async function collectStuckRows(): Promise<StuckRow[]> {
 			`pagination cap reached (${MAX_PAGES} pages) — refine FilterExpression or raise the cap if the table is legitimately growing`,
 		);
 		const page = await table.scan({
+			// The fourth disjunct catches the `summaryStatus="ready" AND
+			// attribute_not_exists(summary)` inconsistency the 2026-05-10
+			// freshness-refresh regression introduced — without it the row
+			// passes both status checks and the canary reports green while the
+			// reader UI polls "Generating summary…" forever.
 			FilterExpression:
 				"summaryStatus IN (:pending, :failed) " +
 				"OR crawlStatus IN (:pending, :failed) " +
-				"OR (attribute_not_exists(summaryStatus) AND attribute_not_exists(crawlStatus) AND attribute_not_exists(summary))",
+				"OR (attribute_not_exists(summaryStatus) AND attribute_not_exists(crawlStatus) AND attribute_not_exists(summary)) " +
+				"OR (summaryStatus = :ready AND attribute_not_exists(summary))",
 			ProjectionExpression:
 				"originalUrl, #u, summaryStatus, crawlStatus, summaryFailureReason, crawlFailureReason, contentFetchedAt, summary",
 			ExpressionAttributeNames: { "#u": "url" },
-			ExpressionAttributeValues: { ":pending": "pending", ":failed": "failed" },
+			ExpressionAttributeValues: { ":pending": "pending", ":failed": "failed", ":ready": "ready" },
 			ExclusiveStartKey: lastEvaluatedKey,
 		});
 		for (const row of page.items) {

--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -34,6 +34,7 @@ import {
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import { filterReachable } from "./check-reachable";
+import { checkTerminalState } from "./check-terminal-state";
 import { type StuckReason, classifyRow } from "./classify-row";
 import { EXCLUDE_PATTERNS } from "./exclude-patterns";
 
@@ -75,6 +76,13 @@ interface StuckRow {
 	contentFetchedAt: string | undefined;
 	failureReason: string | undefined;
 	recrawlUrl: string;
+	/**
+	 * Human-readable explanation of which sub-state(s) are non-terminal,
+	 * computed via checkTerminalState. Surfaced in the failing test message
+	 * so an operator reading the GitHub Actions output knows at a glance
+	 * which writer to suspect without cross-referencing the reason enum.
+	 */
+	terminalCheckMessage: string;
 }
 
 /**
@@ -136,8 +144,9 @@ async function collectStuckRows(): Promise<StuckRow[]> {
 			ExclusiveStartKey: lastEvaluatedKey,
 		});
 		for (const row of page.items) {
+			const verdict = checkTerminalState(row);
+			if (verdict.terminal) continue;
 			const reasons = classifyRow(row);
-			if (reasons.length === 0) continue;
 			if (row.originalUrl === undefined) {
 				skippedNoOriginal += 1;
 				continue;
@@ -152,6 +161,7 @@ async function collectStuckRows(): Promise<StuckRow[]> {
 				contentFetchedAt: row.contentFetchedAt,
 				failureReason: row.summaryFailureReason ?? row.crawlFailureReason,
 				recrawlUrl: `${ORIGIN}/admin/recrawl/${encodeURIComponent(row.originalUrl)}`,
+				terminalCheckMessage: verdict.message,
 			});
 		}
 		lastEvaluatedKey = page.lastEvaluatedKey;
@@ -190,7 +200,7 @@ test("Stuck articles canary", async (t) => {
 		const label = `[${row.reasons.join(",")}] ${row.originalUrl}`;
 		await t.test(label, () => {
 			assert.fail(
-				`Stuck article — fetched: ${row.contentFetchedAt ?? "-"}; failure: ${row.failureReason ?? "-"}; recrawl: ${row.recrawlUrl}`,
+				`Stuck article — ${row.terminalCheckMessage}; fetched: ${row.contentFetchedAt ?? "-"}; failure: ${row.failureReason ?? "-"}; recrawl: ${row.recrawlUrl}`,
 			);
 		});
 	}

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { checkTerminalState } from "./check-terminal-state";
+
+describe("checkTerminalState", () => {
+	it("returns terminal:true when both state machines are ready and the summary text is present", () => {
+		// Why this matters: the happy path on the production write contract —
+		// saveGeneratedSummary writes `summary`, `summaryExcerpt`, and
+		// `summaryStatus='ready'` together; the crawl pipeline writes
+		// `crawlStatus='ready'` on a successful tier promotion. Any future
+		// regression that treats this combination as stuck would page the
+		// operator on every healthy article.
+		const result = checkTerminalState({
+			summaryStatus: "ready",
+			crawlStatus: "ready",
+			summary: "the summary",
+		});
+		assert.deepStrictEqual(result, { terminal: true });
+	});
+
+	it("returns terminal:true when the summary was deliberately skipped (content-too-short etc.)", () => {
+		// Why this matters: `skipped` is a terminal outcome with a documented
+		// reason (e.g. content-too-short). The canary must not surface these
+		// as stuck — they represent a deliberate decision by the summariser
+		// and the reader UI renders a "no summary available" message rather
+		// than polling forever.
+		const result = checkTerminalState({
+			summaryStatus: "skipped",
+			crawlStatus: "ready",
+			summary: undefined,
+		});
+		assert.deepStrictEqual(result, { terminal: true });
+	});
+
+	it("returns terminal:false with the writer-contract message when summaryStatus=ready but the summary text is missing", () => {
+		// Why this matters: this is the exact regression that left 44 rows
+		// stuck after the 2026-05-10 freshness refresh. The classifier alone
+		// returns a code; this presentation layer is what an on-call operator
+		// reads first in the CI log to know whether to escalate to the
+		// engineer who owns the producer side. The message intentionally
+		// names the writer-contract violation, not just the row state.
+		const result = checkTerminalState({
+			summaryStatus: "ready",
+			crawlStatus: "ready",
+			summary: undefined,
+		});
+		assert.deepStrictEqual(result, {
+			terminal: false,
+			message:
+				"summaryStatus is 'ready' but the summary text is missing (writer-contract violation: a producer dropped 'summary' without resetting 'summaryStatus' to 'pending')",
+		});
+	});
+
+	it("concatenates messages when BOTH state machines are non-terminal", () => {
+		// Why this matters: a single row can stall on more than one axis at
+		// the same time (e.g. a crawl that failed before the summary worker
+		// got a chance to run, with a leftover pending summaryStatus from a
+		// prior attempt). The output has to surface both axes so the operator
+		// fixes the right one first — not just the one classifyRow happened
+		// to list first.
+		const result = checkTerminalState({
+			summaryStatus: "pending",
+			crawlStatus: "failed",
+			summary: undefined,
+		});
+		assert.equal(result.terminal, false);
+		assert.equal(
+			result.terminal === false ? result.message : "",
+			"summaryStatus is 'pending' — summary worker never produced a terminal outcome; crawlStatus is 'failed' — crawl worker recorded a non-recoverable failure",
+		);
+	});
+
+	it("returns terminal:false with the legacy-stub message for rows with no statuses and no summary", () => {
+		// Why this matters: legacy stubs pre-date the state machines. The
+		// canary surfaces them so they can be re-primed via the existing
+		// resolveReaderState heal branch (article-reader.ts:101); the
+		// operator-facing message must say "legacy stub" — not "pending" —
+		// so the operator knows the fix is "kick the row through /view"
+		// rather than "wait for the worker to finish".
+		const result = checkTerminalState({
+			summaryStatus: undefined,
+			crawlStatus: undefined,
+			summary: undefined,
+		});
+		assert.deepStrictEqual(result, {
+			terminal: false,
+			message:
+				"legacy stub — row pre-dates the state machines and carries neither status attributes nor a backfilled summary",
+		});
+	});
+
+	it("treats a row with a backfilled summary and no status as terminal", () => {
+		// Why this matters: rowToGeneratedSummary maps these to {status:
+		// 'ready'} via the legacy fall-through; the reader renders the
+		// pre-computed summary. They are NOT stuck and the canary must not
+		// page on them — there are still some left in production from the
+		// pre-state-machine era and they will only fully migrate when each
+		// is touched again.
+		const result = checkTerminalState({
+			summaryStatus: undefined,
+			crawlStatus: undefined,
+			summary: "backfilled summary",
+		});
+		assert.deepStrictEqual(result, { terminal: true });
+	});
+});

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
@@ -1,0 +1,55 @@
+import type { CrawlStatus, SummaryStatus } from "@packages/article-state-types";
+import { type StuckReason, classifyRow } from "./classify-row";
+
+/**
+ * The article-row attributes that participate in deciding whether an article
+ * has reached a terminal-good state. Mirrors the projection used by the
+ * canary's DDB scan (see `check-stuck-articles.ts`) so an unattested attribute
+ * cannot accidentally influence the verdict.
+ */
+type ArticleStateFields = {
+	summaryStatus: SummaryStatus | undefined;
+	crawlStatus: CrawlStatus | undefined;
+	summary: string | undefined;
+};
+
+type TerminalCheckResult = { terminal: true } | { terminal: false; message: string };
+
+/**
+ * Human-readable explanations for each reason code. Surface in CI logs so an
+ * operator reading the workflow output understands which sub-state went off
+ * the rails without having to cross-reference the classifier enum. The
+ * "summary-ready-without-text" message intentionally names the writer-contract
+ * violation rather than just restating the row state — the actionable detail
+ * is that a writer dropped the summary text without flipping the status, not
+ * that the row is currently inconsistent.
+ */
+const REASON_MESSAGES: Record<StuckReason, string> = {
+	"summary-pending": "summaryStatus is 'pending' — summary worker never produced a terminal outcome",
+	"summary-failed": "summaryStatus is 'failed' — summary worker recorded a non-recoverable failure",
+	"summary-ready-without-text":
+		"summaryStatus is 'ready' but the summary text is missing (writer-contract violation: a producer dropped 'summary' without resetting 'summaryStatus' to 'pending')",
+	"crawl-pending": "crawlStatus is 'pending' — crawl worker never produced a terminal outcome",
+	"crawl-failed": "crawlStatus is 'failed' — crawl worker recorded a non-recoverable failure",
+	"legacy-stub":
+		"legacy stub — row pre-dates the state machines and carries neither status attributes nor a backfilled summary",
+};
+
+/**
+ * Decide whether an article row's combined crawl+summary state is terminal,
+ * and if not, return a single human-readable sentence per non-terminal axis
+ * suitable for logging in CI output. Both state machines are inspected — a
+ * row is terminal only when BOTH are terminal AND the writer contract holds
+ * (in particular, `summaryStatus='ready'` MUST be accompanied by a non-empty
+ * `summary` attribute).
+ *
+ * Built on top of `classifyRow` so the canonical "is this row stuck?"
+ * decision tree lives in one place; this function is the diagnostic
+ * presentation layer.
+ */
+export function checkTerminalState(fields: ArticleStateFields): TerminalCheckResult {
+	const reasons = classifyRow(fields);
+	if (reasons.length === 0) return { terminal: true };
+	const message = reasons.map((reason) => REASON_MESSAGES[reason]).join("; ");
+	return { terminal: false, message };
+}

--- a/src/packages/check-stuck-articles/scripts/classify-row.test.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.test.ts
@@ -14,9 +14,23 @@ describe("classifyRow", () => {
 			assert.deepStrictEqual(reasons, ["summary-failed"]);
 		});
 
-		it("returns no reason for ready", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: undefined });
+		it("returns no reason for ready when summary text is present", () => {
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: "the summary" });
 			assert.deepStrictEqual(reasons, []);
+		});
+
+		it("returns summary-ready-without-text when status=ready but the text is missing", () => {
+			// Why this matters: this is the smoking-gun state the
+			// fagnerbrack.com/why-developers-become-frustrated-… row was left
+			// in after the 2026-05-10 freshness refresh — summaryStatus="ready"
+			// but `summary` removed by the UpdateExpression. The original
+			// FilterExpression only matched (pending|failed) statuses and
+			// "all-fields-absent" legacy stubs, so the canary missed this
+			// entire class of stuck row. The reason name is in the report
+			// body the @claude tracking issue prints, so it is also the
+			// single string operators search for when triaging this regression.
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: undefined });
+			assert.deepStrictEqual(reasons, ["summary-ready-without-text"]);
 		});
 
 		it("returns no reason for skipped", () => {
@@ -27,17 +41,17 @@ describe("classifyRow", () => {
 
 	describe("crawlStatus", () => {
 		it("returns crawl-pending for pending", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "pending", summary: undefined });
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "pending", summary: "the summary" });
 			assert.deepStrictEqual(reasons, ["crawl-pending"]);
 		});
 
 		it("returns crawl-failed for failed", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "failed", summary: undefined });
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "failed", summary: "the summary" });
 			assert.deepStrictEqual(reasons, ["crawl-failed"]);
 		});
 
 		it("returns no reason for ready", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: undefined });
+			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready", summary: "the summary" });
 			assert.deepStrictEqual(reasons, []);
 		});
 	});

--- a/src/packages/check-stuck-articles/scripts/classify-row.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.ts
@@ -3,6 +3,7 @@ import type { CrawlStatus, SummaryStatus } from "@packages/article-state-types";
 export type StuckReason =
 	| "summary-pending"
 	| "summary-failed"
+	| "summary-ready-without-text"
 	| "crawl-pending"
 	| "crawl-failed"
 	| "legacy-stub";
@@ -13,6 +14,12 @@ export type StuckReason =
  * `summary`). The two switches use exhaustive `never` defaults so a new
  * SummaryStatus or CrawlStatus added to @packages/article-state-types breaks
  * `tsc --noEmit` until the classifier handles it.
+ *
+ * "summary-ready-without-text" catches the writer-contract violation that
+ * left fagnerbrack.com/why-developers-become-frustrated-… stuck on
+ * 2026-05-10: a row with summaryStatus="ready" but no `summary` text. The
+ * status enums alone do not surface this — a row in that state passes both
+ * status checks and would otherwise fall through as healthy.
  */
 export function classifyRow(
 	row: {
@@ -31,6 +38,10 @@ export function classifyRow(
 				reasons.push("summary-failed");
 				break;
 			case "ready":
+				if (row.summary === undefined) {
+					reasons.push("summary-ready-without-text");
+				}
+				break;
 			case "skipped":
 				break;
 			default: {


### PR DESCRIPTION
## Summary
- After a freshness refresh, `refresh-article-content` REMOVEd `summary, summaryInputTokens, summaryOutputTokens` but left `summaryStatus="ready"` in place and never dispatched a follow-up `GenerateSummaryCommand`. The row was left in a self-inconsistent state — status=ready, no summary text — which `rowToGeneratedSummary` silently mapped to `undefined`, defaulting the reader UI to "Generating summary…" and polling `/view/summary` every 3s forever. Caught after the 2026-05-10 refresh ran on `fagnerbrack.com/why-developers-become-frustrated-…` and the row stayed stuck for the rest of the day with the canary green.
- **Producer**: `refresh-article-content` now atomically resets `summaryStatus="pending"` and clears every summary-derived attribute inside the same UpdateExpression; the handler then dispatches `GenerateSummaryCommand`. Mirrors the unconditional dispatch pattern `recrawl-content-extracted-handler` already uses.
- **Consumer**: `rowToGeneratedSummary` gains an explicit `summaryStatus="ready"` branch with `assert(row.summary)` (both copies). A future writer that drops summary text without flipping status now surfaces as a loud 500, instead of the silent forever-polling UI. A small `readyFromRow` helper de-duplicates excerpt-attach logic across the explicit branch and the legacy fall-through.
- **Canary**: `classifyRow` gains `"summary-ready-without-text"` and the DDB scan `FilterExpression` gains `summaryStatus=:ready AND attribute_not_exists(summary)` so this entire class of stuck row is detected on the next scheduled run instead of passing as healthy.

## Test plan
- [x] `pnpm nx run-many --target=test --projects=save-link,hutch,@packages/check-stuck-articles` — all 1118 tests pass
- [x] `pnpm nx run save-link:test-with-coverage` — 100% across statements/branches/functions/lines
- [x] `pnpm nx run save-link:check` (the pre-commit hook target) — green
- [x] New tests:
  - `refresh-article-content-handler` dispatches `GenerateSummaryCommand` AFTER `refreshArticleContent` resolves
  - `refresh-article-content-handler` does NOT dispatch when the DDB update throws (lets SQS replay the whole transaction)
  - `rowToGeneratedSummary` (both copies) throws `summaryStatus=ready row must carry a summary` when status=ready but text missing
  - `classifyRow` returns `["summary-ready-without-text"]` for the new failure mode
- [ ] After merge: trigger the stuck-articles canary (`workflow_dispatch`) so existing stuck rows surface, then `forceMarkSummaryPending` each one to recover.