### PR TITLE
fix(@packages/article-store): clear summaryStage on terminal summary transitions

### DIFF
--- a/src/packages/article-store/src/dynamodb-article-store.test.ts
+++ b/src/packages/article-store/src/dynamodb-article-store.test.ts
@@ -653,6 +653,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			expect(command.input.UpdateExpression).toContain(
 				"REMOVE summaryFailureReason, summarySkippedReason",
 			);
+			expect(command.input.UpdateExpression).toContain("summaryStage");
 			expect(command.input.ExpressionAttributeValues?.[":summary"]).toBe("abc");
 			expect(command.input.ExpressionAttributeValues?.[":summaryStatus"]).toBe(
 				"ready",
@@ -722,6 +723,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			expect(command.input.UpdateExpression).toContain(
 				"REMOVE summarySkippedReason",
 			);
+			expect(command.input.UpdateExpression).toContain("summaryStage");
 			expect(command.input.ExpressionAttributeValues?.[":summaryStatus"]).toBe(
 				"failed",
 			);
@@ -762,6 +764,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			expect(command.input.UpdateExpression).toContain(
 				"REMOVE summaryFailureReason",
 			);
+			expect(command.input.UpdateExpression).toContain("summaryStage");
 			expect(command.input.ExpressionAttributeValues?.[":summaryStatus"]).toBe(
 				"skipped",
 			);
@@ -793,6 +796,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			expect(command.input.UpdateExpression).toContain(
 				"REMOVE summarySkippedReason, summaryFailureReason",
 			);
+			expect(command.input.UpdateExpression).toContain("summaryStage");
 			expect(
 				command.input.ExpressionAttributeValues?.[":summarySkippedReason"],
 			).toBeUndefined();

--- a/src/packages/article-store/src/dynamodb-article-store.ts
+++ b/src/packages/article-store/src/dynamodb-article-store.ts
@@ -250,14 +250,19 @@ function appendSummaryClauses(
 		values[":summaryExcerpt"] = article.summary.excerpt ?? null;
 		values[":summaryInputTokens"] = article.summary.inputTokens ?? null;
 		values[":summaryOutputTokens"] = article.summary.outputTokens ?? null;
-		removes.push("summaryFailureReason", "summarySkippedReason", "summaryPendingSince");
+		removes.push(
+			"summaryFailureReason",
+			"summarySkippedReason",
+			"summaryPendingSince",
+			"summaryStage",
+		);
 		return;
 	}
 	if (article.summary.kind === "failed") {
 		sets.push("summaryFailureReason = :summaryFailureReason");
 		values[":summaryStatus"] = "failed";
 		values[":summaryFailureReason"] = JSON.stringify(article.summary.reason);
-		removes.push("summarySkippedReason", "summaryPendingSince");
+		removes.push("summarySkippedReason", "summaryPendingSince", "summaryStage");
 		return;
 	}
 	values[":summaryStatus"] = "skipped";
@@ -267,7 +272,7 @@ function appendSummaryClauses(
 	} else {
 		removes.push("summarySkippedReason");
 	}
-	removes.push("summaryFailureReason", "summaryPendingSince");
+	removes.push("summaryFailureReason", "summaryPendingSince", "summaryStage");
 }
 
 function appendCrawlClauses(


### PR DESCRIPTION
## Summary

- `summaryStage` is a transient progress marker meant to exist only while `summaryStatus = "pending"`. The contract documented in [`mark-summary-stage.ts`](https://github.com/Readplace/readplace.com/blob/main/projects/save-link/src/runtime/providers/article-crawl/mark-summary-stage.ts#L24-L26) states that aggregate writers MUST remove the stage attribute on transitions to terminal states.
- Only the `pending` branch of `appendSummaryClauses` in [`dynamodb-article-store.ts`](src/packages/article-store/src/dynamodb-article-store.ts) honoured the contract. The `ready`, `failed`, and `skipped` branches did not — so a row could land at `summaryStatus="ready"` while still carrying `summaryStage="summary-generating"` (observed on the recent medium.com DLQ redrive).
- Adds `"summaryStage"` to the `REMOVE` clause in all three terminal branches and expands the four corresponding tests (`writes a ready summary…`, `writes a failed summary…`, `writes a skipped summary with reason…`, `writes a skipped summary without reason…`) to assert the stage attribute is cleared.

The only reader of `summaryStage` ([`dynamodb-generated-summary.ts:60-63`](projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.ts)) gates on `summaryStatus === "pending"` and is null-safe, so clearing the attribute on terminal transitions is safe for every current consumer.

## Test plan

- [x] `pnpm nx run @packages/article-store:test` — all 38 tests pass, including the four updated terminal-branch assertions and the pre-existing pending-branch assertion at line 472.
- [x] `pnpm test-with-coverage` in `src/packages/article-store` — 100% statements / branches / functions / lines.
- [x] `pnpm nx run @packages/article-store:check` — tsc, biome, and knip clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JksAE2SoD1Hw92EitujUuG)_