### PR TITLE
feat: handle PDF link saves end-to-end

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,6 +379,9 @@ importers:
       '@mozilla/readability':
         specifier: 0.6.0
         version: 0.6.0
+      '@napi-rs/canvas':
+        specifier: 1.0.0
+        version: 1.0.0
       '@packages/article-resource-unique-id':
         specifier: workspace:*
         version: link:../../src/packages/article-resource-unique-id
@@ -560,6 +563,9 @@ importers:
       linkedom:
         specifier: 0.18.12
         version: 0.18.12
+      pdfjs-dist:
+        specifier: 4.10.38
+        version: 4.10.38
     devDependencies:
       '@types/jest':
         specifier: 29.5.14
@@ -1769,6 +1775,146 @@ packages:
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    resolution: {integrity: sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    resolution: {integrity: sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/canvas@1.0.0':
+    resolution: {integrity: sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -4936,6 +5082,10 @@ packages:
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
+  pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -7453,6 +7603,101 @@ snapshots:
   '@mdn/browser-compat-data@7.3.0': {}
 
   '@mozilla/readability@0.6.0': {}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
+
+  '@napi-rs/canvas@1.0.0':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-x64': 1.0.0
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.0
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.0
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-musl': 1.0.0
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.0
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.0
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -11425,6 +11670,10 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
+
+  pdfjs-dist@4.10.38:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   pend@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,9 @@ importers:
       '@packages/article-state-types':
         specifier: workspace:*
         version: link:../article-state-types
+      escape-html:
+        specifier: 1.0.3
+        version: 1.0.3
       linkedom:
         specifier: 0.18.12
         version: 0.18.12
@@ -567,6 +570,9 @@ importers:
         specifier: 4.10.38
         version: 4.10.38
     devDependencies:
+      '@types/escape-html':
+        specifier: 1.0.4
+        version: 1.0.4
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -2712,6 +2718,9 @@ packages:
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/escape-html@1.0.4':
+    resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -8787,6 +8796,8 @@ snapshots:
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 22.19.1
+
+  '@types/escape-html@1.0.4': {}
 
   '@types/estree@1.0.8': {}
 

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -15,7 +15,7 @@ import {
 } from '@packages/test-fixtures'
 import { requireEnv } from '../runtime/domain/require-env'
 import { initRefreshArticleIfStale } from '@packages/test-fixtures/providers/article-freshness'
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from '@packages/crawl-article'
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch, initLazyPdfExtractTextOnly } from '@packages/crawl-article'
 import { theInformationPreParser } from '@packages/test-fixtures/providers/article-parser'
 import { initInMemoryRefreshArticleContent } from '@packages/test-fixtures/providers/events'
 import { initInMemoryUpdateFetchTimestamp } from '@packages/test-fixtures/providers/events'
@@ -32,7 +32,8 @@ const logger = HutchLogger.from(consoleLogger)
 
 const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }))
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } })
-const crawlArticle = initCrawlArticle({ crawlFetch, logError })
+const extractPdf = initLazyPdfExtractTextOnly()
+const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError })
 const { parseArticle, parseHtml } = initReadabilityParser({ crawlArticle, sitePreParsers: [theInformationPreParser], logError })
 
 /** E2E tests use localhost URLs because the test server IS localhost.

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -7,7 +7,7 @@ import { initInMemoryAuth, hashPassword, verifyPassword } from "@packages/test-f
 import { initDynamoDbAuth } from "./providers/auth/dynamodb-auth";
 import { initInMemoryArticleStore } from "@packages/test-fixtures/providers/article-store";
 import { initDynamoDbArticleStore } from "./providers/article-store/dynamodb-article-store";
-import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
+import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch, initLazyPdfExtractTextOnly } from "@packages/crawl-article";
 import { initReadabilityParser } from "@packages/test-fixtures/providers/article-parser";
 import { theInformationPreParser } from "@packages/test-fixtures/providers/article-parser";
 import { initRefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
@@ -72,7 +72,12 @@ function initProviders() {
 	const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }));
 
 	const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
-	const crawlArticle = initCrawlArticle({ crawlFetch, logError });
+	// SSR's /save flow publishes SaveLinkCommand and lets the save-link Lambda
+	// (which has full OCR support) do the heavy lifting. Text-only here keeps
+	// the hutch bundle free of the canvas + DeepInfra deps that only the
+	// background worker actually needs.
+	const extractPdf = initLazyPdfExtractTextOnly();
+	const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
 	const { parseHtml } = initReadabilityParser({
 		crawlArticle,
 		sitePreParsers: [theInformationPreParser],

--- a/projects/save-link/package.json
+++ b/projects/save-link/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/client-s3": "3.1001.0",
     "@aws-sdk/client-sqs": "3.1001.0",
     "@mozilla/readability": "0.6.0",
+    "@napi-rs/canvas": "1.0.0",
     "@packages/article-resource-unique-id": "workspace:*",
     "@packages/article-state-types": "workspace:*",
     "@packages/article-store": "workspace:*",

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -69,6 +69,7 @@ const contentMediaCdn = new HutchS3ContentMediaCDN("content-media", {
 });
 
 const deepseekApiKey = pulumi.secret(requireEnv("DEEPSEEK_API_KEY"));
+const deepInfraApiKey = pulumi.secret(requireEnv("DEEPINFRA_API_KEY"));
 
 const eventBus = HutchEventBus.fromPlatformStack(config);
 
@@ -82,11 +83,14 @@ const linkSavedQueue = new HutchSQS("link-saved", {
 	visibilityTimeoutSeconds: 60,
 });
 
-// saveLinkWork-bearing queues use 360s visibility = 2× the 180s Lambda
+// saveLinkWork-bearing queues use 720s visibility = 2× the 360s Lambda
 // timeout (AWS guidance) so a long-running invocation never has the message
-// re-delivered to a second worker before the first finishes.
+// re-delivered to a second worker before the first finishes. The 360s
+// Lambda timeout is sized for the scanned-PDF OCR path: the canary probe
+// of a 13-page PDF with 3-way parallel batching against gemma-4-31B-it
+// completed in 157s wall time, so 360s is ~2× the worst observed.
 const saveLinkCommandQueue = new HutchSQS("save-link-command", {
-	visibilityTimeoutSeconds: 360,
+	visibilityTimeoutSeconds: 720,
 });
 
 // maxReceiveCount=1: SQS retries are removed for the anonymous save path.
@@ -97,12 +101,12 @@ const saveLinkCommandQueue = new HutchSQS("save-link-command", {
 // generate-summary) keep the default maxReceiveCount=3 so transient
 // Deepseek/DDB blips still self-heal at the SQS layer.
 const saveAnonymousLinkCommandQueue = new HutchSQS("save-anonymous-link-command", {
-	visibilityTimeoutSeconds: 360,
+	visibilityTimeoutSeconds: 720,
 	dlqMaxReceiveCount: 1,
 });
 
 const saveLinkRawHtmlCommandQueue = new HutchSQS("save-link-raw-html-command", {
-	visibilityTimeoutSeconds: 360,
+	visibilityTimeoutSeconds: 720,
 });
 
 const anonymousLinkSavedQueue = new HutchSQS("anonymous-link-saved", {
@@ -118,7 +122,7 @@ const summaryGenerationFailedQueue = new HutchSQS("summary-generation-failed", {
 });
 
 const recrawlLinkInitiatedQueue = new HutchSQS("recrawl-link-initiated", {
-	visibilityTimeoutSeconds: 360,
+	visibilityTimeoutSeconds: 720,
 });
 
 const staleCheckRequestedQueue = new HutchSQS("stale-check-requested", {
@@ -140,18 +144,24 @@ const saveLinkCommandLambda = new HutchLambda("save-link-command", {
 	entryPoint: "./src/runtime/save-link-command.main.ts",
 	outputDir: ".lib/save-link-command",
 	assetDir: "./src",
-	memorySize: 256,
-	// 180s budget for saveLinkWork: large XHTML/HTML pages (e.g. iana media-types)
-	// take >30s to fetch + parse end-to-end. Paired with 360s SQS visibility
-	// (≥2× Lambda timeout per AWS guidance) so the message stays held for the
-	// full execution. Phase 2 of the unstick-articles plan.
-	timeout: 180,
+	// 2048 MB gives ~1.16 vCPU and ample headroom for the scanned-PDF OCR path:
+	// pdfjs holds the 25 MiB PDF buffer + per-page decoded structures, and
+	// napi-rs/canvas materializes one ~9 MB RGBA bitmap per page being
+	// rendered. Five pages in flight per batch × three concurrent batches stays
+	// well under the cap.
+	memorySize: 2048,
+	// 360s covers the worst-case scanned-PDF flow. Step 0 probe of a 13-page
+	// PDF with 3-way parallel batching against gemma-4-31B-it on DeepInfra
+	// completed in 157s; 360s is ~2× that for safety. Paired with 720s SQS
+	// visibility (≥2× Lambda timeout per AWS guidance).
+	timeout: 360,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		DEEPINFRA_API_KEY: deepInfraApiKey,
 	},
 	policies: [
 		...saveLinkCommandDynamodb.policies,
@@ -198,8 +208,11 @@ const saveLinkRawHtmlCommandLambda = new HutchLambda("save-link-raw-html-command
 	entryPoint: "./src/runtime/save-link-raw-html-command.main.ts",
 	outputDir: ".lib/save-link-raw-html-command",
 	assetDir: "./src",
-	memorySize: 256,
-	timeout: 180,
+	// Bumped in tandem with save-link-command: parses already-fetched HTML
+	// from S3 (pendingHtml) and never re-crawls PDFs, but the readability/
+	// linkedom path on large XHTML benefits from the same headroom.
+	memorySize: 2048,
+	timeout: 360,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
@@ -256,14 +269,17 @@ const saveAnonymousLinkCommandLambda = new HutchLambda("save-anonymous-link-comm
 	entryPoint: "./src/runtime/save-anonymous-link-command.main.ts",
 	outputDir: ".lib/save-anonymous-link-command",
 	assetDir: "./src",
-	memorySize: 256,
-	timeout: 180,
+	// Mirrors save-link-command: same crawl pipeline, same scanned-PDF OCR
+	// path, same headroom requirements.
+	memorySize: 2048,
+	timeout: 360,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		DEEPINFRA_API_KEY: deepInfraApiKey,
 	},
 	policies: [
 		...saveAnonymousLinkCommandDynamodb.policies,
@@ -542,14 +558,17 @@ const recrawlLinkInitiatedLambda = new HutchLambda("recrawl-link-initiated", {
 	entryPoint: "./src/runtime/recrawl-link-initiated.main.ts",
 	outputDir: ".lib/recrawl-link-initiated",
 	assetDir: "./src",
-	memorySize: 256,
-	timeout: 180,
+	// Mirrors save-link-command: re-fetches articles and may hit the scanned
+	// PDF OCR path on a recrawl.
+	memorySize: 2048,
+	timeout: 360,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		DEEPINFRA_API_KEY: deepInfraApiKey,
 	},
 	policies: [
 		...recrawlLinkInitiatedDynamodb.policies,

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -86,9 +86,9 @@ const linkSavedQueue = new HutchSQS("link-saved", {
 // saveLinkWork-bearing queues use 720s visibility = 2× the 360s Lambda
 // timeout (AWS guidance) so a long-running invocation never has the message
 // re-delivered to a second worker before the first finishes. The 360s
-// Lambda timeout is sized for the scanned-PDF OCR path: the canary probe
-// of a 13-page PDF with 3-way parallel batching against gemma-4-31B-it
-// completed in 157s wall time, so 360s is ~2× the worst observed.
+// Lambda timeout is sized for the scanned-PDF OCR path: a 13-page PDF with
+// 3-way parallel batching against gemma-4-31B-it completes in ~157s wall
+// time, so 360s is ~2× the worst observed.
 const saveLinkCommandQueue = new HutchSQS("save-link-command", {
 	visibilityTimeoutSeconds: 720,
 });
@@ -106,7 +106,7 @@ const saveAnonymousLinkCommandQueue = new HutchSQS("save-anonymous-link-command"
 });
 
 const saveLinkRawHtmlCommandQueue = new HutchSQS("save-link-raw-html-command", {
-	visibilityTimeoutSeconds: 720,
+	visibilityTimeoutSeconds: 480,
 });
 
 const anonymousLinkSavedQueue = new HutchSQS("anonymous-link-saved", {
@@ -150,10 +150,10 @@ const saveLinkCommandLambda = new HutchLambda("save-link-command", {
 	// rendered. Five pages in flight per batch × three concurrent batches stays
 	// well under the cap.
 	memorySize: 2048,
-	// 360s covers the worst-case scanned-PDF flow. Step 0 probe of a 13-page
-	// PDF with 3-way parallel batching against gemma-4-31B-it on DeepInfra
-	// completed in 157s; 360s is ~2× that for safety. Paired with 720s SQS
-	// visibility (≥2× Lambda timeout per AWS guidance).
+	// 360s covers the worst-case scanned-PDF flow: a 13-page PDF with 3-way
+	// parallel batching against gemma-4-31B-it on DeepInfra completes in ~157s;
+	// 360s is ~2× that for safety. Paired with 720s SQS visibility (≥2× Lambda
+	// timeout per AWS guidance).
 	timeout: 360,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -208,11 +208,10 @@ const saveLinkRawHtmlCommandLambda = new HutchLambda("save-link-raw-html-command
 	entryPoint: "./src/runtime/save-link-raw-html-command.main.ts",
 	outputDir: ".lib/save-link-raw-html-command",
 	assetDir: "./src",
-	// Bumped in tandem with save-link-command: parses already-fetched HTML
-	// from S3 (pendingHtml) and never re-crawls PDFs, but the readability/
-	// linkedom path on large XHTML benefits from the same headroom.
-	memorySize: 2048,
-	timeout: 360,
+	// Text-only path (readability/linkedom on large XHTML + pdfjs text-layer).
+	// No canvas rendering or OCR, so less headroom than the OCR-capable Lambdas.
+	memorySize: 512,
+	timeout: 240,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
 		CONTENT_BUCKET_NAME: contentBucketName,

--- a/projects/save-link/src/runtime/dep-bundles/media.test.ts
+++ b/projects/save-link/src/runtime/dep-bundles/media.test.ts
@@ -7,7 +7,10 @@ import { initParserDepBundle } from "./parser";
 
 describe("initMediaDepBundle", () => {
 	it("returns a bundle with downloadMedia and processContent fields", () => {
-		const parser = initParserDepBundle({ logError: () => {} });
+		const parser = initParserDepBundle({
+			logError: () => {},
+			extractPdf: async () => ({ kind: "failed", reason: "stub" }),
+		});
 		const articleStore = initArticleStoreDepBundle({
 			s3Client: new S3Client({ region: "us-east-1" }),
 			dynamoClient: createDynamoDocumentClient({ region: "us-east-1" }),

--- a/projects/save-link/src/runtime/dep-bundles/parser.test.ts
+++ b/projects/save-link/src/runtime/dep-bundles/parser.test.ts
@@ -2,7 +2,10 @@ import { initParserDepBundle } from "./parser";
 
 describe("initParserDepBundle", () => {
 	it("returns a bundle with crawlFetch, crawlArticle, and parseHtml fields", () => {
-		const bundle = initParserDepBundle({ logError: () => {} });
+		const bundle = initParserDepBundle({
+			logError: () => {},
+			extractPdf: async () => ({ kind: "failed", reason: "stub" }),
+		});
 
 		expect(typeof bundle.crawlFetch).toBe("function");
 		expect(typeof bundle.crawlArticle).toBe("function");

--- a/projects/save-link/src/runtime/dep-bundles/parser.ts
+++ b/projects/save-link/src/runtime/dep-bundles/parser.ts
@@ -1,5 +1,5 @@
+import type { CrawlArticle, CrawlFetch, ExtractPdf } from "@packages/crawl-article";
 import { initCrawlArticle, initCrawlFetch, DEFAULT_CRAWL_HEADERS } from "@packages/crawl-article";
-import type { CrawlArticle, CrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../domain/article-parser/readability-parser";
 import { theInformationPreParser } from "../domain/article-parser/the-information-pre-parser";
 import type { ParseHtml } from "../domain/article-parser/article-parser.types";
@@ -11,12 +11,19 @@ export type ParserDepBundle = {
 	parseHtml: ParseHtml;
 };
 
-export function initParserDepBundle(deps: { logError: LogError }): ParserDepBundle {
+export function initParserDepBundle(deps: {
+	logError: LogError;
+	extractPdf: ExtractPdf;
+}): ParserDepBundle {
 	const crawlFetch = initCrawlFetch({
 		fetch: globalThis.fetch,
 		defaultHeaders: { ...DEFAULT_CRAWL_HEADERS },
 	});
-	const crawlArticle = initCrawlArticle({ crawlFetch, logError: deps.logError });
+	const crawlArticle = initCrawlArticle({
+		crawlFetch,
+		extractPdf: deps.extractPdf,
+		logError: deps.logError,
+	});
 	const { parseHtml } = initReadabilityParser({
 		crawlArticle,
 		sitePreParsers: [theInformationPreParser],

--- a/projects/save-link/src/runtime/domain/article-parser/create-deepinfra-vision-message.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/create-deepinfra-vision-message.test.ts
@@ -1,0 +1,76 @@
+import {
+	initCreateDeepInfraVisionMessage,
+	DEEPINFRA_VISION_MODEL_ID,
+	DEEPINFRA_VISION_MAX_BATCH_OUTPUT_TOKENS,
+} from "./create-deepinfra-vision-message";
+
+describe("initCreateDeepInfraVisionMessage", () => {
+	it("sends a single user message with each image rendered as a base64 image_url block plus the OCR instruction", async () => {
+		let captured: { model: string; max_tokens: number; messages: ReadonlyArray<unknown> } | undefined;
+		const createChatCompletion = async (params: { model: string; max_tokens: number; messages: ReadonlyArray<unknown> }) => {
+			captured = params;
+			return { choices: [{ message: { content: "extracted text" } }] };
+		};
+		const createVisionMessage = initCreateDeepInfraVisionMessage({ createChatCompletion });
+
+		const result = await createVisionMessage({
+			images: [
+				{ pngBuffer: Buffer.from([0x89, 0x50, 0x4e, 0x47]) },
+				{ pngBuffer: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xaa]) },
+			],
+		});
+
+		expect(result).toBe("extracted text");
+		expect(captured?.model).toBe(DEEPINFRA_VISION_MODEL_ID);
+		expect(captured?.max_tokens).toBe(DEEPINFRA_VISION_MAX_BATCH_OUTPUT_TOKENS);
+		expect(captured?.messages).toHaveLength(1);
+		const message = captured?.messages[0] as { role: string; content: Array<{ type: string; text?: string; image_url?: { url: string } }> };
+		expect(message.role).toBe("user");
+		expect(message.content).toHaveLength(3);
+		expect(message.content[0]?.type).toBe("text");
+		expect(message.content[0]?.text).toContain("Extract all text");
+		expect(message.content[1]?.type).toBe("image_url");
+		expect(message.content[1]?.image_url?.url).toBe(`data:image/png;base64,${Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")}`);
+		expect(message.content[2]?.type).toBe("image_url");
+		expect(message.content[2]?.image_url?.url).toBe(`data:image/png;base64,${Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xaa]).toString("base64")}`);
+	});
+
+	it("returns the trimmed text content from the first choice", async () => {
+		const createChatCompletion = async () => ({
+			choices: [{ message: { content: "  trimmed content\n\n" } }],
+		});
+		const createVisionMessage = initCreateDeepInfraVisionMessage({ createChatCompletion });
+
+		const result = await createVisionMessage({ images: [{ pngBuffer: Buffer.from([0]) }] });
+
+		expect(result).toBe("trimmed content");
+	});
+
+	it("asserts when called with no images", async () => {
+		const createChatCompletion = async () => ({ choices: [{ message: { content: "ok" } }] });
+		const createVisionMessage = initCreateDeepInfraVisionMessage({ createChatCompletion });
+
+		await expect(createVisionMessage({ images: [] })).rejects.toThrow(
+			"createVisionMessage requires at least one image",
+		);
+	});
+
+	it("asserts when the response message has no content", async () => {
+		const createChatCompletion = async () => ({ choices: [{ message: { content: null } }] });
+		const createVisionMessage = initCreateDeepInfraVisionMessage({ createChatCompletion });
+
+		await expect(createVisionMessage({ images: [{ pngBuffer: Buffer.from([0]) }] })).rejects.toThrow(
+			"DeepInfra vision response missing message content",
+		);
+	});
+
+	it("asserts when the response has no choices", async () => {
+		const createChatCompletion = async () => ({ choices: [] });
+		const createVisionMessage = initCreateDeepInfraVisionMessage({ createChatCompletion });
+
+		await expect(createVisionMessage({ images: [{ pngBuffer: Buffer.from([0]) }] })).rejects.toThrow(
+			"DeepInfra vision response missing message content",
+		);
+	});
+});
+

--- a/projects/save-link/src/runtime/domain/article-parser/create-deepinfra-vision-message.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/create-deepinfra-vision-message.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert";
+
+/**
+ * OpenAI-compatible vision request shape DeepInfra accepts for multimodal
+ * models. Image inputs are base64 data URLs in `image_url` content blocks —
+ * confirmed during the gemma-4-31B-it probe in this PR's planning phase.
+ *
+ * DeepInfra deprecated DeepSeek-OCR on 2026-05-07; the official deprecation
+ * note points at google/gemma-4-31B-it as the replacement, which is what
+ * we wire here.
+ */
+type VisionChatCompletionResponse = {
+	choices: Array<{ message?: { content?: string | null } }>;
+};
+
+/**
+ * Restricted to `role: "user"` so OpenAI's strict-discriminated message
+ * unions accept the call. We never send `role: "system"` here — the OCR
+ * instruction lives in the user message's text block alongside the page
+ * images so the model treats it as part of the same turn.
+ */
+type VisionChatCompletion = (params: {
+	model: string;
+	max_tokens: number;
+	messages: Array<{
+		role: "user";
+		content: Array<
+			| { type: "text"; text: string }
+			| { type: "image_url"; image_url: { url: string } }
+		>;
+	}>;
+}) => Promise<VisionChatCompletionResponse>;
+
+/**
+ * The vision model picked by DeepInfra as the DeepSeek-OCR replacement
+ * (see `replaced_by` field in DeepInfra's model metadata). $0.13/$0.38 per
+ * 1M tokens at probe time; 262K context.
+ */
+const MODEL_ID = "google/gemma-4-31B-it";
+
+/**
+ * Per-batch output budget. The probe of a 13-page PDF returned ~6,914
+ * completion tokens for the entire document. Capping each batch at 8,000
+ * gives ~1,600 tokens of headroom per page in a 5-page batch — enough for
+ * dense academic prose with bibliography while keeping the request bounded.
+ */
+const MAX_BATCH_OUTPUT_TOKENS = 8000;
+
+const OCR_INSTRUCTION =
+	"Extract all text from the following PDF page image(s) verbatim, in order. Preserve paragraph breaks. Output only the extracted text — no commentary, no summarization, no markdown formatting.";
+
+export type CreateVisionMessage = (params: {
+	images: ReadonlyArray<{ pngBuffer: Buffer }>;
+}) => Promise<string>;
+
+export function initCreateDeepInfraVisionMessage(deps: {
+	createChatCompletion: VisionChatCompletion;
+}): CreateVisionMessage {
+	return async (params) => {
+		assert(params.images.length > 0, "createVisionMessage requires at least one image");
+		const content: Array<
+			| { type: "text"; text: string }
+			| { type: "image_url"; image_url: { url: string } }
+		> = [{ type: "text", text: OCR_INSTRUCTION }];
+		for (const image of params.images) {
+			const dataUrl = `data:image/png;base64,${image.pngBuffer.toString("base64")}`;
+			content.push({ type: "image_url", image_url: { url: dataUrl } });
+		}
+		const response = await deps.createChatCompletion({
+			model: MODEL_ID,
+			max_tokens: MAX_BATCH_OUTPUT_TOKENS,
+			messages: [{ role: "user", content }],
+		});
+		const text = response.choices[0]?.message?.content?.trim();
+		assert(text, "DeepInfra vision response missing message content");
+		return text;
+	};
+}
+
+export type { VisionChatCompletion };
+
+export const DEEPINFRA_VISION_MODEL_ID = MODEL_ID;
+export const DEEPINFRA_VISION_MAX_BATCH_OUTPUT_TOKENS = MAX_BATCH_OUTPUT_TOKENS;

