### PR TITLE
feat: first-party UTM attribution via click cookie + user_created events

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -60,6 +60,7 @@ import { initLogParseError, type ParseErrorEvent } from "@packages/hutch-infra-c
 import { validateSaveableUrl } from "@packages/domain/article";
 import { createApp } from "./server";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
+import type { ConversionEvent } from "./conversions";
 import { httpErrorMessageMapping } from "./web/pages/queue/queue.error";
 import {
 	PROD_FOUNDING_MEMBER_LIMIT,
@@ -377,6 +378,7 @@ export function createHutchApp(deps?: {
 		importSessionStore,
 		now: () => new Date(),
 		botDefenseLogger: HutchLogger.fromJSON<BotDefenseEvent>(),
+		conversionLogger: HutchLogger.fromJSON<ConversionEvent>(),
 		foundingAllocation: initFoundingAllocation({
 			foundingMemberLimit: PROD_FOUNDING_MEMBER_LIMIT,
 		}),

--- a/projects/hutch/src/runtime/conversions.test.ts
+++ b/projects/hutch/src/runtime/conversions.test.ts
@@ -1,0 +1,157 @@
+import type { HutchLogger } from "@packages/hutch-logger";
+import { UserIdSchema } from "@packages/domain/user";
+import { type ConversionEvent, emitUserCreated } from "./conversions";
+import type { ClickAttribution } from "./web/click-attribution.middleware";
+
+function createCapturingLogger(): {
+	logger: HutchLogger.Typed<ConversionEvent>;
+	captured: ConversionEvent[];
+} {
+	const captured: ConversionEvent[] = [];
+	const logger: HutchLogger.Typed<ConversionEvent> = {
+		info: (data) => {
+			captured.push(data);
+		},
+		error: () => {},
+		warn: () => {},
+		debug: () => {},
+	};
+	return { logger, captured };
+}
+
+const TEST_USER_ID = UserIdSchema.parse("1234567890abcdef1234567890abcdef");
+const TEST_NOW = () => new Date("2026-05-13T10:00:00.000Z");
+
+describe("emitUserCreated", () => {
+	it("emits a free signup event with the lowercased-email sha256 prefix and no stripe id", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "Alice@Example.com",
+				method: "email",
+				tier: "free",
+				attribution: undefined,
+			},
+		);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]).toEqual({
+			stream: "conversions",
+			event: "user_created",
+			timestamp: "2026-05-13T10:00:00.000Z",
+			user_id: TEST_USER_ID,
+			email_hash: "ff8d9819fc0e12bf",
+			method: "email",
+			tier: "free",
+		});
+		expect(JSON.stringify(captured[0])).not.toContain("stripe_checkout_session_id");
+	});
+
+	it("includes stripe_checkout_session_id for paid signups so the event can be joined to Stripe payment data downstream", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "bob@example.com",
+				method: "google",
+				tier: "paid",
+				stripeCheckoutSessionId: "cs_test_123",
+				attribution: undefined,
+			},
+		);
+
+		expect(captured[0]).toMatchObject({
+			tier: "paid",
+			stripe_checkout_session_id: "cs_test_123",
+			method: "google",
+		});
+	});
+
+	it("flattens click attribution into the event so downstream queries can group by utm_* without a join", () => {
+		const { logger, captured } = createCapturingLogger();
+		const attribution: ClickAttribution = {
+			utm_source: "twitter",
+			utm_medium: "social",
+			utm_campaign: "spring",
+			referrer_host: "t.co",
+			first_seen_at: "2026-05-01T00:00:00.000Z",
+			landing_path: "/blog/launch",
+		};
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "c@example.com",
+				method: "email",
+				tier: "free",
+				attribution,
+			},
+		);
+
+		expect(captured[0]).toMatchObject({
+			utm_source: "twitter",
+			utm_medium: "social",
+			utm_campaign: "spring",
+			referrer_host: "t.co",
+			first_seen_at: "2026-05-01T00:00:00.000Z",
+			landing_path: "/blog/launch",
+		});
+	});
+
+	it("normalizes email case before hashing so Alice@Example.com and alice@example.com produce the same hash", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "Alice@Example.com",
+				method: "email",
+				tier: "free",
+				attribution: undefined,
+			},
+		);
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "alice@example.com",
+				method: "email",
+				tier: "free",
+				attribution: undefined,
+			},
+		);
+
+		expect(captured[0].email_hash).toBe(captured[1].email_hash);
+	});
+
+	it("emits attribution-less signups without leaking utm_* keys into the JSON (saves bytes per event)", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "d@example.com",
+				method: "email",
+				tier: "free",
+				attribution: undefined,
+			},
+		);
+
+		const serialized = JSON.stringify(captured[0]);
+		expect(serialized).not.toContain("utm_source");
+		expect(serialized).not.toContain("utm_medium");
+		expect(serialized).not.toContain("utm_campaign");
+		expect(serialized).not.toContain("utm_content");
+		expect(serialized).not.toContain("referrer_host");
+		expect(serialized).not.toContain("first_seen_at");
+		expect(serialized).not.toContain("landing_path");
+	});
+});

