### PR TITLE
refactor(hutch): drop total-articles label from /queue header

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/queue-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/queue-actions.ts
@@ -259,11 +259,7 @@ export function createQueueActions(
         return saveForm.isVisible().catch(() => false)
       },
       execute: async (page) => {
-        const countLocator = page.locator('[data-test-article-count]')
-        await expect(countLocator).toBeVisible()
-        const totalBeforeText = await countLocator.textContent()
-        assert.ok(totalBeforeText, 'article count element should have text content')
-        const totalBefore = parseInt(totalBeforeText, 10)
+        const cardsBefore = await page.locator('.queue-article').count()
 
         // Re-save an already-saved URL so refreshArticleIfStale takes the
         // handleFullFetch branch and publishes publishRefreshArticleContent.
@@ -275,11 +271,8 @@ export function createQueueActions(
           page.locator('[data-test-form="save-article"] button[type="submit"]'),
         )
 
-        await expect(countLocator).toBeVisible()
-        const totalAfterText = await countLocator.textContent()
-        assert.ok(totalAfterText, 'article count element should have text content')
-        const totalAfter = parseInt(totalAfterText, 10)
-        assert.equal(totalAfter, totalBefore, 'Re-saving an existing URL must not duplicate the article')
+        const cardsAfter = await page.locator('.queue-article').count()
+        assert.equal(cardsAfter, cardsBefore, 'Re-saving an existing URL must not duplicate the article')
 
         progress.refreshedExistingArticle = true
       },
@@ -294,18 +287,11 @@ export function createQueueActions(
       },
       execute: async (page) => {
         const targetCount = TEST_URLS.length
-        const countLocator = page.locator('[data-test-article-count]')
-        await expect(countLocator).toBeVisible()
-        let totalText = await countLocator.textContent()
-        assert.ok(totalText, 'article count element should have text content')
-        let total = parseInt(totalText, 10)
+        let cards = await page.locator('.queue-article').count()
 
-        while (total > targetCount) {
+        while (cards > targetCount) {
           await clickAndWaitForPageReload(page, page.locator('[data-test-action="delete"]').first())
-          await expect(countLocator).toBeVisible()
-          totalText = await countLocator.textContent()
-          assert.ok(totalText, 'article count element should have text content')
-          total = parseInt(totalText, 10)
+          cards = await page.locator('.queue-article').count()
         }
 
         progress.paginationArticlesDeleted = true

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -13,8 +13,6 @@ import { tabQuery } from "./queue.tabs";
 const QUEUE_TEMPLATE = readFileSync(join(__dirname, "queue.template.html"), "utf-8");
 
 interface QueueDisplayModel {
-	total: number;
-	pluralSuffix: string;
 	saveError?: string;
 	saveErrorCode?: string;
 	importFlash?: string;
@@ -65,8 +63,6 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		});
 
 	return {
-		total: vm.total,
-		pluralSuffix: vm.total !== 1 ? "s" : "",
 		saveError: vm.saveError,
 		saveErrorCode: vm.saveErrorCode,
 		importFlash: vm.importFlash,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -50,15 +50,6 @@ describe("Queue routes", () => {
 			expect(doc.querySelector('[data-test-form="save-article"]')?.getAttribute("action")).toBe("/queue/save");
 		});
 
-		it("should show article count", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
-
-			const response = await agent.get("/queue");
-
-			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-article-count]")?.textContent).toContain("0");
-		});
 	});
 
 	describe("POST /queue/save", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -5,9 +5,6 @@
 }
 
 .queue__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   margin-bottom: 24px;
 }
 
@@ -15,11 +12,6 @@
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--foreground);
-}
-
-.queue__count {
-  font-size: 0.875rem;
-  color: var(--muted-foreground);
 }
 
 .queue__save-form {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -2,7 +2,6 @@
       {{{onboardingHtml}}}
       <div class="queue__header">
         <h1 class="queue__title">My Queue</h1>
-        <span class="queue__count" data-test-article-count>{{total}} article{{pluralSuffix}}</span>
       </div>
       <form class="queue__save-form" method="POST" action="/queue/save" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}">


### PR DESCRIPTION
## Summary

- Removes the `"{{total}} article{{pluralSuffix}}"` span from the queue header along with its `.queue__count` CSS rule, the `total`/`pluralSuffix` fields on `QueueDisplayModel`, and the `should show article count` integration test that asserted it. `.queue__header` no longer needs `display: flex` / `justify-content: space-between`.
- The `To read (N)` tab badge still renders the unread count, and `vm.total` on the queue view-model stays put (used for `isEmpty` and `totalPages`).
- Two E2E actions in `queue-flow/queue-actions.ts` that previously read `[data-test-article-count]` now count rendered `.queue-article` cards directly.

## Caveat about performance

This is **UI cleanup only**. The `Select: "COUNT"` DynamoDB scan in `dynamodb-article-store.ts` is still issued on every page render to compute `totalPages` for pagination, so Done-tab load time is unchanged. If the goal is faster Done-tab loads for users with thousands of articles, a follow-up is needed: either switch to cursor-based pagination (drop `totalPages`/`total`) or skip the unread-count query when on the Done tab.

## Test plan

- [x] `pnpm nx test hutch --testPathPattern=queue` — 226 tests pass; the deleted `should show article count` test is the only assertion removed
- [x] `pnpm nx lint hutch` — biome, knip, and unused-CSS check all green
- [x] Pre-commit `nx check` (compile + test-with-coverage + lint across all projects) — all coverage thresholds met
- [ ] Manual smoke on `/queue`: no `X articles` next to title; `To read (N)` tab badge still shows; pagination block (`Page 1 of N`) still renders; empty-state copy still renders
- [ ] `pnpm nx e2e hutch --grep="queue-flow"` — covers rewritten `resave-existing-article-triggers-refresh` and `delete-pagination-articles`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MMHyGcvG4gvfjEfoL8PW7Y)_