### PR TITLE
feat(save-link): route entry-point handlers through the Article aggregate for crawl/summary status writes

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -150,12 +150,14 @@ const saveLinkCommandLambda = new HutchLambda("save-link-command", {
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...saveLinkCommandDynamodb.policies,
 		// readTierSnapshot HEAD-checks tier-0 source when logging the crawl outcome.
 		...contentBucket.readPolicies("save-link-command-content-read"),
 		...contentBucket.writePolicies("save-link-command-s3"),
+		...renamePolicies(generateSummaryQueue.policies, "save-link-command"),
 	],
 });
 
@@ -203,6 +205,7 @@ const saveLinkRawHtmlCommandLambda = new HutchLambda("save-link-raw-html-command
 		PENDING_HTML_BUCKET_NAME: pendingHtmlBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...saveLinkRawHtmlCommandDynamodb.policies,
@@ -212,6 +215,7 @@ const saveLinkRawHtmlCommandLambda = new HutchLambda("save-link-raw-html-command
 		// readTierSnapshot HEAD-checks tier-0 source when logging the crawl outcome.
 		...contentBucket.readPolicies("save-link-raw-html-command-content-read"),
 		...contentBucket.writePolicies("save-link-raw-html-command-s3"),
+		...renamePolicies(generateSummaryQueue.policies, "save-link-raw-html-command"),
 	],
 });
 
@@ -258,12 +262,14 @@ const saveAnonymousLinkCommandLambda = new HutchLambda("save-anonymous-link-comm
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...saveAnonymousLinkCommandDynamodb.policies,
 		// readTierSnapshot HEAD-checks tier-0 source when logging the crawl outcome.
 		...contentBucket.readPolicies("save-anonymous-link-command-content-read"),
 		...contentBucket.writePolicies("save-anonymous-link-command-s3"),
+		...renamePolicies(generateSummaryQueue.policies, "save-anonymous-link-command"),
 	],
 });
 
@@ -526,12 +532,14 @@ const recrawlLinkInitiatedLambda = new HutchLambda("recrawl-link-initiated", {
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...recrawlLinkInitiatedDynamodb.policies,
 		// readTierSnapshot HEAD-checks tier-0 source when logging the crawl outcome.
 		...contentBucket.readPolicies("recrawl-link-initiated-content-read"),
 		...contentBucket.writePolicies("recrawl-link-initiated-s3"),
+		...renamePolicies(generateSummaryQueue.policies, "recrawl-link-initiated"),
 	],
 });
 

--- a/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
@@ -1,8 +1,20 @@
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
+import {
+	GenerateSummaryCommand,
+	initLogParseError,
+	type ParseErrorEvent,
+	initLogCrawlOutcome,
+	type CrawlOutcomeEvent,
+} from "@packages/hutch-infra-components";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import { requireEnv } from "../require-env";
 import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../article-parser/readability-parser";
@@ -19,15 +31,18 @@ import { initDownloadMedia } from "../save-link/download-media";
 import { initRecrawlLinkInitiatedHandler } from "../save-link/recrawl-link-initiated-handler";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import { initPutTierSource } from "../select-content/put-tier-source";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const client = createDynamoDocumentClient();
 const s3Client = new S3Client({});
+const sqsClient = new SQSClient({});
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
@@ -54,15 +69,10 @@ const { updateFetchTimestamp } = initUpdateFetchTimestamp({
 	tableName: articlesTable,
 });
 