--- a/projects/hutch/src/runtime/conversions.ts
+++ b/projects/hutch/src/runtime/conversions.ts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+import type { HutchLogger } from "@packages/hutch-logger";
+import type { UserId } from "@packages/domain/user";
+import type { ConversionEvent } from "@packages/test-fixtures/providers/auth";
+import type { ClickAttribution } from "./web/click-attribution.middleware";
+
+export type { ConversionEvent };
+
+function hashEmail(email: string): string {
+	return createHash("sha256").update(email.toLowerCase()).digest("hex").slice(0, 16);
+}
+
+/**
+ * Emits a single user_created event for every signup — both free and paid.
+ * For paid signups the Stripe checkout session id is included so the event
+ * can be cross-joined with Stripe payment data downstream. Attribution is
+ * the first-touch click cookie at the moment of signup; the cookie is
+ * device-scoped so a user who pays from a different browser than they
+ * landed on will have no attribution on their paid event.
+ */
+export function emitUserCreated(
+	deps: {
+		logger: HutchLogger.Typed<ConversionEvent>;
+		now: () => Date;
+	},
+	params: {
+		userId: UserId;
+		email: string;
+		method: "email" | "google";
+		tier: "free" | "paid";
+		stripeCheckoutSessionId?: string;
+		attribution: ClickAttribution | undefined;
+	},
+): void {
+	const event: ConversionEvent = {
+		stream: "conversions",
+		event: "user_created",
+		timestamp: deps.now().toISOString(),
+		user_id: params.userId,
+		email_hash: hashEmail(params.email),
+		method: params.method,
+		tier: params.tier,
+		...(params.stripeCheckoutSessionId
+			? { stripe_checkout_session_id: params.stripeCheckoutSessionId }
+			: {}),
+		...(params.attribution ?? {}),
+	};
+	deps.logger.info(event);
+}

--- a/projects/hutch/src/runtime/conversions.ts
+++ b/projects/hutch/src/runtime/conversions.ts
@@ -11,12 +11,9 @@ function hashEmail(email: string): string {
 }
 
 /**
- * Emits a single user_created event for every signup — both free and paid.
- * For paid signups the Stripe checkout session id is included so the event
- * can be cross-joined with Stripe payment data downstream. Attribution is
- * the first-touch click cookie at the moment of signup; the cookie is
- * device-scoped so a user who pays from a different browser than they
- * landed on will have no attribution on their paid event.
+ * Stripe checkout session id is included so events can be cross-joined with
+ * payment data downstream. Attribution is device-scoped — a user who pays from
+ * a different browser will have no attribution on their paid event.
  */
 export function emitUserCreated(
 	deps: {

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -73,6 +73,8 @@ import type { OAuthModel } from "@packages/test-fixtures/providers/oauth";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { initAuthRoutes } from "./web/auth/auth.page";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
+import type { ConversionEvent } from "./conversions";
+import { createClickAttributionMiddleware } from "./web/click-attribution.middleware";
 import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { SESSION_COOKIE_NAME } from "./web/auth/session-cookie";
 import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
@@ -176,6 +178,7 @@ interface AppDependencies {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
+	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	foundingAllocation: FoundingAllocation;
 }
 
@@ -201,6 +204,7 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	app.use(express.urlencoded({ extended: true }));
 	app.use(cookieParser());
+	app.use(createClickAttributionMiddleware({ now: dependencies.now }));
 
 	// Same-origin client bundles — the Lambda packaging step copies
 	// src/runtime/web/client-dist/ into the bundle, so `__dirname/web/client-dist`
@@ -426,6 +430,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		logError: deps.logError,
 		now: deps.now,
 		botDefenseLogger: deps.botDefenseLogger,
+		conversionLogger: deps.conversionLogger,
 		foundingAllocation,
 	});
 	app.use(authRouter);
@@ -447,6 +452,8 @@ export function createApp(dependencies: AppDependencies): Express {
 			storePendingSignup: deps.storePendingSignup,
 			sendEmail: deps.sendEmail,
 			logError: deps.logError,
+			now: deps.now,
+			conversionLogger: deps.conversionLogger,
 			foundingAllocation,
 		});
 		app.use(googleAuthRouter);

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -66,6 +66,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			stripe: fixture.stripe,
 			pendingSignup: fixture.pendingSignup,
 			botDefense: fixture.botDefense,
+			conversions: fixture.conversions,
 			foundingAllocation: fixture.foundingAllocation,
 		});
 

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -4,6 +4,7 @@ import type { CrawlArticle } from "@packages/crawl-article";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
+import type { ConversionEvent } from "./conversions";
 import type { ParseArticle } from "@packages/test-fixtures/providers/article-parser";
 import type { PublishLinkSaved } from "@packages/test-fixtures/providers/events";
 import type { PublishRecrawlLinkInitiated } from "@packages/test-fixtures/providers/events";