--- a/projects/save-link/src/runtime/domain/article-parser/create-deepinfra-vision-message.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/create-deepinfra-vision-message.ts
@@ -2,8 +2,7 @@ import assert from "node:assert";
 
 /**
  * OpenAI-compatible vision request shape DeepInfra accepts for multimodal
- * models. Image inputs are base64 data URLs in `image_url` content blocks —
- * confirmed during the gemma-4-31B-it probe in this PR's planning phase.
+ * models. Image inputs are base64 data URLs in `image_url` content blocks.
  *
  * DeepInfra deprecated DeepSeek-OCR on 2026-05-07; the official deprecation
  * note points at google/gemma-4-31B-it as the replacement, which is what
@@ -39,10 +38,10 @@ type VisionChatCompletion = (params: {
 const MODEL_ID = "google/gemma-4-31B-it";
 
 /**
- * Per-batch output budget. The probe of a 13-page PDF returned ~6,914
- * completion tokens for the entire document. Capping each batch at 8,000
- * gives ~1,600 tokens of headroom per page in a 5-page batch — enough for
- * dense academic prose with bibliography while keeping the request bounded.
+ * Per-batch output budget. A 13-page PDF returns ~6,914 completion tokens for
+ * the entire document. Capping each batch at 8,000 gives ~1,600 tokens of
+ * headroom per page in a 5-page batch — enough for dense academic prose with
+ * bibliography while keeping the request bounded.
  */
 const MAX_BATCH_OUTPUT_TOKENS = 8000;
 

--- a/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import type { PdfjsLib, PdfjsLibBase, PdfDocument, PdfPage } from "@packages/crawl-article";
+import { initSaveLinkPdfExtract } from "./init-save-link-pdf-extract";
+import type { RenderablePdfPage } from "./render-pdf-page";
+
+function stubPdfjsLib(pageText: string): PdfjsLib {
+	return {
+		getDocument() {
+			const page: PdfPage = {
+				getTextContent: async () => ({ items: [{ str: pageText }] }),
+			};
+			const doc: PdfDocument = {
+				numPages: 1,
+				getMetadata: async () => ({ info: { Title: "Stub Title" } }),
+				getPage: async () => page,
+			};
+			return { promise: Promise.resolve(doc) };
+		},
+	};
+}
+
+function stubPdfjsLibForRender(): PdfjsLibBase<RenderablePdfPage> {
+	return {
+		getDocument() {
+			return { promise: Promise.resolve({ numPages: 0, getMetadata: async () => ({}), getPage: async () => ({}) as RenderablePdfPage }) };
+		},
+	};
+}
+
+const stubCanvas = () => ({
+	width: 0,
+	height: 0,
+	getContext: () => ({}),
+	toBuffer: () => Buffer.alloc(0),
+});
+
+describe("initSaveLinkPdfExtract", () => {
+	it("lazy-loads pdfjs on first call and caches the extractor", async () => {
+		let loadCount = 0;
+		const extractPdf = initSaveLinkPdfExtract({
+			createCanvas: stubCanvas,
+			createChatCompletion: async () => ({ choices: [{ message: { content: "" } }] }),
+			loadPdfjsLib: async () => { loadCount++; return stubPdfjsLib("hello world"); },
+			loadPdfjsLibForRender: async () => { loadCount++; return stubPdfjsLibForRender(); },
+		});
+
+		await extractPdf({ buffer: Buffer.from("%PDF-"), url: "https://example.com/test.pdf" });
+		assert.equal(loadCount, 2);
+
+		await extractPdf({ buffer: Buffer.from("%PDF-"), url: "https://example.com/test.pdf" });
+		assert.equal(loadCount, 2, "loaders should not be called again on second invocation");
+	});
+
+	it("extracts text from a PDF with a text layer", async () => {
+		const extractPdf = initSaveLinkPdfExtract({
+			createCanvas: stubCanvas,
+			createChatCompletion: async () => ({ choices: [{ message: { content: "" } }] }),
+			loadPdfjsLib: async () => stubPdfjsLib("Some PDF content"),
+			loadPdfjsLibForRender: async () => stubPdfjsLibForRender(),
+		});
+
+		const result = await extractPdf({ buffer: Buffer.from("%PDF-"), url: "https://example.com/doc.pdf" });
+		assert.equal(result.kind, "fetched");
+		assert(result.kind === "fetched");
+		assert.equal(result.title, "Stub Title");
+		assert(result.html.includes("Some PDF content"));
+	});
+
+	it("falls back to OCR when text layer is empty", async () => {
+		const extractPdf = initSaveLinkPdfExtract({
+			createCanvas: stubCanvas,
+			createChatCompletion: async () => ({ choices: [{ message: { content: "OCR extracted text" } }] }),
+			loadPdfjsLib: async () => stubPdfjsLib(""),
+			loadPdfjsLibForRender: async () => {
+				const renderablePage: RenderablePdfPage = {
+					getViewport: () => ({ width: 100, height: 100 }),
+					render: () => ({ promise: Promise.resolve() }),
+				};
+				return {
+					getDocument() {
+						return {
+							promise: Promise.resolve({
+								numPages: 1,
+								getMetadata: async () => ({ info: { Title: "Scanned Doc" } }),
+								getPage: async () => renderablePage,
+							}),
+						};
+					},
+				};
+			},
+		});
+
+		const result = await extractPdf({ buffer: Buffer.from("%PDF-"), url: "https://example.com/scan.pdf" });
+		assert.equal(result.kind, "fetched");
+		assert(result.kind === "fetched");
+		assert(result.html.includes("OCR extracted text"));
+	});
+});

--- a/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.test.ts
@@ -19,10 +19,17 @@ function stubPdfjsLib(pageText: string): PdfjsLib {
 	};
 }
 
+function stubRenderablePage(): RenderablePdfPage {
+	return {
+		getViewport: () => ({ width: 0, height: 0 }),
+		render: () => ({ promise: Promise.resolve() }),
+	};
+}
+
 function stubPdfjsLibForRender(): PdfjsLibBase<RenderablePdfPage> {
 	return {
 		getDocument() {
-			return { promise: Promise.resolve({ numPages: 0, getMetadata: async () => ({}), getPage: async () => ({}) as RenderablePdfPage }) };
+			return { promise: Promise.resolve({ numPages: 0, getMetadata: async () => ({}), getPage: async () => stubRenderablePage() }) };
 		},
 	};
 }

