### PR TITLE
refactor(@packages/test-fixtures): make the stale-check terminal-state policy exhaustive

### DIFF
--- a/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
@@ -8,12 +8,6 @@ import type { FindArticleFreshness } from "../article-store/article-store.types"
 import type { PublishRefreshArticleContent } from "../events/publish-refresh-article-content.types";
 import type { PublishUpdateFetchTimestamp } from "../events/publish-update-fetch-timestamp.types";
 import { calculateReadTime } from "@packages/domain/article";
-// failed / unsupported are terminal: the operator owns recovery via
-// /admin/recrawl and the DLQ → email signal. Reader-side reprime is
-// gone (was: code-driven auto-heal on view). A row without a crawl
-// status row at all is a legacy stub — still nothing to refresh here
-// because no contentFetchedAt is recorded; let it fall through to the
-// stale-TTL check which already short-circuits when no timestamp exists.
 import { decideTerminalAction } from "./decide-terminal-action";
 
 export type ContentFreshnessResult =

--- a/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts
@@ -8,6 +8,13 @@ import type { FindArticleFreshness } from "../article-store/article-store.types"
 import type { PublishRefreshArticleContent } from "../events/publish-refresh-article-content.types";
 import type { PublishUpdateFetchTimestamp } from "../events/publish-update-fetch-timestamp.types";
 import { calculateReadTime } from "@packages/domain/article";
+// failed / unsupported are terminal: the operator owns recovery via
+// /admin/recrawl and the DLQ → email signal. Reader-side reprime is
+// gone (was: code-driven auto-heal on view). A row without a crawl
+// status row at all is a legacy stub — still nothing to refresh here
+// because no contentFetchedAt is recorded; let it fall through to the
+// stale-TTL check which already short-circuits when no timestamp exists.
+import { decideTerminalAction } from "./decide-terminal-action";
 
 export type ContentFreshnessResult =
 	| { action: "new" }