@@ -235,6 +236,11 @@ export interface BotDefenseBundle {
 	events: BotDefenseEvent[];
 }
 
+export interface ConversionsBundle {
+	logger: HutchLogger.Typed<ConversionEvent>;
+	events: ConversionEvent[];
+}
+
 /** Carries the founding-member cap as a plain number. The runtime predicate is
  * constructed via `initFoundingAllocation` inside `flattenFixtureToAppDependencies`
  * so the test-fixtures package can keep the same shape without importing from
@@ -263,6 +269,7 @@ export interface TestAppFixture {
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
 	botDefense: BotDefenseBundle;
+	conversions: ConversionsBundle;
 	foundingAllocation: FoundingAllocationBundle;
 }
 
@@ -279,6 +286,7 @@ export interface TestAppResult {
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
 	botDefense: BotDefenseBundle;
+	conversions: ConversionsBundle;
 }
 
 function flattenFixtureToAppDependencies(
@@ -348,6 +356,7 @@ function flattenFixtureToAppDependencies(
 		storePendingSignup: fixture.pendingSignup.storePendingSignup,
 		consumePendingSignup: fixture.pendingSignup.consumePendingSignup,
 		botDefenseLogger: fixture.botDefense.logger,
+		conversionLogger: fixture.conversions.logger,
 		foundingAllocation: initFoundingAllocation({
 			foundingMemberLimit: fixture.foundingAllocation.foundingMemberLimit,
 		}),
@@ -369,6 +378,7 @@ export function createTestApp(fixture: TestAppFixture): TestAppResult {
 		stripe: fixture.stripe,
 		pendingSignup: fixture.pendingSignup,
 		botDefense: fixture.botDefense,
+		conversions: fixture.conversions,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -40,6 +40,9 @@ import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
 import { initSendWelcomeEmail } from "./send-welcome-email";
 import type { FoundingAllocation } from "../shared/founding-progress/founding-allocation";
+import { readClickAttribution } from "../click-attribution.middleware";
+import type { ConversionEvent } from "../../conversions";
+import { emitUserCreated } from "../../conversions";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
@@ -76,6 +79,7 @@ interface AuthDependencies {
 	logError: (message: string, error?: Error) => void;
 	now: () => Date;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
+	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	foundingAllocation: FoundingAllocation;
 }
 
@@ -329,6 +333,16 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 			sendVerificationEmail(created.userId, email);
+			emitUserCreated(
+				{ logger: deps.conversionLogger, now: deps.now },
+				{
+					userId: created.userId,
+					email,
+					method: "email",
+					tier: "free",
+					attribution: readClickAttribution(req),
+				},
+			);
 			res.redirect(303, parseReturnUrl({ return: returnUrl }));
 			return;
 		}
@@ -413,6 +427,17 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 			sendVerificationEmail(created.userId, pending.email);
+			emitUserCreated(
+				{ logger: deps.conversionLogger, now: deps.now },
+				{
+					userId: created.userId,
+					email: pending.email,
+					method: "email",
+					tier: "paid",
+					stripeCheckoutSessionId: checkoutSessionId,
+					attribution: readClickAttribution(req),
+				},
+			);
 			res.redirect(303, returnPath);
 			return;
 		}
@@ -439,6 +464,17 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
 		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 		sendWelcomeEmail(pending.email);
+		emitUserCreated(
+			{ logger: deps.conversionLogger, now: deps.now },
+			{
+				userId: created.userId,
+				email: pending.email,
+				method: "google",
+				tier: "paid",
+				stripeCheckoutSessionId: checkoutSessionId,
+				attribution: readClickAttribution(req),
+			},
+		);
 		res.redirect(303, returnPath);
 	});
 

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -380,6 +380,29 @@ describe("Auth routes", () => {
 			expect(verification.subject).toBe("Verify your email — Readplace");
 		});
 
+		it("should emit a user_created conversion event on free email signup", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { conversions } = harness;
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "convert-free@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(303);
+			expect(conversions.events).toHaveLength(1);
+			expect(conversions.events[0]).toMatchObject({
+				stream: "conversions",
+				event: "user_created",
+				method: "email",
+				tier: "free",
+			});
+			expect(conversions.events[0].email_hash).toBeDefined();
+			expect(conversions.events[0].user_id).toBeDefined();
+		});
+
 		it("should show duplicate-email error when a race condition causes createUserWithPasswordHash to fail during free signup", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			let raceFindCount = 0;

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -3,6 +3,7 @@ import type { Request, Response, Router } from "express";
 import express from "express";
 import { z } from "zod";
 import { UserIdSchema } from "@packages/domain/user";
+import type { HutchLogger } from "@packages/hutch-logger";
 import type {
 	CountUsers,
 	CreateGoogleUser,
@@ -22,6 +23,9 @@ import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
 import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "./session-cookie";
 import { LoginPage } from "./auth.component";
 import { initFetchUserCount } from "./fetch-user-count";
+import { readClickAttribution } from "../click-attribution.middleware";
+import type { ConversionEvent } from "../../conversions";
+import { emitUserCreated } from "../../conversions";
 
 const CallbackQuerySchema = z.object({
 	code: z.string().min(1),
@@ -53,6 +57,8 @@ interface GoogleAuthDependencies {
 	storePendingSignup: StorePendingSignup;
 	sendEmail: SendEmail;
 	logError: (message: string, error?: Error) => void;
+	now: () => Date;
+	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	foundingAllocation: FoundingAllocation;
 }
 
@@ -198,6 +204,16 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 			sendWelcomeEmail(tokenResult.email);
+			emitUserCreated(
+				{ logger: deps.conversionLogger, now: deps.now },
+				{
+					userId: created.userId,
+					email: tokenResult.email,
+					method: "google",
+					tier: "free",
+					attribution: readClickAttribution(req),
+				},
+			);
 			res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
 			return;
 		}

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.test.ts
@@ -1,0 +1,221 @@
+import type { NextFunction, Request, Response } from "express";
+import {
+	CLICK_COOKIE_NAME,
+	type ClickAttribution,
+	createClickAttributionMiddleware,
+	readClickAttribution,
+} from "./click-attribution.middleware";
+
+interface MockReqOverrides {
+	method?: string;
+	path?: string;
+	hostname?: string;
+	query?: Record<string, unknown>;
+	headers?: Record<string, string | undefined>;
+	cookies?: Record<string, string>;
+}
+
+function createReq(overrides: MockReqOverrides = {}): Request {
+	const headers: Record<string, string | undefined> = { ...overrides.headers };
+	const base = {
+		method: overrides.method ?? "GET",
+		path: overrides.path ?? "/",
+		hostname: overrides.hostname ?? "readplace.com",
+		query: overrides.query ?? {},
+		headers,
+		cookies: overrides.cookies ?? {},
+		get(name: string): string | undefined {
+			return headers[name.toLowerCase()];
+		},
+	};
+	return base as unknown as Request;
+}
+
+interface CapturedCookie {
+	name: string;
+	value: string;
+	options: Record<string, unknown>;
+}
+
+function createRes(): { res: Response; cookies: CapturedCookie[] } {
+	const cookies: CapturedCookie[] = [];
+	const res = {
+		cookie(name: string, value: string, options: Record<string, unknown>) {
+			cookies.push({ name, value, options });
+			return res;
+		},
+	} as unknown as Response;
+	return { res, cookies };
+}
+
+function runMiddleware(req: Request): { cookies: CapturedCookie[]; nextCalled: boolean } {
+	const { res, cookies } = createRes();
+	const middleware = createClickAttributionMiddleware({
+		now: () => new Date("2026-05-13T10:00:00.000Z"),
+	});
+	let nextCalled = false;
+	const next: NextFunction = () => {
+		nextCalled = true;
+	};
+	middleware(req, res, next);
+	return { cookies, nextCalled };
+}
+
+function parseCookieValue(value: string): ClickAttribution {
+	return JSON.parse(value) as ClickAttribution;
+}
+
+describe("createClickAttributionMiddleware", () => {
+	it("captures utm params and writes the click cookie on first hit", () => {
+		const req = createReq({
+			path: "/blog/launch",
+			query: { utm_source: "twitter", utm_medium: "social", utm_campaign: "spring" },
+		});
+		const { cookies, nextCalled } = runMiddleware(req);
+
+		expect(nextCalled).toBe(true);
+		expect(cookies).toHaveLength(1);
+		const [cookie] = cookies;
+		expect(cookie.name).toBe(CLICK_COOKIE_NAME);
+		expect(cookie.options).toMatchObject({
+			httpOnly: true,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 30 * 24 * 60 * 60 * 1000,
+		});
+		expect(parseCookieValue(cookie.value)).toEqual({
+			utm_source: "twitter",
+			utm_medium: "social",
+			utm_campaign: "spring",
+			first_seen_at: "2026-05-13T10:00:00.000Z",
+			landing_path: "/blog/launch",
+		});
+	});
+
+	it("captures referrer host when present and external", () => {
+		const req = createReq({
+			path: "/",
+			headers: { referer: "https://news.ycombinator.com/item?id=1" },
+		});
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toHaveLength(1);
+		expect(parseCookieValue(cookies[0].value)).toMatchObject({
+			referrer_host: "news.ycombinator.com",
+			landing_path: "/",
+		});
+	});
+
+	it("drops self-referrers (internal navigation) so capture only fires on cross-site clicks", () => {
+		const req = createReq({
+			hostname: "readplace.com",
+			headers: { referer: "https://readplace.com/blog/something" },
+		});
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toEqual([]);
+	});
+
+	it("drops unparseable referer headers and does not write a cookie when no other attribution is present", () => {
+		const req = createReq({ headers: { referer: "not a url" } });
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toEqual([]);
+	});
+
+	it("does not write a cookie when no utm or referrer attribution is present", () => {
+		const req = createReq({ path: "/queue" });
+		const { cookies, nextCalled } = runMiddleware(req);
+
+		expect(cookies).toEqual([]);
+		expect(nextCalled).toBe(true);
+	});
+
+	it("skips non-GET requests so form posts can never reset the first-touch cookie", () => {
+		const req = createReq({
+			method: "POST",
+			query: { utm_source: "twitter" },
+		});
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toEqual([]);
+	});
+
+	it("preserves the existing cookie when a valid attribution is already set (first-touch wins)", () => {
+		const existing: ClickAttribution = {
+			utm_source: "hn",
+			first_seen_at: "2026-05-01T00:00:00.000Z",
+			landing_path: "/",
+		};
+		const req = createReq({
+			query: { utm_source: "twitter" },
+			cookies: { [CLICK_COOKIE_NAME]: JSON.stringify(existing) },
+		});
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toEqual([]);
+	});
+
+	it("re-writes the cookie when an existing cookie is malformed JSON so a corrupted value never blocks future attribution", () => {
+		const req = createReq({
+			query: { utm_source: "twitter" },
+			cookies: { [CLICK_COOKIE_NAME]: "not-json-{{{" },
+		});
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toHaveLength(1);
+		expect(parseCookieValue(cookies[0].value)).toMatchObject({ utm_source: "twitter" });
+	});
+
+	it("re-writes the cookie when an existing cookie fails schema validation", () => {
+		const req = createReq({
+			query: { utm_source: "twitter" },
+			cookies: { [CLICK_COOKIE_NAME]: JSON.stringify({ first_seen_at: 12345 }) },
+		});
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toHaveLength(1);
+	});
+
+	it("drops empty-string UTM params (utm_source=\"\" is not meaningful) and does not capture them as keys", () => {
+		const req = createReq({ query: { utm_source: "", utm_medium: "email" } });
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toHaveLength(1);
+		const value = parseCookieValue(cookies[0].value);
+		expect(value).toMatchObject({ utm_medium: "email" });
+		expect(JSON.stringify(value)).not.toContain("utm_source");
+	});
+});
+
+describe("readClickAttribution", () => {
+	function reqWithCookie(value: unknown): Request {
+		return createReq({
+			cookies:
+				typeof value === "string"
+					? { [CLICK_COOKIE_NAME]: value }
+					: { [CLICK_COOKIE_NAME]: JSON.stringify(value) },
+		});
+	}
+
+	it("returns undefined when no cookie is set", () => {
+		expect(readClickAttribution(createReq())).toBeUndefined();
+	});
+
+	it("returns the parsed attribution when the cookie is valid", () => {
+		const attribution: ClickAttribution = {
+			utm_source: "twitter",
+			first_seen_at: "2026-05-01T00:00:00.000Z",
+			landing_path: "/",
+		};
+		expect(readClickAttribution(reqWithCookie(attribution))).toEqual(attribution);
+	});
+
+	it("returns undefined when the cookie value is not parseable JSON", () => {
+		expect(readClickAttribution(reqWithCookie("not-json-{{{"))).toBeUndefined();
+	});
+
+	it("returns undefined when the cookie value fails schema validation", () => {
+		expect(readClickAttribution(reqWithCookie({ first_seen_at: 12345 }))).toBeUndefined();
+	});
+});

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.test.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from "express";
+import type { CookieOptions, NextFunction, Request, Response } from "express";
 import {
 	CLICK_COOKIE_NAME,
 	type ClickAttribution,
@@ -15,9 +15,9 @@ interface MockReqOverrides {
 	cookies?: Record<string, string>;
 }
 
-function createReq(overrides: MockReqOverrides = {}): Request {
+function createReq(overrides: MockReqOverrides = {}): Partial<Request> {
 	const headers: Record<string, string | undefined> = { ...overrides.headers };
-	const base = {
+	return {
 		method: overrides.method ?? "GET",
 		path: overrides.path ?? "/",
 		hostname: overrides.hostname ?? "readplace.com",
@@ -27,28 +27,27 @@ function createReq(overrides: MockReqOverrides = {}): Request {
 		get(name: string): string | undefined {
 			return headers[name.toLowerCase()];
 		},
-	};
-	return base as unknown as Request;
+	} as Partial<Request>;
 }
 
 interface CapturedCookie {
 	name: string;
 	value: string;
-	options: Record<string, unknown>;
+	options: CookieOptions;
 }
 
-function createRes(): { res: Response; cookies: CapturedCookie[] } {
+function createRes(): { res: Partial<Response>; cookies: CapturedCookie[] } {
 	const cookies: CapturedCookie[] = [];
-	const res = {
-		cookie(name: string, value: string, options: Record<string, unknown>) {
-			cookies.push({ name, value, options });
-			return res;
+	const res: Partial<Response> = {
+		cookie(name: string, value: string, options?: CookieOptions) {
+			cookies.push({ name, value, options: options ?? {} });
+			return res as Response;
 		},
-	} as unknown as Response;
+	};
 	return { res, cookies };
 }
 
-function runMiddleware(req: Request): { cookies: CapturedCookie[]; nextCalled: boolean } {
+function runMiddleware(req: Partial<Request>): { cookies: CapturedCookie[]; nextCalled: boolean } {
 	const { res, cookies } = createRes();
 	const middleware = createClickAttributionMiddleware({
 		now: () => new Date("2026-05-13T10:00:00.000Z"),
@@ -57,7 +56,7 @@ function runMiddleware(req: Request): { cookies: CapturedCookie[]; nextCalled: b
 	const next: NextFunction = () => {
 		nextCalled = true;
 	};
-	middleware(req, res, next);
+	middleware(req as Request, res as Response, next);
 	return { cookies, nextCalled };
 }
 
@@ -177,6 +176,16 @@ describe("createClickAttributionMiddleware", () => {
 		expect(cookies).toHaveLength(1);
 	});
 
+	it("truncates UTM values longer than 256 characters so adversarial params cannot exceed browser cookie limits", () => {
+		const longValue = "x".repeat(300);
+		const req = createReq({ query: { utm_source: longValue } });
+		const { cookies } = runMiddleware(req);
+
+		expect(cookies).toHaveLength(1);
+		const value = parseCookieValue(cookies[0].value);
+		expect(value.utm_source).toBe("x".repeat(256));
+	});
+
 	it("drops empty-string UTM params (utm_source=\"\" is not meaningful) and does not capture them as keys", () => {
 		const req = createReq({ query: { utm_source: "", utm_medium: "email" } });
 		const { cookies } = runMiddleware(req);
@@ -189,7 +198,7 @@ describe("createClickAttributionMiddleware", () => {
 });
 
 describe("readClickAttribution", () => {
-	function reqWithCookie(value: unknown): Request {
+	function reqWithCookie(value: unknown): Partial<Request> {
 		return createReq({
 			cookies:
 				typeof value === "string"
@@ -199,7 +208,7 @@ describe("readClickAttribution", () => {
 	}
 
 	it("returns undefined when no cookie is set", () => {
-		expect(readClickAttribution(createReq())).toBeUndefined();
+		expect(readClickAttribution(createReq() as Request)).toBeUndefined();
 	});
 
 	it("returns the parsed attribution when the cookie is valid", () => {
@@ -208,14 +217,14 @@ describe("readClickAttribution", () => {
 			first_seen_at: "2026-05-01T00:00:00.000Z",
 			landing_path: "/",
 		};
-		expect(readClickAttribution(reqWithCookie(attribution))).toEqual(attribution);
+		expect(readClickAttribution(reqWithCookie(attribution) as Request)).toEqual(attribution);
 	});
 
 	it("returns undefined when the cookie value is not parseable JSON", () => {
-		expect(readClickAttribution(reqWithCookie("not-json-{{{"))).toBeUndefined();
+		expect(readClickAttribution(reqWithCookie("not-json-{{{") as Request)).toBeUndefined();
 	});
 
 	it("returns undefined when the cookie value fails schema validation", () => {
-		expect(readClickAttribution(reqWithCookie({ first_seen_at: 12345 }))).toBeUndefined();
+		expect(readClickAttribution(reqWithCookie({ first_seen_at: 12345 }) as Request)).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.ts
@@ -1,0 +1,106 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { z } from "zod";
+
+export const CLICK_COOKIE_NAME = "hutch_click";
+const CLICK_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+const ClickAttributionSchema = z.object({
+	utm_source: z.string().optional(),
+	utm_medium: z.string().optional(),
+	utm_campaign: z.string().optional(),
+	utm_content: z.string().optional(),
+	referrer_host: z.string().optional(),
+	first_seen_at: z.string(),
+	landing_path: z.string(),
+});
+
+export type ClickAttribution = z.infer<typeof ClickAttributionSchema>;
+
+const COOKIE_OPTIONS = {
+	httpOnly: true,
+	sameSite: "lax" as const,
+	path: "/",
+	maxAge: CLICK_COOKIE_MAX_AGE_MS,
+};
+
+function extractQueryString(req: Request, name: string): string | undefined {
+	const value = req.query[name];
+	return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function extractReferrerHost(req: Request): string | undefined {
+	const referer = req.get("referer");
+	if (!referer) return undefined;
+	try {
+		const hostname = new URL(referer).hostname;
+		if (hostname === req.hostname) return undefined;
+		return hostname;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Returns the parsed click attribution stored on the request cookie, or
+ * undefined if no valid attribution exists. A cookie that fails schema
+ * validation is treated as absent so the middleware can re-attribute on the
+ * next eligible request rather than locking the user into a corrupted value.
+ */
+export function readClickAttribution(req: Request): ClickAttribution | undefined {
+	const raw = req.cookies?.[CLICK_COOKIE_NAME];
+	if (typeof raw !== "string") return undefined;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	const result = ClickAttributionSchema.safeParse(parsed);
+	return result.success ? result.data : undefined;
+}
+
+/**
+ * Captures first-touch attribution as a 30-day cookie. On a GET request that
+ * carries any utm_* param OR an external referrer, and where no valid
+ * attribution cookie is already set, this writes a JSON-encoded cookie with
+ * the UTM params, referrer host, landing path, and first-seen timestamp.
+ * Once written, subsequent UTM hits do not overwrite it — first-touch wins.
+ */
+export function createClickAttributionMiddleware(deps: {
+	now: () => Date;
+}): RequestHandler {
+	return (req: Request, res: Response, next: NextFunction) => {
+		if (req.method !== "GET") {
+			next();
+			return;
+		}
+		if (readClickAttribution(req)) {
+			next();
+			return;
+		}
+
+		const utm_source = extractQueryString(req, "utm_source");
+		const utm_medium = extractQueryString(req, "utm_medium");
+		const utm_campaign = extractQueryString(req, "utm_campaign");
+		const utm_content = extractQueryString(req, "utm_content");
+		const referrer_host = extractReferrerHost(req);
+
+		if (!utm_source && !utm_medium && !utm_campaign && !utm_content && !referrer_host) {
+			next();
+			return;
+		}
+
+		const attribution: ClickAttribution = {
+			first_seen_at: deps.now().toISOString(),
+			landing_path: req.path,
+			...(utm_source ? { utm_source } : {}),
+			...(utm_medium ? { utm_medium } : {}),
+			...(utm_campaign ? { utm_campaign } : {}),
+			...(utm_content ? { utm_content } : {}),
+			...(referrer_host ? { referrer_host } : {}),
+		};
+
+		res.cookie(CLICK_COOKIE_NAME, JSON.stringify(attribution), COOKIE_OPTIONS);
+		next();
+	};
+}

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 export const CLICK_COOKIE_NAME = "hutch_click";
 const CLICK_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_UTM_VALUE_LENGTH = 256;
 
 const ClickAttributionSchema = z.object({
 	utm_source: z.string().optional(),
@@ -25,7 +26,8 @@ const COOKIE_OPTIONS = {
 
 function extractQueryString(req: Request, name: string): string | undefined {
 	const value = req.query[name];
-	return typeof value === "string" && value !== "" ? value : undefined;
+	if (typeof value !== "string" || value === "") return undefined;
+	return value.length > MAX_UTM_VALUE_LENGTH ? value.slice(0, MAX_UTM_VALUE_LENGTH) : value;
 }
 
 function extractReferrerHost(req: Request): string | undefined {

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.ts
@@ -43,10 +43,9 @@ function extractReferrerHost(req: Request): string | undefined {
 }
 
 /**
- * Returns the parsed click attribution stored on the request cookie, or
- * undefined if no valid attribution exists. A cookie that fails schema
- * validation is treated as absent so the middleware can re-attribute on the
- * next eligible request rather than locking the user into a corrupted value.
+ * A cookie that fails schema validation is treated as absent so the middleware
+ * can re-attribute on the next eligible request rather than locking the user
+ * into a corrupted value.
  */
 export function readClickAttribution(req: Request): ClickAttribution | undefined {
 	const raw = req.cookies?.[CLICK_COOKIE_NAME];
@@ -61,13 +60,6 @@ export function readClickAttribution(req: Request): ClickAttribution | undefined
 	return result.success ? result.data : undefined;
 }
 
-/**
- * Captures first-touch attribution as a 30-day cookie. On a GET request that
- * carries any utm_* param OR an external referrer, and where no valid
- * attribution cookie is already set, this writes a JSON-encoded cookie with
- * the UTM params, referrer host, landing path, and first-seen timestamp.
- * Once written, subsequent UTM hits do not overwrite it — first-touch wins.
- */
 export function createClickAttributionMiddleware(deps: {
 	now: () => Date;
 }): RequestHandler {

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -4,6 +4,7 @@ import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ArticleMetadata, Minutes, ValidateSaveableUrl } from "@packages/domain/article";
 import type { ImportSessionStore } from "@packages/domain/import-session";
 import type { BotDefenseEvent } from "./providers/auth/bot-defense.types";
+import type { ConversionEvent } from "./providers/auth/conversion.types";
 import type { ExchangeGoogleCode } from "./providers/google-auth/google-token.types";
 import type { ParseArticle } from "./providers/article-parser/article-parser.types";
 import type {
@@ -236,6 +237,11 @@ export interface BotDefenseBundle {
 	events: BotDefenseEvent[];
 }
 
+export interface ConversionsBundle {
+	logger: HutchLogger.Typed<ConversionEvent>;
+	events: ConversionEvent[];
+}
+
 /** Holds the founding-member cap as a plain number. The hutch composition
  * root builds the runtime predicate from this so this package stays free of
  * cross-project imports — same reason `httpErrorMessageMapping` is duplicated
@@ -264,5 +270,6 @@ export interface TestAppFixture {
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
 	botDefense: BotDefenseBundle;
+	conversions: ConversionsBundle;
 	foundingAllocation: FoundingAllocationBundle;
 }

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -4,6 +4,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import { noopLogger } from "@packages/hutch-logger";
 import { calculateReadTime, validateSaveableUrl } from "@packages/domain/article";
 import type { BotDefenseEvent } from "./providers/auth/bot-defense.types";
+import type { ConversionEvent } from "./providers/auth/conversion.types";
 import type { ParseArticle } from "./providers/article-parser/article-parser.types";
 import { initReadabilityParser } from "./providers/article-parser/readability-parser";
 import { initInMemoryArticleCrawl } from "./providers/article-crawl/in-memory-article-crawl";
@@ -240,6 +241,15 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		debug: capture,
 	};
 
+	const conversionEvents: ConversionEvent[] = [];
+	const captureConversion = (data: ConversionEvent) => { conversionEvents.push(data); };
+	const conversionLogger: HutchLogger.Typed<ConversionEvent> = {
+		info: captureConversion,
+		error: captureConversion,
+		warn: captureConversion,
+		debug: captureConversion,
+	};
+
 	return {
 		auth: { ...auth, hashPassword: fastHashPassword },
 		articleStore: {
@@ -311,6 +321,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		stripe,
 		pendingSignup,
 		botDefense: { logger: botDefenseLogger, events: botDefenseEvents },
+		conversions: { logger: conversionLogger, events: conversionEvents },
 		/** Small enough that founding-allocation seed loops finish in
 		 * milliseconds while still leaving room for "one above the limit" tests
 		 * to seed N+1 distinct emails. Production injects 50 via app.ts. */

--- a/src/packages/test-fixtures/src/providers/auth/conversion.types.ts
+++ b/src/packages/test-fixtures/src/providers/auth/conversion.types.ts
@@ -1,0 +1,19 @@
+import type { UserId } from "@packages/domain/user";
+
+export interface ConversionEvent {
+	stream: "conversions";
+	event: "user_created";
+	timestamp: string;
+	user_id: UserId;
+	email_hash: string;
+	method: "email" | "google";
+	tier: "free" | "paid";
+	utm_source?: string;
+	utm_medium?: string;
+	utm_campaign?: string;
+	utm_content?: string;
+	referrer_host?: string;
+	first_seen_at?: string;
+	landing_path?: string;
+	stripe_checkout_session_id?: string;
+}

--- a/src/packages/test-fixtures/src/providers/auth/index.ts
+++ b/src/packages/test-fixtures/src/providers/auth/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth.types";
 export * from "./bot-defense.types";
+export * from "./conversion.types";
 export * from "./in-memory-auth";
 export * from "./normalize-email";
 export * from "./password";


### PR DESCRIPTION
## Summary

- Captures first-touch attribution as a 30-day HttpOnly cookie on the first GET that carries any `utm_*` param or an external referrer. Self-referrers and corrupted cookies trigger re-capture so internal navigation never sets the cookie and a malformed value never locks the user out of future attribution.
- Emits one `user_created` conversion event per signup (free email, paid email, free Google, paid Google) carrying the click cookie's `utm_source`/`utm_medium`/`utm_campaign`/`utm_content`/`referrer_host`/`first_seen_at`/`landing_path` alongside `method`, `tier`, sha256-prefixed `email_hash`, and the Stripe `checkout_session_id` for paid signups. Emission goes through `HutchLogger.fromJSON<ConversionEvent>()` so events land on a `"conversions"` stream in CloudWatch and can be filtered for downstream metrics.
- Cookie is device-scoped, so a user who lands on day 1 and pays from a different browser on day 7 will have no attribution on their paid event — known degradation of the MVP. Follow-up PR will persist attribution onto the Users row so cross-device paid conversions retain UTM.

## Test plan

- [x] `nx run hutch:compile` — typecheck across hutch + test-fixtures bundle changes
- [x] `nx run hutch:test` — 97 suites / 1205 tests passing (includes new `click-attribution.middleware.test` and `conversions.test`)
- [x] `nx run hutch:test-with-coverage` — 100% function coverage, 99.7% statement
- [x] `pnpm lint` — biome + knip + tsc + unused-css all clean
- [ ] Manual: visit `/?utm_source=twitter` and confirm `hutch_click` cookie set; sign up and confirm a `{"stream":"conversions","event":"user_created","tier":"free",...}` line appears in dev logs.

https://claude.ai/code/session_01PzrDWpoVMU48HvUPL46LdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzrDWpoVMU48HvUPL46LdV)_