### PR TITLE
feat(@packages/domain,save-link): add aggregate transitions for crawl and summary status writes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       '@packages/article-resource-unique-id':
         specifier: workspace:*
         version: link:../article-resource-unique-id
+      '@packages/article-state-types':
+        specifier: workspace:*
+        version: link:../article-state-types
       zod:
         specifier: 4.1.13
         version: 4.1.13

--- a/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.test.ts
+++ b/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.test.ts
@@ -1,3 +1,4 @@
+import type { Effect } from "@packages/domain/article-aggregate";
 import { initLambdaEffectDispatcher } from "./lambda-effect-dispatcher";
 
 describe("initLambdaEffectDispatcher", () => {
@@ -108,5 +109,148 @@ describe("initLambdaEffectDispatcher", () => {
 				url: "https://example.com/article",
 			}),
 		).rejects.toThrow("eventbridge throttled");
+	});
+
+	it("publishes a CrawlArticleCompletedEvent for a publish-crawl-article-completed effect, carrying only the url in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-crawl-article-completed",
+			url: "https://example.com/article",
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "CrawlArticleCompleted",
+			detail: JSON.stringify({ url: "https://example.com/article" }),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+	});
+
+	it("publishes a LinkSavedEvent for a publish-link-saved effect, carrying url and userId in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-link-saved",
+			url: "https://example.com/article",
+			userId: "user-123",
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "LinkSaved",
+			detail: JSON.stringify({
+				url: "https://example.com/article",
+				userId: "user-123",
+			}),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+	});
+
+	it("publishes an AnonymousLinkSavedEvent for a publish-anonymous-link-saved effect, carrying only the url in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-anonymous-link-saved",
+			url: "https://example.com/article",
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "AnonymousLinkSaved",
+			detail: JSON.stringify({ url: "https://example.com/article" }),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+	});
+
+	it("publishes a SummaryGeneratedEvent for a publish-summary-generated effect, carrying url and token counts in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-summary-generated",
+			url: "https://example.com/article",
+			inputTokens: 1234,
+			outputTokens: 567,
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "GlobalSummaryGenerated",
+			detail: JSON.stringify({
+				url: "https://example.com/article",
+				inputTokens: 1234,
+				outputTokens: 567,
+			}),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+	});
+
+	it("publishes a SummaryGenerationFailedEvent for a publish-summary-generation-failed effect, carrying url/reason/receiveCount in detail", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await dispatchEffect({
+			kind: "publish-summary-generation-failed",
+			url: "https://example.com/article",
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
+		});
+
+		expect(publishEvent).toHaveBeenCalledWith({
+			source: "hutch.save-link",
+			detailType: "SummaryGenerationFailed",
+			detail: JSON.stringify({
+				url: "https://example.com/article",
+				reason: "exceeded SQS maxReceiveCount",
+				receiveCount: 4,
+			}),
+		});
+		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+	});
+
+	it("throws on unknown effect kind so an unhandled variant surfaces as a Lambda failure", async () => {
+		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { dispatchEffect } = initLambdaEffectDispatcher({
+			dispatchGenerateSummary,
+			publishEvent,
+		});
+
+		await expect(
+			dispatchEffect({
+				kind: "not-a-real-effect",
+				url: "https://example.com/article",
+			} as unknown as Effect),
+		).rejects.toThrow(/Unhandled aggregate effect/);
 	});
 });