-const { markCrawlFailed, markCrawlUnsupported, markCrawlStage } = initDynamoDbArticleCrawl({
+const { markCrawlStage } = initDynamoDbArticleCrawl({
 	client,
 	tableName: articlesTable,
 	now: () => new Date(),
-});
-
-const { markSummarySkipped } = initDynamoDbGeneratedSummary({
-	client,
-	tableName: articlesTable,
 });
 
 const downloadMedia = initDownloadMedia({
@@ -75,6 +85,27 @@ const downloadMedia = initDownloadMedia({
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
+});
+
+const { store } = initDynamoDbArticleStore({
+	client,
+	tableName: articlesTable,
+});
+
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
 });
 
 const processContent = initProcessContentWithLocalMedia({
@@ -116,10 +147,8 @@ export const handler = initRecrawlLinkInitiatedHandler({
 	putTierSource,
 	putImageObject,
 	updateFetchTimestamp,
-	markCrawlFailed,
-	markCrawlUnsupported,
+	transitionAndPersist,
 	markCrawlStage,
-	markSummarySkipped,
 	publishEvent,
 	downloadMedia,
 	processContent,

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -1,8 +1,20 @@
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
+import {
+	GenerateSummaryCommand,
+	initLogParseError,
+	type ParseErrorEvent,
+	initLogCrawlOutcome,
+	type CrawlOutcomeEvent,
+} from "@packages/hutch-infra-components";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import { requireEnv } from "../require-env";
 import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../article-parser/readability-parser";
@@ -19,15 +31,18 @@ import { initDownloadMedia } from "../save-link/download-media";
 import { initSaveAnonymousLinkCommandHandler } from "../save-link/save-anonymous-link-command-handler";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import { initPutTierSource } from "../select-content/put-tier-source";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const client = createDynamoDocumentClient();
 const s3Client = new S3Client({});
+const sqsClient = new SQSClient({});
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
@@ -54,15 +69,10 @@ const { updateFetchTimestamp } = initUpdateFetchTimestamp({
 	tableName: articlesTable,
 });
 
-const { markCrawlFailed, markCrawlUnsupported, markCrawlStage } = initDynamoDbArticleCrawl({
+const { markCrawlStage } = initDynamoDbArticleCrawl({
 	client,
 	tableName: articlesTable,
 	now: () => new Date(),
-});
-
-const { markSummarySkipped } = initDynamoDbGeneratedSummary({
-	client,
-	tableName: articlesTable,
 });
 
 const downloadMedia = initDownloadMedia({
@@ -75,6 +85,27 @@ const downloadMedia = initDownloadMedia({
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
+});
+
+const { store } = initDynamoDbArticleStore({
+	client,
+	tableName: articlesTable,
+});
+
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
 });
 
 const processContent = initProcessContentWithLocalMedia({
@@ -116,10 +147,8 @@ export const handler = initSaveAnonymousLinkCommandHandler({
 	putTierSource,
 	putImageObject,
 	updateFetchTimestamp,
-	markCrawlFailed,
-	markCrawlUnsupported,
+	transitionAndPersist,
 	markCrawlStage,
-	markSummarySkipped,
 	publishEvent,
 	downloadMedia,
 	processContent,

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -1,8 +1,20 @@
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
+import {
+	GenerateSummaryCommand,
+	initLogParseError,
+	type ParseErrorEvent,
+	initLogCrawlOutcome,
+	type CrawlOutcomeEvent,
+} from "@packages/hutch-infra-components";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import { requireEnv } from "../require-env";
 import { DEFAULT_CRAWL_HEADERS, initCrawlArticle, initCrawlFetch } from "@packages/crawl-article";
 import { initReadabilityParser } from "../article-parser/readability-parser";
@@ -19,15 +31,18 @@ import { initDownloadMedia } from "../save-link/download-media";
 import { initSaveLinkCommandHandler } from "../save-link/save-link-command-handler";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import { initPutTierSource } from "../select-content/put-tier-source";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const client = createDynamoDocumentClient();
 const s3Client = new S3Client({});
+const sqsClient = new SQSClient({});
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
@@ -54,15 +69,10 @@ const { updateFetchTimestamp } = initUpdateFetchTimestamp({
 	tableName: articlesTable,
 });
 
-const { markCrawlFailed, markCrawlUnsupported, markCrawlStage } = initDynamoDbArticleCrawl({
+const { markCrawlStage } = initDynamoDbArticleCrawl({
 	client,
 	tableName: articlesTable,
 	now: () => new Date(),
-});
-
-const { markSummarySkipped } = initDynamoDbGeneratedSummary({
-	client,
-	tableName: articlesTable,
 });
 
 const downloadMedia = initDownloadMedia({
@@ -75,6 +85,27 @@ const downloadMedia = initDownloadMedia({
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
+});
+
+const { store } = initDynamoDbArticleStore({
+	client,
+	tableName: articlesTable,
+});
+
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
 });
 
 const processContent = initProcessContentWithLocalMedia({
@@ -116,10 +147,8 @@ export const handler = initSaveLinkCommandHandler({
 	putTierSource,
 	putImageObject,
 	updateFetchTimestamp,
-	markCrawlFailed,
-	markCrawlUnsupported,
+	transitionAndPersist,
 	markCrawlStage,
-	markSummarySkipped,
 	publishEvent,
 	downloadMedia,
 	processContent,

--- a/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
@@ -1,9 +1,21 @@
 import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initCrawlArticle, initCrawlFetch, DEFAULT_CRAWL_HEADERS } from "@packages/crawl-article";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
-import { initLogParseError, type ParseErrorEvent, initLogCrawlOutcome, type CrawlOutcomeEvent } from "@packages/hutch-infra-components";
+import {
+	GenerateSummaryCommand,
+	initLogParseError,
+	type ParseErrorEvent,
+	initLogCrawlOutcome,
+	type CrawlOutcomeEvent,
+} from "@packages/hutch-infra-components";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { requireEnv } from "../require-env";
@@ -14,20 +26,23 @@ import { initDownloadMedia } from "../save-link/download-media";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import { initReadPendingHtml } from "../save-link-raw-html/read-pending-html";
 import { initSaveLinkRawHtmlCommandHandler } from "../save-link-raw-html/save-link-raw-html-command-handler";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
 import { initCheckTier0SourceExistsS3 } from "../crawl-article-state/check-tier-0-source-exists-s3";
 import { initReadArticleCrawlStateDynamoDb } from "../crawl-article-state/read-article-crawl-state-dynamodb";
 import { initReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
 import { initPutTierSource } from "../select-content/put-tier-source";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const pendingHtmlBucketName = requireEnv("PENDING_HTML_BUCKET_NAME");
 const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const logError = (message: string, error?: Error) => consoleLogger.error(message, { error });
 const s3Client = new S3Client({});
+const sqsClient = new SQSClient({});
 const dynamoClient = createDynamoDocumentClient();
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, defaultHeaders: { ...DEFAULT_CRAWL_HEADERS } });
 const crawlArticle = initCrawlArticle({ crawlFetch, logError });
@@ -67,15 +82,30 @@ const { putTierSource } = initPutTierSource({
 	bucketName: contentBucketName,
 });
 
-const { markCrawlFailed } = initDynamoDbArticleCrawl({
-	client: dynamoClient,
-	tableName: articlesTable,
-	now: () => new Date(),
-});
-
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
+});
+
+const { store } = initDynamoDbArticleStore({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
 });
 
 const { logParseError } = initLogParseError({
@@ -111,7 +141,7 @@ export const handler = initSaveLinkRawHtmlCommandHandler({
 	processContent,
 	putTierSource,
 	publishEvent,
-	markCrawlFailed,
+	transitionAndPersist,
 	logger: consoleLogger,
 	logParseError,
 	logCrawlOutcome,

--- a/projects/save-link/src/save-link-raw-html/save-link-raw-html-command-handler.test.ts
+++ b/projects/save-link/src/save-link-raw-html/save-link-raw-html-command-handler.test.ts
@@ -1,6 +1,7 @@
 import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
+import { markCrawlFailed } from "@packages/domain/article-aggregate";
 import { initSaveLinkRawHtmlCommandHandler } from "./save-link-raw-html-command-handler";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import type { ParseHtml } from "../article-parser/article-parser.types";
@@ -76,7 +77,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		processContent,
 		putTierSource: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
-		markCrawlFailed: jest.fn().mockResolvedValue(undefined),
+		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		logger: noopLogger,
 		logParseError: jest.fn(),
 		logCrawlOutcome: jest.fn(),
@@ -137,9 +138,9 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		expect(calls).toEqual(["putTierSource", "publishEvent"]);
 	});
 
-	it("marks crawl 'failed' inline on terminal parse errors and reports the record as a batch failure so SQS redelivers it", async () => {
+	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist and reports the record as a batch failure so SQS redelivers it", async () => {
 		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability returned null" });
-		const markCrawlFailed = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		const error = jest.fn();
@@ -147,7 +148,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		const { handler } = createHandler({
 			parseHtml: failedParse,
-			markCrawlFailed,
+			transitionAndPersist,
 			putTierSource,
 			publishEvent,
 			logger,
@@ -160,9 +161,9 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/bad",
-			reason: "Readability returned null",
+			input: { reason: "Readability returned null" },
 		});
 		expect(putTierSource).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();

--- a/projects/save-link/src/save-link-raw-html/save-link-raw-html-command-handler.ts
+++ b/projects/save-link/src/save-link-raw-html/save-link-raw-html-command-handler.ts
@@ -2,6 +2,10 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
+	markCrawlFailed,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
+import {
 	SaveLinkRawHtmlCommand,
 	TierContentExtractedEvent,
 	type LogCrawlOutcome,
@@ -14,7 +18,6 @@ import type { ProcessContent } from "../save-link/save-link-work";
 import { estimatedReadTimeFromWordCount } from "../save-link/estimated-read-time";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
 import type { ReadPendingHtml } from "./read-pending-html";
-import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
 import type { PutTierSource } from "../select-content/put-tier-source";
 
 const TIER = "tier-0";
@@ -27,7 +30,7 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 	processContent: ProcessContent;
 	putTierSource: PutTierSource;
 	publishEvent: PublishEvent;
-	markCrawlFailed: MarkCrawlFailed;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 	logParseError: LogParseError;
 	logCrawlOutcome: LogCrawlOutcome;
@@ -40,7 +43,7 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 		processContent,
 		putTierSource,
 		publishEvent,
-		markCrawlFailed,
+		transitionAndPersist,
 		logger,
 		logParseError,
 		logCrawlOutcome,
@@ -75,7 +78,10 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 					 * state. Re-throw preserves the SQS retry + DLQ observability path —
 					 * the surrounding try/catch routes the throw to batchItemFailures so
 					 * sibling records still settle under any future batchSize > 1. */
-					await markCrawlFailed({ url: detail.url, reason: parseResult.reason });
+					await transitionAndPersist(markCrawlFailed, {
+						url: detail.url,
+						input: { reason: parseResult.reason },
+					});
 					throw new Error(`save-link-raw-html parse failed for ${detail.url}: ${parseResult.reason}`);
 				}
 

--- a/projects/save-link/src/save-link/recrawl-link-initiated-handler.test.ts
+++ b/projects/save-link/src/save-link/recrawl-link-initiated-handler.test.ts
@@ -2,6 +2,7 @@ import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
+import { markCrawlUnsupported } from "@packages/domain/article-aggregate";
 import { initRecrawlLinkInitiatedHandler } from "./recrawl-link-initiated-handler";
 import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
 import type { ParseHtml } from "../article-parser/article-parser.types";
@@ -78,10 +79,8 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		putTierSource: jest.fn().mockResolvedValue(undefined),
 		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
-		markCrawlFailed: jest.fn().mockResolvedValue(undefined),
-		markCrawlUnsupported: jest.fn().mockResolvedValue(undefined),
+		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
-		markSummarySkipped: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		downloadMedia: noopDownloadMedia,
 		processContent,
@@ -129,9 +128,8 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 
-	it("flips a non-html origin (e.g. PDF) directly to crawlStatus='unsupported' + summaryStatus='skipped', does NOT throw, and does NOT emit RecrawlContentExtracted", async () => {
-		const markCrawlUnsupported = jest.fn().mockResolvedValue(undefined);
-		const markSummarySkipped = jest.fn().mockResolvedValue(undefined);
+	it("flips a non-html origin (e.g. PDF) atomically to crawlStatus='unsupported' + summaryStatus='skipped' via one markCrawlUnsupported transition, does NOT throw, and does NOT emit RecrawlContentExtracted", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		const unsupportedCrawl: CrawlArticle = async () => ({
 			status: "unsupported",
@@ -140,8 +138,7 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 
 		const handler = createHandler({
 			crawlArticle: unsupportedCrawl,
-			markCrawlUnsupported,
-			markSummarySkipped,
+			transitionAndPersist,
 			publishEvent,
 		});
 
@@ -152,13 +149,10 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [] });
-		expect(markCrawlUnsupported).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlUnsupported, {
 			url: "https://example.com/doc.pdf",
-			reason: "non-html content type: application/pdf",
-		});
-		expect(markSummarySkipped).toHaveBeenCalledWith({
-			url: "https://example.com/doc.pdf",
-			reason: "crawl-unsupported",
+			input: { reason: "non-html content type: application/pdf" },
 		});
 		expect(publishEvent).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/save-link/recrawl-link-initiated-handler.ts
+++ b/projects/save-link/src/save-link/recrawl-link-initiated-handler.ts
@@ -2,16 +2,12 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import {
 	RecrawlLinkInitiatedEvent,
 	RecrawlContentExtractedEvent,
 } from "@packages/hutch-infra-components";
-import type {
-	MarkCrawlFailed,
-	MarkCrawlStage,
-	MarkCrawlUnsupported,
-} from "../crawl-article-state/article-crawl.types";
-import type { MarkSummarySkipped } from "../generate-summary/article-summary.types";
+import type { MarkCrawlStage } from "../crawl-article-state/article-crawl.types";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia } from "./download-media";
 import type { PutImageObject } from "./s3-put-image-object";
@@ -27,10 +23,8 @@ export function initRecrawlLinkInitiatedHandler(deps: {
 	putTierSource: PutTierSource;
 	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
-	markCrawlFailed: MarkCrawlFailed;
-	markCrawlUnsupported: MarkCrawlUnsupported;
+	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
-	markSummarySkipped: MarkSummarySkipped;
 	publishEvent: PublishEvent;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
@@ -49,10 +43,8 @@ export function initRecrawlLinkInitiatedHandler(deps: {
 		putTierSource: deps.putTierSource,
 		putImageObject: deps.putImageObject,
 		updateFetchTimestamp: deps.updateFetchTimestamp,
-		markCrawlFailed: deps.markCrawlFailed,
-		markCrawlUnsupported: deps.markCrawlUnsupported,
+		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
-		markSummarySkipped: deps.markSummarySkipped,
 		downloadMedia: deps.downloadMedia,
 		processContent: deps.processContent,
 		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,

--- a/projects/save-link/src/save-link/save-anonymous-link-command-handler.test.ts
+++ b/projects/save-link/src/save-link/save-anonymous-link-command-handler.test.ts
@@ -2,6 +2,7 @@ import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
+import { markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
 import { initSaveAnonymousLinkCommandHandler } from "./save-anonymous-link-command-handler";
 import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
 import type { ParseHtml } from "../article-parser/article-parser.types";
@@ -79,10 +80,8 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		putTierSource: jest.fn().mockResolvedValue(undefined),
 		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
-		markCrawlFailed: jest.fn().mockResolvedValue(undefined),
-		markCrawlUnsupported: jest.fn().mockResolvedValue(undefined),
+		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
-		markSummarySkipped: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		downloadMedia: noopDownloadMedia,
 		processContent,
@@ -171,11 +170,11 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 		});
 	});
 
-	it("marks crawl 'failed' inline on terminal parse errors so /view + /admin/recrawl polling see failure at t+0", async () => {
-		const markCrawlFailed = jest.fn().mockResolvedValue(undefined);
+	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist so /view + /admin/recrawl polling see failure at t+0", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability crashed on this DOM" });
 
-		const handler = createHandler({ parseHtml: failedParse, markCrawlFailed });
+		const handler = createHandler({ parseHtml: failedParse, transitionAndPersist });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad" }),
@@ -184,15 +183,14 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/bad",
-			reason: "Readability crashed on this DOM",
+			input: { reason: "Readability crashed on this DOM" },
 		});
 	});
 
-	it("flips a non-html origin (e.g. PDF) directly to crawlStatus='unsupported' + summaryStatus='skipped', does NOT throw, and does NOT emit TierContentExtracted", async () => {
-		const markCrawlUnsupported = jest.fn().mockResolvedValue(undefined);
-		const markSummarySkipped = jest.fn().mockResolvedValue(undefined);
+	it("flips a non-html origin (e.g. PDF) atomically to crawlStatus='unsupported' + summaryStatus='skipped' via one markCrawlUnsupported transition, does NOT throw, and does NOT emit TierContentExtracted", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const unsupportedCrawl: CrawlArticle = async () => ({
@@ -202,8 +200,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 
 		const handler = createHandler({
 			crawlArticle: unsupportedCrawl,
-			markCrawlUnsupported,
-			markSummarySkipped,
+			transitionAndPersist,
 			publishEvent,
 			putTierSource,
 		});
@@ -215,13 +212,10 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [] });
-		expect(markCrawlUnsupported).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlUnsupported, {
 			url: "https://example.com/doc.pdf",
-			reason: "non-html content type: application/pdf",
-		});
-		expect(markSummarySkipped).toHaveBeenCalledWith({
-			url: "https://example.com/doc.pdf",
-			reason: "crawl-unsupported",
+			input: { reason: "non-html content type: application/pdf" },
 		});
 		expect(putTierSource).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();

--- a/projects/save-link/src/save-link/save-anonymous-link-command-handler.ts
+++ b/projects/save-link/src/save-link/save-anonymous-link-command-handler.ts
@@ -2,16 +2,12 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import {
 	SaveAnonymousLinkCommand,
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
-import type {
-	MarkCrawlFailed,
-	MarkCrawlStage,
-	MarkCrawlUnsupported,
-} from "../crawl-article-state/article-crawl.types";
-import type { MarkSummarySkipped } from "../generate-summary/article-summary.types";
+import type { MarkCrawlStage } from "../crawl-article-state/article-crawl.types";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia } from "./download-media";
 import type { PutImageObject } from "./s3-put-image-object";
@@ -27,10 +23,8 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 	putTierSource: PutTierSource;
 	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
-	markCrawlFailed: MarkCrawlFailed;
-	markCrawlUnsupported: MarkCrawlUnsupported;
+	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
-	markSummarySkipped: MarkSummarySkipped;
 	publishEvent: PublishEvent;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
@@ -49,10 +43,8 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 		putTierSource: deps.putTierSource,
 		putImageObject: deps.putImageObject,
 		updateFetchTimestamp: deps.updateFetchTimestamp,
-		markCrawlFailed: deps.markCrawlFailed,
-		markCrawlUnsupported: deps.markCrawlUnsupported,
+		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
-		markSummarySkipped: deps.markSummarySkipped,
 		downloadMedia: deps.downloadMedia,
 		processContent: deps.processContent,
 		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,

--- a/projects/save-link/src/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/save-link/save-link-command-handler.test.ts
@@ -2,6 +2,7 @@ import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
+import { markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
 import { initSaveLinkCommandHandler } from "./save-link-command-handler";
 import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
 import type { ParseHtml } from "../article-parser/article-parser.types";
@@ -80,10 +81,8 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		putTierSource: jest.fn().mockResolvedValue(undefined),
 		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
-		markCrawlFailed: jest.fn().mockResolvedValue(undefined),
-		markCrawlUnsupported: jest.fn().mockResolvedValue(undefined),
+		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
-		markSummarySkipped: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		downloadMedia: noopDownloadMedia,
 		processContent,
@@ -307,13 +306,13 @@ describe("initSaveLinkCommandHandler", () => {
 		});
 	});
 
-	it("marks crawl 'failed' inline on terminal parse errors so readers see failure at t+0 instead of waiting ~90s for the DLQ", async () => {
-		const markCrawlFailed = jest.fn().mockResolvedValue(undefined);
+	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist so readers see failure at t+0 instead of waiting ~90s for the DLQ", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability crashed on this DOM" });
 		const error = jest.fn();
 		const logger = { ...noopLogger, error };
 
-		const handler = createHandler({ parseHtml: failedParse, markCrawlFailed, logger });
+		const handler = createHandler({ parseHtml: failedParse, transitionAndPersist, logger });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
@@ -322,9 +321,9 @@ describe("initSaveLinkCommandHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/bad",
-			reason: "Readability crashed on this DOM",
+			input: { reason: "Readability crashed on this DOM" },
 		});
 		// Confirms the throw inside the worker propagated to the per-record catch
 		// with the expected diagnostic, even though it no longer escapes the handler.
@@ -339,11 +338,11 @@ describe("initSaveLinkCommandHandler", () => {
 		);
 	});
 
-	it("does NOT mark crawl 'failed' on a transient fetch failure (those stay on the SQS retry / DLQ path)", async () => {
-		const markCrawlFailed = jest.fn().mockResolvedValue(undefined);
+	it("does NOT dispatch a terminal transition on a transient fetch failure (those stay on the SQS retry / DLQ path)", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const failedCrawl: CrawlArticle = async () => ({ status: "failed" });
 
-		const handler = createHandler({ crawlArticle: failedCrawl, markCrawlFailed });
+		const handler = createHandler({ crawlArticle: failedCrawl, transitionAndPersist });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/unreachable", userId: "user-1" }),
@@ -352,13 +351,11 @@ describe("initSaveLinkCommandHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
 
-	it("flips a non-html origin (e.g. PDF) directly to crawlStatus='unsupported' + summaryStatus='skipped', does NOT throw, and does NOT emit TierContentExtracted", async () => {
-		const markCrawlUnsupported = jest.fn().mockResolvedValue(undefined);
-		const markCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummarySkipped = jest.fn().mockResolvedValue(undefined);
+	it("flips a non-html origin (e.g. PDF) atomically to crawlStatus='unsupported' + summaryStatus='skipped' via one markCrawlUnsupported transition, does NOT throw, and does NOT emit TierContentExtracted", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const unsupportedCrawl: CrawlArticle = async () => ({
@@ -368,9 +365,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({
 			crawlArticle: unsupportedCrawl,
-			markCrawlUnsupported,
-			markCrawlFailed,
-			markSummarySkipped,
+			transitionAndPersist,
 			publishEvent,
 			putTierSource,
 		});
@@ -383,15 +378,11 @@ describe("initSaveLinkCommandHandler", () => {
 
 		// Successful terminal outcome — no batch failure, no SQS retry.
 		expect(result).toEqual({ batchItemFailures: [] });
-		expect(markCrawlUnsupported).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlUnsupported, {
 			url: "https://example.com/doc.pdf",
-			reason: "non-html content type: application/pdf",
+			input: { reason: "non-html content type: application/pdf" },
 		});
-		expect(markSummarySkipped).toHaveBeenCalledWith({
-			url: "https://example.com/doc.pdf",
-			reason: "crawl-unsupported",
-		});
-		expect(markCrawlFailed).not.toHaveBeenCalled();
 		expect(putTierSource).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/save-link/save-link-command-handler.ts
+++ b/projects/save-link/src/save-link/save-link-command-handler.ts
@@ -2,16 +2,12 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
+import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import {
 	SaveLinkCommand,
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
-import type {
-	MarkCrawlFailed,
-	MarkCrawlStage,
-	MarkCrawlUnsupported,
-} from "../crawl-article-state/article-crawl.types";
-import type { MarkSummarySkipped } from "../generate-summary/article-summary.types";
+import type { MarkCrawlStage } from "../crawl-article-state/article-crawl.types";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia } from "./download-media";
 import type { PutImageObject } from "./s3-put-image-object";
@@ -27,10 +23,8 @@ export function initSaveLinkCommandHandler(deps: {
 	putTierSource: PutTierSource;
 	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
-	markCrawlFailed: MarkCrawlFailed;
-	markCrawlUnsupported: MarkCrawlUnsupported;
+	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
-	markSummarySkipped: MarkSummarySkipped;
 	publishEvent: PublishEvent;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
@@ -49,10 +43,8 @@ export function initSaveLinkCommandHandler(deps: {
 		putTierSource: deps.putTierSource,
 		putImageObject: deps.putImageObject,
 		updateFetchTimestamp: deps.updateFetchTimestamp,
-		markCrawlFailed: deps.markCrawlFailed,
-		markCrawlUnsupported: deps.markCrawlUnsupported,
+		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
-		markSummarySkipped: deps.markSummarySkipped,
 		downloadMedia: deps.downloadMedia,
 		processContent: deps.processContent,
 		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,

--- a/projects/save-link/src/save-link/save-link-work.ts
+++ b/projects/save-link/src/save-link/save-link-work.ts
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle, ThumbnailImage } from "@packages/crawl-article";
-import type {
-	MarkCrawlFailed,
-	MarkCrawlStage,
-	MarkCrawlUnsupported,
-} from "../crawl-article-state/article-crawl.types";
-import type { MarkSummarySkipped } from "../generate-summary/article-summary.types";
+import {
+	markCrawlFailed,
+	markCrawlUnsupported,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
+import type { MarkCrawlStage } from "../crawl-article-state/article-crawl.types";
 import { ArticleResourceUniqueId } from "./article-resource-unique-id";
 import type { ParseHtml } from "../article-parser/article-parser.types";
 import type { DownloadMedia, DownloadedMedia } from "./download-media";
@@ -37,10 +37,8 @@ export function initSaveLinkWork(deps: {
 	putTierSource: PutTierSource;
 	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
-	markCrawlFailed: MarkCrawlFailed;
-	markCrawlUnsupported: MarkCrawlUnsupported;
+	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
-	markSummarySkipped: MarkSummarySkipped;
 	downloadMedia: DownloadMedia;
 	processContent: ProcessContent;
 	imagesCdnBaseUrl: string;
@@ -57,10 +55,8 @@ export function initSaveLinkWork(deps: {
 		putTierSource,
 		putImageObject,
 		updateFetchTimestamp,
-		markCrawlFailed,
-		markCrawlUnsupported,
+		transitionAndPersist,
 		markCrawlStage,
-		markSummarySkipped,
 		downloadMedia,
 		processContent,
 		imagesCdnBaseUrl,
@@ -87,13 +83,16 @@ export function initSaveLinkWork(deps: {
 		await markCrawlStage({ url, stage: "crawl-fetching" });
 		const crawlResult = await crawlArticle({ url, fetchThumbnail: true });
 		if (crawlResult.status === "unsupported") {
-			// Permanently non-html origin (PDF, image, archive, …). Flip directly
-			// to the terminal `unsupported` state and mark the summary axis
-			// skipped so the canary doesn't keep flagging the row. No throw:
-			// this is a successful terminal outcome, not work to retry.
+			// Permanently non-html origin (PDF, image, archive, …). The aggregate
+			// transition flips both axes atomically — crawl=unsupported AND
+			// summary=skipped("crawl-unsupported") — so the summary canary cannot
+			// see a half-written row pending forever between two updates. No
+			// throw: this is a successful terminal outcome, not work to retry.
 			logParseError({ url, reason: `crawl-unsupported: ${crawlResult.reason}` });
-			await markCrawlUnsupported({ url, reason: crawlResult.reason });
-			await markSummarySkipped({ url, reason: "crawl-unsupported" });
+			await transitionAndPersist(markCrawlUnsupported, {
+				url,
+				input: { reason: crawlResult.reason },
+			});
 			await emitTier1Failure(url);
 			return "unsupported";
 		}
@@ -113,7 +112,10 @@ export function initSaveLinkWork(deps: {
 			// `failed` immediately so readers and the Tier 1+ canary see the
 			// terminal state on the next poll, instead of waiting for SQS
 			// retries → DLQ (~90s+) before the DLQ handler updates it.
-			await markCrawlFailed({ url, reason: parseResult.reason });
+			await transitionAndPersist(markCrawlFailed, {
+				url,
+				input: { reason: parseResult.reason },
+			});
 			await emitTier1Failure(url);
 			throw new Error(`crawl failed for ${url}: ${parseResult.reason}`);
 		}


### PR DESCRIPTION
## Goal

Migrate the four save-link entry-point handlers (`save-link`, `save-anonymous-link`, `save-link-raw-html`, `recrawl-link-initiated`) and their shared worker (`save-link-work.ts`) to write terminal `crawlStatus` / `summaryStatus` via `transitionAndPersist(markCrawlFailed | markCrawlUnsupported, …)` instead of the inline `markCrawlFailed` / `markCrawlUnsupported` / `markSummarySkipped` DynamoDB writers.

After this PR, the four save-link Lambdas write the two status axes atomically; a non-html origin can no longer end up with `crawlStatus="unsupported"` while `summaryStatus="pending"` forever.

## Context

`save-link-work.ts` (called by three of the four handlers: `save-link-command`, `save-anonymous-link-command`, `recrawl-link-initiated`) does the network fetch, parse, and tier-source store for the URL-based save paths. It used to call three inline DDB writers — `markCrawlFailed`, `markCrawlUnsupported`, `markSummarySkipped` — each updating a single attribute. The unsupported branch called TWO writers in sequence (`markCrawlUnsupported` then `markSummarySkipped`); an SQS redelivery between the two could leave the row with `crawlStatus="unsupported", summaryStatus="pending"` forever in the summary canary's pending bucket.

The fourth handler — `save-link-raw-html-command` — handles raw HTML uploads (from the browser extension) and does its own parse + store inline. It used only the inline `markCrawlFailed` writer for the terminal parse-error branch.

The Article aggregate's `markCrawlUnsupported` transition writes both axes in one DDB update. `markCrawlFailed` covers the terminal parse-error branch on both paths. Routing through `transitionAndPersist` makes the orchestrator the only writer that touches these fields.

## Behavior change

The unsupported branch now writes both axes atomically rather than as two separate updates. End-state for happy paths and parse-failure paths is identical to current production.

## Test plan

- [x] `pnpm nx run save-link:compile`
- [x] `pnpm nx run save-link:test` — 313 passed
- [x] `pnpm nx run save-link:test-with-coverage` — 100% statements/branches/functions/lines on all 57 files
- [x] `pnpm nx run save-link:lint`
- [x] `pnpm nx run @packages/domain:test` — 206 passed
- [x] `pnpm nx run hutch:compile`
- [ ] Post-deploy: save a regular HTML URL via `/save` and confirm `crawlStatus=ready` + summary kicks off
- [ ] Post-deploy: save a PDF URL via `/save` and confirm `crawlStatus=unsupported` AND `summaryStatus=skipped("crawl-unsupported")` land in one DDB row
- [ ] Post-deploy: save a malformed page via `/save` and confirm `crawlStatus=failed` flips inline (no ~90s DLQ wait)

https://claude.ai/code/session_01T2L3ZH9aTSzhz7uWwuxChW

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2L3ZH9aTSzhz7uWwuxChW)_