### PR TITLE
feat(save-link): route summary generation through the Article aggregate and fix silent SQS success paths leaving rows pending

### DIFF
--- a/projects/save-link/src/generate-summary/article-summary.types.ts
+++ b/projects/save-link/src/generate-summary/article-summary.types.ts
@@ -6,16 +6,6 @@ export type GeneratedSummary =
 	| { status: "failed"; reason: string }
 	| { status: "skipped"; reason?: string };
 
-export type SummarizeArticle = (params: {
-	url: string;
-	textContent: string;
-}) => Promise<{
-	summary: string;
-	excerpt: string;
-	inputTokens: number;
-	outputTokens: number;
-} | null>;
-
 export type FindGeneratedSummary = (url: string) => Promise<GeneratedSummary | undefined>;
 
 export type SaveGeneratedSummary = (params: {
@@ -46,26 +36,3 @@ export type MarkSummaryStage = (params: {
 	url: string;
 	stage: SummaryStage;
 }) => Promise<void>;
-
-export type DocumentBlock = {
-	type: "document";
-	source: { type: "text"; media_type: "text/plain"; data: string };
-	title: string;
-	citations: { enabled: boolean };
-};
-
-export type CreateAiMessage = (params: {
-	model: string;
-	max_tokens: number;
-	system: string;
-	messages: Array<{ role: "user" | "assistant"; content: string | Array<DocumentBlock> }>;
-	output_config?: {
-		format: {
-			type: "json_schema";
-			schema: Record<string, unknown>;
-		};
-	};
-}) => Promise<{
-	content: Array<{ type: string; text?: string }>;
-	usage: { input_tokens: number; output_tokens: number };
-}>;

--- a/projects/save-link/src/generate-summary/create-ai-message.types.ts
+++ b/projects/save-link/src/generate-summary/create-ai-message.types.ts
@@ -1,0 +1,25 @@
+export type DocumentBlock = {
+	type: "document";
+	source: { type: "text"; media_type: "text/plain"; data: string };
+	title: string;
+	citations: { enabled: boolean };
+};
+
+export type CreateAiMessage = (params: {
+	model: string;
+	max_tokens: number;
+	system: string;
+	messages: Array<{
+		role: "user" | "assistant";
+		content: string | Array<DocumentBlock>;
+	}>;
+	output_config?: {
+		format: {
+			type: "json_schema";
+			schema: Record<string, unknown>;
+		};
+	};
+}) => Promise<{
+	content: Array<{ type: string; text?: string }>;
+	usage: { input_tokens: number; output_tokens: number };
+}>;

--- a/projects/save-link/src/generate-summary/create-deepseek-message.ts
+++ b/projects/save-link/src/generate-summary/create-deepseek-message.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import type { CreateAiMessage, DocumentBlock } from "./article-summary.types";
+import type { CreateAiMessage, DocumentBlock } from "./create-ai-message.types";
 
 type ChatCompletionResponse = {
 	choices: Array<{ message?: { content?: string | null } }>;

--- a/projects/save-link/src/generate-summary/generate-summary-handler.test.ts
+++ b/projects/save-link/src/generate-summary/generate-summary-handler.test.ts
@@ -1,9 +1,13 @@
+import {
+	type Article,
+	markSummaryReady,
+	markSummarySkipped,
+} from "@packages/domain/article-aggregate";
 import { noopLogger } from "@packages/hutch-logger";
+import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
 import { initGenerateSummaryHandler } from "./generate-summary-handler";
-import type { SummarizeArticle } from "./article-summary.types";
+import type { SummarizeArticle } from "./link-summariser";
 import type { FindArticleContent } from "../save-link/find-article-content";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
@@ -43,62 +47,182 @@ function createSqsEvent(detail: { url: string }): SQSEvent {
 	};
 }
 
+function pendingArticle(url: string): Article {
+	return {
+		url,
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary: { kind: "pending" },
+	};
+}
+
+type HandlerDeps = Parameters<typeof initGenerateSummaryHandler>[0];
+
+function createHandler(overrides: Partial<HandlerDeps> = {}) {
+	const deps: HandlerDeps = {
+		summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>(),
+		findArticleContent: jest.fn<ReturnType<FindArticleContent>, Parameters<FindArticleContent>>().mockResolvedValue({ content: "<p>content</p>" }),
+		loadArticle: jest.fn().mockResolvedValue(pendingArticle("https://example.com/x")),
+		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
+		logger: noopLogger,
+		...overrides,
+	};
+	return { handler: initGenerateSummaryHandler(deps), deps };
+}
+
 describe("initGenerateSummaryHandler", () => {
-	it("should summarize article and publish GlobalSummaryGenerated event", async () => {
-		const summarizeArticle: SummarizeArticle = async () => ({
-			summary: "A summary.",
-			excerpt: "A blurb.",
-			inputTokens: 100,
-			outputTokens: 20,
-		});
-		const findArticleContent: FindArticleContent = async () => ({ content: "<p>Article content</p>" });
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
-
-		const handler = initGenerateSummaryHandler({
-			summarizeArticle,
-			findArticleContent,
-			publishEvent,
-			logger: noopLogger,
-		});
-
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
-
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "GlobalSummaryGenerated",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
+	it("fires markSummaryReady with summary/excerpt/inputTokens/outputTokens on the happy path", async () => {
+		const URL = "https://example.com/article";
+		const { handler, deps } = createHandler({
+			summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>().mockResolvedValue({
+				kind: "ready",
+				summary: "A summary.",
+				excerpt: "A blurb.",
 				inputTokens: 100,
-				outputTokens: 20,
+				outputTokens: 50,
 			}),
+			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
+		});
+
+		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummaryReady, {
+			url: URL,
+			input: {
+				summary: "A summary.",
+				excerpt: "A blurb.",
+				inputTokens: 100,
+				outputTokens: 50,
+			},
 		});
 	});
 
-	it("reports the record as a batch failure when article content not found (SQS will retry, DLQ consumer handles terminal failure)", async () => {
-		const summarizeArticle: SummarizeArticle = async () => null;
-		const findArticleContent: FindArticleContent = async () => undefined;
-		const publishEvent: PublishEvent = jest.fn();
-		const error = jest.fn();
-		const logger = { ...noopLogger, error };
-
-		const handler = initGenerateSummaryHandler({
-			summarizeArticle,
-			findArticleContent,
-			publishEvent,
-			logger,
+	it("short-circuits without calling the summariser when the cached row is summary=ready", async () => {
+		const URL = "https://example.com/cached-ready";
+		const cached: Article = {
+			...pendingArticle(URL),
+			summary: { kind: "ready", summary: "cached", excerpt: "cached blurb" },
+		};
+		const { handler, deps } = createHandler({
+			loadArticle: jest.fn().mockResolvedValue(cached),
 		});
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/missing" }),
-			stubContext,
-			() => {},
-		);
+		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(deps.summarizeArticle).not.toHaveBeenCalled();
+		expect(deps.findArticleContent).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("short-circuits without calling the summariser when the cached row is summary=skipped", async () => {
+		const URL = "https://example.com/cached-skipped";
+		const cached: Article = {
+			...pendingArticle(URL),
+			summary: { kind: "skipped", reason: "content-too-short" },
+		};
+		const { handler, deps } = createHandler({
+			loadArticle: jest.fn().mockResolvedValue(cached),
+		});
+
+		await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(deps.summarizeArticle).not.toHaveBeenCalled();
+		expect(deps.findArticleContent).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("does not short-circuit when the cached row is summary=failed (redrive scenario)", async () => {
+		const URL = "https://example.com/cached-failed";
+		const cached: Article = {
+			...pendingArticle(URL),
+			summary: { kind: "failed", reason: "timeout" },
+		};
+		const { handler, deps } = createHandler({
+			summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>().mockResolvedValue({
+				kind: "ready",
+				summary: "Recovered.",
+				excerpt: "Recovered blurb.",
+				inputTokens: 100,
+				outputTokens: 50,
+			}),
+			loadArticle: jest.fn().mockResolvedValue(cached),
+		});
+
+		await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummaryReady, expect.objectContaining({ url: URL }));
+	});
+
+	it("fires markSummarySkipped with reason='content-too-short' when the summariser skips", async () => {
+		const URL = "https://example.com/short";
+		const { handler, deps } = createHandler({
+			summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>().mockResolvedValue({
+				kind: "skipped",
+				reason: "content-too-short",
+			}),
+			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
+		});
+
+		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummarySkipped, {
+			url: URL,
+			input: { reason: "content-too-short" },
+		});
+	});
+
+	it("fires markSummarySkipped with reason='ai-unavailable' when the summariser reports AI unavailable", async () => {
+		const URL = "https://example.com/unavailable";
+		const { handler, deps } = createHandler({
+			summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>().mockResolvedValue({
+				kind: "skipped",
+				reason: "ai-unavailable",
+			}),
+			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
+		});
+
+		await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummarySkipped, {
+			url: URL,
+			input: { reason: "ai-unavailable" },
+		});
+	});
+
+	it("reports batchItemFailures when the summariser returns no-text-block so SQS redelivers and eventually DLQs", async () => {
+		const URL = "https://example.com/no-text-block";
+		const { handler, deps } = createHandler({
+			summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>().mockResolvedValue({ kind: "no-text-block" }),
+			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
+		});
+
+		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(publishEvent).not.toHaveBeenCalled();
-		// Confirms the assert(article) propagated to the per-record catch.
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports batchItemFailures when article content is not found (assert in handler)", async () => {
+		const URL = "https://example.com/missing";
+		const error = jest.fn();
+		const { handler, deps } = createHandler({
+			findArticleContent: jest.fn<ReturnType<FindArticleContent>, Parameters<FindArticleContent>>().mockResolvedValue(undefined),
+			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
+			logger: { ...noopLogger, error },
+		});
+
+		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+		expect(deps.summarizeArticle).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
 		expect(error).toHaveBeenCalledWith(
-			"[GenerateGlobalSummary] record failed",
+			"[GenerateSummary] record failed",
 			expect.objectContaining({
 				messageId: "msg-1",
 				error: expect.objectContaining({
@@ -108,34 +232,8 @@ describe("initGenerateSummaryHandler", () => {
 		);
 	});
 
-	it("should skip publishing when summarization returns null (cache hit or skipped)", async () => {
-		const summarizeArticle: SummarizeArticle = async () => null;
-		const findArticleContent: FindArticleContent = async () => ({ content: "<p>Content</p>" });
-		const publishEvent: PublishEvent = jest.fn();
-
-		const handler = initGenerateSummaryHandler({
-			summarizeArticle,
-			findArticleContent,
-			publishEvent,
-			logger: noopLogger,
-		});
-
-		await handler(createSqsEvent({ url: "https://example.com/cached" }), stubContext, () => {});
-
-		expect(publishEvent).not.toHaveBeenCalled();
-	});
-
-	it("reports the record as a batch failure on invalid command schema (Zod failure)", async () => {
-		const summarizeArticle: SummarizeArticle = async () => null;
-		const findArticleContent: FindArticleContent = async () => ({ content: "content" });
-		const publishEvent: PublishEvent = jest.fn();
-
-		const handler = initGenerateSummaryHandler({
-			summarizeArticle,
-			findArticleContent,
-			publishEvent,
-			logger: noopLogger,
-		});
+	it("reports batchItemFailures on invalid command schema (Zod failure)", async () => {
+		const { handler, deps } = createHandler();
 
 		const invalidEvent: SQSEvent = {
 			Records: [{
@@ -152,6 +250,8 @@ describe("initGenerateSummaryHandler", () => {
 		};
 
 		const result = await handler(invalidEvent, stubContext, () => {});
+
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
 	});
 });

--- a/projects/save-link/src/generate-summary/generate-summary-handler.ts
+++ b/projects/save-link/src/generate-summary/generate-summary-handler.ts
@@ -1,24 +1,27 @@
 import assert from "node:assert";
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
-	GenerateSummaryCommand,
-	SummaryGeneratedEvent,
-} from "./index";
-import type { SummarizeArticle } from "./article-summary.types";
+	markSummaryReady,
+	markSummarySkipped,
+	type LoadArticle,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "./index";
+import type { SummarizeArticle } from "./link-summariser";
 import type { FindArticleContent } from "../save-link/find-article-content";
 
 interface GenerateSummaryHandlerDeps {
 	summarizeArticle: SummarizeArticle;
 	findArticleContent: FindArticleContent;
-	publishEvent: PublishEvent;
+	loadArticle: LoadArticle;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initGenerateSummaryHandler(deps: GenerateSummaryHandlerDeps): Handler<SQSEvent, SQSBatchResponse> {
-	const { summarizeArticle, findArticleContent, publishEvent, logger } = deps;
+	const { summarizeArticle, findArticleContent, loadArticle, transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -28,6 +31,22 @@ export function initGenerateSummaryHandler(deps: GenerateSummaryHandlerDeps): Ha
 				const envelope = JSON.parse(record.body);
 				const command = GenerateSummaryCommand.detailSchema.parse(envelope.detail);
 
+				/* Cache check via the aggregate's loader — `ready` and `skipped` are
+				 * terminal, short-circuit those. `failed` is retryable on redrive so
+				 * a new attempt re-runs the AI. */
+				const existing = await loadArticle(command.url);
+				if (
+					existing &&
+					(existing.summary.kind === "ready" ||
+						existing.summary.kind === "skipped")
+				) {
+					logger.info("[GenerateSummary] cache hit", {
+						url: command.url,
+						kind: existing.summary.kind,
+					});
+					continue;
+				}
+
 				const article = await findArticleContent(command.url);
 				assert(article, `Article content not found: ${command.url}`);
 
@@ -36,28 +55,43 @@ export function initGenerateSummaryHandler(deps: GenerateSummaryHandlerDeps): Ha
 					textContent: article.content,
 				});
 
-				if (!result) {
-					logger.info("[GenerateGlobalSummary] already summarized or skipped", { url: command.url });
-					continue;
-				}
-
-				await publishEvent({
-					source: SummaryGeneratedEvent.source,
-					detailType: SummaryGeneratedEvent.detailType,
-					detail: JSON.stringify({
+				if (result.kind === "ready") {
+					await transitionAndPersist(markSummaryReady, {
+						url: command.url,
+						input: {
+							summary: result.summary,
+							excerpt: result.excerpt,
+							inputTokens: result.inputTokens,
+							outputTokens: result.outputTokens,
+						},
+					});
+					logger.info("[GenerateSummary] completed", {
 						url: command.url,
 						inputTokens: result.inputTokens,
 						outputTokens: result.outputTokens,
-					}),
-				});
+					});
+					continue;
+				}
 
-				logger.info("[GenerateGlobalSummary] completed", {
-					url: command.url,
-					inputTokens: result.inputTokens,
-					outputTokens: result.outputTokens,
-				});
+				if (result.kind === "skipped") {
+					await transitionAndPersist(markSummarySkipped, {
+						url: command.url,
+						input: { reason: result.reason },
+					});
+					logger.info("[GenerateSummary] skipped", {
+						url: command.url,
+						reason: result.reason,
+					});
+					continue;
+				}
+
+				/* no-text-block: the AI returned but the response had no parseable
+				 * text. Throw so the catch block adds the record to
+				 * batchItemFailures — SQS redelivery re-runs; eventual DLQ
+				 * exhaustion flips the row via markSummaryExhausted. */
+				throw new Error(`[GenerateSummary] no text block for ${command.url}`);
 			} catch (error) {
-				logger.error("[GenerateGlobalSummary] record failed", {
+				logger.error("[GenerateSummary] record failed", {
 					messageId: record.messageId,
 					error,
 				});

--- a/projects/save-link/src/generate-summary/generate-summary-handler.ts
+++ b/projects/save-link/src/generate-summary/generate-summary-handler.ts
@@ -88,8 +88,8 @@ export function initGenerateSummaryHandler(deps: GenerateSummaryHandlerDeps): Ha
 				/* no-text-block: the AI returned but the response had no parseable
 				 * text. Throw so the catch block adds the record to
 				 * batchItemFailures — SQS redelivery re-runs; eventual DLQ
-				 * exhaustion flips the row via markSummaryExhausted. */
-				throw new Error(`[GenerateSummary] no text block for ${command.url}`);
+				 * exhaustion flips the row via markSummaryFailed. */
+				throw new Error(`[GenerateSummary] ${result.kind satisfies "no-text-block"} for ${command.url}`);
 			} catch (error) {
 				logger.error("[GenerateSummary] record failed", {
 					messageId: record.messageId,

--- a/projects/save-link/src/generate-summary/link-summariser.test.ts
+++ b/projects/save-link/src/generate-summary/link-summariser.test.ts
@@ -1,12 +1,7 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initLinkSummariser } from "./link-summariser";
-import type {
-	CreateAiMessage,
-	FindGeneratedSummary,
-	MarkSummarySkipped,
-	MarkSummaryStage,
-	SaveGeneratedSummary,
-} from "./article-summary.types";
+import type { CreateAiMessage } from "./create-ai-message.types";
+import type { MarkSummaryStage } from "./article-summary.types";
 
 function createStubCreateMessage(payload: { summary: string; excerpt: string }): CreateAiMessage {
 	return async () => ({
@@ -15,23 +10,43 @@ function createStubCreateMessage(payload: { summary: string; excerpt: string }):
 	});
 }
 
-const noCache: FindGeneratedSummary = async () => undefined;
-const pendingCache: FindGeneratedSummary = async () => ({ status: "pending" });
-const noopSave: SaveGeneratedSummary = async () => {};
-const noopMarkSkipped: MarkSummarySkipped = async () => {};
 const noopMarkStage: MarkSummaryStage = async () => {};
 const identity = (text: string) => text;
 
 describe("initLinkSummariser", () => {
-	it("should skip summarisation and mark the row as skipped when isTooShortToSummarize returns true", async () => {
-		const createMessage = jest.fn();
-		const markSummarySkipped = jest.fn().mockResolvedValue(undefined);
+	it("returns kind 'ready' with summary/excerpt/inputTokens/outputTokens on the happy path", async () => {
+		const createMessage = createStubCreateMessage({
+			summary: "A good summary.",
+			excerpt: "Quick blurb.",
+		});
 
 		const { summarizeArticle } = initLinkSummariser({
 			createMessage,
-			findGeneratedSummary: pendingCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped,
+			markSummaryStage: noopMarkStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		const result = await summarizeArticle({
+			url: "https://example.com/long",
+			textContent: "A long article with lots of content.",
+		});
+
+		expect(result).toEqual({
+			kind: "ready",
+			summary: "A good summary.",
+			excerpt: "Quick blurb.",
+			inputTokens: 50,
+			outputTokens: 10,
+		});
+	});
+
+	it("returns kind 'skipped' with reason='content-too-short' when content is below the threshold", async () => {
+		const createMessage = jest.fn();
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage,
 			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
@@ -43,15 +58,170 @@ describe("initLinkSummariser", () => {
 			textContent: "Short article text.",
 		});
 
-		expect(result).toBeNull();
+		expect(result).toEqual({ kind: "skipped", reason: "content-too-short" });
 		expect(createMessage).not.toHaveBeenCalled();
-		expect(markSummarySkipped).toHaveBeenCalledWith({
-			url: "https://example.com/short",
-			reason: "content-too-short",
-		});
 	});
 
-	it("should pass article content as a document block to createMessage", async () => {
+	it("returns kind 'skipped' with reason='ai-unavailable' when DeepSeek returns 'Summary not available.'", async () => {
+		const createMessage = createStubCreateMessage({
+			summary: "Summary not available.",
+			excerpt: "Summary not available.",
+		});
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage,
+			markSummaryStage: noopMarkStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		const result = await summarizeArticle({
+			url: "https://example.com/unavailable",
+			textContent: "Content that cannot be summarised.",
+		});
+
+		expect(result).toEqual({ kind: "skipped", reason: "ai-unavailable" });
+	});
+
+	it("returns kind 'no-text-block' when the response has no text block", async () => {
+		const createMessage: CreateAiMessage = async () => ({
+			content: [{ type: "tool_use" }],
+			usage: { input_tokens: 50, output_tokens: 10 },
+		});
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage,
+			markSummaryStage: noopMarkStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		const result = await summarizeArticle({
+			url: "https://example.com/no-text-block",
+			textContent: "Some article content.",
+		});
+
+		expect(result).toEqual({ kind: "no-text-block" });
+	});
+
+	it("calls markSummaryStage('summary-started') before any AI call", async () => {
+		const createMessage = createStubCreateMessage({
+			summary: "A summary.",
+			excerpt: "A blurb.",
+		});
+		const order: string[] = [];
+		const markSummaryStage: MarkSummaryStage = async ({ stage }) => {
+			order.push(`stage:${stage}`);
+		};
+		const wrappedCreateMessage: CreateAiMessage = async (params) => {
+			order.push("createMessage");
+			return createMessage(params);
+		};
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage: wrappedCreateMessage,
+			markSummaryStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		await summarizeArticle({
+			url: "https://example.com/x",
+			textContent: "Long content.",
+		});
+
+		expect(order[0]).toBe("stage:summary-started");
+	});
+
+	it("calls markSummaryStage('summary-generating') after the length check but before the AI call", async () => {
+		const createMessage = createStubCreateMessage({
+			summary: "A summary.",
+			excerpt: "A blurb.",
+		});
+		const order: string[] = [];
+		const markSummaryStage: MarkSummaryStage = async ({ stage }) => {
+			order.push(`stage:${stage}`);
+		};
+		const wrappedCreateMessage: CreateAiMessage = async (params) => {
+			order.push("createMessage");
+			return createMessage(params);
+		};
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage: wrappedCreateMessage,
+			markSummaryStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		await summarizeArticle({
+			url: "https://example.com/x",
+			textContent: "Long content.",
+		});
+
+		expect(order).toEqual([
+			"stage:summary-started",
+			"stage:summary-generating",
+			"createMessage",
+		]);
+	});
+
+	it("clips excerpt on a word boundary if it exceeds MAX_EXCERPT_LENGTH", async () => {
+		const overLong = `${"word ".repeat(60)}tail`;
+		const createMessage = createStubCreateMessage({
+			summary: "Body.",
+			excerpt: overLong,
+		});
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage,
+			markSummaryStage: noopMarkStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		const result = await summarizeArticle({
+			url: "https://example.com/long",
+			textContent: "x",
+		});
+
+		expect(result.kind).toBe("ready");
+		if (result.kind !== "ready") throw new Error("unreachable");
+		expect(result.excerpt.length).toBeLessThanOrEqual(160);
+		expect(result.excerpt.endsWith("…")).toBe(true);
+	});
+
+	it("hard-cuts an over-length excerpt that has no whitespace", async () => {
+		const noSpaces = "x".repeat(200);
+		const createMessage = createStubCreateMessage({
+			summary: "Body.",
+			excerpt: noSpaces,
+		});
+
+		const { summarizeArticle } = initLinkSummariser({
+			createMessage,
+			markSummaryStage: noopMarkStage,
+			logger: noopLogger,
+			cleanContent: identity,
+			isTooShortToSummarize: () => false,
+		});
+
+		const result = await summarizeArticle({
+			url: "https://example.com/no-spaces",
+			textContent: "x",
+		});
+
+		expect(result.kind).toBe("ready");
+		if (result.kind !== "ready") throw new Error("unreachable");
+		expect(result.excerpt).toBe(`${"x".repeat(159)}…`);
+	});
+
+	it("passes article content as a document block to createMessage", async () => {
 		const createMessage = jest.fn().mockResolvedValue({
 			content: [{ type: "text", text: JSON.stringify({ summary: "A summary.", excerpt: "Blurb." }) }],
 			usage: { input_tokens: 50, output_tokens: 10 },
@@ -59,9 +229,6 @@ describe("initLinkSummariser", () => {
 
 		const { summarizeArticle } = initLinkSummariser({
 			createMessage,
-			findGeneratedSummary: noCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
 			markSummaryStage: noopMarkStage,
 			logger: noopLogger,
 			cleanContent: identity,
@@ -86,271 +253,5 @@ describe("initLinkSummariser", () => {
 				}],
 			}),
 		);
-	});
-
-	it("should call createMessage and persist both summary and excerpt", async () => {
-		const createMessage = createStubCreateMessage({
-			summary: "A good summary.",
-			excerpt: "Quick blurb.",
-		});
-		const saveGeneratedSummary = jest.fn().mockResolvedValue(undefined);
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: pendingCache,
-			saveGeneratedSummary,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/long",
-			textContent: "A long article with lots of content.",
-		});
-
-		expect(result).toEqual({
-			summary: "A good summary.",
-			excerpt: "Quick blurb.",
-			inputTokens: 50,
-			outputTokens: 10,
-		});
-		expect(saveGeneratedSummary).toHaveBeenCalledWith({
-			url: "https://example.com/long",
-			summary: "A good summary.",
-			excerpt: "Quick blurb.",
-			inputTokens: 50,
-			outputTokens: 10,
-		});
-	});
-
-	it("should clip an over-length excerpt at the last word boundary", async () => {
-		const overLong = `${"word ".repeat(60)}tail`;
-		const createMessage = createStubCreateMessage({
-			summary: "Body.",
-			excerpt: overLong,
-		});
-		const saveGeneratedSummary = jest.fn().mockResolvedValue(undefined);
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: noCache,
-			saveGeneratedSummary,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/long",
-			textContent: "x",
-		});
-
-		expect(result?.excerpt.length).toBeLessThanOrEqual(160);
-		expect(result?.excerpt.endsWith("…")).toBe(true);
-		expect(saveGeneratedSummary).toHaveBeenCalledWith(
-			expect.objectContaining({ excerpt: result?.excerpt }),
-		);
-	});
-
-	it("should hard-cut an over-length excerpt that has no whitespace", async () => {
-		const noSpaces = "x".repeat(200);
-		const createMessage = createStubCreateMessage({
-			summary: "Body.",
-			excerpt: noSpaces,
-		});
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: noCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/no-spaces",
-			textContent: "x",
-		});
-
-		expect(result?.excerpt).toBe(`${"x".repeat(159)}…`);
-	});
-
-	it("should return null on ready cache hit without calling createMessage", async () => {
-		const createMessage = jest.fn();
-		const cachedSummary: FindGeneratedSummary = async () => ({
-			status: "ready",
-			summary: "cached summary",
-			excerpt: "cached excerpt",
-		});
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: cachedSummary,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/cached",
-			textContent: "Some content.",
-		});
-
-		expect(result).toBeNull();
-		expect(createMessage).not.toHaveBeenCalled();
-	});
-
-	it("should return null on skipped cache hit", async () => {
-		const createMessage = jest.fn();
-		const skippedCache: FindGeneratedSummary = async () => ({ status: "skipped" });
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: skippedCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/skipped",
-			textContent: "Some content.",
-		});
-
-		expect(result).toBeNull();
-		expect(createMessage).not.toHaveBeenCalled();
-	});
-
-	it("should retry on failed status (redrive scenario: give the new attempt a chance)", async () => {
-		const createMessage = createStubCreateMessage({
-			summary: "Recovered summary.",
-			excerpt: "Recovered blurb.",
-		});
-		const failedCache: FindGeneratedSummary = async () => ({
-			status: "failed",
-			reason: "timeout",
-		});
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: failedCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/failed",
-			textContent: "Some content.",
-		});
-
-		expect(result).toEqual({
-			summary: "Recovered summary.",
-			excerpt: "Recovered blurb.",
-			inputTokens: 50,
-			outputTokens: 10,
-		});
-	});
-
-	it("should proceed when cache status is pending", async () => {
-		const createMessage = createStubCreateMessage({
-			summary: "Fresh summary.",
-			excerpt: "Fresh blurb.",
-		});
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: pendingCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/pending",
-			textContent: "Long content.",
-		});
-
-		expect(result).toEqual({
-			summary: "Fresh summary.",
-			excerpt: "Fresh blurb.",
-			inputTokens: 50,
-			outputTokens: 10,
-		});
-	});
-
-	it("should return null when response has no text block", async () => {
-		const createMessage: CreateAiMessage = async () => ({
-			content: [{ type: "tool_use" }],
-			usage: { input_tokens: 50, output_tokens: 10 },
-		});
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: noCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped: noopMarkSkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/no-text-block",
-			textContent: "Some article content.",
-		});
-
-		expect(result).toBeNull();
-	});
-
-	it("should mark the row skipped with reason ai-unavailable when AI returns 'Summary not available.'", async () => {
-		const createMessage = createStubCreateMessage({
-			summary: "Summary not available.",
-			excerpt: "Summary not available.",
-		});
-		const markSummarySkipped = jest.fn().mockResolvedValue(undefined);
-
-		const { summarizeArticle } = initLinkSummariser({
-			createMessage,
-			findGeneratedSummary: noCache,
-			saveGeneratedSummary: noopSave,
-			markSummarySkipped,
-			markSummaryStage: noopMarkStage,
-			logger: noopLogger,
-			cleanContent: identity,
-			isTooShortToSummarize: () => false,
-		});
-
-		const result = await summarizeArticle({
-			url: "https://example.com/unavailable",
-			textContent: "Content that cannot be summarised.",
-		});
-
-		expect(result).toBeNull();
-		expect(markSummarySkipped).toHaveBeenCalledWith({
-			url: "https://example.com/unavailable",
-			reason: "ai-unavailable",
-		});
 	});
 });

--- a/projects/save-link/src/generate-summary/link-summariser.ts
+++ b/projects/save-link/src/generate-summary/link-summariser.ts
@@ -1,15 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
+import type { SummarySkipReason } from "@packages/article-state-types";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type {
-	CreateAiMessage,
-	FindGeneratedSummary,
-	MarkSummarySkipped,
-	MarkSummaryStage,
-	SaveGeneratedSummary,
-	SummarizeArticle,
-} from "./article-summary.types";
+import type { CreateAiMessage } from "./create-ai-message.types";
+import type { MarkSummaryStage } from "./article-summary.types";
 import { MAX_EXCERPT_LENGTH, MAX_SUMMARY_LENGTH } from "./max-summary-length";
 
 const SUMMARIZE_PROMPT = readFileSync(
@@ -24,6 +19,22 @@ const SummaryPayload = z.object({
 	excerpt: z.string(),
 });
 
+export type SummarizeResult =
+	| {
+			kind: "ready";
+			summary: string;
+			excerpt: string;
+			inputTokens: number;
+			outputTokens: number;
+	  }
+	| { kind: "skipped"; reason: SummarySkipReason }
+	| { kind: "no-text-block" };
+
+export type SummarizeArticle = (params: {
+	url: string;
+	textContent: string;
+}) => Promise<SummarizeResult>;
+
 // Safety net: if DeepSeek overshoots MAX_EXCERPT_LENGTH despite the prompt
 // instruction, clip on a word boundary so we never persist a row that violates
 // the contract downstream consumers rely on.
@@ -37,9 +48,6 @@ function clipExcerpt(text: string): string {
 
 export function initLinkSummariser(deps: {
 	createMessage: CreateAiMessage;
-	findGeneratedSummary: FindGeneratedSummary;
-	saveGeneratedSummary: SaveGeneratedSummary;
-	markSummarySkipped: MarkSummarySkipped;
 	markSummaryStage: MarkSummaryStage;
 	logger: HutchLogger;
 	cleanContent: (html: string) => string;
@@ -47,20 +55,13 @@ export function initLinkSummariser(deps: {
 }): { summarizeArticle: SummarizeArticle } {
 	const summarizeArticle: SummarizeArticle = async (params) => {
 		await deps.markSummaryStage({ url: params.url, stage: "summary-started" });
-		const cached = await deps.findGeneratedSummary(params.url);
-		// "failed" is retryable on redrive; "ready" and "skipped" are terminal — short-circuit those.
-		if (cached?.status === "ready" || cached?.status === "skipped") {
-			deps.logger.info("[summarize] cache hit", { url: params.url, status: cached.status });
-			return null;
-		}
 
 		const cleanedContent = deps.cleanContent(params.textContent);
 		const visibleLength = cleanedContent.replace(/\s/g, "").length;
 
 		if (deps.isTooShortToSummarize(cleanedContent)) {
 			deps.logger.info("[summarize] content too short, skipping", { url: params.url, visibleLength });
-			await deps.markSummarySkipped({ url: params.url, reason: "content-too-short" });
-			return null;
+			return { kind: "skipped", reason: "content-too-short" };
 		}
 
 		await deps.markSummaryStage({ url: params.url, stage: "summary-generating" });
@@ -104,26 +105,19 @@ export function initLinkSummariser(deps: {
 		);
 		if (!textBlock || textBlock.type !== "text" || !textBlock.text) {
 			deps.logger.info("[summarize] no text block in response", { url: params.url });
-			return null;
+			return { kind: "no-text-block" };
 		}
 
 		const parsed = SummaryPayload.parse(JSON.parse(textBlock.text));
 		const summary = parsed.summary.trim();
 		if (summary === "Summary not available.") {
 			deps.logger.info("[summarize] AI returned unavailable", { url: params.url });
-			await deps.markSummarySkipped({ url: params.url, reason: "ai-unavailable" });
-			return null;
+			return { kind: "skipped", reason: "ai-unavailable" };
 		}
 		const excerpt = clipExcerpt(parsed.excerpt.trim());
 
-		await deps.saveGeneratedSummary({
-			url: params.url,
-			summary,
-			excerpt,
-			inputTokens: response.usage.input_tokens,
-			outputTokens: response.usage.output_tokens,
-		});
 		return {
+			kind: "ready",
 			summary,
 			excerpt,
 			inputTokens: response.usage.input_tokens,

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -410,9 +410,11 @@ const generateSummaryLambda = new HutchLambda("generate-summary", {
 		DEEPSEEK_API_KEY: deepseekApiKey,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		CONTENT_BUCKET_NAME: contentBucketName,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...generateSummaryDynamodb.policies,
+		...generateSummaryQueue.policies,
 		...contentBucket.readPolicies("generate-summary-s3"),
 	],
 });

--- a/projects/save-link/src/runtime/generate-summary.main.ts
+++ b/projects/save-link/src/runtime/generate-summary.main.ts
@@ -1,24 +1,35 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { S3Client } from "@aws-sdk/client-s3";
-import OpenAI from "openai";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import OpenAI from "openai";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
+import { initCreateDeepseekMessage } from "../generate-summary/create-deepseek-message";
+import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { initGenerateSummaryHandler } from "../generate-summary/generate-summary-handler";
+import { initLinkSummariser } from "../generate-summary/link-summariser";
+import { MAX_SUMMARY_LENGTH } from "../generate-summary/max-summary-length";
+import { stripHtml } from "../generate-summary/strip-html";
+import { GENERATE_SUMMARY_TIMEOUTS } from "../generate-summary/timeouts";
 import { requireEnv } from "../require-env";
 import { initFindArticleContent } from "../save-link/find-article-content";
-import { initLinkSummariser } from "../generate-summary/link-summariser";
-import { initCreateDeepseekMessage } from "../generate-summary/create-deepseek-message";
-import { MAX_SUMMARY_LENGTH } from "../generate-summary/max-summary-length";
-import { GENERATE_SUMMARY_TIMEOUTS } from "../generate-summary/timeouts";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
-import { stripHtml } from "../generate-summary/strip-html";
-import { initGenerateSummaryHandler } from "../generate-summary/generate-summary-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const deepseekApiKey = requireEnv("DEEPSEEK_API_KEY");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
 const s3Client = new S3Client({});
+const sqsClient = new SQSClient({});
 const deepseekClient = new OpenAI({
 	apiKey: deepseekApiKey,
 	baseURL: "https://api.deepseek.com",
@@ -48,10 +59,18 @@ const { summarizeArticle } = initLinkSummariser({
 		const visibleLength = cleanedText.replace(/\s/g, "").length;
 		return visibleLength <= MAX_SUMMARY_LENGTH * 3;
 	},
-	findGeneratedSummary: summaryStore.findGeneratedSummary,
-	saveGeneratedSummary: summaryStore.saveGeneratedSummary,
-	markSummarySkipped: summaryStore.markSummarySkipped,
 	markSummaryStage: summaryStore.markSummaryStage,
+});
+
+const { store } = initDynamoDbArticleStore({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -59,9 +78,20 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
 export const handler = initGenerateSummaryHandler({
 	summarizeArticle,
 	findArticleContent,
-	publishEvent,
+	loadArticle: store.load,
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/save-link/anonymous-link-saved-handler.test.ts
+++ b/projects/save-link/src/save-link/anonymous-link-saved-handler.test.ts
@@ -58,7 +58,7 @@ describe("initAnonymousLinkSavedHandler", () => {
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
 	});
 
-	it("skips summary dispatch when the article has no content", async () => {
+	it("reports batchItemFailures when canonical content is not yet readable so SQS redelivers through maxReceiveCount", async () => {
 		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
 		const findArticleContent: FindArticleContent = async () => undefined;
 
@@ -68,9 +68,14 @@ describe("initAnonymousLinkSavedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/no-content" }), stubContext, () => {});
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/no-content" }),
+			stubContext,
+			() => {},
+		);
 
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
 	it("reports the record as a batch failure on invalid event detail (Zod failure)", async () => {

--- a/projects/save-link/src/save-link/anonymous-link-saved-handler.ts
+++ b/projects/save-link/src/save-link/anonymous-link-saved-handler.ts
@@ -23,9 +23,11 @@ export function initAnonymousLinkSavedHandler(deps: {
 				logger.info("[AnonymousLinkSaved] processing", { url: detail.url });
 
 				const content = await findArticleContent(detail.url);
+				/* Canonical S3 object written upstream may not be readable yet (S3
+				 * eventual consistency). Throw so SQS retries through
+				 * maxReceiveCount; on exhaustion the DLQ alarm fires. */
 				if (!content) {
-					logger.info("[AnonymousLinkSaved] no content available, skipping summary", { url: detail.url });
-					continue;
+					throw new Error(`canonical content not yet readable for url=${detail.url}`);
 				}
 
 				await dispatchGenerateSummary({ url: detail.url });

--- a/projects/save-link/src/save-link/link-saved-handler.test.ts
+++ b/projects/save-link/src/save-link/link-saved-handler.test.ts
@@ -58,7 +58,7 @@ describe("initLinkSavedHandler", () => {
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
 	});
 
-	it("skips summary dispatch when article has no content", async () => {
+	it("reports batchItemFailures when canonical content is not yet readable so SQS redelivers through maxReceiveCount", async () => {
 		const dispatchGenerateSummary = jest.fn().mockResolvedValue(undefined);
 		const findArticleContent: FindArticleContent = async () => undefined;
 
@@ -68,9 +68,14 @@ describe("initLinkSavedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/no-content", userId: "user-1" }), stubContext, () => {});
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/no-content", userId: "user-1" }),
+			stubContext,
+			() => {},
+		);
 
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
 	it("reports the record as a batch failure on invalid event detail (Zod failure)", async () => {

--- a/projects/save-link/src/save-link/link-saved-handler.ts
+++ b/projects/save-link/src/save-link/link-saved-handler.ts
@@ -21,7 +21,12 @@ export function initLinkSavedHandler(deps: {
 				const detail = LinkSavedEvent.detailSchema.parse(envelope.detail);
 
 				const content = await findArticleContent(detail.url);
-				if (!content) continue;
+				/* Canonical S3 object written upstream may not be readable yet (S3
+				 * eventual consistency). Throw so SQS retries through
+				 * maxReceiveCount; on exhaustion the DLQ alarm fires. */
+				if (!content) {
+					throw new Error(`canonical content not yet readable for url=${detail.url}`);
+				}
 
 				await dispatchGenerateSummary({ url: detail.url });
 


### PR DESCRIPTION
## Goal

Migrate the `generate-summary` Lambda to write `summaryStatus="ready"` / `summaryStatus="skipped"` through `transitionAndPersist(markSummaryReady | markSummarySkipped, …)` instead of the inline `saveGeneratedSummary` / `markSummarySkipped` DynamoDB writers. Refactor `link-summariser` from a side-effecting function (writes DDB + returns `null` on skip) into a pure function that returns a `SummarizeResult` discriminated union — the handler decides which transition to fire.

Fixes two production silent-skip bugs that left rows stuck at `summaryStatus="pending"` forever:

1. **no-text-block** — when DeepSeek's response had no parseable text block, `link-summariser` returned `null` and the handler logged "already summarized or skipped" without adding the SQS record to `batchItemFailures`. SQS deleted the message silently. After this PR the handler throws on that branch so SQS retries and eventually exhausts to the DLQ.
2. **canonical-content-not-yet-readable** — `link-saved-handler` and `anonymous-link-saved-handler` read the canonical S3 object via `findArticleContent` immediately after a `LinkSavedEvent` / `AnonymousLinkSavedEvent` arrives. The S3 `CopyObject` upstream is eventually-consistent so the read can race the write; on null both handlers `continue`d, SQS deleted the message, no `GenerateSummaryCommand` ever fired, the row stayed `pending` forever. After this PR both handlers throw on the null branch so SQS redelivers up to `maxReceiveCount`; on exhaustion the DLQ alarm fires.

## Context

`link-summariser` previously mixed pure logic (clean → length-check → AI call → parse) with side effects (`findGeneratedSummary`, `saveGeneratedSummary`, `markSummarySkipped`, `markSummaryStage`). That coupling is why the no-text-block branch silently succeeded: there was no explicit "I produced no usable output" return value, only a `null` shared with two other "this is a successful skip" paths.

Splitting the function into a pure `SummarizeResult` producer + a handler that branches on the result kind:

1. Makes the no-text-block path explicit (`{ kind: "no-text-block" }`).
2. Lets the handler use `transitionAndPersist` so summary writes are part of the aggregate's atomic save + dispatch chain.
3. Moves the cache short-circuit (`ready` / `skipped` already in DDB) to the handler via `loadArticle`, decoupling the summariser from storage entirely.

The two `*-link-saved-handler` files have the same shape of bug as no-text-block but in a different file: a happy-path branch (`if (!content) continue;`) that drops the SQS record without writing terminal state. The fix is symmetrical — throw so SQS retries and eventually DLQs.

## Behaviour change (intentional)

- **Bug fix #1 (visible)**: a DeepSeek response with no text block now causes SQS retries and eventual DLQ exhaustion instead of silently deleting the message and stranding the row at `summaryStatus="pending"`.
- **Bug fix #2 (visible)**: `link-saved-handler` and `anonymous-link-saved-handler` now throw on missing canonical content, so a race with S3 CopyObject's eventual-consistency window redelivers via SQS instead of silently dropping the message. On persistent failure the DLQ alarm fires, replacing the previous silent loss with an operator-visible signal.
- **Architecture (invisible)**: `summaryStatus` writes for ready/skipped are now part of the aggregate's atomic save + dispatch chain; on retry after a transient DDB failure, the row re-saves the same state and re-dispatches the same effect.

## Notes for reviewers

- The composition root (`generate-summary.main.ts`) wires the SQS dispatcher even though `markSummaryReady` / `markSummarySkipped` don't emit `generate-summary` effects today. The typed `initLambdaEffectDispatcher` contract requires `dispatchGenerateSummary`; the wiring keeps the dispatcher correct if a future transition adds the effect.
- `GENERATE_SUMMARY_QUEUE_URL` was not previously injected into the `generate-summary` Lambda's environment, so the infra now sets that env var and grants `generateSummaryQueue.policies` to match the pattern used by the other Lambdas that dispatch to that queue.
- The old `SummarizeArticle` type in `article-summary.types.ts` was removed (the new `SummarizeResult`-returning `SummarizeArticle` lives in `link-summariser.ts`); knip flagged the old one as unused after the refactor.

## Test plan

- [x] `pnpm nx run save-link:compile` succeeds
- [x] `pnpm nx run save-link:test` — 316/316 passing
- [x] `pnpm nx run save-link:test-with-coverage` — 100% statements/branches/functions/lines on every changed file
- [x] `pnpm nx run save-link:lint` — biome + knip clean
- [x] `pnpm nx run @packages/domain:test` — 206/206 passing
- [x] `pnpm nx run hutch:compile` succeeds
- [ ] Manual smoke: save a normal article and confirm `summaryStatus=ready` + `SummaryGeneratedEvent` fires
- [ ] Manual smoke: save an article with very short content and confirm `summaryStatus=skipped, reason="content-too-short"`
- [ ] Manual smoke: DeepSeek response with no text block → SQS message ends up in `batchItemFailures` and eventually lands in the DLQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKjNwLJbkTvh87Uv8SWX3u)_