### PR TITLE
refactor(@packages/check-stuck-articles): extract collectStuckRows for unit testing

### DIFF
--- a/src/packages/check-stuck-articles/knip.config.ts
+++ b/src/packages/check-stuck-articles/knip.config.ts
@@ -4,6 +4,7 @@ export default {
 	entry: [
 		"scripts/check-stuck-articles.ts",
 		"scripts/classify-row.ts",
+		"scripts/collect-stuck-rows.ts",
 		"scripts/exclude-patterns.ts",
 	],
 	ignoreDependencies: [

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "compile": "tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint scripts\" \"knip\"",
-    "test": "node --test dist/scripts/classify-row.test.js dist/scripts/check-reachable.test.js dist/scripts/check-terminal-state.test.js",
+    "test": "node --test dist/scripts/classify-row.test.js dist/scripts/check-reachable.test.js dist/scripts/check-terminal-state.test.js dist/scripts/collect-stuck-rows.test.js",
     "check": "pnpm lint && pnpm test",
     "check-infra": "echo 'No infrastructure — canary script'"
   },

--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -23,75 +23,15 @@
 import assert from "node:assert/strict";
 import { writeFile } from "node:fs/promises";
 import { test } from "node:test";
-import {
-	CrawlStatusSchema,
-	SummaryStatusSchema,
-} from "@packages/article-state-types";
-import {
-	createDynamoDocumentClient,
-	defineDynamoTable,
-	dynamoField,
-} from "@packages/hutch-storage-client";
-import { z } from "zod";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { filterReachable } from "./check-reachable";
-import { checkTerminalState } from "./check-terminal-state";
-import { type StuckReason, classifyRow } from "./classify-row";
-import { EXCLUDE_PATTERNS } from "./exclude-patterns";
+import { type StuckRow, collectStuckRows } from "./collect-stuck-rows";
 
 function requireEnv(name: string): string {
 	const value = process.env[name];
 	assert(value, `${name} env var is required`);
 	return value;
 }
-
-const REGION = requireEnv("AWS_REGION");
-const TABLE = requireEnv("DYNAMODB_ARTICLES_TABLE");
-const ORIGIN = requireEnv("READPLACE_ORIGIN");
-
-/**
- * Loose row schema for the canary's projection. Every attribute except `url`
- * is wrapped in `dynamoField` so absent attributes (which DDB returns as
- * `null`) are normalised to `undefined`. The status enums are imported from
- * @packages/article-state-types so adding a new status to the production
- * schemas surfaces here as a tsc error in `classifyRow`.
- */
-const StuckArticleRow = z.object({
-	url: z.string(),
-	originalUrl: dynamoField(z.string()),
-	summaryStatus: dynamoField(SummaryStatusSchema),
-	crawlStatus: dynamoField(CrawlStatusSchema),
-	summaryFailureReason: dynamoField(z.string()),
-	crawlFailureReason: dynamoField(z.string()),
-	contentFetchedAt: dynamoField(z.string()),
-	summary: dynamoField(z.string()),
-});
-
-function isExcluded(url: string): boolean {
-	return EXCLUDE_PATTERNS.some((pattern) => pattern.test(url));
-}
-
-interface StuckRow {
-	originalUrl: string;
-	reasons: StuckReason[];
-	contentFetchedAt: string | undefined;
-	failureReason: string | undefined;
-	recrawlUrl: string;
-	/**
-	 * Human-readable explanation of which sub-state(s) are non-terminal,
-	 * computed via checkTerminalState. Surfaced in the failing test message
-	 * so an operator reading the GitHub Actions output knows at a glance
-	 * which writer to suspect without cross-referencing the reason enum.
-	 */
-	terminalCheckMessage: string;
-}
-
-/**
- * Hard cap on DDB scan pages. The articles table is small enough that a real
- * scan completes in well under 10 pages. Crossing 50 means the FilterExpression
- * stopped narrowing the scan (or the table grew an order of magnitude) — fail
- * loud here instead of burning the runner's 10-minute budget.
- */
-const MAX_PAGES = 50;
 
 /**
  * Reachability ping budget per stuck row. Matches the production crawler's
@@ -108,79 +48,6 @@ const REACHABILITY_TIMEOUT_MS = 10_000;
  */
 const REACHABILITY_CONCURRENCY = 8;
 
-async function collectStuckRows(): Promise<StuckRow[]> {
-	const client = createDynamoDocumentClient({ region: REGION });
-	const table = defineDynamoTable({
-		client,
-		tableName: TABLE,
-		schema: StuckArticleRow,
-	});
-	const stuck: StuckRow[] = [];
-	let skippedNoOriginal = 0;
-	let excludedDomain = 0;
-	let pageCount = 0;
-	let lastEvaluatedKey: Record<string, unknown> | undefined;
-	do {
-		pageCount += 1;
-		assert(
-			pageCount <= MAX_PAGES,
-			`pagination cap reached (${MAX_PAGES} pages) — refine FilterExpression or raise the cap if the table is legitimately growing`,
-		);
-		const page = await table.scan({
-			// The third disjunct catches the `summaryStatus="ready" AND
-			// attribute_not_exists(summary)` inconsistency the 2026-05-10
-			// freshness-refresh regression introduced — without it the row
-			// passes both status checks and the canary reports green while the
-			// reader UI polls "Generating summary…" forever.
-			//
-			// Terminal failures (crawlStatus / summaryStatus = `failed` or
-			// `unsupported`) are excluded from the scan: the operator owns
-			// recovery via /admin/recrawl and the DLQ → SNS email alarm is the
-			// redrive signal, so flagging them here would drown actionable
-			// pending-row reports in noise.
-			FilterExpression:
-				"summaryStatus = :pending " +
-				"OR crawlStatus = :pending " +
-				"OR (attribute_not_exists(summaryStatus) AND attribute_not_exists(crawlStatus) AND attribute_not_exists(summary)) " +
-				"OR (summaryStatus = :ready AND attribute_not_exists(summary))",
-			ProjectionExpression:
-				"originalUrl, #u, summaryStatus, crawlStatus, summaryFailureReason, crawlFailureReason, contentFetchedAt, summary",
-			ExpressionAttributeNames: { "#u": "url" },
-			ExpressionAttributeValues: { ":pending": "pending", ":ready": "ready" },
-			ExclusiveStartKey: lastEvaluatedKey,
-		});
-		for (const row of page.items) {
-			const verdict = checkTerminalState(row);
-			if (verdict.terminal) continue;
-			const reasons = classifyRow(row);
-			if (row.originalUrl === undefined) {
-				skippedNoOriginal += 1;
-				continue;
-			}
-			if (isExcluded(row.originalUrl)) {
-				excludedDomain += 1;
-				continue;
-			}
-			stuck.push({
-				originalUrl: row.originalUrl,
-				reasons,
-				contentFetchedAt: row.contentFetchedAt,
-				failureReason: row.summaryFailureReason ?? row.crawlFailureReason,
-				recrawlUrl: `${ORIGIN}/admin/recrawl/${encodeURIComponent(row.originalUrl)}`,
-				terminalCheckMessage: verdict.message,
-			});
-		}
-		lastEvaluatedKey = page.lastEvaluatedKey;
-	} while (lastEvaluatedKey !== undefined);
-	if (skippedNoOriginal > 0) {
-		process.stderr.write(`[info] skipped ${skippedNoOriginal} row(s) without originalUrl\n`);
-	}
-	if (excludedDomain > 0) {
-		process.stderr.write(`[info] excluded ${excludedDomain} row(s) by domain filter\n`);
-	}
-	return stuck;
-}
-
 /**
  * When STUCK_ARTICLES_REPORT_PATH is set (CI), drop a JSON report so the
  * on-failure workflow step can format the @claude issue body without
@@ -194,7 +61,11 @@ async function writeReportIfRequested(stuck: StuckRow[]): Promise<void> {
 }
 
 test("Stuck articles canary", async (t) => {
-	const stuck = await collectStuckRows();
+	const region = requireEnv("AWS_REGION");
+	const tableName = requireEnv("DYNAMODB_ARTICLES_TABLE");
+	const origin = requireEnv("READPLACE_ORIGIN");
+	const client = createDynamoDocumentClient({ region });
+	const stuck = await collectStuckRows({ client, tableName, origin });
 	const reachable = await filterReachable(stuck, {
 		fetch: globalThis.fetch,
 		timeoutMs: REACHABILITY_TIMEOUT_MS,

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
+import { collectStuckRows } from "./collect-stuck-rows";
+
+type SendFn = DynamoDBDocumentClient["send"];
+
+interface ScanCommandLike {
+	input: {
+		TableName?: string;
+		FilterExpression?: string;
+		ProjectionExpression?: string;
+		ExpressionAttributeNames?: Record<string, string>;
+		ExpressionAttributeValues?: Record<string, unknown>;
+		ExclusiveStartKey?: Record<string, unknown>;
+	};
+}
+
+interface ScanResultLike {
+	Items?: Record<string, unknown>[];
+	Count?: number;
+	LastEvaluatedKey?: Record<string, unknown>;
+}
+
+function createFakeClient(
+	impl: (input: ScanCommandLike) => ScanResultLike,
+): { client: DynamoDBDocumentClient; calls: ScanCommandLike[] } {
+	const calls: ScanCommandLike[] = [];
+	const send = (async (command: ScanCommandLike) => {
+		calls.push(command);
+		return impl(command);
+	}) as unknown as SendFn;
+	const client = { send } as Partial<DynamoDBDocumentClient> as DynamoDBDocumentClient;
+	return { client, calls };
+}
+
+const TABLE = "test-articles";
+const ORIGIN = "https://example.test";
+
+describe("collectStuckRows", () => {
+	it("issues a Scan against the configured table with the canary FilterExpression", async () => {
+		const { client, calls } = createFakeClient(() => ({ Items: [], Count: 0 }));
+		await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0]?.input.TableName, TABLE);
+		assert.equal(
+			calls[0]?.input.FilterExpression,
+			"summaryStatus = :pending " +
+				"OR crawlStatus = :pending " +
+				"OR (attribute_not_exists(summaryStatus) AND attribute_not_exists(crawlStatus) AND attribute_not_exists(summary)) " +
+				"OR (summaryStatus = :ready AND attribute_not_exists(summary))",
+		);
+		assert.deepEqual(calls[0]?.input.ExpressionAttributeValues, {
+			":pending": "pending",
+			":ready": "ready",
+		});
+	});
+
+	it("projects the attributes classifyRow and checkTerminalState consume", async () => {
+		const { client, calls } = createFakeClient(() => ({ Items: [], Count: 0 }));
+		await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const projection = calls[0]?.input.ProjectionExpression ?? "";
+		for (const attr of [
+			"originalUrl",
+			"summaryStatus",
+			"crawlStatus",
+			"summaryFailureReason",
+			"crawlFailureReason",
+			"contentFetchedAt",
+			"summary",
+		]) {
+			assert.ok(projection.includes(attr), `ProjectionExpression must include ${attr}`);
+		}
+		assert.equal(calls[0]?.input.ExpressionAttributeNames?.["#u"], "url");
+		assert.match(projection, /#u/);
+	});
+
+	it("returns a stuck row for a crawl-pending row, with reasons and a recrawl URL bound to origin", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/article",
+					originalUrl: "https://example.test/article",
+					crawlStatus: "pending",
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.equal(stuck.length, 1);
+		assert.equal(stuck[0]?.originalUrl, "https://example.test/article");
+		assert.deepEqual(stuck[0]?.reasons, ["crawl-pending"]);
+		assert.equal(
+			stuck[0]?.recrawlUrl,
+			`${ORIGIN}/admin/recrawl/${encodeURIComponent("https://example.test/article")}`,
+		);
+		assert.match(
+			stuck[0]?.terminalCheckMessage ?? "",
+			/crawlStatus is 'pending'/,
+		);
+	});
+
+	it("skips terminal rows (DDB may surface them via the writer-contract disjunct)", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/done",
+					originalUrl: "https://example.test/done",
+					summaryStatus: "ready",
+					crawlStatus: "ready",
+					summary: "the summary",
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.deepEqual(stuck, []);
+	});
+
+	it("drops a row whose originalUrl matches an operator-driven exclude pattern", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "readplace.com/some-page",
+					originalUrl: "https://readplace.com/some-page",
+					crawlStatus: "pending",
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.deepEqual(stuck, []);
+	});
+
+	it("drops a row missing originalUrl (cannot build a recrawl URL without it)", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/no-original",
+					crawlStatus: "pending",
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.deepEqual(stuck, []);
+	});
+
+	it("paginates: a LastEvaluatedKey on page 1 triggers a second Scan with ExclusiveStartKey", async () => {
+		let callIndex = 0;
+		const { client, calls } = createFakeClient(() => {
+			callIndex += 1;
+			if (callIndex === 1) {
+				return {
+					Items: [
+						{
+							url: "page1.test/a",
+							originalUrl: "https://page1.test/a",
+							crawlStatus: "pending",
+						},
+					],
+					Count: 1,
+					LastEvaluatedKey: { url: "page1.test/a" },
+				};
+			}
+			return {
+				Items: [
+					{
+						url: "page2.test/b",
+						originalUrl: "https://page2.test/b",
+						summaryStatus: "pending",
+					},
+				],
+				Count: 1,
+			};
+		});
+		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.equal(calls.length, 2);
+		assert.equal(calls[0]?.input.ExclusiveStartKey, undefined);
+		assert.deepEqual(calls[1]?.input.ExclusiveStartKey, { url: "page1.test/a" });
+		assert.equal(stuck.length, 2);
+	});
+
+	it("surfaces the summary-ready-without-text writer-contract violation", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/missing-summary",
+					originalUrl: "https://example.test/missing-summary",
+					summaryStatus: "ready",
+					crawlStatus: "ready",
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		assert.equal(stuck.length, 1);
+		assert.deepEqual(stuck[0]?.reasons, ["summary-ready-without-text"]);
+	});
+});

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
@@ -24,14 +24,13 @@ interface ScanResultLike {
 
 function createFakeClient(
 	impl: (input: ScanCommandLike) => ScanResultLike,
-): { client: DynamoDBDocumentClient; calls: ScanCommandLike[] } {
+): { client: Partial<DynamoDBDocumentClient>; calls: ScanCommandLike[] } {
 	const calls: ScanCommandLike[] = [];
 	const send = (async (command: ScanCommandLike) => {
 		calls.push(command);
 		return impl(command);
 	}) as unknown as SendFn;
-	const client = { send } as Partial<DynamoDBDocumentClient> as DynamoDBDocumentClient;
-	return { client, calls };
+	return { client: { send }, calls };
 }
 
 const TABLE = "test-articles";
@@ -40,7 +39,7 @@ const ORIGIN = "https://example.test";
 describe("collectStuckRows", () => {
 	it("issues a Scan against the configured table with the canary FilterExpression", async () => {
 		const { client, calls } = createFakeClient(() => ({ Items: [], Count: 0 }));
-		await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.equal(calls.length, 1);
 		assert.equal(calls[0]?.input.TableName, TABLE);
 		assert.equal(
@@ -58,7 +57,7 @@ describe("collectStuckRows", () => {
 
 	it("projects the attributes classifyRow and checkTerminalState consume", async () => {
 		const { client, calls } = createFakeClient(() => ({ Items: [], Count: 0 }));
-		await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		const projection = calls[0]?.input.ProjectionExpression ?? "";
 		for (const attr of [
 			"originalUrl",
@@ -86,7 +85,7 @@ describe("collectStuckRows", () => {
 			],
 			Count: 1,
 		}));
-		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const stuck = await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.equal(stuck.length, 1);
 		assert.equal(stuck[0]?.originalUrl, "https://example.test/article");
 		assert.deepEqual(stuck[0]?.reasons, ["crawl-pending"]);
@@ -113,7 +112,7 @@ describe("collectStuckRows", () => {
 			],
 			Count: 1,
 		}));
-		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const stuck = await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.deepEqual(stuck, []);
 	});
 
@@ -128,7 +127,7 @@ describe("collectStuckRows", () => {
 			],
 			Count: 1,
 		}));
-		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const stuck = await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.deepEqual(stuck, []);
 	});
 
@@ -142,7 +141,7 @@ describe("collectStuckRows", () => {
 			],
 			Count: 1,
 		}));
-		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const stuck = await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.deepEqual(stuck, []);
 	});
 
@@ -174,7 +173,7 @@ describe("collectStuckRows", () => {
 				Count: 1,
 			};
 		});
-		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const stuck = await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.equal(calls.length, 2);
 		assert.equal(calls[0]?.input.ExclusiveStartKey, undefined);
 		assert.deepEqual(calls[1]?.input.ExclusiveStartKey, { url: "page1.test/a" });
@@ -193,7 +192,7 @@ describe("collectStuckRows", () => {
 			],
 			Count: 1,
 		}));
-		const stuck = await collectStuckRows({ client, tableName: TABLE, origin: ORIGIN });
+		const stuck = await collectStuckRows({ client: client as DynamoDBDocumentClient, tableName: TABLE, origin: ORIGIN });
 		assert.equal(stuck.length, 1);
 		assert.deepEqual(stuck[0]?.reasons, ["summary-ready-without-text"]);
 	});

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
@@ -1,0 +1,143 @@
+/**
+ * Extracted from `check-stuck-articles.ts` so the unit tests can exercise the
+ * canary logic without registering the top-level `test()` block (which fires
+ * `requireEnv` at module load and aborts the test process).
+ */
+import assert from "node:assert/strict";
+import {
+	CrawlStatusSchema,
+	SummaryStatusSchema,
+} from "@packages/article-state-types";
+import {
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+	dynamoField,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { checkTerminalState } from "./check-terminal-state";
+import { type StuckReason, classifyRow } from "./classify-row";
+import { EXCLUDE_PATTERNS } from "./exclude-patterns";
+
+/**
+ * Loose row schema for the canary's projection. Every attribute except `url`
+ * is wrapped in `dynamoField` so absent attributes (which DDB returns as
+ * `null`) are normalised to `undefined`. The status enums are imported from
+ * @packages/article-state-types so adding a new status to the production
+ * schemas surfaces here as a tsc error in `classifyRow`.
+ */
+const StuckArticleRow = z.object({
+	url: z.string(),
+	originalUrl: dynamoField(z.string()),
+	summaryStatus: dynamoField(SummaryStatusSchema),
+	crawlStatus: dynamoField(CrawlStatusSchema),
+	summaryFailureReason: dynamoField(z.string()),
+	crawlFailureReason: dynamoField(z.string()),
+	contentFetchedAt: dynamoField(z.string()),
+	summary: dynamoField(z.string()),
+});
+
+function isExcluded(url: string): boolean {
+	return EXCLUDE_PATTERNS.some((pattern) => pattern.test(url));
+}
+
+export interface StuckRow {
+	originalUrl: string;
+	reasons: StuckReason[];
+	contentFetchedAt: string | undefined;
+	failureReason: string | undefined;
+	recrawlUrl: string;
+	/**
+	 * Surfaced in the failing test message so an operator reading the GitHub
+	 * Actions output knows which writer to suspect without cross-referencing
+	 * the reason enum.
+	 */
+	terminalCheckMessage: string;
+}
+
+/**
+ * Hard cap on DDB scan pages. The articles table is small enough that a real
+ * scan completes in well under 10 pages. Crossing 50 means the FilterExpression
+ * stopped narrowing the scan (or the table grew an order of magnitude) — fail
+ * loud here instead of burning the runner's 10-minute budget.
+ */
+const MAX_PAGES = 50;
+
+/**
+ * The third disjunct catches the `summaryStatus="ready" AND
+ * attribute_not_exists(summary)` inconsistency the 2026-05-10 freshness-refresh
+ * regression introduced — without it the row passes both status checks and the
+ * canary reports green while the reader UI polls "Generating summary…" forever.
+ *
+ * Terminal failures (crawlStatus / summaryStatus = `failed` or `unsupported`)
+ * are excluded from the scan: the operator owns recovery via /admin/recrawl
+ * and the DLQ → SNS email alarm is the redrive signal, so flagging them here
+ * would drown actionable pending-row reports in noise.
+ */
+const SCAN_INPUT = {
+	FilterExpression:
+		"summaryStatus = :pending " +
+		"OR crawlStatus = :pending " +
+		"OR (attribute_not_exists(summaryStatus) AND attribute_not_exists(crawlStatus) AND attribute_not_exists(summary)) " +
+		"OR (summaryStatus = :ready AND attribute_not_exists(summary))",
+	ProjectionExpression:
+		"originalUrl, #u, summaryStatus, crawlStatus, summaryFailureReason, crawlFailureReason, contentFetchedAt, summary",
+	ExpressionAttributeNames: { "#u": "url" },
+	ExpressionAttributeValues: { ":pending": "pending", ":ready": "ready" },
+} as const;
+
+export async function collectStuckRows(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	origin: string;
+}): Promise<StuckRow[]> {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: StuckArticleRow,
+	});
+	const stuck: StuckRow[] = [];
+	let skippedNoOriginal = 0;
+	let excludedDomain = 0;
+	let pageCount = 0;
+	let lastEvaluatedKey: Record<string, unknown> | undefined;
+	do {
+		pageCount += 1;
+		assert(
+			pageCount <= MAX_PAGES,
+			`pagination cap reached (${MAX_PAGES} pages) — refine FilterExpression or raise the cap if the table is legitimately growing`,
+		);
+		const page = await table.scan({
+			...SCAN_INPUT,
+			ExclusiveStartKey: lastEvaluatedKey,
+		});
+		for (const row of page.items) {
+			const verdict = checkTerminalState(row);
+			if (verdict.terminal) continue;
+			const reasons = classifyRow(row);
+			if (row.originalUrl === undefined) {
+				skippedNoOriginal += 1;
+				continue;
+			}
+			if (isExcluded(row.originalUrl)) {
+				excludedDomain += 1;
+				continue;
+			}
+			stuck.push({
+				originalUrl: row.originalUrl,
+				reasons,
+				contentFetchedAt: row.contentFetchedAt,
+				failureReason: row.summaryFailureReason ?? row.crawlFailureReason,
+				recrawlUrl: `${deps.origin}/admin/recrawl/${encodeURIComponent(row.originalUrl)}`,
+				terminalCheckMessage: verdict.message,
+			});
+		}
+		lastEvaluatedKey = page.lastEvaluatedKey;
+	} while (lastEvaluatedKey !== undefined);
+	if (skippedNoOriginal > 0) {
+		process.stderr.write(`[info] skipped ${skippedNoOriginal} row(s) without originalUrl\n`);
+	}
+	if (excludedDomain > 0) {
+		process.stderr.write(`[info] excluded ${excludedDomain} row(s) by domain filter\n`);
+	}
+	return stuck;
+}


