### PR TITLE
fix: close summary silent-skip paths leaving rows pending forever

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-skip-messages.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-skip-messages.ts
@@ -7,6 +7,8 @@ const SUMMARY_SKIP_MESSAGES: Record<SummarySkipReason, string> = {
 	"content-too-short": "This article is too short to summarise.",
 	"ai-unavailable":
 		"Our summariser couldn't produce a useful summary for this article.",
+	"ai-no-text-block":
+		"Our summariser couldn't produce a useful summary for this article.",
 	"crawl-unsupported":
 		"This isn't a webpage we can save, so there's nothing to summarise.",
 };

--- a/projects/save-link/src/generate-summary/link-summariser.test.ts
+++ b/projects/save-link/src/generate-summary/link-summariser.test.ts
@@ -299,17 +299,18 @@ describe("initLinkSummariser", () => {
 		});
 	});
 
-	it("should return null when response has no text block", async () => {
+	it("should mark the row skipped with reason ai-no-text-block when the response has no text block", async () => {
 		const createMessage: CreateAiMessage = async () => ({
 			content: [{ type: "tool_use" }],
 			usage: { input_tokens: 50, output_tokens: 10 },
 		});
+		const markSummarySkipped = jest.fn().mockResolvedValue(undefined);
 
 		const { summarizeArticle } = initLinkSummariser({
 			createMessage,
 			findGeneratedSummary: noCache,
 			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
+			markSummarySkipped,
 			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
@@ -322,6 +323,10 @@ describe("initLinkSummariser", () => {
 		});
 
 		expect(result).toBeNull();
+		expect(markSummarySkipped).toHaveBeenCalledWith({
+			url: "https://example.com/no-text-block",
+			reason: "ai-no-text-block",
+		});
 	});
 
 	it("should mark the row skipped with reason ai-unavailable when AI returns 'Summary not available.'", async () => {

--- a/projects/save-link/src/generate-summary/link-summariser.ts
+++ b/projects/save-link/src/generate-summary/link-summariser.ts
@@ -104,6 +104,7 @@ export function initLinkSummariser(deps: {
 		);
 		if (!textBlock || textBlock.type !== "text" || !textBlock.text) {
 			deps.logger.info("[summarize] no text block in response", { url: params.url });
+			await deps.markSummarySkipped({ url: params.url, reason: "ai-no-text-block" });
 			return null;
 		}
 

--- a/projects/save-link/src/save-link/anonymous-link-saved-handler.test.ts
+++ b/projects/save-link/src/save-link/anonymous-link-saved-handler.test.ts
@@ -58,7 +58,7 @@ describe("initAnonymousLinkSavedHandler", () => {
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
 	});
 
-	it("skips summary dispatch when the article has no content", async () => {
+	it("reports batchItemFailures when canonical content is not yet readable so SQS redelivers through maxReceiveCount", async () => {
 		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
 		const findArticleContent: FindArticleContent = async () => undefined;
 
@@ -68,9 +68,14 @@ describe("initAnonymousLinkSavedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/no-content" }), stubContext, () => {});
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/no-content" }),
+			stubContext,
+			() => {},
+		);
 
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
 	it("reports the record as a batch failure on invalid event detail (Zod failure)", async () => {

--- a/projects/save-link/src/save-link/anonymous-link-saved-handler.ts
+++ b/projects/save-link/src/save-link/anonymous-link-saved-handler.ts
@@ -24,8 +24,10 @@ export function initAnonymousLinkSavedHandler(deps: {
 
 				const content = await findArticleContent(detail.url);
 				if (!content) {
-					logger.info("[AnonymousLinkSaved] no content available, skipping summary", { url: detail.url });
-					continue;
+					/* Canonical S3 object written by promoteTierToCanonical may not be
+					 * readable yet. Throw so SQS retries through maxReceiveCount before
+					 * the DLQ row-mutator flips summaryStatus to "failed". */
+					throw new Error(`canonical content not yet readable for url=${detail.url}`);
 				}
 
 				await dispatchGenerateSummary({ url: detail.url });

--- a/projects/save-link/src/save-link/anonymous-link-saved-handler.ts
+++ b/projects/save-link/src/save-link/anonymous-link-saved-handler.ts
@@ -25,8 +25,8 @@ export function initAnonymousLinkSavedHandler(deps: {
 				const content = await findArticleContent(detail.url);
 				if (!content) {
 					/* Canonical S3 object written by promoteTierToCanonical may not be
-					 * readable yet. Throw so SQS retries through maxReceiveCount before
-					 * the DLQ row-mutator flips summaryStatus to "failed". */
+					 * readable yet (S3 eventual consistency). Throw so SQS retries
+					 * through maxReceiveCount; on exhaustion the DLQ alarm fires. */
 					throw new Error(`canonical content not yet readable for url=${detail.url}`);
 				}
 

--- a/projects/save-link/src/save-link/link-saved-handler.test.ts
+++ b/projects/save-link/src/save-link/link-saved-handler.test.ts
@@ -58,7 +58,7 @@ describe("initLinkSavedHandler", () => {
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
 	});
 
-	it("skips summary dispatch when article has no content", async () => {
+	it("reports batchItemFailures when canonical content is not yet readable so SQS redelivers through maxReceiveCount", async () => {
 		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
 		const findArticleContent: FindArticleContent = async () => undefined;
 
@@ -68,9 +68,14 @@ describe("initLinkSavedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/no-content", userId: "user-1" }), stubContext, () => {});
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/no-content", userId: "user-1" }),
+			stubContext,
+			() => {},
+		);
 
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
 	it("reports the record as a batch failure on invalid event detail (Zod failure)", async () => {

--- a/projects/save-link/src/save-link/link-saved-handler.ts
+++ b/projects/save-link/src/save-link/link-saved-handler.ts
@@ -23,8 +23,8 @@ export function initLinkSavedHandler(deps: {
 				const content = await findArticleContent(detail.url);
 				if (!content) {
 					/* Canonical S3 object written by promoteTierToCanonical may not be
-					 * readable yet. Throw so SQS retries through maxReceiveCount before
-					 * the DLQ row-mutator flips summaryStatus to "failed". */
+					 * readable yet (S3 eventual consistency). Throw so SQS retries
+					 * through maxReceiveCount; on exhaustion the DLQ alarm fires. */
 					throw new Error(`canonical content not yet readable for url=${detail.url}`);
 				}
 

--- a/projects/save-link/src/save-link/link-saved-handler.ts
+++ b/projects/save-link/src/save-link/link-saved-handler.ts
@@ -21,7 +21,12 @@ export function initLinkSavedHandler(deps: {
 				const detail = LinkSavedEvent.detailSchema.parse(envelope.detail);
 
 				const content = await findArticleContent(detail.url);
-				if (!content) continue;
+				if (!content) {
+					/* Canonical S3 object written by promoteTierToCanonical may not be
+					 * readable yet. Throw so SQS retries through maxReceiveCount before
+					 * the DLQ row-mutator flips summaryStatus to "failed". */
+					throw new Error(`canonical content not yet readable for url=${detail.url}`);
+				}
 
 				await dispatchGenerateSummary({ url: detail.url });
 

--- a/src/packages/article-state-types/src/summary-skip-reason.test.ts
+++ b/src/packages/article-state-types/src/summary-skip-reason.test.ts
@@ -1,7 +1,7 @@
 import { SummarySkipReasonSchema } from "./summary-skip-reason";
 
 describe("SummarySkipReasonSchema", () => {
-	it.each(["content-too-short", "ai-unavailable", "crawl-unsupported"])("accepts %s", (value) => {
+	it.each(["content-too-short", "ai-unavailable", "ai-no-text-block", "crawl-unsupported"])("accepts %s", (value) => {
 		expect(SummarySkipReasonSchema.parse(value)).toBe(value);
 	});
 

--- a/src/packages/article-state-types/src/summary-skip-reason.ts
+++ b/src/packages/article-state-types/src/summary-skip-reason.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const SummarySkipReasonSchema = z.enum([
 	"content-too-short",
 	"ai-unavailable",
+	"ai-no-text-block",
 	"crawl-unsupported",
 ]);
 export type SummarySkipReason = z.infer<typeof SummarySkipReasonSchema>;


### PR DESCRIPTION
## Why

Static audit of the EventBridge → SQS chain (see `docs/`) flagged six gaps that can leave a save-link row non-terminal forever (`summaryStatus="pending"`). Two of them are handler-side silent skips that survive Plan 4 (the aggregate-model migration that just landed in #285 / #288) — both stop the state machine from progressing with no DLQ alarm, no log error, and no operator signal.

This PR is **Phase 1** of the remediation plan: the cheapest, highest-signal fixes (no infra, three handlers, unit tests). Phases 2-6 are deferred — Phases 2 and 3 may be subsumed by Plan 4.

## What

**Gap #4 — `link-summariser` "no text block" branch leaves row pending.**
`link-summariser.ts:105-108` returned `null` without calling `markSummarySkipped` when DeepSeek's response had no text block. The two sibling branches (`content-too-short` at line 60-64, `ai-unavailable` at line 112-116) correctly mark the row terminal. This branch was the only return-null path that didn't.

Fix: call `markSummarySkipped({ reason: "ai-no-text-block" })` before returning. Add the new value to the `SummarySkipReason` enum (`src/packages/article-state-types/src/summary-skip-reason.ts`) and the user-facing message map (`projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-skip-messages.ts`).

**Gap #3 — `link-saved-handler` / `anonymous-link-saved-handler` silently continue on missing content.**
Both handlers read the canonical S3 object via `findArticleContent` immediately after a `LinkSavedEvent` arrives. The S3 `CopyObject` written by `promoteTierToCanonical` is eventually-consistent — the read can race the write. On null, the handlers wrote nothing, threw nothing, and let SQS delete the message: `summaryStatus` stayed `pending` forever.

Fix: replace `continue` with `throw`. The existing try/catch pushes the messageId to `batchItemFailures` so SQS redelivers up to `maxReceiveCount` (default 3) before exhausting to DLQ. Today the DLQ alarm fires but the row is not flipped (Phase 4 of the plan adds the row-mutator); with Phase 1 alone, behaviour is **net-better** — a visible alarm replaces a silent loss.

## Test plan

- [x] `pnpm nx run-many --target=test --projects=article-state-types,save-link,hutch` — 1,118 / 1,118 pass
- [x] `pnpm nx run @packages/article-state-types:lint` — clean
- [x] Pre-commit hook (`pnpm check`, 18 projects, full coverage) — passes with 100% function coverage
- [ ] Staging deploy + observation: confirm rows transition `pending → failed` after `maxReceiveCount` exhausts when the canonical S3 write is delayed, instead of stuck `pending`