### PR TITLE
refactor: close supertest sockets so jest can run in parallel

### DIFF
--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -1,16 +1,18 @@
 import request from "supertest";
 import { GoogleIdSchema } from "@packages/test-fixtures/providers/google-auth";
-import { createTestApp } from "./test-app";
+import { createTestApp, useTestServer } from "./test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
+const useApp = useTestServer();
+
 describe("createTestApp + createDefaultTestAppFixture", () => {
 	it("produces a working app with default in-memory dependencies", async () => {
-		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(app).get("/");
+		const response = await request(server).get("/");
 
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -1,3 +1,4 @@
+import type { Server } from "node:http";
 import type { Express } from "express";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { HutchLogger } from "@packages/hutch-logger";
@@ -362,5 +363,42 @@ export function createTestApp(fixture: TestAppFixture): TestAppResult {
 		stripe: fixture.stripe,
 		pendingSignup: fixture.pendingSignup,
 		botDefense: fixture.botDefense,
+	};
+}
+
+export interface TestAppHarness extends TestAppResult {
+	server: Server;
+	close: () => Promise<void>;
+}
+
+/** server.close only invokes the callback with an error when the socket was
+ * never bound — which can't happen below because we always reach here after
+ * listen(0). Treat the callback as completion regardless of the err arg so
+ * coverage doesn't carry a phantom reject branch. */
+function buildHarness(fixture: TestAppFixture): TestAppHarness {
+	const result = createTestApp(fixture);
+	const server = result.app.listen(0);
+	return {
+		...result,
+		server,
+		close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+	};
+}
+
+/** Per-suite factory that registers an `afterEach` to close every harness it
+ * creates. Call once at module scope (or describe scope) and use the returned
+ * function inside `it()` to build a fresh test server — the cleanup is
+ * transparent so tests don't have to thread `close()` through finally blocks
+ * or hoist fixture creation into `beforeEach` just for lifecycle reasons. */
+export function useTestServer(): (fixture: TestAppFixture) => TestAppHarness {
+	const harnesses: TestAppHarness[] = [];
+	afterEach(async () => {
+		const toClose = harnesses.splice(0);
+		await Promise.all(toClose.map((h) => h.close()));
+	});
+	return (fixture) => {
+		const harness = buildHarness(fixture);
+		harnesses.push(harness);
+		return harness;
 	};
 }

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -86,6 +86,7 @@ import type { ExchangeGoogleCode } from "@packages/test-fixtures/providers/googl
 import type { OAuthModel } from "@packages/test-fixtures/providers/oauth";
 import type { ValidateAccessToken } from "./web/dual-auth.middleware";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import request from "supertest";
 import { createApp } from "./server";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
 import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
@@ -401,4 +402,17 @@ export function useTestServer(): (fixture: TestAppFixture) => TestAppHarness {
 		harnesses.push(harness);
 		return harness;
 	};
+}
+
+export async function loginAgent(
+	server: Server,
+	auth: TestAppHarness["auth"],
+) {
+	await auth.createUser({ email: "test@example.com", password: "password123" });
+	const agent = request.agent(server);
+	await agent
+		.post("/login")
+		.type("form")
+		.send({ email: "test@example.com", password: "password123" });
+	return agent;
 }

--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert";
 import request from "supertest";
 import type { Token, Client } from "@node-oauth/oauth2-server";
-import { createTestApp, type TestAppResult } from "../../test-app";
+import { useTestServer } from "../../test-app";
+import type { TestAppHarness } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -34,22 +35,24 @@ function createTestToken(): Token {
 }
 
 async function createAccessToken(
-	testApp: TestAppResult,
+	harness: TestAppHarness,
 ): Promise<string> {
-	const client = await testApp.oauthModel.getClient("hutch-firefox-extension", "");
+	const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
 	assert(client, "Test client must exist");
 
 	const testToken = createTestToken();
-	const token = await testApp.oauthModel.saveToken(testToken, client, { id: TEST_USER_ID });
+	const token = await harness.oauthModel.saveToken(testToken, client, { id: TEST_USER_ID });
 	assert(token, "Token should be saved");
 	return token.accessToken;
 }
 
+const useApp = useTestServer();
+
 describe("GET /queue (Siren content negotiation)", () => {
 	it("returns 401 without token when requesting Siren", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE);
 
@@ -59,10 +62,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("returns empty collection for new user", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -76,10 +79,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("returns articles after saving via HTML form", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+		const agent = request.agent(harness.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -89,18 +92,18 @@ describe("GET /queue (Siren content negotiation)", () => {
 			.type("form")
 			.send({ url: "https://example.com/article" });
 
-		const loginResult = await testApp.auth.verifyCredentials({ email: "test@example.com", password: "password123" });
+		const loginResult = await harness.auth.verifyCredentials({ email: "test@example.com", password: "password123" });
 		assert(loginResult.ok);
 		const userId = loginResult.userId;
 
-		const client = await testApp.oauthModel.getClient("hutch-firefox-extension", "");
+		const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
 		assert(client);
 		const userToken = createTestToken();
 		userToken.user = { id: userId };
-		const token = await testApp.oauthModel.saveToken(userToken, client, { id: userId });
+		const token = await harness.oauthModel.saveToken(userToken, client, { id: userId });
 		assert(token);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${token.accessToken}`);
@@ -113,9 +116,9 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("returns 401 with invalid token", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", "Bearer invalid-token");
@@ -125,10 +128,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("supports status filter parameter", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue?status=unread")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -138,10 +141,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("supports order parameter", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue?order=asc")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -151,10 +154,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("supports page parameter", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue?page=2")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -164,10 +167,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("includes search action", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -187,10 +190,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 	});
 
 	it("includes save-article action", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -205,10 +208,10 @@ describe("GET /queue (Siren content negotiation)", () => {
 
 describe("POST /queue (Siren save article)", () => {
 	it("saves an article and returns Siren entity", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -224,10 +227,10 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("returns 422 for invalid URL", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -239,17 +242,17 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("returns the article collection for a non-saveable scheme when client opts in via Prefer", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		await request(testApp.app)
+		await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ url: "https://example.com/already-saved" });
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -270,10 +273,10 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("returns the article collection with a private_network warning when the host is local", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -290,10 +293,10 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("returns the article collection with a private_network warning for a .home.arpa host", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -306,10 +309,10 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("preserves the legacy stub-save behaviour for a non-saveable scheme without Prefer", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -322,9 +325,9 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("returns 401 without token", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Content-Type", "application/json")
@@ -334,9 +337,9 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("returns 406 when session-authenticated user POSTs without Siren Accept", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+		const agent = request.agent(harness.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -359,7 +362,7 @@ describe("POST /queue (Siren save article)", () => {
 			articleCrawl: fixture.articleCrawl,
 			parseArticle,
 		});
-		const testApp = createTestApp({
+		const harness = useApp({
 			...fixture,
 			parser: { parseArticle, crawlArticle },
 			events: {
@@ -372,13 +375,13 @@ describe("POST /queue (Siren save article)", () => {
 				publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 			},
 		});
-		const client = await testApp.oauthModel.getClient("hutch-firefox-extension", "");
+		const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
 		assert(client);
 		const testToken = createTestToken();
-		const token = await testApp.oauthModel.saveToken(testToken, client, { id: TEST_USER_ID });
+		const token = await harness.oauthModel.saveToken(testToken, client, { id: TEST_USER_ID });
 		assert(token);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${token.accessToken}`)
@@ -390,10 +393,10 @@ describe("POST /queue (Siren save article)", () => {
 	});
 
 	it("includes delete action on saved article", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -411,10 +414,10 @@ describe("POST /queue (Siren save article)", () => {
 
 describe("POST /queue (Siren re-save read article)", () => {
 	it("marks a read article as unread when saved again", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const saveResponse = await request(testApp.app)
+		const saveResponse = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -423,14 +426,14 @@ describe("POST /queue (Siren re-save read article)", () => {
 
 		const articleId = saveResponse.body.properties.id;
 
-		await request(testApp.app)
+		await request(harness.server)
 			.post(`/queue/${articleId}/status`)
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ status: "read" });
 
-		const resaveResponse = await request(testApp.app)
+		const resaveResponse = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -440,7 +443,7 @@ describe("POST /queue (Siren re-save read article)", () => {
 		expect(resaveResponse.status).toBe(201);
 		expect(resaveResponse.body.properties.status).toBe("unread");
 
-		const listResponse = await request(testApp.app)
+		const listResponse = await request(harness.server)
 			.get("/queue?status=unread")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -451,10 +454,10 @@ describe("POST /queue (Siren re-save read article)", () => {
 
 describe("POST /queue/:id/delete (Siren)", () => {
 	it("redirects to collection via 303 after deleting when client opts in via Prefer header", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const saveResponse = await request(testApp.app)
+		const saveResponse = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -463,7 +466,7 @@ describe("POST /queue/:id/delete (Siren)", () => {
 
 		const articleId = saveResponse.body.properties.id;
 
-		const deleteResponse = await request(testApp.app)
+		const deleteResponse = await request(harness.server)
 			.post(`/queue/${articleId}/delete`)
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Prefer", "return=representation")
@@ -475,10 +478,10 @@ describe("POST /queue/:id/delete (Siren)", () => {
 	});
 
 	it("returns empty collection after following the redirect", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const saveResponse = await request(testApp.app)
+		const saveResponse = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -487,7 +490,7 @@ describe("POST /queue/:id/delete (Siren)", () => {
 
 		const articleId = saveResponse.body.properties.id;
 
-		const deleteResponse = await request(testApp.app)
+		const deleteResponse = await request(harness.server)
 			.post(`/queue/${articleId}/delete`)
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Prefer", "return=representation")
@@ -495,7 +498,7 @@ describe("POST /queue/:id/delete (Siren)", () => {
 			.redirects(0);
 
 		assert(deleteResponse.headers.location, "expected Location header");
-		const collectionResponse = await request(testApp.app)
+		const collectionResponse = await request(harness.server)
 			.get(deleteResponse.headers.location)
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -507,10 +510,10 @@ describe("POST /queue/:id/delete (Siren)", () => {
 
 	/** Chrome extension v1.0.66 (still in the web store) sets `redirect: "manual"` on its delete fetch and only treats `status === 204` as success — a 303 surfaces to JS as an opaqueredirect with status 0, leaving the deleted row visible in the popup until reopened. The server keeps returning 204 for Siren clients that don't opt into the new representation flow until v1.0.66 ages out of the wild. */
 	it("returns 204 No Content for legacy Siren clients without Prefer header (chrome-extension v1.0.66 backwards compat)", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const saveResponse = await request(testApp.app)
+		const saveResponse = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -519,7 +522,7 @@ describe("POST /queue/:id/delete (Siren)", () => {
 
 		const articleId = saveResponse.body.properties.id;
 
-		const deleteResponse = await request(testApp.app)
+		const deleteResponse = await request(harness.server)
 			.post(`/queue/${articleId}/delete`)
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -532,9 +535,9 @@ describe("POST /queue/:id/delete (Siren)", () => {
 
 describe("extension-alive cookie middleware", () => {
 	it("sets the alive cookie as httpOnly on the Siren entry point before login", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.redirects(0);
@@ -554,9 +557,9 @@ describe("extension-alive cookie middleware", () => {
 	});
 
 	it("does not set the alive cookie on browser session requests", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+		const agent = request.agent(harness.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -574,9 +577,9 @@ describe("extension-alive cookie middleware", () => {
 	});
 
 	it("renews the hutch_ext_saved cookie on a Siren request when it is already present", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Cookie", "hutch_ext_saved=1")
@@ -593,9 +596,9 @@ describe("extension-alive cookie middleware", () => {
 	});
 
 	it("does not set hutch_ext_saved on a Siren request when the cookie is absent", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.redirects(0);
@@ -610,9 +613,9 @@ describe("extension-alive cookie middleware", () => {
 
 describe("GET / (Siren entry point)", () => {
 	it("redirects Siren clients to /queue", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.redirects(0);
@@ -622,9 +625,9 @@ describe("GET / (Siren entry point)", () => {
 	});
 
 	it("returns home page HTML when Accept is not Siren", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/")
 			.set("Accept", "text/html");
 
@@ -634,9 +637,9 @@ describe("GET / (Siren entry point)", () => {
 
 	/** Firefox extensions send a CORS preflight for fetches with non-simple headers (Accept: application/vnd.siren+json, Authorization). Without an OPTIONS handler here the preflight 404s and firefox aborts the fetch with NetworkError. */
 	it("handles CORS preflight from extension origin", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.options("/")
 			.set("Origin", "moz-extension://d3b07384-d113-4ec6-a7b8-5f7e3b4c9a12")
 			.set("Access-Control-Request-Method", "GET")
@@ -653,24 +656,24 @@ describe("GET / (Siren entry point)", () => {
 
 describe("GET /queue?url= (Siren URL filter)", () => {
 	it("returns matching article when URL filter matches", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		await request(testApp.app)
+		await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ url: "https://example.com/article-1" });
 
-		await request(testApp.app)
+		await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ url: "https://example.com/article-2" });
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue?url=https://example.com/article-1")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -681,17 +684,17 @@ describe("GET /queue?url= (Siren URL filter)", () => {
 	});
 
 	it("returns empty collection when URL filter has no match", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		await request(testApp.app)
+		await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ url: "https://example.com/article" });
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue?url=https://example.com/nonexistent")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -703,17 +706,17 @@ describe("GET /queue?url= (Siren URL filter)", () => {
 
 describe("Article sub-entity actions", () => {
 	it("includes delete action on article sub-entities in collection", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		await request(testApp.app)
+		await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ url: "https://example.com/article" });
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);
@@ -730,9 +733,9 @@ describe("Article sub-entity actions", () => {
 
 describe("Content negotiation", () => {
 	it("returns HTML when Accept header is text/html", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+		const agent = request.agent(harness.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -747,9 +750,9 @@ describe("Content negotiation", () => {
 	});
 
 	it("returns HTML when Accept header is */*", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+		const agent = request.agent(harness.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -764,10 +767,10 @@ describe("Content negotiation", () => {
 	});
 
 	it("returns Siren when Accept header is application/vnd.siren+json", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);

--- a/projects/hutch/src/runtime/web/api/list-articles-via-oauth.integration.ts
+++ b/projects/hutch/src/runtime/web/api/list-articles-via-oauth.integration.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import request from "supertest";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -18,12 +18,14 @@ function generatePkce() {
 	return { codeVerifier, codeChallenge };
 }
 
+const useApp = useTestServer();
+
 describe("List articles via OAuth flow", () => {
 	it("returns empty collection after logging in via OAuth", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+		const agent = request.agent(harness.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -49,7 +51,7 @@ describe("List articles via OAuth flow", () => {
 		const authorizationCode = redirectUrl.searchParams.get("code");
 		expect(authorizationCode).toBeTruthy();
 
-		const tokenResponse = await request(testApp.app)
+		const tokenResponse = await request(harness.server)
 			.post("/oauth/token")
 			.type("form")
 			.send({
@@ -64,7 +66,7 @@ describe("List articles via OAuth flow", () => {
 		const accessToken = tokenResponse.body.access_token;
 		expect(accessToken).toBeTruthy();
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);

--- a/projects/hutch/src/runtime/web/api/save-article-via-oauth.integration.ts
+++ b/projects/hutch/src/runtime/web/api/save-article-via-oauth.integration.ts
@@ -5,7 +5,8 @@ import {
 	SAVE_COOKIE_NAME,
 	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
+import type { TestAppHarness } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -23,9 +24,9 @@ function generatePkce() {
 	return { codeVerifier, codeChallenge };
 }
 
-async function obtainAccessToken(testApp: ReturnType<typeof createTestApp>): Promise<string> {
-	await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(testApp.app);
+async function obtainAccessToken(harness: TestAppHarness): Promise<string> {
+	await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+	const agent = request.agent(harness.server);
 	await agent
 		.post("/login")
 		.type("form")
@@ -51,7 +52,7 @@ async function obtainAccessToken(testApp: ReturnType<typeof createTestApp>): Pro
 	const authorizationCode = redirectUrl.searchParams.get("code");
 	assert(authorizationCode, "authorize endpoint must redirect with a code");
 
-	const tokenResponse = await request(testApp.app)
+	const tokenResponse = await request(harness.server)
 		.post("/oauth/token")
 		.type("form")
 		.send({
@@ -68,12 +69,14 @@ async function obtainAccessToken(testApp: ReturnType<typeof createTestApp>): Pro
 	return accessToken;
 }
 
+const useApp = useTestServer();
+
 describe("Save article via OAuth flow", () => {
 	it("sets the extension-save cookie on a successful POST /queue", async () => {
-		const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await obtainAccessToken(testApp);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
 
-		const response = await request(testApp.app)
+		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import {
@@ -22,11 +22,13 @@ function freshLoadedAt(): string {
 	return String(Date.now() - 5000);
 }
 
+const useApp = useTestServer();
+
 describe("Auth routes", () => {
 	describe("GET /login", () => {
 		it("should render the login form", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/login");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/login");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -36,10 +38,11 @@ describe("Auth routes", () => {
 		});
 
 		it("should redirect authenticated user to /queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({ email: "test@example.com", password: "password123" });
 
 			const response = await agent.get("/login");
@@ -49,8 +52,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should include return URL in form action when provided", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -60,8 +63,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should pass return URL to signup link", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -73,10 +76,11 @@ describe("Auth routes", () => {
 
 	describe("POST /login", () => {
 		it("should redirect to /queue on valid credentials", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			const response = await agent
 				.post("/login")
 				.type("form")
@@ -88,9 +92,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should show error on invalid credentials", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login")
 				.type("form")
 				.send({ email: "test@example.com", password: "wrongpassword" });
@@ -103,10 +107,11 @@ describe("Auth routes", () => {
 		});
 
 		it("should redirect to return URL after successful login", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest")
 				.type("form")
 				.send({ email: "test@example.com", password: "password123" });
@@ -116,10 +121,11 @@ describe("Auth routes", () => {
 		});
 
 		it("should ignore protocol-relative return URLs", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login?return=%2F%2Fevil.com")
 				.type("form")
 				.send({ email: "test@example.com", password: "password123" });
@@ -129,10 +135,11 @@ describe("Auth routes", () => {
 		});
 
 		it("should ignore non-relative return URLs", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login?return=https%3A%2F%2Fevil.com")
 				.type("form")
 				.send({ email: "test@example.com", password: "password123" });
@@ -142,9 +149,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should show validation error for empty email", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login")
 				.type("form")
 				.send({ email: "", password: "password123" });
@@ -155,9 +162,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should preserve return URL in form action after invalid credentials", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest")
 				.type("form")
 				.send({ email: "test@example.com", password: "wrongpassword" });
@@ -170,9 +177,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should preserve return URL in form action after validation error", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/login?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest")
 				.type("form")
 				.send({ email: "", password: "password123" });
@@ -187,8 +194,8 @@ describe("Auth routes", () => {
 
 	describe("GET /signup", () => {
 		it("should render the signup form", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/signup");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -197,8 +204,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should render a visually-hidden honeypot input named 'website' inside the signup form", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/signup");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
 
 			const doc = new JSDOM(response.text).window.document;
 			const form = doc.querySelector('[data-test-form="signup"]');
@@ -214,9 +221,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should render a hidden loadedAt input with the current server-side ms timestamp", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const before = Date.now();
-			const response = await request(app).get("/signup");
+			const response = await request(harness.server).get("/signup");
 			const after = Date.now();
 
 			const doc = new JSDOM(response.text).window.document;
@@ -229,10 +236,11 @@ describe("Auth routes", () => {
 		});
 
 		it("should redirect authenticated user to /queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({ email: "test@example.com", password: "password123" });
 
 			const response = await agent.get("/signup");
@@ -242,8 +250,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should include return URL in form action when provided", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -253,8 +261,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should pass return URL to login link", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -264,8 +272,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should pre-fill the email field when a valid email is provided in the query string", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get(
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get(
 				"/signup?email=jane%40example.com&utm_source=recovery",
 			);
 
@@ -277,8 +285,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should leave the email field empty when the query email is invalid", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/signup?email=not-an-email");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup?email=not-an-email");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -290,11 +298,12 @@ describe("Auth routes", () => {
 
 	describe("POST /signup", () => {
 		it("should create the account directly and redirect to /queue when below the founding limit", async () => {
-			const { app, auth, pendingSignup } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, pendingSignup } = harness;
 			// One founding member
 			await auth.createUser({ email: `seed1@test.com`, password: "password123" });
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "free@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -316,12 +325,13 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should redirect to Stripe checkout when at the founding limit", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "paid@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -333,14 +343,15 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should fall back to free signup after a manual deletion drops the count below the limit", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT + 1; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			await auth.deleteUser("seed0@test.com");
 			await auth.deleteUser("seed1@test.com");
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "after-delete@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -352,9 +363,10 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should send the email verification email on free signup", async () => {
-			const { app, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { email } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "verify-free@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -371,7 +383,7 @@ describe("Auth routes", () => {
 		it("should show duplicate-email error when a race condition causes createUserWithPasswordHash to fail during free signup", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			let raceFindCount = 0;
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				auth: {
 					...fixture.auth,
@@ -386,7 +398,7 @@ describe("Auth routes", () => {
 			});
 			await fixture.auth.createUser({ email: "race@example.com", password: "existing" });
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "race@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -399,12 +411,13 @@ describe("Auth routes", () => {
 		});
 
 		it("should redirect new visitors to a Stripe checkout URL when at the founding limit", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "new@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -416,10 +429,11 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should create the account on successful Stripe checkout and redirect to /queue", async () => {
-			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "new@example.com",
@@ -432,10 +446,11 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should redirect to return URL after successful Stripe checkout", async () => {
-			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "new@example.com",
@@ -448,10 +463,11 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should ignore protocol-relative return URLs on signup", async () => {
-			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "new@example.com",
@@ -464,10 +480,11 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should ignore non-relative return URLs on signup", async () => {
-			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "new@example.com",
@@ -480,10 +497,11 @@ describe("Auth routes", () => {
 		}, 30000);
 
 		it("should show error for duplicate email", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "existing@example.com", password: "password123" });
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "existing@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -498,9 +516,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should show error for mismatched passwords", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "new@example.com",
 				password: "password123",
 				confirmPassword: "differentpassword",
@@ -515,9 +533,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should preserve return URL in form action after mismatched passwords", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest")
 				.type("form")
 				.send({
@@ -535,10 +553,11 @@ describe("Auth routes", () => {
 		});
 
 		it("should preserve return URL in form action after duplicate email", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "existing@example.com", password: "password123" });
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/signup?return=%2Foauth%2Fauthorize%3Fclient_id%3Dtest")
 				.type("form")
 				.send({
@@ -556,9 +575,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should show error for short password", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "new@example.com",
 				password: "short",
 				confirmPassword: "short",
@@ -573,9 +592,10 @@ describe("Auth routes", () => {
 
 	describe("POST /signup — bot defense", () => {
 		it("returns a fake-success 303 to /?signup=pending and logs a 'honeypot' rejection when the hidden website field is filled", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -595,9 +615,10 @@ describe("Auth routes", () => {
 		});
 
 		it("logs 'missing_timestamp' and fakes success when loadedAt is absent from the form payload", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -610,9 +631,10 @@ describe("Auth routes", () => {
 		});
 
 		it("logs 'missing_timestamp' when loadedAt is an empty string", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -626,9 +648,10 @@ describe("Auth routes", () => {
 		});
 
 		it("omits email_domain from the event when the honeypot payload has no email", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
@@ -641,9 +664,10 @@ describe("Auth routes", () => {
 		});
 
 		it("omits email_domain when email has no @ sign", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "no-at-sign",
 				password: "password123",
 				confirmPassword: "password123",
@@ -657,9 +681,10 @@ describe("Auth routes", () => {
 		});
 
 		it("logs 'invalid_timestamp' and fakes success when loadedAt is not a parseable integer", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -673,9 +698,10 @@ describe("Auth routes", () => {
 		});
 
 		it("logs 'invalid_timestamp' when loadedAt is a float string", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -689,9 +715,10 @@ describe("Auth routes", () => {
 		});
 
 		it("logs 'submit_too_fast' with the elapsed time when the form is submitted within the 2.5s window", async () => {
-			const { app, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -709,9 +736,10 @@ describe("Auth routes", () => {
 		});
 
 		it("does not create a Stripe checkout session or store a pending signup when the honeypot is tripped", async () => {
-			const { app, pendingSignup, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { pendingSignup, botDefense } = harness;
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "bot@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -732,12 +760,13 @@ describe("Auth routes", () => {
 		});
 
 		it("falls through to the existing happy path (303 to Stripe) when the honeypot is empty, loadedAt is older than 2.5s, and the founding allocation is exhausted", async () => {
-			const { app, auth, botDefense } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, botDefense } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 
-			const response = await request(app).post("/signup").type("form").send({
+			const response = await request(harness.server).post("/signup").type("form").send({
 				email: "real@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -753,8 +782,8 @@ describe("Auth routes", () => {
 
 	describe("GET /verify-email", () => {
 		it("should show error when no token is provided", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/verify-email");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/verify-email");
 
 			expect(response.status).toBe(400);
 			const doc = new JSDOM(response.text).window.document;
@@ -764,8 +793,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should show error for invalid token", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/verify-email?token=invalid-token");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/verify-email?token=invalid-token");
 
 			expect(response.status).toBe(400);
 			const doc = new JSDOM(response.text).window.document;
@@ -775,7 +804,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should verify email with valid token", async () => {
-			const { app, auth, emailVerification } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, emailVerification } = harness;
 			const createResult = await auth.createUser({ email: "verify@example.com", password: "password123" });
 			expect(createResult.ok).toBe(true);
 			if (!createResult.ok) return;
@@ -785,13 +815,14 @@ describe("Auth routes", () => {
 				email: "verify@example.com",
 			});
 
-			const response = await request(app).get(`/verify-email?token=${token}`);
+			const response = await request(harness.server).get(`/verify-email?token=${token}`);
 
 			expect(response.status).toBe(200);
 		});
 
 		it("should mark session email verified when user is logged in during verification", async () => {
-			const { app, auth, emailVerification } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, emailVerification } = harness;
 			const createResult = await auth.createUser({ email: "session@example.com", password: "password123" });
 			expect(createResult.ok).toBe(true);
 			if (!createResult.ok) return;
@@ -801,7 +832,7 @@ describe("Auth routes", () => {
 				email: "session@example.com",
 			});
 
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({ email: "session@example.com", password: "password123" });
 
 			const response = await agent.get(`/verify-email?token=${token}`);
@@ -812,10 +843,11 @@ describe("Auth routes", () => {
 
 	describe("POST /logout", () => {
 		it("should clear session and redirect to /", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
 
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent
 				.post("/login")
 				.type("form")
@@ -828,9 +860,9 @@ describe("Auth routes", () => {
 		});
 
 		it("should handle logout when no session cookie exists", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).post("/logout");
+			const response = await request(harness.server).post("/logout");
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/");
@@ -848,8 +880,8 @@ describe("Auth routes", () => {
 		}
 
 		it("should render Sign in with Google on /login with the Google logo", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/login");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/login");
 
 			const link = getGoogleButton(response.text);
 			expect(link.getAttribute("href")).toBe("/auth/google");
@@ -865,16 +897,16 @@ describe("Auth routes", () => {
 		});
 
 		it("should pass return URL through to the Google sign-in link on /login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/login?return=%2Fsave%3Furl%3Dhttps%253A%252F%252Fexample.com");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/login?return=%2Fsave%3Furl%3Dhttps%253A%252F%252Fexample.com");
 
 			const link = getGoogleButton(response.text);
 			expect(link.getAttribute("href")).toContain("/auth/google?return=");
 		});
 
 		it("should render Sign up with Google on /signup with the Google logo", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/signup");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
 
 			const link = getGoogleButton(response.text);
 			expect(link.getAttribute("href")).toBe("/auth/google");
@@ -883,10 +915,9 @@ describe("Auth routes", () => {
 	});
 
 	describe("Founding members progress", () => {
-		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 		it("should render the progress bar on GET /signup with zero users", async () => {
-			const response = await request(app).get("/signup");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
 			const doc = new JSDOM(response.text).window.document;
 
 			const label = doc.querySelector("[data-test-founding-progress] .founding-progress__label");
@@ -894,7 +925,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should keep the progress bar on POST /signup 422 responses", async () => {
-			const response = await request(app)
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server)
 				.post("/signup")
 				.type("form")
 				.send({ email: "", password: "short", confirmPassword: "short", loadedAt: freshLoadedAt() });
@@ -906,7 +938,8 @@ describe("Auth routes", () => {
 		});
 
 		it("should render the founding blurb on GET /signup when allocation is available", async () => {
-			const response = await request(app).get("/signup");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
 			const doc = new JSDOM(response.text).window.document;
 
 			const blurb = doc.querySelector("[data-test-founding-blurb]");
@@ -916,12 +949,13 @@ describe("Auth routes", () => {
 
 	describe("Founding members progress — exhausted allocation", () => {
 		it("should hide the founding progress and blurb on /signup when at the limit", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 			}
 
-			const signupDoc = new JSDOM((await request(app).get("/signup")).text).window.document;
+			const signupDoc = new JSDOM((await request(harness.server).get("/signup")).text).window.document;
 			expect(signupDoc.querySelector("[data-test-founding-progress]")).toBeNull();
 			expect(signupDoc.querySelector("[data-test-founding-blurb]")).toBeNull();
 		}, 30000);

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
@@ -17,10 +17,12 @@ async function seedAboveFoundingLimit(auth: { createUser: (params: { email: stri
 	}
 }
 
+const useApp = useTestServer();
+
 describe("GET /auth/checkout/success", () => {
 	it("renders an error and 400 when the session_id query param is missing", async () => {
-		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(app).get("/auth/checkout/success");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/auth/checkout/success");
 
 		expect(response.status).toBe(400);
 		const doc = new JSDOM(response.text).window.document;
@@ -30,8 +32,8 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("renders 404 when Stripe says the session does not exist", async () => {
-		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(app).get("/auth/checkout/success?session_id=cs_test_unknown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/auth/checkout/success?session_id=cs_test_unknown");
 
 		expect(response.status).toBe(404);
 		const doc = new JSDOM(response.text).window.document;
@@ -39,10 +41,11 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("renders 402 when the checkout has not been paid yet", async () => {
-		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, stripe } = harness;
 		await seedAboveFoundingLimit(auth);
 
-		const signup = await request(app).post("/signup").type("form").send({
+		const signup = await request(harness.server).post("/signup").type("form").send({
 			email: "unpaid@example.com",
 			password: "password123",
 			confirmPassword: "password123",
@@ -52,7 +55,7 @@ describe("GET /auth/checkout/success", () => {
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),
 		);
 
-		const response = await request(app).get(
+		const response = await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
 		);
 
@@ -64,17 +67,18 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("renders 409 when the checkout has been paid but the pending signup was already consumed", async () => {
-		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, stripe } = harness;
 
 		const { checkoutSessionId } = await completeStripeSignup({
-			app,
+			server: harness.server,
 			auth,
 			stripe,
 			email: "double@example.com",
 			password: "password123",
 		});
 
-		const replay = await request(app).get(
+		const replay = await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
 		);
 
@@ -84,10 +88,11 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("creates the user, sets a session cookie, and redirects to /queue on first paid visit", async () => {
-		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, stripe } = harness;
 
 		const { successResponse } = await completeStripeSignup({
-			app,
+			server: harness.server,
 			auth,
 			stripe,
 			email: "buyer@example.com",
@@ -110,10 +115,11 @@ describe("GET /auth/checkout/success", () => {
 	});
 
 	it("renders 409 when the email has been claimed since the Stripe redirect started", async () => {
-		const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, stripe } = harness;
 		await seedAboveFoundingLimit(auth);
 
-		const signup = await request(app).post("/signup").type("form").send({
+		const signup = await request(harness.server).post("/signup").type("form").send({
 			email: "race@example.com",
 			password: "password123",
 			confirmPassword: "password123",
@@ -126,7 +132,7 @@ describe("GET /auth/checkout/success", () => {
 
 		await auth.createUser({ email: "race@example.com", password: "different-password" });
 
-		const response = await request(app).get(
+		const response = await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkoutSessionId)}`,
 		);
 
@@ -137,7 +143,8 @@ describe("GET /auth/checkout/success", () => {
 
 	it("creates a Google user with a verified email after Stripe success", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		const { app, auth, stripe, pendingSignup } = createTestApp(fixture);
+		const harness = useApp(fixture);
+		const { auth, stripe, pendingSignup } = harness;
 		const { UserIdSchema } = await import("@packages/domain/user");
 
 		const checkout = await stripe.createCheckoutSession({
@@ -155,7 +162,7 @@ describe("GET /auth/checkout/success", () => {
 		});
 		stripe.markPaid(checkout.id);
 
-		const response = await request(app).get(
+		const response = await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
 		);
 
@@ -169,7 +176,8 @@ describe("GET /auth/checkout/success", () => {
 
 	it("sends a welcome email after a new Google user completes Stripe checkout", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		const { app, email, stripe, pendingSignup } = createTestApp(fixture);
+		const harness = useApp(fixture);
+		const { email, stripe, pendingSignup } = harness;
 		const { UserIdSchema } = await import("@packages/domain/user");
 
 		const checkout = await stripe.createCheckoutSession({
@@ -187,7 +195,7 @@ describe("GET /auth/checkout/success", () => {
 		});
 		stripe.markPaid(checkout.id);
 
-		await request(app).get(
+		await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
 		);
 
@@ -202,7 +210,8 @@ describe("GET /auth/checkout/success", () => {
 
 	it("logs the existing user in when a Google sign-up arrives for an email that already exists", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		const { app, auth, stripe, pendingSignup } = createTestApp(fixture);
+		const harness = useApp(fixture);
+		const { auth, stripe, pendingSignup } = harness;
 		const { UserIdSchema } = await import("@packages/domain/user");
 
 		const existing = await auth.createUser({
@@ -226,7 +235,7 @@ describe("GET /auth/checkout/success", () => {
 		});
 		stripe.markPaid(checkout.id);
 
-		const response = await request(app).get(
+		const response = await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
 		);
 
@@ -240,7 +249,8 @@ describe("GET /auth/checkout/success", () => {
 
 	it("does not send a welcome email when a Google sign-up falls back to an existing email/password account", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		const { app, auth, email, stripe, pendingSignup } = createTestApp(fixture);
+		const harness = useApp(fixture);
+		const { auth, email, stripe, pendingSignup } = harness;
 		const { UserIdSchema } = await import("@packages/domain/user");
 
 		const existing = await auth.createUser({
@@ -264,7 +274,7 @@ describe("GET /auth/checkout/success", () => {
 		});
 		stripe.markPaid(checkout.id);
 
-		await request(app).get(
+		await request(harness.server).get(
 			`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`,
 		);
 

--- a/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/email-verification.route.test.ts
@@ -1,35 +1,24 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-import { initInMemoryAuth } from "@packages/test-fixtures/providers/auth";
-import { initInMemoryArticleStore } from "@packages/test-fixtures/providers/article-store";
-import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
-import { initInMemoryEmailVerification } from "@packages/test-fixtures/providers/email-verification";
-import { initInMemoryPasswordReset } from "@packages/test-fixtures/providers/password-reset";
-import { initInMemoryStripeCheckout } from "@packages/test-fixtures/providers/stripe-checkout";
-import { initInMemoryPendingSignup } from "@packages/test-fixtures/providers/pending-signup";
-import { createOAuthModel, initInMemoryOAuthModel } from "@packages/test-fixtures/providers/oauth";
-import { createValidateAccessToken } from "@packages/test-fixtures/providers/oauth";
-import { initInMemoryImportSession } from "@packages/test-fixtures/providers/import-session";
-import { validateSaveableUrl } from "@packages/domain/article";
-import { createApp } from "../../server";
-import { httpErrorMessageMapping } from "../pages/queue/queue.error";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
-import { initFoundingAllocation } from "../shared/founding-progress/founding-allocation";
+
+const useApp = useTestServer();
 
 describe("Email verification", () => {
 	describe("POST /signup → Stripe → success", () => {
 		it("should send a verification email after successful Stripe checkout", async () => {
-			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email, stripe } = harness;
 
 			await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "new@example.com",
@@ -45,64 +34,26 @@ describe("Email verification", () => {
 		});
 
 		it("should complete signup even when email sending fails", async () => {
-			const auth = initInMemoryAuth();
-			const articleStore = initInMemoryArticleStore();
-			const oauthModel = createOAuthModel(initInMemoryOAuthModel());
-			const emailVerification = initInMemoryEmailVerification();
-			const passwordReset = initInMemoryPasswordReset();
-			const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() });
-			const pendingSignup = initInMemoryPendingSignup();
-
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			let resolveErrorLogged: () => void;
 			const errorLogged = new Promise<void>((resolve) => {
 				resolveErrorLogged = resolve;
 			});
-
-			const app = createApp({
-				validateSaveableUrl,
-				adminEmails: [],
-				recrawlServiceToken: "test-service-token-abcdefghij",
-				appOrigin: "http://localhost:3000",
-				staticBaseUrl: "",
-				...auth,
-				...articleStore,
-				readArticleContent: (url: string) => articleStore.readContent(ArticleResourceUniqueId.parse(url)),
-				...emailVerification,
-				...passwordReset,
-				createCheckoutSession: stripe.createCheckoutSession,
-				retrieveCheckoutSession: stripe.retrieveCheckoutSession,
-				storePendingSignup: pendingSignup.storePendingSignup,
-				consumePendingSignup: pendingSignup.consumePendingSignup,
-				sendEmail: async () => { throw new Error("Email service down"); },
-				baseUrl: "http://localhost:3000",
-				logError: () => { resolveErrorLogged(); },
-				oauthModel,
-				validateAccessToken: createValidateAccessToken(oauthModel),
-				publishLinkSaved: async () => {},
-				publishRecrawlLinkInitiated: async () => {},
-				publishSaveAnonymousLink: async () => {},
-				publishSaveLinkRawHtmlCommand: async () => {},
-				publishStaleCheckRequested: async () => {},
-				publishExportUserDataCommand: async () => {},
-				findGeneratedSummary: async () => undefined,
-				markSummaryPending: async () => {},
-				forceMarkSummaryPending: async () => {},
-				findArticleCrawlStatus: async () => undefined,
-				markCrawlPending: async () => {},
-				forceMarkCrawlPending: async () => {},
-				refreshArticleIfStale: async () => ({ action: "new" as const }),
-				publishUpdateFetchTimestamp: async () => {},
-				putPendingHtml: async () => {},
-				httpErrorMessageMapping,
-				logParseError: () => {},
-				importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
-				now: () => new Date(),
-				botDefenseLogger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
-				foundingAllocation: initFoundingAllocation({ foundingMemberLimit: 3 }),
+			const harness = useApp({
+				...fixture,
+				email: {
+					...fixture.email,
+					sendEmail: async () => { throw new Error("Email service down"); },
+				},
+				shared: {
+					...fixture.shared,
+					logError: () => { resolveErrorLogged(); },
+				},
 			});
+			const { auth, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "fail-email@example.com",
@@ -114,10 +65,11 @@ describe("Email verification", () => {
 		});
 
 		it("should not send a verification email when signup fails (duplicate email)", async () => {
-			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email } = harness;
 			await auth.createUser({ email: "existing@example.com", password: "password123" });
 
-			await request(app).post("/signup").type("form").send({
+			await request(harness.server).post("/signup").type("form").send({
 				email: "existing@example.com",
 				password: "password123",
 				confirmPassword: "password123",
@@ -130,10 +82,11 @@ describe("Email verification", () => {
 
 	describe("GET /verify-email", () => {
 		it("should verify email with a valid token", async () => {
-			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email, stripe } = harness;
 
 			await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "verify@example.com",
@@ -145,7 +98,7 @@ describe("Email verification", () => {
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
-			const verifyResponse = await request(app).get(`/verify-email?token=${token}`);
+			const verifyResponse = await request(harness.server).get(`/verify-email?token=${token}`);
 
 			expect(verifyResponse.status).toBe(200);
 			const doc = new JSDOM(verifyResponse.text).window.document;
@@ -153,9 +106,9 @@ describe("Email verification", () => {
 		});
 
 		it("should reject an invalid token", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/verify-email?token=invalidtoken");
+			const response = await request(harness.server).get("/verify-email?token=invalidtoken");
 
 			expect(response.status).toBe(400);
 			const doc = new JSDOM(response.text).window.document;
@@ -163,9 +116,9 @@ describe("Email verification", () => {
 		});
 
 		it("should reject when no token is provided", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/verify-email");
+			const response = await request(harness.server).get("/verify-email");
 
 			expect(response.status).toBe(400);
 			const doc = new JSDOM(response.text).window.document;
@@ -173,10 +126,11 @@ describe("Email verification", () => {
 		});
 
 		it("should reject a token that has already been used", async () => {
-			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email, stripe } = harness;
 
 			await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "once@example.com",
@@ -188,8 +142,8 @@ describe("Email verification", () => {
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
-			await request(app).get(`/verify-email?token=${token}`);
-			const secondResponse = await request(app).get(`/verify-email?token=${token}`);
+			await request(harness.server).get(`/verify-email?token=${token}`);
+			const secondResponse = await request(harness.server).get(`/verify-email?token=${token}`);
 
 			expect(secondResponse.status).toBe(400);
 			const doc = new JSDOM(secondResponse.text).window.document;
@@ -197,10 +151,11 @@ describe("Email verification", () => {
 		});
 
 		it("should mark email as verified after successful verification", async () => {
-			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "flag@example.com",
@@ -222,7 +177,7 @@ describe("Email verification", () => {
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
-			await request(app).get(`/verify-email?token=${token}`).set("Cookie", `hutch_sid=${sessionId}`);
+			await request(harness.server).get(`/verify-email?token=${token}`).set("Cookie", `hutch_sid=${sessionId}`);
 
 			const updatedSession = await auth.getSessionUserId(sessionId);
 			assert(updatedSession, "Expected session to exist after verification");
@@ -230,10 +185,11 @@ describe("Email verification", () => {
 		});
 
 		it("should not mark email as verified when token is invalid", async () => {
-			const { app, auth, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, stripe } = harness;
 
 			const { successResponse } = await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "noverify@example.com",
@@ -246,7 +202,7 @@ describe("Email verification", () => {
 			assert(sessionMatch, "Expected session cookie");
 			const sessionId = sessionMatch[1];
 
-			await request(app).get("/verify-email?token=invalidtoken").set("Cookie", `hutch_sid=${sessionId}`);
+			await request(harness.server).get("/verify-email?token=invalidtoken").set("Cookie", `hutch_sid=${sessionId}`);
 
 			const session = await auth.getSessionUserId(sessionId);
 			assert(session, "Expected session to exist");
@@ -254,10 +210,11 @@ describe("Email verification", () => {
 		});
 
 		it("should send a welcome email after successful verification", async () => {
-			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email, stripe } = harness;
 
 			await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "welcome@example.com",
@@ -270,7 +227,7 @@ describe("Email verification", () => {
 			assert(tokenMatch, "Expected token in verification email");
 			const token = tokenMatch[1];
 
-			await request(app).get(`/verify-email?token=${token}`);
+			await request(harness.server).get(`/verify-email?token=${token}`);
 
 			const sent = email.getSentEmails();
 			expect(sent).toHaveLength(2);
@@ -283,17 +240,18 @@ describe("Email verification", () => {
 		});
 
 		it("should not send a welcome email when the verification token is invalid", async () => {
-			const { app, auth, email, stripe } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email, stripe } = harness;
 
 			await completeStripeSignup({
-				app,
+				server: harness.server,
 				auth,
 				stripe,
 				email: "nowelcome@example.com",
 				password: "password123",
 			});
 
-			await request(app).get("/verify-email?token=invalidtoken");
+			await request(harness.server).get("/verify-email?token=invalidtoken");
 
 			const sent = email.getSentEmails();
 			expect(sent).toHaveLength(1);

--- a/projects/hutch/src/runtime/web/auth/forgot-password.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.route.test.ts
@@ -1,18 +1,20 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
+const useApp = useTestServer();
+
 describe("Forgot password", () => {
 	describe("GET /forgot-password", () => {
 		it("should render the forgot password form", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/forgot-password");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/forgot-password");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -23,10 +25,11 @@ describe("Forgot password", () => {
 
 	describe("POST /forgot-password", () => {
 		it("should show confirmation page for existing user", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "user@example.com", password: "password123" });
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "user@example.com" });
@@ -37,9 +40,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should show same confirmation page for non-existing user", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "nobody@example.com" });
@@ -50,10 +53,11 @@ describe("Forgot password", () => {
 		});
 
 		it("should send a password reset email for existing user", async () => {
-			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email } = harness;
 			await auth.createUser({ email: "user@example.com", password: "password123" });
 
-			await request(app)
+			await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "user@example.com" });
@@ -67,9 +71,10 @@ describe("Forgot password", () => {
 		});
 
 		it("should not send email for non-existing user", async () => {
-			const { app, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { email } = harness;
 
-			await request(app)
+			await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "nobody@example.com" });
@@ -78,9 +83,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should show validation error for invalid email", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "" });
@@ -93,9 +98,9 @@ describe("Forgot password", () => {
 
 	describe("GET /reset-password", () => {
 		it("should render the reset password form with a valid token", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/reset-password?token=sometoken");
+			const response = await request(harness.server).get("/reset-password?token=sometoken");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -103,9 +108,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should show error when no token is provided", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/reset-password");
+			const response = await request(harness.server).get("/reset-password");
 
 			expect(response.status).toBe(400);
 			const doc = new JSDOM(response.text).window.document;
@@ -115,10 +120,11 @@ describe("Forgot password", () => {
 
 	describe("POST /reset-password", () => {
 		it("should reset password with a valid token", async () => {
-			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email } = harness;
 			await auth.createUser({ email: "user@example.com", password: "oldpassword1" });
 
-			await request(app)
+			await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "user@example.com" });
@@ -128,7 +134,7 @@ describe("Forgot password", () => {
 			assert(tokenMatch, "Expected token in password reset email");
 			const token = tokenMatch[1];
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post(`/reset-password?token=${token}`)
 				.type("form")
 				.send({ password: "newpassword1", confirmPassword: "newpassword1" });
@@ -137,7 +143,7 @@ describe("Forgot password", () => {
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector("h1")?.textContent).toBe("Password reset");
 
-			const loginResponse = await request(app)
+			const loginResponse = await request(harness.server)
 				.post("/login")
 				.type("form")
 				.send({ email: "user@example.com", password: "newpassword1" });
@@ -145,9 +151,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should reject an invalid token", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/reset-password?token=invalidtoken")
 				.type("form")
 				.send({ password: "newpassword1", confirmPassword: "newpassword1" });
@@ -158,10 +164,11 @@ describe("Forgot password", () => {
 		});
 
 		it("should reject a token that has already been used", async () => {
-			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email } = harness;
 			await auth.createUser({ email: "user@example.com", password: "oldpassword1" });
 
-			await request(app)
+			await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "user@example.com" });
@@ -171,12 +178,12 @@ describe("Forgot password", () => {
 			assert(tokenMatch, "Expected token in password reset email");
 			const token = tokenMatch[1];
 
-			await request(app)
+			await request(harness.server)
 				.post(`/reset-password?token=${token}`)
 				.type("form")
 				.send({ password: "newpassword1", confirmPassword: "newpassword1" });
 
-			const secondResponse = await request(app)
+			const secondResponse = await request(harness.server)
 				.post(`/reset-password?token=${token}`)
 				.type("form")
 				.send({ password: "anotherpass1", confirmPassword: "anotherpass1" });
@@ -187,9 +194,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should show error when no token is provided", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/reset-password")
 				.type("form")
 				.send({ password: "newpassword1", confirmPassword: "newpassword1" });
@@ -200,9 +207,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should show validation error for mismatched passwords", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/reset-password?token=sometoken")
 				.type("form")
 				.send({ password: "newpassword1", confirmPassword: "differentpass" });
@@ -213,9 +220,9 @@ describe("Forgot password", () => {
 		});
 
 		it("should show validation error for short password", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.post("/reset-password?token=sometoken")
 				.type("form")
 				.send({ password: "short", confirmPassword: "short" });
@@ -226,10 +233,11 @@ describe("Forgot password", () => {
 		});
 
 		it("should not allow login with old password after reset", async () => {
-			const { app, auth, email } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, email } = harness;
 			await auth.createUser({ email: "user@example.com", password: "oldpassword1" });
 
-			await request(app)
+			await request(harness.server)
 				.post("/forgot-password")
 				.type("form")
 				.send({ email: "user@example.com" });
@@ -239,12 +247,12 @@ describe("Forgot password", () => {
 			assert(tokenMatch, "Expected token in password reset email");
 			const token = tokenMatch[1];
 
-			await request(app)
+			await request(harness.server)
 				.post(`/reset-password?token=${token}`)
 				.type("form")
 				.send({ password: "newpassword1", confirmPassword: "newpassword1" });
 
-			const loginResponse = await request(app)
+			const loginResponse = await request(harness.server)
 				.post("/login")
 				.type("form")
 				.send({ email: "user@example.com", password: "oldpassword1" });
@@ -254,8 +262,8 @@ describe("Forgot password", () => {
 
 	describe("Login page", () => {
 		it("should have a forgot password link", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/login");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/login");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;

--- a/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.route.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -45,11 +45,13 @@ function freshState(overrides?: { returnUrl?: string }) {
 	return { nonce: "test-nonce", returnUrl: overrides?.returnUrl, createdAt: Date.now() };
 }
 
+const useApp = useTestServer();
+
 describe("Google auth routes", () => {
 	describe("GET /auth/google", () => {
 		it("should redirect to Google with correct params and set state cookie", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange(),
@@ -57,7 +59,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			const response = await request(app).get("/auth/google");
+			const response = await request(harness.server).get("/auth/google");
 
 			expect(response.status).toBe(303);
 			const location = new URL(response.headers.location);
@@ -75,7 +77,7 @@ describe("Google auth routes", () => {
 	describe("GET /auth/google/callback", () => {
 		it("should 400 when required params are missing", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange(),
@@ -83,7 +85,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			const response = await request(app).get("/auth/google/callback");
+			const response = await request(harness.server).get("/auth/google/callback");
 
 			expect(response.status).toBe(400);
 			const doc = new JSDOM(response.text).window.document;
@@ -92,7 +94,7 @@ describe("Google auth routes", () => {
 
 		it("should 400 when state cookie is missing", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange(),
@@ -100,7 +102,7 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get("/auth/google/callback?code=test-code&state=something");
 
 			expect(response.status).toBe(400);
@@ -108,7 +110,7 @@ describe("Google auth routes", () => {
 
 		it("should 400 when state cookie does not match state param", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange(),
@@ -117,7 +119,7 @@ describe("Google auth routes", () => {
 				},
 			});
 			const state = signState(freshState());
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", "hutch_gstate=different-value");
 
@@ -126,7 +128,7 @@ describe("Google auth routes", () => {
 
 		it("should 400 when state signature is tampered", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange(),
@@ -136,7 +138,7 @@ describe("Google auth routes", () => {
 			});
 			const valid = signState(freshState());
 			const tampered = `${valid.slice(0, -4)}XXXX`;
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(tampered)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(tampered)}`);
 
@@ -145,7 +147,7 @@ describe("Google auth routes", () => {
 
 		it("should 400 when state is expired", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange(),
@@ -154,7 +156,7 @@ describe("Google auth routes", () => {
 				},
 			});
 			const expiredState = signState({ nonce: "n", createdAt: Date.now() - 10 * 60 * 1000 });
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(expiredState)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(expiredState)}`);
 
@@ -166,7 +168,7 @@ describe("Google auth routes", () => {
 		it("should 400 when token exchange throws", async () => {
 			const errors: string[] = [];
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: async () => { throw new Error("network down"); },
@@ -184,7 +186,7 @@ describe("Google auth routes", () => {
 				},
 			});
 			const state = signState(freshState());
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -194,7 +196,7 @@ describe("Google auth routes", () => {
 
 		it("should 400 when Google email is not verified", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ emailVerified: false }),
@@ -203,7 +205,7 @@ describe("Google auth routes", () => {
 				},
 			});
 			const state = signState(freshState());
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -214,7 +216,7 @@ describe("Google auth routes", () => {
 
 		it("creates the user directly and skips Stripe when below the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth, pendingSignup } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "free-google@example.com" }),
@@ -222,11 +224,12 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			const { auth, pendingSignup } = harness;
 			// Only one founding member
 			await auth.createUser({ email: `seed1@test.com`, password: "password123" });
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -246,7 +249,7 @@ describe("Google auth routes", () => {
 		it("logs in the existing user when a race condition causes createGoogleUser to fail during free signup", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			let raceFindCount = 0;
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				auth: {
 					...fixture.auth,
@@ -267,7 +270,7 @@ describe("Google auth routes", () => {
 			await fixture.auth.createUser({ email: "race-google@example.com", password: "existing" });
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -282,7 +285,7 @@ describe("Google auth routes", () => {
 		it("marks email verified during race condition when existing user is unverified", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			let raceFindCount = 0;
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				auth: {
 					...fixture.auth,
@@ -305,7 +308,7 @@ describe("Google auth routes", () => {
 			expect(beforeLookup?.emailVerified).toBe(false);
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -316,7 +319,7 @@ describe("Google auth routes", () => {
 
 		it("renders error when race condition causes createGoogleUser to fail and user cannot be found", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				auth: {
 					...fixture.auth,
@@ -334,7 +337,7 @@ describe("Google auth routes", () => {
 			});
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -345,7 +348,7 @@ describe("Google auth routes", () => {
 
 		it("redirects a brand-new user through Stripe when at the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "brand-new@example.com" }),
@@ -353,12 +356,13 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			const { auth } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -371,7 +375,7 @@ describe("Google auth routes", () => {
 
 		it("should create the Google user only after successful Stripe checkout when at the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth, stripe } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "brand-new@example.com" }),
@@ -379,11 +383,12 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			const { auth, stripe } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState());
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			const callbackResponse = await agent
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
@@ -407,7 +412,7 @@ describe("Google auth routes", () => {
 
 		it("should preserve the return URL through the Stripe checkout boundary when at the founding limit", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth, stripe } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "return@example.com" }),
@@ -415,11 +420,12 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			const { auth, stripe } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
 			}
 			const state = signState(freshState({ returnUrl: "/save?url=https%3A%2F%2Fexample.com" }));
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			const callbackResponse = await agent
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
@@ -438,7 +444,7 @@ describe("Google auth routes", () => {
 
 		it("should reuse an existing verified email/password account and keep the password working", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "existing@example.com" }),
@@ -446,13 +452,14 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			const { auth } = harness;
 			const createResult = await auth.createUser({ email: "existing@example.com", password: "password123" });
 			assert(createResult.ok, "setup failed");
 			await auth.markEmailVerified("existing@example.com");
 			const existingUserId = createResult.userId;
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 
@@ -469,7 +476,7 @@ describe("Google auth routes", () => {
 
 		it("should upgrade an unverified email/password account to verified", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				google: {
 					exchangeGoogleCode: stubExchange({ email: "unverified@example.com" }),
@@ -477,12 +484,13 @@ describe("Google auth routes", () => {
 					clientSecret: "test-google-client-secret",
 				},
 			});
+			const { auth } = harness;
 			await auth.createUser({ email: "unverified@example.com", password: "password123" });
 			const beforeLookup = await auth.findUserByEmail("unverified@example.com");
 			expect(beforeLookup?.emailVerified).toBe(false);
 			const state = signState(freshState());
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/auth/google/callback?code=test-code&state=${encodeURIComponent(state)}`)
 				.set("Cookie", `hutch_gstate=${encodeURIComponent(state)}`);
 

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
+import type { Server } from "node:http";
 import type { SuperTest, Test } from "supertest";
 import request from "supertest";
-import type { Express } from "express";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import type { CheckoutSessionId } from "@packages/test-fixtures/providers/stripe-checkout";
 import type { AuthBundle } from "../../../test-app";
@@ -21,7 +21,7 @@ interface StripeBundle {
  * subsequent signup onto the paid path. Tests with custom limits pass
  * `foundingMemberLimit` explicitly. */
 export async function completeStripeSignup(params: {
-	app: Express;
+	server: Server;
 	auth: AuthBundle;
 	stripe: StripeBundle;
 	email: string;
@@ -43,7 +43,7 @@ export async function completeStripeSignup(params: {
 		}
 	}
 
-	const agent = params.agent ?? request.agent(params.app);
+	const agent = params.agent ?? request.agent(params.server);
 	const signupPath = params.returnUrl
 		? `/signup?return=${encodeURIComponent(params.returnUrl)}`
 		: "/signup";

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import { createHash, randomBytes } from "node:crypto";
 import request from "supertest";
 import type { Token } from "@node-oauth/oauth2-server";
-import { createTestApp } from "../../test-app";
+import { useTestServer } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -20,12 +20,14 @@ const TEST_USER_ID = "test-user-123" as UserId;
 const TEST_CLIENT_ID = "hutch-firefox-extension";
 const TEST_REDIRECT_URI = "http://127.0.0.1:3000/oauth/callback";
 
+const useApp = useTestServer();
+
 describe("OAuth routes", () => {
 	describe("GET /oauth/authorize", () => {
 		it("redirects to login if not authenticated", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app).get("/oauth/authorize").query({
+			const response = await request(harness.server).get("/oauth/authorize").query({
 				client_id: TEST_CLIENT_ID,
 				redirect_uri: TEST_REDIRECT_URI,
 				response_type: "code",
@@ -38,13 +40,13 @@ describe("OAuth routes", () => {
 		});
 
 		it("shows authorization form when authenticated", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			await testApp.auth.createUser({
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -64,9 +66,9 @@ describe("OAuth routes", () => {
 		});
 
 		it("returns 400 for unknown client", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app).get("/oauth/authorize").query({
+			const response = await request(harness.server).get("/oauth/authorize").query({
 				client_id: "unknown-client",
 				redirect_uri: TEST_REDIRECT_URI,
 				response_type: "code",
@@ -79,9 +81,9 @@ describe("OAuth routes", () => {
 		});
 
 		it("returns 400 for invalid redirect_uri", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app).get("/oauth/authorize").query({
+			const response = await request(harness.server).get("/oauth/authorize").query({
 				client_id: TEST_CLIENT_ID,
 				redirect_uri: "https://evil.com/callback",
 				response_type: "code",
@@ -94,9 +96,9 @@ describe("OAuth routes", () => {
 		});
 
 		it("returns 400 for missing parameters", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app).get("/oauth/authorize").query({
+			const response = await request(harness.server).get("/oauth/authorize").query({
 				client_id: TEST_CLIENT_ID,
 			});
 
@@ -107,9 +109,9 @@ describe("OAuth routes", () => {
 
 	describe("POST /oauth/authorize", () => {
 		it("returns 401 if not authenticated", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app)
+			const response = await request(harness.server)
 				.post("/oauth/authorize")
 				.type("form")
 				.send({
@@ -125,13 +127,13 @@ describe("OAuth routes", () => {
 		});
 
 		it("redirects with error when denied", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			await testApp.auth.createUser({
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -154,13 +156,13 @@ describe("OAuth routes", () => {
 		});
 
 		it("includes state in deny redirect when provided", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			await testApp.auth.createUser({
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -184,14 +186,14 @@ describe("OAuth routes", () => {
 		});
 
 		it("approves authorization and redirects with code", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const pkce = generatePKCE();
-			await testApp.auth.createUser({
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -215,13 +217,13 @@ describe("OAuth routes", () => {
 		});
 
 		it("returns 400 for deny with missing required fields", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			await testApp.auth.createUser({
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -239,13 +241,13 @@ describe("OAuth routes", () => {
 		});
 
 		it("returns 400 for deny with invalid redirect_uri (prevents open redirect)", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			await testApp.auth.createUser({
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -267,14 +269,14 @@ describe("OAuth routes", () => {
 
 	describe("POST /oauth/token", () => {
 		it("exchanges authorization code for access token", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const pkce = generatePKCE();
-			await testApp.auth.createUser({
+			await harness.auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
 
-			const agent = request.agent(testApp.app);
+			const agent = request.agent(harness.server);
 			await agent.post("/login").type("form").send({
 				email: "test@example.com",
 				password: "password123",
@@ -297,7 +299,7 @@ describe("OAuth routes", () => {
 			const code = redirectUrl.searchParams.get("code");
 			assert(code, "Authorization code must be present in redirect");
 
-			const tokenResponse = await request(testApp.app)
+			const tokenResponse = await request(harness.server)
 				.post("/oauth/token")
 				.type("form")
 				.send({
@@ -317,11 +319,11 @@ describe("OAuth routes", () => {
 
 	describe("POST /oauth/revoke", () => {
 		it("revokes refresh token and returns 200", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const client = await testApp.oauthModel.getClient(TEST_CLIENT_ID, "");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const client = await harness.oauthModel.getClient(TEST_CLIENT_ID, "");
 			assert(client, "Test client must exist");
 
-			await testApp.oauthModel.saveToken(
+			await harness.oauthModel.saveToken(
 				{
 					accessToken: "revoke-access",
 					accessTokenExpiresAt: new Date(Date.now() + 3600000),
@@ -332,22 +334,22 @@ describe("OAuth routes", () => {
 				{ id: TEST_USER_ID },
 			);
 
-			const response = await request(testApp.app)
+			const response = await request(harness.server)
 				.post("/oauth/revoke")
 				.send({ token: "revoke-refresh" });
 
 			expect(response.status).toBe(200);
 
-			const revokedToken = await testApp.oauthModel.getRefreshToken(
+			const revokedToken = await harness.oauthModel.getRefreshToken(
 				"revoke-refresh",
 			);
 			expect(revokedToken).toBeNull();
 		});
 
 		it("returns 400 without token parameter", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app)
+			const response = await request(harness.server)
 				.post("/oauth/revoke")
 				.send({});
 
@@ -356,11 +358,11 @@ describe("OAuth routes", () => {
 		});
 
 		it("revokes via access token and removes associated refresh token", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const client = await testApp.oauthModel.getClient(TEST_CLIENT_ID, "");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const client = await harness.oauthModel.getClient(TEST_CLIENT_ID, "");
 			assert(client, "Test client must exist");
 
-			await testApp.oauthModel.saveToken(
+			await harness.oauthModel.saveToken(
 				{
 					accessToken: "access-for-revoke",
 					accessTokenExpiresAt: new Date(Date.now() + 3600000),
@@ -371,22 +373,22 @@ describe("OAuth routes", () => {
 				{ id: TEST_USER_ID },
 			);
 
-			const response = await request(testApp.app)
+			const response = await request(harness.server)
 				.post("/oauth/revoke")
 				.send({ token: "access-for-revoke" });
 
 			expect(response.status).toBe(200);
 
-			const revokedRefresh = await testApp.oauthModel.getRefreshToken(
+			const revokedRefresh = await harness.oauthModel.getRefreshToken(
 				"refresh-for-revoke",
 			);
 			expect(revokedRefresh).toBeNull();
 		});
 
 		it("returns 200 for non-existent token (RFC compliance)", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app)
+			const response = await request(harness.server)
 				.post("/oauth/revoke")
 				.send({ token: "non-existent-token" });
 
@@ -396,9 +398,9 @@ describe("OAuth routes", () => {
 
 	describe("GET /oauth/callback", () => {
 		it("returns authorization complete page", async () => {
-			const testApp = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(testApp.app).get("/oauth/callback");
+			const response = await request(harness.server).get("/oauth/callback");
 
 			expect(response.status).toBe(200);
 			expect(response.text).toContain("Authorization Complete");

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
@@ -1,8 +1,9 @@
+import type { Server } from "node:http";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { MinutesSchema } from "@packages/domain/article";
 import type { ParseArticle, ParseArticleResult } from "@packages/test-fixtures/providers/article-parser";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppHarness } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -31,13 +32,15 @@ function buildParseResult(): ParseArticleResult {
 }
 
 interface RecrawlHarness {
-	app: TestAppResult["app"];
-	auth: TestAppResult["auth"];
-	articleStore: TestAppResult["articleStore"];
-	articleCrawl: TestAppResult["articleCrawl"];
+	server: Server;
+	auth: TestAppHarness["auth"];
+	articleStore: TestAppHarness["articleStore"];
+	articleCrawl: TestAppHarness["articleCrawl"];
 	summary: ReturnType<typeof createFakeSummaryProvider>;
 	recrawlPublishedCalls: { url: string }[];
 }
+
+const useApp = useTestServer();
 
 function buildHarness(options: { adminEmails: readonly string[] }): RecrawlHarness {
 	const parseArticle: ParseArticle = async () => buildParseResult();
@@ -56,7 +59,7 @@ function buildHarness(options: { adminEmails: readonly string[] }): RecrawlHarne
 		recrawlPublishedCalls.push(params);
 	};
 
-	const { app, auth, articleStore, articleCrawl } = createTestApp({
+	const harness = useApp({
 		...fixture,
 		parser:{
  	parseArticle: parseArticle,
@@ -78,15 +81,22 @@ function buildHarness(options: { adminEmails: readonly string[] }): RecrawlHarne
  },
 	});
 
-	return { app, auth, articleStore, articleCrawl, summary, recrawlPublishedCalls };
+	return {
+		server: harness.server,
+		auth: harness.auth,
+		articleStore: harness.articleStore,
+		articleCrawl: harness.articleCrawl,
+		summary,
+		recrawlPublishedCalls,
+	};
 }
 
 async function loginAs(
-	app: RecrawlHarness["app"],
+	server: Server,
 	email: string,
 	password: string,
 ) {
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent.post("/login").type("form").send({ email, password });
 	return agent;
 }
@@ -94,18 +104,18 @@ async function loginAs(
 describe("Admin recrawl routes", () => {
 	describe("authorization", () => {
 		it("redirects unauthenticated visitors to /login (303)", async () => {
-			const { app } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 
-			const response = await request(app).get(`/admin/recrawl/${ENCODED}`);
+			const response = await request(server).get(`/admin/recrawl/${ENCODED}`);
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
 		});
 
 		it("returns 403 when the logged-in user's email is not in the allowlist", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: OTHER_EMAIL, password: OTHER_PASSWORD });
-			const agent = await loginAs(app, OTHER_EMAIL, OTHER_PASSWORD);
+			const agent = await loginAs(server, OTHER_EMAIL, OTHER_PASSWORD);
 
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
@@ -114,9 +124,9 @@ describe("Admin recrawl routes", () => {
 		});
 
 		it("returns 403 when the allowlist is empty (fail-closed)", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [] });
+			const { server, auth } = buildHarness({ adminEmails: [] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
@@ -126,9 +136,9 @@ describe("Admin recrawl routes", () => {
 
 	describe("GET /admin/recrawl (landing)", () => {
 		it("renders the landing form for an admin with no ?url query", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get("/admin/recrawl");
 
@@ -140,9 +150,9 @@ describe("Admin recrawl routes", () => {
 		});
 
 		it("redirects submitted ?url to the encoded article path", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(`/admin/recrawl?url=${encodeURIComponent(ARTICLE_URL)}`);
 
@@ -151,9 +161,9 @@ describe("Admin recrawl routes", () => {
 		});
 
 		it("returns 404 when the submitted ?url is not a valid URL", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get("/admin/recrawl?url=not-a-url");
 
@@ -163,9 +173,9 @@ describe("Admin recrawl routes", () => {
 
 	describe("GET /admin/recrawl/:url", () => {
 		it("returns 404 when the URL is not already in the articles DB", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
@@ -184,7 +194,7 @@ describe("Admin recrawl routes", () => {
 			await harness.articleStore.setContentSourceTier({ url: ARTICLE_URL, tier: "tier-0" });
 			await harness.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
 			expect(response.status).toBe(200);
@@ -207,7 +217,7 @@ describe("Admin recrawl routes", () => {
 			await harness.articleStore.setContentSourceTier({ url: ARTICLE_URL, tier: "tier-1" });
 			await harness.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
@@ -228,7 +238,7 @@ describe("Admin recrawl routes", () => {
 			});
 			await harness.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
@@ -256,7 +266,7 @@ describe("Admin recrawl routes", () => {
 			// recrawl must flip it back to `pending` via forceMarkCrawlPending.
 			await harness.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
@@ -297,7 +307,7 @@ describe("Admin recrawl routes", () => {
 				excerpt: "Stale excerpt blurb",
 			});
 
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
 
@@ -309,9 +319,9 @@ describe("Admin recrawl routes", () => {
 
 	describe("GET /admin/recrawl/reader (poll) — validation", () => {
 		it("returns 400 when the ?url query is missing", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get("/admin/recrawl/reader");
 
@@ -321,9 +331,9 @@ describe("Admin recrawl routes", () => {
 
 	describe("GET /admin/recrawl/summary (poll) — validation", () => {
 		it("returns 400 when the ?url query is missing", async () => {
-			const { app, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
-			const agent = await loginAs(app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get("/admin/recrawl/summary");
 
@@ -347,7 +357,7 @@ describe("Admin recrawl routes", () => {
 				savedAt: new Date(),
 			});
 			await harness.articleCrawl.markCrawlPending({ url: ARTICLE_URL });
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(
 				`/admin/recrawl/summary?url=${encodeURIComponent(ARTICLE_URL)}`,
@@ -375,7 +385,7 @@ describe("Admin recrawl routes", () => {
 				savedAt: new Date(),
 			});
 			await harness.articleCrawl.markCrawlPending({ url: ARTICLE_URL });
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(
 				`/admin/recrawl/reader?url=${encodeURIComponent(ARTICLE_URL)}`,
@@ -403,7 +413,7 @@ describe("Admin recrawl routes", () => {
 			});
 			await harness.articleCrawl.markCrawlPending({ url: ARTICLE_URL });
 
-			const agent = await loginAs(harness.app, ADMIN_EMAIL, ADMIN_PASSWORD);
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
 			const response = await agent.get(
 				`/admin/recrawl/reader?url=${encodeURIComponent(ARTICLE_URL)}&poll=1`,

--- a/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -13,17 +13,19 @@ import { initBlogPosts } from "./blog.posts";
 const blogPosts = initBlogPosts({ foundingMemberLimit: 3 });
 const firstPost = blogPosts.getAllPosts()[0];
 
-describe("GET /blog", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+const useApp = useTestServer();
 
+describe("GET /blog", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("should render blog page title", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		const title = doc.querySelector(".blog__title");
@@ -31,7 +33,8 @@ describe("GET /blog", () => {
 	});
 
 	it("should render links to blog posts", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		const link = doc.querySelector(
@@ -41,7 +44,8 @@ describe("GET /blog", () => {
 	});
 
 	it("should render post titles in the listing", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cardTitles = doc.querySelectorAll(".blog-card__title");
@@ -50,14 +54,16 @@ describe("GET /blog", () => {
 	});
 
 	it("should have correct SEO title", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.title).toBe("Blog — Readplace");
 	});
 
 	it("should have canonical URL", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		const canonical = doc.querySelector('link[rel="canonical"]');
@@ -67,14 +73,16 @@ describe("GET /blog", () => {
 	});
 
 	it("should have the page-blog body class", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.body.classList.contains("page-blog")).toBe(true);
 	});
 
 	it("should have Blog and BreadcrumbList structured data", async () => {
-		const response = await request(app).get("/blog");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog");
 		const doc = new JSDOM(response.text).window.document;
 
 		const scripts = doc.querySelectorAll(
@@ -113,10 +121,9 @@ describe("GET /blog", () => {
 });
 
 describe("GET /blog/:slug", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should return 200 for a valid post slug", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		expect(response.status).toBe(200);
@@ -124,7 +131,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should render the post title as h1", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -134,7 +142,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should render the post content as HTML", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -144,7 +153,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should render post metadata", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -157,7 +167,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should have og:type set to article", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -167,7 +178,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should have BlogPosting structured data", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -182,7 +194,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should have BreadcrumbList structured data", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -220,7 +233,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should have correct canonical URL", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -232,7 +246,8 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should have the page-blog-post body class", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			`/blog/${firstPost.slug}`,
 		);
 		const doc = new JSDOM(response.text).window.document;
@@ -241,28 +256,30 @@ describe("GET /blog/:slug", () => {
 	});
 
 	it("should return 404 for an unknown slug", async () => {
-		const response = await request(app).get("/blog/nonexistent-post");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog/nonexistent-post");
 		expect(response.status).toBe(404);
 	});
 });
 
 describe("old hutch-vs-* slug redirects", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should 301 redirect hutch-vs-readwise-reader to readplace-vs-readwise-reader", async () => {
-		const response = await request(app).get("/blog/hutch-vs-readwise-reader");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog/hutch-vs-readwise-reader");
 		expect(response.status).toBe(301);
 		expect(response.headers.location).toBe("/blog/readplace-vs-readwise-reader");
 	});
 
 	it("should 301 redirect hutch-vs-instapaper to readplace-vs-instapaper", async () => {
-		const response = await request(app).get("/blog/hutch-vs-instapaper");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog/hutch-vs-instapaper");
 		expect(response.status).toBe(301);
 		expect(response.headers.location).toBe("/blog/readplace-vs-instapaper");
 	});
 
 	it("should 301 redirect hutch-vs-karakeep to readplace-vs-karakeep", async () => {
-		const response = await request(app).get("/blog/hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog/hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later");
 		expect(response.status).toBe(301);
 		expect(response.headers.location).toBe("/blog/readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later");
 	});
@@ -270,10 +287,10 @@ describe("old hutch-vs-* slug redirects", () => {
 
 describe("hutch-app.com blog redirect", () => {
 	it("should 301 redirect /blog to readplace.com", async () => {
-		const { app } = createTestApp(
+		const harness = useApp(
 			createDefaultTestAppFixture("https://readplace.com"),
 		);
-		const response = await request(app)
+		const response = await request(harness.server)
 			.get("/blog")
 			.set("Host", "hutch-app.com");
 		expect(response.status).toBe(301);
@@ -281,10 +298,10 @@ describe("hutch-app.com blog redirect", () => {
 	});
 
 	it("should 301 redirect /blog/:slug to readplace.com", async () => {
-		const { app } = createTestApp(
+		const harness = useApp(
 			createDefaultTestAppFixture("https://readplace.com"),
 		);
-		const response = await request(app)
+		const response = await request(harness.server)
 			.get(`/blog/${firstPost.slug}`)
 			.set("Host", "hutch-app.com");
 		expect(response.status).toBe(301);
@@ -295,15 +312,15 @@ describe("hutch-app.com blog redirect", () => {
 });
 
 describe("GET /sitemap.xml", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should include /blog in the sitemap", async () => {
-		const response = await request(app).get("/sitemap.xml");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/sitemap.xml");
 		expect(response.text).toContain("<loc>http://localhost:3000/blog</loc>");
 	});
 
 	it("should include blog post URLs in the sitemap", async () => {
-		const response = await request(app).get("/sitemap.xml");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/sitemap.xml");
 		expect(response.text).toContain(
 			`<loc>http://localhost:3000/blog/${firstPost.slug}</loc>`,
 		);
@@ -311,10 +328,9 @@ describe("GET /sitemap.xml", () => {
 });
 
 describe("GET /blog with Accept: text/markdown", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("returns 200 with text/markdown content-type and an x-markdown-tokens header", async () => {
-		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog").set("Accept", "text/markdown");
 
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
@@ -322,7 +338,8 @@ describe("GET /blog with Accept: text/markdown", () => {
 	});
 
 	it("emits the site-wide Content-Signal policy and Vary: Accept", async () => {
-		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog").set("Accept", "text/markdown");
 
 		expect(response.headers["content-signal"]).toBe(
 			"search=yes, ai-input=yes, ai-train=no",
@@ -331,14 +348,16 @@ describe("GET /blog with Accept: text/markdown", () => {
 	});
 
 	it("renders the page heading as the markdown h1 and lists the first post title", async () => {
-		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog").set("Accept", "text/markdown");
 
 		expect(response.text.startsWith("# Blog")).toBe(true);
 		expect(response.text).toContain(firstPost.title);
 	});
 
 	it("does not include the rendered HTML chrome (no <script>, no htmx, no data-test-*)", async () => {
-		const response = await request(app).get("/blog").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/blog").set("Accept", "text/markdown");
 
 		expect(response.text).not.toContain("<script");
 		expect(response.text).not.toContain("hx-boost");
@@ -347,10 +366,9 @@ describe("GET /blog with Accept: text/markdown", () => {
 });
 
 describe("GET /blog/:slug with Accept: text/markdown", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("returns 200 with text/markdown content-type and the canonical URL header in frontmatter", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get(`/blog/${firstPost.slug}`)
 			.set("Accept", "text/markdown");
 
@@ -362,7 +380,8 @@ describe("GET /blog/:slug with Accept: text/markdown", () => {
 	});
 
 	it("serves the raw markdown source verbatim, without going through HTML conversion", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get(`/blog/${firstPost.slug}`)
 			.set("Accept", "text/markdown");
 
@@ -371,10 +390,9 @@ describe("GET /blog/:slug with Accept: text/markdown", () => {
 });
 
 describe("HTML responses now carry the Content-Signal header", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("sets Content-Signal: search=yes, ai-input=yes, ai-train=no on a plain HTML GET", async () => {
-		const response = await request(app).get(`/blog/${firstPost.slug}`);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(`/blog/${firstPost.slug}`);
 
 		expect(response.headers["content-signal"]).toBe(
 			"search=yes, ai-input=yes, ai-train=no",

--- a/projects/hutch/src/runtime/web/pages/e2e-fixture/e2e-fixture.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/e2e-fixture/e2e-fixture.route.test.ts
@@ -2,29 +2,32 @@ import assert from "node:assert/strict";
 import request from "supertest";
 import { JSDOM } from "jsdom";
 import { MAX_SUMMARY_LENGTH } from "save-link/generate-summary";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-describe("GET /e2e/article/:id", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+const useApp = useTestServer();
 
+describe("GET /e2e/article/:id", () => {
 	it("returns 200 HTML for any :id", async () => {
-		const response = await request(app).get("/e2e/article/12345-anon-view");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/e2e/article/12345-anon-view");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("returns the same body regardless of :id (uniqueness lives in the URL, not the content)", async () => {
-		const a = await request(app).get("/e2e/article/run-a-slot-1");
-		const b = await request(app).get("/e2e/article/run-b-slot-99");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const a = await request(harness.server).get("/e2e/article/run-a-slot-1");
+		const b = await request(harness.server).get("/e2e/article/run-b-slot-99");
 		expect(a.text).toBe(b.text);
 	});
 
 	it("renders an <article> with an <h1> so Mozilla Readability can extract the body cleanly", async () => {
-		const response = await request(app).get("/e2e/article/x");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/e2e/article/x");
 		const doc = new JSDOM(response.text).window.document;
 		const article = doc.querySelector("article");
 		assert(article, "<article> must be rendered");
@@ -33,14 +36,16 @@ describe("GET /e2e/article/:id", () => {
 	});
 
 	it("is marked noindex so search engines do not pick up the fixture URLs", async () => {
-		const response = await request(app).get("/e2e/article/x");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/e2e/article/x");
 		const doc = new JSDOM(response.text).window.document;
 		const robots = doc.querySelector('meta[name="robots"]')?.getAttribute("content");
 		expect(robots).toBe("noindex, nofollow");
 	});
 
 	it("contains enough visible body text to clear the summariser's short-circuit threshold", async () => {
-		const response = await request(app).get("/e2e/article/x");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/e2e/article/x");
 		const doc = new JSDOM(response.text).window.document;
 		const article = doc.querySelector("article");
 		const visibleLength = (article?.textContent ?? "").replace(/\s/g, "").length;

--- a/projects/hutch/src/runtime/web/pages/embed/embed.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/embed/embed.route.test.ts
@@ -1,24 +1,35 @@
 import assert from "node:assert/strict";
+import type { Server } from "node:http";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import express from "express";
 import { initEmbedRoutes } from "./embed.page";
 
-function makeApp(overrides?: { appOrigin?: string }) {
+const servers: Server[] = [];
+afterEach(async () => {
+	/** server.close only errors when the socket was never bound, which can't
+	 * happen here because makeServer always returns from listen(0). Ignore the
+	 * err arg so coverage doesn't carry a phantom reject branch. */
+	await Promise.all(servers.splice(0).map((s) => new Promise<void>((resolve) => s.close(() => resolve()))));
+});
+
+function makeServer(overrides?: { appOrigin?: string }): Server {
 	const app = express();
 	app.use("/embed", initEmbedRoutes({ appOrigin: overrides?.appOrigin ?? "https://readplace.com" }));
-	return app;
+	const server = app.listen(0);
+	servers.push(server);
+	return server;
 }
 
 describe("GET /embed", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("should render the hero title inside the embed page container", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const page = doc.querySelector('[data-test-page="embed"]');
 		assert(page, "embed page container must be rendered");
@@ -28,7 +39,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should render all three variants with numeric byte counts", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.querySelectorAll("[data-test-variant]")).toHaveLength(3);
@@ -41,7 +52,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should render a URL input field inside the variants section so publishers can customise the snippets", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const variants = doc.querySelector("#variants");
 		assert(variants, "variants section must be rendered");
@@ -52,7 +63,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should render every variant preview as a live anchor that passes the page URL via the save endpoint", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 
 		for (const id of ["preview-a", "preview-b", "preview-c"] as const) {
@@ -65,7 +76,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should render every snippet source with the canonical save URL and PAGE_URL placeholder", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 
 		for (const id of ["source-a", "source-b", "source-c"] as const) {
@@ -77,7 +88,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should render the hero demo as snippet B pointing at the embed page itself", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const demo = doc.querySelector('[data-test="hero-demo"]');
 		assert(demo, "hero demo container must be rendered");
@@ -87,7 +98,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should render the quotable privacy statement", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const privacy = doc.querySelector('[data-test="privacy-text"]');
 		assert(privacy, "privacy statement must be rendered");
@@ -96,18 +107,18 @@ describe("GET /embed", () => {
 	});
 
 	it("should expose a copy button for every snippet and the privacy paragraph", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		expect(doc.querySelectorAll("button[data-copy]")).toHaveLength(4);
 	});
 
 	it("should include the copy-to-clipboard inline script", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		expect(response.text).toContain("navigator.clipboard");
 	});
 
 	it("should register / with the default indexable robots directive", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const robots = doc.querySelector('meta[name="robots"]');
 		assert(robots, "robots meta must be rendered");
@@ -115,7 +126,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should substitute the Readplace app origin in live preview save links when appOrigin differs from the canonical value", async () => {
-		const response = await request(makeApp({ appOrigin: "http://127.0.0.1:9999" })).get("/embed");
+		const response = await request(makeServer({ appOrigin: "http://127.0.0.1:9999" })).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const previewAnchor = doc.querySelector('[data-test="preview-b"] a');
 		assert(previewAnchor, "preview-b anchor must be rendered");
@@ -123,7 +134,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should substitute the embed origin in live preview icon URLs so the dev server can serve them", async () => {
-		const response = await request(makeApp({ appOrigin: "http://localhost:3700" })).get("/embed");
+		const response = await request(makeServer({ appOrigin: "http://localhost:3700" })).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const previewImg = doc.querySelector('[data-test="preview-a"] img');
 		assert(previewImg, "preview-a img must be rendered");
@@ -131,7 +142,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should keep the canonical readplace.com URLs and PAGE_URL placeholder inside the copy-paste source blocks regardless of config", async () => {
-		const response = await request(makeApp({ appOrigin: "http://127.0.0.1:9999" })).get("/embed");
+		const response = await request(makeServer({ appOrigin: "http://127.0.0.1:9999" })).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const source = doc.querySelector('[data-test="source-b"]');
 		assert(source, "source-b must be rendered");
@@ -141,7 +152,7 @@ describe("GET /embed", () => {
 	});
 
 	it("should link the footer back to the Readplace app origin", async () => {
-		const response = await request(makeApp()).get("/embed");
+		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;
 		const link = doc.querySelector('[data-test="link-app"]');
 		assert(link, "app link must be rendered");
@@ -151,13 +162,13 @@ describe("GET /embed", () => {
 
 describe("GET /embed/preview", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(makeApp()).get("/embed/preview");
+		const response = await request(makeServer()).get("/embed/preview");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("should be marked noindex so search engines skip the developer preview", async () => {
-		const response = await request(makeApp()).get("/embed/preview");
+		const response = await request(makeServer()).get("/embed/preview");
 		const doc = new JSDOM(response.text).window.document;
 		const robots = doc.querySelector('meta[name="robots"]');
 		assert(robots, "robots meta must be rendered");
@@ -165,7 +176,7 @@ describe("GET /embed/preview", () => {
 	});
 
 	it("should render one stage per background", async () => {
-		const response = await request(makeApp()).get("/embed/preview");
+		const response = await request(makeServer()).get("/embed/preview");
 		const doc = new JSDOM(response.text).window.document;
 		for (const bg of ["white", "surface", "dark"] as const) {
 			const stage = doc.querySelector(`[data-test-bg="${bg}"]`);
@@ -174,7 +185,7 @@ describe("GET /embed/preview", () => {
 	});
 
 	it("should render each variant once inside every background stage", async () => {
-		const response = await request(makeApp()).get("/embed/preview");
+		const response = await request(makeServer()).get("/embed/preview");
 		const doc = new JSDOM(response.text).window.document;
 		const stages = doc.querySelectorAll(".embed-preview__stage");
 		expect(stages).toHaveLength(3);
@@ -186,7 +197,7 @@ describe("GET /embed/preview", () => {
 
 describe("GET /embed/icon.svg", () => {
 	it("should return the embed icon SVG with the correct content type and immutable cache header", async () => {
-		const response = await request(makeApp())
+		const response = await request(makeServer())
 			.get("/embed/icon.svg")
 			.buffer(true)
 			.parse((res, cb) => {

--- a/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
@@ -1,6 +1,7 @@
+import type { Server } from "node:http";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppHarness } from "../../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
@@ -8,11 +9,11 @@ import {
 } from "@packages/test-fixtures";
 
 async function loginAgent(
-	app: TestAppResult['app'],
-	auth: TestAppResult['auth'],
+	server: Server,
+	auth: TestAppHarness["auth"],
 ) {
 	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent
 		.post("/login")
 		.type("form")
@@ -20,11 +21,13 @@ async function loginAgent(
 	return agent;
 }
 
+const useApp = useTestServer();
+
 describe("Export routes", () => {
 	describe("GET /export (unauthenticated)", () => {
 		it("should redirect to /login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/export");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/export");
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
@@ -33,8 +36,8 @@ describe("Export routes", () => {
 
 	describe("GET /export (authenticated)", () => {
 		it("renders the landing page with a POST form pointing at /export/start", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/export");
 
@@ -51,8 +54,8 @@ describe("Export routes", () => {
 		});
 
 		it("renders a 'preparing' confirmation when ?status=preparing is present", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/export?status=preparing");
 
@@ -67,8 +70,8 @@ describe("Export routes", () => {
 
 	describe("POST /export/start (unauthenticated)", () => {
 		it("should redirect to /login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).post("/export/start");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).post("/export/start");
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
@@ -83,8 +86,8 @@ describe("Export routes", () => {
 			fixture.auth.findEmailByUserId = async () => null;
 			let published = 0;
 			fixture.events.publishExportUserDataCommand = async () => { published++; };
-			const { app, auth } = createTestApp(fixture);
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.post("/export/start");
 
@@ -104,8 +107,8 @@ describe("Export routes", () => {
 			fixture.events.publishExportUserDataCommand = async (params) => {
 				published.push(params);
 			};
-			const { app, auth } = createTestApp(fixture);
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.post("/export/start");
 

--- a/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
@@ -1,25 +1,11 @@
-import type { Server } from "node:http";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { useTestServer, type TestAppHarness } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
-
-async function loginAgent(
-	server: Server,
-	auth: TestAppHarness["auth"],
-) {
-	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(server);
-	await agent
-		.post("/login")
-		.type("form")
-		.send({ email: "test@example.com", password: "password123" });
-	return agent;
-}
 
 const useApp = useTestServer();
 

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -18,17 +18,19 @@ const TEST_FOUNDING_MEMBER_LIMIT = 3;
  * test can enumerate blog slugs without reaching into the app's internals. */
 const blogPosts = initBlogPosts({ foundingMemberLimit: TEST_FOUNDING_MEMBER_LIMIT });
 
-describe("GET /", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+const useApp = useTestServer();
 
+describe("GET /", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("should render the hero headline with the full word list for screen readers", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const srOnly = doc.querySelector(".home-hero__title .sr-only");
@@ -36,7 +38,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the visible headline portion aria-hidden with the initial rotator word", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const visible = doc.querySelector(".home-hero__title .hero-headline__visible");
@@ -48,14 +51,16 @@ describe("GET /", () => {
 	});
 
 	it("should include the headline word-swap client script", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		expect(response.text).toContain("hero-headline__rotator");
 		expect(response.text).toContain("newsletters");
 		expect(response.text).toContain("longreads");
 	});
 
 	it("should render a generic install CTA when browser is unrecognized", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
@@ -64,7 +69,8 @@ describe("GET /", () => {
 	});
 
 	it("should render Firefox install CTA when User-Agent is Firefox", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get("/")
 			.set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0");
 		const doc = new JSDOM(response.text).window.document;
@@ -78,7 +84,8 @@ describe("GET /", () => {
 	});
 
 	it("should render Chrome install CTA when User-Agent is Chrome", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get("/")
 			.set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36");
 		const doc = new JSDOM(response.text).window.document;
@@ -92,7 +99,8 @@ describe("GET /", () => {
 	});
 
 	it("should render Chrome install CTA when User-Agent is Edge", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get("/")
 			.set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0");
 		const doc = new JSDOM(response.text).window.document;
@@ -102,7 +110,8 @@ describe("GET /", () => {
 	});
 
 	it("should render generic trust line when browser is unrecognized", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const trust = doc.querySelector(".home-hero__trust");
@@ -110,7 +119,8 @@ describe("GET /", () => {
 	});
 
 	it("should render browser-specific bottom install CTA for Firefox", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get("/")
 			.set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0");
 		const doc = new JSDOM(response.text).window.document;
@@ -121,7 +131,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the public reader-view paste-link form with UTM hidden inputs", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const form = doc.querySelector("[data-test-home-try-form]");
@@ -146,7 +157,8 @@ describe("GET /", () => {
 	});
 
 	it("should redirect homepage paste-link submissions to /view/<encoded-url> preserving UTM on the logged pageview", async () => {
-		const response = await request(app).get(
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
 			"/view?url=https%3A%2F%2Fexample.com%2Farticle&utm_source=homepage&utm_medium=internal&utm_content=homepage-link-input",
 		);
 		expect(response.status).toBe(302);
@@ -156,7 +168,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the secondary CTA linking to GitHub", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector('[data-test-cta="view-github"]');
@@ -165,7 +178,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the core features section with shipped features only", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const coreSection = doc.querySelector('[data-test-section="core-features"]');
@@ -174,7 +188,8 @@ describe("GET /", () => {
 	});
 
 	it("should render three demo videos: Desktop, Firefox Extension, and Chrome Extension", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const demoSection = doc.querySelector('[data-test-section="demo"]');
@@ -184,7 +199,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the backstory section", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const backstory = doc.querySelector('[data-test-section="backstory"]');
@@ -192,7 +208,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the founding pricing card and hide the fallback CTA when under the limit", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const founding = doc.querySelector('[data-test-plan="founding"]');
@@ -210,7 +227,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the founding members progress bar with zero users", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const progress = doc.querySelector("[data-test-founding-progress]");
@@ -223,7 +241,8 @@ describe("GET /", () => {
 
 
 	it("should render the comparison table", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const table = doc.querySelector("[data-test-comparison-table]");
@@ -232,7 +251,8 @@ describe("GET /", () => {
 	});
 
 	it("should render the trust section with two trust items", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const trustSection = doc.querySelector('[data-test-section="trust"]');
@@ -242,14 +262,16 @@ describe("GET /", () => {
 
 
 	it("should have page-home body class", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.body.classList.contains("page-home")).toBe(true);
 	});
 
 	it("should set appropriate SEO metadata", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.title).toContain("Readplace");
@@ -259,7 +281,8 @@ describe("GET /", () => {
 	});
 
 	it("should include author and keywords meta tags", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const author = doc.querySelector('meta[name="author"]');
@@ -270,7 +293,8 @@ describe("GET /", () => {
 	});
 
 	it("should include Open Graph image alt text", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const ogImageAlt = doc.querySelector('meta[property="og:image:alt"]');
@@ -278,7 +302,8 @@ describe("GET /", () => {
 	});
 
 	it("should not include twitter:site when no handle is configured", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const twitterSite = doc.querySelector('meta[name="twitter:site"]');
@@ -286,7 +311,8 @@ describe("GET /", () => {
 	});
 
 	it("should include multiple structured data schemas", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const scripts = doc.querySelectorAll('script[type="application/ld+json"]');
@@ -297,7 +323,8 @@ describe("GET /", () => {
 	});
 
 	it("should include FAQ structured data with questions and answers", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const scripts = doc.querySelectorAll('script[type="application/ld+json"]');
@@ -309,7 +336,8 @@ describe("GET /", () => {
 	});
 
 	it("should render section landmarks with aria-labels", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const hero = doc.querySelector('[data-test-section="hero"]');
@@ -320,7 +348,8 @@ describe("GET /", () => {
 	});
 
 	it("should use scope attributes on comparison table headers", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const colHeaders = doc.querySelectorAll('[data-test-comparison-table] thead th[scope="col"]');
@@ -333,26 +362,28 @@ describe("GET /", () => {
 
 describe("GET / with exhausted founding allocation", () => {
 	it("should hide the founding progress when users exceed the limit", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
 
 		for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 			await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
 		}
 
-		const response = await request(app).get("/");
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.querySelector("[data-test-founding-progress]")).toBeNull();
 	}, 30000);
 
 	it("should hide the founding pricing card and show the fallback CTA when over the limit", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
 
 		for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
 			await auth.createUser({ email: `over${i}@test.com`, password: "password123" });
 		}
 
-		const response = await request(app).get("/");
+		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
 		const founding = doc.querySelector('[data-test-plan="founding"]');
@@ -368,40 +399,38 @@ describe("GET / with exhausted founding allocation", () => {
 });
 
 describe("GET /favicon.ico", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should 301 redirect to the static CDN's favicon.ico", async () => {
-		const response = await request(app).get("/favicon.ico");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/favicon.ico");
 		expect(response.status).toBe(301);
 		expect(response.headers.location).toBe("https://static.test/favicon.ico");
 	});
 });
 
 describe("GET /apple-touch-icon*.png", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it.each([
 		"/apple-touch-icon.png",
 		"/apple-touch-icon-precomposed.png",
 		"/apple-touch-icon-57x57.png",
 		"/apple-touch-icon-180x180.png",
 	])("should 301 redirect %s to the static CDN", async (path) => {
-		const response = await request(app).get(path);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(path);
 		expect(response.status).toBe(301);
 		expect(response.headers.location).toBe(`https://static.test${path}`);
 	});
 
 	it("should fall through to 404 for paths that don't match the apple-touch-icon shape", async () => {
-		const response = await request(app).get("/apple-touch-icon-invalid.png");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/apple-touch-icon-invalid.png");
 		expect(response.status).toBe(404);
 	});
 });
 
 describe("GET /robots.txt", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should return a text response with crawl directives", async () => {
-		const response = await request(app).get("/robots.txt");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/robots.txt");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/plain/);
 		expect(response.text).toContain("User-agent: *");
@@ -412,10 +441,9 @@ describe("GET /robots.txt", () => {
 });
 
 describe("GET /llms.txt", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should return a text response with the product overview", async () => {
-		const response = await request(app).get("/llms.txt");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/llms.txt");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/plain/);
 		expect(response.text).toContain("# Readplace");
@@ -424,16 +452,16 @@ describe("GET /llms.txt", () => {
 	});
 
 	it("advertises the markdown content-negotiation capability", async () => {
-		const response = await request(app).get("/llms.txt");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/llms.txt");
 		expect(response.text).toContain("Accept: text/markdown");
 	});
 });
 
 describe("GET / with Accept: text/markdown", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("returns 200 with text/markdown content-type instead of redirecting to /queue", async () => {
-		const response = await request(app).get("/").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/").set("Accept", "text/markdown");
 
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
@@ -441,13 +469,15 @@ describe("GET / with Accept: text/markdown", () => {
 	});
 
 	it("converts the comparison table into markdown table syntax", async () => {
-		const response = await request(app).get("/").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/").set("Accept", "text/markdown");
 
 		expect(response.text).toMatch(/\|\s+-+\s+\|/);
 	});
 
 	it("emits the Content-Signal policy and Vary: Accept", async () => {
-		const response = await request(app).get("/").set("Accept", "text/markdown");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/").set("Accept", "text/markdown");
 
 		expect(response.headers["content-signal"]).toBe(
 			"search=yes, ai-input=yes, ai-train=no",
@@ -457,10 +487,9 @@ describe("GET / with Accept: text/markdown", () => {
 });
 
 describe("GET / HTML response gains the Content-Signal header", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("sets the site-wide Content-Signal policy on plain HTML GETs", async () => {
-		const response = await request(app).get("/");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
 
 		expect(response.headers["content-signal"]).toBe(
 			"search=yes, ai-input=yes, ai-train=no",
@@ -470,10 +499,9 @@ describe("GET / HTML response gains the Content-Signal header", () => {
 });
 
 describe("GET /llms-full.txt", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should return a text response with the full product details", async () => {
-		const response = await request(app).get("/llms-full.txt");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/llms-full.txt");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/plain/);
 		expect(response.text).toContain("# Readplace");
@@ -484,10 +512,9 @@ describe("GET /llms-full.txt", () => {
 });
 
 describe("GET /sitemap.xml", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should return an XML sitemap with exactly the public pages", async () => {
-		const response = await request(app).get("/sitemap.xml");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/sitemap.xml");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/application\/xml/);
 
@@ -509,10 +536,9 @@ describe("GET /sitemap.xml", () => {
 });
 
 describe("GET /nonexistent", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
 	it("should return 404", async () => {
-		const response = await request(app).get("/nonexistent");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/nonexistent");
 		expect(response.status).toBe(404);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -1,21 +1,11 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { useTestServer, type TestAppHarness } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
-
-async function loginAgent(server: import("node:http").Server, auth: TestAppHarness["auth"]) {
-	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(server);
-	await agent
-		.post("/login")
-		.type("form")
-		.send({ email: "test@example.com", password: "password123" });
-	return agent;
-}
 
 function summaryText(doc: Document): string {
 	return doc.querySelector("[data-test-import-summary]")?.textContent?.replace(/\s+/g, " ").trim() ?? "";

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -1,15 +1,15 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppHarness } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-async function loginAgent(app: TestAppResult["app"], auth: TestAppResult["auth"]) {
+async function loginAgent(server: import("node:http").Server, auth: TestAppHarness["auth"]) {
 	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent
 		.post("/login")
 		.type("form")
@@ -39,11 +39,13 @@ function multipartBody(filename: string, content: Buffer): { body: Buffer; conte
 	};
 }
 
+const useApp = useTestServer();
+
 describe("Import routes", () => {
 	describe("GET /import (unauthenticated)", () => {
 		it("redirects to /login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/import?feature=import");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/import?feature=import");
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
 		});
@@ -51,8 +53,8 @@ describe("Import routes", () => {
 
 	describe("GET /import (authenticated)", () => {
 		it("renders the upload form when the feature flag is on", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?feature=import");
 
@@ -67,8 +69,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects to /queue when the feature flag is missing", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import");
 
@@ -77,8 +79,8 @@ describe("Import routes", () => {
 		});
 
 		it("renders the import_no_urls message when error_code=import_no_urls", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?feature=import&error_code=import_no_urls");
 
@@ -90,8 +92,8 @@ describe("Import routes", () => {
 		});
 
 		it("renders the import_too_large message when error_code=import_too_large", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?feature=import&error_code=import_too_large");
 
@@ -102,8 +104,8 @@ describe("Import routes", () => {
 		});
 
 		it("renders the import_session_not_found message when error_code=import_session_not_found", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?feature=import&error_code=import_session_not_found");
 
@@ -114,8 +116,8 @@ describe("Import routes", () => {
 		});
 
 		it("does not render the error banner when no error_code is present", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?feature=import");
 
@@ -126,8 +128,8 @@ describe("Import routes", () => {
 
 	describe("POST /import (unauthenticated)", () => {
 		it("redirects to /login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).post("/import");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).post("/import");
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
 		});
@@ -135,8 +137,8 @@ describe("Import routes", () => {
 
 	describe("POST /import", () => {
 		it("creates a session and redirects to the review page when URLs are found", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from(
 				"<a href=\"https://example.com/post-1\">x</a> https://example.com/post-2",
 			);
@@ -152,8 +154,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects with import_no_urls when no URLs are found", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const { body, contentType } = multipartBody("empty.txt", Buffer.from("just some prose"));
 
 			const response = await agent
@@ -166,8 +168,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects with import_too_large when the upload exceeds the size cap", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			// 6 MiB body — overshoots the 5 MiB cap so express.raw aborts with
 			// `entity.too.large`, which the size-limit error handler maps to the
 			// import_too_large flash.
@@ -184,8 +186,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects with import_no_urls for non-multipart bodies", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent
 				.post("/import")
@@ -199,8 +201,8 @@ describe("Import routes", () => {
 
 	describe("GET /import/:id", () => {
 		it("renders the review screen with all URLs checked by default", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from(
 				"https://example.com/post-1 https://example.com/post-2 https://example.com/post-3",
 			);
@@ -224,8 +226,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects to /queue for an invalid session id", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import/not-a-session-id");
 
@@ -235,16 +237,17 @@ describe("Import routes", () => {
 
 		it("redirects with import_session_not_found when the session is owned by another user", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth } = createTestApp(fixture);
+			const harness = useApp(fixture);
+			const { auth } = harness;
 			await auth.createUser({ email: "owner@example.com", password: "password123" });
-			const owner = request.agent(app);
+			const owner = request.agent(harness.server);
 			await owner.post("/login").type("form").send({ email: "owner@example.com", password: "password123" });
 			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/owned"));
 			const create = await owner.post("/import").set("Content-Type", contentType).send(body);
 			const sessionPath = create.headers.location;
 
 			await auth.createUser({ email: "intruder@example.com", password: "password123" });
-			const intruder = request.agent(app);
+			const intruder = request.agent(harness.server);
 			await intruder.post("/login").type("form").send({ email: "intruder@example.com", password: "password123" });
 
 			const response = await intruder.get(sessionPath);
@@ -254,8 +257,8 @@ describe("Import routes", () => {
 		});
 
 		it("paginates results across pages", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
 			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -272,8 +275,8 @@ describe("Import routes", () => {
 
 	describe("POST /import/:id/toggle", () => {
 		it("deselects a row and updates the selection summary", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -297,8 +300,8 @@ describe("Import routes", () => {
 		});
 
 		it("returns 422 for malformed body", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/a"));
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
 
@@ -311,8 +314,8 @@ describe("Import routes", () => {
 		});
 
 		it("returns 422 for an invalid session id format", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent
 				.post("/import/not-an-id/toggle")
@@ -325,8 +328,8 @@ describe("Import routes", () => {
 
 	describe("GET /import/:id master checkbox", () => {
 		it("renders the master checkbox checked when every row is selected", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -341,8 +344,8 @@ describe("Import routes", () => {
 		});
 
 		it("renders the master checkbox unchecked-with-indeterminate when partially selected", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -362,8 +365,8 @@ describe("Import routes", () => {
 		});
 
 		it("renders the master checkbox unchecked with no indeterminate marker when all are deselected", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -382,8 +385,8 @@ describe("Import routes", () => {
 
 	describe("POST /import/:id/toggle-all", () => {
 		it("deselects every row and updates the summary to 0 of N", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b https://example.com/c");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -406,8 +409,8 @@ describe("Import routes", () => {
 		});
 
 		it("re-selects every row from a partially-deselected state", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -433,8 +436,8 @@ describe("Import routes", () => {
 		});
 
 		it("deselects rows on pages the user is not currently viewing", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
 			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -452,8 +455,8 @@ describe("Import routes", () => {
 		});
 
 		it("preserves the current page in the redirect", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
 			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -469,8 +472,8 @@ describe("Import routes", () => {
 		});
 
 		it("returns 422 for malformed body", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/a"));
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
 
@@ -483,8 +486,8 @@ describe("Import routes", () => {
 		});
 
 		it("returns 422 for an invalid session id format", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent
 				.post("/import/not-an-id/toggle-all")
@@ -497,8 +500,9 @@ describe("Import routes", () => {
 
 	describe("POST /import/:id/commit", () => {
 		it("imports selected URLs into the user's queue and deletes the session", async () => {
-			const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from(
 				"https://example.com/a https://example.com/b https://example.com/c",
 			);
@@ -527,8 +531,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects when the session id is malformed", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.post("/import/not-an-id/commit");
 
@@ -537,8 +541,8 @@ describe("Import routes", () => {
 		});
 
 		it("redirects when the session no longer exists", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.post("/import/00000000000000000000000000000000/commit");
 
@@ -547,8 +551,9 @@ describe("Import routes", () => {
 		});
 
 		it("skips non-saveable URLs, imports the rest, and reports skipped count in the redirect", async () => {
-			const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from(
 				"https://example.com/a http://localhost:3000/queue http://router.home.arpa/ https://example.com/b",
 			);
@@ -573,8 +578,8 @@ describe("Import routes", () => {
 		});
 
 		it("does not set the import_skipped cookie when every URL is saveable", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from("https://example.com/a https://example.com/b");
 			const { body, contentType } = multipartBody("urls.txt", file);
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
@@ -591,8 +596,8 @@ describe("Import routes", () => {
 		});
 
 		it("renders the skipped URLs on /queue after commit and clears the cookie on first view", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const file = Buffer.from(
 				"https://example.com/a http://localhost/secret http://router.home.arpa/",
 			);

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -1,7 +1,7 @@
 import { firefoxS3Config } from "browser-extension-core/s3-config";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -27,24 +27,27 @@ afterEach(() => {
 	jest.restoreAllMocks();
 });
 
-describe("GET /install", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+const useApp = useTestServer();
 
+describe("GET /install", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(app).get("/install");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("should have page-install body class", async () => {
-		const response = await request(app).get("/install");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.body.classList.contains("page-install")).toBe(true);
 	});
 
 	it("should default to Chrome tab when no browser param is provided", async () => {
-		const response = await request(app).get("/install");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
 		const doc = new JSDOM(response.text).window.document;
 
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
@@ -56,7 +59,8 @@ describe("GET /install", () => {
 	});
 
 	it("should select Firefox tab when browser=firefox", async () => {
-		const response = await request(app).get("/install?browser=firefox");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxTab = doc.querySelector('[data-test-tab="firefox"]');
@@ -68,7 +72,8 @@ describe("GET /install", () => {
 	});
 
 	it("should select Chrome tab when browser=chrome", async () => {
-		const response = await request(app).get("/install?browser=chrome");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=chrome");
 		const doc = new JSDOM(response.text).window.document;
 
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
@@ -79,7 +84,8 @@ describe("GET /install", () => {
 	});
 
 	it("should render Firefox panel content when browser=firefox", async () => {
-		const response = await request(app).get("/install?browser=firefox");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxPanel = doc.querySelector('[data-test-section="firefox"]');
@@ -88,7 +94,8 @@ describe("GET /install", () => {
 	});
 
 	it("should render Chrome panel content when browser=chrome", async () => {
-		const response = await request(app).get("/install?browser=chrome");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=chrome");
 		const doc = new JSDOM(response.text).window.document;
 
 		const chromePanel = doc.querySelector('[data-test-section="chrome"]');
@@ -97,7 +104,8 @@ describe("GET /install", () => {
 	});
 
 	it("should render the Firefox download button linking to the S3 XPI", async () => {
-		const response = await request(app).get("/install?browser=firefox");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector(
@@ -107,7 +115,8 @@ describe("GET /install", () => {
 	});
 
 	it("should render the Chrome download button linking to the Chrome Web Store", async () => {
-		const response = await request(app).get("/install?browser=chrome");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=chrome");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector(
@@ -118,7 +127,8 @@ describe("GET /install", () => {
 	});
 
 	it("should set appropriate SEO metadata", async () => {
-		const response = await request(app).get("/install");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.title).toContain("Install");
@@ -127,7 +137,8 @@ describe("GET /install", () => {
 	});
 
 	it("should have SoftwareApplication and BreadcrumbList structured data", async () => {
-		const response = await request(app).get("/install");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
 		const doc = new JSDOM(response.text).window.document;
 
 		const scripts = doc.querySelectorAll(
@@ -169,7 +180,8 @@ describe("GET /install", () => {
 			return new Response("Not Found", { status: 404 });
 		});
 
-		const response = await request(app).get("/install?browser=firefox");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.querySelector('[data-test-cta="download-firefox"]')).toBeNull();
@@ -185,7 +197,8 @@ describe("GET /install", () => {
 			return new Response("", { status: 200 });
 		});
 
-		const response = await request(app).get("/install?browser=firefox");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		expect(doc.querySelector('[data-test-cta="download-firefox"]')).toBeNull();
@@ -196,7 +209,8 @@ describe("GET /install", () => {
 	});
 
 	it("should link tabs to the correct URLs", async () => {
-		const response = await request(app).get("/install?browser=firefox");
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxTab = doc.querySelector('[data-test-tab="firefox"]');
@@ -207,7 +221,8 @@ describe("GET /install", () => {
 	});
 
 	it("returns markdown when Accept: text/markdown is sent", async () => {
-		const response = await request(app)
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server)
 			.get("/install")
 			.set("Accept", "text/markdown");
 

--- a/projects/hutch/src/runtime/web/pages/privacy/privacy.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/privacy/privacy.route.test.ts
@@ -1,21 +1,23 @@
 import request from "supertest";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-describe("GET /privacy", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+const useApp = useTestServer();
 
+describe("GET /privacy", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(app).get("/privacy");
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(server).get("/privacy");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("returns markdown when Accept: text/markdown is sent", async () => {
-		const response = await request(app)
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(server)
 			.get("/privacy")
 			.set("Accept", "text/markdown");
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
@@ -11,16 +11,16 @@ import {
 	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
 import { ONBOARDING_VERSION } from "../../onboarding/onboarding.steps";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppResult } from "../../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-async function loginAgent(app: TestAppResult['app'], auth: TestAppResult['auth']) {
+async function loginAgent(server: import("node:http").Server, auth: TestAppResult['auth']) {
 	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent
 		.post("/login")
 		.type("form")
@@ -28,10 +28,13 @@ async function loginAgent(app: TestAppResult['app'], auth: TestAppResult['auth']
 	return agent;
 }
 
+const useApp = useTestServer();
+
 describe("Queue onboarding", () => {
 	it("shows onboarding visible with both steps incomplete on empty queue", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent.get("/queue");
 
@@ -50,8 +53,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("does not complete save-first-article when the article was saved via the web form", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		await agent
 			.post("/queue/save")
@@ -70,8 +74,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("marks save-first-article complete when extension save cookie is present", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -84,8 +89,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("marks install-extension complete when alive cookie is present", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -102,8 +108,9 @@ describe("Queue onboarding", () => {
 	 * the extension is currently installed. The server must ignore it for
 	 * onboarding purposes — only the httpOnly hutch_ext_alive cookie counts. */
 	it("does not mark install-extension complete when only the legacy hutch_ext_installed cookie is present", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -116,8 +123,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("shows success message when both the alive and extension-save cookies are present", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -134,8 +142,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("shows 'Install the Chrome browser extension' for Chrome user-agent", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -148,8 +157,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("shows 'Install the Firefox browser extension' for Firefox user-agent", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -162,8 +172,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("shows 'Install a browser extension' for unrecognised user-agent", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -176,8 +187,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("shows success state even when viewing an empty filter tab", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue?status=read")
@@ -217,8 +229,9 @@ describe("Queue onboarding", () => {
 	 *      re-renders, proving the legacy cookie does not satisfy dismissal.
 	 */
 	it("does not render onboarding when dismiss cookie matches current version and extension is alive", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -230,8 +243,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("re-renders onboarding when dismiss cookie is present but alive cookie is missing", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -252,8 +266,9 @@ describe("Queue onboarding", () => {
 	 * written by the content script) but the httpOnly hutch_ext_alive lapses
 	 * once Siren requests stop. Onboarding must come back. */
 	it("re-renders onboarding after uninstall (dismiss + legacy cookie present, alive cookie missing)", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -269,8 +284,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("re-renders onboarding when dismiss cookie has a stale version", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent
 			.get("/queue")
@@ -283,8 +299,9 @@ describe("Queue onboarding", () => {
 	});
 
 	it("POST /queue/dismiss-onboarding sets dismiss cookie to current version and redirects to /queue", async () => {
-		const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const agent = await loginAgent(app, auth);
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		const response = await agent.post("/queue/dismiss-onboarding");
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
-import request from "supertest";
 import {
 	ALIVE_COOKIE_NAME,
 	ALIVE_COOKIE_VALUE,
@@ -11,22 +10,12 @@ import {
 	SAVE_COOKIE_VALUE,
 } from "@packages/onboarding-extension-signal";
 import { ONBOARDING_VERSION } from "../../onboarding/onboarding.steps";
-import { useTestServer, type TestAppResult } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
-
-async function loginAgent(server: import("node:http").Server, auth: TestAppResult['auth']) {
-	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(server);
-	await agent
-		.post("/login")
-		.type("form")
-		.send({ email: "test@example.com", password: "password123" });
-	return agent;
-}
 
 const useApp = useTestServer();
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
@@ -2,21 +2,23 @@ import request from "supertest";
 import { initRefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
 import type { PublishRefreshArticleContent } from "@packages/test-fixtures/providers/events";
 import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/providers/events";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppResult } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-async function loginAgent(app: TestAppResult["app"], auth: TestAppResult["auth"]) {
+async function loginAgent(server: import("node:http").Server, auth: TestAppResult["auth"]) {
 	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent
 		.post("/login")
 		.type("form")
 		.send({ email: "test@example.com", password: "password123" });
 	return agent;
 }
+
+const useApp = useTestServer();
 
 describe("Queue freshness integration", () => {
 	it("publishes UpdateFetchTimestampCommand on first save, then RefreshArticleContentCommand on re-save", async () => {
@@ -53,7 +55,7 @@ describe("Queue freshness integration", () => {
 			staleTtlMs: 0,
 		});
 
-		const { app, auth } = createTestApp({
+		const harness = useApp({
 			...fixture,
 			events: {
 				publishLinkSaved: fixture.events.publishLinkSaved,
@@ -66,7 +68,8 @@ describe("Queue freshness integration", () => {
 			},
 			freshness: { refreshArticleIfStale },
 		});
-		const agent = await loginAgent(app, auth);
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
 
 		await agent
 			.post("/queue/save")

--- a/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
@@ -1,22 +1,11 @@
-import request from "supertest";
 import { initRefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
 import type { PublishRefreshArticleContent } from "@packages/test-fixtures/providers/events";
 import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/providers/events";
-import { useTestServer, type TestAppResult } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
-
-async function loginAgent(server: import("node:http").Server, auth: TestAppResult["auth"]) {
-	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(server);
-	await agent
-		.post("/login")
-		.type("form")
-		.send({ email: "test@example.com", password: "password123" });
-	return agent;
-}
 
 const useApp = useTestServer();
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { MinutesSchema } from "@packages/domain/article";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppResult } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -16,9 +16,9 @@ import {
 
 import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
 
-async function loginAgent(app: TestAppResult['app'], auth: TestAppResult['auth']) {
+async function loginAgent(server: import("node:http").Server, auth: TestAppResult['auth']) {
 	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent
 		.post("/login")
 		.type("form")
@@ -26,11 +26,13 @@ async function loginAgent(app: TestAppResult['app'], auth: TestAppResult['auth']
 	return agent;
 }
 
+const useApp = useTestServer();
+
 describe("Queue routes", () => {
 	describe("GET /queue (unauthenticated)", () => {
 		it("should redirect to /login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/queue");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/queue");
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
@@ -39,8 +41,9 @@ describe("Queue routes", () => {
 
 	describe("GET /queue (authenticated)", () => {
 		it("should render the empty queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 
@@ -49,13 +52,13 @@ describe("Queue routes", () => {
 			expect(doc.querySelector("[data-test-empty-queue]")?.textContent).toContain("empty");
 			expect(doc.querySelector('[data-test-form="save-article"]')?.getAttribute("action")).toBe("/queue/save");
 		});
-
 	});
 
 	describe("POST /queue/save", () => {
 		it("should save an article and redirect", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const saveResponse = await agent
 				.post("/queue/save")
@@ -72,8 +75,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should show error for invalid URL", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -86,8 +90,9 @@ describe("Queue routes", () => {
 		});
 
 		it("rejects a chrome:// URL with an unsupported-scheme message and never saves", async () => {
-			const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -105,8 +110,9 @@ describe("Queue routes", () => {
 		});
 
 		it("rejects a localhost URL with a private-network message and never saves", async () => {
-			const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -124,8 +130,9 @@ describe("Queue routes", () => {
 		});
 
 		it("rejects a .home.arpa URL with a private-network message", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -151,8 +158,9 @@ describe("Queue routes", () => {
 
 			for (const { url, code } of cases) {
 				it(`rejects ${JSON.stringify(url)} with ${code} and never saves`, async () => {
-					const { app, auth, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-					const agent = await loginAgent(app, auth);
+					const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+					const { auth, articleStore } = harness;
+					const agent = await loginAgent(harness.server, auth);
 
 					const response = await agent
 						.post("/queue/save")
@@ -174,11 +182,12 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect with error code when save throws", async () => {
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
 				freshness: { refreshArticleIfStale: async () => { throw new Error("boom"); } },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -190,8 +199,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should render error banner when queue is loaded with error_code=save_failed", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue?error_code=save_failed");
 
@@ -203,7 +213,7 @@ describe("Queue routes", () => {
 		it("does NOT re-prime via /queue/save when refreshArticleIfStale returns 'skip' for a previously-failed crawl (auto-heal removed; operator owns recovery)", async () => {
 			const publishedLinkSaved: { url: string; userId: string }[] = [];
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth, articleStore, articleCrawl } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				events: {
 					publishLinkSaved: async (params) => { publishedLinkSaved.push(params); },
@@ -216,7 +226,8 @@ describe("Queue routes", () => {
 				},
 				freshness: { refreshArticleIfStale: async () => ({ action: "skip" }) },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth, articleStore, articleCrawl } = harness;
+			const agent = await loginAgent(harness.server, auth);
 			await articleStore.saveArticleGlobally({
 				url: "https://example.com/article",
 				metadata: { title: "Failed", siteName: "example.com", excerpt: "", wordCount: 0 },
@@ -235,8 +246,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should bump a re-saved article to the top so #latest-saved points to it", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -272,8 +284,9 @@ describe("Queue routes", () => {
 
 	describe("POST /queue/:id/status", () => {
 		it("should mark article as read", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -298,8 +311,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect preserving queue view state from query params", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -319,8 +333,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect to queue when status value is invalid", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -341,8 +356,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect without error for malformed article id", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const statusResponse = await agent
 				.post("/queue/not-a-valid-hash/status")
@@ -356,8 +372,9 @@ describe("Queue routes", () => {
 
 	describe("POST /queue/:id/delete", () => {
 		it("should delete article", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -379,8 +396,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect preserving queue view state from query params", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -397,8 +415,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect without error for malformed article id", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const deleteResponse = await agent.post("/queue/not-a-valid-hash/delete");
 
@@ -409,8 +428,9 @@ describe("Queue routes", () => {
 
 	describe("Read status indicators", () => {
 		it("should show unread indicator on newly saved articles", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -425,8 +445,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should remove unread indicator after marking as read", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -450,8 +471,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should restore unread indicator when marking back as unread", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -480,8 +502,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should not include htmx attributes on article title links", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -511,7 +534,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -524,7 +547,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -541,11 +565,12 @@ describe("Queue routes", () => {
 
 		it("should not render URL link when siteName is empty", async () => {
 			const skipFreshness: RefreshArticleIfStale = async () => ({ action: "skip" });
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
 				freshness: { refreshArticleIfStale: skipFreshness },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -560,8 +585,9 @@ describe("Queue routes", () => {
 
 	describe("Action forms", () => {
 		it("should render action forms from view model for each article", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -578,8 +604,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should enable htmx boost on the mark-read action form", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -612,7 +639,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -625,7 +652,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -657,7 +685,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -670,7 +698,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -685,8 +714,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should not render thumbnail when page has no images", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -712,7 +742,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -725,7 +755,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -754,7 +785,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -767,7 +798,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -799,7 +831,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -812,7 +844,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -848,7 +881,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -861,7 +894,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -902,7 +936,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -915,7 +949,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -938,8 +973,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect to queue for non-existent article", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue/nonexistent/read");
 
@@ -948,9 +984,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect unauthenticated users to login", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/queue/someid/read");
+			const response = await request(harness.server).get("/queue/someid/read");
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/login");
@@ -973,7 +1009,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -986,7 +1022,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1019,7 +1056,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1037,7 +1074,8 @@ describe("Queue routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1079,7 +1117,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1092,7 +1130,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1136,7 +1175,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1154,7 +1193,8 @@ describe("Queue routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1202,7 +1242,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1220,7 +1260,8 @@ describe("Queue routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1266,7 +1307,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1279,7 +1320,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1313,7 +1355,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1326,7 +1368,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1368,7 +1411,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1386,7 +1429,8 @@ describe("Queue routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1421,7 +1465,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1434,7 +1478,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1464,7 +1509,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1477,7 +1522,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1501,8 +1547,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/summary returns 404 for a missing article", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue/00000000000000000000000000000000/summary");
 			expect(response.status).toBe(404);
@@ -1517,7 +1564,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1530,7 +1577,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1571,7 +1619,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1584,7 +1632,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1625,7 +1674,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1638,7 +1687,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1674,7 +1724,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1692,7 +1742,8 @@ describe("Queue routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1726,7 +1777,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1744,7 +1795,8 @@ describe("Queue routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1775,7 +1827,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1797,7 +1849,8 @@ describe("Queue routes", () => {
  	markCrawlUnsupported: fixture.articleCrawl.markCrawlUnsupported,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1830,7 +1883,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -1852,7 +1905,8 @@ describe("Queue routes", () => {
  	markCrawlUnsupported: fixture.articleCrawl.markCrawlUnsupported,
  },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1875,8 +1929,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/reader returns 404 for a missing article", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue/not-a-valid-hash/reader");
 			expect(response.status).toBe(404);
@@ -1896,7 +1951,7 @@ describe("Queue routes", () => {
 			const findArticleCrawlStatus = async () => ({ status: "pending" as const });
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const fixedNow = new Date("2026-04-25T12:00:00.000Z");
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				articleCrawl: {
 					...fixture.articleCrawl,
@@ -1904,7 +1959,8 @@ describe("Queue routes", () => {
 				},
 				shared: { ...fixture.shared, now: () => fixedNow },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -1944,7 +2000,7 @@ describe("Queue routes", () => {
 			// looks like a legacy stub to the reader core.
 			let markCrawlPendingCalls = 0;
 			let markSummaryPendingCalls = 0;
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				articleCrawl: {
 					findArticleCrawlStatus: async () => undefined,
@@ -1966,7 +2022,8 @@ describe("Queue routes", () => {
 					forceMarkSummaryPending: async (_params) => {},
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2010,7 +2067,7 @@ describe("Queue routes", () => {
 					articleCrawl: fixture.articleCrawl,
 					parseArticle,
 				});
-				const { app, auth } = createTestApp({
+				const harness = useApp({
 					...fixture,
 					parser: { parseArticle, crawlArticle },
 					events: {
@@ -2023,7 +2080,8 @@ describe("Queue routes", () => {
 						publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 					},
 				});
-				const agent = await loginAgent(app, auth);
+				const { auth } = harness;
+				const agent = await loginAgent(harness.server, auth);
 
 				await agent.post("/queue/save").type("form").send({ url: articleUrl });
 				const queueDoc = new JSDOM((await agent.get("/queue")).text).window.document;
@@ -2078,7 +2136,7 @@ describe("Queue routes", () => {
 					articleCrawl: fixture.articleCrawl,
 					parseArticle,
 				});
-				const { app, auth } = createTestApp({
+				const harness = useApp({
 					...fixture,
 					parser: { parseArticle, crawlArticle },
 					events: {
@@ -2091,7 +2149,8 @@ describe("Queue routes", () => {
 						publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 					},
 				});
-				const agent = await loginAgent(app, auth);
+				const { auth } = harness;
+				const agent = await loginAgent(harness.server, auth);
 
 				await agent.post("/queue/save").type("form").send({ url: "https://example.com/hint-copy" });
 				const queueDoc = new JSDOM((await agent.get("/queue")).text).window.document;
@@ -2126,7 +2185,7 @@ describe("Queue routes", () => {
 					articleCrawl: fixture.articleCrawl,
 					parseArticle,
 				});
-				const { app, auth } = createTestApp({
+				const harness = useApp({
 					...fixture,
 					parser: { parseArticle, crawlArticle },
 					events: {
@@ -2139,7 +2198,8 @@ describe("Queue routes", () => {
 						publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 					},
 				});
-				const agent = await loginAgent(app, auth);
+				const { auth } = harness;
+				const agent = await loginAgent(harness.server, auth);
 
 				await agent.post("/queue/save").type("form").send({ url: "https://example.com/bundle-boot" });
 				const queueDoc = new JSDOM((await agent.get("/queue")).text).window.document;
@@ -2169,7 +2229,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -2182,7 +2242,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -2202,7 +2263,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -2215,7 +2276,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2236,7 +2298,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -2249,7 +2311,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2278,7 +2341,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -2291,7 +2354,8 @@ describe("Queue routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2308,8 +2372,9 @@ describe("Queue routes", () => {
 
 	describe("Pagination", () => {
 		it("should render pagination links when articles span multiple pages", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			for (let i = 0; i < 21; i++) {
 				await agent
@@ -2325,8 +2390,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should render previous link on page 2", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			for (let i = 0; i < 21; i++) {
 				await agent
@@ -2344,8 +2410,9 @@ describe("Queue routes", () => {
 
 	describe("Filter and sort", () => {
 		it("should filter by status", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2366,8 +2433,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should render sort toggle", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 			const doc = new JSDOM(response.text).window.document;
@@ -2375,8 +2443,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should include tab in sort toggle URL when on done tab", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue?tab=done");
 			const doc = new JSDOM(response.text).window.document;
@@ -2385,8 +2454,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should toggle sort order from desc to asc", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 			const doc = new JSDOM(response.text).window.document;
@@ -2396,8 +2466,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should toggle sort order from asc to desc", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue?order=asc");
 			const doc = new JSDOM(response.text).window.document;
@@ -2407,8 +2478,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should order Done tab by readAt descending (most recently read first)", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/a" });
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/b" });
@@ -2446,8 +2518,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should order Done tab by readAt ascending when order=asc", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/a" });
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/b" });
@@ -2485,8 +2558,9 @@ describe("Queue routes", () => {
 
 	describe("Re-saving a read article marks it unread", () => {
 		it("should mark a read article as unread when saved again via form", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2525,11 +2599,12 @@ describe("Queue routes", () => {
 	describe("POST /queue/save with existing article (skip freshness)", () => {
 		it("should save user-article relationship without re-fetching", async () => {
 			const skipFreshness: RefreshArticleIfStale = async () => ({ action: "skip" });
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
 				freshness: { refreshArticleIfStale: skipFreshness },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -2542,11 +2617,12 @@ describe("Queue routes", () => {
 
 		it("should save for unchanged content (304)", async () => {
 			const unchangedFreshness: RefreshArticleIfStale = async () => ({ action: "unchanged" });
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
 				freshness: { refreshArticleIfStale: unchangedFreshness },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -2572,7 +2648,7 @@ describe("Queue routes", () => {
 				},
 			});
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				events: {
 					publishLinkSaved: async () => { linkSavedPublished = true; },
@@ -2585,7 +2661,8 @@ describe("Queue routes", () => {
 				},
 				freshness: { refreshArticleIfStale: refreshedFreshness },
 			});
-			const agent = await loginAgent(app, auth);
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.post("/queue/save")
@@ -2599,8 +2676,9 @@ describe("Queue routes", () => {
 
 	describe("Unread tab count", () => {
 		it("should show unread count on the Unread tab", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/1" });
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/2" });
@@ -2612,8 +2690,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should show unread count when viewing read tab", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/1" });
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/2" });
@@ -2631,8 +2710,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should not show count on the Read tab", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 			const doc = new JSDOM(response.text).window.document;
@@ -2641,8 +2721,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should show zero unread count on empty queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 			const doc = new JSDOM(response.text).window.document;
@@ -2653,8 +2734,9 @@ describe("Queue routes", () => {
 
 	describe("CORS for browser extensions", () => {
 		it("should allow requests from browser extensions", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.get("/queue")
@@ -2665,8 +2747,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should allow requests from the legacy hutch-app.com origin", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent
 				.get("/queue")
@@ -2677,9 +2760,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should reject requests from non-extension origins", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.options("/queue")
 				.set("Origin", "https://evil.com")
 				.set("Access-Control-Request-Method", "GET");
@@ -2690,8 +2773,9 @@ describe("Queue routes", () => {
 
 	describe("GET /queue?url=", () => {
 		it("should pre-fill save input and add auto-submit attribute", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue?url=https%3A%2F%2Fexample.com%2Farticle");
 
@@ -2704,8 +2788,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should include auto-submit script", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue?url=https%3A%2F%2Fexample.com%2Farticle");
 
@@ -2714,8 +2799,9 @@ describe("Queue routes", () => {
 		});
 
 		it("should not add auto-submit when url is absent", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 
@@ -2730,8 +2816,9 @@ describe("Queue routes", () => {
 
 	describe("GET /queue?feature=import", () => {
 		it("surfaces the Import Links nav item but no longer renders the upload form on /queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue?feature=import");
 
@@ -2745,8 +2832,9 @@ describe("Queue routes", () => {
 		});
 
 		it("does not surface the Import Links nav item when the feature flag is missing", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue");
 
@@ -2781,7 +2869,7 @@ describe("Queue routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			return createTestApp({
+			return useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle },
 				events: {
@@ -2803,8 +2891,9 @@ describe("Queue routes", () => {
 
 		it("renders hx-get polling on the queue list card while crawl is pending", async () => {
 			// Default fixture leaves crawl in pending state — no fake publish wiring.
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2823,8 +2912,9 @@ describe("Queue routes", () => {
 		});
 
 		it("does not render hx-get on the queue list card once both pipelines terminate", async () => {
-			const { app, auth } = createTerminalPipelineFixture();
-			const agent = await loginAgent(app, auth);
+			const harness = createTerminalPipelineFixture();
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2841,8 +2931,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card returns a single card fragment with the next-poll URL when pending", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2862,8 +2953,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card stops polling once both pipelines terminate", async () => {
-			const { app, auth } = createTerminalPipelineFixture();
-			const agent = await loginAgent(app, auth);
+			const harness = createTerminalPipelineFixture();
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2882,8 +2974,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card stops polling at MAX_CARD_POLLS even while still pending", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2901,16 +2994,18 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card returns 404 for an unknown article", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			const response = await agent.get("/queue/00000000000000000000000000000000/card");
 			expect(response.status).toBe(404);
 		});
 
 		it("GET /queue/:id/card sets ETag and revalidation cache directives", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2928,8 +3023,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card returns 304 when If-None-Match matches the current ETag", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2950,8 +3046,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card returns 200 with a new ETag when If-None-Match does not match", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")
@@ -2969,8 +3066,9 @@ describe("Queue routes", () => {
 		});
 
 		it("GET /queue/:id/card preserves filter context (tab/order/page) on the next-poll URL", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
 
 			await agent
 				.post("/queue/save")

--- a/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.route.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { MinutesSchema } from "@packages/domain/article";
-import { useTestServer, type TestAppResult } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -15,16 +15,6 @@ import {
 } from "@packages/test-fixtures";
 
 import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
-
-async function loginAgent(server: import("node:http").Server, auth: TestAppResult['auth']) {
-	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(server);
-	await agent
-		.post("/login")
-		.type("form")
-		.send({ email: "test@example.com", password: "password123" });
-	return agent;
-}
 
 const useApp = useTestServer();
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import type { Token, Client } from "@node-oauth/oauth2-server";
 import type { PublishSaveLinkRawHtmlCommand } from "@packages/test-fixtures/providers/events";
 import type { UserId } from "@packages/domain/user";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppHarness, type TestAppResult } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -37,8 +37,15 @@ async function createAccessToken(testApp: TestAppResult): Promise<string> {
 	return token.accessToken;
 }
 
+const useApp = useTestServer();
+
 describe("POST /queue/save-html", () => {
-	function setup() {
+	function setup(): {
+		testApp: TestAppHarness;
+		pendingHtml: TestAppHarness["pendingHtml"];
+		publishedSaveHtml: Parameters<PublishSaveLinkRawHtmlCommand>[0][];
+		publishedLinkSaved: { url: string; userId: string }[];
+	} {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const publishedSaveHtml: Parameters<PublishSaveLinkRawHtmlCommand>[0][] = [];
 		const publishedLinkSaved: { url: string; userId: string }[] = [];
@@ -47,7 +54,7 @@ describe("POST /queue/save-html", () => {
 			publishedSaveHtml.push(params);
 		};
 
-		const testApp = createTestApp({
+		const testApp = useApp({
 			...fixture,
 			events: {
 				publishLinkSaved: async (params) => {
@@ -69,7 +76,7 @@ describe("POST /queue/save-html", () => {
 		const { testApp } = setup();
 		const accessToken = await createAccessToken(testApp);
 
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -90,7 +97,7 @@ describe("POST /queue/save-html", () => {
 		const { testApp, publishedSaveHtml, publishedLinkSaved } = setup();
 		const accessToken = await createAccessToken(testApp);
 
-		await request(testApp.app)
+		await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -115,7 +122,7 @@ describe("POST /queue/save-html", () => {
 		const { testApp, pendingHtml } = setup();
 		const accessToken = await createAccessToken(testApp);
 
-		await request(testApp.app)
+		await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -131,7 +138,7 @@ describe("POST /queue/save-html", () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const errors: Error[] = [];
 
-		const testApp = createTestApp({
+		const testApp = useApp({
 			...fixture,
 			events: {
 				publishLinkSaved: fixture.events.publishLinkSaved,
@@ -155,7 +162,7 @@ describe("POST /queue/save-html", () => {
 		});
 		const accessToken = await createAccessToken(testApp);
 
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -174,7 +181,7 @@ describe("POST /queue/save-html", () => {
 		const accessToken = await createAccessToken(testApp);
 
 		const oversized = "x".repeat(MAX_RAW_HTML_BYTES + 1024);
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -195,7 +202,7 @@ describe("POST /queue/save-html", () => {
 		const accessToken = await createAccessToken(testApp);
 
 		const oversized = "x".repeat(MAX_RAW_HTML_BYTES + 1024);
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -213,7 +220,7 @@ describe("POST /queue/save-html", () => {
 		const accessToken = await createAccessToken(testApp);
 
 		const oversized = "x".repeat(MAX_RAW_HTML_REQUEST_BYTES + 1024);
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -238,7 +245,7 @@ describe("POST /queue/save-html", () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const parseErrorCalls: { url: string | null; reason: string }[] = [];
 
-		const testApp = createTestApp({
+		const testApp = useApp({
 			...fixture,
 			shared: {
 				validateSaveableUrl: fixture.shared.validateSaveableUrl,
@@ -253,7 +260,7 @@ describe("POST /queue/save-html", () => {
 		const accessToken = await createAccessToken(testApp);
 
 		const oversized = "x".repeat(MAX_RAW_HTML_REQUEST_BYTES + 1);
-		await request(testApp.app)
+		await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -268,7 +275,7 @@ describe("POST /queue/save-html", () => {
 		const { testApp } = setup();
 		const accessToken = await createAccessToken(testApp);
 
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue/save-html")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -281,7 +288,7 @@ describe("POST /queue/save-html", () => {
 	it("returns 406 when an authenticated cookie session requests text/html on a Siren-only route", async () => {
 		const { testApp } = setup();
 		await testApp.auth.createUser({ email: "test@example.com", password: "password123" });
-		const agent = request.agent(testApp.app);
+		const agent = request.agent(testApp.server);
 		await agent
 			.post("/login")
 			.type("form")
@@ -302,7 +309,7 @@ describe("POST /queue/save-html", () => {
 		const { testApp, publishedSaveHtml, publishedLinkSaved } = setup();
 		const accessToken = await createAccessToken(testApp);
 
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
@@ -317,7 +324,7 @@ describe("POST /queue/save-html", () => {
 describe("Collection-Siren advertises both save actions", () => {
 	it("includes both save-article and save-html actions on the queue collection", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		const testApp = createTestApp({
+		const testApp = useApp({
 			...fixture,
 			events: {
 				publishLinkSaved: fixture.events.publishLinkSaved,
@@ -331,7 +338,7 @@ describe("Collection-Siren advertises both save actions", () => {
 		});
 		const accessToken = await createAccessToken(testApp);
 
-		const response = await request(testApp.app)
+		const response = await request(testApp.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`);

--- a/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
@@ -1,22 +1,12 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { useTestServer, type TestAppHarness } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
-
-async function loginAgent(server: import("node:http").Server, auth: TestAppHarness['auth']) {
-	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(server);
-	await agent
-		.post("/login")
-		.type("form")
-		.send({ email: "test@example.com", password: "password123" });
-	return agent;
-}
 
 const useApp = useTestServer();
 

--- a/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
@@ -1,16 +1,16 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { createTestApp, type TestAppResult } from "../../../test-app";
+import { useTestServer, type TestAppHarness } from "../../../test-app";
 
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-async function loginAgent(app: TestAppResult['app'], auth: TestAppResult['auth']) {
+async function loginAgent(server: import("node:http").Server, auth: TestAppHarness['auth']) {
 	await auth.createUser({ email: "test@example.com", password: "password123" });
-	const agent = request.agent(app);
+	const agent = request.agent(server);
 	await agent
 		.post("/login")
 		.type("form")
@@ -18,11 +18,13 @@ async function loginAgent(app: TestAppResult['app'], auth: TestAppResult['auth']
 	return agent;
 }
 
+const useApp = useTestServer();
+
 describe("Save routes", () => {
 	describe("GET /save (no url, unauthenticated)", () => {
 		it("should render an error page with a meta refresh to home", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/save");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/save");
 
 			expect(response.status).toBe(200);
 			expect(response.headers["content-type"]).toMatch(/text\/html/);
@@ -33,8 +35,8 @@ describe("Save routes", () => {
 		});
 
 		it("should show a fallback link to home", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/save");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/save");
 			const doc = new JSDOM(response.text).window.document;
 			const link = doc.querySelector(".save-error__link");
 			assert(link, "fallback link must be rendered");
@@ -44,8 +46,8 @@ describe("Save routes", () => {
 
 	describe("GET /save (no url, authenticated)", () => {
 		it("should render an error page with a meta refresh to queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const response = await agent.get("/save");
 
 			expect(response.status).toBe(200);
@@ -57,8 +59,8 @@ describe("Save routes", () => {
 		});
 
 		it("should show a fallback link to queue", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const response = await agent.get("/save");
 			const doc = new JSDOM(response.text).window.document;
 			const link = doc.querySelector(".save-error__link");
@@ -67,8 +69,8 @@ describe("Save routes", () => {
 		});
 
 		it("should display the countdown seconds", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const response = await agent.get("/save");
 			const doc = new JSDOM(response.text).window.document;
 			const countdown = doc.querySelector(".save-error__seconds");
@@ -79,8 +81,8 @@ describe("Save routes", () => {
 
 	describe("GET /save?url=invalid", () => {
 		it("should render an error page for an invalid URL when unauthenticated", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/save?url=not-a-url");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/save?url=not-a-url");
 
 			expect(response.status).toBe(200);
 			expect(response.headers["content-type"]).toMatch(/text\/html/);
@@ -91,8 +93,8 @@ describe("Save routes", () => {
 		});
 
 		it("should render an error page for an invalid URL when authenticated", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const response = await agent.get("/save?url=not-a-url");
 
 			expect(response.status).toBe(200);
@@ -106,8 +108,8 @@ describe("Save routes", () => {
 
 	describe("GET /save with Referer but no url param", () => {
 		it("should ignore the Referer and render the error page", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 			const response = await agent
 				.get("/save")
 				.set("Referer", "https://publisher.com/article-1");
@@ -123,8 +125,8 @@ describe("Save routes", () => {
 
 	describe("GET /save?url=https://example.com (unauthenticated)", () => {
 		it("should redirect to login with return URL", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(app).get("/save?url=https://example.com/article");
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/save?url=https://example.com/article");
 
 			expect(response.status).toBe(303);
 			const location = response.headers.location;
@@ -137,8 +139,8 @@ describe("Save routes", () => {
 
 	describe("GET /save?url=https://example.com (authenticated)", () => {
 		it("should redirect to queue with url", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/save?url=https://example.com/article");
 
@@ -149,9 +151,10 @@ describe("Save routes", () => {
 
 	describe("login round-trip", () => {
 		it("should carry URL through login and redirect to queue with url", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 
 			const saveResponse = await agent.get("/save?url=https://example.com/article");
 			expect(saveResponse.status).toBe(303);
@@ -173,8 +176,8 @@ describe("Save routes", () => {
 
 	describe("utm_* passthrough", () => {
 		it("forwards utm_* params on the authenticated /queue redirect", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/save?url=https://example.com/article&utm_source=medium&utm_campaign=spring");
 
@@ -187,8 +190,8 @@ describe("Save routes", () => {
 		});
 
 		it("drops non-utm query params from the /queue redirect", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const agent = await loginAgent(app, auth);
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/save?url=https://example.com/article&foo=bar&utm_source=twitter");
 
@@ -199,9 +202,9 @@ describe("Save routes", () => {
 		});
 
 		it("preserves the full originalUrl (utm included) in the /login return param", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/save?url=https://example.com/article&utm_source=medium");
+			const response = await request(harness.server).get("/save?url=https://example.com/article&utm_source=medium");
 
 			expect(response.status).toBe(303);
 			const location = response.headers.location;

--- a/projects/hutch/src/runtime/web/pages/terms/terms.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/terms/terms.route.test.ts
@@ -1,21 +1,23 @@
 import request from "supertest";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-describe("GET /terms", () => {
-	const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+const useApp = useTestServer();
 
+describe("GET /terms", () => {
 	it("should return 200 and HTML content", async () => {
-		const response = await request(app).get("/terms");
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(server).get("/terms");
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 	});
 
 	it("returns markdown when Accept: text/markdown is sent", async () => {
-		const response = await request(app)
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(server)
 			.get("/terms")
 			.set("Accept", "text/markdown");
 

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -9,7 +9,7 @@ import type {
 } from "@packages/test-fixtures/providers/article-parser";
 import type { FindArticleCrawlStatus } from "@packages/test-fixtures/providers/article-crawl";
 import type { FindGeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
-import { createTestApp } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -48,6 +48,8 @@ function ctaAction(doc: Document): Element {
 	return link;
 }
 
+const useApp = useTestServer();
+
 describe("View routes", () => {
 	describe("GET /view/<encoded-url>", () => {
 		it("renders the article body for an anonymous visitor (200)", async () => {
@@ -58,7 +60,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -75,7 +77,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -95,7 +97,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -112,7 +114,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ARTICLE_URL}`);
+			const response = await request(harness.server).get(`/view/${ARTICLE_URL}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -129,7 +131,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -146,7 +148,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/${ARTICLE_URL.replace("://", ":/")}`,
 			);
 
@@ -165,7 +167,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -182,7 +184,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -202,7 +204,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -219,7 +221,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/${ENCODED}?utm_source=medium&utm_campaign=x&foo=bar`,
 			);
 
@@ -241,7 +243,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -257,11 +259,12 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { auth } = harness;
 			await auth.createUser({
 				email: "reader@example.com",
 				password: "password123",
 			});
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent
 				.post("/login")
 				.type("form")
@@ -283,7 +286,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -299,11 +302,12 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { auth } = harness;
 			await auth.createUser({
 				email: "reader@example.com",
 				password: "password123",
 			});
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent
 				.post("/login")
 				.type("form")
@@ -326,7 +330,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -342,11 +346,12 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { auth } = harness;
 			await auth.createUser({
 				email: "owner@example.com",
 				password: "password123",
 			});
-			const ownerAgent = request.agent(app);
+			const ownerAgent = request.agent(harness.server);
 			await ownerAgent
 				.post("/login")
 				.type("form")
@@ -356,7 +361,7 @@ describe("View routes", () => {
 				.type("form")
 				.send({ url: ARTICLE_URL });
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -372,7 +377,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -389,7 +394,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const actions = doc.querySelectorAll("[data-test-view-cta-action]");
@@ -416,7 +421,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -433,7 +438,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const wrap = doc.querySelector("[data-test-share-balloon-wrap]");
@@ -470,7 +475,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -487,7 +492,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const closeBtn = doc.querySelector("[data-test-share-balloon-close]");
@@ -503,7 +508,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -520,7 +525,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const script = doc.querySelector(
@@ -538,7 +543,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -555,7 +560,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const status = doc.querySelector("[data-share-balloon-status]");
@@ -572,7 +577,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -589,7 +594,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const label = doc.querySelector("[data-test-share-balloon-copied]");
@@ -606,7 +611,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -623,7 +628,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const btn = doc.querySelector("[data-test-share-balloon]");
@@ -632,9 +637,9 @@ describe("View routes", () => {
 		});
 
 		it("is not rendered on the /view landing page", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/view");
+			const response = await request(harness.server).get("/view");
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector("[data-test-share-balloon]")).toBeNull();
@@ -648,7 +653,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -665,7 +670,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const avatar = doc.querySelector("[data-test-share-balloon-avatar]");
@@ -681,7 +686,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -698,7 +703,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -726,7 +731,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -748,7 +753,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -772,7 +777,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -794,7 +799,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -818,7 +823,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -840,7 +845,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -868,7 +873,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -890,7 +895,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -918,7 +923,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -940,7 +945,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -960,7 +965,7 @@ describe("View routes", () => {
 				summary: "Fragment summary.",
 			});
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				summary:{
  	findGeneratedSummary: findGeneratedSummary,
@@ -969,7 +974,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/summary?url=${encodeURIComponent(ARTICLE_URL)}`,
 			);
 
@@ -984,7 +989,7 @@ describe("View routes", () => {
 		it("increments the poll counter when status=pending under the cap", async () => {
 			const findGeneratedSummary: FindGeneratedSummary = async () => ({ status: "pending" });
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				summary:{
  	findGeneratedSummary: findGeneratedSummary,
@@ -993,7 +998,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/summary?url=${encodeURIComponent(ARTICLE_URL)}&poll=5`,
 			);
 
@@ -1007,7 +1012,7 @@ describe("View routes", () => {
 		it("stops polling at the cap and renders a terminal message", async () => {
 			const findGeneratedSummary: FindGeneratedSummary = async () => ({ status: "pending" });
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				summary:{
  	findGeneratedSummary: findGeneratedSummary,
@@ -1016,7 +1021,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/summary?url=${encodeURIComponent(ARTICLE_URL)}&poll=40`,
 			);
 
@@ -1031,9 +1036,9 @@ describe("View routes", () => {
 		});
 
 		it("returns 400 for an invalid url", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/view/summary?url=not-a-url");
+			const response = await request(harness.server).get("/view/summary?url=not-a-url");
 
 			expect(response.status).toBe(400);
 		});
@@ -1045,7 +1050,7 @@ describe("View routes", () => {
 			});
 			const findGeneratedSummary: FindGeneratedSummary = async () => ({ status: "pending" });
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				articleCrawl:{
  	findArticleCrawlStatus: findArticleCrawlStatus,
@@ -1063,7 +1068,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/summary?url=${encodeURIComponent(ARTICLE_URL)}&poll=5`,
 			);
 
@@ -1096,7 +1101,7 @@ describe("View routes", () => {
 				parseArticle,
 			});
 			const fixedNow = new Date("2026-04-25T12:00:00.000Z");
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
 				events: {
@@ -1117,9 +1122,9 @@ describe("View routes", () => {
 
 			// Land on /view first so the row exists; then the reader poll has
 			// something to read back.
-			await request(app).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${ENCODED}`);
 
-			const first = await request(app).get(
+			const first = await request(harness.server).get(
 				`/view/reader?url=${encodeURIComponent(ARTICLE_URL)}&poll=1`,
 			);
 			expect(first.status).toBe(200);
@@ -1137,7 +1142,7 @@ describe("View routes", () => {
 			// Format owned by view.component.ts — keep in sync if you change it there.
 			expect(titleEl.textContent).toMatch(/\| Reader View$/);
 
-			const second = await request(app)
+			const second = await request(harness.server)
 				.get(`/view/reader?url=${encodeURIComponent(ARTICLE_URL)}&poll=1`)
 				.set("If-None-Match", etag);
 			expect(second.status).toBe(304);
@@ -1154,7 +1159,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1171,7 +1176,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -1218,7 +1223,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1235,7 +1240,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -1256,7 +1261,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1273,7 +1278,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const script = doc.querySelector('script[type="application/ld+json"]');
@@ -1291,7 +1296,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1308,7 +1313,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -1319,9 +1324,9 @@ describe("View routes", () => {
 
 	describe("Error paths", () => {
 		it("renders the error page for an invalid URL path param (unauthenticated)", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/${encodeURIComponent("not-a-url")}`,
 			);
 
@@ -1333,12 +1338,13 @@ describe("View routes", () => {
 		});
 
 		it("renders the error page redirecting to /queue when authenticated", async () => {
-			const { app, auth } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
 			await auth.createUser({
 				email: "test@example.com",
 				password: "password123",
 			});
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent
 				.post("/login")
 				.type("form")
@@ -1358,9 +1364,9 @@ describe("View routes", () => {
 		});
 
 		it("renders the landing form for GET /view without a path param", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/view");
+			const response = await request(harness.server).get("/view");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -1377,9 +1383,9 @@ describe("View routes", () => {
 		});
 
 		it("renders the landing form with UTM hidden inputs identifying the 'Open in reader view' click", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/view");
+			const response = await request(harness.server).get("/view");
 
 			const doc = new JSDOM(response.text).window.document;
 			const form = doc.querySelector("[data-test-view-landing-form]");
@@ -1399,9 +1405,9 @@ describe("View routes", () => {
 		});
 
 		it("redirects GET /view?url=<valid> to /view/<encoded-url>", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view?url=${encodeURIComponent(ARTICLE_URL)}`,
 			);
 
@@ -1410,9 +1416,9 @@ describe("View routes", () => {
 		});
 
 		it("renders the save-error page when GET /view?url=<invalid>", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app).get("/view?url=not-a-url");
+			const response = await request(harness.server).get("/view?url=not-a-url");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -1421,9 +1427,10 @@ describe("View routes", () => {
 		});
 
 		it("renders the save-error page when GET /view/<chrome://...> and never saves an anonymous stub", async () => {
-			const { app, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { articleStore } = harness;
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/${encodeURIComponent("chrome://extensions/")}`,
 			);
 
@@ -1437,9 +1444,10 @@ describe("View routes", () => {
 		});
 
 		it("renders the save-error page when GET /view/<localhost> and never saves an anonymous stub", async () => {
-			const { app, articleStore } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { articleStore } = harness;
 
-			const response = await request(app).get(
+			const response = await request(harness.server).get(
 				`/view/${encodeURIComponent("http://localhost:3000/queue")}`,
 			);
 
@@ -1463,7 +1471,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1480,7 +1488,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -1505,7 +1513,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, articleStore, articleCrawl } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1521,6 +1529,7 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { articleStore, articleCrawl } = harness;
 			await articleStore.saveArticle({
 				userId: UserIdSchema.parse("seed-user"),
 				url: ARTICLE_URL,
@@ -1539,7 +1548,7 @@ describe("View routes", () => {
 			});
 			await articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
 			expect(parseSpy).not.toHaveBeenCalled();
@@ -1570,7 +1579,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, articleStore, articleCrawl } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1586,6 +1595,7 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { articleStore, articleCrawl } = harness;
 			await articleStore.saveArticle({
 				userId: UserIdSchema.parse("seed-user"),
 				url: ARTICLE_URL,
@@ -1599,7 +1609,7 @@ describe("View routes", () => {
 			});
 			await articleCrawl.markCrawlFailed({ url: ARTICLE_URL, reason: "blocked" });
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
 			// /view never re-parses inline; recovery happens in the stale-check Lambda.
@@ -1625,7 +1635,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, articleStore } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1641,8 +1651,9 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { articleStore } = harness;
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
 			expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
@@ -1664,7 +1675,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, auth } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1680,8 +1691,9 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
-			const agent = request.agent(app);
+			const agent = request.agent(harness.server);
 			await agent
 				.post("/login")
 				.type("form")
@@ -1708,7 +1720,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, articleStore, articleCrawl } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1729,6 +1741,7 @@ describe("View routes", () => {
  	forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
  },
 			});
+			const { articleStore, articleCrawl } = harness;
 			await articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
 				metadata: {
@@ -1743,7 +1756,7 @@ describe("View routes", () => {
 			});
 			await articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			await request(app).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 			expect(publishStaleCheckRequested).toHaveBeenCalledWith({ url: ARTICLE_URL });
@@ -1763,7 +1776,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, articleStore } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1779,6 +1792,7 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { articleStore } = harness;
 			await articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
 				metadata: {
@@ -1791,7 +1805,7 @@ describe("View routes", () => {
 				savedAt: new Date(),
 			});
 
-			await request(app).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 			expect(publishStaleCheckRequested).toHaveBeenCalledWith({ url: ARTICLE_URL });
@@ -1807,7 +1821,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app, articleStore, articleCrawl } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1823,6 +1837,7 @@ describe("View routes", () => {
 					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
 				},
 			});
+			const { articleStore, articleCrawl } = harness;
 			await articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
 				metadata: {
@@ -1840,8 +1855,8 @@ describe("View routes", () => {
 			// visit would have re-published SaveAnonymousLinkCommand. Now it must
 			// stay quiet for both — the stale-check Lambda observes a failed row
 			// and short-circuits to action=skip.
-			await request(app).get(`/view/${ENCODED}`);
-			await request(app).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 			expect(publishStaleCheckRequested).toHaveBeenCalledWith({ url: ARTICLE_URL });
@@ -1849,13 +1864,14 @@ describe("View routes", () => {
 
 		it("renders the unsupported reader slot for a cached article whose crawl was marked unsupported, with no polling stub", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app, articleStore, articleCrawl } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				events: {
 					...fixture.events,
 					publishSaveAnonymousLink: async () => {},
 				},
 			});
+			const { articleStore, articleCrawl } = harness;
 			await articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
 				metadata: {
@@ -1872,7 +1888,7 @@ describe("View routes", () => {
 				reason: "non-html content type: application/pdf",
 			});
 
-			const response = await request(app).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -1891,7 +1907,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1908,7 +1924,7 @@ describe("View routes", () => {
 				},
 			});
 
-			await request(app).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${ENCODED}`);
 
 			expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: ARTICLE_URL });
 		});
@@ -1928,7 +1944,7 @@ describe("View routes", () => {
 				articleCrawl: fixture.articleCrawl,
 				parseArticle,
 			});
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				parser: {
 					parseArticle,
@@ -1945,7 +1961,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/view/${ENCODED}`)
 				.set("Accept", "text/markdown");
 
@@ -1962,7 +1978,7 @@ describe("View routes", () => {
 
 		it("returns markdown with empty body when article content is not yet available", async () => {
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-			const { app } = createTestApp({
+			const harness = useApp({
 				...fixture,
 				events: {
 					...fixture.events,
@@ -1970,7 +1986,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get(`/view/${ENCODED}`)
 				.set("Accept", "text/markdown");
 
@@ -1981,9 +1997,9 @@ describe("View routes", () => {
 		});
 
 		it("renders the landing page as markdown when /view is requested without a URL", async () => {
-			const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
-			const response = await request(app)
+			const response = await request(harness.server)
 				.get("/view")
 				.set("Accept", "text/markdown");
 

--- a/src/packages/test-phase-runner/src/run-test-phases.test.ts
+++ b/src/packages/test-phase-runner/src/run-test-phases.test.ts
@@ -66,7 +66,7 @@ describe("jest phase resolution", () => {
 		expect(plan.phases[0]).toEqual({
 			type: "jest",
 			name: "unit tests",
-			command: 'node_modules/.bin/jest --testMatch="**/dist/**/*.test.js" --testTimeout=10000 --runInBand --forceExit',
+			command: 'node_modules/.bin/jest --testMatch="**/dist/**/*.test.js" --testTimeout=10000',
 			skip: false,
 			e2e: false,
 		});

--- a/src/packages/test-phase-runner/src/run-test-phases.ts
+++ b/src/packages/test-phase-runner/src/run-test-phases.ts
@@ -111,12 +111,6 @@ function resolveJestPhase(phase: JestPhase): ResolvedJestPhase {
 		"node_modules/.bin/jest",
 		`--testMatch="${phase.testMatch}"`,
 		`--testTimeout=${phase.timeout}`,
-		"--runInBand",
-		// Without --forceExit, jest occasionally hangs after every test passes
-		// because supertest's per-request HTTP servers leave handles open. The
-		// hang causes c8 to flush partial coverage data, dropping branch
-		// coverage below 97% and failing the threshold gate.
-		"--forceExit",
 	];
 	if (phase.testPathIgnorePatterns) {
 		parts.push(`--testPathIgnorePatterns="${phase.testPathIgnorePatterns}"`);


### PR DESCRIPTION
## Summary

- Add `useTestServer()` in `projects/hutch/src/runtime/test-app.ts` — a per-suite factory that binds the test app to an ephemeral port and closes the socket in `afterEach`, eliminating the supertest handle leak that previously forced `--runInBand --forceExit`.
- Migrate every supertest call site in hutch (28 test files, ~420 sites) from `request(app)` to `request(harness.server)`, where `harness.server` is the `http.Server` produced by `useApp(fixture)`. The `complete-stripe-signup` helper now takes `server` instead of `app`; the `loginAgent` / `obtainAccessToken` helpers in queue/api/save/import/export/admin tests follow the same convention.
- Drop `--runInBand` and `--forceExit` from the Jest command emitted by `@packages/test-phase-runner` so unit and integration phases run across workers; update the runner's unit test to assert the new command string.

The previous `createTestApp(...) + request(app)` pattern lifted a transient HTTP server inside each supertest call and never closed it, so Jest hung on open handles unless `--forceExit` was passed — and `--forceExit` truncated c8's coverage flush, which is why the threshold gate also demanded `--runInBand`. With handles closed deterministically, both flags become unnecessary and the unit phase drops from ~90 s to ~37 s locally (3 workers on this box) while holding the 99 / 96 / 100 / 99 thresholds.

## Test plan

- [x] `npx tsc --noEmit` from `projects/hutch` exits 0
- [x] `pnpm test-with-coverage` in `projects/hutch` — 99.69 / 96.27 / 100 / 99.69, no open-handle warnings, ~37 s wall-clock
- [x] `npx nx run @packages/test-phase-runner:check` — all 30 cases pass with the new command string
- [x] `pnpm check` across all 19 projects — green
- [ ] CI green on this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01NEE4ti1WDsA9RUXK9xAaKY)_