### PR TITLE
feat(save-link,@packages/domain): route content selection through the Article aggregate and refresh metadata on recrawl

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -361,11 +361,13 @@ const selectMostCompleteContentLambda = new HutchLambda("select-most-complete-co
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		DEEPSEEK_API_KEY: deepseekApiKey,
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 	},
 	policies: [
 		...selectMostCompleteContentDynamodb.policies,
 		...contentBucket.readPolicies("select-most-complete-content-content-read"),
 		...contentBucket.writePolicies("select-most-complete-content-content-write"),
+		...renamePolicies(generateSummaryQueue.policies, "select-most-complete-content"),
 	],
 });
 

--- a/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
@@ -15,7 +15,7 @@ import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-d
 import { requireEnv } from "../require-env";
 import { initFindContentSourceTier } from "../select-content/find-content-source-tier";
 import { initListAvailableTierSources } from "../select-content/list-available-tier-sources";
-import { initPromoteTierToCanonical } from "../select-content/promote-tier-to-canonical";
+import { initWriteCanonicalContent } from "../select-content/promote-tier-to-canonical";
 import { initReadTierSource } from "../select-content/read-tier-source";
 import { initRecrawlContentExtractedHandler } from "../select-content/recrawl-content-extracted-handler";
 import { initSelectMostCompleteContent } from "../select-content/select-content";
@@ -50,12 +50,11 @@ const { selectMostCompleteContent } = initSelectMostCompleteContent({
 	logger: consoleLogger,
 });
 