### PR DESCRIPTION
## Summary

Pure structural split of the stuck-articles canary so the scan/classify/exclude/paginate path is reachable from a unit test without firing `requireEnv` at module load. **No behavior change** — same `FilterExpression`, same `ProjectionExpression`, same skip/exclude rules, same `MAX_PAGES` cap.

Carved out of #282 so that PR can rebase onto this base and its diff reduces to just the canary timing logic (`firstSeenAt` stamping, `CRAWL_MIN_AGE_MS` / `SUMMARY_MIN_AGE_MS`, age-gated disjuncts).

### What moves

- New `scripts/collect-stuck-rows.ts` exports `collectStuckRows({ client, tableName, origin })` plus the `StuckRow` shape. Internals (`StuckArticleRow` schema, `isExcluded`, `MAX_PAGES`, the scan body) move with it.
- `scripts/check-stuck-articles.ts` keeps the `test()` block, the report writer, and the reachability wiring. The three `requireEnv` calls move from module top-level into the test body so loading `collect-stuck-rows.ts` no longer aborts a unit-test process.
- `package.json` test script picks up the new `dist/scripts/collect-stuck-rows.test.js`.
- `knip.config.ts` entries cover the new file.

### What does NOT change

- `FilterExpression` is byte-for-byte identical (still 4 disjuncts: `summaryStatus=pending`, `crawlStatus=pending`, all-attrs-absent legacy stub, `summaryStatus=ready AND attribute_not_exists(summary)`).
- `ProjectionExpression`, `ExpressionAttributeNames`, `ExpressionAttributeValues` unchanged.
- No new fields projected, no schema additions, no new constants, no `now` dep.
- Canary workflow target (`pnpm nx run @packages/check-stuck-articles:check-stuck-articles`) still runs `dist/scripts/check-stuck-articles.js` only — the new test file is invoked from `:check`, not from the canary cron.

## Test plan

- [x] `pnpm nx run @packages/check-stuck-articles:check` — 42 tests pass (8 new in `collect-stuck-rows.test.ts` covering scan body, projection, crawl-pending capture, terminal-row skip, exclude-pattern drop, missing-originalUrl drop, pagination, summary-ready-without-text capture).
- [x] Pre-commit hook (lint + test + coverage across 18 projects) passed.

https://claude.ai/code/session_01Mj1sEJWWqCJCWGfBUsc5VP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mj1sEJWWqCJCWGfBUsc5VP)_