--- a/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts
+++ b/projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts
@@ -1,8 +1,13 @@
 import type { DispatchEffect } from "@packages/domain/article-aggregate";
 import {
+	AnonymousLinkSavedEvent,
+	CrawlArticleCompletedEvent,
 	CrawlArticleFailedEvent,
 	type GenerateSummaryCommand,
+	LinkSavedEvent,
 	RecrawlCompletedEvent,
+	SummaryGeneratedEvent,
+	SummaryGenerationFailedEvent,
 } from "@packages/hutch-infra-components";
 import type {
 	DispatchCommand,
@@ -36,6 +41,49 @@ export function initLambdaEffectDispatcher(deps: {
 					source: RecrawlCompletedEvent.source,
 					detailType: RecrawlCompletedEvent.detailType,
 					detail: JSON.stringify({ url: effect.url }),
+				});
+				return;
+			case "publish-crawl-article-completed":
+				await publishEvent({
+					source: CrawlArticleCompletedEvent.source,
+					detailType: CrawlArticleCompletedEvent.detailType,
+					detail: JSON.stringify({ url: effect.url }),
+				});
+				return;
+			case "publish-link-saved":
+				await publishEvent({
+					source: LinkSavedEvent.source,
+					detailType: LinkSavedEvent.detailType,
+					detail: JSON.stringify({ url: effect.url, userId: effect.userId }),
+				});
+				return;
+			case "publish-anonymous-link-saved":
+				await publishEvent({
+					source: AnonymousLinkSavedEvent.source,
+					detailType: AnonymousLinkSavedEvent.detailType,
+					detail: JSON.stringify({ url: effect.url }),
+				});
+				return;
+			case "publish-summary-generated":
+				await publishEvent({
+					source: SummaryGeneratedEvent.source,
+					detailType: SummaryGeneratedEvent.detailType,
+					detail: JSON.stringify({
+						url: effect.url,
+						inputTokens: effect.inputTokens,
+						outputTokens: effect.outputTokens,
+					}),
+				});
+				return;
+			case "publish-summary-generation-failed":
+				await publishEvent({
+					source: SummaryGenerationFailedEvent.source,
+					detailType: SummaryGenerationFailedEvent.detailType,
+					detail: JSON.stringify({
+						url: effect.url,
+						reason: effect.reason,
+						receiveCount: effect.receiveCount,
+					}),
 				});
 				return;
 			default: {

--- a/src/packages/domain/knip.config.ts
+++ b/src/packages/domain/knip.config.ts
@@ -11,6 +11,7 @@ export default {
 		// knip doesn't resolve workspace subpath for @packages/* imports
 		// (consistent with the workaround in @packages/crawl-article)
 		"@packages/article-resource-unique-id",
+		"@packages/article-state-types",
 	],
 	ignoreBinaries: [
 		"knip",

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@packages/article-resource-unique-id": "workspace:*",
+    "@packages/article-state-types": "workspace:*",
     "zod": "4.1.13"
   },
   "devDependencies": {

--- a/src/packages/domain/src/article-aggregate/effects.types.ts
+++ b/src/packages/domain/src/article-aggregate/effects.types.ts
@@ -14,4 +14,19 @@ export type Effect =
 			reason: string;
 			receiveCount: number;
 	  }
-	| { kind: "publish-recrawl-completed"; url: string };
+	| { kind: "publish-recrawl-completed"; url: string }
+	| { kind: "publish-crawl-article-completed"; url: string }
+	| { kind: "publish-link-saved"; url: string; userId: string }
+	| { kind: "publish-anonymous-link-saved"; url: string }
+	| {
+			kind: "publish-summary-generated";
+			url: string;
+			inputTokens: number;
+			outputTokens: number;
+	  }
+	| {
+			kind: "publish-summary-generation-failed";
+			url: string;
+			reason: string;
+			receiveCount: number;
+	  };

--- a/src/packages/domain/src/article-aggregate/index.ts
+++ b/src/packages/domain/src/article-aggregate/index.ts
@@ -21,6 +21,30 @@ export {
 	markCrawlExhausted,
 	type MarkCrawlExhaustedInput,
 } from "./transitions/mark-crawl-exhausted";
+export {
+	markCrawlFailed,
+	type MarkCrawlFailedInput,
+} from "./transitions/mark-crawl-failed";
+export {
+	markCrawlUnsupported,
+	type MarkCrawlUnsupportedInput,
+} from "./transitions/mark-crawl-unsupported";
+export {
+	markSummarySkipped,
+	type MarkSummarySkippedInput,
+} from "./transitions/mark-summary-skipped";
+export {
+	markSummaryReady,
+	type MarkSummaryReadyInput,
+} from "./transitions/mark-summary-ready";
+export {
+	markSummaryExhausted,
+	type MarkSummaryExhaustedInput,
+} from "./transitions/mark-summary-exhausted";
+export {
+	promoteTier,
+	type PromoteTierInput,
+} from "./transitions/promote-tier";
 export { recrawlTieKeptCanonical } from "./transitions/recrawl-tie-kept-canonical";
 export { recrawlPromoteTier } from "./transitions/recrawl-promote-tier";
 export {

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-failed.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-failed.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markCrawlFailed } from "./mark-crawl-failed";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "pending" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("markCrawlFailed", () => {
+	it("flips crawl to failed with the supplied reason", () => {
+		const { article } = markCrawlFailed(buildArticle(), {
+			reason: "fetch returned 500",
+		});
+
+		assert.deepEqual(article.crawl, {
+			kind: "failed",
+			reason: "fetch returned 500",
+		});
+	});
+
+	it("emits no effects (terminal status write only)", () => {
+		const { effects } = markCrawlFailed(buildArticle(), {
+			reason: "fetch returned 500",
+		});
+
+		assert.deepEqual(effects, []);
+	});
+
+	it("declares writes for crawl only so a concurrent inline summary writer is not clobbered", () => {
+		const { writes } = markCrawlFailed(buildArticle(), {
+			reason: "fetch returned 500",
+		});
+
+		assert.deepEqual([...writes].sort(), ["crawl"]);
+	});
+
+	it("preserves summary so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			summary: {
+				kind: "ready",
+				summary: "kept summary",
+				excerpt: "kept excerpt",
+			},
+		});
+
+		const { article } = markCrawlFailed(before, { reason: "fetch returned 500" });
+
+		assert.deepEqual(article.summary, {
+			kind: "ready",
+			summary: "kept summary",
+			excerpt: "kept excerpt",
+		});
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markCrawlFailed(before, { reason: "fetch returned 500" });
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markCrawlFailed(before, { reason: "fetch returned 500" });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markCrawlFailed.name, "markCrawlFailed");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-failed.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-failed.ts
@@ -1,0 +1,25 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkCrawlFailedInput {
+	reason: string;
+}
+
+/* `writes` scoped to crawl only so a concurrent inline summary writer is not clobbered. */
+export function markCrawlFailed(
+	article: Article,
+	input: MarkCrawlFailedInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		crawl: { kind: "failed", reason: input.reason },
+	};
+	const effects: readonly Effect[] = [];
+	const writes: readonly AggregateField[] = ["crawl"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-unsupported.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-unsupported.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markCrawlUnsupported } from "./mark-crawl-unsupported";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "pending" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("markCrawlUnsupported", () => {
+	it("flips crawl to unsupported with the supplied reason", () => {
+		const { article } = markCrawlUnsupported(buildArticle(), {
+			reason: "edge-sniffer blocked: Cloudflare TLS fingerprint",
+		});
+
+		assert.deepEqual(article.crawl, {
+			kind: "unsupported",
+			reason: "edge-sniffer blocked: Cloudflare TLS fingerprint",
+		});
+	});
+
+	it("flips summary to skipped with reason 'crawl-unsupported' so the summary canary doesn't keep flagging the row", () => {
+		const { article } = markCrawlUnsupported(buildArticle(), {
+			reason: "edge-sniffer blocked",
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "skipped",
+			reason: "crawl-unsupported",
+		});
+	});
+
+	it("emits no effects (terminal status write only)", () => {
+		const { effects } = markCrawlUnsupported(buildArticle(), {
+			reason: "edge-sniffer blocked",
+		});
+
+		assert.deepEqual(effects, []);
+	});
+
+	it("declares writes for crawl and summary so the aggregate save scopes to the two axes the transition mutated", () => {
+		const { writes } = markCrawlUnsupported(buildArticle(), {
+			reason: "edge-sniffer blocked",
+		});
+
+		assert.deepEqual([...writes].sort(), ["crawl", "summary"]);
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markCrawlUnsupported(before, {
+			reason: "edge-sniffer blocked",
+		});
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markCrawlUnsupported(before, { reason: "edge-sniffer blocked" });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markCrawlUnsupported.name, "markCrawlUnsupported");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-unsupported.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-unsupported.ts
@@ -1,0 +1,27 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkCrawlUnsupportedInput {
+	reason: string;
+}
+
+/* Cross-axis: pairs the unsupported crawl with summary=skipped so the summary
+ * canary doesn't keep flagging the row forever waiting on a pending summary. */
+export function markCrawlUnsupported(
+	article: Article,
+	input: MarkCrawlUnsupportedInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		crawl: { kind: "unsupported", reason: input.reason },
+		summary: { kind: "skipped", reason: "crawl-unsupported" },
+	};
+	const effects: readonly Effect[] = [];
+	const writes: readonly AggregateField[] = ["crawl", "summary"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-exhausted.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-exhausted.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markSummaryExhausted } from "./mark-summary-exhausted";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("markSummaryExhausted", () => {
+	it("flips summary to failed with the supplied reason", () => {
+		const { article } = markSummaryExhausted(buildArticle(), {
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "failed",
+			reason: "exceeded SQS maxReceiveCount",
+		});
+	});
+
+	it("emits a publish-summary-generation-failed effect carrying the url, reason, and receiveCount", () => {
+		const { effects } = markSummaryExhausted(
+			buildArticle({ url: "https://example.com/post" }),
+			{ reason: "exceeded SQS maxReceiveCount", receiveCount: 7 },
+		);
+
+		assert.deepEqual(effects, [
+			{
+				kind: "publish-summary-generation-failed",
+				url: "https://example.com/post",
+				reason: "exceeded SQS maxReceiveCount",
+				receiveCount: 7,
+			},
+		]);
+	});
+
+	it("declares writes for summary only so a concurrent inline crawl writer is not clobbered", () => {
+		const { writes } = markSummaryExhausted(buildArticle(), {
+			reason: "x",
+			receiveCount: 1,
+		});
+
+		assert.deepEqual([...writes].sort(), ["summary"]);
+	});
+
+	it("preserves crawl so a concurrent inline writer's values are not clobbered on save (this transition is the summary-only DLQ path, unlike markCrawlExhausted which is cross-axis)", () => {
+		const before = buildArticle({ crawl: { kind: "ready" } });
+
+		const { article } = markSummaryExhausted(before, {
+			reason: "x",
+			receiveCount: 1,
+		});
+
+		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markSummaryExhausted(before, {
+			reason: "x",
+			receiveCount: 1,
+		});
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markSummaryExhausted(before, { reason: "x", receiveCount: 1 });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markSummaryExhausted.name, "markSummaryExhausted");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-exhausted.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-exhausted.ts
@@ -1,0 +1,34 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkSummaryExhaustedInput {
+	reason: string;
+	receiveCount: number;
+}
+
+/* Summary-only DLQ path: crawl axis is left untouched (unlike markCrawlExhausted
+ * which is cross-axis), so a concurrent inline crawl writer is not clobbered. */
+export function markSummaryExhausted(
+	article: Article,
+	input: MarkSummaryExhaustedInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		summary: { kind: "failed", reason: input.reason },
+	};
+	const effects: readonly Effect[] = [
+		{
+			kind: "publish-summary-generation-failed",
+			url: article.url,
+			reason: input.reason,
+			receiveCount: input.receiveCount,
+		},
+	];
+	const writes: readonly AggregateField[] = ["summary"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markSummaryReady } from "./mark-summary-ready";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("markSummaryReady", () => {
+	it("flips summary to ready with the supplied summary and excerpt", () => {
+		const { article } = markSummaryReady(buildArticle(), {
+			summary: "AI-generated summary",
+			excerpt: "AI-generated excerpt",
+			inputTokens: 1234,
+			outputTokens: 567,
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "ready",
+			summary: "AI-generated summary",
+			excerpt: "AI-generated excerpt",
+		});
+	});
+
+	it("emits a publish-summary-generated effect carrying url and token counts", () => {
+		const { effects } = markSummaryReady(
+			buildArticle({ url: "https://example.com/post" }),
+			{
+				summary: "summary",
+				excerpt: "excerpt",
+				inputTokens: 1234,
+				outputTokens: 567,
+			},
+		);
+
+		assert.deepEqual(effects, [
+			{
+				kind: "publish-summary-generated",
+				url: "https://example.com/post",
+				inputTokens: 1234,
+				outputTokens: 567,
+			},
+		]);
+	});
+
+	it("declares writes for summary only so a concurrent inline crawl writer is not clobbered", () => {
+		const { writes } = markSummaryReady(buildArticle(), {
+			summary: "summary",
+			excerpt: "excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
+		});
+
+		assert.deepEqual([...writes].sort(), ["summary"]);
+	});
+
+	it("preserves crawl so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({ crawl: { kind: "ready" } });
+
+		const { article } = markSummaryReady(before, {
+			summary: "summary",
+			excerpt: "excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
+		});
+
+		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markSummaryReady(before, {
+			summary: "summary",
+			excerpt: "excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
+		});
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markSummaryReady(before, {
+			summary: "summary",
+			excerpt: "excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
+		});
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markSummaryReady.name, "markSummaryReady");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.ts
@@ -1,0 +1,39 @@
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkSummaryReadyInput {
+	summary: string;
+	excerpt: string;
+	inputTokens: number;
+	outputTokens: number;
+}
+
+/* `writes` scoped to summary only so a concurrent inline crawl writer is not clobbered. */
+export function markSummaryReady(
+	article: Article,
+	input: MarkSummaryReadyInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		summary: {
+			kind: "ready",
+			summary: input.summary,
+			excerpt: input.excerpt,
+		},
+	};
+	const effects: readonly Effect[] = [
+		{
+			kind: "publish-summary-generated",
+			url: article.url,
+			inputTokens: input.inputTokens,
+			outputTokens: input.outputTokens,
+		},
+	];
+	const writes: readonly AggregateField[] = ["summary"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-skipped.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-skipped.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markSummarySkipped } from "./mark-summary-skipped";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("markSummarySkipped", () => {
+	it("flips summary to skipped with the supplied SummarySkipReason", () => {
+		const { article } = markSummarySkipped(buildArticle(), {
+			reason: "content-too-short",
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "skipped",
+			reason: "content-too-short",
+		});
+	});
+
+	it("emits no effects (terminal status write only)", () => {
+		const { effects } = markSummarySkipped(buildArticle(), {
+			reason: "ai-unavailable",
+		});
+
+		assert.deepEqual(effects, []);
+	});
+
+	it("declares writes for summary only so a concurrent inline crawl writer is not clobbered", () => {
+		const { writes } = markSummarySkipped(buildArticle(), {
+			reason: "content-too-short",
+		});
+
+		assert.deepEqual([...writes].sort(), ["summary"]);
+	});
+
+	it("preserves crawl so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({ crawl: { kind: "ready" } });
+
+		const { article } = markSummarySkipped(before, {
+			reason: "content-too-short",
+		});
+
+		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markSummarySkipped(before, {
+			reason: "content-too-short",
+		});
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markSummarySkipped(before, { reason: "content-too-short" });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markSummarySkipped.name, "markSummarySkipped");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-skipped.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-skipped.ts
@@ -1,0 +1,26 @@
+import type { SummarySkipReason } from "@packages/article-state-types";
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkSummarySkippedInput {
+	reason: SummarySkipReason;
+}
+
+/* `writes` scoped to summary only so a concurrent inline crawl writer is not clobbered. */
+export function markSummarySkipped(
+	article: Article,
+	input: MarkSummarySkippedInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		summary: { kind: "skipped", reason: input.reason },
+	};
+	const effects: readonly Effect[] = [];
+	const writes: readonly AggregateField[] = ["summary"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/article-aggregate/transitions/promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/promote-tier.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { promoteTier } from "./promote-tier";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Old title",
+			siteName: "Old site",
+			excerpt: "Old excerpt",
+			wordCount: 100,
+		},
+		freshness: {
+			etag: '"old-etag"',
+			contentFetchedAt: "2026-01-01T00:00:00.000Z",
+		},
+		estimatedReadTime: 1,
+		crawl: { kind: "pending" },
+		summary: { kind: "pending" },
+		...overrides,
+	};
+}
+
+describe("promoteTier", () => {
+	it("overwrites metadata with the supplied values", () => {
+		const { article } = promoteTier(buildArticle(), {
+			tier: "tier-0",
+			metadata: {
+				title: "New title",
+				siteName: "New site",
+				excerpt: "New excerpt",
+				wordCount: 250,
+				imageUrl: "https://example.com/image.jpg",
+			},
+			estimatedReadTime: 2,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.equal(article.metadata.title, "New title");
+		assert.equal(article.metadata.wordCount, 250);
+		assert.equal(article.metadata.imageUrl, "https://example.com/image.jpg");
+	});
+
+	it("updates contentFetchedAt on freshness while preserving other freshness attributes (etag, lastModified)", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"kept-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+			},
+		});
+
+		const { article } = promoteTier(before, {
+			tier: "tier-0",
+			metadata: before.metadata,
+			estimatedReadTime: 2,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.equal(article.freshness.contentFetchedAt, "2026-05-10T12:00:00.000Z");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.freshness.lastModified, "Thu, 01 Jan 2026 00:00:00 GMT");
+	});
+
+	it("overwrites estimatedReadTime with the supplied value", () => {
+		const { article } = promoteTier(buildArticle(), {
+			tier: "tier-0",
+			metadata: buildArticle().metadata,
+			estimatedReadTime: 7,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.equal(article.estimatedReadTime, 7);
+	});
+
+	it("flips crawl to ready", () => {
+		const { article } = promoteTier(buildArticle(), {
+			tier: "tier-0",
+			metadata: buildArticle().metadata,
+			estimatedReadTime: 1,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("resets summary to pending so the worker regenerates the cached text against the freshly-selected canonical", () => {
+		const before = buildArticle({
+			summary: {
+				kind: "ready",
+				summary: "stale summary",
+				excerpt: "stale excerpt",
+			},
+		});
+
+		const { article } = promoteTier(before, {
+			tier: "tier-0",
+			metadata: before.metadata,
+			estimatedReadTime: 1,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.deepEqual(article.summary, { kind: "pending" });
+	});
+
+	it("emits generate-summary and publish-crawl-article-completed in that order, plus publish-link-saved when canonicalChanged + userId is supplied", () => {
+		const { effects } = promoteTier(
+			buildArticle({ url: "https://example.com/post" }),
+			{
+				tier: "tier-0",
+				metadata: buildArticle().metadata,
+				estimatedReadTime: 1,
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+				canonicalChanged: true,
+				userId: "user-123",
+			},
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{
+				kind: "publish-crawl-article-completed",
+				url: "https://example.com/post",
+			},
+			{
+				kind: "publish-link-saved",
+				url: "https://example.com/post",
+				userId: "user-123",
+			},
+		]);
+	});
+
+	it("emits publish-anonymous-link-saved when canonicalChanged is true and userId is absent", () => {
+		const { effects } = promoteTier(
+			buildArticle({ url: "https://example.com/post" }),
+			{
+				tier: "tier-0",
+				metadata: buildArticle().metadata,
+				estimatedReadTime: 1,
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+				canonicalChanged: true,
+			},
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{
+				kind: "publish-crawl-article-completed",
+				url: "https://example.com/post",
+			},
+			{
+				kind: "publish-anonymous-link-saved",
+				url: "https://example.com/post",
+			},
+		]);
+	});
+
+	it("omits the user-facing event when canonicalChanged is false (re-pick of the same tier must not re-fire link-saved notifications)", () => {
+		const { effects } = promoteTier(
+			buildArticle({ url: "https://example.com/post" }),
+			{
+				tier: "tier-0",
+				metadata: buildArticle().metadata,
+				estimatedReadTime: 1,
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+				canonicalChanged: false,
+				userId: "user-123",
+			},
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{
+				kind: "publish-crawl-article-completed",
+				url: "https://example.com/post",
+			},
+		]);
+	});
+
+	it("declares writes for metadata, freshness, crawl, and summary so the aggregate save scopes to the four axes the transition mutated", () => {
+		const { writes } = promoteTier(buildArticle(), {
+			tier: "tier-0",
+			metadata: buildArticle().metadata,
+			estimatedReadTime: 1,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.deepEqual([...writes].sort(), [
+			"crawl",
+			"freshness",
+			"metadata",
+			"summary",
+		]);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		promoteTier(before, {
+			tier: "tier-1",
+			metadata: {
+				title: "Different",
+				siteName: "Example",
+				excerpt: "Different",
+				wordCount: 200,
+			},
+			estimatedReadTime: 3,
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			canonicalChanged: true,
+		});
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(promoteTier.name, "promoteTier");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/promote-tier.ts
@@ -1,0 +1,53 @@
+import type { Article, ArticleMetadata } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface PromoteTierInput {
+	tier: "tier-0" | "tier-1";
+	metadata: ArticleMetadata;
+	estimatedReadTime: number;
+	contentFetchedAt: string;
+	/** True when the canonical tier flipped this run; gates the publish-link-saved / publish-anonymous-link-saved effect so a re-pick of the same tier does not re-fire user-facing notifications. */
+	canonicalChanged: boolean;
+	/** Authenticated save: emits publish-link-saved. Absent: emits publish-anonymous-link-saved. */
+	userId?: string;
+}
+
+/* Selector promotion: writes metadata + freshness + crawl=ready + summary=pending.
+ * `canonicalChanged` gates the user-facing event so a re-pick of the same tier
+ * does not re-fire link-saved / anonymous-link-saved notifications. */
+export function promoteTier(
+	article: Article,
+	input: PromoteTierInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		metadata: input.metadata,
+		freshness: { ...article.freshness, contentFetchedAt: input.contentFetchedAt },
+		estimatedReadTime: input.estimatedReadTime,
+		crawl: { kind: "ready" },
+		summary: { kind: "pending" },
+	};
+	const effects: Effect[] = [
+		{ kind: "generate-summary", url: article.url },
+		{ kind: "publish-crawl-article-completed", url: article.url },
+	];
+	if (input.canonicalChanged) {
+		effects.push(
+			input.userId
+				? { kind: "publish-link-saved", url: article.url, userId: input.userId }
+				: { kind: "publish-anonymous-link-saved", url: article.url },
+		);
+	}
+	const writes: readonly AggregateField[] = [
+		"metadata",
+		"freshness",
+		"crawl",
+		"summary",
+	];
+	return { article: next, effects, writes };
+}


### PR DESCRIPTION
## Goal

Introduce six pure transitions on the `Article` aggregate (`@packages/domain/article-aggregate`) and five matching `Effect` variants so any future caller can write a terminal `crawlStatus` or `summaryStatus` via `transitionAndPersist` instead of an ad-hoc DynamoDB update. Wire the runtime effect dispatcher in `projects/save-link/src/article-aggregate/lambda-effect-dispatcher.ts` to translate the new effects onto EventBridge.

This change is **purely additive**: no application handler is rewired and no production behavior changes. The new API becomes available for callers to opt into in later work.

## Context

The aggregate currently exposes four transitions (`refreshContent`, `markCrawlExhausted`, `recrawlTieKeptCanonical`, `recrawlPromoteTier`). Callers that need to flip terminal failure / unsupported / skipped / ready states still write DynamoDB directly through `dynamodb-article-crawl.ts` / `dynamodb-generated-summary.ts`. Those inline writers update one axis at a time and have produced the "Class #1 — writer skips correlated attribute" stuck-row pattern (e.g. `crawlStatus="unsupported"` paired with `summaryStatus="pending"` forever).

Closing that pattern requires routing every status write through aggregate transitions. This PR adds the missing transitions so that work can proceed.

## Transitions added

| Transition | Axis | Effects |
|---|---|---|
| `markCrawlFailed` | crawl only | none |
| `markCrawlUnsupported` | crawl + summary=`skipped`/`crawl-unsupported` (cross-axis so the summary canary stops flagging the row) | none |
| `markSummarySkipped` | summary only (typed `SummarySkipReason`) | none |
| `markSummaryReady` | summary only | `publish-summary-generated` |
| `markSummaryExhausted` | summary only (summary-only DLQ path, unlike the cross-axis `markCrawlExhausted`) | `publish-summary-generation-failed` |
| `promoteTier` | metadata + freshness + crawl=`ready` + summary=`pending` | `generate-summary`, `publish-crawl-article-completed`, and `publish-link-saved` / `publish-anonymous-link-saved` gated on `canonicalChanged` |

## Effect variants added

`publish-crawl-article-completed`, `publish-link-saved`, `publish-anonymous-link-saved`, `publish-summary-generated`, `publish-summary-generation-failed`. The Lambda dispatcher translates each onto the existing EventBridge event definitions (no new events created).

## Verification

- `pnpm nx run @packages/domain:compile`
- `pnpm nx run @packages/domain:test` — 206 tests pass
- `pnpm nx run @packages/domain:test-with-coverage` — 100% lines/branches/functions/statements
- `pnpm nx run save-link:compile`
- `pnpm nx run save-link:test` — 313 tests pass
- `pnpm nx run save-link:test-with-coverage` — 100%
- `pnpm nx run save-link:lint`
- `pnpm nx run hutch:compile` — confirms no downstream consumer regressed

https://claude.ai/code/session_01XB34NPGiABvKSEizyPptVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XB34NPGiABvKSEizyPptVB)_