### PR TITLE
fix(@packages/check-stuck-articles): handle missing originalUrl on legacy DDB rows

### DIFF
--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
@@ -246,6 +246,32 @@ describe("collectStuckRows", () => {
 		assert.equal(stuck.length, 2);
 	});
 
+	it("falls back to url when originalUrl is missing (legacy rows)", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/legacy",
+					crawlStatus: "pending",
+					summaryStatus: "pending",
+					savedAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+		});
+		assert.equal(stuck.length, 1);
+		assert.equal(stuck[0]?.originalUrl, "example.test/legacy");
+		assert.equal(
+			stuck[0]?.recrawlUrl,
+			`${ORIGIN}/admin/recrawl/${encodeURIComponent("example.test/legacy")}`,
+		);
+	});
+
 	it("buckets stuck rows produced by Phase 2 migrated transitions under the -after-aggregate-migration variant (falsifiable measurement)", async () => {
 		const { client } = createFakeClient(() => ({
 			Items: [

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
@@ -20,7 +20,7 @@ import { type StuckReason, classifyRow } from "./classify-row";
 /* `dynamoField` normalises DDB's `null` for absent attributes to `undefined`. */
 const StuckArticleRow = z.object({
 	url: z.string(),
-	originalUrl: z.string(),
+	originalUrl: dynamoField(z.string()),
 	summaryStatus: dynamoField(SummaryStatusSchema),
 	crawlStatus: dynamoField(CrawlStatusSchema),
 	contentFetchedAt: dynamoField(z.string()),
@@ -122,11 +122,12 @@ export async function collectStuckRows(deps: {
 			const verdict = checkTerminalState(row);
 			if (verdict.terminal) continue;
 			const reasons = classifyRow(row);
+			const effectiveUrl = row.originalUrl ?? row.url;
 			stuck.push({
-				originalUrl: row.originalUrl,
+				originalUrl: effectiveUrl,
 				reasons,
 				contentFetchedAt: row.contentFetchedAt,
-				recrawlUrl: `${deps.origin}/admin/recrawl/${encodeURIComponent(row.originalUrl)}`,
+				recrawlUrl: `${deps.origin}/admin/recrawl/${encodeURIComponent(effectiveUrl)}`,
 				terminalCheckMessage: verdict.message,
 			});
 		}


### PR DESCRIPTION
The stuck-articles canary crashed with a ZodError because some DDB rows matching the scan filter lack the `originalUrl` attribute. These are legacy rows that predate the field.

- Make `originalUrl` optional via `dynamoField()`
- Fall back to the `url` partition key when absent
- Add test covering the legacy-row scenario

Closes #295

Generated with [Claude Code](https://claude.ai/code)