### PR TITLE
feat(hutch): add bottom back-to-queue link with utm tracking

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -853,7 +853,8 @@ describe("Queue routes", () => {
 			const doc = new JSDOM(readerResponse.text).window.document;
 			expect(doc.querySelector("[data-test-reader-content]")?.textContent).toContain("archived content");
 			expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe("Saved Post");
-			expect(doc.querySelector("[data-test-back-link]")?.getAttribute("href")).toBe("/queue");
+			expect(doc.querySelector("[data-test-back-link]")?.getAttribute("href")).toBe("/queue?utm_source=reader&utm_medium=internal&utm_content=back-top");
+			expect(doc.querySelector("[data-test-back-bottom-link]")?.getAttribute("href")).toBe("/queue?utm_source=reader&utm_medium=internal&utm_content=back-bottom");
 			expect(doc.querySelector("[data-test-original-link]")?.getAttribute("href")).toBe("https://example.com/saved-post");
 		});
 

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -54,7 +54,11 @@ export function ReaderPage(
 		summaryOpen: true,
 		progress: options?.progress,
 		audioEnabled: options?.audioEnabled,
-		backLink: { href: "/queue", label: "← Back to queue" },
+		backLink: {
+			topHref: "/queue?utm_source=reader&utm_medium=internal&utm_content=back-top",
+			bottomHref: "/queue?utm_source=reader&utm_medium=internal&utm_content=back-bottom",
+			label: "← Back to queue",
+		},
 		extensionInstallUrl: options?.extensionInstallUrl,
 	});
 	const shareBalloon = renderShareBalloon({

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -55,6 +55,16 @@ describe("ViewPage", () => {
 		);
 	});
 
+	it("marks the bottom back slot as hidden on the view page", () => {
+		const doc = render();
+
+		const slot = doc.querySelector("[data-test-back-bottom-slot]");
+		assert(slot, "bottom back slot must be rendered");
+		expect(
+			slot.classList.contains("article-body__back-bottom-slot--hidden"),
+		).toBe(true);
+	});
+
 	it("renders each action as an anchor with name and href from the model", () => {
 		const doc = render({
 			...baseInput,

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
@@ -54,7 +54,11 @@ describe("renderArticleBody", () => {
 		const html = renderArticleBody({
 			...baseInput,
 			content: "<p>Body</p>",
-			backLink: { href: "/queue", label: "← Back" },
+			backLink: {
+				topHref: "/queue?utm_content=back-top",
+				bottomHref: "/queue?utm_content=back-bottom",
+				label: "← Back",
+			},
 		});
 		const doc = parse(html);
 
@@ -65,7 +69,7 @@ describe("renderArticleBody", () => {
 		);
 		const link = slot.querySelector("[data-test-back-link]");
 		assert(link, "back link must be rendered when backLink is provided");
-		expect(link.getAttribute("href")).toBe("/queue");
+		expect(link.getAttribute("href")).toBe("/queue?utm_content=back-top");
 		expect(link.textContent).toBe("← Back");
 	});
 
@@ -80,6 +84,67 @@ describe("renderArticleBody", () => {
 		assert(slot, "back slot must be rendered");
 		expect(slot.classList.contains("article-body__back-slot--hidden")).toBe(
 			true,
+		);
+	});
+
+	it("renders the bottom back link inside the bottom back slot when backLink is provided", () => {
+		const html = renderArticleBody({
+			...baseInput,
+			content: "<p>Body</p>",
+			backLink: {
+				topHref: "/queue?utm_content=back-top",
+				bottomHref: "/queue?utm_content=back-bottom",
+				label: "← Back",
+			},
+		});
+		const doc = parse(html);
+
+		const slot = doc.querySelector("[data-test-back-bottom-slot]");
+		assert(slot, "bottom back slot must be rendered");
+		expect(
+			slot.classList.contains("article-body__back-bottom-slot--visible"),
+		).toBe(true);
+		const link = slot.querySelector("[data-test-back-bottom-link]");
+		assert(link, "bottom back link must be rendered when backLink is provided");
+		expect(link.getAttribute("href")).toBe("/queue?utm_content=back-bottom");
+		expect(link.textContent).toBe("← Back");
+	});
+
+	it("marks the bottom back slot as hidden when backLink is not provided", () => {
+		const html = renderArticleBody({
+			...baseInput,
+			content: "<p>Body</p>",
+		});
+		const doc = parse(html);
+
+		const slot = doc.querySelector("[data-test-back-bottom-slot]");
+		assert(slot, "bottom back slot must be rendered");
+		expect(
+			slot.classList.contains("article-body__back-bottom-slot--hidden"),
+		).toBe(true);
+	});
+
+	it("renders independent hrefs for the top and bottom back links so they can carry distinct UTM markers", () => {
+		const html = renderArticleBody({
+			...baseInput,
+			content: "<p>Body</p>",
+			backLink: {
+				topHref: "/queue?utm_source=reader&utm_content=back-top",
+				bottomHref: "/queue?utm_source=reader&utm_content=back-bottom",
+				label: "← Back to queue",
+			},
+		});
+		const doc = parse(html);
+
+		const topLink = doc.querySelector("[data-test-back-link]");
+		const bottomLink = doc.querySelector("[data-test-back-bottom-link]");
+		assert(topLink, "top back link must be rendered");
+		assert(bottomLink, "bottom back link must be rendered");
+		expect(topLink.getAttribute("href")).toBe(
+			"/queue?utm_source=reader&utm_content=back-top",
+		);
+		expect(bottomLink.getAttribute("href")).toBe(
+			"/queue?utm_source=reader&utm_content=back-bottom",
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
@@ -30,7 +30,7 @@ export interface ArticleBodyInput {
 	summaryPollUrl?: string;
 	summaryOpen?: boolean;
 	audioEnabled?: boolean;
-	backLink?: { href: string; label: string };
+	backLink?: { topHref: string; bottomHref: string; label: string };
 	extensionInstallUrl?: string;
 	/**
 	 * Single unified progress tick. When omitted (everything terminal, or
@@ -64,7 +64,9 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		siteName: input.siteName,
 		estimatedReadTime: input.estimatedReadTime,
 		url: input.url,
-		backLink: input.backLink,
+		backLink: input.backLink
+			? { href: input.backLink.topHref, label: input.backLink.label }
+			: undefined,
 	});
 
 	return render(ARTICLE_BODY_TEMPLATE, {
@@ -74,5 +76,6 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		progressBarHtml,
 		audioEnabled: input.audioEnabled,
 		staticBaseUrl: STATIC_BASE_URL,
+		backLink: input.backLink,
 	});
 }

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -375,3 +375,25 @@
   display: block;
   margin-top: 0.5rem;
 }
+
+.article-body__back-bottom-slot--visible {
+  display: block;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.article-body__back-bottom-slot--hidden {
+  display: none;
+}
+
+.article-body__back-bottom {
+  display: inline-block;
+  font-size: 0.875rem;
+  color: var(--color-brand);
+  text-decoration: none;
+}
+
+.article-body__back-bottom:hover {
+  text-decoration: underline;
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
@@ -5,3 +5,4 @@
       <audio controls preload="metadata" src="{{staticBaseUrl}}/sample-audio.opus" data-audio-element></audio>
     </div></div>{{else}}<div class="article-body__audio-slot article-body__audio-slot--hidden" data-test-audio-player></div>{{/if}}
     {{{readerSlotHtml}}}
+    {{#if backLink}}<div class="article-body__back-bottom-slot article-body__back-bottom-slot--visible" data-test-back-bottom-slot><a class="article-body__back-bottom" href="{{backLink.bottomHref}}" data-test-back-bottom-link>{{backLink.label}}</a></div>{{else}}<div class="article-body__back-bottom-slot article-body__back-bottom-slot--hidden" data-test-back-bottom-slot></div>{{/if}}


### PR DESCRIPTION
## Summary

- Add a "← Back to queue" link at the **bottom** of the reader page (`/queue/:id/read`), mirroring the top link, so users finishing a long article don't have to scroll all the way back up to navigate.
- Tag both top and bottom back links with distinct `utm_content` markers (`back-top`, `back-bottom`) so the existing analytics pipeline in [analytics.ts](projects/hutch/src/runtime/analytics.ts) can measure relative click-rates and inform whether the bottom CTA is worth keeping.
- View Page (`/view/:url`) is unaffected — back slots stay hidden there as today.

## Why

Long articles force readers to scroll to the top of the page to navigate back to their queue. A bottom back link puts the next-action navigation exactly where the user's eyes finish, removing that friction. The UTM markers on *both* links let us validate the bet: if `back-bottom` carries meaningful click share, keep it; if not, revisit.

The UTM convention (`utm_source=<page>&utm_medium=internal&utm_content=<link-id>`) matches the existing internal-navigation tracking used by `login.template.html`, `view.page.ts`, etc., so existing analytics dashboards pick up the new clicks without any plumbing changes.

## Changes

| File | Change |
|---|---|
| `shared/article-body/article-body.component.ts` | `backLink` shape: `{ href, label }` → `{ topHref, bottomHref, label }` |
| `shared/article-body/article-body.template.html` | New bottom back-slot rendered after the reader slot |
| `shared/article-body/article-body.styles.css` | Bottom back-slot styles (full-width separator on the slot, link text styled like top) |
| `pages/reader/reader.component.ts` | Pass UTM-tagged top + bottom hrefs |
| `shared/article-body/article-body.component.test.ts` | Updated existing tests; added bottom slot visible/hidden tests; added test proving top + bottom carry independent hrefs |
| `pages/view/view.component.test.ts` | Asserts the bottom slot is also hidden on the View Page |
| `pages/queue/queue.route.test.ts` | Reader-route integration test now asserts both UTM hrefs |

## Test plan

- [x] `pnpm nx run hutch:check` passes (all unit + integration tests + 100% coverage threshold met)
- [x] `pnpm check` (full repo) passes locally
- [ ] Visual verification on the reader page that the bottom link appears below the article content with a separator and matches the top link's text styling
- [ ] After deploy, confirm analytics events surface `utm_content=back-top` and `utm_content=back-bottom` for `/queue` visits originating from the reader page

https://claude.ai/code/session_01SVuB8j7pz5R3u3XHn56Lsi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVuB8j7pz5R3u3XHn56Lsi)_