### PR TITLE
feat(save-link): route DLQ handlers through the Article aggregate for atomic terminal-failure writes

### DIFF
--- a/projects/save-link/src/generate-summary/generate-summary-dlq-handler.test.ts
+++ b/projects/save-link/src/generate-summary/generate-summary-dlq-handler.test.ts
@@ -1,8 +1,10 @@
 import { noopLogger } from "@packages/hutch-logger";
+import {
+	markSummaryExhausted,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
 import { initGenerateSummaryDlqHandler } from "./generate-summary-dlq-handler";
-import type { MarkSummaryFailed } from "./article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecord, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -28,77 +30,118 @@ const stubContext: Context = {
 	succeed: () => {},
 };
 
-function createSqsEvent(detail: { url: string }, receiveCount = 3): SQSEvent {
+function createRecord(detail: unknown, receiveCount: number, messageId = "msg-1"): SQSRecord {
 	return {
-		Records: [{
-			messageId: "msg-1",
-			receiptHandle: "receipt-1",
-			body: JSON.stringify({ detail }),
-			attributes: attributes(receiveCount),
-			messageAttributes: {},
-			md5OfBody: "",
-			eventSource: "aws:sqs",
-			eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:GenerateGlobalSummary-dlq",
-			awsRegion: "ap-southeast-2",
-		}],
+		messageId,
+		receiptHandle: `receipt-${messageId}`,
+		body: JSON.stringify({ detail }),
+		attributes: attributes(receiveCount),
+		messageAttributes: {},
+		md5OfBody: "",
+		eventSource: "aws:sqs",
+		eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:GenerateGlobalSummary-dlq",
+		awsRegion: "ap-southeast-2",
 	};
 }
 
+function createSqsEvent(detail: { url: string }, receiveCount = 3): SQSEvent {
+	return { Records: [createRecord(detail, receiveCount)] };
+}
+
 describe("initGenerateSummaryDlqHandler", () => {
-	it("marks the summary as failed and publishes SummaryGenerationFailed when a message lands in DLQ", async () => {
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches markSummaryExhausted with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined) as unknown as TransitionAndPersist;
 
 		const handler = initGenerateSummaryDlqHandler({
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/failed" }, 4), stubContext, () => {});
 
-		expect(markSummaryFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markSummaryExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "SummaryGenerationFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 4,
-			}),
+			},
 		});
 	});
 
