### PR TITLE
refactor(hutch): extract /queue/:id/read redirect logic into a testable component

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -46,7 +46,9 @@ import type { PutPendingHtml } from "@packages/test-fixtures/providers/pending-h
 import { saveArticleFromUrl, saveUnsaveableUrlStub } from "../../shared/save-article/save-article-from-url";
 import { renderPage } from "../../render-page";
 import { sendComponent } from "../../send-component";
+import { RedirectComponent } from "../../redirect.component";
 import { CacheableComponent } from "../../conditional-get";
+import { initReaderPermalink } from "./reader-permalink";
 import { wantsSiren } from "../../content-negotiation";
 import type { QuerystringFeatureToggle } from "../../feature-toggle";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
@@ -71,24 +73,6 @@ import {
 	isExtensionInstalled,
 	isExtensionSavedArticle,
 } from "../../onboarding/extension-install";
-import { collectUtmParams } from "../../shared/utm";
-
-/** UTM params on the /view redirect let analytics distinguish shared
- * /read clicks from organic /view traffic. Preserve any incoming UTM
- * (e.g. a campaign-tagged share URL) over the defaults so external
- * attribution survives the redirect. */
-function buildShareRedirectUrl(articleUrl: string, query: Request["query"]): string {
-	const incomingUtm = collectUtmParams(query);
-	const utmParams: [string, string][] = incomingUtm.length > 0
-		? incomingUtm
-		: [
-			["utm_source", "read"],
-			["utm_medium", "share"],
-			["utm_campaign", "read-permalink"],
-		];
-	return `/view/${encodeURIComponent(articleUrl)}?${new URLSearchParams(utmParams).toString()}`;
-}
-
 function readImportSkippedFlash(
 	req: Request,
 	res: Response,
@@ -182,6 +166,10 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		backLink: { href: "/queue", label: "← Back to queue" },
 		now: deps.now,
 	});
