### PR TITLE
refactor(hutch): drop redundant status check before marking article read

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -205,9 +205,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			return;
 		}
 
-		if (ownedArticle.status === "unread") {
-			await deps.updateArticleStatus(ownedArticle.id, ownedArticle.userId, "read");
-		}
+		await deps.updateArticleStatus(ownedArticle.id, ownedArticle.userId, "read");
 
 		const audioEnabled = req.query.feature === "audio";
 		const state = await reader.resolveReaderState({


### PR DESCRIPTION
## Summary

- `GET /queue/:id/read` previously guarded the status update with `if (article.status === "unread")`. The guard is redundant: `updateArticleStatus(..., "read")` is already idempotent — setting `status = "read"` and `readAt = now` works regardless of the prior status, and re-opening an already-read article naturally refreshes its `readAt` (which matches the Done tab's "most recently read first" sort).
- Dropping the conditional removes one branch of cyclomatic complexity from the route.

## Test plan

- [x] `pnpm nx test hutch --testPathPattern=queue.route.test` — 107 tests pass, including `should mark unread article as read when opening reader`.
- [x] `pnpm lint` — clean (tsc, biome, knip, unused-css).
- [x] `pnpm test-with-coverage` — all coverage thresholds met.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCX2rehJLeHDPTSWEwit7P)_