### PR TITLE
refactor(hutch): inject QuerystringFeatureToggle into route bundles

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -96,6 +96,7 @@ import { renderPage } from "./web/render-page";
 import { sendComponent } from "./web/send-component";
 import { wantsMarkdown, wantsSiren } from "./web/content-negotiation";
 import { contentSignalMiddleware } from "./web/content-signal.middleware";
+import { QuerystringFeatureToggle } from "./web/feature-toggle";
 import { HomePage } from "./web/pages/home";
 import { PrivacyPage } from "./web/pages/privacy";
 import { TermsPage } from "./web/pages/terms";
@@ -464,6 +465,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		validateAccessToken: deps.validateAccessToken,
 	});
 
+	const featureToggle = new QuerystringFeatureToggle();
+
 	const queueRouter = initQueueRoutes({
 		validateSaveableUrl: deps.validateSaveableUrl,
 		findArticlesByUser: deps.findArticlesByUser,
@@ -488,6 +491,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		logError: deps.logError,
 		logParseError: deps.logParseError,
 		now: deps.now,
+		featureToggle,
 	});
 	/** `dualAuthMiddleware` is applied INSIDE the queue router rather than at this
 	 * mount so that `GET /queue/:id/read` can stay publicly reachable. Shared
@@ -507,6 +511,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		publishLinkSaved: deps.publishLinkSaved,
 		refreshArticleIfStale: deps.refreshArticleIfStale,
 		logError: deps.logError,
+		featureToggle,
 	});
 	app.use("/import", requireAuth, importRouter);
 

--- a/projects/hutch/src/runtime/web/feature-toggle.test.ts
+++ b/projects/hutch/src/runtime/web/feature-toggle.test.ts
@@ -1,0 +1,32 @@
+import type { Request } from "express";
+import { QuerystringFeatureToggle } from "./feature-toggle";
+
+function requestWithQuery(query: Record<string, unknown>): Request {
+	return { query } as unknown as Request;
+}
+
+describe("QuerystringFeatureToggle", () => {
+	it("returns true when ?feature=<name> matches the queried feature", () => {
+		const toggle = new QuerystringFeatureToggle();
+
+		expect(toggle.isEnabled(requestWithQuery({ feature: "audio" }), "audio")).toBe(true);
+	});
+
+	it("returns false when ?feature=<name> names a different feature", () => {
+		const toggle = new QuerystringFeatureToggle();
+
+		expect(toggle.isEnabled(requestWithQuery({ feature: "import" }), "audio")).toBe(false);
+	});
+
+	it("returns false when the request has no feature query param", () => {
+		const toggle = new QuerystringFeatureToggle();
+
+		expect(toggle.isEnabled(requestWithQuery({}), "audio")).toBe(false);
+	});
+
+	it("returns false when feature is provided as an array (?feature=a&feature=b)", () => {
+		const toggle = new QuerystringFeatureToggle();
+
+		expect(toggle.isEnabled(requestWithQuery({ feature: ["audio", "import"] }), "audio")).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/feature-toggle.ts
+++ b/projects/hutch/src/runtime/web/feature-toggle.ts
@@ -1,0 +1,7 @@
+import type { Request } from "express";
+
+export class QuerystringFeatureToggle {
+	isEnabled(req: Request, feature: string): boolean {
+		return req.query.feature === feature;
+	}
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -14,6 +14,7 @@ import type { ImportSessionStore } from "@packages/domain/import-session";
 import type { ValidateSaveableUrl, SaveableUrl, SaveableUrlErrorCode } from "@packages/domain/article";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
+import type { QuerystringFeatureToggle } from "../../feature-toggle";
 import { saveArticleFromUrl, type SaveArticleFromUrlDependencies } from "../../shared/save-article/save-article-from-url";
 import {
 	IMPORT_SKIPPED_COOKIE_NAME,
@@ -29,6 +30,7 @@ interface ImportRouteDependencies extends SaveArticleFromUrlDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
 	importSessionStore: ImportSessionStore;
 	logError: (message: string, error?: Error) => void;
+	featureToggle: QuerystringFeatureToggle;
 }
 
 const UPLOAD_ERROR_REDIRECT = {
@@ -51,7 +53,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 
 	router.get("/", (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
-		if (req.query.feature !== "import") {
+		if (!deps.featureToggle.isEnabled(req, "import")) {
 			res.redirect(303, "/queue");
 			return;
 		}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -48,6 +48,7 @@ import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
 import { CacheableComponent } from "../../conditional-get";
 import { wantsSiren } from "../../content-negotiation";
+import type { QuerystringFeatureToggle } from "../../feature-toggle";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
 import { toArticleEntity } from "../../api/article-siren";
@@ -126,6 +127,7 @@ interface QueueDependencies {
 	logError: (message: string, error?: Error) => void;
 	logParseError: LogParseError;
 	now: () => Date;
+	featureToggle: QuerystringFeatureToggle;
 }
 
 import type { SavedArticle } from "@packages/domain/article";
@@ -209,7 +211,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			await deps.updateArticleStatus(ownedArticle.id, ownedArticle.userId, "read");
 		}
 
-		const audioEnabled = req.query.feature === "audio";
+		const audioEnabled = deps.featureToggle.isEnabled(req, "audio");
 		const state = await reader.resolveReaderState({
 			article: {
 				url: ownedArticle.url,


### PR DESCRIPTION
## Summary

- Introduces a `QuerystringFeatureToggle` class (`projects/hutch/src/runtime/web/feature-toggle.ts`) that wraps `req.query.feature === '<name>'` behind an `isEnabled(req, feature)` method.
- Injects a single instance through the queue and import route bundles from the composition root (`projects/hutch/src/runtime/server.ts`) instead of routes reading `req.query.feature` directly.
- Replaces the two inline checks:
  - `queue.page.ts:464` — `audioEnabled` for the reader audio slot.
  - `import.page.ts:54` — `/import` feature gate.

## Test plan

- [x] `feature-toggle.test.ts` covers the truthy match, mismatched name, missing query param, and the array-typed query (`?feature=a&feature=b`) edge case.
- [x] `queue.route.test.ts` (107 tests) and `import.route.test.ts` (34 tests) pass unchanged, exercising both call sites through the real composition root.
- [x] `pnpm check` succeeds with 100% coverage thresholds met across all 19 projects.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjfKqRznCCVpFCUTt2gunw)_