### PR TITLE
feat: migrate cross-axis writers onto Article aggregate (Phase 2)

### DIFF
--- a/projects/save-link/src/article-aggregate/dynamodb-article-store.test.ts
+++ b/projects/save-link/src/article-aggregate/dynamodb-article-store.test.ts
@@ -1,4 +1,4 @@
-import type { Article } from "@packages/domain/article-aggregate";
+import type { AggregateField, Article } from "@packages/domain/article-aggregate";
 import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
 import { initDynamoDbArticleStore } from "./dynamodb-article-store";
 
@@ -14,6 +14,11 @@ function createFakeClient(
 
 const TABLE = "test-articles";
 const URL = "https://example.com/article";
+const REFRESH_WRITES: readonly AggregateField[] = [
+	"metadata",
+	"freshness",
+	"summary",
+];
 
 function buildArticle(overrides: Partial<Article> = {}): Article {
 	return {
@@ -230,7 +235,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 		});
 	});
 
-	describe("save (refresh-content shape)", () => {
+	describe("save (refresh-content shape: writes metadata, freshness, summary)", () => {
 		it("issues an UpdateItem that writes metadata, freshness, estimatedReadTime, and resets summary to pending", async () => {
 			let received: unknown;
 			const client = createFakeClient((input) => {
@@ -242,7 +247,11 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(buildArticle());
+			await store.save({
+				article: buildArticle(),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: {
@@ -279,7 +288,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			);
 		});
 
-		it("never touches crawl attributes so a concurrent crawl writer is not clobbered (Phase 1)", async () => {
+		it("never touches crawl attributes when the transition does not declare a crawl write", async () => {
 			let received: unknown;
 			const client = createFakeClient((input) => {
 				received = input;
@@ -290,7 +299,11 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(buildArticle({ crawl: { kind: "failed", reason: "x" } }));
+			await store.save({
+				article: buildArticle({ crawl: { kind: "failed", reason: "x" } }),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
@@ -313,8 +326,8 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(
-				buildArticle({
+			await store.save({
+				article: buildArticle({
 					summary: {
 						kind: "ready",
 						summary: "abc",
@@ -323,7 +336,9 @@ describe("initDynamoDbArticleStore (unit)", () => {
 						outputTokens: 50,
 					},
 				}),
-			);
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
@@ -364,9 +379,11 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(
-				buildArticle({ summary: { kind: "ready", summary: "abc" } }),
-			);
+			await store.save({
+				article: buildArticle({ summary: { kind: "ready", summary: "abc" } }),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { ExpressionAttributeValues?: Record<string, unknown> };
@@ -391,9 +408,13 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(
-				buildArticle({ summary: { kind: "failed", reason: "rate limited" } }),
-			);
+			await store.save({
+				article: buildArticle({
+					summary: { kind: "failed", reason: "rate limited" },
+				}),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
@@ -423,11 +444,13 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(
-				buildArticle({
+			await store.save({
+				article: buildArticle({
 					summary: { kind: "skipped", reason: "content-too-short" },
 				}),
-			);
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
@@ -457,7 +480,11 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(buildArticle({ summary: { kind: "skipped" } }));
+			await store.save({
+				article: buildArticle({ summary: { kind: "skipped" } }),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
@@ -481,8 +508,8 @@ describe("initDynamoDbArticleStore (unit)", () => {
 				tableName: TABLE,
 			});
 
-			await store.save(
-				buildArticle({
+			await store.save({
+				article: buildArticle({
 					freshness: { contentFetchedAt: "2026-05-10T12:00:00.000Z" },
 					metadata: {
 						title: "x",
@@ -491,7 +518,9 @@ describe("initDynamoDbArticleStore (unit)", () => {
 						wordCount: 1,
 					},
 				}),
-			);
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
 
 			const command = received as {
 				input: { ExpressionAttributeValues?: Record<string, unknown> };
@@ -499,6 +528,274 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			expect(command.input.ExpressionAttributeValues?.[":etag"]).toBeNull();
 			expect(command.input.ExpressionAttributeValues?.[":lm"]).toBeNull();
 			expect(command.input.ExpressionAttributeValues?.[":img"]).toBeNull();
+		});
+	});
+
+	describe("save (canary marker)", () => {
+		it("always writes aggregateTransitionName so the check-stuck-articles scan can attribute the row", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle(),
+				transitionName: "markCrawlExhausted",
+				writes: ["crawl", "summary"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"aggregateTransitionName = :atn",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":atn"]).toBe(
+				"markCrawlExhausted",
+			);
+		});
+	});
+
+	describe("save (markCrawlExhausted shape: writes crawl, summary)", () => {
+		it("writes crawlStatus=failed with the supplied reason and clears crawlUnsupportedReason", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					crawl: { kind: "failed", reason: "exceeded SQS maxReceiveCount" },
+					summary: { kind: "failed", reason: "crawl failed" },
+				}),
+				transitionName: "markCrawlExhausted",
+				writes: ["crawl", "summary"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"crawlStatus = :crawlStatus",
+			);
+			expect(command.input.UpdateExpression).toContain(
+				"crawlFailureReason = :crawlFailureReason",
+			);
+			expect(command.input.UpdateExpression).toContain(
+				"REMOVE",
+			);
+			expect(command.input.UpdateExpression).toContain("crawlUnsupportedReason");
+			expect(command.input.ExpressionAttributeValues?.[":crawlStatus"]).toBe(
+				"failed",
+			);
+			expect(
+				command.input.ExpressionAttributeValues?.[":crawlFailureReason"],
+			).toBe("exceeded SQS maxReceiveCount");
+		});
+
+		it("writes summaryStatus=failed with 'crawl failed' reason when both axes mark failed together", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					crawl: { kind: "failed", reason: "x" },
+					summary: { kind: "failed", reason: "crawl failed" },
+				}),
+				transitionName: "markCrawlExhausted",
+				writes: ["crawl", "summary"],
+			});
+
+			const command = received as {
+				input: { ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.ExpressionAttributeValues?.[":summaryStatus"]).toBe(
+				"failed",
+			);
+			expect(
+				command.input.ExpressionAttributeValues?.[":summaryFailureReason"],
+			).toBe("crawl failed");
+		});
+
+		it("does not touch metadata or freshness attributes when the transition only writes crawl + summary", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					crawl: { kind: "failed", reason: "x" },
+					summary: { kind: "failed", reason: "crawl failed" },
+				}),
+				transitionName: "markCrawlExhausted",
+				writes: ["crawl", "summary"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string };
+			};
+			expect(command.input.UpdateExpression).not.toContain("title = :title");
+			expect(command.input.UpdateExpression).not.toContain(
+				"contentFetchedAt = :cfa",
+			);
+			expect(command.input.UpdateExpression).not.toContain("etag = :etag");
+			expect(command.input.UpdateExpression).not.toContain("imageUrl = :img");
+		});
+	});
+
+	describe("save (other crawl states, writes crawl)", () => {
+		it("writes crawlStatus=unsupported with the supplied reason and clears crawlFailureReason", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					crawl: {
+						kind: "unsupported",
+						reason: "non-html content type: application/pdf",
+					},
+				}),
+				transitionName: "markCrawlUnsupportedFromAggregate",
+				writes: ["crawl"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"crawlUnsupportedReason = :crawlUnsupportedReason",
+			);
+			expect(command.input.UpdateExpression).toContain(
+				"crawlFailureReason",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":crawlStatus"]).toBe(
+				"unsupported",
+			);
+			expect(
+				command.input.ExpressionAttributeValues?.[":crawlUnsupportedReason"],
+			).toBe("non-html content type: application/pdf");
+		});
+
+		it("writes crawlStatus=pending and removes both failure / unsupported reasons (a future re-prime transition's shape)", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({ crawl: { kind: "pending" } }),
+				transitionName: "rePrimeCrawl",
+				writes: ["crawl"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"crawlStatus = :crawlStatus",
+			);
+			expect(command.input.UpdateExpression).toContain("crawlFailureReason");
+			expect(command.input.UpdateExpression).toContain("crawlUnsupportedReason");
+			expect(command.input.ExpressionAttributeValues?.[":crawlStatus"]).toBe(
+				"pending",
+			);
+		});
+	});
+
+	describe("save (recrawl-tie-kept-canonical shape: writes crawl only)", () => {
+		it("writes crawlStatus=ready and REMOVEs lingering failure / failedAt attributes", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({ crawl: { kind: "ready" } }),
+				transitionName: "recrawlTieKeptCanonical",
+				writes: ["crawl"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"crawlStatus = :crawlStatus",
+			);
+			expect(command.input.UpdateExpression).toContain("crawlFailureReason");
+			expect(command.input.UpdateExpression).toContain("crawlUnsupportedReason");
+			expect(command.input.UpdateExpression).toContain("crawlFailedAt");
+			expect(command.input.ExpressionAttributeValues?.[":crawlStatus"]).toBe(
+				"ready",
+			);
+		});
+
+		it("does not touch summary when only crawl is in writes (preserves a freshly-generated summary on recrawl)", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					crawl: { kind: "ready" },
+					summary: { kind: "ready", summary: "kept" },
+				}),
+				transitionName: "recrawlTieKeptCanonical",
+				writes: ["crawl"],
+			});
+
+			const command = received as {
+				input: { UpdateExpression?: string };
+			};
+			expect(command.input.UpdateExpression).not.toContain(
+				"summaryStatus = :summaryStatus",
+			);
+			expect(command.input.UpdateExpression).not.toContain("summary = :summary");
 		});
 	});
 });

--- a/projects/save-link/src/article-aggregate/dynamodb-article-store.ts
+++ b/projects/save-link/src/article-aggregate/dynamodb-article-store.ts
@@ -4,6 +4,7 @@ import {
 	SummaryStatusSchema,
 } from "@packages/article-state-types";
 import type {
+	AggregateField,
 	Article,
 	ArticleStore,
 	CrawlState,
@@ -26,6 +27,12 @@ import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id
  * Fields outside this schema (routeId, originalUrl, content, contentSourceTier)
  * are owned by separate writers and are *not* touched by the aggregate save —
  * the UpdateExpression below only writes the attributes the aggregate models.
+ *
+ * `aggregateTransitionName` is the Phase 2 canary tag: the name of the
+ * transition function that last wrote this row through the aggregate. The
+ * check-stuck-articles scan reads it to bucket stuck rows by migrated vs.
+ * legacy writer; if a row produced by a migrated transition still shows up
+ * stuck a week later, the aggregate hypothesis is wrong and Phase 3+ stops.
  */
 const ArticleAggregateRow = z.object({
 	title: dynamoField(z.string()),
@@ -47,6 +54,7 @@ const ArticleAggregateRow = z.object({
 	summaryOutputTokens: dynamoField(z.number()),
 	summaryFailureReason: dynamoField(z.string()),
 	summarySkippedReason: dynamoField(z.string()),
+	aggregateTransitionName: dynamoField(z.string()),
 });
 
 type RowShape = z.infer<typeof ArticleAggregateRow>;
@@ -122,51 +130,50 @@ function rowToArticle(url: string, row: RowShape): Article {
 	};
 }
 
-/**
- * Build the UpdateExpression that writes the aggregate fields refresh-content
- * mutates today. Only metadata, freshness, estimatedReadTime, and summary are
- * touched — crawl state is loaded into the aggregate for completeness but not
- * written back here, so a concurrent crawl-state writer cannot be clobbered
- * by an aggregate save in Phase 1.
- *
- * Summary fields are written based on the discriminant: a `pending` summary
- * REMOVEs every summary-detail attribute (mirroring the inline UpdateExpression
- * the aggregate replaces) so a row never sits in the inconsistent
- * (status=ready, summary text missing) state that left rows stuck on the
- * forever-polling "Generating summary…" panel.
- */
-function buildSaveCommand(article: Article): {
-	UpdateExpression: string;
-	ExpressionAttributeValues: Record<string, unknown>;
-} {
-	const sets: string[] = [
+function appendMetadataClauses(
+	article: Article,
+	sets: string[],
+	values: Record<string, unknown>,
+): void {
+	sets.push(
 		"title = :title",
 		"siteName = :siteName",
 		"excerpt = :excerpt",
 		"wordCount = :wordCount",
 		"estimatedReadTime = :ert",
+		"imageUrl = :img",
+	);
+	values[":title"] = article.metadata.title;
+	values[":siteName"] = article.metadata.siteName;
+	values[":excerpt"] = article.metadata.excerpt;
+	values[":wordCount"] = article.metadata.wordCount;
+	values[":ert"] = article.estimatedReadTime;
+	values[":img"] = article.metadata.imageUrl ?? null;
+}
+
+function appendFreshnessClauses(
+	article: Article,
+	sets: string[],
+	values: Record<string, unknown>,
+): void {
+	sets.push(
 		"contentFetchedAt = :cfa",
 		"etag = :etag",
 		"lastModified = :lm",
-		"imageUrl = :img",
-	];
+	);
+	values[":cfa"] = article.freshness.contentFetchedAt;
+	values[":etag"] = article.freshness.etag ?? null;
+	values[":lm"] = article.freshness.lastModified ?? null;
+}
 
-	const values: Record<string, unknown> = {
-		":title": article.metadata.title,
-		":siteName": article.metadata.siteName,
-		":excerpt": article.metadata.excerpt,
-		":wordCount": article.metadata.wordCount,
-		":ert": article.estimatedReadTime,
-		":cfa": article.freshness.contentFetchedAt,
-		":etag": article.freshness.etag ?? null,
-		":lm": article.freshness.lastModified ?? null,
-		":img": article.metadata.imageUrl ?? null,
-	};
-
-	const removes: string[] = [];
-
+function appendSummaryClauses(
+	article: Article,
+	sets: string[],
+	removes: string[],
+	values: Record<string, unknown>,
+): void {
+	sets.push("summaryStatus = :summaryStatus");
 	if (article.summary.kind === "pending") {
-		sets.push("summaryStatus = :summaryStatus");
 		values[":summaryStatus"] = "pending";
 		removes.push(
 			"summary",
@@ -177,34 +184,107 @@ function buildSaveCommand(article: Article): {
 			"summaryFailureReason",
 			"summarySkippedReason",
 		);
-	} else if (article.summary.kind === "ready") {
-		sets.push("summaryStatus = :summaryStatus");
-		sets.push("summary = :summary");
+		return;
+	}
+	if (article.summary.kind === "ready") {
+		sets.push(
+			"summary = :summary",
+			"summaryExcerpt = :summaryExcerpt",
+			"summaryInputTokens = :summaryInputTokens",
+			"summaryOutputTokens = :summaryOutputTokens",
+		);
 		values[":summaryStatus"] = "ready";
 		values[":summary"] = article.summary.summary;
-		sets.push("summaryExcerpt = :summaryExcerpt");
 		values[":summaryExcerpt"] = article.summary.excerpt ?? null;
-		sets.push("summaryInputTokens = :summaryInputTokens");
 		values[":summaryInputTokens"] = article.summary.inputTokens ?? null;
-		sets.push("summaryOutputTokens = :summaryOutputTokens");
 		values[":summaryOutputTokens"] = article.summary.outputTokens ?? null;
 		removes.push("summaryFailureReason", "summarySkippedReason");
-	} else if (article.summary.kind === "failed") {
-		sets.push("summaryStatus = :summaryStatus");
+		return;
+	}
+	if (article.summary.kind === "failed") {
 		sets.push("summaryFailureReason = :summaryFailureReason");
 		values[":summaryStatus"] = "failed";
 		values[":summaryFailureReason"] = article.summary.reason;
 		removes.push("summarySkippedReason");
+		return;
+	}
+	values[":summaryStatus"] = "skipped";
+	if (article.summary.reason) {
+		sets.push("summarySkippedReason = :summarySkippedReason");
+		values[":summarySkippedReason"] = article.summary.reason;
 	} else {
-		sets.push("summaryStatus = :summaryStatus");
-		values[":summaryStatus"] = "skipped";
-		if (article.summary.reason) {
-			sets.push("summarySkippedReason = :summarySkippedReason");
-			values[":summarySkippedReason"] = article.summary.reason;
-		} else {
-			removes.push("summarySkippedReason");
-		}
-		removes.push("summaryFailureReason");
+		removes.push("summarySkippedReason");
+	}
+	removes.push("summaryFailureReason");
+}
+
+function appendCrawlClauses(
+	article: Article,
+	sets: string[],
+	removes: string[],
+	values: Record<string, unknown>,
+): void {
+	sets.push("crawlStatus = :crawlStatus");
+	if (article.crawl.kind === "failed") {
+		sets.push("crawlFailureReason = :crawlFailureReason");
+		values[":crawlStatus"] = "failed";
+		values[":crawlFailureReason"] = article.crawl.reason;
+		removes.push("crawlUnsupportedReason");
+		return;
+	}
+	if (article.crawl.kind === "unsupported") {
+		sets.push("crawlUnsupportedReason = :crawlUnsupportedReason");
+		values[":crawlStatus"] = "unsupported";
+		values[":crawlUnsupportedReason"] = article.crawl.reason;
+		removes.push("crawlFailureReason");
+		return;
+	}
+	if (article.crawl.kind === "ready") {
+		values[":crawlStatus"] = "ready";
+		removes.push("crawlFailureReason", "crawlUnsupportedReason", "crawlFailedAt");
+		return;
+	}
+	values[":crawlStatus"] = "pending";
+	removes.push("crawlFailureReason", "crawlUnsupportedReason");
+}
+
+/**
+ * Build the UpdateExpression scoped to the aggregate fields this transition
+ * actually mutated. The `writes` set is the transition's promise to the
+ * storage adapter: any field not in `writes` is left untouched on the row,
+ * so a concurrent inline writer on a different axis is never clobbered by
+ * an aggregate save it didn't intend to.
+ *
+ * `aggregateTransitionName` is written on every save regardless of `writes`
+ * — it is the canary tag, not a domain field, and a non-Phase-2 transition
+ * (refreshContent) writing `"refreshContent"` is correct.
+ */
+function buildSaveCommand(params: {
+	article: Article;
+	transitionName: string;
+	writes: readonly AggregateField[];
+}): {
+	UpdateExpression: string;
+	ExpressionAttributeValues: Record<string, unknown>;
+} {
+	const sets: string[] = ["aggregateTransitionName = :atn"];
+	const removes: string[] = [];
+	const values: Record<string, unknown> = {
+		":atn": params.transitionName,
+	};
+
+	const writesSet = new Set<AggregateField>(params.writes);
+	if (writesSet.has("metadata")) {
+		appendMetadataClauses(params.article, sets, values);
+	}
+	if (writesSet.has("freshness")) {
+		appendFreshnessClauses(params.article, sets, values);
+	}
+	if (writesSet.has("summary")) {
+		appendSummaryClauses(params.article, sets, removes, values);
+	}
+	if (writesSet.has("crawl")) {
+		appendCrawlClauses(params.article, sets, removes, values);
 	}
 
 	const setClause = `SET ${sets.join(", ")}`;
@@ -234,10 +314,13 @@ export function initDynamoDbArticleStore(deps: {
 			if (!row) return undefined;
 			return rowToArticle(url, row);
 		},
-		save: async (article) => {
+		save: async ({ article, transitionName, writes }) => {
 			const articleResourceUniqueId = ArticleResourceUniqueId.parse(article.url);
-			const { UpdateExpression, ExpressionAttributeValues } =
-				buildSaveCommand(article);
+			const { UpdateExpression, ExpressionAttributeValues } = buildSaveCommand({
+				article,
+				transitionName,
+				writes,
+			});
 			await table.update({
 				Key: { url: articleResourceUniqueId.value },
 				UpdateExpression,

--- a/projects/save-link/src/article-aggregate/dynamodb-article-store.ts
+++ b/projects/save-link/src/article-aggregate/dynamodb-article-store.ts
@@ -27,12 +27,6 @@ import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id
  * Fields outside this schema (routeId, originalUrl, content, contentSourceTier)
  * are owned by separate writers and are *not* touched by the aggregate save —
  * the UpdateExpression below only writes the attributes the aggregate models.
- *
- * `aggregateTransitionName` is the Phase 2 canary tag: the name of the
- * transition function that last wrote this row through the aggregate. The
- * check-stuck-articles scan reads it to bucket stuck rows by migrated vs.
- * legacy writer; if a row produced by a migrated transition still shows up
- * stuck a week later, the aggregate hypothesis is wrong and Phase 3+ stops.
  */
 const ArticleAggregateRow = z.object({
 	title: dynamoField(z.string()),
@@ -248,17 +242,6 @@ function appendCrawlClauses(
 	removes.push("crawlFailureReason", "crawlUnsupportedReason");
 }
 
-/**
- * Build the UpdateExpression scoped to the aggregate fields this transition
- * actually mutated. The `writes` set is the transition's promise to the
- * storage adapter: any field not in `writes` is left untouched on the row,
- * so a concurrent inline writer on a different axis is never clobbered by
- * an aggregate save it didn't intend to.
- *
- * `aggregateTransitionName` is written on every save regardless of `writes`
- * — it is the canary tag, not a domain field, and a non-Phase-2 transition
- * (refreshContent) writing `"refreshContent"` is correct.
- */
 function buildSaveCommand(params: {
 	article: Article;
 	transitionName: string;

--- a/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.test.ts
+++ b/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.test.ts
@@ -3,9 +3,11 @@ import { initLambdaEffectDispatcher } from "./lambda-effect-dispatcher";
 describe("initLambdaEffectDispatcher", () => {
 	it("forwards a generate-summary effect to dispatchGenerateSummary", async () => {
 		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const { dispatchEffect } = initLambdaEffectDispatcher({
 			dispatchGenerateSummary,
+			publishEvent,
 		});
 
 		await dispatchEffect({
@@ -17,15 +19,68 @@ describe("initLambdaEffectDispatcher", () => {
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({
 			url: "https://example.com/article",
 		});
+		expect(publishEvent).not.toHaveBeenCalled();
+	});
+
+	it("publishes a CrawlArticleFailedEvent for a publish-crawl-article-failed effect, carrying url/reason/receiveCount in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-crawl-article-failed",
+			url: "https://example.com/article",
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "CrawlArticleFailed",
+			detail: JSON.stringify({
+				url: "https://example.com/article",
+				reason: "exceeded SQS maxReceiveCount",
+				receiveCount: 4,
+			}),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+	});
+
+	it("publishes a RecrawlCompletedEvent for a publish-recrawl-completed effect, carrying only the url in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-recrawl-completed",
+			url: "https://example.com/article",
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "RecrawlCompleted",
+			detail: JSON.stringify({ url: "https://example.com/article" }),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
 
 	it("propagates the dispatcher's rejection so the orchestrator's caller can retry", async () => {
 		const dispatchGenerateSummary = jest
 			.fn()
 			.mockRejectedValue(new Error("sqs send failed"));
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const { dispatchEffect } = initLambdaEffectDispatcher({
 			dispatchGenerateSummary,
+			publishEvent,
 		});
 
 		await expect(
@@ -34,5 +89,24 @@ describe("initLambdaEffectDispatcher", () => {
 				url: "https://example.com/article",
 			}),
 		).rejects.toThrow("sqs send failed");
+	});
+
+	it("propagates a publish failure so SQS replays the whole transition", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest
+			.fn()
+			.mockRejectedValue(new Error("eventbridge throttled"));
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await expect(
+			dispatchEffect({
+				kind: "publish-recrawl-completed",
+				url: "https://example.com/article",
+			}),
+		).rejects.toThrow("eventbridge throttled");
 	});
 });

--- a/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts
+++ b/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts
@@ -1,31 +1,59 @@
+import type { DispatchEffect } from "@packages/domain/article-aggregate";
+import {
+	CrawlArticleFailedEvent,
+	type GenerateSummaryCommand,
+	RecrawlCompletedEvent,
+} from "@packages/hutch-infra-components";
 import type {
-	DispatchEffect,
-	Effect,
-} from "@packages/domain/article-aggregate";
-import type { GenerateSummaryCommand } from "@packages/hutch-infra-components";
-import type { DispatchCommand } from "@packages/hutch-infra-components/runtime";
+	DispatchCommand,
+	PublishEvent,
+} from "@packages/hutch-infra-components/runtime";
 
 /**
- * Wires the typed Effect union to the existing SQS command dispatchers.
- * The orchestrator iterates effects after a successful store.save(), so a
- * thrown SQS failure propagates back to the Lambda handler and SQS retries
- * the whole transition.
+ * Wires the typed Effect union to the existing SQS command dispatchers and
+ * EventBridge publisher. The orchestrator iterates effects after a successful
+ * store.save(), so a thrown failure propagates back to the Lambda handler
+ * and SQS retries the whole transition.
  *
- * The `satisfies Record<Effect["kind"], ...>` assertion ensures that adding
- * a new Effect variant without a handler here is a compile error.
+ * The switch is exhaustive via a `never` default — adding a new Effect
+ * variant without a case here is a compile error.
  */
 export function initLambdaEffectDispatcher(deps: {
 	dispatchGenerateSummary: DispatchCommand<typeof GenerateSummaryCommand>;
+	publishEvent: PublishEvent;
 }): { dispatchEffect: DispatchEffect } {
-	const { dispatchGenerateSummary } = deps;
+	const { dispatchGenerateSummary, publishEvent } = deps;
 
 	const dispatchEffect: DispatchEffect = async (effect) => {
-		const handlers = {
-			"generate-summary": () =>
-				dispatchGenerateSummary({ url: effect.url }),
-		} satisfies Record<Effect["kind"], () => Promise<void>>;
-
-		await handlers[effect.kind]();
+		switch (effect.kind) {
+			case "generate-summary":
+				await dispatchGenerateSummary({ url: effect.url });
+				return;
+			case "publish-crawl-article-failed":
+				await publishEvent({
+					source: CrawlArticleFailedEvent.source,
+					detailType: CrawlArticleFailedEvent.detailType,
+					detail: JSON.stringify({
+						url: effect.url,
+						reason: effect.reason,
+						receiveCount: effect.receiveCount,
+					}),
+				});
+				return;
+			case "publish-recrawl-completed":
+				await publishEvent({
+					source: RecrawlCompletedEvent.source,
+					detailType: RecrawlCompletedEvent.detailType,
+					detail: JSON.stringify({ url: effect.url }),
+				});
+				return;
+			default: {
+				const _exhaustive: never = effect;
+				throw new Error(
+					`Unhandled aggregate effect: ${JSON.stringify(_exhaustive)}`,
+				);
+			}
+		}
 	};
 
 	return { dispatchEffect };

--- a/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts
+++ b/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts
@@ -9,15 +9,6 @@ import type {
 	PublishEvent,
 } from "@packages/hutch-infra-components/runtime";
 
-/**
- * Wires the typed Effect union to the existing SQS command dispatchers and
- * EventBridge publisher. The orchestrator iterates effects after a successful
- * store.save(), so a thrown failure propagates back to the Lambda handler
- * and SQS retries the whole transition.
- *
- * The switch is exhaustive via a `never` default — adding a new Effect
- * variant without a case here is a compile error.
- */
 export function initLambdaEffectDispatcher(deps: {
 	dispatchGenerateSummary: DispatchCommand<typeof GenerateSummaryCommand>;
 	publishEvent: PublishEvent;

--- a/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.test.ts
@@ -1,8 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initRecrawlLinkInitiatedDlqHandler } from "./recrawl-link-initiated-dlq-handler";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
@@ -49,15 +48,13 @@ function createSqsEvent(
 }
 
 describe("initRecrawlLinkInitiatedDlqHandler", () => {
-	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches the markCrawlExhausted transition with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockResolvedValue(undefined);
 
 		const handler = initRecrawlLinkInitiatedDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -67,34 +64,21 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(markSummaryFailed).toHaveBeenCalledWith({
-			url: "https://example.com/failed",
-			reason: "crawl failed",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 4,
-			}),
+			},
 		});
 	});
 
-	it("reports the record as a batch failure on invalid event envelope (Zod failure)", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn();
-		const markSummaryFailed: MarkSummaryFailed = jest.fn();
-		const publishEvent: PublishEvent = jest.fn();
+	it("reports the record as a batch failure on invalid event envelope (Zod failure) and does NOT dispatch the transition", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest.fn();
 
 		const handler = initRecrawlLinkInitiatedDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -114,8 +98,25 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 
 		const result = await handler(invalidEvent, stubContext, () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).not.toHaveBeenCalled();
-		expect(markSummaryFailed).not.toHaveBeenCalled();
-		expect(publishEvent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled"));
+
+		const handler = initRecrawlLinkInitiatedDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed" }),
+			stubContext,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/recrawl-link-initiated-dlq-handler.ts
@@ -1,17 +1,16 @@
-import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import {
-	CrawlArticleFailedEvent,
-	RecrawlLinkInitiatedEvent,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
+import { RecrawlLinkInitiatedEvent } from "@packages/hutch-infra-components";
 
 interface RecrawlLinkInitiatedDlqHandlerDeps {
-	markCrawlFailed: MarkCrawlFailed;
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
@@ -19,7 +18,7 @@ interface RecrawlLinkInitiatedDlqHandlerDeps {
 export function initRecrawlLinkInitiatedDlqHandler(
 	deps: RecrawlLinkInitiatedDlqHandlerDeps,
 ): Handler<SQSEvent, SQSBatchResponse> {
-	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -31,18 +30,14 @@ export function initRecrawlLinkInitiatedDlqHandler(
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[RecrawlLinkInitiatedDlq] marking crawl failed", {
+				logger.info("[RecrawlLinkInitiatedDlq] marking crawl exhausted", {
 					url: detail.url,
 					receiveCount,
 				});
 
-				await markCrawlFailed({ url: detail.url, reason });
-				await markSummaryFailed({ url: detail.url, reason: "crawl failed" });
-
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url, reason, receiveCount }),
+				await transitionAndPersist(markCrawlExhausted, {
+					url: detail.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[RecrawlLinkInitiatedDlq] record failed", {

--- a/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.test.ts
@@ -1,8 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveAnonymousLinkDlqHandler } from "./save-anonymous-link-dlq-handler";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
@@ -49,15 +48,13 @@ function createSqsEvent(
 }
 
 describe("initSaveAnonymousLinkDlqHandler", () => {
-	it("marks the crawl and summary as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches the markCrawlExhausted transition with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockResolvedValue(undefined);
 
 		const handler = initSaveAnonymousLinkDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -67,34 +64,21 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(markSummaryFailed).toHaveBeenCalledWith({
-			url: "https://example.com/failed",
-			reason: "crawl failed",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 2,
-			}),
+			},
 		});
 	});
 
-	it("reports the record as a batch failure on invalid command envelope (Zod failure)", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn();
-		const markSummaryFailed: MarkSummaryFailed = jest.fn();
-		const publishEvent: PublishEvent = jest.fn();
+	it("reports the record as a batch failure on invalid command envelope (Zod failure) and does NOT dispatch the transition", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest.fn();
 
 		const handler = initSaveAnonymousLinkDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -114,8 +98,25 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 
 		const result = await handler(invalidEvent, stubContext, () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).not.toHaveBeenCalled();
-		expect(markSummaryFailed).not.toHaveBeenCalled();
-		expect(publishEvent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled"));
+
+		const handler = initSaveAnonymousLinkDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed" }),
+			stubContext,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/save-anonymous-link-dlq-handler.ts
@@ -1,17 +1,16 @@
-import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import {
-	CrawlArticleFailedEvent,
-	SaveAnonymousLinkCommand,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
+import { SaveAnonymousLinkCommand } from "@packages/hutch-infra-components";
 
 interface SaveAnonymousLinkDlqHandlerDeps {
-	markCrawlFailed: MarkCrawlFailed;
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
@@ -19,7 +18,7 @@ interface SaveAnonymousLinkDlqHandlerDeps {
 export function initSaveAnonymousLinkDlqHandler(
 	deps: SaveAnonymousLinkDlqHandlerDeps,
 ): Handler<SQSEvent, SQSBatchResponse> {
-	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -31,18 +30,14 @@ export function initSaveAnonymousLinkDlqHandler(
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[SaveAnonymousLinkDlq] marking crawl failed", {
+				logger.info("[SaveAnonymousLinkDlq] marking crawl exhausted", {
 					url: command.url,
 					receiveCount,
 				});
 
-				await markCrawlFailed({ url: command.url, reason });
-				await markSummaryFailed({ url: command.url, reason: "crawl failed" });
-
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({ url: command.url, reason, receiveCount }),
+				await transitionAndPersist(markCrawlExhausted, {
+					url: command.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[SaveAnonymousLinkDlq] record failed", {

--- a/projects/save-link/src/crawl-article-state/save-link-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-dlq-handler.test.ts
@@ -1,8 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveLinkDlqHandler } from "./save-link-dlq-handler";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
@@ -49,15 +48,13 @@ function createSqsEvent(
 }
 
 describe("initSaveLinkDlqHandler", () => {
-	it("marks the crawl and summary as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches the markCrawlExhausted transition with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockResolvedValue(undefined);
 
 		const handler = initSaveLinkDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -67,34 +64,21 @@ describe("initSaveLinkDlqHandler", () => {
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(markSummaryFailed).toHaveBeenCalledWith({
-			url: "https://example.com/failed",
-			reason: "crawl failed",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 4,
-			}),
+			},
 		});
 	});
 
-	it("reports the record as a batch failure on invalid command envelope (Zod failure)", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn();
-		const markSummaryFailed: MarkSummaryFailed = jest.fn();
-		const publishEvent: PublishEvent = jest.fn();
+	it("reports the record as a batch failure on invalid command envelope (Zod failure) and does NOT dispatch the transition", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest.fn();
 
 		const handler = initSaveLinkDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -114,8 +98,25 @@ describe("initSaveLinkDlqHandler", () => {
 
 		const result = await handler(invalidEvent, stubContext, () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).not.toHaveBeenCalled();
-		expect(markSummaryFailed).not.toHaveBeenCalled();
-		expect(publishEvent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled"));
+
+		const handler = initSaveLinkDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed", userId: "user-1" }),
+			stubContext,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/crawl-article-state/save-link-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-dlq-handler.ts
@@ -1,23 +1,24 @@
-import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import {
-	CrawlArticleFailedEvent,
-	SaveLinkCommand,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
+import { SaveLinkCommand } from "@packages/hutch-infra-components";
 
 interface SaveLinkDlqHandlerDeps {
-	markCrawlFailed: MarkCrawlFailed;
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
-export function initSaveLinkDlqHandler(deps: SaveLinkDlqHandlerDeps): Handler<SQSEvent, SQSBatchResponse> {
-	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
+export function initSaveLinkDlqHandler(
+	deps: SaveLinkDlqHandlerDeps,
+): Handler<SQSEvent, SQSBatchResponse> {
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -29,18 +30,14 @@ export function initSaveLinkDlqHandler(deps: SaveLinkDlqHandlerDeps): Handler<SQ
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[SaveLinkDlq] marking crawl failed", {
+				logger.info("[SaveLinkDlq] marking crawl exhausted", {
 					url: command.url,
 					receiveCount,
 				});
 
-				await markCrawlFailed({ url: command.url, reason });
-				await markSummaryFailed({ url: command.url, reason: "crawl failed" });
-
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({ url: command.url, reason, receiveCount }),
+				await transitionAndPersist(markCrawlExhausted, {
+					url: command.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[SaveLinkDlq] record failed", {

--- a/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.test.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.test.ts
@@ -1,8 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveLinkRawHtmlDlqHandler } from "./save-link-raw-html-dlq-handler";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
@@ -49,15 +48,13 @@ function createSqsEvent(
 }
 
 describe("initSaveLinkRawHtmlDlqHandler", () => {
-	it("marks the crawl and summary as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches the markCrawlExhausted transition with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockResolvedValue(undefined);
 
 		const handler = initSaveLinkRawHtmlDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -67,34 +64,21 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(markSummaryFailed).toHaveBeenCalledWith({
-			url: "https://example.com/failed",
-			reason: "crawl failed",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 4,
-			}),
+			},
 		});
 	});
 
-	it("reports the record as a batch failure on invalid command envelope (Zod failure)", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn();
-		const markSummaryFailed: MarkSummaryFailed = jest.fn();
-		const publishEvent: PublishEvent = jest.fn();
+	it("reports the record as a batch failure on invalid command envelope (Zod failure) and does NOT dispatch the transition", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest.fn();
 
 		const handler = initSaveLinkRawHtmlDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -114,8 +98,25 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 
 		const result = await handler(invalidEvent, stubContext, () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).not.toHaveBeenCalled();
-		expect(markSummaryFailed).not.toHaveBeenCalled();
-		expect(publishEvent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist: TransitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled"));
+
+		const handler = initSaveLinkRawHtmlDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed", userId: "user-1" }),
+			stubContext,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.ts
+++ b/projects/save-link/src/crawl-article-state/save-link-raw-html-dlq-handler.ts
@@ -1,23 +1,24 @@
-import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import {
-	CrawlArticleFailedEvent,
-	SaveLinkRawHtmlCommand,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed } from "./article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
+import { markCrawlExhausted } from "@packages/domain/article-aggregate";
+import { SaveLinkRawHtmlCommand } from "@packages/hutch-infra-components";
 
 interface SaveLinkRawHtmlDlqHandlerDeps {
-	markCrawlFailed: MarkCrawlFailed;
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
-export function initSaveLinkRawHtmlDlqHandler(deps: SaveLinkRawHtmlDlqHandlerDeps): Handler<SQSEvent, SQSBatchResponse> {
-	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
+export function initSaveLinkRawHtmlDlqHandler(
+	deps: SaveLinkRawHtmlDlqHandlerDeps,
+): Handler<SQSEvent, SQSBatchResponse> {
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -29,18 +30,14 @@ export function initSaveLinkRawHtmlDlqHandler(deps: SaveLinkRawHtmlDlqHandlerDep
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[SaveLinkRawHtmlDlq] marking crawl failed", {
+				logger.info("[SaveLinkRawHtmlDlq] marking crawl exhausted", {
 					url: command.url,
 					receiveCount,
 				});
 
-				await markCrawlFailed({ url: command.url, reason });
-				await markSummaryFailed({ url: command.url, reason: "crawl failed" });
-
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({ url: command.url, reason, receiveCount }),
+				await transitionAndPersist(markCrawlExhausted, {
+					url: command.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[SaveLinkRawHtmlDlq] record failed", {

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -160,15 +160,27 @@ const saveLinkCommandLambdaWithSQS = new HutchSQSBackedLambda("save-link-command
 eventBus.subscribe(SaveLinkCommand, saveLinkCommandLambdaWithSQS);
 
 // --- SaveLinkCommand DLQ consumer ---
-// Flips crawlStatus to "failed" and publishes CrawlArticleFailedEvent when a
-// SaveLinkCommand message exhausts maxReceiveCount. The HutchSQSBackedLambda
-// above already wires the DLQ-arrival CloudWatch alarm + admin email.
+// Drives the markCrawlExhausted aggregate transition: flips crawl + summary
+// to failed in one atomic save and publishes CrawlArticleFailedEvent. The
+// HutchSQSBackedLambda above already wires the DLQ-arrival CloudWatch alarm
+// + admin email. The aggregate's `store.load` needs GetItem in addition to
+// UpdateItem; the effect dispatcher is wired with the generate-summary SQS
+// queue so a future transition change at this callsite cannot regress
+// without re-wiring infra.
 new HutchDLQEventHandler("save-link-dlq", {
 	sourceQueue: saveLinkCommandQueue,
 	tableArn: articlesTableArn,
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: generateSummaryQueue.policies.map((p) => ({
+		...p,
+		name: `save-link-dlq-${p.name}`,
+	})),
 });
 
 // --- SaveLinkRawHtmlCommand handler ---
@@ -214,16 +226,23 @@ const saveLinkRawHtmlCommandLambdaWithSQS = new HutchSQSBackedLambda("save-link-
 eventBus.subscribe(SaveLinkRawHtmlCommand, saveLinkRawHtmlCommandLambdaWithSQS);
 
 // --- SaveLinkRawHtmlCommand DLQ consumer ---
-// Mirrors save-link-dlq: flips crawlStatus to "failed" and publishes
-// CrawlArticleFailedEvent when a SaveLinkRawHtmlCommand message exhausts
-// maxReceiveCount. The HutchSQSBackedLambda above already wires the
-// DLQ-arrival CloudWatch alarm + admin email.
+// Mirrors save-link-dlq: drives the markCrawlExhausted aggregate transition
+// after maxReceiveCount on the raw-HTML save chain. See save-link-dlq above
+// for the same env/policy rationale.
 new HutchDLQEventHandler("save-link-raw-html-dlq", {
 	sourceQueue: saveLinkRawHtmlCommandQueue,
 	tableArn: articlesTableArn,
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: generateSummaryQueue.policies.map((p) => ({
+		...p,
+		name: `save-link-raw-html-dlq-${p.name}`,
+	})),
 });
 
 // --- SaveAnonymousLinkCommand handler ---
@@ -265,12 +284,22 @@ const saveAnonymousLinkCommandLambdaWithSQS = new HutchSQSBackedLambda("save-ano
 eventBus.subscribe(SaveAnonymousLinkCommand, saveAnonymousLinkCommandLambdaWithSQS);
 
 // --- SaveAnonymousLinkCommand DLQ consumer ---
+// Drives the markCrawlExhausted aggregate transition for the anonymous
+// /view auto-heal chain. See save-link-dlq for env/policy rationale.
 new HutchDLQEventHandler("save-anonymous-link-dlq", {
 	sourceQueue: saveAnonymousLinkCommandQueue,
 	tableArn: articlesTableArn,
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: generateSummaryQueue.policies.map((p) => ({
+		...p,
+		name: `save-anonymous-link-dlq-${p.name}`,
+	})),
 });
 
 // --- StaleCheckRequested handler ---
@@ -528,12 +557,22 @@ const recrawlLinkInitiatedLambdaWithSQS = new HutchSQSBackedLambda("recrawl-link
 eventBus.subscribe(RecrawlLinkInitiatedEvent, recrawlLinkInitiatedLambdaWithSQS);
 
 // --- RecrawlLinkInitiated DLQ consumer ---
+// Drives the markCrawlExhausted aggregate transition for the admin recrawl
+// chain. See save-link-dlq for env/policy rationale.
 new HutchDLQEventHandler("recrawl-link-initiated-dlq", {
 	sourceQueue: recrawlLinkInitiatedQueue,
 	tableArn: articlesTableArn,
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: generateSummaryQueue.policies.map((p) => ({
+		...p,
+		name: `recrawl-link-initiated-dlq-${p.name}`,
+	})),
 });
 
 // --- RecrawlContentExtracted handler ---

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -676,7 +676,7 @@ const refreshArticleContentQueue = new HutchSQS("refresh-article-content", {
 
 const refreshArticleContentDynamodb = new HutchDynamoDBAccess("refresh-article-content-dynamodb", {
 	tables: [{ arn: articlesTableArn, includeIndexes: false }],
-	actions: ["dynamodb:UpdateItem"],
+	actions: ["dynamodb:GetItem", "dynamodb:UpdateItem"],
 });
 
 const refreshArticleContentLambda = new HutchLambda("refresh-article-content", {
@@ -687,6 +687,7 @@ const refreshArticleContentLambda = new HutchLambda("refresh-article-content", {
 	timeout: 30,
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
+		EVENT_BUS_NAME: eventBus.eventBusName,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
@@ -694,6 +695,8 @@ const refreshArticleContentLambda = new HutchLambda("refresh-article-content", {
 		...generateSummaryQueue.policies.map((p) => ({ ...p, name: `refresh-${p.name}` })),
 	],
 });
+
+eventBus.grantPublish(refreshArticleContentLambda);
 
 const refreshArticleContentWithSQS = new HutchSQSBackedLambda("refresh-article-content", {
 	lambda: refreshArticleContentLambda,

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -160,13 +160,6 @@ const saveLinkCommandLambdaWithSQS = new HutchSQSBackedLambda("save-link-command
 eventBus.subscribe(SaveLinkCommand, saveLinkCommandLambdaWithSQS);
 
 // --- SaveLinkCommand DLQ consumer ---
-// Drives the markCrawlExhausted aggregate transition: flips crawl + summary
-// to failed in one atomic save and publishes CrawlArticleFailedEvent. The
-// HutchSQSBackedLambda above already wires the DLQ-arrival CloudWatch alarm
-// + admin email. The aggregate's `store.load` needs GetItem in addition to
-// UpdateItem; the effect dispatcher is wired with the generate-summary SQS
-// queue so a future transition change at this callsite cannot regress
-// without re-wiring infra.
 new HutchDLQEventHandler("save-link-dlq", {
 	sourceQueue: saveLinkCommandQueue,
 	tableArn: articlesTableArn,
@@ -226,9 +219,6 @@ const saveLinkRawHtmlCommandLambdaWithSQS = new HutchSQSBackedLambda("save-link-
 eventBus.subscribe(SaveLinkRawHtmlCommand, saveLinkRawHtmlCommandLambdaWithSQS);
 
 // --- SaveLinkRawHtmlCommand DLQ consumer ---
-// Mirrors save-link-dlq: drives the markCrawlExhausted aggregate transition
-// after maxReceiveCount on the raw-HTML save chain. See save-link-dlq above
-// for the same env/policy rationale.
 new HutchDLQEventHandler("save-link-raw-html-dlq", {
 	sourceQueue: saveLinkRawHtmlCommandQueue,
 	tableArn: articlesTableArn,
@@ -284,8 +274,6 @@ const saveAnonymousLinkCommandLambdaWithSQS = new HutchSQSBackedLambda("save-ano
 eventBus.subscribe(SaveAnonymousLinkCommand, saveAnonymousLinkCommandLambdaWithSQS);
 
 // --- SaveAnonymousLinkCommand DLQ consumer ---
-// Drives the markCrawlExhausted aggregate transition for the anonymous
-// /view auto-heal chain. See save-link-dlq for env/policy rationale.
 new HutchDLQEventHandler("save-anonymous-link-dlq", {
 	sourceQueue: saveAnonymousLinkCommandQueue,
 	tableArn: articlesTableArn,
@@ -557,8 +545,6 @@ const recrawlLinkInitiatedLambdaWithSQS = new HutchSQSBackedLambda("recrawl-link
 eventBus.subscribe(RecrawlLinkInitiatedEvent, recrawlLinkInitiatedLambdaWithSQS);
 
 // --- RecrawlLinkInitiated DLQ consumer ---
-// Drives the markCrawlExhausted aggregate transition for the admin recrawl
-// chain. See save-link-dlq for env/policy rationale.
 new HutchDLQEventHandler("recrawl-link-initiated-dlq", {
 	sourceQueue: recrawlLinkInitiatedQueue,
 	tableArn: articlesTableArn,

--- a/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
@@ -1,19 +1,25 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { SQSClient } from "@aws-sdk/client-sqs";
-import OpenAI from "openai";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
-import { EventBridgeClient, initEventBridgePublisher, initSqsCommandDispatcher } from "@packages/hutch-infra-components/runtime";
-import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import OpenAI from "openai";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { requireEnv } from "../require-env";
-import { initReadTierSource } from "../select-content/read-tier-source";
+import { initFindContentSourceTier } from "../select-content/find-content-source-tier";
 import { initListAvailableTierSources } from "../select-content/list-available-tier-sources";
+import { initPromoteTierToCanonical } from "../select-content/promote-tier-to-canonical";
+import { initReadTierSource } from "../select-content/read-tier-source";
+import { initRecrawlContentExtractedHandler } from "../select-content/recrawl-content-extracted-handler";
 import { initSelectMostCompleteContent } from "../select-content/select-content";
 import { SELECT_CONTENT_TIMEOUTS } from "../select-content/timeouts";
-import { initPromoteTierToCanonical } from "../select-content/promote-tier-to-canonical";
-import { initFindContentSourceTier } from "../select-content/find-content-source-tier";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initRecrawlContentExtractedHandler } from "../select-content/recrawl-content-extracted-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
@@ -57,10 +63,9 @@ const { findContentSourceTier } = initFindContentSourceTier({
 	tableName: articlesTable,
 });
 
-const { markCrawlReady } = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
 const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
@@ -74,14 +79,22 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
 export const handler = initRecrawlContentExtractedHandler({
 	listAvailableTierSources,
 	selectMostCompleteContent,
 	promoteTierToCanonical,
 	findContentSourceTier,
-	markCrawlReady,
-	dispatchGenerateSummary,
-	publishEvent,
+	transitionAndPersist,
 	imagesCdnBaseUrl,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/recrawl-link-initiated-dlq.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated-dlq.main.ts
@@ -1,25 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { requireEnv } from "../require-env";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { initRecrawlLinkInitiatedDlqHandler } from "../crawl-article-state/recrawl-link-initiated-dlq-handler";
+import { requireEnv } from "../require-env";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const crawlStore = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
-const summaryStore = initDynamoDbGeneratedSummary({
-	client: dynamoClient,
-	tableName: articlesTable,
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -27,9 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initRecrawlLinkInitiatedDlqHandler({
-	markCrawlFailed: crawlStore.markCrawlFailed,
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initRecrawlLinkInitiatedDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/refresh-article-content.main.ts
+++ b/projects/save-link/src/runtime/refresh-article-content.main.ts
@@ -1,7 +1,11 @@
 import { SQSClient } from "@aws-sdk/client-sqs";
 import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
-import { initSqsCommandDispatcher } from "@packages/hutch-infra-components/runtime";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
@@ -10,6 +14,7 @@ import { requireEnv } from "../require-env";
 import { initRefreshArticleContentHandler } from "../save-link/refresh-article-content-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
+const eventBusName = requireEnv("EVENT_BUS_NAME");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const client = createDynamoDocumentClient();
@@ -26,8 +31,14 @@ const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
 	command: GenerateSummaryCommand,
 });
 
+const { publishEvent } = initEventBridgePublisher({
+	client: new EventBridgeClient({}),
+	eventBusName,
+});
+
 const { dispatchEffect } = initLambdaEffectDispatcher({
 	dispatchGenerateSummary,
+	publishEvent,
 });
 
 const { transitionAndPersist } = initTransitionAndPersist({

--- a/projects/save-link/src/runtime/save-anonymous-link-dlq.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-dlq.main.ts
@@ -1,25 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { requireEnv } from "../require-env";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { initSaveAnonymousLinkDlqHandler } from "../crawl-article-state/save-anonymous-link-dlq-handler";
+import { requireEnv } from "../require-env";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const crawlStore = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
-const summaryStore = initDynamoDbGeneratedSummary({
-	client: dynamoClient,
-	tableName: articlesTable,
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -27,9 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initSaveAnonymousLinkDlqHandler({
-	markCrawlFailed: crawlStore.markCrawlFailed,
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initSaveAnonymousLinkDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/save-link-dlq.main.ts
+++ b/projects/save-link/src/runtime/save-link-dlq.main.ts
@@ -1,25 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { requireEnv } from "../require-env";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { initSaveLinkDlqHandler } from "../crawl-article-state/save-link-dlq-handler";
+import { requireEnv } from "../require-env";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const crawlStore = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
-const summaryStore = initDynamoDbGeneratedSummary({
-	client: dynamoClient,
-	tableName: articlesTable,
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -27,9 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initSaveLinkDlqHandler({
-	markCrawlFailed: crawlStore.markCrawlFailed,
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initSaveLinkDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/save-link-raw-html-dlq.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-dlq.main.ts
@@ -1,25 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { requireEnv } from "../require-env";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { initSaveLinkRawHtmlDlqHandler } from "../crawl-article-state/save-link-raw-html-dlq-handler";
+import { requireEnv } from "../require-env";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const crawlStore = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
-const summaryStore = initDynamoDbGeneratedSummary({
-	client: dynamoClient,
-	tableName: articlesTable,
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -27,9 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initSaveLinkRawHtmlDlqHandler({
-	markCrawlFailed: crawlStore.markCrawlFailed,
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initSaveLinkRawHtmlDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/save-link/refresh-article-content-handler.test.ts
+++ b/projects/save-link/src/save-link/refresh-article-content-handler.test.ts
@@ -1,4 +1,8 @@
-import type { Article, Effect } from "@packages/domain/article-aggregate";
+import type {
+	Article,
+	ArticleStore,
+	Effect,
+} from "@packages/domain/article-aggregate";
 import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import { noopLogger } from "@packages/hutch-logger";
 import {
@@ -153,11 +157,11 @@ describe("initRefreshArticleContentHandler (aggregate-driven)", () => {
 		const articleStore = initInMemoryArticleStore();
 		articleStore.seed(seededArticle(URL));
 
-		const wrappedStore = {
+		const wrappedStore: ArticleStore = {
 			load: articleStore.load,
-			save: async (article: Article) => {
-				order.push(`save:${article.summary.kind}`);
-				await articleStore.save(article);
+			save: async (params) => {
+				order.push(`save:${params.article.summary.kind}`);
+				await articleStore.save(params);
 			},
 		};
 		const { dispatchEffect: realDispatch } = initInMemoryEffectDispatcher();

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
@@ -1,4 +1,8 @@
 import { noopLogger } from "@packages/hutch-logger";
+import {
+	recrawlPromoteTier,
+	recrawlTieKeptCanonical,
+} from "@packages/domain/article-aggregate";
 import { initRecrawlContentExtractedHandler } from "./recrawl-content-extracted-handler";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
@@ -71,9 +75,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		selectMostCompleteContent: jest.fn<ReturnType<SelectMostCompleteContent>, Parameters<SelectMostCompleteContent>>().mockResolvedValue({ winner: "tie", reason: "" }),
 		promoteTierToCanonical: jest.fn<ReturnType<PromoteTierToCanonical>, Parameters<PromoteTierToCanonical>>().mockResolvedValue(undefined),
 		findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
-		markCrawlReady: jest.fn().mockResolvedValue(undefined),
-		dispatchGenerateSummary: jest.fn().mockResolvedValue(undefined),
-		publishEvent: jest.fn().mockResolvedValue(undefined),
+		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
 		logger: noopLogger,
 		...overrides,
@@ -95,21 +97,18 @@ describe("initRecrawlContentExtractedHandler", () => {
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(deps.promoteTierToCanonical).not.toHaveBeenCalled();
-		expect(deps.dispatchGenerateSummary).not.toHaveBeenCalled();
-		expect(deps.publishEvent).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
 	});
 
-	it("with one tier source, promotes it and dispatches GenerateSummaryCommand", async () => {
+	it("with one tier source, promotes it and dispatches the recrawlPromoteTier aggregate transition (GenerateSummary + RecrawlCompleted effects)", async () => {
 		const tier1 = tierSource("tier-1");
 		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
-		const publishEvent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
 			promoteTierToCanonical,
-			dispatchGenerateSummary,
-			publishEvent,
+			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
@@ -119,38 +118,33 @@ describe("initRecrawlContentExtractedHandler", () => {
 			tier: "tier-1",
 			metadata: tier1.metadata,
 		});
-		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/a" });
-		expect(publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({ detailType: "RecrawlCompleted" }),
-		);
+		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
+			url: "https://example.com/a",
+			input: { winnerTier: "tier-1" },
+		});
 	});
 
-	it("on a tie with an existing canonical, keeps canonical unchanged, flips crawlStatus back to 'ready' (the canary unsticks here), and still dispatches GenerateSummaryCommand", async () => {
+	it("on a tie with an existing canonical, skips promotion and dispatches the recrawlTieKeptCanonical aggregate transition (one save flips crawl=ready AND emits the same effects)", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
 		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const markCrawlReady = jest.fn().mockResolvedValue(undefined);
-		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
-		const publishEvent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
 			promoteTierToCanonical,
-			markCrawlReady,
-			dispatchGenerateSummary,
-			publishEvent,
+			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
 		expect(promoteTierToCanonical).not.toHaveBeenCalled();
-		expect(markCrawlReady).toHaveBeenCalledWith({ url: "https://example.com/a" });
-		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/a" });
-		expect(publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({ detailType: "RecrawlCompleted" }),
-		);
+		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
+			url: "https://example.com/a",
+			input: undefined,
+		});
 	});
 
 	it("on a tie, breaks in favour of the candidate with more CDN-host URLs even when canonical exists", async () => {
@@ -182,18 +176,18 @@ describe("initRecrawlContentExtractedHandler", () => {
 		});
 	});
 
-	it("on a tie with no canonical (recovering a stuck row), defaults to tier-1 and promotes so summary generation can find content", async () => {
+	it("on a tie with no canonical (recovering a stuck row), defaults to tier-1 and dispatches recrawlPromoteTier so summary generation can find content", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
 		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "identical content" }),
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 			promoteTierToCanonical,
-			dispatchGenerateSummary,
+			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
@@ -203,7 +197,10 @@ describe("initRecrawlContentExtractedHandler", () => {
 			tier: "tier-1",
 			metadata: tier1.metadata,
 		});
-		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/a" });
+		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
+			url: "https://example.com/a",
+			input: { winnerTier: "tier-1" },
+		});
 	});
 
 	it("tie with no canonical and only tier-0 sources available falls back to tier-0", async () => {
@@ -225,17 +222,17 @@ describe("initRecrawlContentExtractedHandler", () => {
 		);
 	});
 
-	it("with multiple sources and a definite winner, promotes the winner and dispatches summary", async () => {
+	it("with multiple sources and a definite winner, promotes the winner and dispatches recrawlPromoteTier", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
 		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-1", reason: "more complete" }),
 			promoteTierToCanonical,
-			dispatchGenerateSummary,
+			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
@@ -245,6 +242,9 @@ describe("initRecrawlContentExtractedHandler", () => {
 			tier: "tier-1",
 			metadata: tier1.metadata,
 		});
-		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/a" });
+		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
+			url: "https://example.com/a",
+			input: { winnerTier: "tier-1" },
+		});
 	});
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
@@ -1,13 +1,17 @@
 import assert from "node:assert";
-import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { DispatchCommand, PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
-	type GenerateSummaryCommand,
-	RecrawlContentExtractedEvent,
-	RecrawlCompletedEvent,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlReady } from "../crawl-article-state/article-crawl.types";
+	type TransitionAndPersist,
+	recrawlPromoteTier,
+	recrawlTieKeptCanonical,
+} from "@packages/domain/article-aggregate";
+import { RecrawlContentExtractedEvent } from "@packages/hutch-infra-components";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
 import type { PromoteTierToCanonical } from "./promote-tier-to-canonical";
@@ -19,9 +23,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 	selectMostCompleteContent: SelectMostCompleteContent;
 	promoteTierToCanonical: PromoteTierToCanonical;
 	findContentSourceTier: FindContentSourceTier;
-	markCrawlReady: MarkCrawlReady;
-	dispatchGenerateSummary: DispatchCommand<typeof GenerateSummaryCommand>;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	imagesCdnBaseUrl: string;
 	logger: HutchLogger;
 }): Handler<SQSEvent, SQSBatchResponse> {
@@ -30,9 +32,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 		selectMostCompleteContent,
 		promoteTierToCanonical,
 		findContentSourceTier,
-		markCrawlReady,
-		dispatchGenerateSummary,
-		publishEvent,
+		transitionAndPersist,
 		imagesCdnBaseUrl,
 		logger,
 	} = deps;
@@ -98,8 +98,11 @@ export function initRecrawlContentExtractedHandler(deps: {
 							reason = cdnTie.reason;
 						} else if (existingTier) {
 							/* Recrawl tie + canonical already set: keep canonical
-							 * exactly as-is; the operator still gets a fresh summary
-							 * via the unconditional dispatchGenerateSummary below. */
+							 * exactly as-is; the aggregate's recrawlTieKeptCanonical
+							 * transition flips the crawl row to ready and emits
+							 * GenerateSummary + RecrawlCompleted effects together.
+							 * Skipping promotion is encoded by `winnerTier ===
+							 * undefined` and is handled below. */
 							winnerTier = undefined;
 							reason = decision.reason;
 						} else {
@@ -137,30 +140,34 @@ export function initRecrawlContentExtractedHandler(deps: {
 						tier: winnerTier,
 						reason,
 					});
+
+					/* The recrawlPromoteTier aggregate transition pairs the
+					 * crawl-ready flip with both effects (generate-summary,
+					 * publish-recrawl-completed) in one save+dispatch — a future
+					 * branch that returns before invoking it would leave the row
+					 * in a partial state, which is exactly the cross-axis writer
+					 * pathology Phase 2 is betting it can eliminate. */
+					await transitionAndPersist(recrawlPromoteTier, {
+						url: detail.url,
+						input: { winnerTier },
+					});
 				} else {
-					// Tie + canonical preserved: promoteTierToCanonical (the only writer
-					// of crawlStatus="ready") was skipped, so we must flip the row back
-					// out of the "pending" state that admin/recrawl's
-					// forceMarkCrawlPending unconditionally wrote — otherwise readers
-					// (and the Tier 1+ canary) poll a forever-"pending" row that never
-					// resolves, since the canonical content is already on disk.
-					await markCrawlReady({ url: detail.url });
+					/* Tie + canonical preserved: promoteTierToCanonical (the only
+					 * tier-promoting writer of crawlStatus="ready") was skipped,
+					 * so the aggregate's recrawlTieKeptCanonical transition flips
+					 * the row back out of the "pending" state that admin/recrawl's
+					 * forceMarkCrawlPending unconditionally wrote, and pairs it
+					 * with the same generate-summary + publish-recrawl-completed
+					 * effects so the operator always sees a fresh AI excerpt. */
+					await transitionAndPersist(recrawlTieKeptCanonical, {
+						url: detail.url,
+						input: undefined,
+					});
 					logger.info("[RecrawlContentExtracted] tie kept canonical unchanged", {
 						url: detail.url,
 						reason,
 					});
 				}
-
-				/* Always dispatch — the user-save chain gates this on canonical
-				 * change to dedup re-saves; recrawl explicitly opts out so the
-				 * operator gets a fresh AI excerpt every time. */
-				await dispatchGenerateSummary({ url: detail.url });
-
-				await publishEvent({
-					source: RecrawlCompletedEvent.source,
-					detailType: RecrawlCompletedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url }),
-				});
 			} catch (error) {
 				logger.error("[RecrawlContentExtracted] record failed", {
 					messageId: record.messageId,

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
@@ -97,12 +97,6 @@ export function initRecrawlContentExtractedHandler(deps: {
 							winnerTier = cdnTie.tier;
 							reason = cdnTie.reason;
 						} else if (existingTier) {
-							/* Recrawl tie + canonical already set: keep canonical
-							 * exactly as-is; the aggregate's recrawlTieKeptCanonical
-							 * transition flips the crawl row to ready and emits
-							 * GenerateSummary + RecrawlCompleted effects together.
-							 * Skipping promotion is encoded by `winnerTier ===
-							 * undefined` and is handled below. */
 							winnerTier = undefined;
 							reason = decision.reason;
 						} else {
@@ -141,24 +135,11 @@ export function initRecrawlContentExtractedHandler(deps: {
 						reason,
 					});
 
-					/* The recrawlPromoteTier aggregate transition pairs the
-					 * crawl-ready flip with both effects (generate-summary,
-					 * publish-recrawl-completed) in one save+dispatch — a future
-					 * branch that returns before invoking it would leave the row
-					 * in a partial state, which is exactly the cross-axis writer
-					 * pathology Phase 2 is betting it can eliminate. */
 					await transitionAndPersist(recrawlPromoteTier, {
 						url: detail.url,
 						input: { winnerTier },
 					});
 				} else {
-					/* Tie + canonical preserved: promoteTierToCanonical (the only
-					 * tier-promoting writer of crawlStatus="ready") was skipped,
-					 * so the aggregate's recrawlTieKeptCanonical transition flips
-					 * the row back out of the "pending" state that admin/recrawl's
-					 * forceMarkCrawlPending unconditionally wrote, and pairs it
-					 * with the same generate-summary + publish-recrawl-completed
-					 * effects so the operator always sees a fresh AI excerpt. */
 					await transitionAndPersist(recrawlTieKeptCanonical, {
 						url: detail.url,
 						input: undefined,

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
@@ -7,6 +7,7 @@ describe("checkTerminalState", () => {
 		const result = checkTerminalState({
 			summaryStatus: "ready",
 			crawlStatus: "ready",
+			aggregateTransitionName: undefined,
 		});
 		assert.deepStrictEqual(result, { terminal: true });
 	});
@@ -15,6 +16,7 @@ describe("checkTerminalState", () => {
 		const result = checkTerminalState({
 			summaryStatus: "skipped",
 			crawlStatus: "ready",
+			aggregateTransitionName: undefined,
 		});
 		assert.deepStrictEqual(result, { terminal: true });
 	});
@@ -23,6 +25,7 @@ describe("checkTerminalState", () => {
 		const result = checkTerminalState({
 			summaryStatus: "pending",
 			crawlStatus: "ready",
+			aggregateTransitionName: undefined,
 		});
 		assert.deepStrictEqual(result, {
 			terminal: false,
@@ -34,6 +37,7 @@ describe("checkTerminalState", () => {
 		const result = checkTerminalState({
 			summaryStatus: "pending",
 			crawlStatus: "pending",
+			aggregateTransitionName: undefined,
 		});
 		assert.equal(result.terminal, false);
 		assert.equal(
@@ -46,12 +50,14 @@ describe("checkTerminalState", () => {
 		const failedCrawl = checkTerminalState({
 			summaryStatus: "ready",
 			crawlStatus: "failed",
+			aggregateTransitionName: undefined,
 		});
 		assert.deepStrictEqual(failedCrawl, { terminal: true });
 
 		const unsupportedCrawl = checkTerminalState({
 			summaryStatus: "skipped",
 			crawlStatus: "unsupported",
+			aggregateTransitionName: undefined,
 		});
 		assert.deepStrictEqual(unsupportedCrawl, { terminal: true });
 	});
@@ -60,7 +66,21 @@ describe("checkTerminalState", () => {
 		const result = checkTerminalState({
 			summaryStatus: undefined,
 			crawlStatus: undefined,
+			aggregateTransitionName: undefined,
 		});
 		assert.deepStrictEqual(result, { terminal: true });
+	});
+
+	it("surfaces the -after-aggregate-migration message for a stuck row produced by a Phase 2 transition (falsifiable measurement)", () => {
+		const result = checkTerminalState({
+			summaryStatus: "ready",
+			crawlStatus: "pending",
+			aggregateTransitionName: "recrawlTieKeptCanonical",
+		});
+		assert.equal(result.terminal, false);
+		assert.match(
+			result.terminal === false ? result.message : "",
+			/Phase 2 aggregate transition/,
+		);
 	});
 });

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
@@ -4,13 +4,23 @@ import { type StuckReason, classifyRow } from "./classify-row";
 type ArticleStateFields = {
 	summaryStatus: SummaryStatus | undefined;
 	crawlStatus: CrawlStatus | undefined;
+	aggregateTransitionName: string | undefined;
 };
 
 type TerminalCheckResult = { terminal: true } | { terminal: false; message: string };
 
+/**
+ * "-after-aggregate-migration" variants spell out the Phase 2 falsifiable
+ * measurement context so an operator reading the canary report knows the
+ * row implicates the migration plan, not generic backlog drift.
+ */
 const REASON_MESSAGES: Record<StuckReason, string> = {
 	"summary-pending": "summaryStatus is 'pending' — summary worker never produced a terminal outcome",
 	"crawl-pending": "crawlStatus is 'pending' — crawl worker never produced a terminal outcome",
+	"summary-pending-after-aggregate-migration":
+		"summaryStatus is 'pending' after a Phase 2 aggregate transition wrote this row — the migration was supposed to flip both axes to terminal in one save; non-zero counts here falsify the Phase 2 hypothesis",
+	"crawl-pending-after-aggregate-migration":
+		"crawlStatus is 'pending' after a Phase 2 aggregate transition wrote this row — the migration was supposed to flip the crawl axis to terminal/ready in one save; non-zero counts here falsify the Phase 2 hypothesis",
 };
 
 export function checkTerminalState(fields: ArticleStateFields): TerminalCheckResult {

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
@@ -9,11 +9,6 @@ type ArticleStateFields = {
 
 type TerminalCheckResult = { terminal: true } | { terminal: false; message: string };
 
-/**
- * "-after-aggregate-migration" variants spell out the Phase 2 falsifiable
- * measurement context so an operator reading the canary report knows the
- * row implicates the migration plan, not generic backlog drift.
- */
 const REASON_MESSAGES: Record<StuckReason, string> = {
 	"summary-pending": "summaryStatus is 'pending' — summary worker never produced a terminal outcome",
 	"crawl-pending": "crawlStatus is 'pending' — crawl worker never produced a terminal outcome",

--- a/src/packages/check-stuck-articles/scripts/classify-row.test.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.test.ts
@@ -5,64 +5,173 @@ import { classifyRow } from "./classify-row";
 describe("classifyRow", () => {
 	describe("summaryStatus", () => {
 		it("returns summary-pending for pending", () => {
-			const reasons = classifyRow({ summaryStatus: "pending", crawlStatus: "ready" });
+			const reasons = classifyRow({
+				summaryStatus: "pending",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, ["summary-pending"]);
 		});
 
 		it("returns no reason for failed (terminal — operator owns recovery via /admin/recrawl, DLQ alarm is the signal)", () => {
-			const reasons = classifyRow({ summaryStatus: "failed", crawlStatus: "ready" });
+			const reasons = classifyRow({
+				summaryStatus: "failed",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 
 		it("returns no reason for ready", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready" });
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 
 		it("returns no reason for skipped", () => {
-			const reasons = classifyRow({ summaryStatus: "skipped", crawlStatus: "ready" });
+			const reasons = classifyRow({
+				summaryStatus: "skipped",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 	});
 
 	describe("crawlStatus", () => {
 		it("returns crawl-pending for pending", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "pending" });
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "pending",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, ["crawl-pending"]);
 		});
 
 		it("returns no reason for failed (terminal — DLQ → email is the redrive signal)", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "failed" });
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "failed",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 
 		it("returns no reason for unsupported (terminal — non-html origin, no recovery to drive)", () => {
-			const reasons = classifyRow({ summaryStatus: "skipped", crawlStatus: "unsupported" });
+			const reasons = classifyRow({
+				summaryStatus: "skipped",
+				crawlStatus: "unsupported",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 
 		it("returns no reason for ready", () => {
-			const reasons = classifyRow({ summaryStatus: "ready", crawlStatus: "ready" });
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 	});
 
 	describe("combined statuses", () => {
 		it("returns both reasons when summary and crawl are pending", () => {
-			const reasons = classifyRow({ summaryStatus: "pending", crawlStatus: "pending" });
+			const reasons = classifyRow({
+				summaryStatus: "pending",
+				crawlStatus: "pending",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, ["summary-pending", "crawl-pending"]);
 		});
 
 		it("returns no reasons when summary and crawl are both terminal failures", () => {
-			const reasons = classifyRow({ summaryStatus: "failed", crawlStatus: "failed" });
+			const reasons = classifyRow({
+				summaryStatus: "failed",
+				crawlStatus: "failed",
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
 		});
 	});
 
 	describe("undefined statuses", () => {
 		it("returns no reasons when both statuses are undefined (canary only flags pending — terminal absence is not stuck)", () => {
-			const reasons = classifyRow({ summaryStatus: undefined, crawlStatus: undefined });
+			const reasons = classifyRow({
+				summaryStatus: undefined,
+				crawlStatus: undefined,
+				aggregateTransitionName: undefined,
+			});
 			assert.deepStrictEqual(reasons, []);
+		});
+	});
+
+	describe("Phase 2 cross-axis writer migration", () => {
+		it("flips a summary-pending row written by markCrawlExhausted to the -after-aggregate-migration variant", () => {
+			const reasons = classifyRow({
+				summaryStatus: "pending",
+				crawlStatus: "ready",
+				aggregateTransitionName: "markCrawlExhausted",
+			});
+			assert.deepStrictEqual(reasons, [
+				"summary-pending-after-aggregate-migration",
+			]);
+		});
+
+		it("flips a crawl-pending row written by recrawlTieKeptCanonical to the -after-aggregate-migration variant", () => {
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "pending",
+				aggregateTransitionName: "recrawlTieKeptCanonical",
+			});
+			assert.deepStrictEqual(reasons, [
+				"crawl-pending-after-aggregate-migration",
+			]);
+		});
+
+		it("flips a crawl-pending row written by recrawlPromoteTier to the -after-aggregate-migration variant", () => {
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "pending",
+				aggregateTransitionName: "recrawlPromoteTier",
+			});
+			assert.deepStrictEqual(reasons, [
+				"crawl-pending-after-aggregate-migration",
+			]);
+		});
+
+		it("does NOT flip a row written by refreshContent (Phase 1 — not in the Phase 2 bet)", () => {
+			const reasons = classifyRow({
+				summaryStatus: "pending",
+				crawlStatus: "ready",
+				aggregateTransitionName: "refreshContent",
+			});
+			assert.deepStrictEqual(reasons, ["summary-pending"]);
+		});
+
+		it("returns no reasons when the migrated transition succeeded (failed crawl is terminal, not stuck)", () => {
+			const reasons = classifyRow({
+				summaryStatus: "failed",
+				crawlStatus: "failed",
+				aggregateTransitionName: "markCrawlExhausted",
+			});
+			assert.deepStrictEqual(reasons, []);
+		});
+
+		it("emits both axes with -after-aggregate-migration when both are pending under a migrated writer", () => {
+			const reasons = classifyRow({
+				summaryStatus: "pending",
+				crawlStatus: "pending",
+				aggregateTransitionName: "markCrawlExhausted",
+			});
+			assert.deepStrictEqual(reasons, [
+				"summary-pending-after-aggregate-migration",
+				"crawl-pending-after-aggregate-migration",
+			]);
 		});
 	});
 });

--- a/src/packages/check-stuck-articles/scripts/classify-row.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.ts
@@ -1,6 +1,25 @@
 import type { CrawlStatus, SummaryStatus } from "@packages/article-state-types";
 
-export type StuckReason = "summary-pending" | "crawl-pending";
+export type StuckReason =
+	| "summary-pending"
+	| "crawl-pending"
+	| "summary-pending-after-aggregate-migration"
+	| "crawl-pending-after-aggregate-migration";
+
+/**
+ * Transitions whose rows are produced by the Phase 2 cross-axis writer
+ * migration. A stuck row carrying one of these names in
+ * `aggregateTransitionName` is the falsifiable result of the migration: the
+ * aggregate is supposed to flip the row to a terminal/ready state in one
+ * save, so seeing it still stuck a week later means the design is wrong and
+ * Phases 3+ stop. We surface those rows under a separate StuckReason so the
+ * canary report buckets them away from legacy-writer noise.
+ */
+const PHASE_2_MIGRATED_TRANSITIONS: ReadonlySet<string> = new Set([
+	"markCrawlExhausted",
+	"recrawlTieKeptCanonical",
+	"recrawlPromoteTier",
+]);
 
 /**
  * Map a row to the reasons it is "stuck". Empty array = the row is healthy
@@ -8,13 +27,38 @@ export type StuckReason = "summary-pending" | "crawl-pending";
  * / skipped). Only `pending` is non-terminal — the canary's job is to surface
  * rows that the workers never moved past `pending`, not to grade legacy data
  * or writer-contract violations.
+ *
+ * "-after-aggregate-migration" variants: rows whose `aggregateTransitionName`
+ * column names a Phase 2 transition (markCrawlExhausted, recrawlTieKeptCanonical,
+ * recrawlPromoteTier) emit the suffixed variant of the pending reason instead.
+ * After one week of Phase 2 in production, the count of these variants is the
+ * pass/fail signal: zero = the aggregate flips terminal states reliably and
+ * Phase 3+ proceeds; non-zero = the aggregate doesn't do what we claim and
+ * the migration plan is cancelled.
  */
 export function classifyRow(row: {
 	summaryStatus: SummaryStatus | undefined;
 	crawlStatus: CrawlStatus | undefined;
+	aggregateTransitionName: string | undefined;
 }): StuckReason[] {
+	const migratedWriter =
+		row.aggregateTransitionName !== undefined &&
+		PHASE_2_MIGRATED_TRANSITIONS.has(row.aggregateTransitionName);
+
 	const reasons: StuckReason[] = [];
-	if (row.summaryStatus === "pending") reasons.push("summary-pending");
-	if (row.crawlStatus === "pending") reasons.push("crawl-pending");
+	if (row.summaryStatus === "pending") {
+		reasons.push(
+			migratedWriter
+				? "summary-pending-after-aggregate-migration"
+				: "summary-pending",
+		);
+	}
+	if (row.crawlStatus === "pending") {
+		reasons.push(
+			migratedWriter
+				? "crawl-pending-after-aggregate-migration"
+				: "crawl-pending",
+		);
+	}
 	return reasons;
 }

--- a/src/packages/check-stuck-articles/scripts/classify-row.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.ts
@@ -6,15 +6,6 @@ export type StuckReason =
 	| "summary-pending-after-aggregate-migration"
 	| "crawl-pending-after-aggregate-migration";
 
-/**
- * Transitions whose rows are produced by the Phase 2 cross-axis writer
- * migration. A stuck row carrying one of these names in
- * `aggregateTransitionName` is the falsifiable result of the migration: the
- * aggregate is supposed to flip the row to a terminal/ready state in one
- * save, so seeing it still stuck a week later means the design is wrong and
- * Phases 3+ stop. We surface those rows under a separate StuckReason so the
- * canary report buckets them away from legacy-writer noise.
- */
 const PHASE_2_MIGRATED_TRANSITIONS: ReadonlySet<string> = new Set([
 	"markCrawlExhausted",
 	"recrawlTieKeptCanonical",
@@ -27,14 +18,6 @@ const PHASE_2_MIGRATED_TRANSITIONS: ReadonlySet<string> = new Set([
  * / skipped). Only `pending` is non-terminal — the canary's job is to surface
  * rows that the workers never moved past `pending`, not to grade legacy data
  * or writer-contract violations.
- *
- * "-after-aggregate-migration" variants: rows whose `aggregateTransitionName`
- * column names a Phase 2 transition (markCrawlExhausted, recrawlTieKeptCanonical,
- * recrawlPromoteTier) emit the suffixed variant of the pending reason instead.
- * After one week of Phase 2 in production, the count of these variants is the
- * pass/fail signal: zero = the aggregate flips terminal states reliably and
- * Phase 3+ proceeds; non-zero = the aggregate doesn't do what we claim and
- * the migration plan is cancelled.
  */
 export function classifyRow(row: {
 	summaryStatus: SummaryStatus | undefined;

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
@@ -134,6 +134,7 @@ describe("collectStuckRows", () => {
 			"crawlStatus",
 			"contentFetchedAt",
 			"savedAt",
+			"aggregateTransitionName",
 		]) {
 			assert.ok(projection.includes(attr), `ProjectionExpression must include ${attr}`);
 		}
@@ -243,5 +244,30 @@ describe("collectStuckRows", () => {
 		assert.equal(calls[0]?.input.ExclusiveStartKey, undefined);
 		assert.deepEqual(calls[1]?.input.ExclusiveStartKey, { url: "page1.test/a" });
 		assert.equal(stuck.length, 2);
+	});
+
+	it("buckets stuck rows produced by Phase 2 migrated transitions under the -after-aggregate-migration variant (falsifiable measurement)", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/migrated-but-stuck",
+					originalUrl: "https://example.test/migrated-but-stuck",
+					crawlStatus: "pending",
+					savedAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+					aggregateTransitionName: "recrawlTieKeptCanonical",
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+		});
+		assert.equal(stuck.length, 1);
+		assert.deepEqual(stuck[0]?.reasons, [
+			"crawl-pending-after-aggregate-migration",
+		]);
 	});
 });

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
@@ -25,6 +25,10 @@ const StuckArticleRow = z.object({
 	crawlStatus: dynamoField(CrawlStatusSchema),
 	contentFetchedAt: dynamoField(z.string()),
 	savedAt: z.string(),
+	/* Phase 2 canary tag — the transition function name from the most recent
+	 * aggregate save. classifyRow reads it to bucket stuck rows by migrated vs.
+	 * legacy writer. Legacy rows do not carry the attribute. */
+	aggregateTransitionName: dynamoField(z.string()),
 });
 
 export interface StuckRow {
@@ -82,7 +86,7 @@ export function buildScanInput(now: Date) {
 			`(summaryStatus = :pending AND ${ageGate(":summaryMinAge")}) ` +
 			`OR (crawlStatus = :pending AND ${ageGate(":crawlMinAge")})`,
 		ProjectionExpression:
-			"originalUrl, #u, summaryStatus, crawlStatus, contentFetchedAt, savedAt",
+			"originalUrl, #u, summaryStatus, crawlStatus, contentFetchedAt, savedAt, aggregateTransitionName",
 		ExpressionAttributeNames: { "#u": "url" },
 		ExpressionAttributeValues: {
 			":pending": "pending",

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
@@ -25,9 +25,6 @@ const StuckArticleRow = z.object({
 	crawlStatus: dynamoField(CrawlStatusSchema),
 	contentFetchedAt: dynamoField(z.string()),
 	savedAt: z.string(),
-	/* Phase 2 canary tag — the transition function name from the most recent
-	 * aggregate save. classifyRow reads it to bucket stuck rows by migrated vs.
-	 * legacy writer. Legacy rows do not carry the attribute. */
 	aggregateTransitionName: dynamoField(z.string()),
 });
 

--- a/src/packages/domain/src/article-aggregate/effects.types.ts
+++ b/src/packages/domain/src/article-aggregate/effects.types.ts
@@ -6,4 +6,12 @@
  * orchestrator fires effects only after the store accepts the new aggregate,
  * so a handler can't return success without persisting AND dispatching.
  */
-export type Effect = { kind: "generate-summary"; url: string };
+export type Effect =
+	| { kind: "generate-summary"; url: string }
+	| {
+			kind: "publish-crawl-article-failed";
+			url: string;
+			reason: string;
+			receiveCount: number;
+	  }
+	| { kind: "publish-recrawl-completed"; url: string };

--- a/src/packages/domain/src/article-aggregate/index.ts
+++ b/src/packages/domain/src/article-aggregate/index.ts
@@ -7,6 +7,7 @@ export type {
 } from "./article.types";
 export type { Effect } from "./effects.types";
 export type {
+	AggregateField,
 	ArticleStore,
 	LoadArticle,
 	SaveArticle,
@@ -16,6 +17,15 @@ export {
 	refreshContent,
 	type RefreshContentInput,
 } from "./transitions/refresh-content";
+export {
+	markCrawlExhausted,
+	type MarkCrawlExhaustedInput,
+} from "./transitions/mark-crawl-exhausted";
+export { recrawlTieKeptCanonical } from "./transitions/recrawl-tie-kept-canonical";
+export {
+	recrawlPromoteTier,
+	type RecrawlPromoteTierInput,
+} from "./transitions/recrawl-promote-tier";
 export {
 	initTransitionAndPersist,
 	type Transition,

--- a/src/packages/domain/src/article-aggregate/storage.types.ts
+++ b/src/packages/domain/src/article-aggregate/storage.types.ts
@@ -1,6 +1,20 @@
 import type { Article } from "./article.types";
 
 /**
+ * Aggregate-owned field groups. A transition declares which groups it mutates
+ * so the storage adapter can scope its UpdateExpression and avoid clobbering
+ * concurrent inline writers on fields the transition did NOT touch.
+ *
+ * Phase 2 introduces crawl-state writers on the aggregate (markCrawlExhausted,
+ * recrawl transitions). Without this scope hint, the unconditional whole-row
+ * save would write `crawlStatus` back from the article snapshot — including on
+ * a refreshContent that only touches metadata/freshness/summary — and could
+ * race a concurrent inline `markCrawlFailed`/`markCrawlReady` into an
+ * inconsistent state.
+ */
+export type AggregateField = "metadata" | "freshness" | "summary" | "crawl";
+
+/**
  * Storage adapter contract for the Article aggregate.
  *
  * `save` is an unconditional whole-row write — Phase 1 accepts last-writer-wins
@@ -8,9 +22,19 @@ import type { Article } from "./article.types";
  * per URL per second in practice. Adding optimistic concurrency would mean
  * reading a `version` attribute and re-writing under a ConditionExpression;
  * we defer that until a measured conflict rate justifies the complexity.
+ *
+ * `transitionName` is the name of the transition function that produced this
+ * article. The storage adapter persists it as a row attribute so the
+ * `@packages/check-stuck-articles` canary can attribute a stuck row back to
+ * the specific aggregate writer that last touched it — the Phase 2
+ * falsifiable-measurement loop.
  */
 export type LoadArticle = (url: string) => Promise<Article | undefined>;
-export type SaveArticle = (article: Article) => Promise<void>;
+export type SaveArticle = (params: {
+	article: Article;
+	transitionName: string;
+	writes: readonly AggregateField[];
+}) => Promise<void>;
 
 export interface ArticleStore {
 	load: LoadArticle;

--- a/src/packages/domain/src/article-aggregate/storage.types.ts
+++ b/src/packages/domain/src/article-aggregate/storage.types.ts
@@ -1,17 +1,6 @@
 import type { Article } from "./article.types";
 
-/**
- * Aggregate-owned field groups. A transition declares which groups it mutates
- * so the storage adapter can scope its UpdateExpression and avoid clobbering
- * concurrent inline writers on fields the transition did NOT touch.
- *
- * Phase 2 introduces crawl-state writers on the aggregate (markCrawlExhausted,
- * recrawl transitions). Without this scope hint, the unconditional whole-row
- * save would write `crawlStatus` back from the article snapshot — including on
- * a refreshContent that only touches metadata/freshness/summary — and could
- * race a concurrent inline `markCrawlFailed`/`markCrawlReady` into an
- * inconsistent state.
- */
+/* Scopes the aggregate save so concurrent inline writers on untouched axes are not clobbered. */
 export type AggregateField = "metadata" | "freshness" | "summary" | "crawl";
 
 /**
@@ -22,12 +11,6 @@ export type AggregateField = "metadata" | "freshness" | "summary" | "crawl";
  * per URL per second in practice. Adding optimistic concurrency would mean
  * reading a `version` attribute and re-writing under a ConditionExpression;
  * we defer that until a measured conflict rate justifies the complexity.
- *
- * `transitionName` is the name of the transition function that produced this
- * article. The storage adapter persists it as a row attribute so the
- * `@packages/check-stuck-articles` canary can attribute a stuck row back to
- * the specific aggregate writer that last touched it — the Phase 2
- * falsifiable-measurement loop.
  */
 export type LoadArticle = (url: string) => Promise<Article | undefined>;
 export type SaveArticle = (params: {

--- a/src/packages/domain/src/article-aggregate/transition-and-persist.test.ts
+++ b/src/packages/domain/src/article-aggregate/transition-and-persist.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { Article } from "./article.types";
 import type { DispatchEffect } from "./effect-dispatcher.types";
 import type { Effect } from "./effects.types";
-import type { ArticleStore } from "./storage.types";
+import type { AggregateField, ArticleStore, SaveArticle } from "./storage.types";
 import {
 	initTransitionAndPersist,
 	type Transition,
@@ -24,20 +24,27 @@ function seededArticle(url: string): Article {
 	};
 }
 
+interface SavedCall {
+	article: Article;
+	transitionName: string;
+	writes: readonly AggregateField[];
+}
+
 function createFakeStore(initial: readonly Article[]): {
 	store: ArticleStore;
-	saved: Article[];
+	saved: SavedCall[];
 } {
 	const rows = new Map<string, Article>();
 	for (const a of initial) rows.set(a.url, a);
-	const saved: Article[] = [];
+	const saved: SavedCall[] = [];
 
+	const save: SaveArticle = async ({ article, transitionName, writes }) => {
+		saved.push({ article, transitionName, writes });
+		rows.set(article.url, article);
+	};
 	const store: ArticleStore = {
 		load: async (url) => rows.get(url),
-		save: async (article) => {
-			saved.push(article);
-			rows.set(article.url, article);
-		},
+		save,
 	};
 
 	return { store, saved };
@@ -50,30 +57,38 @@ describe("initTransitionAndPersist", () => {
 		const order: string[] = [];
 		const seed = seededArticle(URL);
 
+		const save: SaveArticle = async ({ article }) => {
+			order.push(`save:${article.summary.kind}`);
+		};
 		const store: ArticleStore = {
 			load: async (url) => {
 				order.push(`load:${url}`);
 				return seed;
 			},
-			save: async (article) => {
-				order.push(`save:${article.summary.kind}`);
-			},
+			save,
 		};
 		const dispatchEffect: DispatchEffect = async (effect) => {
 			order.push(`dispatch:${effect.kind}`);
 		};
 
-		const transition: Transition<undefined> = (article) => ({
-			article: { ...article, summary: { kind: "pending" } },
-			effects: [{ kind: "generate-summary", url: article.url }],
-		});
+		function exampleTransition(article: Article): {
+			article: Article;
+			effects: readonly Effect[];
+			writes: readonly AggregateField[];
+		} {
+			return {
+				article: { ...article, summary: { kind: "pending" } },
+				effects: [{ kind: "generate-summary", url: article.url }],
+				writes: ["summary"],
+			};
+		}
 
 		const { transitionAndPersist } = initTransitionAndPersist({
 			store,
 			dispatchEffect,
 		});
 
-		await transitionAndPersist(transition, { url: URL, input: undefined });
+		await transitionAndPersist(exampleTransition, { url: URL, input: undefined });
 
 		assert.deepEqual(order, [
 			`load:${URL}`,
@@ -82,12 +97,60 @@ describe("initTransitionAndPersist", () => {
 		]);
 	});
 
+	it("threads the transition function's name through to store.save so the canary can attribute stuck rows", async () => {
+		const { store, saved } = createFakeStore([seededArticle(URL)]);
+		const dispatchEffect: DispatchEffect = async () => {};
+		function exampleTransition(article: Article): {
+			article: Article;
+			effects: readonly Effect[];
+			writes: readonly AggregateField[];
+		} {
+			return { article, effects: [], writes: ["summary"] };
+		}
+
+		const { transitionAndPersist } = initTransitionAndPersist({
+			store,
+			dispatchEffect,
+		});
+
+		await transitionAndPersist(exampleTransition, { url: URL, input: undefined });
+
+		assert.equal(saved.length, 1);
+		assert.equal(saved[0]?.transitionName, "exampleTransition");
+	});
+
+	it("threads the transition's writes scope through to store.save so the storage adapter can omit untouched axes", async () => {
+		const { store, saved } = createFakeStore([seededArticle(URL)]);
+		const dispatchEffect: DispatchEffect = async () => {};
+		function exampleTransition(article: Article): {
+			article: Article;
+			effects: readonly Effect[];
+			writes: readonly AggregateField[];
+		} {
+			return {
+				article: { ...article, crawl: { kind: "failed", reason: "x" } },
+				effects: [],
+				writes: ["crawl", "summary"],
+			};
+		}
+
+		const { transitionAndPersist } = initTransitionAndPersist({
+			store,
+			dispatchEffect,
+		});
+
+		await transitionAndPersist(exampleTransition, { url: URL, input: undefined });
+
+		assert.deepEqual([...(saved[0]?.writes ?? [])], ["crawl", "summary"]);
+	});
+
 	it("throws when the aggregate is missing so SQS retries the whole transition", async () => {
+		const save: SaveArticle = async () => {
+			throw new Error("save must not be called when load returns undefined");
+		};
 		const store: ArticleStore = {
 			load: async () => undefined,
-			save: async () => {
-				throw new Error("save must not be called when load returns undefined");
-			},
+			save,
 		};
 		const dispatchEffect: DispatchEffect = async () => {
 			throw new Error("dispatch must not be called when load returns undefined");
@@ -95,6 +158,7 @@ describe("initTransitionAndPersist", () => {
 		const transition: Transition<undefined> = (article) => ({
 			article,
 			effects: [],
+			writes: [],
 		});
 
 		const { transitionAndPersist } = initTransitionAndPersist({
@@ -111,11 +175,12 @@ describe("initTransitionAndPersist", () => {
 
 	it("does not dispatch when save throws (handler's catch path drives SQS retry)", async () => {
 		const seed = seededArticle(URL);
+		const save: SaveArticle = async () => {
+			throw new Error("ddb throttled");
+		};
 		const store: ArticleStore = {
 			load: async () => seed,
-			save: async () => {
-				throw new Error("ddb throttled");
-			},
+			save,
 		};
 		const dispatched: Effect[] = [];
 		const dispatchEffect: DispatchEffect = async (effect) => {
@@ -124,6 +189,7 @@ describe("initTransitionAndPersist", () => {
 		const transition: Transition<undefined> = (article) => ({
 			article,
 			effects: [{ kind: "generate-summary", url: article.url }],
+			writes: ["summary"],
 		});
 
 		const { transitionAndPersist } = initTransitionAndPersist({
@@ -146,6 +212,7 @@ describe("initTransitionAndPersist", () => {
 		const transition: Transition<undefined> = (article) => ({
 			article,
 			effects: [{ kind: "generate-summary", url: article.url }],
+			writes: ["summary"],
 		});
 
 		const { transitionAndPersist } = initTransitionAndPersist({
@@ -173,6 +240,7 @@ describe("initTransitionAndPersist", () => {
 		const transition: Transition<undefined> = (article) => ({
 			article: { ...article, summary: { kind: "pending" } },
 			effects: [{ kind: "generate-summary", url: article.url }],
+			writes: ["summary"],
 		});
 
 		const { transitionAndPersist } = initTransitionAndPersist({
@@ -186,13 +254,13 @@ describe("initTransitionAndPersist", () => {
 		);
 
 		assert.equal(saved.length, 1, "first call persisted the transition");
-		assert.equal(saved[0]?.summary.kind, "pending");
+		assert.equal(saved[0]?.article.summary.kind, "pending");
 		assert.deepEqual(dispatched, [], "first call did not dispatch");
 
 		await transitionAndPersist(transition, { url: URL, input: undefined });
 
 		assert.equal(saved.length, 2, "second call re-saved idempotently");
-		assert.equal(saved[1]?.summary.kind, "pending");
+		assert.equal(saved[1]?.article.summary.kind, "pending");
 		assert.deepEqual(dispatched, [{ kind: "generate-summary", url: URL }]);
 	});
 
@@ -206,8 +274,9 @@ describe("initTransitionAndPersist", () => {
 			article,
 			effects: [
 				{ kind: "generate-summary", url: article.url },
-				{ kind: "generate-summary", url: `${article.url}#second` },
+				{ kind: "publish-recrawl-completed", url: article.url },
 			],
+			writes: [],
 		});
 
 		const { transitionAndPersist } = initTransitionAndPersist({
@@ -219,7 +288,7 @@ describe("initTransitionAndPersist", () => {
 
 		assert.deepEqual(dispatched, [
 			{ kind: "generate-summary", url: URL },
-			{ kind: "generate-summary", url: `${URL}#second` },
+			{ kind: "publish-recrawl-completed", url: URL },
 		]);
 	});
 
@@ -232,6 +301,7 @@ describe("initTransitionAndPersist", () => {
 				metadata: { ...article.metadata, title: input.newTitle },
 			},
 			effects: [],
+			writes: ["metadata"],
 		});
 
 		const { transitionAndPersist } = initTransitionAndPersist({
@@ -245,6 +315,6 @@ describe("initTransitionAndPersist", () => {
 		});
 
 		assert.equal(saved.length, 1);
-		assert.equal(saved[0]?.metadata.title, "Updated");
+		assert.equal(saved[0]?.article.metadata.title, "Updated");
 	});
 });

--- a/src/packages/domain/src/article-aggregate/transition-and-persist.ts
+++ b/src/packages/domain/src/article-aggregate/transition-and-persist.ts
@@ -2,12 +2,16 @@ import assert from "node:assert";
 import type { Article } from "./article.types";
 import type { DispatchEffect } from "./effect-dispatcher.types";
 import type { Effect } from "./effects.types";
-import type { ArticleStore } from "./storage.types";
+import type { AggregateField, ArticleStore } from "./storage.types";
 
 export type Transition<TInput> = (
 	article: Article,
 	input: TInput,
-) => { article: Article; effects: readonly Effect[] };
+) => {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+};
 
 export type TransitionAndPersist = <TInput>(
 	transition: Transition<TInput>,
@@ -24,6 +28,11 @@ export type TransitionAndPersist = <TInput>(
  * re-runs the (idempotent) transition, re-saves identical state, and re-
  * dispatches. The summary worker short-circuits on cached `ready` rows so a
  * duplicate `generate-summary` is harmless.
+ *
+ * The transition's runtime `name` (via Function.name) is threaded through to
+ * `store.save` so the storage adapter can tag the row with the most recent
+ * aggregate writer. The Phase 2 canary uses that tag to bucket stuck rows
+ * by migrated vs. legacy writer.
  */
 export function initTransitionAndPersist(deps: {
 	store: ArticleStore;
@@ -37,8 +46,12 @@ export function initTransitionAndPersist(deps: {
 	) => {
 		const existing = await store.load(params.url);
 		assert(existing, `Article aggregate not found for url: ${params.url}`);
-		const { article, effects } = transition(existing, params.input);
-		await store.save(article);
+		const { article, effects, writes } = transition(existing, params.input);
+		await store.save({
+			article,
+			transitionName: transition.name,
+			writes,
+		});
 		for (const effect of effects) {
 			await dispatchEffect(effect);
 		}

--- a/src/packages/domain/src/article-aggregate/transition-and-persist.ts
+++ b/src/packages/domain/src/article-aggregate/transition-and-persist.ts
@@ -28,11 +28,6 @@ export type TransitionAndPersist = <TInput>(
  * re-runs the (idempotent) transition, re-saves identical state, and re-
  * dispatches. The summary worker short-circuits on cached `ready` rows so a
  * duplicate `generate-summary` is harmless.
- *
- * The transition's runtime `name` (via Function.name) is threaded through to
- * `store.save` so the storage adapter can tag the row with the most recent
- * aggregate writer. The Phase 2 canary uses that tag to bucket stuck rows
- * by migrated vs. legacy writer.
  */
 export function initTransitionAndPersist(deps: {
 	store: ArticleStore;

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-exhausted.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-exhausted.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markCrawlExhausted } from "./mark-crawl-exhausted";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "pending" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("markCrawlExhausted", () => {
+	it("flips crawl to failed with the supplied reason", () => {
+		const { article } = markCrawlExhausted(buildArticle(), {
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
+		});
+
+		assert.deepEqual(article.crawl, {
+			kind: "failed",
+			reason: "exceeded SQS maxReceiveCount",
+		});
+	});
+
+	it("flips summary to failed with a 'crawl failed' reason (the cross-axis pairing the four DLQ handlers used to inline)", () => {
+		const { article } = markCrawlExhausted(buildArticle(), {
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "failed",
+			reason: "crawl failed",
+		});
+	});
+
+	it("emits a publish-crawl-article-failed effect carrying the url, reason, and receiveCount", () => {
+		const { effects } = markCrawlExhausted(
+			buildArticle({ url: "https://example.com/post" }),
+			{ reason: "exceeded SQS maxReceiveCount", receiveCount: 7 },
+		);
+
+		assert.deepEqual(effects, [
+			{
+				kind: "publish-crawl-article-failed",
+				url: "https://example.com/post",
+				reason: "exceeded SQS maxReceiveCount",
+				receiveCount: 7,
+			},
+		]);
+	});
+
+	it("declares writes for crawl and summary so the aggregate save scopes to the two axes the transition mutated", () => {
+		const { writes } = markCrawlExhausted(buildArticle(), {
+			reason: "x",
+			receiveCount: 1,
+		});
+
+		assert.deepEqual([...writes].sort(), ["crawl", "summary"]);
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markCrawlExhausted(before, {
+			reason: "x",
+			receiveCount: 1,
+		});
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markCrawlExhausted(before, { reason: "x", receiveCount: 1 });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markCrawlExhausted.name, "markCrawlExhausted");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-exhausted.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-exhausted.ts
@@ -1,0 +1,44 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkCrawlExhaustedInput {
+	reason: string;
+	receiveCount: number;
+}
+
+/**
+ * Collapse the four DLQ handlers' hand-rolled "markCrawlFailed +
+ * markSummaryFailed + publish CrawlArticleFailedEvent" sequence onto one
+ * transition. Returning both terminal states alongside the publish effect
+ * makes it a compile error for a future writer to flip only one axis — the
+ * cross-axis stuck-row pathology this Phase 2 migration is betting it can
+ * eliminate.
+ *
+ * `writes: ["crawl", "summary"]` scopes the aggregate save so a concurrent
+ * inline metadata/freshness writer is not clobbered on retry.
+ */
+export function markCrawlExhausted(
+	article: Article,
+	input: MarkCrawlExhaustedInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		crawl: { kind: "failed", reason: input.reason },
+		summary: { kind: "failed", reason: "crawl failed" },
+	};
+	const effects: readonly Effect[] = [
+		{
+			kind: "publish-crawl-article-failed",
+			url: article.url,
+			reason: input.reason,
+			receiveCount: input.receiveCount,
+		},
+	];
+	const writes: readonly AggregateField[] = ["crawl", "summary"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-exhausted.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-exhausted.ts
@@ -7,17 +7,7 @@ export interface MarkCrawlExhaustedInput {
 	receiveCount: number;
 }
 
-/**
- * Collapse the four DLQ handlers' hand-rolled "markCrawlFailed +
- * markSummaryFailed + publish CrawlArticleFailedEvent" sequence onto one
- * transition. Returning both terminal states alongside the publish effect
- * makes it a compile error for a future writer to flip only one axis — the
- * cross-axis stuck-row pathology this Phase 2 migration is betting it can
- * eliminate.
- *
- * `writes: ["crawl", "summary"]` scopes the aggregate save so a concurrent
- * inline metadata/freshness writer is not clobbered on retry.
- */
+/* `writes` scoped to crawl + summary so a concurrent inline metadata/freshness writer is not clobbered. */
 export function markCrawlExhausted(
 	article: Article,
 	input: MarkCrawlExhaustedInput,

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { recrawlPromoteTier } from "./recrawl-promote-tier";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "pending" },
+		summary: { kind: "ready", summary: "old" },
+		...overrides,
+	};
+}
+
+describe("recrawlPromoteTier", () => {
+	it("flips crawl from pending to ready after a tier promotion", () => {
+		const { article } = recrawlPromoteTier(buildArticle(), {
+			winnerTier: "tier-1",
+		});
+
+		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("emits generate-summary and publish-recrawl-completed effects in that order", () => {
+		const { effects } = recrawlPromoteTier(
+			buildArticle({ url: "https://example.com/post" }),
+			{ winnerTier: "tier-0" },
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{ kind: "publish-recrawl-completed", url: "https://example.com/post" },
+		]);
+	});
+
+	it("declares writes for crawl only (the canonical metadata + S3 copy are owned by promoteTierToCanonical outside the aggregate)", () => {
+		const { writes } = recrawlPromoteTier(buildArticle(), {
+			winnerTier: "tier-1",
+		});
+
+		assert.deepEqual([...writes], ["crawl"]);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		recrawlPromoteTier(before, { winnerTier: "tier-1" });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("produces the same aggregate state regardless of which tier won (sibling-transition contract)", () => {
+		const tier0 = recrawlPromoteTier(buildArticle(), { winnerTier: "tier-0" });
+		const tier1 = recrawlPromoteTier(buildArticle(), { winnerTier: "tier-1" });
+
+		assert.deepEqual(tier0.article, tier1.article);
+		assert.deepEqual(tier0.effects, tier1.effects);
+		assert.deepEqual(tier0.writes, tier1.writes);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(recrawlPromoteTier.name, "recrawlPromoteTier");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
@@ -1,0 +1,40 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface RecrawlPromoteTierInput {
+	winnerTier: "tier-0" | "tier-1";
+}
+
+/**
+ * The recrawl selector promoted one tier to canonical. The S3 CopyObject
+ * + DynamoDB canonical metadata write live outside the aggregate (the
+ * promote-tier-to-canonical adapter owns those reads); this transition flips
+ * the crawl row to ready and emits the post-recrawl effects.
+ *
+ * `winnerTier` is captured on input so a future change that needs to vary
+ * the effects by tier (e.g., different summary prompt per tier) has a place
+ * to add it without re-shaping the call sites. Sibling to
+ * `recrawlTieKeptCanonical`: the two paths produce the same aggregate state
+ * (`crawl: ready`) and the same effects, but they exist as separate
+ * transitions so reviewers can grep the call sites by intent.
+ */
+export function recrawlPromoteTier(
+	article: Article,
+	_input: RecrawlPromoteTierInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		crawl: { kind: "ready" },
+	};
+	const effects: readonly Effect[] = [
+		{ kind: "generate-summary", url: article.url },
+		{ kind: "publish-recrawl-completed", url: article.url },
+	];
+	const writes: readonly AggregateField[] = ["crawl"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
@@ -6,19 +6,6 @@ export interface RecrawlPromoteTierInput {
 	winnerTier: "tier-0" | "tier-1";
 }
 
-/**
- * The recrawl selector promoted one tier to canonical. The S3 CopyObject
- * + DynamoDB canonical metadata write live outside the aggregate (the
- * promote-tier-to-canonical adapter owns those reads); this transition flips
- * the crawl row to ready and emits the post-recrawl effects.
- *
- * `winnerTier` is captured on input so a future change that needs to vary
- * the effects by tier (e.g., different summary prompt per tier) has a place
- * to add it without re-shaping the call sites. Sibling to
- * `recrawlTieKeptCanonical`: the two paths produce the same aggregate state
- * (`crawl: ready`) and the same effects, but they exist as separate
- * transitions so reviewers can grep the call sites by intent.
- */
 export function recrawlPromoteTier(
 	article: Article,
 	_input: RecrawlPromoteTierInput,

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { recrawlTieKeptCanonical } from "./recrawl-tie-kept-canonical";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "pending" },
+		summary: { kind: "ready", summary: "old" },
+		...overrides,
+	};
+}
+
+describe("recrawlTieKeptCanonical", () => {
+	it("flips crawl from pending to ready (unsticks the row admin/recrawl wrote pending)", () => {
+		const { article } = recrawlTieKeptCanonical(buildArticle(), undefined);
+
+		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("preserves summary so a freshly-generated AI excerpt is not invalidated by the recrawl no-op", () => {
+		const before = buildArticle({
+			summary: { kind: "ready", summary: "kept", excerpt: "kept excerpt" },
+		});
+
+		const { article } = recrawlTieKeptCanonical(before, undefined);
+
+		assert.deepEqual(article.summary, {
+			kind: "ready",
+			summary: "kept",
+			excerpt: "kept excerpt",
+		});
+	});
+
+	it("emits a generate-summary effect so the operator always sees a freshly-regenerated excerpt", () => {
+		const { effects } = recrawlTieKeptCanonical(
+			buildArticle({ url: "https://example.com/post" }),
+			undefined,
+		);
+
+		assert.ok(
+			effects.some(
+				(e) =>
+					e.kind === "generate-summary" && e.url === "https://example.com/post",
+			),
+			"generate-summary effect must be emitted on every recrawl",
+		);
+	});
+
+	it("emits a publish-recrawl-completed effect after the generate-summary effect", () => {
+		const { effects } = recrawlTieKeptCanonical(
+			buildArticle({ url: "https://example.com/post" }),
+			undefined,
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{ kind: "publish-recrawl-completed", url: "https://example.com/post" },
+		]);
+	});
+
+	it("declares writes for crawl only (canonical is preserved by definition of this branch)", () => {
+		const { writes } = recrawlTieKeptCanonical(buildArticle(), undefined);
+
+		assert.deepEqual([...writes], ["crawl"]);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		recrawlTieKeptCanonical(before, undefined);
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(recrawlTieKeptCanonical.name, "recrawlTieKeptCanonical");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
@@ -1,0 +1,35 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+/**
+ * The recrawl selector decided the Deepseek tie should keep the existing
+ * canonical. The canonical S3 object is unchanged, so we only need to flip
+ * the crawl row back out of the "pending" state that admin/recrawl's
+ * `forceMarkCrawlPending` unconditionally wrote — otherwise readers (and the
+ * Tier 1+ canary) poll a forever-"pending" row whose canonical content is
+ * already on disk.
+ *
+ * Pairing the crawl-state flip with both effects in the transition means a
+ * reviewer can't ship a branch that returns early without producing a valid
+ * next aggregate state — there is no early-return shape that typechecks.
+ */
+export function recrawlTieKeptCanonical(
+	article: Article,
+	_input: undefined,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		crawl: { kind: "ready" },
+	};
+	const effects: readonly Effect[] = [
+		{ kind: "generate-summary", url: article.url },
+		{ kind: "publish-recrawl-completed", url: article.url },
+	];
+	const writes: readonly AggregateField[] = ["crawl"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
@@ -2,18 +2,8 @@ import type { Article } from "../article.types";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
-/**
- * The recrawl selector decided the Deepseek tie should keep the existing
- * canonical. The canonical S3 object is unchanged, so we only need to flip
- * the crawl row back out of the "pending" state that admin/recrawl's
- * `forceMarkCrawlPending` unconditionally wrote — otherwise readers (and the
- * Tier 1+ canary) poll a forever-"pending" row whose canonical content is
- * already on disk.
- *
- * Pairing the crawl-state flip with both effects in the transition means a
- * reviewer can't ship a branch that returns early without producing a valid
- * next aggregate state — there is no early-return shape that typechecks.
- */
+/* forceMarkCrawlPending unconditionally sets "pending" — without this
+ * transition the row stays pending forever with canonical content on disk. */
 export function recrawlTieKeptCanonical(
 	article: Article,
 	_input: undefined,

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -101,6 +101,19 @@ describe("refreshContent", () => {
 		]);
 	});
 
+	it("declares writes for metadata, freshness, and summary so crawl-state is not clobbered by a concurrent inline writer", () => {
+		const before = buildArticle();
+
+		const { writes } = refreshContent(before, {
+			metadata: before.metadata,
+			freshness: before.freshness,
+			estimatedReadTime: before.estimatedReadTime,
+		});
+
+		assert.deepEqual([...writes].sort(), ["freshness", "metadata", "summary"]);
+		assert.ok(!writes.includes("crawl"), "refresh must not declare crawl writes");
+	});
+
 	it("does not mutate the input article (pure function)", () => {
 		const before = buildArticle();
 		const beforeSnapshot = JSON.parse(JSON.stringify(before));

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
@@ -4,6 +4,7 @@ import type {
 	ArticleMetadata,
 } from "../article.types";
 import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
 
 export interface RefreshContentInput {
 	metadata: ArticleMetadata;
@@ -22,11 +23,19 @@ export interface RefreshContentInput {
  * 2026-05-10 (REMOVE summary attributes but no GenerateSummaryCommand
  * dispatched, leaving the row stuck on "Generating summary…") fails at
  * compile/unit time rather than as a stuck production row.
+ *
+ * `writes` deliberately excludes "crawl" — a concurrent inline crawl writer
+ * must not be clobbered by the refresh aggregate save when the crawl is still
+ * in flight.
  */
 export function refreshContent(
 	article: Article,
 	input: RefreshContentInput,
-): { article: Article; effects: readonly Effect[] } {
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
 	const next: Article = {
 		...article,
 		metadata: input.metadata,
@@ -37,5 +46,6 @@ export function refreshContent(
 	const effects: readonly Effect[] = [
 		{ kind: "generate-summary", url: article.url },
 	];
-	return { article: next, effects };
+	const writes: readonly AggregateField[] = ["metadata", "freshness", "summary"];
+	return { article: next, effects, writes };
 }

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
@@ -12,22 +12,8 @@ export interface RefreshContentInput {
 	estimatedReadTime: number;
 }
 
-/**
- * Refresh an article's metadata + content freshness after the periodic
- * staleness check fetched new bytes. Invalidates the cached summary by
- * resetting `summary` to `pending` and emits a `generate-summary` effect.
- *
- * Returning the effect alongside the new aggregate means a writer can't
- * silently drop the regen command — the test suite asserts that
- * `refreshContent({...}).effects` contains the dispatch, so the bug from
- * 2026-05-10 (REMOVE summary attributes but no GenerateSummaryCommand
- * dispatched, leaving the row stuck on "Generating summary…") fails at
- * compile/unit time rather than as a stuck production row.
- *
- * `writes` deliberately excludes "crawl" — a concurrent inline crawl writer
- * must not be clobbered by the refresh aggregate save when the crawl is still
- * in flight.
- */
+/* `writes` excludes "crawl" — a concurrent inline crawl writer must not be
+ * clobbered by the refresh aggregate save when the crawl is still in flight. */
 export function refreshContent(
 	article: Article,
 	input: RefreshContentInput,

--- a/src/packages/hutch-infra-components/src/infra/hutch-dlq-event-handler.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-dlq-event-handler.ts
@@ -2,18 +2,27 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import type { HutchEventBus } from "./event-bus";
 import { HutchDynamoDBAccess } from "./hutch-dynamodb-access";
-import { HutchLambda } from "./hutch-lambda";
+import { HutchLambda, type LambdaPolicy } from "./hutch-lambda";
 import type { HutchSQS } from "./hutch-sqs";
 
 /**
  * Attaches a Lambda to the DLQ of an existing `HutchSQS` so dead-lettered
  * messages drive a state transition on the articles table and publish a
  * domain failure event. Most configuration is fixed (256MB memory, 30s
- * timeout, dynamodb:UpdateItem only, DYNAMODB_ARTICLES_TABLE +
- * EVENT_BUS_NAME env vars, entry point derived from the component name);
- * `batchSize` is required so every callsite makes the choice explicit. The
- * mapping always wires ReportBatchItemFailures so a future `batchSize > 1`
- * does not silently drop sibling records on a partial failure.
+ * timeout, DYNAMODB_ARTICLES_TABLE + EVENT_BUS_NAME env vars, entry point
+ * derived from the component name); `batchSize` is required so every
+ * callsite makes the choice explicit. The mapping always wires
+ * ReportBatchItemFailures so a future `batchSize > 1` does not silently
+ * drop sibling records on a partial failure.
+ *
+ * `additionalDynamoActions`, `additionalEnvironment`, and `additionalPolicies`
+ * are escape hatches for callers whose transition needs richer access than
+ * the default "UpdateItem only, no extra env". Phase 2 of the aggregate
+ * migration uses them to add `dynamodb:GetItem` (the aggregate's
+ * `store.load` reads before it writes) and to pass `GENERATE_SUMMARY_QUEUE_URL`
+ * even though the migrated DLQ transition never dispatches a summary command —
+ * the aggregate effect dispatcher is wired uniformly so a future transition
+ * change at the same callsite cannot regress without re-wiring infra.
  */
 export class HutchDLQEventHandler extends pulumi.ComponentResource {
 	constructor(
@@ -25,6 +34,9 @@ export class HutchDLQEventHandler extends pulumi.ComponentResource {
 			eventBus: HutchEventBus;
 			/** Valid range: 1–10 (AWS SQS EventSourceMapping limit for standard queues). */
 			batchSize: number;
+			additionalDynamoActions?: readonly string[];
+			additionalEnvironment?: Record<string, pulumi.Input<string>>;
+			additionalPolicies?: readonly LambdaPolicy[];
 		},
 		opts?: pulumi.ComponentResourceOptions,
 	) {
@@ -32,7 +44,7 @@ export class HutchDLQEventHandler extends pulumi.ComponentResource {
 
 		const dynamodb = new HutchDynamoDBAccess(`${name}-dynamodb`, {
 			tables: [{ arn: args.tableArn, includeIndexes: false }],
-			actions: ["dynamodb:UpdateItem"],
+			actions: ["dynamodb:UpdateItem", ...(args.additionalDynamoActions ?? [])],
 		});
 
 		const lambda = new HutchLambda(name, {
@@ -44,8 +56,9 @@ export class HutchDLQEventHandler extends pulumi.ComponentResource {
 			environment: {
 				DYNAMODB_ARTICLES_TABLE: args.tableName,
 				EVENT_BUS_NAME: args.eventBus.eventBusName,
+				...args.additionalEnvironment,
 			},
-			policies: [...dynamodb.policies],
+			policies: [...dynamodb.policies, ...(args.additionalPolicies ?? [])],
 		}, { parent: this });
 
 		args.eventBus.grantPublish(lambda);

--- a/src/packages/hutch-infra-components/src/infra/hutch-dlq-event-handler.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-dlq-event-handler.ts
@@ -17,11 +17,11 @@ import type { HutchSQS } from "./hutch-sqs";
  *
  * `additionalDynamoActions`, `additionalEnvironment`, and `additionalPolicies`
  * are escape hatches for callers whose transition needs richer access than
- * the default "UpdateItem only, no extra env". Phase 2 of the aggregate
- * migration uses them to add `dynamodb:GetItem` (the aggregate's
- * `store.load` reads before it writes) and to pass `GENERATE_SUMMARY_QUEUE_URL`
- * even though the migrated DLQ transition never dispatches a summary command —
- * the aggregate effect dispatcher is wired uniformly so a future transition
+ * the default "UpdateItem only, no extra env". Aggregate-migrated DLQ
+ * handlers use them to add `dynamodb:GetItem` (the aggregate's `store.load`
+ * reads before it writes) and to pass `GENERATE_SUMMARY_QUEUE_URL` even
+ * when the current transition does not dispatch a summary command — the
+ * aggregate effect dispatcher is wired uniformly so a future transition
  * change at the same callsite cannot regress without re-wiring infra.
  */
 export class HutchDLQEventHandler extends pulumi.ComponentResource {

--- a/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-article-store.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-article-store.test.ts
@@ -34,7 +34,11 @@ describe("initInMemoryArticleStore", () => {
 			summary: "x",
 		});
 
-		await store.save(article);
+		await store.save({
+			article,
+			transitionName: "exampleTransition",
+			writes: ["metadata", "freshness", "summary"],
+		});
 		const loaded = await store.load("https://example.com/article");
 
 		assert.deepEqual(loaded, article);
@@ -54,7 +58,11 @@ describe("initInMemoryArticleStore", () => {
 		const store = initInMemoryArticleStore();
 		const article = buildArticle("https://example.com/article");
 
-		await store.save(article);
+		await store.save({
+			article,
+			transitionName: "exampleTransition",
+			writes: ["metadata"],
+		});
 		const loaded = await store.load(
 			"https://example.com/article?utm_source=newsletter",
 		);
@@ -65,12 +73,34 @@ describe("initInMemoryArticleStore", () => {
 
 	it("overwrites the previously saved aggregate on a second save (last-writer-wins)", async () => {
 		const store = initInMemoryArticleStore();
-		await store.save(buildArticle("https://example.com/a", { kind: "ready", summary: "old" }));
+		await store.save({
+			article: buildArticle("https://example.com/a", { kind: "ready", summary: "old" }),
+			transitionName: "first",
+			writes: ["summary"],
+		});
 
-		await store.save(buildArticle("https://example.com/a", { kind: "pending" }));
+		await store.save({
+			article: buildArticle("https://example.com/a", { kind: "pending" }),
+			transitionName: "second",
+			writes: ["summary"],
+		});
 		const loaded = await store.load("https://example.com/a");
 
 		assert(loaded, "loaded should not be undefined after save");
 		assert.deepEqual(loaded.summary, { kind: "pending" });
+	});
+
+	it("records each save's transitionName and writes scope so tests can assert what the orchestrator threaded through", async () => {
+		const store = initInMemoryArticleStore();
+
+		await store.save({
+			article: buildArticle("https://example.com/a"),
+			transitionName: "markCrawlExhausted",
+			writes: ["crawl", "summary"],
+		});
+
+		assert.equal(store.savedCalls.length, 1);
+		assert.equal(store.savedCalls[0]?.transitionName, "markCrawlExhausted");
+		assert.deepEqual([...(store.savedCalls[0]?.writes ?? [])], ["crawl", "summary"]);
 	});
 });

--- a/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-article-store.ts
+++ b/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-article-store.ts
@@ -1,16 +1,31 @@
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
-import type { Article, ArticleStore } from "@packages/domain/article-aggregate";
+import type {
+	AggregateField,
+	Article,
+	ArticleStore,
+} from "@packages/domain/article-aggregate";
+
+interface SavedCall {
+	article: Article;
+	transitionName: string;
+	writes: readonly AggregateField[];
+}
 
 /**
  * In-memory ArticleStore for tests. Stores aggregates keyed on the normalized
  * URL (the same key the production DynamoDB store uses) so a `save({url:
  * "https://example.com/a?utm=x"})` followed by `load("https://example.com/a")`
  * reads the same row — mirroring DynamoDB's normalization at the boundary.
+ *
+ * Records each `save` call on `savedCalls` so tests can assert on the
+ * transition name and the `writes` scope the orchestrator threaded through.
  */
 export function initInMemoryArticleStore(): ArticleStore & {
 	seed: (article: Article) => void;
+	savedCalls: readonly SavedCall[];
 } {
 	const rows = new Map<string, Article>();
+	const savedCalls: SavedCall[] = [];
 
 	function key(url: string): string {
 		return ArticleResourceUniqueId.parse(url).value;
@@ -22,7 +37,8 @@ export function initInMemoryArticleStore(): ArticleStore & {
 			if (!stored) return undefined;
 			return { ...stored, url };
 		},
-		save: async (article) => {
+		save: async ({ article, transitionName, writes }) => {
+			savedCalls.push({ article, transitionName, writes });
 			rows.set(key(article.url), article);
 		},
 	};
@@ -32,5 +48,6 @@ export function initInMemoryArticleStore(): ArticleStore & {
 		seed: (article) => {
 			rows.set(key(article.url), article);
 		},
+		savedCalls,
 	};
 }

--- a/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-article-store.ts
+++ b/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-article-store.ts
@@ -16,9 +16,6 @@ interface SavedCall {
  * URL (the same key the production DynamoDB store uses) so a `save({url:
  * "https://example.com/a?utm=x"})` followed by `load("https://example.com/a")`
  * reads the same row — mirroring DynamoDB's normalization at the boundary.
- *
- * Records each `save` call on `savedCalls` so tests can assert on the
- * transition name and the `writes` scope the orchestrator threaded through.
  */
 export function initInMemoryArticleStore(): ArticleStore & {
 	seed: (article: Article) => void;

--- a/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-effect-dispatcher.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-aggregate/in-memory-effect-dispatcher.test.ts
@@ -19,4 +19,37 @@ describe("initInMemoryEffectDispatcher", () => {
 			{ kind: "generate-summary", url: "https://example.com/b" },
 		]);
 	});
+
+	it("records the publish-crawl-article-failed payload (Phase 2 cross-axis writer migration)", async () => {
+		const { dispatchEffect, dispatched } = initInMemoryEffectDispatcher();
+
+		await dispatchEffect({
+			kind: "publish-crawl-article-failed",
+			url: "https://example.com/a",
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
+		});
+
+		assert.deepEqual(dispatched, [
+			{
+				kind: "publish-crawl-article-failed",
+				url: "https://example.com/a",
+				reason: "exceeded SQS maxReceiveCount",
+				receiveCount: 4,
+			},
+		]);
+	});
+
+	it("records the publish-recrawl-completed payload (Phase 2 cross-axis writer migration)", async () => {
+		const { dispatchEffect, dispatched } = initInMemoryEffectDispatcher();
+
+		await dispatchEffect({
+			kind: "publish-recrawl-completed",
+			url: "https://example.com/a",
+		});
+
+		assert.deepEqual(dispatched, [
+			{ kind: "publish-recrawl-completed", url: "https://example.com/a" },
+		]);
+	});
 });


### PR DESCRIPTION
## Summary

Phase 2 of the Article aggregate migration. Collapses the two highest-risk cross-axis writers onto typed aggregate transitions so a future writer cannot ship a branch that flips one state machine without the other.

- **Four DLQ handlers** (`save-link`, `save-anonymous-link`, `recrawl-link-initiated`, `save-link-raw-html`) now dispatch a single `markCrawlExhausted` transition that writes `crawl.failed` + `summary.failed` and emits `CrawlArticleFailedEvent` via the aggregate effect dispatcher.
- **`recrawl-content-extracted-handler`'s tie-kept-canonical and promotion branches** become sibling transitions (`recrawlTieKeptCanonical`, `recrawlPromoteTier`) — both flip `crawl.ready` and emit the same `GenerateSummaryCommand` + `RecrawlCompletedEvent` effects so the operator always sees a fresh AI excerpt.
- **Falsifiable canary measurement.** Storage tags every saved row with the transition function name (`aggregateTransitionName`), and `classify-row.ts` buckets stuck rows produced by the three Phase 2 transitions under separate `-after-aggregate-migration` reason variants. After one week the count of these variants is the pass/fail signal — non-zero falsifies the Phase 2 bet and cancels Phase 3+.

## Design notes

- `Transition` return type gains a `writes` scope so the aggregate save only touches the axes the transition mutated. `refreshContent` keeps `crawl` untouched so a concurrent inline crawl writer is not clobbered.
- New `Effect` variants `publish-crawl-article-failed` and `publish-recrawl-completed` are dispatched by `initLambdaEffectDispatcher` via EventBridge.
- `HutchDLQEventHandler` grows optional `additionalEnvironment` / `additionalDynamoActions` / `additionalPolicies` so the migrated DLQ Lambdas can wire `GetItem` + the generate-summary queue without coupling the shared component to project-specific knobs.

## Test plan

- [x] Unit tests for `markCrawlExhausted`, `recrawlTieKeptCanonical`, `recrawlPromoteTier` (state, effects, writes scope, function-name tag).
- [x] Updated `transitionAndPersist` test asserts the transition name is threaded into `store.save`.
- [x] `dynamodb-article-store` tests cover writes-scoped UpdateExpression for every crawl + summary kind and the `aggregateTransitionName` attribute.
- [x] `lambda-effect-dispatcher` tests cover the two new publish effects.
- [x] DLQ handler tests assert the markCrawlExhausted transition is dispatched with `{ url, reason, receiveCount }`.
- [x] `recrawl-content-extracted-handler` tests cover both branches (`recrawlPromoteTier` after promotion, `recrawlTieKeptCanonical` after tie-with-canonical).
- [x] `classify-row.ts` tests cover the `-after-aggregate-migration` reason variants for the three Phase 2 transitions.
- [x] 100% coverage across `@packages/domain`, `save-link`, `@packages/test-fixtures`.
- [x] `pnpm nx run-many --target=lint` passes across all projects.
- [x] `pnpm nx run-many --target=test` passes (1162 tests across 93 suites, excluding pre-existing failing test in `@packages/article-resource-unique-id`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6pGQPYx35pES5bDxuuLhU)_