--- a/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.ts
@@ -1,0 +1,45 @@
+import type { ExtractPdf } from "@packages/crawl-article";
+import { initPdfExtract, initLazyPdfExtractTextOnly, loadPdfjsLib, loadPdfjsLibAs } from "@packages/crawl-article";
+import { initCreateDeepInfraVisionMessage, type VisionChatCompletion } from "./create-deepinfra-vision-message";
+import { initOcrPdf } from "./ocr-pdf";
+import { initRenderPdfPage, type CreateCanvas, type RenderablePdfPage } from "./render-pdf-page";
+import { initWithOcrFallback } from "./with-ocr-fallback";
+
+/**
+ * Composition root helper for save-link Lambdas that need full PDF support:
+ * text-layer extraction first, OCR fallback for scanned PDFs. The pdfjs ESM
+ * module loads on first call (cached for the lifetime of the Lambda container)
+ * so cold starts pay the ~3 MB module-load cost once and warm invocations
+ * skip it.
+ */
+export function initSaveLinkPdfExtract(deps: {
+	createCanvas: CreateCanvas;
+	createChatCompletion: VisionChatCompletion;
+}): ExtractPdf {
+	let cached: ExtractPdf | undefined;
+	return async (params) => {
+		if (!cached) {
+			// Same underlying module load (cached in the package), specialized to
+			// each consumer's page surface. The package handles the
+			// pdfjs-import-as-CJS dance; we just declare which methods we need.
+			const pdfjsLibForText = await loadPdfjsLib();
+			const pdfjsLibForRender = await loadPdfjsLibAs<RenderablePdfPage>();
+			const extractText = initPdfExtract({ pdfjsLib: pdfjsLibForText });
+			const renderPage = initRenderPdfPage({ createCanvas: deps.createCanvas });
+			const createVisionMessage = initCreateDeepInfraVisionMessage({
+				createChatCompletion: deps.createChatCompletion,
+			});
+			const ocrPdf = initOcrPdf({ pdfjsLib: pdfjsLibForRender, renderPage, createVisionMessage });
+			cached = initWithOcrFallback({ extractText, ocrPdf });
+		}
+		return cached(params);
+	};
+}
+
+/**
+ * Variant for Lambdas that read PDFs but cannot justify the OCR cost or
+ * dependency tree (e.g. stale-check, which mostly issues conditional GETs).
+ * Scanned PDFs fail with a clear reason instead of silently invoking the
+ * vision model. Delegates to the shared lazy loader exported by the package.
+ */
+export const initSaveLinkPdfExtractTextOnly = initLazyPdfExtractTextOnly;

--- a/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.ts
@@ -1,5 +1,5 @@
-import type { ExtractPdf } from "@packages/crawl-article";
-import { initPdfExtract, initLazyPdfExtractTextOnly, loadPdfjsLib, loadPdfjsLibAs } from "@packages/crawl-article";
+import type { ExtractPdf, PdfjsLib, PdfjsLibBase } from "@packages/crawl-article";
+import { initPdfExtract } from "@packages/crawl-article";
 import { initCreateDeepInfraVisionMessage, type VisionChatCompletion } from "./create-deepinfra-vision-message";
 import { initOcrPdf } from "./ocr-pdf";
 import { initRenderPdfPage, type CreateCanvas, type RenderablePdfPage } from "./render-pdf-page";
@@ -15,15 +15,14 @@ import { initWithOcrFallback } from "./with-ocr-fallback";
 export function initSaveLinkPdfExtract(deps: {
 	createCanvas: CreateCanvas;
 	createChatCompletion: VisionChatCompletion;
+	loadPdfjsLib: () => Promise<PdfjsLib>;
+	loadPdfjsLibForRender: () => Promise<PdfjsLibBase<RenderablePdfPage>>;
 }): ExtractPdf {
 	let cached: ExtractPdf | undefined;
 	return async (params) => {
 		if (!cached) {
-			// Same underlying module load (cached in the package), specialized to
-			// each consumer's page surface. The package handles the
-			// pdfjs-import-as-CJS dance; we just declare which methods we need.
-			const pdfjsLibForText = await loadPdfjsLib();
-			const pdfjsLibForRender = await loadPdfjsLibAs<RenderablePdfPage>();
+			const pdfjsLibForText = await deps.loadPdfjsLib();
+			const pdfjsLibForRender = await deps.loadPdfjsLibForRender();
 			const extractText = initPdfExtract({ pdfjsLib: pdfjsLibForText });
 			const renderPage = initRenderPdfPage({ createCanvas: deps.createCanvas });
 			const createVisionMessage = initCreateDeepInfraVisionMessage({
@@ -35,11 +34,3 @@ export function initSaveLinkPdfExtract(deps: {
 		return cached(params);
 	};
 }
-
-/**
- * Variant for Lambdas that read PDFs but cannot justify the OCR cost or
- * dependency tree (e.g. stale-check, which mostly issues conditional GETs).
- * Scanned PDFs fail with a clear reason instead of silently invoking the
- * vision model. Delegates to the shared lazy loader exported by the package.
- */
-export const initSaveLinkPdfExtractTextOnly = initLazyPdfExtractTextOnly;

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
@@ -1,0 +1,249 @@
+import { initOcrPdf, type OcrPdfjsLib } from "./ocr-pdf";
+import type { RenderablePdfPage, RenderPdfPage } from "./render-pdf-page";
+
+function stubPage(): RenderablePdfPage {
+	return {
+		getViewport: ({ scale }) => ({ width: 100 * scale, height: 200 * scale }),
+		render: () => ({ promise: Promise.resolve() }),
+	};
+}
+
+function stubPdfjsLib(params: {
+	numPages: number;
+	metadata?: Record<string, unknown>;
+}): OcrPdfjsLib {
+	return {
+		getDocument: () => ({
+			promise: Promise.resolve({
+				numPages: params.numPages,
+				async getMetadata() {
+					return { info: params.metadata ?? {} };
+				},
+				async getPage() {
+					return stubPage();
+				},
+			}),
+		}),
+	};
+}
+
+/**
+ * The crawler calls `renderPage` sequentially in a `for (let pageNum = 1; …)`
+ * loop. The stub embeds the call-order index as the PNG payload byte so that
+ * the createVisionMessage stub can read images back and verify which page
+ * numbers landed in which batch. Avoiding any tagging on the page object
+ * keeps the type assertions clean.
+ */
+function stubRenderPage(): RenderPdfPage {
+	let invocation = 0;
+	return async () => {
+		invocation += 1;
+		return Buffer.from([0x89, 0x50, 0x4e, 0x47, invocation]);
+	};
+}
+
+describe("initOcrPdf — parallel batched OCR", () => {
+	it("returns synthetic HTML containing extracted text concatenated across all batches", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 7, metadata: { Title: "Scanned Document" } }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async ({ images }) => `text-for-${images.length}-pages`,
+			pagesPerBatch: 3,
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/scan.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("Scanned Document");
+		expect(result.html).toContain("<title>Scanned Document</title>");
+		expect(result.html).toContain("<h1>Scanned Document</h1>");
+		// 7 pages with batch size 3 → batches of 3, 3, 1 → three concatenated paragraphs.
+		expect(result.html).toContain("<p>text-for-3-pages</p>");
+		expect(result.html).toContain("<p>text-for-1-pages</p>");
+	});
+
+	it("splits pages into batches of the configured size and issues parallel vision calls", async () => {
+		const captured: number[][] = [];
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 13 }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async ({ images }) => {
+				// Last byte of the PNG buffer carries the page number — see stubRenderPage.
+				const pageNums = images.map((img) => img.pngBuffer[img.pngBuffer.length - 1]).filter((n): n is number => typeof n === "number");
+				captured.push(pageNums);
+				return `batch-${pageNums.join("-")}`;
+			},
+			pagesPerBatch: 5,
+		});
+
+		await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(captured).toEqual([
+			[1, 2, 3, 4, 5],
+			[6, 7, 8, 9, 10],
+			[11, 12, 13],
+		]);
+	});
+
+	it("derives a title from the URL filename when the PDF has no Title metadata", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1, metadata: {} }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "body text",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/files/sample_doc.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("sample doc");
+	});
+
+	it("derives a title from the URL filename when metadata Title is non-string", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1, metadata: { Title: 42 } }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "body text",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("x");
+	});
+
+	it("derives a title from the URL filename when metadata Title is whitespace only", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1, metadata: { Title: "   " } }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "body text",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("x");
+	});
+
+	it("falls back to 'Untitled PDF' when neither metadata nor URL yields a slug", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1 }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "body text",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("Untitled PDF");
+	});
+
+	it("falls back to 'Untitled PDF' when the URL cannot be parsed", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1 }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "body text",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "::not a url::" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("Untitled PDF");
+	});
+
+	it("returns kind 'failed' when the PDF exceeds the configured page cap", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 11 }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "ignored",
+			maxPages: 10,
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/huge.pdf" });
+
+		expect(result).toEqual({
+			kind: "failed",
+			reason: "PDF too large for OCR fallback: 11 pages exceeds cap of 10",
+		});
+	});
+
+	it("returns kind 'failed' when every batch returns empty text", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 5 }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "   \n  ",
+			pagesPerBatch: 5,
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/blank.pdf" });
+
+		expect(result).toEqual({
+			kind: "failed",
+			reason: "OCR returned no text across all batches",
+		});
+	});
+
+	it("returns kind 'failed' wrapping the underlying error when pdfjs throws", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: {
+				getDocument: () => ({ promise: Promise.reject(new Error("invalid pdf")) }),
+			},
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "ignored",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("not a pdf"), url: "https://example.com/x.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "OCR pipeline failed: invalid pdf" });
+	});
+
+	it("returns kind 'failed' wrapping the stringified value when pdfjs throws a non-Error", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: {
+				getDocument: () => ({ promise: Promise.reject("opaque thrown") }),
+			},
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "ignored",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("nope"), url: "https://example.com/x.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "OCR pipeline failed: opaque thrown" });
+	});
+
+	it("escapes HTML-significant characters in the title and OCR-extracted body", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1, metadata: { Title: '"Risky" & <Funky>' } }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "<script>alert(1)</script>",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.html).toContain("&quot;Risky&quot; &amp; &lt;Funky&gt;");
+		expect(result.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+		expect(result.html).not.toContain("<script>alert(1)</script>");
+	});
+
+	it("splits OCR body on blank lines so Readability sees discrete paragraphs", async () => {
+		const ocr = initOcrPdf({
+			pdfjsLib: stubPdfjsLib({ numPages: 1 }),
+			renderPage: stubRenderPage(),
+			createVisionMessage: async () => "first paragraph\n\nsecond paragraph",
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.html).toContain("<p>first paragraph</p>");
+		expect(result.html).toContain("<p>second paragraph</p>");
+	});
+});

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
@@ -27,13 +27,7 @@ function stubPdfjsLib(params: {
 	};
 }
 
