### PR TITLE
chore(@packages/check-stuck-articles,hutch): retire exclude-patterns debris and add form-level URL-validation regression

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -16,6 +16,7 @@ interface QueueDisplayModel {
 	total: number;
 	pluralSuffix: string;
 	saveError?: string;
+	saveErrorCode?: string;
 	importFlash?: string;
 	hasImportSkipped: boolean;
 	importSkippedEntries: ReadonlyArray<{ url: string; reasonLabel: string }>;
@@ -67,6 +68,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		total: vm.total,
 		pluralSuffix: vm.total !== 1 ? "s" : "",
 		saveError: vm.saveError,
+		saveErrorCode: vm.saveErrorCode,
 		importFlash: vm.importFlash,
 		hasImportSkipped: Boolean(vm.importSkipped && vm.importSkipped.entries.length > 0),
 		importSkippedEntries: vm.importSkipped?.entries ?? [],

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -408,6 +408,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			]);
 			const vm = toQueueViewModel(result, urlState, {
 				saveError: validation.error.message,
+				saveErrorCode: validation.error.code,
 				unreadCount,
 				summaryByUrl,
 				crawlByUrl,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -146,6 +146,42 @@ describe("Queue routes", () => {
 			expect(doc.querySelector("[data-test-save-error]")?.textContent).toMatch(/[Pp]rivate-network/);
 		});
 
+		describe("form-level URL-validation regression (canary-historical inputs)", () => {
+			const cases: Array<{ url: string; code: "unsupported_scheme" | "private_network" | "malformed_url" }> = [
+				{ url: "chrome://extensions/",       code: "unsupported_scheme" },
+				{ url: "about:blank",                code: "unsupported_scheme" },
+				{ url: "https://cd.home.arpa/x",     code: "private_network" },
+				{ url: "http://localhost:3000/x",    code: "private_network" },
+				{ url: "https://192.168.1.1/x",      code: "private_network" },
+				{ url: "www.theinformation....",     code: "malformed_url" },
+				{ url: "https://server",             code: "malformed_url" },
+				{ url: "",                           code: "malformed_url" },
+			];
+
+			for (const { url, code } of cases) {
+				it(`rejects ${JSON.stringify(url)} with ${code} and never saves`, async () => {
+					const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+					const agent = await loginAgent(app, auth);
+
+					const response = await agent
+						.post("/queue/save")
+						.type("form")
+						.send({ url });
+
+					expect(response.status).toBe(422);
+					const doc = new JSDOM(response.text).window.document;
+					const pill = doc.querySelector("[data-test-save-error]");
+					assert.ok(pill, "error pill should render");
+					expect(pill.getAttribute("data-test-saveable-url-code")).toBe(code);
+
+					const userId = (await auth.findUserByEmail("test@example.com"))?.userId;
+					assert.ok(userId);
+					const stored = await articleStore.findArticlesByUser({ userId });
+					expect(stored.articles).toHaveLength(0);
+				});
+			}
+		});
+
 		it("should redirect with error code when save throws", async () => {
 			const { app, auth } = createTestApp({
 				...createDefaultTestAppFixture(TEST_APP_ORIGIN),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -8,7 +8,7 @@
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}">
         <button class="queue__save-btn" type="submit"><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
       </form>
-      {{#if saveError}}<p class="queue__save-error" data-test-save-error>{{saveError}}</p>{{/if}}
+      {{#if saveError}}<p class="queue__save-error" data-test-save-error{{#if saveErrorCode}} data-test-saveable-url-code="{{saveErrorCode}}"{{/if}}>{{saveError}}</p>{{/if}}
       {{#if importFlash}}<p class="queue__import-flash" data-test-import-flash>{{importFlash}}</p>{{/if}}
       {{#if hasImportSkipped}}
       <div class="queue__import-skipped" data-test-import-skipped role="status">

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -1,4 +1,4 @@
-import type { SavedArticle } from "@packages/domain/article";
+import type { SavedArticle, SaveableUrlErrorCode } from "@packages/domain/article";
 import type { FindArticlesResult } from "@packages/test-fixtures/providers/article-store";
 import { pickExcerpt } from "../../../providers/article-summary/article-summary.helpers";
 import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
@@ -66,6 +66,7 @@ export interface QueueViewModel {
 		next?: string;
 	};
 	saveError?: string;
+	saveErrorCode?: SaveableUrlErrorCode;
 	importFlash?: string;
 	importSkipped?: ImportSkippedViewModel;
 }
@@ -176,6 +177,7 @@ export function toQueueViewModel(
 	options?: {
 		now?: Date;
 		saveError?: string;
+		saveErrorCode?: SaveableUrlErrorCode;
 		importFlash?: string;
 		importSkipped?: ImportSkippedViewModel;
 		unreadCount?: number;
@@ -223,6 +225,7 @@ export function toQueueViewModel(
 					: undefined,
 		},
 		saveError: options?.saveError,
+		saveErrorCode: options?.saveErrorCode,
 		importFlash: options?.importFlash,
 		importSkipped: options?.importSkipped,
 	};

--- a/src/packages/check-stuck-articles/knip.config.ts
+++ b/src/packages/check-stuck-articles/knip.config.ts
@@ -5,7 +5,6 @@ export default {
 		"scripts/check-stuck-articles.ts",
 		"scripts/classify-row.ts",
 		"scripts/collect-stuck-rows.ts",
-		"scripts/exclude-patterns.ts",
 	],
 	ignoreDependencies: [
 		// knip doesn't resolve workspace subpath for @packages/* imports


### PR DESCRIPTION
## Goal

Close out the two remaining items from the URL-validation hardening exercise after PR #274 and the existing 31-case `saveable-url.test.ts`:

1. Retire the last stale `exclude-patterns` reference in source control.
2. Cover the canary-historical rejection classes at the form-submit round-trip level so a future refactor that breaks the typed-error branch fails a regression instead of breaking the user-facing flow silently.

## Context

Class #5 of `docs/article-aggregate-design-gaps-2026-05-11.md` listed four sub-types of unsaveable URL: browser-internal (`chrome://`), local-network (`*.home.arpa`), malformed (`[www.theinformation](https://www.theinformation)....`), and permanently non-HTML (`*.pdf`). The first three are now blocked at intake — confirmed by `saveable-url.test.ts`'s `describe("legacy canary exclude patterns (the ones intake should now block)")`. The fourth stays with the aggregate via `markCrawlUnsupported`.

Two loose ends remained:

- `src/packages/check-stuck-articles/knip.config.ts:8` still listed `scripts/exclude-patterns.ts` as an entry — the only `exclude-patterns` reference left in source control after the source module and dist artefacts went away. A reader grepping for `EXCLUDE_PATTERNS` would still find it and think the canary still maintains a runtime exclude list.
- The unit tests in `saveable-url.test.ts` cover `validateSaveableUrl`'s return value but not the form HTTP round-trip. A future refactor that breaks the 422 status or the typed-code branch passes unit tests while silently breaking the user-facing flow.

## What changed

- **knip cleanup**: removed the stale `scripts/exclude-patterns.ts` entry from `@packages/check-stuck-articles`'s knip config — the source file is gone and the build doesn't regenerate the corresponding dist artefacts (verified by running `pnpm nx run @packages/check-stuck-articles:check` and checking `dist/scripts/` after).
- **Typed error code on the error pill**: surfaced `SaveableUrlErrorCode` through `QueueViewModel.saveErrorCode` → `queue.component.ts` → `queue.template.html`, rendering a new `data-test-saveable-url-code="<code>"` attribute on the existing `[data-test-save-error]` pill. Behaviour unchanged; the attribute is only present when a saveable-url validation produced the error (not for `error_code=save_failed` redirects).
- **Form-level regression**: extended `queue.route.test.ts` with a `describe("form-level URL-validation regression (canary-historical inputs)")` block that walks each of the brief's eight inputs (`chrome://extensions/`, `about:blank`, `https://cd.home.arpa/x`, `http://localhost:3000/x`, `https://192.168.1.1/x`, `www.theinformation....`, `https://server`, `""`) and asserts the form-submit round-trip:
  - HTTP status is 422,
  - the error pill carries the matching typed code,
  - no article row was stored against the user.

## Implementation note: integration over e2e

The original brief proposed a Playwright e2e spec. After investigation, the form-level regression is covered by integration tests instead because:

1. CLAUDE.md says **"Use integration tests for comprehensive filter/query functionality testing, not E2E tests"** — and the existing `queue.route.test.ts` already supertest-tests the chrome:// and localhost cases at the form level, so the patterns were already in place.
2. The e2e server at `projects/hutch/src/e2e/e2e-server.main.ts:41` deliberately overrides `validateSaveableUrl` so the local server can save its own `localhost` test URLs — which means an e2e Playwright spec would silently see the three `private_network` cases (`*.home.arpa`, `localhost`, `192.168.1.1`) succeed with 201, not 422, and would never have been a real regression.

The integration test runs in <2s and exercises the same handler, viewmodel, component, and template as the production form post.

## Verification

- `pnpm nx run @packages/check-stuck-articles:check` → 51 tests pass, `dist/scripts/exclude-patterns.*` does not regenerate.
- `pnpm nx run hutch:check` → 108 tests pass in `queue.route.test`, all coverage thresholds met (172 files: 99.69 / 96.15 / 100 / 99.69).
- Pre-commit hook ran the full monorepo `pnpm check` (18 projects), all green.

## Out of scope (deliberate)

- Adding new rejection classes — content-type rejection stays with the crawler/aggregate via `markCrawlUnsupported`.
- Refactoring `validateSaveableUrl` itself.
- Re-introducing the canary's exclude-pattern list (PR #286 retired it).
- Touching `ArticleResourceUniqueId.parse` or the tracking-param stripper.
- Adding more unit tests — `saveable-url.test.ts` already covers every documented rejection class with 31 cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsJrZBjgzruGeAMkxWVhCA)_