### PR TITLE
fix(hutch): redirect shared /queue/:id/read to /view/<url> for non-owners

### DIFF
--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -19,6 +19,7 @@ import type {
 	FindArticleById,
 	FindArticleByUrl,
 	FindArticleFreshness,
+	FindArticleUrlById,
 	FindArticlesByUser,
 	SaveArticle,
 	SaveArticleGlobally,
@@ -93,6 +94,7 @@ export function initDynamoDbArticleStore(deps: {
 	saveArticleGlobally: SaveArticleGlobally;
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
+	findArticleUrlById: FindArticleUrlById;
 	findArticlesByUser: FindArticlesByUser;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
@@ -350,6 +352,11 @@ export function initDynamoDbArticleStore(deps: {
 		};
 	};
 
+	const findArticleUrlById: FindArticleUrlById = async (id) => {
+		const article = await findArticleByRouteId(id);
+		return article ? article.originalUrl : null;
+	};
+
 	const findArticleByUrl: FindArticleByUrl = async (url) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
 		const row = await articles.get(
@@ -399,6 +406,7 @@ export function initDynamoDbArticleStore(deps: {
 		saveArticleGlobally,
 		findArticleById,
 		findArticleByUrl,
+		findArticleUrlById,
 		findArticlesByUser,
 		deleteArticle,
 		updateArticleStatus,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -34,6 +34,7 @@ import type {
 	DeleteArticle,
 	FindArticleById,
 	FindArticleByUrl,
+	FindArticleUrlById,
 	FindArticlesByUser,
 	SaveArticle,
 	SaveArticleGlobally,
@@ -128,6 +129,7 @@ interface AppDependencies {
 	};
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
+	findArticleUrlById: FindArticleUrlById;
 	findArticlesByUser: FindArticlesByUser;
 	saveArticle: SaveArticle;
 	saveArticleGlobally: SaveArticleGlobally;
@@ -467,6 +469,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		findArticlesByUser: deps.findArticlesByUser,
 		findArticleById: deps.findArticleById,
 		findArticleByUrl: deps.findArticleByUrl,
+		findArticleUrlById: deps.findArticleUrlById,
 		saveArticle: deps.saveArticle,
 		deleteArticle: deps.deleteArticle,
 		updateArticleStatus: deps.updateArticleStatus,
@@ -481,11 +484,17 @@ export function createApp(dependencies: AppDependencies): Express {
 		publishUpdateFetchTimestamp: deps.publishUpdateFetchTimestamp,
 		readArticleContent: deps.readArticleContent,
 		httpErrorMessageMapping: deps.httpErrorMessageMapping,
+		dualAuth: dualAuthMiddleware,
 		logError: deps.logError,
 		logParseError: deps.logParseError,
 		now: deps.now,
 	});
-	app.use("/queue", extensionCors, dualAuthMiddleware, queueRouter);
+	/** `dualAuthMiddleware` is applied INSIDE the queue router rather than at this
+	 * mount so that `GET /queue/:id/read` can stay publicly reachable. Shared
+	 * `/read` permalinks (people copy them from the browser URL bar) redirect
+	 * non-owners and anonymous visitors to `/view/<url>` instead of bouncing
+	 * them to /login. */
+	app.use("/queue", extensionCors, queueRouter);
 
 	const importRouter = initImportSessionRoutes({
 		validateSaveableUrl: deps.validateSaveableUrl,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -64,6 +64,7 @@ import type {
 	FindArticleById,
 	FindArticleByUrl,
 	FindArticleFreshness,
+	FindArticleUrlById,
 	FindArticlesByUser,
 	SaveArticle,
 	SaveArticleGlobally,
@@ -125,6 +126,7 @@ export interface PendingSignupBundle {
 export interface ArticleStoreBundle {
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
+	findArticleUrlById: FindArticleUrlById;
 	findArticleFreshness: FindArticleFreshness;
 	findArticlesByUser: FindArticlesByUser;
 	saveArticle: SaveArticle;
@@ -305,6 +307,7 @@ function flattenFixtureToAppDependencies(
 		findEmailByUserId: fixture.auth.findEmailByUserId,
 		findArticleById: fixture.articleStore.findArticleById,
 		findArticleByUrl: fixture.articleStore.findArticleByUrl,
+		findArticleUrlById: fixture.articleStore.findArticleUrlById,
 		findArticlesByUser: fixture.articleStore.findArticlesByUser,
 		saveArticle: fixture.articleStore.saveArticle,
 		saveArticleGlobally: fixture.articleStore.saveArticleGlobally,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -5,7 +5,7 @@ import {
 	SAVE_COOKIE_NAME,
 	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
-import type { ErrorRequestHandler, Request, Response, Router } from "express";
+import type { ErrorRequestHandler, Request, RequestHandler, Response, Router } from "express";
 import express from "express";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
@@ -21,6 +21,7 @@ import type {
 	DeleteArticle,
 	FindArticleById,
 	FindArticleByUrl,
+	FindArticleUrlById,
 	FindArticlesByUser,
 	SaveArticle,
 	UpdateArticleStatus,
@@ -103,6 +104,7 @@ interface QueueDependencies {
 	findArticlesByUser: FindArticlesByUser;
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
+	findArticleUrlById: FindArticleUrlById;
 	saveArticle: SaveArticle;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
@@ -117,6 +119,10 @@ interface QueueDependencies {
 	publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp;
 	readArticleContent: ReadArticleContent;
 	httpErrorMessageMapping: HttpErrorMessageMapping;
+	/** Auth middleware applied to every queue route except the public
+	 * `GET /:id/read` permalink. Owned by the composition root so the same
+	 * middleware applies to all other authenticated mounts. */
+	dualAuth: RequestHandler;
 	logError: (message: string, error?: Error) => void;
 	logParseError: LogParseError;
 	now: () => Date;
@@ -148,6 +154,86 @@ async function loadCrawls(
 
 export function initQueueRoutes(deps: QueueDependencies): Router {
 	const router = express.Router();
+	const reader = initArticleReader({
+		findArticleCrawlStatus: deps.findArticleCrawlStatus,
+		findGeneratedSummary: deps.findGeneratedSummary,
+		readArticleContent: deps.readArticleContent,
+		findArticleByUrl: deps.findArticleByUrl,
+		formatDocumentTitle: formatReaderDocumentTitle,
+		backLink: { href: "/queue", label: "← Back to queue" },
+		now: deps.now,
+	});
+
+	function pollUrlBuilderForId(articleId: string): PollUrlBuilder {
+		return {
+			summary: (n) => `/queue/${articleId}/summary?poll=${n}`,
+			reader: (n) => `/queue/${articleId}/reader?poll=${n}`,
+		};
+	}
+
+	/** Public share-able permalink. Users copy this URL from the browser
+	 * address bar to share an article, so any visitor — owner, different
+	 * logged-in user, or anonymous — must land somewhere useful. Owners get
+	 * their personalised reader (mark-as-read, progress). Everyone else is
+	 * redirected to `/view/<original-url>`, the public route that already
+	 * has full OG/Twitter/Schema.org metadata so social-media previews
+	 * unfurl correctly. Declared BEFORE `router.use(deps.dualAuth)` so the
+	 * auth middleware doesn't pre-empt anonymous traffic with a /login
+	 * redirect. */
+	router.get("/:id/read", async (req: Request, res: Response) => {
+		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
+		if (!parsedId.success) {
+			res.redirect(303, "/queue");
+			return;
+		}
+
+		const requesterId = req.userId;
+		const ownedArticle = requesterId
+			? await deps.findArticleById(parsedId.data, requesterId)
+			: null;
+
+		if (!ownedArticle) {
+			const articleUrl = await deps.findArticleUrlById(parsedId.data);
+			if (!articleUrl) {
+				res.redirect(303, "/queue");
+				return;
+			}
+			/** 302 (not 301) because the redirect is conditional on
+			 * auth/ownership — the same URL renders differently for the
+			 * owner, so caches must not pin a single response. */
+			res.redirect(302, `/view/${encodeURIComponent(articleUrl)}`);
+			return;
+		}
+
+		if (ownedArticle.status === "unread") {
+			await deps.updateArticleStatus(ownedArticle.id, ownedArticle.userId, "read");
+		}
+
+		const audioEnabled = req.query.feature === "audio";
+		const state = await reader.resolveReaderState({
+			article: {
+				url: ownedArticle.url,
+				metadata: ownedArticle.metadata,
+				estimatedReadTime: ownedArticle.estimatedReadTime,
+			},
+			pollUrlBuilder: pollUrlBuilderForId(ownedArticle.id.value),
+		});
+
+		sendComponent(
+			req, res,
+			renderPage(req, ReaderPage({ ...ownedArticle, content: state.content }, {
+				summary: state.summary,
+				summaryPollUrl: state.summaryPollUrl,
+				crawl: state.crawl,
+				readerPollUrl: state.readerPollUrl,
+				progress: state.progress,
+				audioEnabled,
+				extensionInstallUrl: extensionInstallUrlIfMissing(req),
+			})),
+		);
+	});
+
+	router.use(deps.dualAuth);
 
 	router.get("/", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
@@ -425,64 +511,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);
 			res.redirect(303, "/queue?error_code=save_failed");
 		}
-	});
-
-	const reader = initArticleReader({
-		findArticleCrawlStatus: deps.findArticleCrawlStatus,
-		findGeneratedSummary: deps.findGeneratedSummary,
-		readArticleContent: deps.readArticleContent,
-		findArticleByUrl: deps.findArticleByUrl,
-		formatDocumentTitle: formatReaderDocumentTitle,
-		backLink: { href: "/queue", label: "← Back to queue" },
-		now: deps.now,
-	});
-
-	function pollUrlBuilderForId(articleId: string): PollUrlBuilder {
-		return {
-			summary: (n) => `/queue/${articleId}/summary?poll=${n}`,
-			reader: (n) => `/queue/${articleId}/reader?poll=${n}`,
-		};
-	}
-
-	router.get("/:id/read", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
-		const userId = req.userId;
-		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
-		const article = parsedId.success
-			? await deps.findArticleById(parsedId.data, userId)
-			: null;
-
-		if (!article) {
-			res.redirect(303, "/queue");
-			return;
-		}
-
-		if (article.status === "unread") {
-			await deps.updateArticleStatus(article.id, userId, "read");
-		}
-
-		const audioEnabled = req.query.feature === "audio";
-		const state = await reader.resolveReaderState({
-			article: {
-				url: article.url,
-				metadata: article.metadata,
-				estimatedReadTime: article.estimatedReadTime,
-			},
-			pollUrlBuilder: pollUrlBuilderForId(article.id.value),
-		});
-
-		sendComponent(
-			req, res,
-			renderPage(req, ReaderPage({ ...article, content: state.content }, {
-				summary: state.summary,
-				summaryPollUrl: state.summaryPollUrl,
-				crawl: state.crawl,
-				readerPollUrl: state.readerPollUrl,
-				progress: state.progress,
-				audioEnabled,
-				extensionInstallUrl: extensionInstallUrlIfMissing(req),
-			})),
-		);
 	});
 
 	router.get("/:id/summary", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -973,13 +973,69 @@ describe("Queue routes", () => {
 			expect(response.headers.location).toBe("/queue");
 		});
 
-		it("should redirect unauthenticated users to login", async () => {
+		it("should redirect anonymous visitors with a malformed id to /queue", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const response = await request(harness.server).get("/queue/someid/read");
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/login");
+			expect(response.headers.location).toBe("/queue");
+		});
+
+		it("should redirect anonymous visitors with an unknown but well-formed hash to /queue", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(`/queue/${"a".repeat(32)}/read`);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+		});
+
+		it("should redirect anonymous visitors to the public /view permalink so social-media previews unfurl", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const ownerAgent = await loginAgent(harness.server, auth);
+
+			const articleUrl = "https://example.com/shared-article";
+			await ownerAgent.post("/queue/save").type("form").send({ url: articleUrl });
+
+			const queueResponse = await ownerAgent.get("/queue");
+			const articleId = new JSDOM(queueResponse.text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert.ok(articleId, "owner must see the saved article in their queue");
+
+			const response = await request(harness.server).get(`/queue/${articleId}/read`);
+
+			expect(response.status).toBe(302);
+			expect(response.headers.location).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+		});
+
+		it("should redirect logged-in non-owners to the public /view permalink", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const ownerAgent = await loginAgent(harness.server, auth);
+
+			const articleUrl = "https://example.com/owner-only";
+			await ownerAgent.post("/queue/save").type("form").send({ url: articleUrl });
+
+			const queueResponse = await ownerAgent.get("/queue");
+			const articleId = new JSDOM(queueResponse.text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert.ok(articleId, "owner must see the saved article in their queue");
+
+			await auth.createUser({ email: "guest@example.com", password: "password123" });
+			const guestAgent = request.agent(harness.server);
+			await guestAgent
+				.post("/login")
+				.type("form")
+				.send({ email: "guest@example.com", password: "password123" });
+
+			const response = await guestAgent.get(`/queue/${articleId}/read`);
+
+			expect(response.status).toBe(302);
+			expect(response.headers.location).toBe(`/view/${encodeURIComponent(articleUrl)}`);
 		});
 
 		it("should link article title to reader view in queue when content exists", async () => {

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -62,6 +62,7 @@ import type {
 	FindArticleById,
 	FindArticleByUrl,
 	FindArticleFreshness,
+	FindArticleUrlById,
 	FindArticlesByUser,
 	SaveArticle,
 	SaveArticleGlobally,
@@ -126,6 +127,7 @@ export interface PendingSignupBundle {
 export interface ArticleStoreBundle {
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
+	findArticleUrlById: FindArticleUrlById;
 	findArticleFreshness: FindArticleFreshness;
 	findArticlesByUser: FindArticlesByUser;
 	saveArticle: SaveArticle;

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -243,6 +243,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		articleStore: {
 			findArticleById: articleStoreMemory.findArticleById,
 			findArticleByUrl: articleStoreMemory.findArticleByUrl,
+			findArticleUrlById: articleStoreMemory.findArticleUrlById,
 			findArticleFreshness: articleStoreMemory.findArticleFreshness,
 			findArticlesByUser: articleStoreMemory.findArticlesByUser,
 			saveArticle: articleStoreMemory.saveArticle,

--- a/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
@@ -51,6 +51,14 @@ export type FindArticleById = (
 	userId: UserId,
 ) => Promise<SavedArticle | null>;
 
+/** Resolve the original URL for a shared `/queue/<id>/read` permalink without
+ * requiring the requester to own the article. Used to redirect non-owners
+ * (anonymous or different account) to the public `/view/<url>` route. Returns
+ * `null` when the hash doesn't match any saved article. */
+export type FindArticleUrlById = (
+	id: ReaderArticleHashId,
+) => Promise<string | null>;
+
 export interface GlobalArticleData {
 	id: ReaderArticleHashId;
 	url: string;

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
@@ -67,6 +67,37 @@ describe("initInMemoryArticleStore", () => {
 		});
 	});
 
+	describe("findArticleUrlById", () => {
+		it("should return null for an unknown hash", async () => {
+			const store = initInMemoryArticleStore();
+			const unknown = ReaderArticleHashId.from("https://nobody-saved.com/this");
+
+			const url = await store.findArticleUrlById(unknown);
+
+			expect(url).toBeNull();
+		});
+
+		it("should return the original URL even when no user owns the article", async () => {
+			const store = initInMemoryArticleStore();
+			await store.saveArticleGlobally({
+				url: "https://example.com/global-only",
+				metadata: {
+					title: "Global Only",
+					siteName: "example.com",
+					excerpt: "",
+					wordCount: 0,
+				},
+				estimatedReadTime: 0 as Minutes,
+				savedAt: new Date(),
+			});
+			const id = ReaderArticleHashId.from("https://example.com/global-only");
+
+			const url = await store.findArticleUrlById(id);
+
+			expect(url).toBe("https://example.com/global-only");
+		});
+	});
+
 	describe("article deduplication", () => {
 		it("should reuse the same global article when two users save the same URL", async () => {
 			const store = initInMemoryArticleStore();

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
@@ -13,6 +13,7 @@ import type {
 	FindArticleById,
 	FindArticleByUrl,
 	FindArticleFreshness,
+	FindArticleUrlById,
 	FindArticlesByUser,
 	SaveArticle,
 	SaveArticleGlobally,
@@ -64,6 +65,7 @@ export function initInMemoryArticleStore(): {
 	saveArticleGlobally: SaveArticleGlobally;
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
+	findArticleUrlById: FindArticleUrlById;
 	findArticleFreshness: FindArticleFreshness;
 	findArticlesByUser: FindArticlesByUser;
 	deleteArticle: DeleteArticle;
@@ -139,6 +141,11 @@ export function initInMemoryArticleStore(): {
 		if (!ua) return null;
 
 		return toSavedArticle(article, ua);
+	};
+
+	const findArticleUrlById: FindArticleUrlById = async (id) => {
+		const article = findArticleByRouteId(id);
+		return article ? article.originalUrl : null;
 	};
 
 	const findArticleByUrl: FindArticleByUrl = async (url) => {
@@ -268,6 +275,7 @@ export function initInMemoryArticleStore(): {
 		saveArticleGlobally,
 		findArticleById,
 		findArticleByUrl,
+		findArticleUrlById,
 		findArticleFreshness,
 		findArticlesByUser,
 		deleteArticle,


### PR DESCRIPTION
## Why

People share Readplace links by copying from the **browser URL bar** — that's the universal share gesture. The address bar on the reader shows `/queue/<id>/read`, but that route is **private**:

- **Anonymous viewer** (someone clicks the link without being logged in) → redirected to `/login`. Wrong context, wrong account, no article in sight.
- **Logged-in non-owner** (someone clicks while logged into their own account) → silently bounced to their own `/queue`. Looks like the link did nothing.

Both are dead-ends, and we have direct evidence of the broken flow: a user shared `/queue/<id>/read`, it didn't work; they then manually constructed `/view/<url>` and *that* worked. We can't expect users to try twice — most shares die at the first failed click, and social-media unfurls hitting the broken link never recover.

We already have `/view/<url>` — a **public**, share-able route with full OG / Twitter / Schema.org metadata, the same article body, and `robots: index, follow`. Make `/queue/:id/read` transparently fall back to it for anyone who doesn't own the article. Owner experience unchanged. Social-media crawlers follow the `302` and land on `/view/<url>`, where OG tags already render correctly — so previews unfurl without needing duplicate OG tags on `/read`.

This converts every accidentally-shared private-reader URL into a working share link in one redirect hop.

## How

1. **New article-store lookup `findArticleUrlById`** — returns the article's original URL by `routeId` without requiring a user filter. The hash is `sha256` (one-way) so we can't reverse it; we need a real lookup. DynamoDB delegates to the existing private `findArticleByRouteId`, which is a single GSI hop on `routeId-index` — no additional cost.
2. **Move the auth gate inside the queue router.** `dualAuthMiddleware` is removed from the `/queue` mount in `server.ts` and applied as `router.use(deps.dualAuth)` **after** the public `GET /:id/read` declaration inside `initQueueRoutes`. Every other queue route (`GET /`, `POST /save`, `/save-html`, `/:id/summary`, `/:id/reader`, `/:id/card`, `/:id/status`, `/:id/delete`, `POST /dismiss-onboarding`) continues to require auth.
3. **`GET /queue/:id/read` handler branches:**
   - Malformed `:id` (regex fails) → `303 /queue` (preserves existing behavior).
   - Valid hash, article doesn't exist → `303 /queue`.
   - `req.userId` set AND user owns the article → render `ReaderPage`, mark-as-read (unchanged owner path).
   - Anonymous OR logged-in non-owner → `302 /view/<encodeURIComponent(originalUrl)>`.

`302` (not `301`) because the response is conditional on auth/ownership; a cached permanent redirect would hijack future owner visits with someone else's session.

## Tests

`projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts`:
- **Replaced** "should redirect unauthenticated users to login" → "should redirect anonymous visitors with a malformed id to /queue" (`303 /queue` now, not `303 /login`).
- **Added** "should redirect anonymous visitors with an unknown but well-formed hash to /queue".
- **Added** "should redirect anonymous visitors to the public /view permalink so social-media previews unfurl" — saves an article as owner, captures hashId from the queue listing, then makes an unauthenticated request; asserts `302 /view/<encoded-url>`.
- **Added** "should redirect logged-in non-owners to the public /view permalink" — same setup but the request comes from a second logged-in agent (different email).
- **Kept** "should redirect to queue for non-existent article" (the existing `nonexistent` malformed-id case) — still `303 /queue`.

`src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts`:
- **Added** unit coverage for `findArticleUrlById` (null on unknown hash, returns URL even when no user owns the article).

## Test plan

- [x] `pnpm nx run-many --target=test --projects=hutch,@packages/test-fixtures` — 1137 + 251 tests passing.
- [x] `pnpm nx run-many --target=lint --projects=hutch,@packages/test-fixtures` — clean.
- [x] `pnpm check` (full monorepo coverage gate, runs via pre-commit) — all 18 projects pass, coverage thresholds met.
- [ ] Manual smoke once deployed: paste an owner's `/queue/<id>/read` URL into a logged-out browser, confirm redirect to `/view/<url>` and that the OG preview unfurls correctly in Slack/Twitter/iMessage.

## Non-goals

- **No OG tags on `/queue/:id/read`** — owner reader stays `noindex,nofollow` (it's personal data). Crawlers follow the redirect; `/view` has the tags.
- **No Share Balloon changes** — it already targets `/view/<url>`.
- **Polling endpoints untouched** — `/queue/:id/summary`, `/queue/:id/reader`, `/queue/:id/card` only fire from the rendered owner reader page; they keep their auth.

https://claude.ai/code/session_015WYeGpdBPdVMY8yYVryunp

---
_Generated by [Claude Code](https://claude.ai/code/session_015WYeGpdBPdVMY8yYVryunp)_