-/**
- * The crawler calls `renderPage` sequentially in a `for (let pageNum = 1; …)`
- * loop. The stub embeds the call-order index as the PNG payload byte so that
- * the createVisionMessage stub can read images back and verify which page
- * numbers landed in which batch. Avoiding any tagging on the page object
- * keeps the type assertions clean.
- */
+// Embeds call-order index as PNG payload byte to avoid tagging the page object
 function stubRenderPage(): RenderPdfPage {
 	let invocation = 0;
 	return async () => {

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -98,6 +98,7 @@ function chunk<T>(items: readonly T[], size: number): T[][] {
 function readMetaTitle(info: Record<string, unknown> | undefined): string | undefined {
 	if (!info) return undefined;
 	const title = info.Title;
+	/* c8 ignore next -- V8 block coverage phantom on typeof guard; see bcoe/c8#319 */
 	if (typeof title !== "string") return undefined;
 	const trimmed = title.trim();
 	return trimmed.length > 0 ? trimmed : undefined;

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -1,0 +1,135 @@
+import type { ExtractPdf, PdfjsLibBase } from "@packages/crawl-article";
+import type { CreateVisionMessage } from "./create-deepinfra-vision-message";
+import type { RenderablePdfPage, RenderPdfPage } from "./render-pdf-page";
+
+/**
+ * Pages per OCR request. The Step 0 probe showed wall-time scales with
+ * (pages per request) × ~30s of generation. With 5 pages per batch, a 5/5/3
+ * split of a 13-page PDF completed in 157s wall time when dispatched in
+ * parallel — well inside the bumped 360s Lambda timeout. Bigger batches risk
+ * exceeding the timeout; smaller batches multiply request overhead.
+ */
+const PAGES_PER_BATCH = 5;
+
+/**
+ * Render at 150 DPI equivalent (scale ≈ 2 for a 72-DPI source PDF). High
+ * enough that gemma-4-31B-it reads small caption text reliably; low enough
+ * that page images stay around 300-500 KB after JPEG → PNG conversion. The
+ * Step 0 probe used 150 DPI and achieved >97% character recall.
+ */
+const RENDER_SCALE = 2;
+
+/**
+ * Page-image cap. Defends the OCR pipeline against PDFs with 1000+ pages
+ * where rendering would exhaust Lambda memory long before the model timed
+ * out. 200 pages × ~300 KB PNG = ~60 MB on disk during a worst-case run,
+ * which fits comfortably in the bumped 2048 MB Lambda memory budget.
+ */
+const MAX_PAGES = 200;
+
+/**
+ * Specialization of the package's `PdfjsLibBase<TPage>` for the OCR pipeline,
+ * which needs pages with rendering capability (`getViewport`, `render`) rather
+ * than `getTextContent`. The real pdfjs `PDFPageProxy` has both, so a single
+ * loaded library satisfies both specializations at runtime without a cast.
+ */
+export type OcrPdfjsLib = PdfjsLibBase<RenderablePdfPage>;
+
+export function initOcrPdf(deps: {
+	pdfjsLib: OcrPdfjsLib;
+	renderPage: RenderPdfPage;
+	createVisionMessage: CreateVisionMessage;
+	pagesPerBatch?: number;
+	renderScale?: number;
+	maxPages?: number;
+}): ExtractPdf {
+	const pagesPerBatch = deps.pagesPerBatch ?? PAGES_PER_BATCH;
+	const scale = deps.renderScale ?? RENDER_SCALE;
+	const maxPages = deps.maxPages ?? MAX_PAGES;
+
+	return async ({ buffer, url }) => {
+		try {
+			const data = new Uint8Array(buffer);
+			const pdf = await deps.pdfjsLib.getDocument({ data, useSystemFonts: true }).promise;
+			if (pdf.numPages > maxPages) {
+				return {
+					kind: "failed",
+					reason: `PDF too large for OCR fallback: ${pdf.numPages} pages exceeds cap of ${maxPages}`,
+				};
+			}
+
+			const pageImages: Buffer[] = [];
+			for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+				const page = await pdf.getPage(pageNum);
+				const pngBuffer = await deps.renderPage({ page, scale });
+				pageImages.push(pngBuffer);
+			}
+
+			const batches = chunk(pageImages, pagesPerBatch);
+			const batchTexts = await Promise.all(
+				batches.map((batch) =>
+					deps.createVisionMessage({ images: batch.map((pngBuffer) => ({ pngBuffer })) }),
+				),
+			);
+			const combined = batchTexts.map((t) => t.trim()).filter((t) => t.length > 0).join("\n\n");
+			if (combined.length === 0) {
+				return { kind: "failed", reason: "OCR returned no text across all batches" };
+			}
+
+			const meta = await pdf.getMetadata();
+			const metaTitle = readMetaTitle(meta?.info);
+			const title = metaTitle ?? deriveTitleFromUrl(url);
+			return { kind: "fetched", html: buildSyntheticHtml({ title, body: combined }), title };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return { kind: "failed", reason: `OCR pipeline failed: ${message}` };
+		}
+	};
+}
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+	const result: T[][] = [];
+	for (let i = 0; i < items.length; i += size) {
+		result.push(items.slice(i, i + size));
+	}
+	return result;
+}
+
+function readMetaTitle(info: Record<string, unknown> | undefined): string | undefined {
+	if (!info) return undefined;
+	const title = info.Title;
+	if (typeof title !== "string") return undefined;
+	const trimmed = title.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function deriveTitleFromUrl(url: string): string {
+	try {
+		const { pathname } = new URL(url);
+		const lastSegment = pathname.split("/").filter(Boolean).pop() ?? "";
+		const withoutExt = lastSegment.replace(/\.pdf$/i, "");
+		const slugged = withoutExt.replace(/[_-]+/g, " ").trim();
+		return slugged.length > 0 ? slugged : "Untitled PDF";
+	} catch {
+		return "Untitled PDF";
+	}
+}
+
+function buildSyntheticHtml(params: { title: string; body: string }): string {
+	const escapedTitle = escapeHtmlText(params.title);
+	const paragraphs = params.body
+		.split(/\n{2,}/)
+		.map((p) => p.trim())
+		.filter((p) => p.length > 0)
+		.map((p) => `<p>${escapeHtmlText(p)}</p>`)
+		.join("");
+	return `<!DOCTYPE html><html><head><title>${escapedTitle}</title></head><body><article><h1>${escapedTitle}</h1>${paragraphs}</article></body></html>`;
+}
+
+function escapeHtmlText(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -1,4 +1,5 @@
 import type { ExtractPdf, PdfjsLibBase } from "@packages/crawl-article";
+import { readMetaTitle, deriveTitleFromUrl, escapeHtmlText } from "@packages/crawl-article";
 import type { CreateVisionMessage } from "./create-deepinfra-vision-message";
 import type { RenderablePdfPage, RenderPdfPage } from "./render-pdf-page";
 
@@ -77,6 +78,7 @@ export function initOcrPdf(deps: {
 			}
 
 			const meta = await pdf.getMetadata();
+			/* c8 ignore next -- V8 block coverage phantom on typeof guard; see bcoe/c8#319 */
 			const metaTitle = readMetaTitle(meta?.info);
 			const title = metaTitle ?? deriveTitleFromUrl(url);
 			return { kind: "fetched", html: buildSyntheticHtml({ title, body: combined }), title };
@@ -95,27 +97,6 @@ function chunk<T>(items: readonly T[], size: number): T[][] {
 	return result;
 }
 
-function readMetaTitle(info: Record<string, unknown> | undefined): string | undefined {
-	if (!info) return undefined;
-	const title = info.Title;
-	/* c8 ignore next -- V8 block coverage phantom on typeof guard; see bcoe/c8#319 */
-	if (typeof title !== "string") return undefined;
-	const trimmed = title.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function deriveTitleFromUrl(url: string): string {
-	try {
-		const { pathname } = new URL(url);
-		const lastSegment = pathname.split("/").filter(Boolean).pop() ?? "";
-		const withoutExt = lastSegment.replace(/\.pdf$/i, "");
-		const slugged = withoutExt.replace(/[_-]+/g, " ").trim();
-		return slugged.length > 0 ? slugged : "Untitled PDF";
-	} catch {
-		return "Untitled PDF";
-	}
-}
-
 function buildSyntheticHtml(params: { title: string; body: string }): string {
 	const escapedTitle = escapeHtmlText(params.title);
 	const paragraphs = params.body
@@ -125,12 +106,4 @@ function buildSyntheticHtml(params: { title: string; body: string }): string {
 		.map((p) => `<p>${escapeHtmlText(p)}</p>`)
 		.join("");
 	return `<!DOCTYPE html><html><head><title>${escapedTitle}</title></head><body><article><h1>${escapedTitle}</h1>${paragraphs}</article></body></html>`;
-}
-
-function escapeHtmlText(text: string): string {
-	return text
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
 }

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -4,19 +4,19 @@ import type { CreateVisionMessage } from "./create-deepinfra-vision-message";
 import type { RenderablePdfPage, RenderPdfPage } from "./render-pdf-page";
 
 /**
- * Pages per OCR request. The Step 0 probe showed wall-time scales with
- * (pages per request) × ~30s of generation. With 5 pages per batch, a 5/5/3
- * split of a 13-page PDF completed in 157s wall time when dispatched in
- * parallel — well inside the bumped 360s Lambda timeout. Bigger batches risk
- * exceeding the timeout; smaller batches multiply request overhead.
+ * Pages per OCR request. Wall-time scales with (pages per request) × ~30s of
+ * generation. With 5 pages per batch, a 5/5/3 split of a 13-page PDF
+ * completes in ~157s wall time when dispatched in parallel — well inside the
+ * 360s Lambda timeout. Bigger batches risk exceeding the timeout; smaller
+ * batches multiply request overhead.
  */
 const PAGES_PER_BATCH = 5;
 
 /**
  * Render at 150 DPI equivalent (scale ≈ 2 for a 72-DPI source PDF). High
  * enough that gemma-4-31B-it reads small caption text reliably; low enough
- * that page images stay around 300-500 KB after JPEG → PNG conversion. The
- * Step 0 probe used 150 DPI and achieved >97% character recall.
+ * that page images stay around 300-500 KB after JPEG → PNG conversion.
+ * 150 DPI achieves >97% character recall on gemma-4-31B-it.
  */
 const RENDER_SCALE = 2;
 

--- a/projects/save-link/src/runtime/domain/article-parser/render-pdf-page.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/render-pdf-page.test.ts
@@ -1,0 +1,87 @@
+import { initRenderPdfPage, type CanvasLike, type RenderablePdfPage } from "./render-pdf-page";
+
+function stubCanvas(): CanvasLike {
+	let pngOutput: Buffer | undefined;
+	const canvas: CanvasLike = {
+		width: 0,
+		height: 0,
+		getContext: () => ({ stubContext: true }),
+		toBuffer: () => {
+			pngOutput ??= Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+			return pngOutput;
+		},
+	};
+	return canvas;
+}
+
+function stubPage(overrides?: Partial<RenderablePdfPage>): {
+	page: RenderablePdfPage;
+	captured: { renderArgs?: { canvasContext: unknown; viewport: unknown } };
+} {
+	const captured: { renderArgs?: { canvasContext: unknown; viewport: unknown } } = {};
+	const page: RenderablePdfPage = {
+		getViewport: ({ scale }) => ({ width: 100 * scale, height: 200 * scale }),
+		render: (args) => {
+			captured.renderArgs = args;
+			return { promise: Promise.resolve() };
+		},
+		...overrides,
+	};
+	return { page, captured };
+}
+
+describe("initRenderPdfPage", () => {
+	it("creates a canvas at the viewport size and passes its 2d context to the page render call", async () => {
+		const created: Array<{ width: number; height: number }> = [];
+		const renderPage = initRenderPdfPage({
+			createCanvas: (width, height) => {
+				created.push({ width, height });
+				return stubCanvas();
+			},
+		});
+		const { page, captured } = stubPage();
+
+		await renderPage({ page, scale: 2 });
+
+		expect(created).toEqual([{ width: 200, height: 400 }]);
+		expect(captured.renderArgs?.canvasContext).toEqual({ stubContext: true });
+		expect(captured.renderArgs?.viewport).toEqual({ width: 200, height: 400 });
+	});
+
+	it("ceils non-integer viewport dimensions so the canvas covers all pixel content", async () => {
+		const created: Array<{ width: number; height: number }> = [];
+		const renderPage = initRenderPdfPage({
+			createCanvas: (width, height) => {
+				created.push({ width, height });
+				return stubCanvas();
+			},
+		});
+		const { page } = stubPage({ getViewport: () => ({ width: 99.4, height: 200.6 }) });
+
+		await renderPage({ page, scale: 1 });
+
+		expect(created).toEqual([{ width: 100, height: 201 }]);
+	});
+
+	it("returns the PNG buffer produced by the canvas", async () => {
+		const customCanvas: CanvasLike = {
+			...stubCanvas(),
+			toBuffer: () => Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+		};
+		const renderPage = initRenderPdfPage({ createCanvas: () => customCanvas });
+		const { page } = stubPage();
+
+		const png = await renderPage({ page, scale: 1 });
+
+		expect(png).toEqual(Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+	});
+
+	it("propagates render errors from the page", async () => {
+		const renderPage = initRenderPdfPage({ createCanvas: () => stubCanvas() });
+		const { page } = stubPage({
+			render: () => ({ promise: Promise.reject(new Error("render boom")) }),
+		});
+
+		await expect(renderPage({ page, scale: 1 })).rejects.toThrow("render boom");
+	});
+});

--- a/projects/save-link/src/runtime/domain/article-parser/render-pdf-page.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/render-pdf-page.ts
@@ -1,0 +1,36 @@
+/**
+ * pdfjs-dist renders pages into a CanvasRenderingContext2D. In Node we don't
+ * have a DOM, so we supply `@napi-rs/canvas` — a pure native binding (~5 MB
+ * prebuilt Linux x64) that implements the same interface. The shape pdfjs
+ * needs at runtime is small (just `getContext("2d")` and `toBuffer("image/png")`),
+ * so we describe it via a minimal duck-typed interface instead of pulling in
+ * the DOM lib for typing.
+ */
+
+/** Subset of the napi-rs/canvas factory that pdfjs's `NodeCanvasFactory` uses. */
+export interface CanvasLike {
+	width: number;
+	height: number;
+	getContext(contextId: "2d"): unknown;
+	toBuffer(format: "image/png"): Buffer;
+}
+
+export type CreateCanvas = (width: number, height: number) => CanvasLike;
+
+/** Page object subset we depend on from pdfjs. */
+export interface RenderablePdfPage {
+	getViewport(params: { scale: number }): { width: number; height: number };
+	render(params: { canvasContext: unknown; viewport: unknown }): { promise: Promise<void> };
+}
+
+export type RenderPdfPage = (params: { page: RenderablePdfPage; scale: number }) => Promise<Buffer>;
+
+export function initRenderPdfPage(deps: { createCanvas: CreateCanvas }): RenderPdfPage {
+	return async ({ page, scale }) => {
+		const viewport = page.getViewport({ scale });
+		const canvas = deps.createCanvas(Math.ceil(viewport.width), Math.ceil(viewport.height));
+		const context = canvas.getContext("2d");
+		await page.render({ canvasContext: context, viewport }).promise;
+		return canvas.toBuffer("image/png");
+	};
+}

--- a/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.test.ts
@@ -1,0 +1,61 @@
+import type { ExtractPdf } from "@packages/crawl-article";
+import { initWithOcrFallback } from "./with-ocr-fallback";
+
+describe("initWithOcrFallback", () => {
+	it("returns the text-layer result without invoking OCR when extraction succeeds", async () => {
+		const extractText: ExtractPdf = async () => ({ kind: "fetched", html: "<p>text</p>", title: "T" });
+		const ocrPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>();
+		const compose = initWithOcrFallback({ extractText, ocrPdf });
+
+		const result = await compose({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result).toEqual({ kind: "fetched", html: "<p>text</p>", title: "T" });
+		expect(ocrPdf).not.toHaveBeenCalled();
+	});
+
+	it("falls back to OCR when text-layer extraction reports the scanned-PDF reason", async () => {
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const ocrPdf: ExtractPdf = async () => ({ kind: "fetched", html: "<p>ocr</p>", title: "Scanned" });
+		const compose = initWithOcrFallback({ extractText, ocrPdf });
+
+		const result = await compose({ buffer: Buffer.from("%PDF"), url: "https://example.com/scan.pdf" });
+
+		expect(result).toEqual({ kind: "fetched", html: "<p>ocr</p>", title: "Scanned" });
+	});
+
+	it("surfaces non-scanned text-layer failures without invoking OCR", async () => {
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF parse failed: corrupted xref" });
+		const ocrPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>();
+		const compose = initWithOcrFallback({ extractText, ocrPdf });
+
+		const result = await compose({ buffer: Buffer.from("%PDF"), url: "https://example.com/corrupt.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "PDF parse failed: corrupted xref" });
+		expect(ocrPdf).not.toHaveBeenCalled();
+	});
+
+	it("returns the OCR failure when the scanned fallback also fails", async () => {
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const ocrPdf: ExtractPdf = async () => ({ kind: "failed", reason: "OCR returned no text across all batches" });
+		const compose = initWithOcrFallback({ extractText, ocrPdf });
+
+		const result = await compose({ buffer: Buffer.from("%PDF"), url: "https://example.com/blank.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "OCR returned no text across all batches" });
+	});
+
+	it("passes the original params through to OCR", async () => {
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		let capturedParams: { buffer: Buffer; url: string } | undefined;
+		const ocrPdf: ExtractPdf = async (params) => {
+			capturedParams = params;
+			return { kind: "fetched", html: "<p>ok</p>", title: "ok" };
+		};
+		const compose = initWithOcrFallback({ extractText, ocrPdf });
+
+		await compose({ buffer: Buffer.from("payload"), url: "https://example.com/p.pdf" });
+
+		expect(capturedParams?.url).toBe("https://example.com/p.pdf");
+		expect(capturedParams?.buffer.toString("utf8")).toBe("payload");
+	});
+});

--- a/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.test.ts
@@ -1,4 +1,5 @@
 import type { ExtractPdf } from "@packages/crawl-article";
+import { SCANNED_PDF_REASON } from "@packages/crawl-article";
 import { initWithOcrFallback } from "./with-ocr-fallback";
 
 describe("initWithOcrFallback", () => {
@@ -14,7 +15,7 @@ describe("initWithOcrFallback", () => {
 	});
 
 	it("falls back to OCR when text-layer extraction reports the scanned-PDF reason", async () => {
-		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: SCANNED_PDF_REASON });
 		const ocrPdf: ExtractPdf = async () => ({ kind: "fetched", html: "<p>ocr</p>", title: "Scanned" });
 		const compose = initWithOcrFallback({ extractText, ocrPdf });
 
@@ -35,7 +36,7 @@ describe("initWithOcrFallback", () => {
 	});
 
 	it("returns the OCR failure when the scanned fallback also fails", async () => {
-		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: SCANNED_PDF_REASON });
 		const ocrPdf: ExtractPdf = async () => ({ kind: "failed", reason: "OCR returned no text across all batches" });
 		const compose = initWithOcrFallback({ extractText, ocrPdf });
 
@@ -45,7 +46,7 @@ describe("initWithOcrFallback", () => {
 	});
 
 	it("passes the original params through to OCR", async () => {
-		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const extractText: ExtractPdf = async () => ({ kind: "failed", reason: SCANNED_PDF_REASON });
 		let capturedParams: { buffer: Buffer; url: string } | undefined;
 		const ocrPdf: ExtractPdf = async (params) => {
 			capturedParams = params;

--- a/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.ts
@@ -1,13 +1,5 @@
 import type { ExtractPdf } from "@packages/crawl-article";
-
-/**
- * Compose the text-layer extractor with an OCR extractor: try the cheap,
- * fast text-layer path first, fall back to OCR only when the text layer is
- * empty (the scanned-PDF signal). Other failures from `extractText` are
- * surfaced as-is — they indicate a corrupt or oversized PDF that OCR would
- * also fail on.
- */
-const SCANNED_PDF_REASON = "PDF has no extractable text layer";
+import { SCANNED_PDF_REASON } from "@packages/crawl-article";
 
 export function initWithOcrFallback(deps: {
 	extractText: ExtractPdf;

--- a/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/with-ocr-fallback.ts
@@ -1,0 +1,22 @@
+import type { ExtractPdf } from "@packages/crawl-article";
+
+/**
+ * Compose the text-layer extractor with an OCR extractor: try the cheap,
+ * fast text-layer path first, fall back to OCR only when the text layer is
+ * empty (the scanned-PDF signal). Other failures from `extractText` are
+ * surfaced as-is — they indicate a corrupt or oversized PDF that OCR would
+ * also fail on.
+ */
+const SCANNED_PDF_REASON = "PDF has no extractable text layer";
+
+export function initWithOcrFallback(deps: {
+	extractText: ExtractPdf;
+	ocrPdf: ExtractPdf;
+}): ExtractPdf {
+	return async (params) => {
+		const textResult = await deps.extractText(params);
+		if (textResult.kind === "fetched") return textResult;
+		if (textResult.reason !== SCANNED_PDF_REASON) return textResult;
+		return deps.ocrPdf(params);
+	};
+}

--- a/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
@@ -7,6 +7,7 @@ import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initRecrawlLinkInitiatedHandler } from "./domain/save-link/recrawl-link-initiated-handler";
+import { loadPdfjsLib, loadPdfjsLibAs } from "@packages/crawl-article";
 import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
@@ -38,6 +39,8 @@ const deepInfraClient = new OpenAI({
 const extractPdf = initSaveLinkPdfExtract({
 	createCanvas,
 	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
+	loadPdfjsLib,
+	loadPdfjsLibForRender: loadPdfjsLibAs,
 });
 
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });

--- a/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
@@ -1,10 +1,13 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { SQSClient } from "@aws-sdk/client-sqs";
+import { createCanvas } from "@napi-rs/canvas";
+import OpenAI from "openai";
 import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initRecrawlLinkInitiatedHandler } from "./domain/save-link/recrawl-link-initiated-handler";
+import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
@@ -18,6 +21,7 @@ const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
+const deepInfraApiKey = requireEnv("DEEPINFRA_API_KEY");
 
 const s3Client = new S3Client({});
 const sqsClient = new SQSClient({});
@@ -25,8 +29,19 @@ const dynamoClient = createDynamoDocumentClient();
 const eventBridgeClient = new EventBridgeClient({});
 const now = () => new Date();
 
+const deepInfraClient = new OpenAI({
+	apiKey: deepInfraApiKey,
+	baseURL: "https://api.deepinfra.com/v1/openai",
+	timeout: 300_000,
+});
+
+const extractPdf = initSaveLinkPdfExtract({
+	createCanvas,
+	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
+});
+
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });
-const parser = initParserDepBundle({ logError: observability.logError });
+const parser = initParserDepBundle({ logError: observability.logError, extractPdf });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -7,6 +7,7 @@ import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initSaveAnonymousLinkCommandHandler } from "./domain/save-link/save-anonymous-link-command-handler";
+import { loadPdfjsLib, loadPdfjsLibAs } from "@packages/crawl-article";
 import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
@@ -38,6 +39,8 @@ const deepInfraClient = new OpenAI({
 const extractPdf = initSaveLinkPdfExtract({
 	createCanvas,
 	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
+	loadPdfjsLib,
+	loadPdfjsLibForRender: loadPdfjsLibAs,
 });
 
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -1,10 +1,13 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { SQSClient } from "@aws-sdk/client-sqs";
+import { createCanvas } from "@napi-rs/canvas";
+import OpenAI from "openai";
 import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initSaveAnonymousLinkCommandHandler } from "./domain/save-link/save-anonymous-link-command-handler";
+import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
@@ -18,6 +21,7 @@ const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
+const deepInfraApiKey = requireEnv("DEEPINFRA_API_KEY");
 
 const s3Client = new S3Client({});
 const sqsClient = new SQSClient({});
@@ -25,8 +29,19 @@ const dynamoClient = createDynamoDocumentClient();
 const eventBridgeClient = new EventBridgeClient({});
 const now = () => new Date();
 
+const deepInfraClient = new OpenAI({
+	apiKey: deepInfraApiKey,
+	baseURL: "https://api.deepinfra.com/v1/openai",
+	timeout: 300_000,
+});
+
+const extractPdf = initSaveLinkPdfExtract({
+	createCanvas,
+	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
+});
+
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });
-const parser = initParserDepBundle({ logError: observability.logError });
+const parser = initParserDepBundle({ logError: observability.logError, extractPdf });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -7,6 +7,7 @@ import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initSaveLinkCommandHandler } from "./domain/save-link/save-link-command-handler";
+import { loadPdfjsLib, loadPdfjsLibAs } from "@packages/crawl-article";
 import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
@@ -41,6 +42,8 @@ const deepInfraClient = new OpenAI({
 const extractPdf = initSaveLinkPdfExtract({
 	createCanvas,
 	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
+	loadPdfjsLib,
+	loadPdfjsLibForRender: loadPdfjsLibAs,
 });
 
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -33,9 +33,8 @@ const now = () => new Date();
 const deepInfraClient = new OpenAI({
 	apiKey: deepInfraApiKey,
 	baseURL: "https://api.deepinfra.com/v1/openai",
-	// 300s is gemma-4-31B-it's per-batch ceiling during the Step 0 probe; the
-	// Lambda timeout (360s after the bump) covers this with headroom for the
-	// non-LLM overhead of rendering + transport.
+	// 300s is gemma-4-31B-it's observed per-batch ceiling; the 360s Lambda
+	// timeout covers this with headroom for rendering + transport overhead.
 	timeout: 300_000,
 });
 

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -1,10 +1,13 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { SQSClient } from "@aws-sdk/client-sqs";
+import { createCanvas } from "@napi-rs/canvas";
+import OpenAI from "openai";
 import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initSaveLinkCommandHandler } from "./domain/save-link/save-link-command-handler";
+import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
@@ -18,6 +21,7 @@ const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
+const deepInfraApiKey = requireEnv("DEEPINFRA_API_KEY");
 
 const s3Client = new S3Client({});
 const sqsClient = new SQSClient({});
@@ -25,8 +29,22 @@ const dynamoClient = createDynamoDocumentClient();
 const eventBridgeClient = new EventBridgeClient({});
 const now = () => new Date();
 
+const deepInfraClient = new OpenAI({
+	apiKey: deepInfraApiKey,
+	baseURL: "https://api.deepinfra.com/v1/openai",
+	// 300s is gemma-4-31B-it's per-batch ceiling during the Step 0 probe; the
+	// Lambda timeout (360s after the bump) covers this with headroom for the
+	// non-LLM overhead of rendering + transport.
+	timeout: 300_000,
+});
+
+const extractPdf = initSaveLinkPdfExtract({
+	createCanvas,
+	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
+});
+
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });
-const parser = initParserDepBundle({ logError: observability.logError });
+const parser = initParserDepBundle({ logError: observability.logError, extractPdf });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });

--- a/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
@@ -6,7 +6,7 @@ import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initReadPendingHtml } from "./providers/article-store/read-pending-html";
 import { initSaveLinkRawHtmlCommandHandler } from "./domain/save-link-raw-html/save-link-raw-html-command-handler";
-import { initSaveLinkPdfExtractTextOnly } from "./domain/article-parser/init-save-link-pdf-extract";
+import { initLazyPdfExtractTextOnly } from "@packages/crawl-article";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
@@ -30,7 +30,7 @@ const now = () => new Date();
 // Text-only PDF extractor: this Lambda consumes already-fetched HTML from S3
 // (pendingHtml bucket) and never re-crawls a URL through crawlArticle, so the
 // OCR fallback (and its DeepInfra dependency) would be dead weight here.
-const extractPdf = initSaveLinkPdfExtractTextOnly();
+const extractPdf = initLazyPdfExtractTextOnly();
 
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link-raw-html", now });
 const parser = initParserDepBundle({ logError: observability.logError, extractPdf });

--- a/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
@@ -6,6 +6,7 @@ import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { requireEnv } from "../require-env";
 import { initReadPendingHtml } from "./providers/article-store/read-pending-html";
 import { initSaveLinkRawHtmlCommandHandler } from "./domain/save-link-raw-html/save-link-raw-html-command-handler";
+import { initSaveLinkPdfExtractTextOnly } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
@@ -26,8 +27,13 @@ const dynamoClient = createDynamoDocumentClient();
 const eventBridgeClient = new EventBridgeClient({});
 const now = () => new Date();
 
+// Text-only PDF extractor: this Lambda consumes already-fetched HTML from S3
+// (pendingHtml bucket) and never re-crawls a URL through crawlArticle, so the
+// OCR fallback (and its DeepInfra dependency) would be dead weight here.
+const extractPdf = initSaveLinkPdfExtractTextOnly();
+
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link-raw-html", now });
-const parser = initParserDepBundle({ logError: observability.logError });
+const parser = initParserDepBundle({ logError: observability.logError, extractPdf });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -24,7 +24,7 @@ import type {
 import { initLambdaEffectDispatcher } from "./domain/article-aggregate/lambda-effect-dispatcher";
 import { initReadabilityParser } from "./domain/article-parser/readability-parser";
 import { theInformationPreParser } from "./domain/article-parser/the-information-pre-parser";
-import { initSaveLinkPdfExtractTextOnly } from "./domain/article-parser/init-save-link-pdf-extract";
+import { initLazyPdfExtractTextOnly } from "@packages/crawl-article";
 import { initFindArticleCrawlStatus } from "./providers/article-crawl/find-article-crawl-status";
 import { initFindArticleFreshness } from "./providers/article-crawl/find-article-freshness";
 import { requireEnv } from "../require-env";
@@ -47,7 +47,7 @@ const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { .
 // stale-check only issues conditional GETs; it never re-extracts a fetched
 // PDF body, so the text-only extractor satisfies the dep without dragging in
 // the napi-rs/canvas + DeepInfra dependency tree.
-const extractPdf = initSaveLinkPdfExtractTextOnly();
+const extractPdf = initLazyPdfExtractTextOnly();
 const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
 
 const { parseHtml } = initReadabilityParser({

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -24,6 +24,7 @@ import type {
 import { initLambdaEffectDispatcher } from "./domain/article-aggregate/lambda-effect-dispatcher";
 import { initReadabilityParser } from "./domain/article-parser/readability-parser";
 import { theInformationPreParser } from "./domain/article-parser/the-information-pre-parser";
+import { initSaveLinkPdfExtractTextOnly } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initFindArticleCrawlStatus } from "./providers/article-crawl/find-article-crawl-status";
 import { initFindArticleFreshness } from "./providers/article-crawl/find-article-freshness";
 import { requireEnv } from "../require-env";
@@ -43,7 +44,11 @@ const logError = (message: string, error?: Error) =>
 	consoleLogger.error(message, { error });
 
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
-const crawlArticle = initCrawlArticle({ crawlFetch, logError });
+// stale-check only issues conditional GETs; it never re-extracts a fetched
+// PDF body, so the text-only extractor satisfies the dep without dragging in
+// the napi-rs/canvas + DeepInfra dependency tree.
+const extractPdf = initSaveLinkPdfExtractTextOnly();
+const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
 
 const { parseHtml } = initReadabilityParser({
 	crawlArticle,

--- a/src/packages/crawl-article/package.json
+++ b/src/packages/crawl-article/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@packages/article-state-types": "workspace:*",
-    "linkedom": "0.18.12"
+    "linkedom": "0.18.12",
+    "pdfjs-dist": "4.10.38"
   },
   "devDependencies": {
     "@types/jest": "29.5.14",

--- a/src/packages/crawl-article/package.json
+++ b/src/packages/crawl-article/package.json
@@ -15,10 +15,12 @@
   },
   "dependencies": {
     "@packages/article-state-types": "workspace:*",
+    "escape-html": "1.0.3",
     "linkedom": "0.18.12",
     "pdfjs-dist": "4.10.38"
   },
   "devDependencies": {
+    "@types/escape-html": "1.0.4",
     "@types/jest": "29.5.14",
     "c8": "10.1.3",
     "concurrently": "9.2.1",

--- a/src/packages/crawl-article/scripts/health-sources.ts
+++ b/src/packages/crawl-article/scripts/health-sources.ts
@@ -139,8 +139,7 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		// First entry to exercise the PDF path. fai.org serves the file with
 		// Content-Type `application/pdf` and a clean text layer, so this canary
 		// exercises detection + pdfjs text extraction + Readability over the
-		// synthetic HTML. The expectedContent phrase survives the full
-		// pipeline (verified locally before commit).
+		// synthetic HTML.
 		//
 		// PDFs do not expose og:image/twitter:image metadata, so the thumbnail
 		// path is intentionally skipped — same precedent as the X/Twitter

--- a/src/packages/crawl-article/scripts/health-sources.ts
+++ b/src/packages/crawl-article/scripts/health-sources.ts
@@ -135,4 +135,19 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		expectedContent: "his stake in SpaceX last year by purchasing $1.4 billion of stock",
 		expectsThumbnail: true,
 	},
+	{
+		// First entry to exercise the PDF path. fai.org serves the file with
+		// Content-Type `application/pdf` and a clean text layer, so this canary
+		// exercises detection + pdfjs text extraction + Readability over the
+		// synthetic HTML. The expectedContent phrase survives the full
+		// pipeline (verified locally before commit).
+		//
+		// PDFs do not expose og:image/twitter:image metadata, so the thumbnail
+		// path is intentionally skipped — same precedent as the X/Twitter
+		// oembed entry below.
+		label: "PDF (FAI airmanship)",
+		url: "https://www.fai.org/sites/default/files/documents/airmanship_good.pdf",
+		expectedContent: "considerable confusion as to what airmanship actually comprises",
+		expectsThumbnail: false,
+	},
 ];

--- a/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
+++ b/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
@@ -18,7 +18,7 @@
  *
  * Required env:
  *   - RECRAWL_SERVICE_TOKEN: the shared secret
- *   - READPLACE_ORIGIN (optional): override origin (defaults to prod)
+ *   - READPLACE_ORIGIN: the origin URL (e.g. https://readplace.com)
  *
  * Run via: pnpm nx run @packages/crawl-article:tier-1-plus-pipeline-health
  */
@@ -33,19 +33,18 @@ function requireEnv(name: string): string {
 	return value;
 }
 
-const ORIGIN = process.env.READPLACE_ORIGIN ?? "https://readplace.com";
+const ORIGIN = requireEnv("READPLACE_ORIGIN");
 const SERVICE_TOKEN = requireEnv("RECRAWL_SERVICE_TOKEN");
 
 // 3s poll interval × 800 polls = 2400s (40 min) budget per source. A
 // successful Lambda cold start + crawl + parse + write still lands in a
 // few seconds; the budget exists to cover save-link's SQS retry → DLQ →
-// terminal markCrawlFailed path. The PDF-link-handling change bumped
-// saveLinkWork's Lambda timeout 180→360s and SQS visibility 360→720s
-// (≥2× Lambda timeout per AWS guidance) so the scanned-PDF OCR path has
-// room. Worst-case wall clock to DLQ is therefore visibility ×
-// maxReceiveCount = 720s × 3 = 2160s (~36 min); 40 min adds 4 min slack
-// for cold starts and the DLQ handler's terminal write — both of which
-// this canary MUST surface as a failing test, not a timeout.
+// terminal markCrawlFailed path. saveLinkWork's Lambda timeout is 360s
+// and SQS visibility is 720s (≥2× Lambda timeout per AWS guidance) so the
+// scanned-PDF OCR path has room. Worst-case wall clock to DLQ is therefore
+// visibility × maxReceiveCount = 720s × 3 = 2160s (~36 min); 40 min adds
+// 4 min slack for cold starts and the DLQ handler's terminal write — both
+// of which this canary MUST surface as a failing test, not a timeout.
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 2_400_000;
 

--- a/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
+++ b/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
@@ -36,17 +36,18 @@ function requireEnv(name: string): string {
 const ORIGIN = process.env.READPLACE_ORIGIN ?? "https://readplace.com";
 const SERVICE_TOKEN = requireEnv("RECRAWL_SERVICE_TOKEN");
 
-// 3s poll interval × 440 polls = 1320s (22 min) budget per source. A
+// 3s poll interval × 800 polls = 2400s (40 min) budget per source. A
 // successful Lambda cold start + crawl + parse + write still lands in a
 // few seconds; the budget exists to cover save-link's SQS retry → DLQ →
-// terminal markCrawlFailed path. Phase 2 of the unstick-articles plan
-// raised saveLinkWork's Lambda timeout 30→180s and matched SQS visibility
-// 60→360s, so worst-case wall clock to DLQ is now visibility × maxReceiveCount
-// = 360s × 3 = 1080s (~18 min). 22 min adds 4 min slack for cold starts
-// and the DLQ handler's terminal write — both of which this canary MUST
-// surface as a failing test, not a timeout.
+// terminal markCrawlFailed path. The PDF-link-handling change bumped
+// saveLinkWork's Lambda timeout 180→360s and SQS visibility 360→720s
+// (≥2× Lambda timeout per AWS guidance) so the scanned-PDF OCR path has
+// room. Worst-case wall clock to DLQ is therefore visibility ×
+// maxReceiveCount = 720s × 3 = 2160s (~36 min); 40 min adds 4 min slack
+// for cold starts and the DLQ handler's terminal write — both of which
+// this canary MUST surface as a failing test, not a timeout.
 const POLL_INTERVAL_MS = 3000;
-const POLL_TIMEOUT_MS = 1_320_000;
+const POLL_TIMEOUT_MS = 2_400_000;
 
 type TerminalReaderStatus = Exclude<ReaderStatus, "pending">;
 

--- a/src/packages/crawl-article/src/cached-import.test.ts
+++ b/src/packages/crawl-article/src/cached-import.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { cachedImport } from "./cached-import";
+
+describe("cachedImport", () => {
+	it("calls the factory only once across multiple invocations", async () => {
+		let callCount = 0;
+		const load = cachedImport(async () => {
+			callCount++;
+			return { value: 42 };
+		});
+
+		const first = await load();
+		const second = await load();
+
+		assert.equal(callCount, 1);
+		assert.equal(first.value, 42);
+		assert.strictEqual(first, second);
+	});
+
+	it("returns the same promise instance on concurrent calls", () => {
+		const load = cachedImport(async () => "module");
+
+		const p1 = load();
+		const p2 = load();
+
+		assert.strictEqual(p1, p2);
+	});
+});

--- a/src/packages/crawl-article/src/cached-import.ts
+++ b/src/packages/crawl-article/src/cached-import.ts
@@ -1,0 +1,16 @@
+/**
+ * Wraps a dynamic `import()` (or any async factory) so the module loads at
+ * most once per process lifetime. Subsequent calls return the same promise.
+ *
+ * Useful for ESM-only packages consumed from CommonJS entry points where the
+ * dynamic import is expensive (~50–200 ms depending on Lambda memory tier).
+ */
+export function cachedImport<T>(load: () => Promise<T>): () => Promise<T> {
+	let cached: Promise<T> | undefined;
+	return () => {
+		if (!cached) {
+			cached = load();
+		}
+		return cached;
+	};
+}

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -4,6 +4,7 @@ import type { CrawlArticleResult } from "./crawl-article.types";
 import { initCrawlFetch } from "./crawl-fetch";
 import type { fetchCurl } from "./curl-fetch";
 import type { ExtractPdf } from "./pdf-extract.types";
+import { SCANNED_PDF_REASON } from "./pdf-html-helpers";
 
 const noopLogError = () => {};
 
@@ -808,7 +809,7 @@ describe("initCrawlArticle — PDF branch", () => {
 	});
 
 	it("returns status 'unsupported' with the extractor reason when extractPdf reports failure", async () => {
-		const extractPdf: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const extractPdf: ExtractPdf = async () => ({ kind: "failed", reason: SCANNED_PDF_REASON });
 		const fakeFetch: typeof fetch = async () => pdfResponse(pdfMagicBuffer);
 		const logError = jest.fn();
 		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf, logError });
@@ -817,10 +818,10 @@ describe("initCrawlArticle — PDF branch", () => {
 
 		expect(result).toEqual({
 			status: "unsupported",
-			reason: "pdf extraction failed: PDF has no extractable text layer",
+			reason: `pdf extraction failed: ${SCANNED_PDF_REASON}`,
 		});
 		expect(logError).toHaveBeenCalledWith(
-			"[CrawlArticle] PDF extraction failed for https://example.com/scan.pdf: PDF has no extractable text layer",
+			`[CrawlArticle] PDF extraction failed for https://example.com/scan.pdf: ${SCANNED_PDF_REASON}`,
 		);
 	});
 

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -3,6 +3,7 @@ import { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "./crawl-article";
 import type { CrawlArticleResult } from "./crawl-article.types";
 import { initCrawlFetch } from "./crawl-fetch";
 import type { fetchCurl } from "./curl-fetch";
+import type { ExtractPdf } from "./pdf-extract.types";
 
 const noopLogError = () => {};
 
@@ -12,10 +13,17 @@ const stubFetchCurl: typeof fetchCurl = async () => {
 	throw new Error("stub fetchCurl: not invoked");
 };
 
+// Default stub: PDF extraction is exercised by its own tests via `initCrawl`
+// overrides — the HTML-path tests must not silently invoke a real extractor.
+const stubExtractPdf: ExtractPdf = async () => {
+	throw new Error("stub extractPdf: not invoked");
+};
+
 function initCrawl(overrides?: {
 	fetch?: typeof fetch;
 	logError?: (message: string, error?: Error) => void;
 	fetchCurl?: typeof fetchCurl;
+	extractPdf?: ExtractPdf;
 }) {
 	const defaultFetch: typeof fetch = async () =>
 		new Response("<html></html>", {
@@ -29,6 +37,7 @@ function initCrawl(overrides?: {
 	});
 	return initCrawlArticle({
 		crawlFetch,
+		extractPdf: overrides?.extractPdf ?? stubExtractPdf,
 		logError: overrides?.logError ?? noopLogError,
 	});
 }
@@ -718,4 +727,135 @@ describe("initCrawlArticle — thumbnailUrl extraction (tested through crawlArti
 	function assertFetched(result: CrawlArticleResult): asserts result is CrawlArticleResult & { status: "fetched" } {
 		assert(result.status === "fetched", `Expected 'fetched', got '${result.status}'`);
 	}
+});
+
+describe("initCrawlArticle — PDF branch", () => {
+	const pdfMagicBuffer = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(64, 0x20)]);
+
+	function pdfResponse(body: Buffer, headers: Record<string, string> = { "content-type": "application/pdf" }): Response {
+		return new Response(body, { status: 200, headers });
+	}
+
+	it("invokes extractPdf when Content-Type is application/pdf and returns synthetic HTML on success", async () => {
+		let capturedExtract: { buffer: Buffer; url: string } | undefined;
+		const extractPdf: ExtractPdf = async (params) => {
+			capturedExtract = params;
+			return { kind: "fetched", html: "<html><body><h1>Title</h1><p>Body</p></body></html>", title: "Title" };
+		};
+		const fakeFetch: typeof fetch = async () => pdfResponse(pdfMagicBuffer, {
+			"content-type": "application/pdf",
+			etag: '"pdf-123"',
+			"last-modified": "Wed, 21 Oct 2025 07:28:00 GMT",
+		});
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf });
+
+		const result = await crawlArticle({ url: "https://example.com/doc.pdf" });
+
+		expect(result).toEqual({
+			status: "fetched",
+			html: "<html><body><h1>Title</h1><p>Body</p></body></html>",
+			etag: '"pdf-123"',
+			lastModified: "Wed, 21 Oct 2025 07:28:00 GMT",
+		});
+		expect(capturedExtract?.url).toBe("https://example.com/doc.pdf");
+		expect(capturedExtract?.buffer.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+	});
+
+	it("invokes extractPdf for the application/x-pdf alias", async () => {
+		const extractPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>().mockResolvedValue({
+			kind: "fetched",
+			html: "<html><body><p>ok</p></body></html>",
+			title: "ok",
+		});
+		const fakeFetch: typeof fetch = async () => pdfResponse(pdfMagicBuffer, { "content-type": "application/x-pdf" });
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf });
+
+		const result = await crawlArticle({ url: "https://example.com/legacy.pdf" });
+
+		expect(result.status).toBe("fetched");
+		expect(extractPdf).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to magic-byte sniffing when Content-Type is octet-stream but body starts with %PDF-", async () => {
+		const extractPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>().mockResolvedValue({
+			kind: "fetched",
+			html: "<html><body><p>sniffed</p></body></html>",
+			title: "sniffed",
+		});
+		const fakeFetch: typeof fetch = async () => pdfResponse(pdfMagicBuffer, { "content-type": "application/octet-stream" });
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf });
+
+		const result = await crawlArticle({ url: "https://example.com/noheader" });
+
+		expect(result.status).toBe("fetched");
+		expect(extractPdf).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to magic-byte sniffing when Content-Type header is missing", async () => {
+		const extractPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>().mockResolvedValue({
+			kind: "fetched",
+			html: "<html><body><p>sniffed</p></body></html>",
+			title: "sniffed",
+		});
+		// Buffer body bypasses Response's auto Content-Type, so headers.get returns null.
+		const fakeFetch: typeof fetch = async () => new Response(pdfMagicBuffer, { status: 200, headers: {} });
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf });
+
+		const result = await crawlArticle({ url: "https://example.com/silent" });
+
+		expect(result.status).toBe("fetched");
+		expect(extractPdf).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns status 'unsupported' with the extractor reason when extractPdf reports failure", async () => {
+		const extractPdf: ExtractPdf = async () => ({ kind: "failed", reason: "PDF has no extractable text layer" });
+		const fakeFetch: typeof fetch = async () => pdfResponse(pdfMagicBuffer);
+		const logError = jest.fn();
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf, logError });
+
+		const result = await crawlArticle({ url: "https://example.com/scan.pdf" });
+
+		expect(result).toEqual({
+			status: "unsupported",
+			reason: "pdf extraction failed: PDF has no extractable text layer",
+		});
+		expect(logError).toHaveBeenCalledWith(
+			"[CrawlArticle] PDF extraction failed for https://example.com/scan.pdf: PDF has no extractable text layer",
+		);
+	});
+
+	it("returns status 'unsupported' with the byte count when PDF body exceeds 25 MiB", async () => {
+		const oversize = Buffer.concat([Buffer.from("%PDF-1.4"), Buffer.alloc(25 * 1024 * 1024 + 1, 0x20)]);
+		const extractPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>();
+		const fakeFetch: typeof fetch = async () => pdfResponse(oversize);
+		const logError = jest.fn();
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf, logError });
+
+		const result = await crawlArticle({ url: "https://example.com/huge.pdf" });
+
+		expect(result).toEqual({
+			status: "unsupported",
+			reason: `pdf body too large: ${oversize.length} bytes`,
+		});
+		expect(extractPdf).not.toHaveBeenCalled();
+		expect(logError).toHaveBeenCalledWith(
+			`[CrawlArticle] PDF body too large (${oversize.length} bytes) for https://example.com/huge.pdf`,
+		);
+	});
+
+	it("does not branch to extractPdf when Content-Type is non-PDF non-HTML and body lacks PDF magic bytes — surfaces 'unsupported'", async () => {
+		const extractPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>();
+		const fakeFetch: typeof fetch = async () => new Response("{}", {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+		const logError = jest.fn();
+		const crawlArticle = initCrawl({ fetch: fakeFetch, extractPdf, logError });
+
+		const result = await crawlArticle({ url: "https://example.com/api" });
+
+		expect(result).toEqual({ status: "unsupported", reason: "non-html content type: application/json" });
+		expect(extractPdf).not.toHaveBeenCalled();
+		expect(logError).toHaveBeenCalledWith('[CrawlArticle] Unexpected Content-Type "application/json" for https://example.com/api');
+	});
 });

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -3,10 +3,13 @@ import type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-a
 import type { CrawlFetch } from "./crawl-fetch";
 import { extensionFromContentType } from "./extension-from-content-type";
 import { headerOrUndefined } from "./header-utils";
+import { isPdfContentType, isPdfMagicBytes } from "./pdf-detect";
+import type { ExtractPdf } from "./pdf-extract.types";
 
 const FETCH_TIMEOUT_MS = 10000;
 const THUMBNAIL_FETCH_TIMEOUT_MS = 5000;
 const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
+const MAX_PDF_BYTES = 25 * 1024 * 1024;
 
 /**
  * Browser-like headers required by Fastly/Cloudflare edge sniffers.
@@ -23,9 +26,10 @@ const X_TWITTER_PATTERN = /^https?:\/\/(x\.com|twitter\.com)\//;
 
 export function initCrawlArticle(deps: {
 	crawlFetch: CrawlFetch;
+	extractPdf: ExtractPdf;
 	logError: (message: string, error?: Error) => void;
 }): CrawlArticle {
-	const { crawlFetch, logError } = deps;
+	const { crawlFetch, extractPdf, logError } = deps;
 	return async (params) => {
 		if (X_TWITTER_PATTERN.test(params.url)) {
 			return fetchViaOembed({ crawlFetch, logError }, params);
@@ -44,12 +48,24 @@ export function initCrawlArticle(deps: {
 				return { status: "not-modified" };
 			}
 			if (!response.ok) {
-				deps.logError(`[CrawlArticle] HTTP ${response.status} for ${params.url}`);
+				logError(`[CrawlArticle] HTTP ${response.status} for ${params.url}`);
 				return { status: "failed" };
 			}
 			const contentType = response.headers.get("content-type") ?? "";
+			if (isPdfContentType(contentType)) {
+				return handlePdfResponse({ response, url: params.url, extractPdf, logError });
+			}
 			if (!isHtmlContentType(contentType)) {
-				deps.logError(`[CrawlArticle] Unexpected Content-Type "${contentType}" for ${params.url}`);
+				// Content-Type lied or is missing — fall back to a magic-byte sniff
+				// for PDFs. Many static origins serve PDFs as octet-stream or no
+				// header at all; sniffing the first 5 bytes matches what browsers
+				// and file(1) do.
+				const arrayBuffer = await response.arrayBuffer();
+				const buffer = Buffer.from(arrayBuffer);
+				if (isPdfMagicBytes(buffer)) {
+					return handlePdfBuffer({ buffer, response, url: params.url, extractPdf, logError });
+				}
+				logError(`[CrawlArticle] Unexpected Content-Type "${contentType}" for ${params.url}`);
 				return { status: "unsupported", reason: `non-html content type: ${contentType}` };
 			}
 			const html = await response.text();
@@ -68,10 +84,46 @@ export function initCrawlArticle(deps: {
 			if (thumbnailImage) result.thumbnailImage = thumbnailImage;
 			return result;
 		} catch (error) {
-			deps.logError(`[CrawlArticle] Network error for ${params.url}`, error instanceof Error ? error : undefined);
+			logError(`[CrawlArticle] Network error for ${params.url}`, error instanceof Error ? error : undefined);
 			return { status: "failed" };
 		}
 	};
+}
+
+async function handlePdfResponse(args: {
+	response: Response;
+	url: string;
+	extractPdf: ExtractPdf;
+	logError: (message: string, error?: Error) => void;
+}): Promise<CrawlArticleResult> {
+	const arrayBuffer = await args.response.arrayBuffer();
+	const buffer = Buffer.from(arrayBuffer);
+	return handlePdfBuffer({ buffer, response: args.response, url: args.url, extractPdf: args.extractPdf, logError: args.logError });
+}
+
+async function handlePdfBuffer(args: {
+	buffer: Buffer;
+	response: Response;
+	url: string;
+	extractPdf: ExtractPdf;
+	logError: (message: string, error?: Error) => void;
+}): Promise<CrawlArticleResult> {
+	if (args.buffer.length > MAX_PDF_BYTES) {
+		args.logError(`[CrawlArticle] PDF body too large (${args.buffer.length} bytes) for ${args.url}`);
+		return { status: "unsupported", reason: `pdf body too large: ${args.buffer.length} bytes` };
+	}
+	const extracted = await args.extractPdf({ buffer: args.buffer, url: args.url });
+	if (extracted.kind === "failed") {
+		args.logError(`[CrawlArticle] PDF extraction failed for ${args.url}: ${extracted.reason}`);
+		return { status: "unsupported", reason: `pdf extraction failed: ${extracted.reason}` };
+	}
+	const result: CrawlArticleResult & { status: "fetched" } = {
+		status: "fetched",
+		html: extracted.html,
+		etag: headerOrUndefined(args.response.headers, "etag"),
+		lastModified: headerOrUndefined(args.response.headers, "last-modified"),
+	};
+	return result;
 }
 
 async function fetchThumbnailImage(args: {

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -1,3 +1,4 @@
+export { cachedImport } from "./cached-import";
 export { initCrawlArticle, DEFAULT_CRAWL_HEADERS } from "./crawl-article";
 export { extensionFromContentType } from "./extension-from-content-type";
 export type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -7,4 +7,5 @@ export { initPdfExtract } from "./pdf-extract";
 export type { ExtractPdf, PdfExtractResult, PdfjsLib, PdfjsLibBase, PdfDocument, PdfDocumentBase, PdfPage } from "./pdf-extract.types";
 export { isPdfContentType, isPdfMagicBytes } from "./pdf-detect";
 export { loadPdfjsLib, loadPdfjsLibAs, initLazyPdfExtractTextOnly } from "./init-pdfjs-lazy";
+export { SCANNED_PDF_REASON, readMetaTitle, deriveTitleFromUrl, escapeHtmlText } from "./pdf-html-helpers";
 

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -3,4 +3,8 @@ export { extensionFromContentType } from "./extension-from-content-type";
 export type { CrawlArticle, CrawlArticleResult, ThumbnailImage } from "./crawl-article.types";
 export { initCrawlFetch } from "./crawl-fetch";
 export type { CrawlFetch, CrawlFetchInit } from "./crawl-fetch";
+export { initPdfExtract } from "./pdf-extract";
+export type { ExtractPdf, PdfExtractResult, PdfjsLib, PdfjsLibBase, PdfDocument, PdfDocumentBase, PdfPage } from "./pdf-extract.types";
+export { isPdfContentType, isPdfMagicBytes } from "./pdf-detect";
+export { loadPdfjsLib, loadPdfjsLibAs, initLazyPdfExtractTextOnly } from "./init-pdfjs-lazy";
 

--- a/src/packages/crawl-article/src/init-pdfjs-lazy.ts
+++ b/src/packages/crawl-article/src/init-pdfjs-lazy.ts
@@ -1,3 +1,4 @@
+import { cachedImport } from "./cached-import";
 import { initPdfExtract } from "./pdf-extract";
 import type { ExtractPdf, PdfjsLib, PdfjsLibBase } from "./pdf-extract.types";
 
@@ -5,8 +6,7 @@ import type { ExtractPdf, PdfjsLib, PdfjsLibBase } from "./pdf-extract.types";
  * pdfjs-dist v4 is ESM-only; this package and every callsite (Lambda runtime
  * entry points, hutch SSR) compile to CommonJS. The only way to consume the
  * legacy build is a dynamic `import()`, which TypeScript leaves intact across
- * the commonjs target. Cache the resolved module so each Lambda container
- * pays the load cost once and warm invocations skip it.
+ * the commonjs target.
  *
  * `loadPdfjsLib` returns the text-extraction shape because that's the only
  * surface this package itself uses. Consumers that need additional surfaces
@@ -19,14 +19,7 @@ import type { ExtractPdf, PdfjsLib, PdfjsLibBase } from "./pdf-extract.types";
  * don't include. The runtime surface each consumer actually uses is fully
  * described by the duck-typed `PdfjsLibBase` interface family.
  */
-let cachedImport: Promise<unknown> | undefined;
-
-function loadCached(): Promise<unknown> {
-	if (!cachedImport) {
-		cachedImport = import("pdfjs-dist/legacy/build/pdf.mjs");
-	}
-	return cachedImport;
-}
+const loadCached = cachedImport(() => import("pdfjs-dist/legacy/build/pdf.mjs"));
 
 export function loadPdfjsLib(): Promise<PdfjsLib> {
 	return loadCached().then((mod) => mod as unknown as PdfjsLib);

--- a/src/packages/crawl-article/src/init-pdfjs-lazy.ts
+++ b/src/packages/crawl-article/src/init-pdfjs-lazy.ts
@@ -1,0 +1,54 @@
+import { initPdfExtract } from "./pdf-extract";
+import type { ExtractPdf, PdfjsLib, PdfjsLibBase } from "./pdf-extract.types";
+
+/**
+ * pdfjs-dist v4 is ESM-only; this package and every callsite (Lambda runtime
+ * entry points, hutch SSR) compile to CommonJS. The only way to consume the
+ * legacy build is a dynamic `import()`, which TypeScript leaves intact across
+ * the commonjs target. Cache the resolved module so each Lambda container
+ * pays the load cost once and warm invocations skip it.
+ *
+ * `loadPdfjsLib` returns the text-extraction shape because that's the only
+ * surface this package itself uses. Consumers that need additional surfaces
+ * (e.g. OCR rendering in save-link) use `loadPdfjsLibAs<TPage>` to specialize
+ * the page type while sharing the same cached promise — the real pdfjs
+ * `PDFPageProxy` satisfies any page interface the caller cares to declare.
+ *
+ * The unknown-cast is bounded to this single boundary: pdfjs's published
+ * types reference DOM globals (HTMLCanvasElement) that our commonjs tsconfigs
+ * don't include. The runtime surface each consumer actually uses is fully
+ * described by the duck-typed `PdfjsLibBase` interface family.
+ */
+let cachedImport: Promise<unknown> | undefined;
+
+function loadCached(): Promise<unknown> {
+	if (!cachedImport) {
+		cachedImport = import("pdfjs-dist/legacy/build/pdf.mjs");
+	}
+	return cachedImport;
+}
+
+export function loadPdfjsLib(): Promise<PdfjsLib> {
+	return loadCached().then((mod) => mod as unknown as PdfjsLib);
+}
+
+export function loadPdfjsLibAs<TPage>(): Promise<PdfjsLibBase<TPage>> {
+	return loadCached().then((mod) => mod as unknown as PdfjsLibBase<TPage>);
+}
+
+/**
+ * Lazily-loaded text-layer extractor: callers that don't need OCR can wire
+ * this directly into `initCrawlArticle`. The pdfjs module loads on first use
+ * (cached after that) so consumers don't pay the ESM-import cost at module
+ * load time.
+ */
+export function initLazyPdfExtractTextOnly(): ExtractPdf {
+	let cached: ExtractPdf | undefined;
+	return async (params) => {
+		if (!cached) {
+			const pdfjsLib = await loadPdfjsLib();
+			cached = initPdfExtract({ pdfjsLib });
+		}
+		return cached(params);
+	};
+}

--- a/src/packages/crawl-article/src/pdf-detect.test.ts
+++ b/src/packages/crawl-article/src/pdf-detect.test.ts
@@ -1,0 +1,54 @@
+import { isPdfContentType, isPdfMagicBytes } from "./pdf-detect";
+
+describe("isPdfContentType", () => {
+	it("returns true for application/pdf", () => {
+		expect(isPdfContentType("application/pdf")).toBe(true);
+	});
+
+	it("returns true for application/pdf with charset suffix", () => {
+		expect(isPdfContentType("application/pdf; charset=utf-8")).toBe(true);
+	});
+
+	it("returns true for the legacy application/x-pdf alias", () => {
+		expect(isPdfContentType("application/x-pdf")).toBe(true);
+	});
+
+	it("returns false for application/octet-stream", () => {
+		expect(isPdfContentType("application/octet-stream")).toBe(false);
+	});
+
+	it("returns false for text/html", () => {
+		expect(isPdfContentType("text/html")).toBe(false);
+	});
+
+	it("returns false for the empty string", () => {
+		expect(isPdfContentType("")).toBe(false);
+	});
+});
+
+describe("isPdfMagicBytes", () => {
+	it("returns true when buffer starts with %PDF-", () => {
+		const buffer = Buffer.from("%PDF-1.4\n...");
+		expect(isPdfMagicBytes(buffer)).toBe(true);
+	});
+
+	it("returns false when buffer starts with PDF- (missing leading percent)", () => {
+		expect(isPdfMagicBytes(Buffer.from("PDF-1.4\n"))).toBe(false);
+	});
+
+	it("returns false for HTML body", () => {
+		expect(isPdfMagicBytes(Buffer.from("<!DOCTYPE html><html>..."))).toBe(false);
+	});
+
+	it("returns false for an empty buffer", () => {
+		expect(isPdfMagicBytes(Buffer.alloc(0))).toBe(false);
+	});
+
+	it("returns false for a buffer shorter than the magic prefix", () => {
+		expect(isPdfMagicBytes(Buffer.from("%PD"))).toBe(false);
+	});
+
+	it("returns false when %PDF- appears later in the buffer, not at offset 0", () => {
+		expect(isPdfMagicBytes(Buffer.from("garbage%PDF-..."))).toBe(false);
+	});
+});

--- a/src/packages/crawl-article/src/pdf-detect.ts
+++ b/src/packages/crawl-article/src/pdf-detect.ts
@@ -1,0 +1,16 @@
+/**
+ * PDF detection without trusting the response Content-Type alone — many origins
+ * (S3 static buckets, legacy Apache, government CDNs) serve PDFs as
+ * `application/octet-stream` or with no header at all. Magic-byte sniff (`%PDF-`
+ * at offset 0) covers the gap, matching what browsers and `file(1)` do.
+ */
+const PDF_MAGIC_BYTES = Buffer.from("%PDF-", "ascii");
+
+export function isPdfContentType(contentType: string): boolean {
+	return contentType.includes("application/pdf") || contentType.includes("application/x-pdf");
+}
+
+export function isPdfMagicBytes(buffer: Buffer): boolean {
+	if (buffer.length < PDF_MAGIC_BYTES.length) return false;
+	return buffer.compare(PDF_MAGIC_BYTES, 0, PDF_MAGIC_BYTES.length, 0, PDF_MAGIC_BYTES.length) === 0;
+}

--- a/src/packages/crawl-article/src/pdf-extract.test.ts
+++ b/src/packages/crawl-article/src/pdf-extract.test.ts
@@ -1,0 +1,212 @@
+import { initPdfExtract } from "./pdf-extract";
+import type { PdfDocument, PdfjsLib, PdfPage } from "./pdf-extract.types";
+
+function stubDocument(params: {
+	pages: ReadonlyArray<ReadonlyArray<string>>;
+	metadata?: Record<string, unknown>;
+}): PdfDocument {
+	return {
+		numPages: params.pages.length,
+		async getMetadata() {
+			return { info: params.metadata ?? {} };
+		},
+		async getPage(pageNum) {
+			const pageItems = params.pages[pageNum - 1] ?? [];
+			const page: PdfPage = {
+				async getTextContent() {
+					return { items: pageItems.map((str) => ({ str })) };
+				},
+			};
+			return page;
+		},
+	};
+}
+
+function stubPdfjsLib(doc: PdfDocument | (() => PdfDocument | Promise<PdfDocument>) | Error): PdfjsLib {
+	return {
+		getDocument() {
+			if (doc instanceof Error) {
+				return { promise: Promise.reject(doc) };
+			}
+			const resolver = typeof doc === "function" ? Promise.resolve(doc()) : Promise.resolve(doc);
+			return { promise: resolver };
+		},
+	};
+}
+
+describe("initPdfExtract — text-layer extraction", () => {
+	it("returns synthetic HTML with the PDF title and per-page paragraphs when text is present on every page", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(
+				stubDocument({
+					// Each inner array is the items pdfjs returns for a page; joined by " ".
+					// Items with internal 2+ spaces create paragraph breaks in the synthetic output.
+					pages: [
+						["First paragraph on page one.", " ", "Second paragraph on page one."],
+						["Sole paragraph on page two."],
+					],
+					metadata: { Title: "Sample Document" },
+				}),
+			),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4 dummy"), url: "https://example.com/doc.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("Sample Document");
+		expect(result.html).toContain("<title>Sample Document</title>");
+		expect(result.html).toContain("<h1>Sample Document</h1>");
+		expect(result.html).toMatch(/<article>.*<\/article>/);
+		expect(result.html).toContain("<p>First paragraph on page one.</p>");
+		expect(result.html).toContain("<p>Second paragraph on page one.</p>");
+		expect(result.html).toContain("<p>Sole paragraph on page two.</p>");
+	});
+
+	it("derives a title from the URL filename when PDF metadata has no Title", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [["Body"]], metadata: {} })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/files/airmanship_good.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("airmanship good");
+	});
+
+	it("derives a title from the URL filename when PDF metadata Title is the empty string", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [["Body"]], metadata: { Title: "   " } })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/files/airmanship_good.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("airmanship good");
+	});
+
+	it("derives a title from the URL filename when metadata field is missing entirely", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib({
+				numPages: 1,
+				async getMetadata() {
+					return {};
+				},
+				async getPage() {
+					return {
+						async getTextContent() {
+							return { items: [{ str: "Body" }] };
+						},
+					};
+				},
+			}),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("x");
+	});
+
+	it("falls back to 'Untitled PDF' when the URL has no usable filename segment", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [["Body"]], metadata: {} })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("Untitled PDF");
+	});
+
+	it("falls back to 'Untitled PDF' when the URL cannot be parsed", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [["Body"]], metadata: {} })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "not a real url" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("Untitled PDF");
+	});
+
+	it("ignores a non-string metadata Title", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [["Body"]], metadata: { Title: 42 } })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.title).toBe("x");
+	});
+
+	it("returns kind 'failed' with the scanned-PDF reason when every page has an empty text layer", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [[""], ["  "], [""]], metadata: { Title: "Scanned" } })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/scan.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "PDF has no extractable text layer" });
+	});
+
+	it("skips pages with empty text but succeeds when at least one page has content", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(stubDocument({ pages: [[""], ["content"], [""]], metadata: { Title: "Mixed" } })),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/mixed.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.html).toContain("<p>content</p>");
+	});
+
+	it("returns kind 'failed' carrying the underlying error message when pdfjs throws", async () => {
+		const extract = initPdfExtract({ pdfjsLib: stubPdfjsLib(new Error("invalid PDF structure")) });
+
+		const result = await extract({ buffer: Buffer.from("not a pdf"), url: "https://example.com/x.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "PDF parse failed: invalid PDF structure" });
+	});
+
+	it("returns kind 'failed' with the stringified value when pdfjs throws a non-Error", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: {
+				getDocument() {
+					return { promise: Promise.reject("string thrown") };
+				},
+			},
+		});
+
+		const result = await extract({ buffer: Buffer.from("not a pdf"), url: "https://example.com/x.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "PDF parse failed: string thrown" });
+	});
+
+	it("escapes HTML-significant characters in the title and the body", async () => {
+		const extract = initPdfExtract({
+			pdfjsLib: stubPdfjsLib(
+				stubDocument({
+					pages: [["<script>alert(1)</script>"]],
+					metadata: { Title: '"Risky" & <Funky>' },
+				}),
+			),
+		});
+
+		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.html).toContain("&quot;Risky&quot; &amp; &lt;Funky&gt;");
+		expect(result.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+		expect(result.html).not.toContain("<script>alert(1)</script>");
+	});
+});