-	it("reports the record as a batch failure on invalid command envelope (Zod failure)", async () => {
-		const markSummaryFailed: MarkSummaryFailed = jest.fn();
-		const publishEvent: PublishEvent = jest.fn();
+	it("returns an empty batchItemFailures when there are no records", async () => {
+		const transitionAndPersist = jest.fn() as unknown as TransitionAndPersist;
 
 		const handler = initGenerateSummaryDlqHandler({
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
-		const invalidEvent: SQSEvent = {
-			Records: [{
-				messageId: "msg-1",
-				receiptHandle: "receipt-1",
-				body: JSON.stringify({ detail: { invalid: true } }),
-				attributes: attributes(3),
-				messageAttributes: {},
-				md5OfBody: "",
-				eventSource: "aws:sqs",
-				eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:GenerateGlobalSummary-dlq",
-				awsRegion: "ap-southeast-2",
-			}],
-		};
+		const result = await handler({ Records: [] }, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure on invalid command envelope (Zod failure)", async () => {
+		const transitionAndPersist = jest.fn() as unknown as TransitionAndPersist;
+
+		const handler = initGenerateSummaryDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const invalidEvent: SQSEvent = { Records: [createRecord({ invalid: true }, 3)] };
 
 		const result = await handler(invalidEvent, stubContext, () => {});
+
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markSummaryFailed).not.toHaveBeenCalled();
-		expect(publishEvent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled")) as unknown as TransitionAndPersist;
+
+		const handler = initGenerateSummaryDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed" }, 4),
+			stubContext,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+	});
+
+	it("isolates per-record failures: only the failing record ends up in batchItemFailures", async () => {
+		const transitionAndPersist = jest
+			.fn()
+			.mockImplementation(async (_transition: unknown, params: { url: string }) => {
+				if (params.url === "https://example.com/explode") {
+					throw new Error("downstream blew up");
+				}
+			}) as unknown as TransitionAndPersist;
+
+		const handler = initGenerateSummaryDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const event: SQSEvent = {
+			Records: [
+				createRecord({ url: "https://example.com/ok" }, 4, "msg-ok"),
+				createRecord({ url: "https://example.com/explode" }, 4, "msg-bad"),
+			],
+		};
+
+		const result = await handler(event, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-bad" }] });
+		expect(transitionAndPersist).toHaveBeenCalledTimes(2);
 	});
 });

--- a/projects/save-link/src/generate-summary/generate-summary-dlq-handler.ts
+++ b/projects/save-link/src/generate-summary/generate-summary-dlq-handler.ts
@@ -1,21 +1,19 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
-	GenerateSummaryCommand,
-	SummaryGenerationFailedEvent,
-} from "./index";
-import type { MarkSummaryFailed } from "./article-summary.types";
+	markSummaryExhausted,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "./index";
 
 interface GenerateSummaryDlqHandlerDeps {
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initGenerateSummaryDlqHandler(deps: GenerateSummaryDlqHandlerDeps): Handler<SQSEvent, SQSBatchResponse> {
-	const { markSummaryFailed, publishEvent, logger } = deps;
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -27,14 +25,14 @@ export function initGenerateSummaryDlqHandler(deps: GenerateSummaryDlqHandlerDep
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[GenerateSummaryDlq] marking failed", { url: command.url, receiveCount });
+				logger.info("[GenerateSummaryDlq] marking summary exhausted", {
+					url: command.url,
+					receiveCount,
+				});
 
-				await markSummaryFailed({ url: command.url, reason });
-
-				await publishEvent({
-					source: SummaryGenerationFailedEvent.source,
-					detailType: SummaryGenerationFailedEvent.detailType,
-					detail: JSON.stringify({ url: command.url, reason, receiveCount }),
+				await transitionAndPersist(markSummaryExhausted, {
+					url: command.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[GenerateSummaryDlq] record failed", {

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -390,6 +390,11 @@ new HutchDLQEventHandler("select-most-complete-content-dlq", {
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: renamePolicies(generateSummaryQueue.policies, "select-most-complete-content-dlq"),
 });
 
 // --- GenerateSummary handler ---
@@ -436,6 +441,11 @@ new HutchDLQEventHandler("generate-summary-dlq", {
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: renamePolicies(generateSummaryQueue.policies, "generate-summary-dlq"),
 });
 
 // --- LinkSaved handler ---
@@ -609,6 +619,11 @@ new HutchDLQEventHandler("recrawl-content-extracted-dlq", {
 	tableName: articlesTableName,
 	eventBus,
 	batchSize: 1,
+	additionalDynamoActions: ["dynamodb:GetItem"],
+	additionalEnvironment: {
+		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+	},
+	additionalPolicies: renamePolicies(generateSummaryQueue.policies, "recrawl-content-extracted-dlq"),
 });
 
 // --- SummaryGenerated handler ---

--- a/projects/save-link/src/runtime/generate-summary-dlq.main.ts
+++ b/projects/save-link/src/runtime/generate-summary-dlq.main.ts
@@ -1,18 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
-import { requireEnv } from "../require-env";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { initGenerateSummaryDlqHandler } from "../generate-summary/generate-summary-dlq-handler";
+import { requireEnv } from "../require-env";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const summaryStore = initDynamoDbGeneratedSummary({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
+});
+
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -20,8 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initGenerateSummaryDlqHandler({
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initGenerateSummaryDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/recrawl-content-extracted-dlq.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted-dlq.main.ts
@@ -1,25 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { requireEnv } from "../require-env";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initRecrawlContentExtractedDlqHandler } from "../select-content/recrawl-content-extracted-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const crawlStore = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
-const summaryStore = initDynamoDbGeneratedSummary({
-	client: dynamoClient,
-	tableName: articlesTable,
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -27,9 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initRecrawlContentExtractedDlqHandler({
-	markCrawlFailed: crawlStore.markCrawlFailed,
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initRecrawlContentExtractedDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/runtime/select-most-complete-content-dlq.main.ts
+++ b/projects/save-link/src/runtime/select-most-complete-content-dlq.main.ts
@@ -1,25 +1,34 @@
-import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { initTransitionAndPersist } from "@packages/domain/article-aggregate";
+import { GenerateSummaryCommand } from "@packages/hutch-infra-components";
+import {
+	EventBridgeClient,
+	initEventBridgePublisher,
+	initSqsCommandDispatcher,
+} from "@packages/hutch-infra-components/runtime";
 import { consoleLogger } from "@packages/hutch-logger";
-import { EventBridgeClient, initEventBridgePublisher } from "@packages/hutch-infra-components/runtime";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleStore } from "../article-aggregate/dynamodb-article-store";
+import { initLambdaEffectDispatcher } from "../article-aggregate/lambda-effect-dispatcher";
 import { requireEnv } from "../require-env";
-import { initDynamoDbArticleCrawl } from "../crawl-article-state/dynamodb-article-crawl";
-import { initDynamoDbGeneratedSummary } from "../generate-summary/dynamodb-generated-summary";
 import { initSelectMostCompleteContentDlqHandler } from "../select-content/select-most-complete-content-dlq-handler";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 
 const dynamoClient = createDynamoDocumentClient();
+const sqsClient = new SQSClient({});
 
-const crawlStore = initDynamoDbArticleCrawl({
+const { store } = initDynamoDbArticleStore({
 	client: dynamoClient,
 	tableName: articlesTable,
-	now: () => new Date(),
 });
 
-const summaryStore = initDynamoDbGeneratedSummary({
-	client: dynamoClient,
-	tableName: articlesTable,
+const { dispatch: dispatchGenerateSummary } = initSqsCommandDispatcher({
+	sqsClient,
+	queueUrl: generateSummaryQueueUrl,
+	command: GenerateSummaryCommand,
 });
 
 const { publishEvent } = initEventBridgePublisher({
@@ -27,9 +36,17 @@ const { publishEvent } = initEventBridgePublisher({
 	eventBusName,
 });
 
-export const handler = initSelectMostCompleteContentDlqHandler({
-	markCrawlFailed: crawlStore.markCrawlFailed,
-	markSummaryFailed: summaryStore.markSummaryFailed,
+const { dispatchEffect } = initLambdaEffectDispatcher({
+	dispatchGenerateSummary,
 	publishEvent,
+});
+
+const { transitionAndPersist } = initTransitionAndPersist({
+	store,
+	dispatchEffect,
+});
+
+export const handler = initSelectMostCompleteContentDlqHandler({
+	transitionAndPersist,
 	logger: consoleLogger,
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.test.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.test.ts
@@ -1,9 +1,10 @@
 import { noopLogger } from "@packages/hutch-logger";
+import {
+	markCrawlExhausted,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
 import { initRecrawlContentExtractedDlqHandler } from "./recrawl-content-extracted-dlq-handler";
-import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecord, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -29,35 +30,30 @@ const stubContext: Context = {
 	succeed: () => {},
 };
 
-function createSqsEvent(
-	detail: { url: string },
-	receiveCount = 3,
-): SQSEvent {
+function createRecord(detail: unknown, receiveCount: number, messageId = "msg-1"): SQSRecord {
 	return {
-		Records: [{
-			messageId: "msg-1",
-			receiptHandle: "receipt-1",
-			body: JSON.stringify({ detail }),
-			attributes: attributes(receiveCount),
-			messageAttributes: {},
-			md5OfBody: "",
-			eventSource: "aws:sqs",
-			eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:recrawl-content-extracted-dlq",
-			awsRegion: "ap-southeast-2",
-		}],
+		messageId,
+		receiptHandle: `receipt-${messageId}`,
+		body: JSON.stringify({ detail }),
+		attributes: attributes(receiveCount),
+		messageAttributes: {},
+		md5OfBody: "",
+		eventSource: "aws:sqs",
+		eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:recrawl-content-extracted-dlq",
+		awsRegion: "ap-southeast-2",
 	};
 }
 
+function createSqsEvent(detail: { url: string }, receiveCount = 3): SQSEvent {
+	return { Records: [createRecord(detail, receiveCount)] };
+}
+
 describe("initRecrawlContentExtractedDlqHandler", () => {
-	it("marks the crawl as failed and publishes CrawlArticleFailedEvent when a message lands in DLQ", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches markCrawlExhausted with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined) as unknown as TransitionAndPersist;
 
 		const handler = initRecrawlContentExtractedDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -67,55 +63,89 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(markSummaryFailed).toHaveBeenCalledWith({
-			url: "https://example.com/failed",
-			reason: "crawl failed",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 4,
-			}),
+			},
 		});
 	});
 
-	it("reports the record as a batch failure on invalid event envelope (Zod failure)", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn();
-		const markSummaryFailed: MarkSummaryFailed = jest.fn();
-		const publishEvent: PublishEvent = jest.fn();
+	it("returns an empty batchItemFailures when there are no records", async () => {
+		const transitionAndPersist = jest.fn() as unknown as TransitionAndPersist;
 
 		const handler = initRecrawlContentExtractedDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
-		const invalidEvent: SQSEvent = {
-			Records: [{
-				messageId: "msg-1",
-				receiptHandle: "receipt-1",
-				body: JSON.stringify({ detail: { invalid: true } }),
-				attributes: attributes(3),
-				messageAttributes: {},
-				md5OfBody: "",
-				eventSource: "aws:sqs",
-				eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:recrawl-content-extracted-dlq",
-				awsRegion: "ap-southeast-2",
-			}],
-		};
+		const result = await handler({ Records: [] }, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure on invalid event envelope (Zod failure)", async () => {
+		const transitionAndPersist = jest.fn() as unknown as TransitionAndPersist;
+
+		const handler = initRecrawlContentExtractedDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const invalidEvent: SQSEvent = { Records: [createRecord({ invalid: true }, 3)] };
 
 		const result = await handler(invalidEvent, stubContext, () => {});
+
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(markCrawlFailed).not.toHaveBeenCalled();
-		expect(markSummaryFailed).not.toHaveBeenCalled();
-		expect(publishEvent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled")) as unknown as TransitionAndPersist;
+
+		const handler = initRecrawlContentExtractedDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed" }, 4),
+			stubContext,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+	});
+
+	it("isolates per-record failures: only the failing record ends up in batchItemFailures", async () => {
+		const transitionAndPersist = jest
+			.fn()
+			.mockImplementation(async (_transition: unknown, params: { url: string }) => {
+				if (params.url === "https://example.com/explode") {
+					throw new Error("downstream blew up");
+				}
+			}) as unknown as TransitionAndPersist;
+
+		const handler = initRecrawlContentExtractedDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const event: SQSEvent = {
+			Records: [
+				createRecord({ url: "https://example.com/ok" }, 4, "msg-ok"),
+				createRecord({ url: "https://example.com/explode" }, 4, "msg-bad"),
+			],
+		};
+
+		const result = await handler(event, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-bad" }] });
+		expect(transitionAndPersist).toHaveBeenCalledTimes(2);
 	});
 });

--- a/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.ts
+++ b/projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.ts
@@ -1,17 +1,13 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
-	CrawlArticleFailedEvent,
-	RecrawlContentExtractedEvent,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
+	markCrawlExhausted,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
+import { RecrawlContentExtractedEvent } from "@packages/hutch-infra-components";
 
 interface RecrawlContentExtractedDlqHandlerDeps {
-	markCrawlFailed: MarkCrawlFailed;
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
@@ -19,7 +15,7 @@ interface RecrawlContentExtractedDlqHandlerDeps {
 export function initRecrawlContentExtractedDlqHandler(
 	deps: RecrawlContentExtractedDlqHandlerDeps,
 ): Handler<SQSEvent, SQSBatchResponse> {
-	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -31,18 +27,14 @@ export function initRecrawlContentExtractedDlqHandler(
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[RecrawlContentExtractedDlq] marking crawl failed", {
+				logger.info("[RecrawlContentExtractedDlq] marking crawl exhausted", {
 					url: detail.url,
 					receiveCount,
 				});
 
-				await markCrawlFailed({ url: detail.url, reason });
-				await markSummaryFailed({ url: detail.url, reason: "crawl failed" });
-
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url, reason, receiveCount }),
+				await transitionAndPersist(markCrawlExhausted, {
+					url: detail.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[RecrawlContentExtractedDlq] record failed", {

--- a/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.test.ts
+++ b/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.test.ts
@@ -1,9 +1,10 @@
 import { noopLogger } from "@packages/hutch-logger";
+import {
+	markCrawlExhausted,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
 import { initSelectMostCompleteContentDlqHandler } from "./select-most-complete-content-dlq-handler";
-import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecord, SQSRecordAttributes, Context } from "aws-lambda";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -29,35 +30,33 @@ const stubContext: Context = {
 	succeed: () => {},
 };
 
+function createRecord(detail: unknown, receiveCount: number, messageId = "msg-1"): SQSRecord {
+	return {
+		messageId,
+		receiptHandle: `receipt-${messageId}`,
+		body: JSON.stringify({ detail }),
+		attributes: attributes(receiveCount),
+		messageAttributes: {},
+		md5OfBody: "",
+		eventSource: "aws:sqs",
+		eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:select-most-complete-content-dlq",
+		awsRegion: "ap-southeast-2",
+	};
+}
+
 function createSqsEvent(
 	detail: { url: string; tier: "tier-0" | "tier-1"; userId?: string },
 	receiveCount = 3,
 ): SQSEvent {
-	return {
-		Records: [{
-			messageId: "msg-1",
-			receiptHandle: "receipt-1",
-			body: JSON.stringify({ detail }),
-			attributes: attributes(receiveCount),
-			messageAttributes: {},
-			md5OfBody: "",
-			eventSource: "aws:sqs",
-			eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:select-most-complete-content-dlq",
-			awsRegion: "ap-southeast-2",
-		}],
-	};
+	return { Records: [createRecord(detail, receiveCount)] };
 }
 
 describe("initSelectMostCompleteContentDlqHandler", () => {
-	it("marks crawl and summary failed and publishes CrawlArticleFailedEvent when a TierContentExtractedEvent message exhausts retries", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("dispatches markCrawlExhausted with the URL, reason, and receiveCount from the DLQ record", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined) as unknown as TransitionAndPersist;
 
 		const handler = initSelectMostCompleteContentDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
@@ -67,70 +66,89 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalledWith({
+		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
+		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlExhausted, {
 			url: "https://example.com/failed",
-			reason: "exceeded SQS maxReceiveCount",
-		});
-		expect(markSummaryFailed).toHaveBeenCalledWith({
-			url: "https://example.com/failed",
-			reason: "crawl failed",
-		});
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/failed",
+			input: {
 				reason: "exceeded SQS maxReceiveCount",
 				receiveCount: 4,
-			}),
+			},
 		});
 	});
 
-	it("works without userId (anonymous source)", async () => {
-		const markCrawlFailed: MarkCrawlFailed = jest.fn().mockResolvedValue(undefined);
-		const markSummaryFailed: MarkSummaryFailed = jest.fn().mockResolvedValue(undefined);
-		const publishEvent: PublishEvent = jest.fn().mockResolvedValue(undefined);
+	it("returns an empty batchItemFailures when there are no records", async () => {
+		const transitionAndPersist = jest.fn() as unknown as TransitionAndPersist;
 
 		const handler = initSelectMostCompleteContentDlqHandler({
-			markCrawlFailed,
-			markSummaryFailed,
-			publishEvent,
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
-		await handler(
-			createSqsEvent({ url: "https://example.com/anon", tier: "tier-1" }, 3),
+		const result = await handler({ Records: [] }, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [] });
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure on invalid envelope detail (Zod failure)", async () => {
+		const transitionAndPersist = jest.fn() as unknown as TransitionAndPersist;
+
+		const handler = initSelectMostCompleteContentDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const invalid: SQSEvent = { Records: [createRecord({ invalid: true }, 3)] };
+
+		const result = await handler(invalid, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+		expect(transitionAndPersist).not.toHaveBeenCalled();
+	});
+
+	it("reports the record as a batch failure when the transition throws (SQS redelivers; canary catches the stuck row)", async () => {
+		const transitionAndPersist = jest
+			.fn()
+			.mockRejectedValue(new Error("ddb throttled")) as unknown as TransitionAndPersist;
+
+		const handler = initSelectMostCompleteContentDlqHandler({
+			transitionAndPersist,
+			logger: noopLogger,
+		});
+
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/failed", tier: "tier-1" }, 4),
 			stubContext,
 			() => {},
 		);
 
-		expect(markCrawlFailed).toHaveBeenCalled();
-		expect(publishEvent).toHaveBeenCalled();
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
-	it("reports the record as a batch failure on invalid envelope detail (Zod failure)", async () => {
+	it("isolates per-record failures: only the failing record ends up in batchItemFailures", async () => {
+		const transitionAndPersist = jest
+			.fn()
+			.mockImplementation(async (_transition: unknown, params: { url: string }) => {
+				if (params.url === "https://example.com/explode") {
+					throw new Error("downstream blew up");
+				}
+			}) as unknown as TransitionAndPersist;
+
 		const handler = initSelectMostCompleteContentDlqHandler({
-			markCrawlFailed: jest.fn(),
-			markSummaryFailed: jest.fn(),
-			publishEvent: jest.fn(),
+			transitionAndPersist,
 			logger: noopLogger,
 		});
 
-		const invalid: SQSEvent = {
-			Records: [{
-				messageId: "msg-1",
-				receiptHandle: "receipt-1",
-				body: JSON.stringify({ detail: { invalid: true } }),
-				attributes: attributes(3),
-				messageAttributes: {},
-				md5OfBody: "",
-				eventSource: "aws:sqs",
-				eventSourceARN: "arn:aws:sqs:ap-southeast-2:123456789:select-most-complete-content-dlq",
-				awsRegion: "ap-southeast-2",
-			}],
+		const event: SQSEvent = {
+			Records: [
+				createRecord({ url: "https://example.com/ok", tier: "tier-1" }, 4, "msg-ok"),
+				createRecord({ url: "https://example.com/explode", tier: "tier-1" }, 4, "msg-bad"),
+			],
 		};
 
-		const result = await handler(invalid, stubContext, () => {});
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+		const result = await handler(event, stubContext, () => {});
+
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-bad" }] });
+		expect(transitionAndPersist).toHaveBeenCalledTimes(2);
 	});
 });

--- a/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.ts
+++ b/projects/save-link/src/select-content/select-most-complete-content-dlq-handler.ts
@@ -1,17 +1,13 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
-	CrawlArticleFailedEvent,
-	TierContentExtractedEvent,
-} from "@packages/hutch-infra-components";
-import type { MarkCrawlFailed } from "../crawl-article-state/article-crawl.types";
-import type { MarkSummaryFailed } from "../generate-summary/article-summary.types";
+	markCrawlExhausted,
+	type TransitionAndPersist,
+} from "@packages/domain/article-aggregate";
+import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 
 interface SelectMostCompleteContentDlqHandlerDeps {
-	markCrawlFailed: MarkCrawlFailed;
-	markSummaryFailed: MarkSummaryFailed;
-	publishEvent: PublishEvent;
+	transitionAndPersist: TransitionAndPersist;
 	logger: HutchLogger;
 }
 
@@ -19,7 +15,7 @@ interface SelectMostCompleteContentDlqHandlerDeps {
 export function initSelectMostCompleteContentDlqHandler(
 	deps: SelectMostCompleteContentDlqHandlerDeps,
 ): Handler<SQSEvent, SQSBatchResponse> {
-	const { markCrawlFailed, markSummaryFailed, publishEvent, logger } = deps;
+	const { transitionAndPersist, logger } = deps;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -31,19 +27,15 @@ export function initSelectMostCompleteContentDlqHandler(
 				const receiveCount = Number(record.attributes.ApproximateReceiveCount);
 				const reason = "exceeded SQS maxReceiveCount";
 
-				logger.info("[SelectMostCompleteContentDlq] marking crawl failed", {
+				logger.info("[SelectMostCompleteContentDlq] marking crawl exhausted", {
 					url: detail.url,
 					tier: detail.tier,
 					receiveCount,
 				});
 
-				await markCrawlFailed({ url: detail.url, reason });
-				await markSummaryFailed({ url: detail.url, reason: "crawl failed" });
-
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url, reason, receiveCount }),
+				await transitionAndPersist(markCrawlExhausted, {
+					url: detail.url,
+					input: { reason, receiveCount },
 				});
 			} catch (error) {
 				logger.error("[SelectMostCompleteContentDlq] record failed", {


### PR DESCRIPTION
## Goal

Migrate the three DLQ handlers (`generate-summary-dlq`, `select-most-complete-content-dlq`, `recrawl-content-extracted-dlq`) to flip terminal failure state via `transitionAndPersist(markCrawlExhausted | markSummaryExhausted, …)` instead of the inline `markCrawlFailed` / `markSummaryFailed` DynamoDB writers + direct EventBridge publishes.

After this PR no DLQ handler writes `crawlStatus` / `summaryStatus` outside the aggregate, closing the "DLQ flips one axis but not the correlated one" stuck-row pattern.

## Context

Each DLQ today does two things: writes a terminal failure to DynamoDB via the inline mark functions, then publishes a failure event to EventBridge. Two separate writes mean a partial failure between them can leave the row in `failed` state but with no observability event (or vice versa on a retry — emitting a `CrawlArticleFailedEvent` twice for the same row).

The aggregate's `markCrawlExhausted` atomically flips both crawl AND summary axes terminal and emits `publish-crawl-article-failed`. The aggregate's `markSummaryExhausted` does the equivalent for the summary-only DLQ. Routing all three DLQ handlers through `transitionAndPersist` makes the save + dispatch ordering safe under SQS redelivery: save first, dispatch after; on SQS redelivery the same transition re-runs idempotently against the (now-terminal) row state.

## Changes

**Handlers** (deps swapped from `markSummaryFailed`/`markCrawlFailed` + `publishEvent` to a single `transitionAndPersist`):
- `projects/save-link/src/generate-summary/generate-summary-dlq-handler.ts` → `markSummaryExhausted`
- `projects/save-link/src/select-content/select-most-complete-content-dlq-handler.ts` → `markCrawlExhausted`
- `projects/save-link/src/select-content/recrawl-content-extracted-dlq-handler.ts` → `markCrawlExhausted`

**Composition roots** wired identically to the already-migrated DLQs (`store → dispatchGenerateSummary → dispatchEffect → transitionAndPersist`):
- `projects/save-link/src/runtime/generate-summary-dlq.main.ts`
- `projects/save-link/src/runtime/select-most-complete-content-dlq.main.ts`
- `projects/save-link/src/runtime/recrawl-content-extracted-dlq.main.ts`

**Infra** — three `HutchDLQEventHandler` entries gain `dynamodb:GetItem` (the aggregate's `store.load` reads before it writes), `GENERATE_SUMMARY_QUEUE_URL`, and the SendMessage policy so the uniform effect dispatcher can run.

**Tests** — handler tests rewritten to assert the dispatched transition (`markSummaryExhausted` / `markCrawlExhausted`) and its params (`{ url, input: { reason, receiveCount } }`). Each handler covers happy path, empty event, Zod failure, transition throw, and per-record isolation across a 2-record batch.

## Verification

- `pnpm nx run save-link:compile` ✅
- `pnpm nx run save-link:test` ✅ 321 tests pass
- `pnpm nx run save-link:test-with-coverage` ✅ 100% statements/branches/functions/lines
- `pnpm nx run save-link:lint` ✅
- `pnpm nx run @packages/domain:test` ✅ 206 tests pass

## Test plan

- [ ] Force a generate-summary message to exhaust retries — confirm `summaryStatus="failed"` + `SummaryGenerationFailedEvent` fires.
- [ ] Force a select-most-complete-content message to exhaust — confirm `crawlStatus="failed"` AND `summaryStatus="failed"` paired on one DDB write + `CrawlArticleFailedEvent` fires.
- [ ] Same for recrawl-content-extracted DLQ.

https://claude.ai/code/session_01PDVyQcJk8dr7FSCQgSbZDQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDVyQcJk8dr7FSCQgSbZDQ)_