-const { promoteTierToCanonical } = initPromoteTierToCanonical({
+const { writeCanonicalContent } = initWriteCanonicalContent({
 	dynamoClient,
 	s3Client,
 	tableName: articlesTable,
 	bucketName: contentBucketName,
-	now: () => new Date(),
 });
 
 const { findContentSourceTier } = initFindContentSourceTier({
@@ -92,9 +91,10 @@ const { transitionAndPersist } = initTransitionAndPersist({
 export const handler = initRecrawlContentExtractedHandler({
 	listAvailableTierSources,
 	selectMostCompleteContent,
-	promoteTierToCanonical,
+	writeCanonicalContent,
 	findContentSourceTier,
 	transitionAndPersist,
 	imagesCdnBaseUrl,
+	now: () => new Date(),
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/select-most-complete-content.main.ts
+++ b/projects/save-link/src/runtime/select-most-complete-content.main.ts
@@ -1,14 +1,23 @@
 import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
 import OpenAI from "openai";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
 import { consoleLogger } from "@packages/hutch-logger";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { requireEnv } from "../require-env";
 import { initReadTierSource } from "../select-content/read-tier-source";
 import { initListAvailableTierSources } from "../select-content/list-available-tier-sources";
 import { initSelectMostCompleteContent } from "../select-content/select-content";
 import { SELECT_CONTENT_TIMEOUTS } from "../select-content/timeouts";
-import { initPromoteTierToCanonical } from "../select-content/promote-tier-to-canonical";
+import { initWriteCanonicalContent } from "../select-content/promote-tier-to-canonical";
 import { initFindContentSourceTier } from "../select-content/find-content-source-tier";
 import { initSelectMostCompleteContentHandler } from "../select-content/select-most-complete-content-handler";
 
@@ -16,9 +25,11 @@ const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const deepseekApiKey = requireEnv("DEEPSEEK_API_KEY");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const s3Client = new S3Client({});
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 const deepseekClient = new OpenAI({
 	apiKey: deepseekApiKey,
 	baseURL: "https://api.deepseek.com",
@@ -38,12 +49,11 @@ const { selectMostCompleteContent } = initSelectMostCompleteContent({
 	logger: consoleLogger,
 });
 
-const { promoteTierToCanonical } = initPromoteTierToCanonical({
+const { writeCanonicalContent } = initWriteCanonicalContent({
 	dynamoClient,
 	s3Client,
 	tableName: articlesTable,
 	bucketName: contentBucketName,
-	now: () => new Date(),
 });
 
 const { findContentSourceTier } = initFindContentSourceTier({
@@ -51,16 +61,39 @@ const { findContentSourceTier } = initFindContentSourceTier({
 	tableName: articlesTable,
 });
 
+const { store } = initDynamoDbArticleStore({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
+});
+
 const { publishEvent } = initEventBridgePublisher({
 	client: new EventBridgeClient({}),
 	eventBusName,
 });
 
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
+	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
 export const handler = initSelectMostCompleteContentHandler({
 	listAvailableTierSources,
 	selectMostCompleteContent,
-	promoteTierToCanonical,
+	writeCanonicalContent,
 	findContentSourceTier,
+	transitionAndPersist,
 	publishEvent,
+	now: () => new Date(),
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/select-content/promote-tier-to-canonical.ts
+++ b/projects/save-link/src/select-content/promote-tier-to-canonical.ts
@@ -9,42 +9,43 @@ import {
 import { z } from "zod";
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import type { Tier } from "./tier.types";
-import type { TierSourceMetadata } from "./tier-source.types";
 
-const ArticleRow = z.object({
-	title: dynamoField(z.string()),
-	siteName: dynamoField(z.string()),
-	excerpt: dynamoField(z.string()),
-	wordCount: dynamoField(z.number()),
-	estimatedReadTime: dynamoField(z.number()),
-	imageUrl: dynamoField(z.string()),
+const CanonicalContentRow = z.object({
 	contentLocation: dynamoField(z.string()),
 	contentSourceTier: dynamoField(z.string()),
-	contentFetchedAt: dynamoField(z.string()),
 });
 
-export type PromoteTierToCanonical = (params: {
+/**
+ * Copies the winning per-tier source to the canonical S3 key and writes the
+ * three columns the Article aggregate does not own: contentLocation,
+ * contentSourceTier, canonicalSourceTier.
+ *
+ * Callers MUST invoke this BEFORE the aggregate's `promoteTier` /
+ * `recrawlPromoteTier` transition: the aggregate save flips `crawlStatus` to
+ * "ready", which is the signal anything observing the row uses to decide that
+ * canonical content is readable. If we flipped the status first, a concurrent
+ * read could see "ready" before the canonical object exists in S3.
+ */
+export type WriteCanonicalContent = (params: {
 	url: string;
 	tier: Tier;
-	metadata: TierSourceMetadata;
 }) => Promise<void>;
 
-export function initPromoteTierToCanonical(deps: {
+export function initWriteCanonicalContent(deps: {
 	dynamoClient: DynamoDBDocumentClient;
 	s3Client: S3Client;
 	tableName: string;
 	bucketName: string;
-	now: () => Date;
-}): { promoteTierToCanonical: PromoteTierToCanonical } {
-	const { dynamoClient, s3Client, tableName, bucketName, now } = deps;
+}): { writeCanonicalContent: WriteCanonicalContent } {
+	const { dynamoClient, s3Client, tableName, bucketName } = deps;
 
 	const articleTable = defineDynamoTable({
 		client: dynamoClient,
 		tableName,
-		schema: ArticleRow,
+		schema: CanonicalContentRow,
 	});
 
-	const promoteTierToCanonical: PromoteTierToCanonical = async (params) => {
+	const writeCanonicalContent: WriteCanonicalContent = async (params) => {
 		const id = ArticleResourceUniqueId.parse(params.url);
 		const sourceKey = id.toS3SourceKey({ tier: params.tier });
 		const canonicalKey = id.toS3ContentKey();
@@ -59,46 +60,17 @@ export function initPromoteTierToCanonical(deps: {
 			}),
 		);
 
-		const setClauses = [
-			"title = :t",
-			"siteName = :s",
-			"excerpt = :e",
-			"wordCount = :w",
-			"estimatedReadTime = :r",
-			"contentLocation = :cl",
-			"contentSourceTier = :cst",
-			"contentFetchedAt = :cfa",
-			"canonicalSourceTier = :cst",
-			// crawlStatus flips to "ready" atomically with the canonical write so
-			// "ready" exclusively means "canonical content is available to read".
-			// Per-tier workers no longer pre-mark ready; that previously left rows
-			// reading ready while title/excerpt/wordCount were still hostname stubs
-			// when the selector returned a tie and never promoted a canonical.
-			"crawlStatus = :ready",
-		];
-		const values: Record<string, unknown> = {
-			":t": params.metadata.title,
-			":s": params.metadata.siteName,
-			":e": params.metadata.excerpt,
-			":w": params.metadata.wordCount,
-			":r": params.metadata.estimatedReadTime,
-			":cl": `s3://${bucketName}/${canonicalKey}`,
-			":cst": params.tier,
-			":cfa": now().toISOString(),
-			":ready": "ready",
-		};
-		if (params.metadata.imageUrl) {
-			setClauses.push("imageUrl = :img");
-			values[":img"] = params.metadata.imageUrl;
-		}
-
 		await articleTable.update({
 			Key: { url: id.value },
-			UpdateExpression: `SET ${setClauses.join(", ")} REMOVE crawlFailureReason, crawlFailedAt, crawlUnsupportedReason`,
-			ExpressionAttributeValues: values,
+			UpdateExpression:
+				"SET contentLocation = :cl, contentSourceTier = :cst, canonicalSourceTier = :cst",
+			ExpressionAttributeValues: {
+				":cl": `s3://${bucketName}/${canonicalKey}`,
+				":cst": params.tier,
+			},
 		});
 	};
 
-	return { promoteTierToCanonical };
+	return { writeCanonicalContent };
 }
 /* c8 ignore stop */

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.test.ts
@@ -2,11 +2,12 @@ import { noopLogger } from "@packages/hutch-logger";
 import {
 	recrawlPromoteTier,
 	recrawlTieKeptCanonical,
+	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
 import { initRecrawlContentExtractedHandler } from "./recrawl-content-extracted-handler";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
-import type { PromoteTierToCanonical } from "./promote-tier-to-canonical";
+import type { WriteCanonicalContent } from "./promote-tier-to-canonical";
 import type { FindContentSourceTier } from "./find-content-source-tier";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
@@ -32,6 +33,8 @@ const stubContext: Context = {
 	fail: () => {},
 	succeed: () => {},
 };
+
+const FIXED_NOW = new Date("2026-05-12T10:00:00.000Z");
 
 const stubMetadata = (overrides: Partial<TierSourceMetadata> = {}): TierSourceMetadata => ({
 	title: "Title",
@@ -70,13 +73,15 @@ function createSqsEvent(detail: { url: string }): SQSEvent {
 type HandlerDeps = Parameters<typeof initRecrawlContentExtractedHandler>[0];
 
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
+	const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 	const deps: HandlerDeps = {
 		listAvailableTierSources: jest.fn<ReturnType<ListAvailableTierSources>, Parameters<ListAvailableTierSources>>().mockResolvedValue([]),
 		selectMostCompleteContent: jest.fn<ReturnType<SelectMostCompleteContent>, Parameters<SelectMostCompleteContent>>().mockResolvedValue({ winner: "tie", reason: "" }),
-		promoteTierToCanonical: jest.fn<ReturnType<PromoteTierToCanonical>, Parameters<PromoteTierToCanonical>>().mockResolvedValue(undefined),
+		writeCanonicalContent: jest.fn<ReturnType<WriteCanonicalContent>, Parameters<WriteCanonicalContent>>().mockResolvedValue(undefined),
 		findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
-		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
+		transitionAndPersist,
 		imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
+		now: () => FIXED_NOW,
 		logger: noopLogger,
 		...overrides,
 	};
@@ -96,51 +101,118 @@ describe("initRecrawlContentExtractedHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(deps.promoteTierToCanonical).not.toHaveBeenCalled();
+		expect(deps.writeCanonicalContent).not.toHaveBeenCalled();
 		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
 	});
 
-	it("with one tier source, promotes it and dispatches the recrawlPromoteTier aggregate transition (GenerateSummary + RecrawlCompleted effects)", async () => {
-		const tier1 = tierSource("tier-1");
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+	it("with one tier source, writes canonical content and dispatches the recrawlPromoteTier aggregate transition with the refreshed metadata + freshness payload", async () => {
+		const tier1 = tierSource("tier-1", {
+			metadata: stubMetadata({
+				title: "Refreshed",
+				excerpt: "Refreshed excerpt",
+				wordCount: 500,
+				estimatedReadTime: 4,
+				imageUrl: "https://cdn.example/img.png",
+			}),
+		});
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
-			promoteTierToCanonical,
+			writeCanonicalContent,
 			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
-		expect(promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",
-			metadata: tier1.metadata,
 		});
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
 			url: "https://example.com/a",
-			input: undefined,
+			input: {
+				winnerTier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+			},
 		});
 	});
 
-	it("on a tie with an existing canonical, skips promotion and dispatches the recrawlTieKeptCanonical aggregate transition (one save flips crawl=ready AND emits the same effects)", async () => {
+	it("refreshes user-facing metadata (title/excerpt/wordCount/imageUrl) into the aggregate input on a recrawl — bug-fix coverage for the previously-frozen card", async () => {
+		const tier1 = tierSource("tier-1", {
+			metadata: stubMetadata({
+				title: "Brand-new upstream title",
+				excerpt: "Brand-new excerpt",
+				wordCount: 1234,
+				imageUrl: "https://cdn.example/new-image.png",
+			}),
+		});
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
+			transitionAndPersist,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(transitionAndPersist).toHaveBeenCalledWith(
+			recrawlPromoteTier,
+			expect.objectContaining({
+				url: "https://example.com/a",
+				input: expect.objectContaining({
+					metadata: expect.objectContaining({
+						title: "Brand-new upstream title",
+						excerpt: "Brand-new excerpt",
+						wordCount: 1234,
+						imageUrl: "https://cdn.example/new-image.png",
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("calls writeCanonicalContent BEFORE the aggregate transition so canonical S3 content exists by the time crawlStatus flips to ready", async () => {
+		const tier1 = tierSource("tier-1");
+		const callOrder: string[] = [];
+		const writeCanonicalContent = jest.fn(async () => {
+			callOrder.push("writeCanonicalContent");
+		});
+		const transitionAndPersist: TransitionAndPersist = jest.fn(async () => {
+			callOrder.push("transitionAndPersist");
+		});
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
+			writeCanonicalContent,
+			transitionAndPersist,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(callOrder).toEqual(["writeCanonicalContent", "transitionAndPersist"]);
+	});
+
+	it("on a tie with an existing canonical, skips canonical write and dispatches the recrawlTieKeptCanonical aggregate transition (crawl flips to ready, summariser short-circuits on cache hit)", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
-			promoteTierToCanonical,
+			writeCanonicalContent,
 			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
-		expect(promoteTierToCanonical).not.toHaveBeenCalled();
+		expect(writeCanonicalContent).not.toHaveBeenCalled();
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
 			url: "https://example.com/a",
 			input: undefined,
@@ -155,96 +227,104 @@ describe("initRecrawlContentExtractedHandler", () => {
 		const tier1 = tierSource("tier-1", {
 			html: '<p>same body</p><img src="https://cdn.example.cloudfront.net/a.png"><img src="https://cdn.example.cloudfront.net/b.png">',
 		});
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
 		const findContentSourceTier = jest.fn().mockResolvedValue("tier-0");
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "only image URLs differ" }),
 			findContentSourceTier,
-			promoteTierToCanonical,
+			writeCanonicalContent,
 			imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
 		expect(findContentSourceTier).not.toHaveBeenCalled();
-		expect(promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",
-			metadata: tier1.metadata,
 		});
 	});
 
 	it("on a tie with no canonical (recovering a stuck row), defaults to tier-1 and dispatches recrawlPromoteTier so summary generation can find content", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "identical content" }),
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
-			promoteTierToCanonical,
+			writeCanonicalContent,
 			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
-		expect(promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",
-			metadata: tier1.metadata,
 		});
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
 			url: "https://example.com/a",
-			input: undefined,
+			input: {
+				winnerTier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+			},
 		});
 	});
 
 	it("tie with no canonical and only tier-0 sources available falls back to tier-0", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier0Alt = tierSource("tier-0", { metadata: stubMetadata({ title: "Alt" }) });
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier0Alt]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "tied tier-0 candidates" }),
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
-			promoteTierToCanonical,
+			writeCanonicalContent,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
-		expect(promoteTierToCanonical).toHaveBeenCalledWith(
-			expect.objectContaining({ url: "https://example.com/a", tier: "tier-0" }),
-		);
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-0",
+		});
 	});
 
-	it("with multiple sources and a definite winner, promotes the winner and dispatches recrawlPromoteTier", async () => {
+	it("with multiple sources and a definite winner, writes canonical and dispatches recrawlPromoteTier", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
-		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-1", reason: "more complete" }),
-			promoteTierToCanonical,
+			writeCanonicalContent,
 			transitionAndPersist,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
 
-		expect(promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",
-			metadata: tier1.metadata,
 		});
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
 			url: "https://example.com/a",
-			input: undefined,
+			input: {
+				winnerTier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+			},
 		});
 	});
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-handler.ts
@@ -14,26 +14,28 @@ import {
 import { RecrawlContentExtractedEvent } from "@packages/hutch-infra-components";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
-import type { PromoteTierToCanonical } from "./promote-tier-to-canonical";
+import type { WriteCanonicalContent } from "./promote-tier-to-canonical";
 import type { FindContentSourceTier } from "./find-content-source-tier";
 import type { TierSource } from "./tier-source.types";
 
 export function initRecrawlContentExtractedHandler(deps: {
 	listAvailableTierSources: ListAvailableTierSources;
 	selectMostCompleteContent: SelectMostCompleteContent;
-	promoteTierToCanonical: PromoteTierToCanonical;
+	writeCanonicalContent: WriteCanonicalContent;
 	findContentSourceTier: FindContentSourceTier;
 	transitionAndPersist: TransitionAndPersist;
 	imagesCdnBaseUrl: string;
+	now: () => Date;
 	logger: HutchLogger;
 }): Handler<SQSEvent, SQSBatchResponse> {
 	const {
 		listAvailableTierSources,
 		selectMostCompleteContent,
-		promoteTierToCanonical,
+		writeCanonicalContent,
 		findContentSourceTier,
 		transitionAndPersist,
 		imagesCdnBaseUrl,
+		now,
 		logger,
 	} = deps;
 	const cdnHost = new URL(imagesCdnBaseUrl).host;
@@ -123,21 +125,22 @@ export function initRecrawlContentExtractedHandler(deps: {
 					const winnerSource = sources.find((source) => source.tier === winnerTier);
 					assert(winnerSource, `winner tier ${winnerTier} missing from candidate set`);
 
-					await promoteTierToCanonical({
+					await writeCanonicalContent({ url: detail.url, tier: winnerTier });
+
+					await transitionAndPersist(recrawlPromoteTier, {
 						url: detail.url,
-						tier: winnerTier,
-						metadata: winnerSource.metadata,
+						input: {
+							winnerTier,
+							metadata: winnerSource.metadata,
+							estimatedReadTime: winnerSource.metadata.estimatedReadTime,
+							contentFetchedAt: now().toISOString(),
+						},
 					});
 
 					logger.info("[RecrawlContentExtracted] promoted tier to canonical", {
 						url: detail.url,
 						tier: winnerTier,
 						reason,
-					});
-
-					await transitionAndPersist(recrawlPromoteTier, {
-						url: detail.url,
-						input: undefined,
 					});
 				} else {
 					await transitionAndPersist(recrawlTieKeptCanonical, {

--- a/projects/save-link/src/select-content/select-most-complete-content-handler.test.ts
+++ b/projects/save-link/src/select-content/select-most-complete-content-handler.test.ts
@@ -1,8 +1,12 @@
 import { noopLogger } from "@packages/hutch-logger";
+import {
+	promoteTier,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
 import { initSelectMostCompleteContentHandler } from "./select-most-complete-content-handler";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
-import type { PromoteTierToCanonical } from "./promote-tier-to-canonical";
+import type { WriteCanonicalContent } from "./promote-tier-to-canonical";
 import type { FindContentSourceTier } from "./find-content-source-tier";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
@@ -28,6 +32,8 @@ const stubContext: Context = {
 	fail: () => {},
 	succeed: () => {},
 };
+
+const FIXED_NOW = new Date("2026-05-12T10:00:00.000Z");
 
 const stubMetadata = (overrides: Partial<TierSourceMetadata> = {}): TierSourceMetadata => ({
 	title: "Title",
@@ -66,12 +72,15 @@ function createSqsEvent(detail: { url: string; tier: "tier-0" | "tier-1"; userId
 type HandlerDeps = Parameters<typeof initSelectMostCompleteContentHandler>[0];
 
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
+	const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 	const deps: HandlerDeps = {
 		listAvailableTierSources: jest.fn<ReturnType<ListAvailableTierSources>, Parameters<ListAvailableTierSources>>().mockResolvedValue([]),
 		selectMostCompleteContent: jest.fn<ReturnType<SelectMostCompleteContent>, Parameters<SelectMostCompleteContent>>().mockResolvedValue({ winner: "tie", reason: "" }),
-		promoteTierToCanonical: jest.fn<ReturnType<PromoteTierToCanonical>, Parameters<PromoteTierToCanonical>>().mockResolvedValue(undefined),
+		writeCanonicalContent: jest.fn<ReturnType<WriteCanonicalContent>, Parameters<WriteCanonicalContent>>().mockResolvedValue(undefined),
 		findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
+		transitionAndPersist,
 		publishEvent: jest.fn().mockResolvedValue(undefined),
+		now: () => FIXED_NOW,
 		logger: noopLogger,
 		...overrides,
 	};
@@ -91,44 +100,68 @@ describe("initSelectMostCompleteContentHandler", () => {
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(deps.promoteTierToCanonical).not.toHaveBeenCalled();
+		expect(deps.writeCanonicalContent).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
 		expect(deps.publishEvent).not.toHaveBeenCalled();
 	});
 
-	it("single source short-circuits the contest and promotes that tier without calling Deepseek", async () => {
+	it("single source short-circuits the contest, writes canonical content, and dispatches promoteTier with userId so the aggregate emits LinkSaved", async () => {
 		const tier1 = tierSource("tier-1");
-		const promoteTierToCanonical = jest.fn().mockResolvedValue(undefined);
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const selectMostCompleteContent = jest.fn();
-		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const { handler } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
 			selectMostCompleteContent,
-			promoteTierToCanonical,
+			writeCanonicalContent,
+			transitionAndPersist,
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
-			publishEvent,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
 
 		expect(selectMostCompleteContent).not.toHaveBeenCalled();
-		expect(promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",
-			metadata: tier1.metadata,
 		});
-		expect(publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({ detailType: "CrawlArticleCompleted" }),
-		);
-		expect(publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({
-				detailType: "LinkSaved",
-				detail: JSON.stringify({ url: "https://example.com/a", userId: "user-1" }),
-			}),
-		);
+		expect(transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
+			url: "https://example.com/a",
+			input: {
+				tier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				canonicalChanged: true,
+				userId: "user-1",
+			},
+		});
 	});
 
-	it("two sources, tier-0 wins — promotes tier-0 and emits LinkSaved with userId", async () => {
+	it("calls writeCanonicalContent BEFORE the aggregate transition so canonical S3 content exists by the time crawlStatus flips to ready", async () => {
+		const tier1 = tierSource("tier-1");
+		const callOrder: string[] = [];
+		const writeCanonicalContent = jest.fn(async () => {
+			callOrder.push("writeCanonicalContent");
+		});
+		const transitionAndPersist: TransitionAndPersist = jest.fn(async () => {
+			callOrder.push("transitionAndPersist");
+		});
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
+			writeCanonicalContent,
+			transitionAndPersist,
+			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }), stubContext, () => {});
+
+		expect(callOrder).toEqual(["writeCanonicalContent", "transitionAndPersist"]);
+	});
+
+	it("two sources, tier-0 wins — writes canonical and dispatches promoteTier with canonicalChanged=true and userId", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
 
@@ -140,20 +173,24 @@ describe("initSelectMostCompleteContentHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
 
-		expect(deps.promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-0",
-			metadata: tier0.metadata,
 		});
-		expect(deps.publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({
-				detailType: "LinkSaved",
-				detail: JSON.stringify({ url: "https://example.com/a", userId: "user-1" }),
-			}),
-		);
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
+			url: "https://example.com/a",
+			input: {
+				tier: "tier-0",
+				metadata: tier0.metadata,
+				estimatedReadTime: tier0.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				canonicalChanged: true,
+				userId: "user-1",
+			},
+		});
 	});
 
-	it("two sources, tier-1 wins — promotes tier-1 and emits AnonymousLinkSaved when no userId", async () => {
+	it("two sources, tier-1 wins — dispatches promoteTier without userId (aggregate will emit AnonymousLinkSaved)", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
 
@@ -165,23 +202,20 @@ describe("initSelectMostCompleteContentHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }), stubContext, () => {});
 
-		expect(deps.promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
 			url: "https://example.com/a",
-			tier: "tier-1",
-			metadata: tier1.metadata,
+			input: {
+				tier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				canonicalChanged: true,
+				userId: undefined,
+			},
 		});
-		expect(deps.publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({
-				detailType: "AnonymousLinkSaved",
-				detail: JSON.stringify({ url: "https://example.com/a" }),
-			}),
-		);
-		expect(deps.publishEvent).not.toHaveBeenCalledWith(
-			expect.objectContaining({ detailType: "LinkSaved" }),
-		);
 	});
 
-	it("tie with an existing canonical keeps it unchanged — emits CrawlArticleCompleted only, no LinkSaved/AnonymousLinkSaved", async () => {
+	it("tie with an existing canonical keeps it unchanged — emits CrawlArticleCompleted directly and skips the aggregate transition entirely", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
@@ -195,32 +229,39 @@ describe("initSelectMostCompleteContentHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
 
-		expect(deps.promoteTierToCanonical).not.toHaveBeenCalled();
+		expect(deps.writeCanonicalContent).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
 		const events = publishEvent.mock.calls.map((call: [{ detailType: string }]) => call[0].detailType);
 		expect(events).toEqual(["CrawlArticleCompleted"]);
 	});
 
-	it("tie with no canonical yet (first save) defaults to tier-1 and emits LinkSaved so the row never sits stuck", async () => {
+	it("tie with no canonical yet (first save) defaults to tier-1 and dispatches promoteTier with canonicalChanged=true so the row never sits stuck", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
-		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const { handler, deps } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "identical content" }),
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
-			publishEvent,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
 
-		expect(deps.promoteTierToCanonical).toHaveBeenCalledWith({
+		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
 			tier: "tier-1",
-			metadata: tier1.metadata,
 		});
-		const events = publishEvent.mock.calls.map((call: [{ detailType: string }]) => call[0].detailType);
-		expect(events).toEqual(["CrawlArticleCompleted", "LinkSaved"]);
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
+			url: "https://example.com/a",
+			input: {
+				tier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				canonicalChanged: true,
+				userId: "user-1",
+			},
+		});
 	});
 
 	it("tie with no canonical and only tier-0 available (no tier-1) defaults to tier-0", async () => {
@@ -235,31 +276,49 @@ describe("initSelectMostCompleteContentHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
 
-		expect(deps.promoteTierToCanonical).toHaveBeenCalledWith(
-			expect.objectContaining({ url: "https://example.com/a", tier: "tier-0" }),
+		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-0",
+		});
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			promoteTier,
+			expect.objectContaining({
+				url: "https://example.com/a",
+				input: expect.objectContaining({ tier: "tier-0", canonicalChanged: true }),
+			}),
 		);
 	});
 
-	it("re-selecting the same winner does not emit LinkSaved (canonical unchanged) but still emits CrawlArticleCompleted", async () => {
+	it("re-selecting the same winner dispatches promoteTier with canonicalChanged=false so the aggregate suppresses LinkSaved (canonical unchanged)", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");
-		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
 		const { handler, deps } = createHandler({
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-0", reason: "still tier-0" }),
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
-			publishEvent,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
 
-		expect(deps.promoteTierToCanonical).toHaveBeenCalled(); // metadata may have changed; safe to overwrite
-		const events = publishEvent.mock.calls.map((call: [{ detailType: string }]) => call[0].detailType);
-		expect(events).toEqual(["CrawlArticleCompleted"]);
+		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-0",
+		});
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
+			url: "https://example.com/a",
+			input: {
+				tier: "tier-0",
+				metadata: tier0.metadata,
+				estimatedReadTime: tier0.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				canonicalChanged: false,
+				userId: "user-1",
+			},
+		});
 	});
 
-	it("first save (no prior canonical) on a single-tier short-circuit emits LinkSaved", async () => {
+	it("first save (no prior canonical) on a single-tier short-circuit dispatches promoteTier with canonicalChanged=true and userId so the aggregate emits LinkSaved", async () => {
 		const tier0 = tierSource("tier-0");
 
 		const { handler, deps } = createHandler({
@@ -269,8 +328,11 @@ describe("initSelectMostCompleteContentHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
 
-		expect(deps.publishEvent).toHaveBeenCalledWith(
-			expect.objectContaining({ detailType: "LinkSaved" }),
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			promoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({ canonicalChanged: true, userId: "user-1" }),
+			}),
 		);
 	});
 
@@ -283,8 +345,15 @@ describe("initSelectMostCompleteContentHandler", () => {
 		});
 		await handler2.handler(createSqsEvent({ url: "https://example.com/x", tier: "tier-1" }), stubContext, () => {});
 		expect(handler2.deps.selectMostCompleteContent).not.toHaveBeenCalled();
-		expect(handler2.deps.promoteTierToCanonical).toHaveBeenCalledWith(
-			expect.objectContaining({ tier: "tier-1" }),
+		expect(handler2.deps.writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/x",
+			tier: "tier-1",
+		});
+		expect(handler2.deps.transitionAndPersist).toHaveBeenCalledWith(
+			promoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({ tier: "tier-1" }),
+			}),
 		);
 	});
 

--- a/projects/save-link/src/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/select-content/select-most-complete-content-handler.ts
@@ -3,14 +3,16 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
+	type TransitionAndPersist,
+	promoteTier,
+} from "@packages/domain/article-aggregate";
+import {
 	TierContentExtractedEvent,
-	LinkSavedEvent,
-	AnonymousLinkSavedEvent,
 	CrawlArticleCompletedEvent,
 } from "@packages/hutch-infra-components";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
-import type { PromoteTierToCanonical } from "./promote-tier-to-canonical";
+import type { WriteCanonicalContent } from "./promote-tier-to-canonical";
 import type { FindContentSourceTier } from "./find-content-source-tier";
 import type { TierSource } from "./tier-source.types";
 
@@ -18,17 +20,21 @@ import type { TierSource } from "./tier-source.types";
 export function initSelectMostCompleteContentHandler(deps: {
 	listAvailableTierSources: ListAvailableTierSources;
 	selectMostCompleteContent: SelectMostCompleteContent;
-	promoteTierToCanonical: PromoteTierToCanonical;
+	writeCanonicalContent: WriteCanonicalContent;
 	findContentSourceTier: FindContentSourceTier;
+	transitionAndPersist: TransitionAndPersist;
 	publishEvent: PublishEvent;
+	now: () => Date;
 	logger: HutchLogger;
 }): Handler<SQSEvent, SQSBatchResponse> {
 	const {
 		listAvailableTierSources,
 		selectMostCompleteContent,
-		promoteTierToCanonical,
+		writeCanonicalContent,
 		findContentSourceTier,
+		transitionAndPersist,
 		publishEvent,
+		now,
 		logger,
 	} = deps;
 
@@ -86,7 +92,9 @@ export function initSelectMostCompleteContentHandler(deps: {
 							/* Recrawl tie: a canonical already exists. Promoting the
 							 * same content again would be a no-op write but a real
 							 * summary regeneration — wasted Deepseek tokens. Emit
-							 * CrawlArticleCompleted to settle the pipeline and skip. */
+							 * CrawlArticleCompleted directly to settle the pipeline
+							 * and skip; no aggregate transition because crawl/summary
+							 * state is unchanged. */
 							await publishEvent({
 								source: CrawlArticleCompletedEvent.source,
 								detailType: CrawlArticleCompletedEvent.detailType,
@@ -99,7 +107,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 						 * one is a deterministic tiebreaker rather than a quality
 						 * call. Prefer tier-1 (Readability-parsed) when present,
 						 * else tier-0 (raw HTML). Without this default the row
-						 * sits at crawlStatus=pending forever — promoteTierToCanonical
+						 * sits at crawlStatus=pending forever — promoteTier
 						 * is the only writer of crawlStatus="ready". */
 						const fallback =
 							sources.find((source) => source.tier === "tier-1") ??
@@ -124,44 +132,26 @@ export function initSelectMostCompleteContentHandler(deps: {
 				const currentTier = await findContentSourceTier(detail.url);
 				const canonicalChanged = currentTier !== winnerTier;
 
-				await promoteTierToCanonical({
+				await writeCanonicalContent({ url: detail.url, tier: winnerTier });
+
+				await transitionAndPersist(promoteTier, {
 					url: detail.url,
-					tier: winnerTier,
-					metadata: winnerSource.metadata,
+					input: {
+						tier: winnerTier,
+						metadata: winnerSource.metadata,
+						estimatedReadTime: winnerSource.metadata.estimatedReadTime,
+						contentFetchedAt: now().toISOString(),
+						canonicalChanged,
+						userId: detail.userId,
+					},
 				});
 
-				await publishEvent({
-					source: CrawlArticleCompletedEvent.source,
-					detailType: CrawlArticleCompletedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url }),
-				});
-
-				if (canonicalChanged) {
-					if (detail.userId) {
-						await publishEvent({
-							source: LinkSavedEvent.source,
-							detailType: LinkSavedEvent.detailType,
-							detail: JSON.stringify({ url: detail.url, userId: detail.userId }),
-						});
-					} else {
-						await publishEvent({
-							source: AnonymousLinkSavedEvent.source,
-							detailType: AnonymousLinkSavedEvent.detailType,
-							detail: JSON.stringify({ url: detail.url }),
-						});
-					}
-					logger.info("[SelectContent] promoted tier to canonical", {
-						url: detail.url,
-						tier: winnerTier,
-						reason,
-					});
-				} else {
-					logger.info("[SelectContent] re-selected same tier; canonical unchanged", {
-						url: detail.url,
-						tier: winnerTier,
-						reason,
-					});
-				}
+				logger.info(
+					canonicalChanged
+						? "[SelectContent] promoted tier to canonical"
+						: "[SelectContent] re-selected same tier; canonical unchanged",
+					{ url: detail.url, tier: winnerTier, reason },
+				);
 			} catch (error) {
 				logger.error("[SelectContent] record failed", {
 					messageId: record.messageId,

--- a/src/packages/domain/src/article-aggregate/index.ts
+++ b/src/packages/domain/src/article-aggregate/index.ts
@@ -46,7 +46,10 @@ export {
 	type PromoteTierInput,
 } from "./transitions/promote-tier";
 export { recrawlTieKeptCanonical } from "./transitions/recrawl-tie-kept-canonical";
-export { recrawlPromoteTier } from "./transitions/recrawl-promote-tier";
+export {
+	recrawlPromoteTier,
+	type RecrawlPromoteTierInput,
+} from "./transitions/recrawl-promote-tier";
 export {
 	initTransitionAndPersist,
 	type Transition,

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
@@ -1,17 +1,24 @@
 import assert from "node:assert/strict";
 import type { Article } from "../article.types";
-import { recrawlPromoteTier } from "./recrawl-promote-tier";
+import {
+	recrawlPromoteTier,
+	type RecrawlPromoteTierInput,
+} from "./recrawl-promote-tier";
 
 function buildArticle(overrides: Partial<Article> = {}): Article {
 	return {
 		url: "https://example.com/article",
 		metadata: {
-			title: "Title",
-			siteName: "Example",
-			excerpt: "Excerpt",
+			title: "Old title",
+			siteName: "Old site",
+			excerpt: "Old excerpt",
 			wordCount: 100,
 		},
-		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		freshness: {
+			etag: '"old-etag"',
+			lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+			contentFetchedAt: "2026-01-01T00:00:00.000Z",
+		},
 		estimatedReadTime: 1,
 		crawl: { kind: "pending" },
 		summary: { kind: "ready", summary: "old" },
@@ -19,17 +26,96 @@ function buildArticle(overrides: Partial<Article> = {}): Article {
 	};
 }
 
+function buildInput(overrides: Partial<RecrawlPromoteTierInput> = {}): RecrawlPromoteTierInput {
+	return {
+		winnerTier: "tier-1",
+		metadata: {
+			title: "New title",
+			siteName: "New site",
+			excerpt: "New excerpt",
+			wordCount: 250,
+			imageUrl: "https://example.com/image.jpg",
+		},
+		estimatedReadTime: 3,
+		contentFetchedAt: "2026-05-10T12:00:00.000Z",
+		...overrides,
+	};
+}
+
 describe("recrawlPromoteTier", () => {
 	it("flips crawl from pending to ready after a tier promotion", () => {
-		const { article } = recrawlPromoteTier(buildArticle(), undefined);
+		const { article } = recrawlPromoteTier(buildArticle(), buildInput());
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
+	});
+
+	it("writes the incoming metadata onto the article (refreshing title/excerpt/wordCount/imageUrl on every recrawl)", () => {
+		const { article } = recrawlPromoteTier(
+			buildArticle(),
+			buildInput({
+				metadata: {
+					title: "Refreshed title",
+					siteName: "Refreshed site",
+					excerpt: "Refreshed excerpt",
+					wordCount: 999,
+					imageUrl: "https://example.com/refreshed.jpg",
+				},
+			}),
+		);
+
+		assert.equal(article.metadata.title, "Refreshed title");
+		assert.equal(article.metadata.siteName, "Refreshed site");
+		assert.equal(article.metadata.excerpt, "Refreshed excerpt");
+		assert.equal(article.metadata.wordCount, 999);
+		assert.equal(article.metadata.imageUrl, "https://example.com/refreshed.jpg");
+	});
+
+	it("writes the incoming contentFetchedAt onto article.freshness, preserving other freshness fields (etag/lastModified)", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"kept-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+			},
+		});
+
+		const { article } = recrawlPromoteTier(
+			before,
+			buildInput({ contentFetchedAt: "2026-05-10T12:00:00.000Z" }),
+		);
+
+		assert.equal(article.freshness.contentFetchedAt, "2026-05-10T12:00:00.000Z");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.freshness.lastModified, "Thu, 01 Jan 2026 00:00:00 GMT");
+	});
+
+	it("overwrites estimatedReadTime with the supplied value", () => {
+		const { article } = recrawlPromoteTier(
+			buildArticle(),
+			buildInput({ estimatedReadTime: 7 }),
+		);
+
+		assert.equal(article.estimatedReadTime, 7);
+	});
+
+	it("resets summary to pending so the regenerate fires against the new canonical body", () => {
+		const before = buildArticle({
+			summary: {
+				kind: "ready",
+				summary: "stale summary",
+				excerpt: "stale excerpt",
+			},
+		});
+
+		const { article } = recrawlPromoteTier(before, buildInput());
+
+		assert.deepEqual(article.summary, { kind: "pending" });
 	});
 
 	it("emits generate-summary and publish-recrawl-completed effects in that order", () => {
 		const { effects } = recrawlPromoteTier(
 			buildArticle({ url: "https://example.com/post" }),
-			undefined,
+			buildInput(),
 		);
 
 		assert.deepEqual(effects, [
@@ -38,17 +124,22 @@ describe("recrawlPromoteTier", () => {
 		]);
 	});
 
-	it("declares writes for crawl only (the canonical metadata + S3 copy are owned by promoteTierToCanonical outside the aggregate)", () => {
-		const { writes } = recrawlPromoteTier(buildArticle(), undefined);
+	it("declares writes for metadata, freshness, crawl, summary so the aggregate save scopes to the four axes the transition mutated", () => {
+		const { writes } = recrawlPromoteTier(buildArticle(), buildInput());
 
-		assert.deepEqual([...writes], ["crawl"]);
+		assert.deepEqual([...writes].sort(), [
+			"crawl",
+			"freshness",
+			"metadata",
+			"summary",
+		]);
 	});
 
 	it("does not mutate the input article (pure function)", () => {
 		const before = buildArticle();
 		const snapshot = JSON.parse(JSON.stringify(before));
 
-		recrawlPromoteTier(before, undefined);
+		recrawlPromoteTier(before, buildInput());
 
 		assert.deepEqual(before, snapshot);
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
@@ -1,10 +1,17 @@
-import type { Article } from "../article.types";
+import type { Article, ArticleMetadata } from "../article.types";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
+export interface RecrawlPromoteTierInput {
+	winnerTier: "tier-0" | "tier-1";
+	metadata: ArticleMetadata;
+	estimatedReadTime: number;
+	contentFetchedAt: string;
+}
+
 export function recrawlPromoteTier(
 	article: Article,
-	_input: undefined,
+	input: RecrawlPromoteTierInput,
 ): {
 	article: Article;
 	effects: readonly Effect[];
@@ -12,12 +19,24 @@ export function recrawlPromoteTier(
 } {
 	const next: Article = {
 		...article,
+		metadata: input.metadata,
+		freshness: {
+			...article.freshness,
+			contentFetchedAt: input.contentFetchedAt,
+		},
+		estimatedReadTime: input.estimatedReadTime,
 		crawl: { kind: "ready" },
+		summary: { kind: "pending" },
 	};
 	const effects: readonly Effect[] = [
 		{ kind: "generate-summary", url: article.url },
 		{ kind: "publish-recrawl-completed", url: article.url },
 	];
-	const writes: readonly AggregateField[] = ["crawl"];
+	const writes: readonly AggregateField[] = [
+		"metadata",
+		"freshness",
+		"crawl",
+		"summary",
+	];
 	return { article: next, effects, writes };
 }

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
@@ -2,8 +2,10 @@ import type { Article } from "../article.types";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
-/* forceMarkCrawlPending unconditionally sets "pending" — without this
- * transition the row stays pending forever with canonical content on disk. */
+/* Tie kept canonical: the selector returned a tie and a canonical already
+ * exists on disk. No tier flip, no metadata refresh, no summary reset — but
+ * crawl still flips to ready and generate-summary still fires (the summariser
+ * short-circuits on cache hit) so the row exits pending. */
 export function recrawlTieKeptCanonical(
 	article: Article,
 	_input: undefined,


### PR DESCRIPTION
## Goal

Migrate the content-selection pipeline — both the initial-save selector (`select-most-complete-content-handler`) and the recrawl handler (`recrawl-content-extracted-handler`) — to flip `crawlStatus="ready"` plus the metadata, freshness, and summary-reset fields atomically via Article-aggregate transitions. Rename the inline writer `promoteTierToCanonical` to `writeCanonicalContent` and narrow it to the responsibilities the aggregate cannot own (S3 CopyObject + `contentLocation` / `contentSourceTier` / `canonicalSourceTier` columns).

## Bug fix (behavior change)

**Fixes a missing-refresh bug on `/admin/recrawl`.** Previously the row's user-facing title / excerpt / wordCount / image stayed frozen at the original-save values because `recrawlPromoteTier` only flipped the crawl axis. After this PR a recrawl refreshes metadata + freshness alongside the crawl/summary state. This is the user-visible motivation for the change — reviewers should be aware that the queue card now updates after a recrawl pulls a new upstream title.

## Context

Today the selector handler calls `promoteTierToCanonical(url, tier, metadata)` which does THREE things at once: copies the winning tier source to the canonical S3 key, writes `contentLocation` / `contentSourceTier` / `canonicalSourceTier`, AND writes title / excerpt / wordCount / imageUrl / contentFetchedAt / `crawlStatus="ready"`. After that the handler publishes `CrawlArticleCompletedEvent` and (if the canonical tier changed) `LinkSavedEvent` or `AnonymousLinkSavedEvent` directly.

Splitting this so the aggregate owns the status/metadata writes lets a single transition emit the right effects in the right order — and, importantly, lets the recrawl handler use the SAME transition shape so a recrawl actually refreshes user-facing metadata. The previous `recrawlPromoteTier` only wrote `crawl: { kind: "ready" }`, leaving stale metadata behind.

## What changed

### Domain (`@packages/domain`)

- `recrawlPromoteTier` now takes a `RecrawlPromoteTierInput` (winnerTier, metadata, estimatedReadTime, contentFetchedAt). It writes metadata + freshness + crawl=ready + summary=pending and declares writes for all four axes.
- New exported type `RecrawlPromoteTierInput` from `@packages/domain/article-aggregate`.
- Comment on `recrawlTieKeptCanonical` rewritten to describe the tie case faithfully (no tier flip, no metadata refresh, no summary reset; generate-summary still fires so the summariser short-circuits on cache hit).
- Tests cover the new metadata/freshness/summary-reset writes plus the existing crawl flip, effect order, and write declaration.

### save-link

- `promote-tier-to-canonical.ts` renamed exports to `initWriteCanonicalContent` / `WriteCanonicalContent`. The function now only does the S3 CopyObject and writes `contentLocation` + `contentSourceTier` + `canonicalSourceTier`. The aggregate transitions take over the metadata / freshness / crawl / summary writes. File path unchanged to avoid a churn-only diff in importers.
- `select-most-complete-content-handler` now calls `writeCanonicalContent` then dispatches `promoteTier` via `transitionAndPersist`. The `canonicalChanged` gating moves into the transition's effect logic. The recrawl-tie branch still publishes `CrawlArticleCompletedEvent` directly (no aggregate transition because crawl/summary state is unchanged).
- `recrawl-content-extracted-handler` now calls `writeCanonicalContent` then dispatches `recrawlPromoteTier` with the new input shape — this is the bug fix.
- Both composition roots updated to wire the aggregate (store, dispatcher, transitionAndPersist) and a `now: () => new Date()` clock.

## Test plan

- [x] `pnpm nx run @packages/domain:compile`
- [x] `pnpm nx run @packages/domain:test` (210 passed)
- [x] `pnpm nx run @packages/domain:test-with-coverage` (100% across the board)
- [x] `pnpm nx run save-link:compile`
- [x] `pnpm nx run save-link:test` (316 passed)
- [x] `pnpm nx run save-link:test-with-coverage` (100% across the board)
- [x] `pnpm nx run save-link:lint`
- [x] `pnpm nx run hutch:compile`
- [ ] Save a URL with both tier-0 and tier-1 sources — confirm `crawlStatus=ready`, the metadata sidecar is correct, and `LinkSavedEvent` (or `AnonymousLinkSavedEvent`) fires exactly once.
- [ ] Save a URL where the selector returns a tie and a canonical already exists — confirm no metadata regression and the canonical content is unchanged.
- [ ] `/admin/recrawl` a URL whose upstream title has changed — confirm the queue card shows the NEW title after the next htmx poll.
- [ ] `/admin/recrawl` a URL where the recrawl ties with the existing canonical — confirm the summariser short-circuits on cache hit and the row exits `pending`.

## Out of scope

- 4 save-link entry-point handlers (`save-link-command`, etc.) — still inline writers.
- 3 DLQ handlers.
- Summary generation handler and `link-summariser`.
- Deletion of legacy DDB writers.
- `recrawlTieKeptCanonical` transition body (only its leading comment changes).

https://claude.ai/code/session_014DKj8kTsAwr69hfELqFFNF

---
_Generated by [Claude Code](https://claude.ai/code/session_014DKj8kTsAwr69hfELqFFNF)_