### PR TITLE
refactor(hutch): inject founding member limit instead of importing

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -61,6 +61,10 @@ import { validateSaveableUrl } from "@packages/domain/article";
 import { createApp } from "./server";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
 import { httpErrorMessageMapping } from "./web/pages/queue/queue.error";
+import {
+	PROD_FOUNDING_MEMBER_LIMIT,
+	initFoundingAllocation,
+} from "./web/shared/founding-progress/founding-allocation";
 import { getEnv, requireEnv } from "./require-env";
 
 function initProviders() {
@@ -366,6 +370,9 @@ export function createHutchApp(deps?: {
 		importSessionStore,
 		now: () => new Date(),
 		botDefenseLogger: HutchLogger.fromJSON<BotDefenseEvent>(),
+		foundingAllocation: initFoundingAllocation({
+			foundingMemberLimit: PROD_FOUNDING_MEMBER_LIMIT,
+		}),
 	});
 
 	return { app, auth, articleStore, oauthModel };

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -86,7 +86,8 @@ import { initAdminRecrawlRoutes } from "./web/pages/admin/recrawl.page";
 import { initEmbedRoutes } from "./web/pages/embed/embed.page";
 import { initExportRoutes } from "./web/pages/export/export.page";
 import { initBlogRoutes } from "./web/pages/blog";
-import { getAllPostMetadata } from "./web/pages/blog/blog.posts";
+import { initBlogPosts } from "./web/pages/blog/blog.posts";
+import type { FoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import { initDualAuth, type ValidateAccessToken } from "./web/dual-auth.middleware";
 import { initMarkExtensionInstalled } from "./web/mark-extension-installed.middleware";
 import { initOAuthRoutes } from "./web/oauth/oauth.routes";
@@ -171,6 +172,7 @@ interface AppDependencies {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
+	foundingAllocation: FoundingAllocation;
 }
 
 function requireAuth(req: Request, res: Response, next: NextFunction): void {
@@ -186,8 +188,12 @@ const LLMS_FULL_TXT = readFileSync(join(__dirname, "llms-full.txt"), "utf-8");
 const INDEXNOW_KEY = getEnv("INDEXNOW_KEY");
 
 export function createApp(dependencies: AppDependencies): Express {
-	const { appOrigin, staticBaseUrl, getSessionUserId, countUsers, ...deps } = dependencies;
+	const { appOrigin, staticBaseUrl, getSessionUserId, countUsers, foundingAllocation, ...deps } = dependencies;
 	const app: Express = express();
+
+	const blogPosts = initBlogPosts({
+		foundingMemberLimit: foundingAllocation.foundingMemberLimit,
+	});
 
 	app.use(express.urlencoded({ extended: true }));
 	app.use(cookieParser());
@@ -293,7 +299,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			{ loc: "/llms-full.txt", priority: "0.3", changefreq: "monthly", lastmod: "2026-04-08" },
 		];
 
-		for (const post of getAllPostMetadata()) {
+		for (const post of blogPosts.getAllPostMetadata()) {
 			pages.push({
 				loc: `/blog/${post.slug}`,
 				priority: blogPriorityMap[post.slug] ?? "0.7",
@@ -344,7 +350,11 @@ export function createApp(dependencies: AppDependencies): Express {
 			: ua.includes("Chrome/") ? "chrome"
 			: "other";
 		const userCount = await countUsers().catch(() => 0);
-		sendComponent(req, res, renderPage(req, HomePage({ userCount, staticBaseUrl, browser })));
+		sendComponent(
+			req,
+			res,
+			renderPage(req, HomePage({ userCount, staticBaseUrl, browser, foundingAllocation })),
+		);
 	});
 
 	app.get("/privacy", (req: Request, res: Response) => {
@@ -377,7 +387,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		sendComponent(req, res, renderPage(req, InstallPage({ firefox, chrome, browser })));
 	});
 
-	const blogRouter = initBlogRoutes();
+	const blogRouter = initBlogRoutes({ blogPosts });
 	app.use("/blog", (req: Request, res: Response, next: NextFunction) => {
 		if (req.headers.host === "hutch-app.com") {
 			res.redirect(301, `${appOrigin}${req.originalUrl}`);
@@ -411,6 +421,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		logError: deps.logError,
 		now: deps.now,
 		botDefenseLogger: deps.botDefenseLogger,
+		foundingAllocation,
 	});
 	app.use(authRouter);
 
@@ -431,6 +442,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			storePendingSignup: deps.storePendingSignup,
 			sendEmail: deps.sendEmail,
 			logError: deps.logError,
+			foundingAllocation,
 		});
 		app.use(googleAuthRouter);
 	}

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -64,6 +64,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			stripe: fixture.stripe,
 			pendingSignup: fixture.pendingSignup,
 			botDefense: fixture.botDefense,
+			foundingAllocation: fixture.foundingAllocation,
 		});
 
 		expect(typeof result.app).toBe("function");

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -88,6 +88,7 @@ import type { ImportSessionStore } from "@packages/domain/import-session";
 import { createApp } from "./server";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
 import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
+import { initFoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 
 export interface AuthBundle {
 	createUser: CreateUser;
@@ -229,6 +230,14 @@ export interface BotDefenseBundle {
 	events: BotDefenseEvent[];
 }
 
+/** Carries the founding-member cap as a plain number. The runtime predicate is
+ * constructed via `initFoundingAllocation` inside `flattenFixtureToAppDependencies`
+ * so the test-fixtures package can keep the same shape without importing from
+ * projects/hutch (mirrors the SharedBundle.validateSaveableUrl pattern). */
+export interface FoundingAllocationBundle {
+	foundingMemberLimit: number;
+}
+
 export interface TestAppFixture {
 	auth: AuthBundle;
 	articleStore: ArticleStoreBundle;
@@ -249,6 +258,7 @@ export interface TestAppFixture {
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
 	botDefense: BotDefenseBundle;
+	foundingAllocation: FoundingAllocationBundle;
 }
 
 export interface TestAppResult {
@@ -331,6 +341,9 @@ function flattenFixtureToAppDependencies(
 		storePendingSignup: fixture.pendingSignup.storePendingSignup,
 		consumePendingSignup: fixture.pendingSignup.consumePendingSignup,
 		botDefenseLogger: fixture.botDefense.logger,
+		foundingAllocation: initFoundingAllocation({
+			foundingMemberLimit: fixture.foundingAllocation.foundingMemberLimit,
+		}),
 	};
 }
 

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -3,10 +3,7 @@ import { join } from "node:path";
 import type { PageBody } from "../page-body.types";
 import { render } from "../render";
 import { renderFoundingProgress } from "../shared/founding-progress/founding-progress.component";
-import {
-	FOUNDING_MEMBER_LIMIT,
-	isFoundingAllocationExhausted,
-} from "../shared/founding-progress/founding-allocation";
+import type { FoundingAllocation } from "../shared/founding-progress/founding-allocation";
 import { STRIPE_TRIAL_PERIOD_DAYS } from "../../providers/stripe-checkout/stripe-trial-config";
 import { AUTH_STYLES } from "./auth.styles";
 
@@ -27,6 +24,7 @@ interface AuthFormData {
 	globalError?: string;
 	returnUrl?: string;
 	userCount: number;
+	foundingAllocation: FoundingAllocation;
 }
 
 interface SignupFormData extends AuthFormData {
@@ -94,7 +92,7 @@ export function VerifyEmailPage(data: { success: boolean; error?: string }): Pag
 export function SignupPage(data: SignupFormData, options?: { statusCode?: number }): PageBody {
 	const email = data.email ?? "";
 	const errors = data.errors;
-	const trialSuffix = isFoundingAllocationExhausted(data.userCount)
+	const trialSuffix = data.foundingAllocation.isFoundingAllocationExhausted(data.userCount)
 		? ` (${STRIPE_TRIAL_PERIOD_DAYS} days free)`
 		: "";
 
@@ -110,9 +108,10 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		googleLabel: `Sign up with Google${trialSuffix}`,
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
+			foundingAllocation: data.foundingAllocation,
 		}),
-		foundingMemberLimit: FOUNDING_MEMBER_LIMIT,
-		foundingAvailable: !isFoundingAllocationExhausted(data.userCount),
+		foundingMemberLimit: data.foundingAllocation.foundingMemberLimit,
+		foundingAvailable: !data.foundingAllocation.isFoundingAllocationExhausted(data.userCount),
 	});
 
 	return {

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -40,7 +40,7 @@ import { buildVerificationEmailHtml } from "./verification-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
 import { initSendWelcomeEmail } from "./send-welcome-email";
-import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
+import type { FoundingAllocation } from "../shared/founding-progress/founding-allocation";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
@@ -76,6 +76,7 @@ interface AuthDependencies {
 	logError: (message: string, error?: Error) => void;
 	now: () => Date;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
+	foundingAllocation: FoundingAllocation;
 }
 
 type BotDefenseResult =
@@ -171,7 +172,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 		const returnUrl = extractReturnUrl(req.query);
 		const userCount = await fetchUserCount();
-		sendComponent(req, res, renderPage(req, LoginPage({ returnUrl, userCount })));
+		sendComponent(req, res, renderPage(req, LoginPage({ returnUrl, userCount, foundingAllocation: deps.foundingAllocation })));
 	});
 
 	router.post("/login", async (req: Request, res: Response) => {
@@ -186,6 +187,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					{
 						returnUrl,
 						userCount,
+						foundingAllocation: deps.foundingAllocation,
 						email: req.body?.email,
 						errors: flattenZodErrors(parsed.error.issues),
 					},
@@ -206,6 +208,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					{
 						returnUrl,
 						userCount,
+						foundingAllocation: deps.foundingAllocation,
 						email,
 						globalError: "Invalid email or password",
 					},
@@ -229,7 +232,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const userCount = await fetchUserCount();
 		const parsed = SignupQuerySchema.safeParse(req.query);
 		const email = parsed.success ? parsed.data.email : undefined;
-		sendComponent(req, res, renderPage(req, SignupPage({ returnUrl, userCount, loadedAt: deps.now().getTime(), email })));
+		sendComponent(req, res, renderPage(req, SignupPage({ returnUrl, userCount, foundingAllocation: deps.foundingAllocation, loadedAt: deps.now().getTime(), email })));
 	});
 
 	router.post("/signup", async (req: Request, res: Response) => {
@@ -265,6 +268,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					{
 						returnUrl,
 						userCount,
+						foundingAllocation: deps.foundingAllocation,
 						loadedAt: deps.now().getTime(),
 						email: req.body?.email,
 						errors: flattenZodErrors(parsed.error.issues),
@@ -286,6 +290,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					{
 						returnUrl,
 						userCount,
+						foundingAllocation: deps.foundingAllocation,
 						loadedAt: deps.now().getTime(),
 						email,
 						globalError: "An account with this email already exists",
@@ -299,7 +304,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const passwordHash = await hashPassword(password);
 
 		const userCount = await fetchUserCount();
-		if (!isFoundingAllocationExhausted(userCount)) {
+		if (!deps.foundingAllocation.isFoundingAllocationExhausted(userCount)) {
 			const created = await deps.createUserWithPasswordHash({ email, passwordHash });
 			if (!created.ok) {
 				const refreshedCount = await fetchUserCount();
@@ -310,6 +315,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						{
 							returnUrl,
 							userCount: refreshedCount,
+							foundingAllocation: deps.foundingAllocation,
 							loadedAt: deps.now().getTime(),
 							email,
 							globalError: "An account with this email already exists",
@@ -355,6 +361,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				renderPage(req, SignupPage(
 					{
 						userCount,
+						foundingAllocation: deps.foundingAllocation,
 						loadedAt: deps.now().getTime(),
 						globalError: "Missing checkout session — please start again.",
 					},
@@ -371,7 +378,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				req, res,
-				renderPage(req, SignupPage({ userCount, loadedAt: deps.now().getTime(), globalError }, { statusCode })),
+				renderPage(req, SignupPage({ userCount, foundingAllocation: deps.foundingAllocation, loadedAt: deps.now().getTime(), globalError }, { statusCode })),
 			);
 		};
 

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -9,7 +9,12 @@ import {
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
-import { FOUNDING_MEMBER_LIMIT } from "../shared/founding-progress/founding-allocation"
+
+/** Matches the default test fixture's `foundingAllocation.foundingMemberLimit`.
+ * Tests use this constant for seed-loop bounds and assertion text so the
+ * coupling lives inside the test layer — production code can change
+ * `PROD_FOUNDING_MEMBER_LIMIT` without rippling through these specs. */
+const TEST_FOUNDING_MEMBER_LIMIT = 3;
 
 /** A loadedAt value safely older than the bot-defense minimum submit window
  * (2.5s), so the form submission passes the timing gate. */
@@ -312,7 +317,7 @@ describe("Auth routes", () => {
 
 		it("should redirect to Stripe checkout when at the founding limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -329,7 +334,7 @@ describe("Auth routes", () => {
 
 		it("should fall back to free signup after a manual deletion drops the count below the limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT + 1; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT + 1; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			await auth.deleteUser("seed0@test.com");
@@ -395,7 +400,7 @@ describe("Auth routes", () => {
 
 		it("should redirect new visitors to a Stripe checkout URL when at the founding limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -728,7 +733,7 @@ describe("Auth routes", () => {
 
 		it("falls through to the existing happy path (303 to Stripe) when the honeypot is empty, loadedAt is older than 2.5s, and the founding allocation is exhausted", async () => {
 			const { app, auth, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
@@ -885,7 +890,7 @@ describe("Auth routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 
 			const label = doc.querySelector("[data-test-founding-progress] .founding-progress__label");
-			expect(label?.textContent).toBe(`0 / ${FOUNDING_MEMBER_LIMIT} founding members`);
+			expect(label?.textContent).toBe(`0 / ${TEST_FOUNDING_MEMBER_LIMIT} founding members`);
 		});
 
 		it("should keep the progress bar on POST /signup 422 responses", async () => {
@@ -897,7 +902,7 @@ describe("Auth routes", () => {
 			expect(response.status).toBe(422);
 			const doc = new JSDOM(response.text).window.document;
 			const label = doc.querySelector("[data-test-founding-progress] .founding-progress__label");
-			expect(label?.textContent).toBe(`0 / ${FOUNDING_MEMBER_LIMIT} founding members`);
+			expect(label?.textContent).toBe(`0 / ${TEST_FOUNDING_MEMBER_LIMIT} founding members`);
 		});
 
 		it("should render the founding blurb on GET /signup when allocation is available", async () => {
@@ -905,14 +910,14 @@ describe("Auth routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 
 			const blurb = doc.querySelector("[data-test-founding-blurb]");
-			expect(blurb?.textContent).toBe(`Free account for the first ${FOUNDING_MEMBER_LIMIT} readers`);
+			expect(blurb?.textContent).toBe(`Free account for the first ${TEST_FOUNDING_MEMBER_LIMIT} readers`);
 		});
 	});
 
 	describe("Founding members progress — exhausted allocation", () => {
 		it("should hide the founding progress and blurb on /signup when at the limit", async () => {
 			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 			}
 

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -5,10 +5,14 @@ import { createTestApp } from "../../test-app";
 import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
-import { FOUNDING_MEMBER_LIMIT } from "../shared/founding-progress/founding-allocation";
+
+/** Matches the default test fixture's `foundingAllocation.foundingMemberLimit`.
+ * Tests own this constant so production changes to `PROD_FOUNDING_MEMBER_LIMIT`
+ * cannot ripple through seed loops or assertions. */
+const TEST_FOUNDING_MEMBER_LIMIT = 3;
 
 async function seedAboveFoundingLimit(auth: { createUser: (params: { email: string; password: string }) => Promise<{ ok: boolean }> }) {
-	for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+	for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 		await auth.createUser({ email: `gate-${i}@test.invalid`, password: "password123" });
 	}
 }

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -21,6 +21,7 @@ import { validateSaveableUrl } from "@packages/domain/article";
 import { createApp } from "../../server";
 import { httpErrorMessageMapping } from "../pages/queue/queue.error";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
+import { initFoundingAllocation } from "../shared/founding-progress/founding-allocation";
 
 describe("Email verification", () => {
 	describe("POST /signup → Stripe → success", () => {
@@ -97,6 +98,7 @@ describe("Email verification", () => {
 				importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
 				now: () => new Date(),
 				botDefenseLogger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+				foundingAllocation: initFoundingAllocation({ foundingMemberLimit: 3 }),
 			});
 
 			const { successResponse } = await completeStripeSignup({

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -14,7 +14,7 @@ import type { SendEmail } from "@packages/test-fixtures/providers/email";
 import type { ExchangeGoogleCode } from "@packages/test-fixtures/providers/google-auth";
 import type { StorePendingSignup } from "@packages/test-fixtures/providers/pending-signup";
 import type { CreateCheckoutSession } from "@packages/test-fixtures/providers/stripe-checkout";
-import { isFoundingAllocationExhausted } from "../shared/founding-progress/founding-allocation";
+import type { FoundingAllocation } from "../shared/founding-progress/founding-allocation";
 import { initSendWelcomeEmail } from "./send-welcome-email";
 import { renderPage } from "../render-page";
 import { sendComponent } from "../send-component";
@@ -53,6 +53,7 @@ interface GoogleAuthDependencies {
 	storePendingSignup: StorePendingSignup;
 	sendEmail: SendEmail;
 	logError: (message: string, error?: Error) => void;
+	foundingAllocation: FoundingAllocation;
 }
 
 const signState = (payload: string, secret: string): string => {
@@ -117,7 +118,14 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 
 		const renderError = async (globalError: string) => {
 			const userCount = await fetchUserCount();
-			sendComponent(req, res, renderPage(req, LoginPage({ userCount, globalError }, { statusCode: 400 })));
+			sendComponent(
+				req,
+				res,
+				renderPage(req, LoginPage(
+					{ userCount, foundingAllocation: deps.foundingAllocation, globalError },
+					{ statusCode: 400 },
+				)),
+			);
 		};
 
 		if (!parsedQuery.success || !stateCookie || parsedQuery.data.state !== stateCookie) {
@@ -167,7 +175,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 		const safeReturnUrl = extractReturnUrl({ return: stateData.returnUrl });
 
 		const userCount = await fetchUserCount();
-		if (!isFoundingAllocationExhausted(userCount)) {
+		if (!deps.foundingAllocation.isFoundingAllocationExhausted(userCount)) {
 			const created = await deps.createGoogleUser({
 				email: tokenResult.email,
 				userId: newUserId,

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -11,7 +11,11 @@ import {
 import { GoogleIdSchema } from "@packages/test-fixtures/providers/google-auth";
 import type { ExchangeGoogleCode } from "@packages/test-fixtures/providers/google-auth";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
-import { FOUNDING_MEMBER_LIMIT } from "../shared/founding-progress/founding-allocation";
+
+/** Matches the default test fixture's `foundingAllocation.foundingMemberLimit`.
+ * Tests own this constant so production changes to `PROD_FOUNDING_MEMBER_LIMIT`
+ * cannot ripple through seed loops or assertions. */
+const TEST_FOUNDING_MEMBER_LIMIT = 3;
 
 const TEST_CLIENT_ID = "test-google-client-id";
 const TEST_CLIENT_SECRET = "test-google-client-secret";
@@ -349,7 +353,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
@@ -375,7 +379,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
@@ -411,7 +415,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState({ returnUrl: "/save?url=https%3A%2F%2Fexample.com" }));

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -5,7 +5,6 @@ import type { Express } from "express";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import type { CheckoutSessionId } from "@packages/test-fixtures/providers/stripe-checkout";
 import type { AuthBundle } from "../../../test-app";
-import { FOUNDING_MEMBER_LIMIT } from "../../shared/founding-progress/founding-allocation";
 
 interface StripeBundle {
 	markPaid: (id: CheckoutSessionId) => void;
@@ -17,9 +16,10 @@ interface StripeBundle {
  * the shared agent so the session cookie persists.
  *
  * Stripe checkout is gated behind the founding-member allocation: signups only
- * route through Stripe once the user count reaches FOUNDING_MEMBER_LIMIT. This
- * helper seeds enough fake users to meet that boundary so callers can
- * exercise the paid path without needing to know about it. */
+ * route through Stripe once the user count reaches the configured limit. The
+ * default test fixture uses limit=3, so seeding 3 fake users here pushes any
+ * subsequent signup onto the paid path. Tests with custom limits pass
+ * `foundingMemberLimit` explicitly. */
 export async function completeStripeSignup(params: {
 	app: Express;
 	auth: AuthBundle;
@@ -28,12 +28,14 @@ export async function completeStripeSignup(params: {
 	password: string;
 	returnUrl?: string;
 	agent?: SuperTest<Test>;
+	foundingMemberLimit?: number;
 }): Promise<{
 	signupResponse: import("supertest").Response;
 	successResponse: import("supertest").Response;
 	checkoutSessionId: CheckoutSessionId;
 }> {
-	for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+	const seedCount = params.foundingMemberLimit ?? 3;
+	for (let i = 0; i < seedCount; i++) {
 		const seedEmail = `stripe-seed-${i}@test.invalid`;
 		const existing = await params.auth.findUserByEmail(seedEmail);
 		if (!existing) {

--- a/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
@@ -5,7 +5,7 @@ import { sendComponent } from "../../send-component";
 import { BlogIndexPage } from "./blog-index.component";
 import { BlogPostPage } from "./blog-post.component";
 import { NotFoundPage } from "../not-found";
-import { getAllPosts, findPostBySlug } from "./blog.posts";
+import type { BlogPosts } from "./blog.posts";
 
 const SLUG_REDIRECTS: Record<string, string> = {
 	"hutch-vs-readwise-reader": "readplace-vs-readwise-reader",
@@ -13,11 +13,12 @@ const SLUG_REDIRECTS: Record<string, string> = {
 	"hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later": "readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later",
 };
 
-export function initBlogRoutes(): Router {
+export function initBlogRoutes(deps: { blogPosts: BlogPosts }): Router {
 	const router = express.Router();
+	const { blogPosts } = deps;
 
 	router.get("/", (req: Request, res: Response) => {
-		const posts = getAllPosts();
+		const posts = blogPosts.getAllPosts();
 		sendComponent(req, res, renderPage(req, BlogIndexPage({ posts })));
 	});
 
@@ -27,7 +28,7 @@ export function initBlogRoutes(): Router {
 			res.redirect(301, `/blog/${newSlug}`);
 			return;
 		}
-		const post = findPostBySlug(req.params.slug);
+		const post = blogPosts.findPostBySlug(req.params.slug);
 		if (!post) {
 			sendComponent(req, res, renderPage(req, NotFoundPage()));
 			return;

--- a/projects/hutch/src/runtime/web/pages/blog/blog.posts.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.posts.test.ts
@@ -1,7 +1,9 @@
-import { getAllPosts, findPostBySlug, getAllSlugs } from "./blog.posts";
+import { initBlogPosts } from "./blog.posts";
+
+const blogPosts = initBlogPosts({ foundingMemberLimit: 3 });
 
 describe("blog posts", () => {
-	const posts = getAllPosts();
+	const posts = blogPosts.getAllPosts();
 
 	it("should load at least one post", () => {
 		expect(posts.length).toBeGreaterThan(0);
@@ -53,25 +55,33 @@ describe("blog posts", () => {
 		const slugs = posts.map((p) => p.slug);
 		expect(new Set(slugs).size).toBe(slugs.length);
 	});
+
+	it("should substitute the injected foundingMemberLimit into markdown placeholders", () => {
+		const customLimit = 17;
+		const customBlogPosts = initBlogPosts({ foundingMemberLimit: customLimit });
+		const omnivore = customBlogPosts.findPostBySlug("omnivore-alternative");
+		expect(omnivore).toBeDefined();
+		expect(omnivore?.markdownContent).toContain(`The first ${customLimit} founding members`);
+	});
 });
 
 describe("findPostBySlug", () => {
 	it("should return a post for a known slug", () => {
-		const firstPost = getAllPosts()[0];
-		const post = findPostBySlug(firstPost.slug);
+		const firstPost = blogPosts.getAllPosts()[0];
+		const post = blogPosts.findPostBySlug(firstPost.slug);
 		expect(post).toBeDefined();
 		expect(post?.title).toBe(firstPost.title);
 	});
 
 	it("should return undefined for an unknown slug", () => {
-		expect(findPostBySlug("nonexistent-post")).toBeUndefined();
+		expect(blogPosts.findPostBySlug("nonexistent-post")).toBeUndefined();
 	});
 });
 
 describe("getAllSlugs", () => {
 	it("should return slugs matching loaded posts", () => {
-		const slugs = getAllSlugs();
-		const posts = getAllPosts();
+		const slugs = blogPosts.getAllSlugs();
+		const posts = blogPosts.getAllPosts();
 		expect(slugs).toEqual(posts.map((p) => p.slug));
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/blog/blog.posts.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.posts.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
 import { render } from "../../render";
-import { FOUNDING_MEMBER_LIMIT } from "../../shared/founding-progress/founding-allocation";
 
 const md = new MarkdownIt({ html: true });
 
@@ -34,47 +33,48 @@ function formatDate(isoDate: string): string {
 	});
 }
 
-const postsDir = join(__dirname, "posts");
-
-const files = readdirSync(postsDir).filter((f) => f.endsWith(".md"));
-
-const posts: BlogPost[] = files
-	.map((file) => {
-		const raw = readFileSync(join(postsDir, file), "utf-8");
-		const { data, content } = matter(raw);
-		const frontmatter = BlogFrontmatter.parse(data);
-
-		const expectedSlug = basename(file, ".md");
-		assert(
-			frontmatter.slug === expectedSlug,
-			`Slug "${frontmatter.slug}" in ${file} does not match filename "${expectedSlug}"`,
-		);
-
-		const substituted = render(content, { foundingMemberLimit: FOUNDING_MEMBER_LIMIT });
-		return {
-			...frontmatter,
-			htmlContent: md.render(substituted),
-			markdownContent: substituted,
-			formattedDate: formatDate(frontmatter.date),
-		};
-	})
-	.sort((a, b) => b.date.localeCompare(a.date));
-
-const slugSet = new Set(posts.map((p) => p.slug));
-assert(slugSet.size === posts.length, "Duplicate blog post slugs detected");
-
-export function getAllPosts(): BlogPost[] {
-	return posts;
+export interface BlogPosts {
+	getAllPosts: () => BlogPost[];
+	findPostBySlug: (slug: string) => BlogPost | undefined;
+	getAllSlugs: () => string[];
+	getAllPostMetadata: () => { slug: string; date: string }[];
 }
 
-export function findPostBySlug(slug: string): BlogPost | undefined {
-	return posts.find((p) => p.slug === slug);
-}
+export function initBlogPosts(deps: { foundingMemberLimit: number }): BlogPosts {
+	const postsDir = join(__dirname, "posts");
+	const files = readdirSync(postsDir).filter((f) => f.endsWith(".md"));
 
-export function getAllSlugs(): string[] {
-	return posts.map((p) => p.slug);
-}
+	const posts: BlogPost[] = files
+		.map((file) => {
+			const raw = readFileSync(join(postsDir, file), "utf-8");
+			const { data, content } = matter(raw);
+			const frontmatter = BlogFrontmatter.parse(data);
 
-export function getAllPostMetadata(): { slug: string; date: string }[] {
-	return posts.map((p) => ({ slug: p.slug, date: p.date }));
+			const expectedSlug = basename(file, ".md");
+			assert(
+				frontmatter.slug === expectedSlug,
+				`Slug "${frontmatter.slug}" in ${file} does not match filename "${expectedSlug}"`,
+			);
+
+			const substituted = render(content, {
+				foundingMemberLimit: deps.foundingMemberLimit,
+			});
+			return {
+				...frontmatter,
+				htmlContent: md.render(substituted),
+				markdownContent: substituted,
+				formattedDate: formatDate(frontmatter.date),
+			};
+		})
+		.sort((a, b) => b.date.localeCompare(a.date));
+
+	const slugSet = new Set(posts.map((p) => p.slug));
+	assert(slugSet.size === posts.length, "Duplicate blog post slugs detected");
+
+	return {
+		getAllPosts: () => posts,
+		findPostBySlug: (slug) => posts.find((p) => p.slug === slug),
+		getAllSlugs: () => posts.map((p) => p.slug),
+		getAllPostMetadata: () => posts.map((p) => ({ slug: p.slug, date: p.date })),
+	};
 }

--- a/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
@@ -6,9 +6,12 @@ import {
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-import { getAllPosts } from "./blog.posts";
+import { initBlogPosts } from "./blog.posts";
 
-const firstPost = getAllPosts()[0];
+/** Initialised with the same limit as the default test fixture so post markdown
+ * substitution matches what the running app produces. */
+const blogPosts = initBlogPosts({ foundingMemberLimit: 3 });
+const firstPost = blogPosts.getAllPosts()[0];
 
 describe("GET /blog", () => {
 	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -4,10 +4,7 @@ import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { switchHelpers } from "../../handlebars-switch";
 import { renderFoundingProgress } from "../../shared/founding-progress/founding-progress.component";
-import {
-	FOUNDING_MEMBER_LIMIT,
-	isFoundingAllocationExhausted,
-} from "../../shared/founding-progress/founding-allocation";
+import type { FoundingAllocation } from "../../shared/founding-progress/founding-allocation";
 import { HOME_PAGE_STYLES } from "./home.styles";
 
 const HOME_TEMPLATE = readFileSync(join(__dirname, "home.template.html"), "utf-8");
@@ -103,10 +100,16 @@ const HOME_SCROLL_HINT_SCRIPT = `<script>
 })();
 </script>`;
 
-export function HomePage(params: { userCount: number; staticBaseUrl: string; browser: "firefox" | "chrome" | "other" }): PageBody {
-	const { userCount, staticBaseUrl, browser } = params;
-	const foundingProgressHtml = renderFoundingProgress({ userCount });
-	const foundingAllocationAvailable = !isFoundingAllocationExhausted(userCount);
+export function HomePage(params: {
+	userCount: number;
+	staticBaseUrl: string;
+	browser: "firefox" | "chrome" | "other";
+	foundingAllocation: FoundingAllocation;
+}): PageBody {
+	const { userCount, staticBaseUrl, browser, foundingAllocation } = params;
+	const foundingMemberLimit = foundingAllocation.foundingMemberLimit;
+	const foundingProgressHtml = renderFoundingProgress({ userCount, foundingAllocation });
+	const foundingAllocationAvailable = !foundingAllocation.isFoundingAllocationExhausted(userCount);
 	const pricingGridStateClass = foundingAllocationAvailable
 		? "pricing-grid--visible"
 		: "pricing-grid--hidden";
@@ -153,10 +156,10 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 							name: "Founding Member",
 							price: "0",
 							priceCurrency: "USD",
-							description: `Free forever for the first ${FOUNDING_MEMBER_LIMIT} founding members`,
+							description: `Free forever for the first ${foundingMemberLimit} founding members`,
 							eligibleQuantity: {
 								"@type": "QuantitativeValue",
-								value: FOUNDING_MEMBER_LIMIT,
+								value: foundingMemberLimit,
 							},
 						},
 						{
@@ -249,7 +252,7 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 							name: "Is Readplace free?",
 							acceptedAnswer: {
 								"@type": "Answer",
-								text: `The first ${FOUNDING_MEMBER_LIMIT} founding members get full access free, forever. After that, $3.99/month — includes TL;DR summaries.`,
+								text: `The first ${foundingMemberLimit} founding members get full access free, forever. After that, $3.99/month — includes TL;DR summaries.`,
 							},
 						},
 						{
@@ -288,7 +291,7 @@ export function HomePage(params: { userCount: number; staticBaseUrl: string; bro
 			browserName: browser,
 			founderAvatarUrl: `${staticBaseUrl}/fayner-brack.jpg`,
 			foundingProgressHtml,
-			foundingMemberLimit: FOUNDING_MEMBER_LIMIT,
+			foundingMemberLimit,
 			pricingGridStateClass,
 			fallbackCtaStateClass,
 			featuredFeatures: [

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -7,8 +7,16 @@ import {
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-import { getAllSlugs } from "../blog/blog.posts";
-import { FOUNDING_MEMBER_LIMIT } from "../../shared/founding-progress/founding-allocation";
+import { initBlogPosts } from "../blog/blog.posts";
+
+/** Matches the default test fixture's `foundingAllocation.foundingMemberLimit`.
+ * Tests own this constant so production changes to `PROD_FOUNDING_MEMBER_LIMIT`
+ * cannot ripple through seed loops or assertions. */
+const TEST_FOUNDING_MEMBER_LIMIT = 3;
+
+/** Re-initialised here with the same limit as the test fixture so the sitemap
+ * test can enumerate blog slugs without reaching into the app's internals. */
+const blogPosts = initBlogPosts({ foundingMemberLimit: TEST_FOUNDING_MEMBER_LIMIT });
 
 describe("GET /", () => {
 	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -207,7 +215,7 @@ describe("GET /", () => {
 
 		const progress = doc.querySelector("[data-test-founding-progress]");
 		const label = progress?.querySelector(".founding-progress__label");
-		expect(label?.textContent).toBe(`0 / ${FOUNDING_MEMBER_LIMIT} founding members`);
+		expect(label?.textContent).toBe(`0 / ${TEST_FOUNDING_MEMBER_LIMIT} founding members`);
 
 		const fill = progress?.querySelector(".founding-progress__fill");
 		expect(fill?.getAttribute("style")).toBe("width: 0%");
@@ -327,7 +335,7 @@ describe("GET / with exhausted founding allocation", () => {
 	it("should hide the founding progress when users exceed the limit", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+		for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 			await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 		}
 
@@ -340,7 +348,7 @@ describe("GET / with exhausted founding allocation", () => {
 	it("should hide the founding pricing card and show the fallback CTA when over the limit", async () => {
 		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		for (let i = 0; i < FOUNDING_MEMBER_LIMIT; i++) {
+		for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 			await auth.createUser({ email: `over${i}@test.com`, password: "password123" });
 		}
 
@@ -484,7 +492,7 @@ describe("GET /sitemap.xml", () => {
 		expect(response.headers["content-type"]).toMatch(/application\/xml/);
 
 		const urls = Array.from(response.text.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1]);
-		const blogPostUrls = getAllSlugs().map((slug) => `http://localhost:3000/blog/${slug}`);
+		const blogPostUrls = blogPosts.getAllSlugs().map((slug) => `http://localhost:3000/blog/${slug}`);
 		expect(urls).toEqual([
 			"http://localhost:3000/",
 			"http://localhost:3000/blog",

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
@@ -1,5 +1,20 @@
-export const FOUNDING_MEMBER_LIMIT = 50;
+/** Consumed only by the production composition root in app.ts. Every other
+ * call site receives the limit via the FoundingAllocation bundle so tests can
+ * substitute a smaller value without rewriting production code. */
+export const PROD_FOUNDING_MEMBER_LIMIT = 50;
 
-export function isFoundingAllocationExhausted(userCount: number): boolean {
-	return userCount >= FOUNDING_MEMBER_LIMIT;
+export interface FoundingAllocation {
+	foundingMemberLimit: number;
+	isFoundingAllocationExhausted: (userCount: number) => boolean;
+}
+
+export function initFoundingAllocation(deps: {
+	foundingMemberLimit: number;
+}): FoundingAllocation {
+	const { foundingMemberLimit } = deps;
+	return {
+		foundingMemberLimit,
+		isFoundingAllocationExhausted: (userCount) =>
+			userCount >= foundingMemberLimit,
+	};
 }

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.component.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.component.ts
@@ -1,25 +1,27 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { render } from "../../render";
-import {
-	FOUNDING_MEMBER_LIMIT,
-	isFoundingAllocationExhausted,
-} from "./founding-allocation";
+import type { FoundingAllocation } from "./founding-allocation";
 
 const FOUNDING_PROGRESS_TEMPLATE = readFileSync(
 	join(__dirname, "founding-progress.template.html"),
 	"utf-8",
 );
 
-export function renderFoundingProgress(input: { userCount: number }): string {
-	const { userCount } = input;
-	if (isFoundingAllocationExhausted(userCount)) {
+export function renderFoundingProgress(input: {
+	userCount: number;
+	foundingAllocation: FoundingAllocation;
+}): string {
+	const { userCount, foundingAllocation } = input;
+	if (foundingAllocation.isFoundingAllocationExhausted(userCount)) {
 		return "";
 	}
-	const progressPercent = Math.round((userCount / FOUNDING_MEMBER_LIMIT) * 100);
+	const progressPercent = Math.round(
+		(userCount / foundingAllocation.foundingMemberLimit) * 100,
+	);
 	return render(FOUNDING_PROGRESS_TEMPLATE, {
 		userCount,
-		foundingMemberLimit: FOUNDING_MEMBER_LIMIT,
+		foundingMemberLimit: foundingAllocation.foundingMemberLimit,
 		progressPercent,
 	});
 }

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -233,6 +233,14 @@ export interface BotDefenseBundle {
 	events: BotDefenseEvent[];
 }
 
+/** Holds the founding-member cap as a plain number. The hutch composition
+ * root builds the runtime predicate from this so this package stays free of
+ * cross-project imports — same reason `httpErrorMessageMapping` is duplicated
+ * inline in fixture.ts instead of imported from projects/hutch. */
+export interface FoundingAllocationBundle {
+	foundingMemberLimit: number;
+}
+
 export interface TestAppFixture {
 	auth: AuthBundle;
 	articleStore: ArticleStoreBundle;
@@ -253,4 +261,5 @@ export interface TestAppFixture {
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
 	botDefense: BotDefenseBundle;
+	foundingAllocation: FoundingAllocationBundle;
 }

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -308,5 +308,9 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		stripe,
 		pendingSignup,
 		botDefense: { logger: botDefenseLogger, events: botDefenseEvents },
+		/** Small enough that founding-allocation seed loops finish in
+		 * milliseconds while still leaving room for "one above the limit" tests
+		 * to seed N+1 distinct emails. Production injects 50 via app.ts. */
+		foundingAllocation: { foundingMemberLimit: 3 },
 	};
 }


### PR DESCRIPTION
## Summary

- Replace the `FOUNDING_MEMBER_LIMIT` module constant with `initFoundingAllocation({ foundingMemberLimit })`, returning a `{ foundingMemberLimit, isFoundingAllocationExhausted }` bundle that flows from each composition root.
- Production wires `PROD_FOUNDING_MEMBER_LIMIT = 50` in `app.ts`; the default test fixture wires `3`; tests own a local `TEST_FOUNDING_MEMBER_LIMIT = 3` for seed loops and assertion text.
- Convert `blog.posts.ts` to `initBlogPosts({ foundingMemberLimit })` so its module-load handlebars substitution participates in DI; sitemap and blog routes read posts from the bundle returned by the factory.

## Why

Tests that imported `FOUNDING_MEMBER_LIMIT` made assertions tautological with production (`expect(...).toBe(\`0 / ${FOUNDING_MEMBER_LIMIT}\`)` proves nothing about the rendered "0 / 50") and silently auto-resized seed loops if the constant changed. Bumping the production cap to 5000 would have rewritten dozens of tests with no diff to review — green CI on a behaviour that wasn't tested. Injection moves the coupling into the test layer: production can change its limit without rippling through the test suite, and the 13 boundary tests that previously seeded 50 in-memory users now seed 3.

## Test plan

- [x] `pnpm nx run hutch:check` — 1135 tests pass, lint clean, coverage 100% functions / 99.55% lines (founding-allocation.ts at 100%/100%)
- [x] `pnpm nx run-many --target=check --all` — all 18 projects green
- [x] No references to bare `FOUNDING_MEMBER_LIMIT` remain (`grep` confirmed only `PROD_FOUNDING_MEMBER_LIMIT` and per-test `TEST_FOUNDING_MEMBER_LIMIT` remain)
- [x] Production composition root `app.ts` injects `50`; default test fixture injects `3`
- [ ] Manual sanity in dev: `/`, `/signup`, `/blog/omnivore-alternative` still render the correct number when under / at / over the limit

https://claude.ai/code/session_01DRks1YbYwkiXtyEGroLYwX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRks1YbYwkiXtyEGroLYwX)_