+	const resolveReaderPermalink = initReaderPermalink({
+		findArticleById: deps.findArticleById,
+		findArticleUrlById: deps.findArticleUrlById,
+	});
 
 	function pollUrlBuilderForId(articleId: string): PollUrlBuilder {
 		return {
@@ -200,29 +188,18 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 	 * auth middleware doesn't pre-empt anonymous traffic with a /login
 	 * redirect. */
 	router.get("/:id/read", async (req: Request, res: Response) => {
-		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
-		if (!parsedId.success) {
-			res.redirect(303, "/queue");
+		const result = await resolveReaderPermalink({
+			rawId: req.params.id,
+			requesterId: req.userId,
+			query: req.query,
+		});
+
+		if (result.kind === "redirect") {
+			sendComponent(req, res, RedirectComponent(result.redirect));
 			return;
 		}
 
-		const requesterId = req.userId;
-		const ownedArticle = requesterId
-			? await deps.findArticleById(parsedId.data, requesterId)
-			: null;
-
-		if (!ownedArticle) {
-			const articleUrl = await deps.findArticleUrlById(parsedId.data);
-			if (!articleUrl) {
-				res.redirect(303, "/queue");
-				return;
-			}
-			/** 302 (not 301) because the redirect is conditional on
-			 * auth/ownership — the same URL renders differently for the
-			 * owner, so caches must not pin a single response. */
-			res.redirect(302, buildShareRedirectUrl(articleUrl, req.query));
-			return;
-		}
+		const ownedArticle = result.article;
 
 		await deps.updateArticleStatus(ownedArticle.id, ownedArticle.userId, "read");
 

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
@@ -1,0 +1,148 @@
+import type { Minutes, SavedArticle } from "@packages/domain/article";
+import { ReaderArticleHashId } from "@packages/domain/article";
+import { UserIdSchema } from "@packages/domain/user";
+import { initReaderPermalink, type ReaderPermalinkDeps } from "./reader-permalink";
+
+const OWNER_ID = UserIdSchema.parse("owner-user");
+const STRANGER_ID = UserIdSchema.parse("stranger-user");
+const ARTICLE_URL = "https://example.com/shared-article";
+const ARTICLE_ID = ReaderArticleHashId.from(ARTICLE_URL);
+const UNKNOWN_HASH = "0".repeat(32);
+
+const DEFAULT_UTM = "utm_source=read&utm_medium=share&utm_campaign=read-permalink";
+
+function savedArticleFor(userId = OWNER_ID): SavedArticle {
+	return {
+		id: ARTICLE_ID,
+		userId,
+		url: ARTICLE_URL,
+		metadata: { title: "Post", siteName: "example.com", excerpt: "", wordCount: 100 },
+		estimatedReadTime: 1 as Minutes,
+		status: "unread",
+		savedAt: new Date("2026-01-01T00:00:00.000Z"),
+	};
+}
+
+function createDeps(overrides: Partial<ReaderPermalinkDeps> = {}): ReaderPermalinkDeps {
+	return {
+		findArticleById: async () => null,
+		findArticleUrlById: async () => null,
+		...overrides,
+	};
+}
+
+describe("resolveReaderPermalink", () => {
+	it("redirects to /queue when the id is malformed (not a 32-char hex hash)", async () => {
+		const resolve = initReaderPermalink(createDeps());
+
+		const result = await resolve({ rawId: "not-a-hash", requesterId: OWNER_ID, query: {} });
+
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: { statusCode: 303, location: "/queue" },
+		});
+	});
+
+	it("returns the article for an authenticated owner so the route can render the reader", async () => {
+		const owned = savedArticleFor(OWNER_ID);
+		const resolve = initReaderPermalink(createDeps({
+			findArticleById: async (id, userId) =>
+				id.value === ARTICLE_ID.value && userId === OWNER_ID ? owned : null,
+		}));
+
+		const result = await resolve({ rawId: ARTICLE_ID.value, requesterId: OWNER_ID, query: {} });
+
+		expect(result).toEqual({ kind: "article", article: owned });
+	});
+
+	it("redirects a logged-in non-owner to the public /view permalink with default UTM params", async () => {
+		const resolve = initReaderPermalink(createDeps({
+			findArticleById: async () => null,
+			findArticleUrlById: async (id) =>
+				id.value === ARTICLE_ID.value ? ARTICLE_URL : null,
+		}));
+
+		const result = await resolve({ rawId: ARTICLE_ID.value, requesterId: STRANGER_ID, query: {} });
+
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: {
+				statusCode: 302,
+				location: `/view/${encodeURIComponent(ARTICLE_URL)}?${DEFAULT_UTM}`,
+			},
+		});
+	});
+
+	it("redirects an anonymous visitor to the public /view permalink without consulting findArticleById", async () => {
+		let ownerLookupCalls = 0;
+		const resolve = initReaderPermalink(createDeps({
+			findArticleById: async () => {
+				ownerLookupCalls++;
+				return null;
+			},
+			findArticleUrlById: async () => ARTICLE_URL,
+		}));
+
+		const result = await resolve({ rawId: ARTICLE_ID.value, requesterId: undefined, query: {} });
+
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: {
+				statusCode: 302,
+				location: `/view/${encodeURIComponent(ARTICLE_URL)}?${DEFAULT_UTM}`,
+			},
+		});
+		expect(ownerLookupCalls).toBe(0);
+	});
+
+	it("preserves incoming UTM params over the defaults", async () => {
+		const resolve = initReaderPermalink(createDeps({
+			findArticleUrlById: async () => ARTICLE_URL,
+		}));
+
+		const result = await resolve({
+			rawId: ARTICLE_ID.value,
+			requesterId: undefined,
+			query: { utm_source: "newsletter", utm_campaign: "weekly" },
+		});
+
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: {
+				statusCode: 302,
+				location: `/view/${encodeURIComponent(ARTICLE_URL)}?utm_source=newsletter&utm_campaign=weekly`,
+			},
+		});
+	});
+
+	it("redirects to /queue when the hash is well-formed but no article matches", async () => {
+		const resolve = initReaderPermalink(createDeps({
+			findArticleById: async () => null,
+			findArticleUrlById: async () => null,
+		}));
+
+		const result = await resolve({ rawId: UNKNOWN_HASH, requesterId: OWNER_ID, query: {} });
+
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: { statusCode: 303, location: "/queue" },
+		});
+	});
+
+	it("percent-encodes special characters in the article URL when building the /view redirect", async () => {
+		const trickyUrl = "https://example.com/path with spaces?a=b&c=d";
+		const resolve = initReaderPermalink(createDeps({
+			findArticleUrlById: async () => trickyUrl,
+		}));
+
+		const result = await resolve({ rawId: ARTICLE_ID.value, requesterId: undefined, query: {} });
+
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: {
+				statusCode: 302,
+				location: `/view/${encodeURIComponent(trickyUrl)}?${DEFAULT_UTM}`,
+			},
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
@@ -1,0 +1,71 @@
+import type { Request } from "express";
+import type { SavedArticle } from "@packages/domain/article";
+import { ReaderArticleHashIdSchema } from "@packages/domain/article";
+import type { UserId } from "@packages/domain/user";
+import type {
+	FindArticleById,
+	FindArticleUrlById,
+} from "@packages/test-fixtures/providers/article-store";
+import type { Redirect } from "../../redirect.component";
+import { collectUtmParams } from "../../shared/utm";
+
+export interface ReaderPermalinkDeps {
+	findArticleById: FindArticleById;
+	findArticleUrlById: FindArticleUrlById;
+}
+
+export interface ReaderPermalinkInput {
+	rawId: string;
+	requesterId: UserId | undefined;
+	query: Request["query"];
+}
+
+export type ReaderPermalinkResult =
+	| { kind: "redirect"; redirect: Redirect }
+	| { kind: "article"; article: SavedArticle };
+
+const REDIRECT_TO_QUEUE: ReaderPermalinkResult = {
+	kind: "redirect",
+	redirect: { statusCode: 303, location: "/queue" },
+};
+
+/** UTM params on the /view redirect let analytics distinguish shared
+ * /read clicks from organic /view traffic. Preserve any incoming UTM
+ * (e.g. a campaign-tagged share URL) over the defaults so external
+ * attribution survives the redirect. */
+function buildShareRedirectUrl(articleUrl: string, query: Request["query"]): string {
+	const incomingUtm = collectUtmParams(query);
+	const utmParams: [string, string][] = incomingUtm.length > 0
+		? incomingUtm
+		: [
+			["utm_source", "read"],
+			["utm_medium", "share"],
+			["utm_campaign", "read-permalink"],
+		];
+	return `/view/${encodeURIComponent(articleUrl)}?${new URLSearchParams(utmParams).toString()}`;
+}
+
+export function initReaderPermalink(deps: ReaderPermalinkDeps) {
+	return async function resolveReaderPermalink(
+		input: ReaderPermalinkInput,
+	): Promise<ReaderPermalinkResult> {
+		const parsedId = ReaderArticleHashIdSchema.safeParse(input.rawId);
+		if (!parsedId.success) return REDIRECT_TO_QUEUE;
+
+		const ownedArticle = input.requesterId
+			? await deps.findArticleById(parsedId.data, input.requesterId)
+			: null;
+		if (ownedArticle) return { kind: "article", article: ownedArticle };
+
+		const articleUrl = await deps.findArticleUrlById(parsedId.data);
+		if (!articleUrl) return REDIRECT_TO_QUEUE;
+
+		/** 302 (not 301) because the redirect is conditional on
+		 * auth/ownership — the same URL renders differently for the
+		 * owner, so caches must not pin a single response. */
+		return {
+			kind: "redirect",
+			redirect: { statusCode: 302, location: buildShareRedirectUrl(articleUrl, input.query) },
+		};
+	};
+}

--- a/projects/hutch/src/runtime/web/redirect.component.test.ts
+++ b/projects/hutch/src/runtime/web/redirect.component.test.ts
@@ -1,0 +1,25 @@
+import { RedirectComponent } from "./redirect.component";
+
+describe("RedirectComponent", () => {
+	it("emits the status code and Location header for text/html", () => {
+		const parsed = RedirectComponent({
+			statusCode: 303,
+			location: "/queue",
+		}).to("text/html");
+
+		expect(parsed.statusCode).toBe(303);
+		expect(parsed.headers.Location).toBe("/queue");
+		expect(parsed.body).toBe("");
+	});
+
+	it("emits the same response for text/markdown — redirects are media-type agnostic", () => {
+		const parsed = RedirectComponent({
+			statusCode: 302,
+			location: "/view/https%3A%2F%2Fexample.com",
+		}).to("text/markdown");
+
+		expect(parsed.statusCode).toBe(302);
+		expect(parsed.headers.Location).toBe("/view/https%3A%2F%2Fexample.com");
+		expect(parsed.body).toBe("");
+	});
+});

--- a/projects/hutch/src/runtime/web/redirect.component.ts
+++ b/projects/hutch/src/runtime/web/redirect.component.ts
@@ -1,0 +1,16 @@
+import type { Component, ParsedComponent } from "./component.types";
+
+export interface Redirect {
+	statusCode: 302 | 303;
+	location: string;
+}
+
+export function RedirectComponent(redirect: Redirect): Component {
+	return {
+		to: (_mediaType): ParsedComponent => ({
+			statusCode: redirect.statusCode,
+			headers: { Location: redirect.location },
+			body: "",
+		}),
+	};
+}


### PR DESCRIPTION
## Summary

- The `/queue/:id/read` handler hard-coded three `res.redirect(...)` branches mixed with the page render path. Adding a fourth redirect rule meant editing the middle of the handler and was hard to unit-test in isolation.
- Extracted the decision into `initReaderPermalink` (partial application with injected `findArticleById` + `findArticleUrlById`). It returns a discriminated `{ kind: "redirect", redirect }` / `{ kind: "article", article }` result.
- Added a generic `RedirectComponent` that emits the status code and `Location` header through the existing `Component.to(mediaType)` contract, so redirects flow through `sendComponent` like every other response.
- The handler now dispatches on the result; future redirect rules are additions inside the resolver rather than new `if`/`return` branches in the handler.

## Test plan

- [x] New unit tests cover every branch of the resolver with injected fakes (malformed id, owner, logged-in non-owner, anonymous, unknown hash, percent-encoding of the article URL).
- [x] New unit tests cover `RedirectComponent` for both `text/html` and `text/markdown` (redirects are media-type agnostic).
- [x] Existing `queue.route.test.ts` (110 tests, including the four `/queue/:id/read` redirect cases) still passes with no modifications.
- [x] `pnpm lint` and `pnpm test-with-coverage` pass — both new files are at 100% line/branch/function coverage and the project-wide thresholds still hold.

https://claude.ai/code/session_01Eb18E1MyYYVPBpzKpfmeC1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb18E1MyYYVPBpzKpfmeC1)_