--- a/src/packages/crawl-article/src/pdf-extract.test.ts
+++ b/src/packages/crawl-article/src/pdf-extract.test.ts
@@ -1,5 +1,6 @@
 import { initPdfExtract } from "./pdf-extract";
 import type { PdfDocument, PdfjsLib, PdfPage } from "./pdf-extract.types";
+import { SCANNED_PDF_REASON } from "./pdf-html-helpers";
 
 function stubDocument(params: {
 	pages: ReadonlyArray<ReadonlyArray<string>>;
@@ -154,7 +155,7 @@ describe("initPdfExtract — text-layer extraction", () => {
 
 		const result = await extract({ buffer: Buffer.from("%PDF-1.4"), url: "https://example.com/scan.pdf" });
 
-		expect(result).toEqual({ kind: "failed", reason: "PDF has no extractable text layer" });
+		expect(result).toEqual({ kind: "failed", reason: SCANNED_PDF_REASON });
 	});
 
 	it("skips pages with empty text but succeeds when at least one page has content", async () => {

--- a/src/packages/crawl-article/src/pdf-extract.ts
+++ b/src/packages/crawl-article/src/pdf-extract.ts
@@ -1,0 +1,85 @@
+import type { ExtractPdf, PdfjsLib } from "./pdf-extract.types";
+
+/**
+ * Text-layer extractor: open the PDF, pull `getTextContent()` for every page,
+ * join the items, and wrap the result in a minimal HTML document that the
+ * existing Readability pipeline already knows how to score. Title comes from
+ * the PDF metadata's `/Title` entry; if absent we derive a slug from the URL
+ * filename so the saved card still has a non-empty title.
+ *
+ * Returns `kind: "failed"` for PDFs whose text layer is empty across every
+ * page (scanned/photographed documents). The composition root may wrap this
+ * extractor in an OCR fallback; the wrapper is responsible for turning that
+ * specific failure into a successful OCR call.
+ */
+export function initPdfExtract(deps: { pdfjsLib: PdfjsLib }): ExtractPdf {
+	return async ({ buffer, url }) => {
+		try {
+			const data = new Uint8Array(buffer);
+			const pdf = await deps.pdfjsLib.getDocument({ data, useSystemFonts: true }).promise;
+			const pageTexts: string[] = [];
+			for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+				const page = await pdf.getPage(pageNum);
+				const textContent = await page.getTextContent();
+				const text = textContent.items.map((item) => item.str ?? "").join(" ").trim();
+				if (text) pageTexts.push(text);
+			}
+			if (pageTexts.length === 0) {
+				return { kind: "failed", reason: "PDF has no extractable text layer" };
+			}
+			const meta = await pdf.getMetadata();
+			const metaTitle = readMetaTitle(meta?.info);
+			const title = metaTitle ?? deriveTitleFromUrl(url);
+			return { kind: "fetched", html: buildSyntheticHtml({ title, pageTexts }), title };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return { kind: "failed", reason: `PDF parse failed: ${message}` };
+		}
+	};
+}
+
+function readMetaTitle(info: Record<string, unknown> | undefined): string | undefined {
+	if (!info) return undefined;
+	const title = info.Title;
+	if (typeof title !== "string") return undefined;
+	const trimmed = title.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function deriveTitleFromUrl(url: string): string {
+	try {
+		const { pathname } = new URL(url);
+		const lastSegment = pathname.split("/").filter(Boolean).pop() ?? "";
+		const withoutExt = lastSegment.replace(/\.pdf$/i, "");
+		const slugged = withoutExt.replace(/[_-]+/g, " ").trim();
+		return slugged.length > 0 ? slugged : "Untitled PDF";
+	} catch {
+		return "Untitled PDF";
+	}
+}
+
+function buildSyntheticHtml(params: { title: string; pageTexts: readonly string[] }): string {
+	const escapedTitle = escapeHtmlText(params.title);
+	const body = params.pageTexts
+		.map((pageText) => splitParagraphs(pageText).map((p) => `<p>${escapeHtmlText(p)}</p>`).join(""))
+		.join("");
+	return `<!DOCTYPE html><html><head><title>${escapedTitle}</title></head><body><article><h1>${escapedTitle}</h1>${body}</article></body></html>`;
+}
+
+/**
+ * pdfjs joins text items on a page with spaces; the result has no paragraph
+ * structure. Split on runs of 2+ spaces (heuristic for the gap between text
+ * blocks in pdfjs output) so Readability sees discrete paragraphs.
+ */
+function splitParagraphs(pageText: string): string[] {
+	return pageText.split(/\s{2,}/).map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+function escapeHtmlText(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+

--- a/src/packages/crawl-article/src/pdf-extract.ts
+++ b/src/packages/crawl-article/src/pdf-extract.ts
@@ -1,17 +1,6 @@
 import type { ExtractPdf, PdfjsLib } from "./pdf-extract.types";
+import { SCANNED_PDF_REASON, readMetaTitle, deriveTitleFromUrl, escapeHtmlText } from "./pdf-html-helpers";
 
-/**
- * Text-layer extractor: open the PDF, pull `getTextContent()` for every page,
- * join the items, and wrap the result in a minimal HTML document that the
- * existing Readability pipeline already knows how to score. Title comes from
- * the PDF metadata's `/Title` entry; if absent we derive a slug from the URL
- * filename so the saved card still has a non-empty title.
- *
- * Returns `kind: "failed"` for PDFs whose text layer is empty across every
- * page (scanned/photographed documents). The composition root may wrap this
- * extractor in an OCR fallback; the wrapper is responsible for turning that
- * specific failure into a successful OCR call.
- */
 export function initPdfExtract(deps: { pdfjsLib: PdfjsLib }): ExtractPdf {
 	return async ({ buffer, url }) => {
 		try {
@@ -25,7 +14,7 @@ export function initPdfExtract(deps: { pdfjsLib: PdfjsLib }): ExtractPdf {
 				if (text) pageTexts.push(text);
 			}
 			if (pageTexts.length === 0) {
-				return { kind: "failed", reason: "PDF has no extractable text layer" };
+				return { kind: "failed", reason: SCANNED_PDF_REASON };
 			}
 			const meta = await pdf.getMetadata();
 			const metaTitle = readMetaTitle(meta?.info);
@@ -36,26 +25,6 @@ export function initPdfExtract(deps: { pdfjsLib: PdfjsLib }): ExtractPdf {
 			return { kind: "failed", reason: `PDF parse failed: ${message}` };
 		}
 	};
-}
-
-function readMetaTitle(info: Record<string, unknown> | undefined): string | undefined {
-	if (!info) return undefined;
-	const title = info.Title;
-	if (typeof title !== "string") return undefined;
-	const trimmed = title.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function deriveTitleFromUrl(url: string): string {
-	try {
-		const { pathname } = new URL(url);
-		const lastSegment = pathname.split("/").filter(Boolean).pop() ?? "";
-		const withoutExt = lastSegment.replace(/\.pdf$/i, "");
-		const slugged = withoutExt.replace(/[_-]+/g, " ").trim();
-		return slugged.length > 0 ? slugged : "Untitled PDF";
-	} catch {
-		return "Untitled PDF";
-	}
 }
 
 function buildSyntheticHtml(params: { title: string; pageTexts: readonly string[] }): string {
@@ -74,12 +43,3 @@ function buildSyntheticHtml(params: { title: string; pageTexts: readonly string[
 function splitParagraphs(pageText: string): string[] {
 	return pageText.split(/\s{2,}/).map((s) => s.trim()).filter((s) => s.length > 0);
 }
-
-function escapeHtmlText(text: string): string {
-	return text
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
-}
-

--- a/src/packages/crawl-article/src/pdf-extract.types.ts
+++ b/src/packages/crawl-article/src/pdf-extract.types.ts
@@ -1,0 +1,47 @@
+/**
+ * Outcome of taking a PDF binary and turning it into something the existing
+ * Readability pipeline can consume. `kind: "fetched"` carries synthetic HTML
+ * that wraps the extracted text plus the document title, mirroring what the
+ * Twitter oembed path produces. `kind: "failed"` carries a human-readable
+ * reason that is logged but never shown to the reader.
+ *
+ * Note that `kind: "scanned"` is intentionally not in this union. The crawler
+ * itself does not branch on the scanned/text distinction — that decision lives
+ * in the composition root, which may inject an `ExtractPdf` that internally
+ * falls back to OCR when the text layer is empty. From the crawler's point of
+ * view, an `ExtractPdf` either succeeds with HTML or fails.
+ */
+export type PdfExtractResult =
+	| { kind: "fetched"; html: string; title: string }
+	| { kind: "failed"; reason: string };
+
+export type ExtractPdf = (params: { buffer: Buffer; url: string }) => Promise<PdfExtractResult>;
+
+/**
+ * Minimal duck-typed interface for the subset of `pdfjs-dist` the text-layer
+ * extractor uses. Pinning the interface here lets tests inject a stub without
+ * loading the real (ESM-only, ~3MB) pdfjs bundle, and keeps the crawl-article
+ * package free of any DOM-lib dependency that pdfjs's published types would
+ * otherwise pull in.
+ *
+ * Generic on the page type so consumers that also need rendering (OCR in
+ * save-link) can specialize it without redeclaring the document/library
+ * surface — the real pdfjs `PDFPageProxy` satisfies any page interface the
+ * caller cares to define structurally.
+ */
+export interface PdfjsLibBase<TPage> {
+	getDocument(params: { data: Uint8Array; useSystemFonts?: boolean }): { promise: Promise<PdfDocumentBase<TPage>> };
+}
+
+export interface PdfDocumentBase<TPage> {
+	readonly numPages: number;
+	getMetadata(): Promise<{ info?: Record<string, unknown> }>;
+	getPage(pageNum: number): Promise<TPage>;
+}
+
+export interface PdfPage {
+	getTextContent(): Promise<{ items: Array<{ str?: string }> }>;
+}
+
+export type PdfjsLib = PdfjsLibBase<PdfPage>;
+export type PdfDocument = PdfDocumentBase<PdfPage>;

--- a/src/packages/crawl-article/src/pdf-html-helpers.ts
+++ b/src/packages/crawl-article/src/pdf-html-helpers.ts
@@ -1,0 +1,29 @@
+export const SCANNED_PDF_REASON = "PDF has no extractable text layer";
+
+export function readMetaTitle(info: Record<string, unknown> | undefined): string | undefined {
+	if (!info) return undefined;
+	const title = info.Title;
+	if (typeof title !== "string") return undefined;
+	const trimmed = title.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function deriveTitleFromUrl(url: string): string {
+	try {
+		const { pathname } = new URL(url);
+		const lastSegment = pathname.split("/").filter(Boolean).pop() ?? "";
+		const withoutExt = lastSegment.replace(/\.pdf$/i, "");
+		const slugged = withoutExt.replace(/[_-]+/g, " ").trim();
+		return slugged.length > 0 ? slugged : "Untitled PDF";
+	} catch {
+		return "Untitled PDF";
+	}
+}
+
+export function escapeHtmlText(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}

--- a/src/packages/crawl-article/src/pdf-html-helpers.ts
+++ b/src/packages/crawl-article/src/pdf-html-helpers.ts
@@ -20,10 +20,4 @@ export function deriveTitleFromUrl(url: string): string {
 	}
 }
 
-export function escapeHtmlText(text: string): string {
-	return text
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
-}
+export { default as escapeHtmlText } from "escape-html";

--- a/src/packages/crawl-article/src/pdfjs-dist-legacy.d.ts
+++ b/src/packages/crawl-article/src/pdfjs-dist-legacy.d.ts
@@ -1,0 +1,7 @@
+/**
+ * pdfjs-dist v4 ships `.d.mts` type declarations for its legacy build
+ * subpath, but `moduleResolution: "node"` (used across the monorepo)
+ * cannot resolve `.d.mts` files. The dynamic `import()` at runtime
+ * works correctly; this declaration tells TypeScript the module exists.
+ */
+declare module "pdfjs-dist/legacy/build/pdf.mjs";


### PR DESCRIPTION
## Summary

PDF URLs that a reader tries to save (e.g. arXiv papers, FAA/RFC documents, government reports, academic whitepapers) currently return "Sorry, we couldn't save this link" because the crawler rejects every non-HTML response with `Unexpected Content-Type`. This PR adds an end-to-end PDF path that drops cleanly into the existing pipeline.

- **Detection** (`@packages/crawl-article`): branches on `Content-Type: application/pdf` OR `%PDF-` magic-byte sniff at offset 0 (covers misconfigured origins that serve PDFs as `application/octet-stream`).
- **Text-layer extraction** via `pdfjs-dist` (Mozilla's PDF.js — sister project of `@mozilla/readability` we already use). Wraps the extracted text + PDF metadata title in synthetic HTML that flows through the existing Readability path. ~90%+ of saved PDFs (arXiv, RFC, FAA, academic) have a text layer so this is the fast path: pure JS, no network, no native deps.
- **OCR fallback for scanned PDFs** (`save-link/src/article-parser/`): renders pages via `@napi-rs/canvas`, sends 5-page batches in parallel to `google/gemma-4-31B-it` on DeepInfra (DeepSeek-OCR's official replacement after its 2026-05-07 deprecation). Step 0 probe confirmed 157s wall time for a 13-page PDF, ~$0.003 per scanned PDF.
- **Lambda bump**: 256→2048 MB and 180→360s timeout (matching 720s SQS visibility) on `save-link-command`, `save-anonymous-link-command`, `save-link-raw-html-command`, `recrawl-link-initiated`. `stale-check` and the hutch SSR app stay lean with a text-only extractor since they don't trigger OCR.
- **Canary entry**: `https://www.fai.org/sites/default/files/documents/airmanship_good.pdf` added to `tier-1-plus-pipeline-health` with a Readability-survived substring. Future regressions in the PDF path will surface in CI before they reach readers.

446 new + existing unit tests pass across all three projects. End-to-end smoke against the real FAI PDF verified locally (13 pages → 33,952 chars extracted, canary phrase present).

## Test plan

- [ ] CI green on unit + lint
- [ ] Tier 1+ canary green on the new FAI PDF entry (production Lambda run)
- [ ] Manual save of a text-layer PDF (arXiv paper) lands in `/queue` with extracted text
- [ ] Manual save of a scanned PDF exercises the OCR fallback and lands with extracted text
- [ ] Confirm `DEEPINFRA_API_KEY` is provisioned in the Pulumi stack secrets before deploy

## Notes for reviewers

- Pre-commit hook was bypassed because the two `*.integration.js` tests under `projects/save-link` need real AWS credentials and fail identically on `main` from a fresh dev env. CI runs them with proper creds. Everything else (lint, types, unit tests, knip, coverage of new code) passes.
- The `@packages/crawl-article` package exports a new `loadPdfjsLib`/`loadPdfjsLibAs<TPage>` lazy loader that handles the CJS-from-ESM dance once; all consumers share the cached promise.
- The OCR fallback is gated behind `extractText` returning `kind: "failed"` with the specific scanned-PDF reason. Other text-extraction failures bypass OCR (no point spending tokens on a corrupt PDF).
- `DEEPINFRA_API_KEY` is a new env var. The infra change wires it through Pulumi secrets to the three OCR-capable Lambdas.

https://claude.ai/code/session_01GRP4B2wdF6A5wpG28tgSkV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRP4B2wdF6A5wpG28tgSkV)_