@@ -37,15 +44,8 @@ export function initRefreshArticleIfStale(deps: {
 		}
 
 		const crawl = await deps.findArticleCrawlStatus(params.url);
-		// failed / unsupported are terminal: the operator owns recovery via
-		// /admin/recrawl and the DLQ → email signal. Reader-side reprime is
-		// gone (was: code-driven auto-heal on view). A row without a crawl
-		// status row at all is a legacy stub — still nothing to refresh here
-		// because no contentFetchedAt is recorded; let it fall through to the
-		// stale-TTL check which already short-circuits when no timestamp exists.
-		if (crawl?.status === "failed" || crawl?.status === "unsupported") {
-			return { action: "skip" };
-		}
+		const action = decideTerminalAction(crawl);
+		if (action === "skip") return { action: "skip" };
 
 		if (freshness.contentFetchedAt) {
 			const fetchedAt = new Date(freshness.contentFetchedAt).getTime();

--- a/src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { decideTerminalAction } from "./decide-terminal-action";
+
+describe("decideTerminalAction", () => {
+	it("treats undefined crawl as refresh-eligible so the TTL gate decides", () => {
+		assert.equal(decideTerminalAction(undefined), "refresh-eligible");
+	});
+
+	it("treats pending crawl as refresh-eligible (in-flight; TTL gate decides)", () => {
+		assert.equal(
+			decideTerminalAction({ status: "pending" }),
+			"refresh-eligible",
+		);
+	});
+
+	it("treats ready crawl as refresh-eligible (stale-TTL applies)", () => {
+		assert.equal(
+			decideTerminalAction({ status: "ready" }),
+			"refresh-eligible",
+		);
+	});
+
+	it("skips failed crawl — operator owns recovery via /admin/recrawl", () => {
+		assert.equal(
+			decideTerminalAction({ status: "failed", reason: "parse-error" }),
+			"skip",
+		);
+	});
+
+	it("skips unsupported crawl — PDFs / paywalls never auto-reprime", () => {
+		assert.equal(
+			decideTerminalAction({ status: "unsupported", reason: "pdf" }),
+			"skip",
+		);
+	});
+});

--- a/src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.ts
@@ -8,20 +8,16 @@ import type { ArticleCrawl } from "../article-crawl/article-crawl.types";
  */
 type TerminalAction = "refresh-eligible" | "skip";
 
+const TERMINAL_ACTIONS = {
+	ready: "refresh-eligible",
+	pending: "refresh-eligible",
+	failed: "skip",
+	unsupported: "skip",
+} satisfies Record<ArticleCrawl["status"], TerminalAction>;
+
 export function decideTerminalAction(
 	crawl: ArticleCrawl | undefined,
 ): TerminalAction {
-	/** Legacy row with no crawl status — the TTL gate decides (no
-	 * contentFetchedAt means "treat as new"; refresh-eligible drops it back
-	 * onto the caller's existing branches). */
 	if (!crawl) return "refresh-eligible";
-
-	switch (crawl.status) {
-		case "ready":
-		case "pending":
-			return "refresh-eligible";
-		case "failed":
-		case "unsupported":
-			return "skip";
-	}
+	return TERMINAL_ACTIONS[crawl.status];
 }

--- a/src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.ts
+++ b/src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.ts
@@ -1,0 +1,27 @@
+import type { ArticleCrawl } from "../article-crawl/article-crawl.types";
+
+/**
+ * The stale-check has three possible decisions when a row exists. Encoded as
+ * a typed action so a new ArticleCrawl variant breaks the build here — the
+ * single owner of "should the stale-check reprime this row?". Operator-only
+ * recovery (via /admin/recrawl) is encoded as "skip" on terminal states.
+ */
+type TerminalAction = "refresh-eligible" | "skip";
+
+export function decideTerminalAction(
+	crawl: ArticleCrawl | undefined,
+): TerminalAction {
+	/** Legacy row with no crawl status — the TTL gate decides (no
+	 * contentFetchedAt means "treat as new"; refresh-eligible drops it back
+	 * onto the caller's existing branches). */
+	if (!crawl) return "refresh-eligible";
+
+	switch (crawl.status) {
+		case "ready":
+		case "pending":
+			return "refresh-eligible";
+		case "failed":
+		case "unsupported":
+			return "skip";
+	}
+}


### PR DESCRIPTION
## Goal

Convert the implicit `crawl?.status === "failed" || crawl?.status === "unsupported"` terminal check at `src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts:46` into an explicit, exhaustive function `decideTerminalAction(crawl: ArticleCrawl | undefined): "refresh-eligible" | "skip"` whose body is a switch over `crawl.status` with no `default` clause. Adding a new `ArticleCrawl` variant in the future (e.g. a hypothetical `blocked` or `paywall`) becomes a build break inside this function — the file that owns the auto-heal policy — instead of a silent fall-through that re-primes terminal rows.

**This is purely a refactor — no behavior change.** The current policy ("failed and unsupported skip; pending lets the TTL gate decide") is preserved exactly. The change is structural — making the policy decision a typed function instead of an inline boolean.

## Context

The freshness check today inlines its terminal-state check:

```ts
if (crawl?.status === "failed" || crawl?.status === "unsupported") {
  return { action: "skip" };
}
```

The comment above it encodes the policy correctly. The boolean does not. If a future contributor adds `crawl: { status: "blocked"; reason }` to `ArticleCrawl` and forgets to update this boolean, the new variant falls through to the TTL-gate branch — which triggers `crawlArticle()` — and a `blocked` row gets re-fetched on every stale check. Same class of bug as the 30-day stuck-row pattern: the type system does not enforce what the comment claims.

Promoting the check to an exhaustive switch fixes the class at compile time. The discriminated union already has a `status` discriminant; we just stop ignoring it.

This is the producer-side counterpart to [[12-exhaustive-reader-slot-render-over-crawl-state]] which does the same thing on the consumer side for rendering.

## Files

**New**
- `src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.ts`
- `src/packages/test-fixtures/src/providers/article-freshness/decide-terminal-action.test.ts`

**Modified**
- `src/packages/test-fixtures/src/providers/article-freshness/check-content-freshness.ts` — inline boolean replaced with a call to the new helper; the policy comment moved above the helper's import so the operator-policy reasoning stays at the use site.

**Not touched** (deliberately out of scope)
- The crawl-result branch at `check-content-freshness.ts:72` (`result.status === "failed" || "unsupported"`) — consumes a different union (`CrawlArticleResult`, not `ArticleCrawl`).
- The composition root `projects/save-link/src/runtime/stale-check.main.ts` — no wiring change.
- The `ArticleCrawl` union itself.

## Verification

- `pnpm nx run @packages/test-fixtures:compile` ✅
- `pnpm nx run @packages/test-fixtures:test` ✅ (261 passed)
- `pnpm nx run @packages/test-fixtures:test-with-coverage` ✅ (100% lines / branches / statements on `decide-terminal-action.ts` and `check-content-freshness.ts`)
- `pnpm nx run @packages/test-fixtures:lint` ✅
- `pnpm nx run save-link:compile` ✅
- `pnpm nx run save-link:test` ✅ (311 passed)
- `pnpm nx run hutch:compile` ✅
- `pnpm nx run hutch:test` ✅ (1162 passed)

## Test plan

- [x] Unit-test the helper exhaustively over every `ArticleCrawl` variant plus `undefined`
- [x] Confirm 100% coverage on the new file
- [x] Confirm `check-content-freshness.test.ts` still passes unchanged (no behavior change)
- [x] Confirm downstream `save-link` and `hutch` projects still compile and test green
- [ ] Manual smoke post-deploy: save a PDF URL (lands as `crawlStatus=unsupported`), repeatedly visit `/view/<pdf-url>`, confirm CloudWatch shows no `[StaleCheckRequested] re-published SaveAnonymousLinkCommand` log lines
- [ ] Manual smoke post-deploy: force `crawlStatus=failed` on a row via the DLQ path, visit `/view/<url>`, confirm no reprime
- [ ] Manual smoke post-deploy: save a normal article, confirm the stale-TTL gate still decides correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_011YpbwQE1iRWteGvVmKm7bR)_