### PR TITLE
feat(hutch): add UTM tracking to /read share-link redirects

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -70,6 +70,23 @@ import {
 	isExtensionInstalled,
 	isExtensionSavedArticle,
 } from "../../onboarding/extension-install";
+import { collectUtmParams } from "../../shared/utm";
+
+/** UTM params on the /view redirect let analytics distinguish shared
+ * /read clicks from organic /view traffic. Preserve any incoming UTM
+ * (e.g. a campaign-tagged share URL) over the defaults so external
+ * attribution survives the redirect. */
+function buildShareRedirectUrl(articleUrl: string, query: Request["query"]): string {
+	const incomingUtm = collectUtmParams(query);
+	const utmParams: [string, string][] = incomingUtm.length > 0
+		? incomingUtm
+		: [
+			["utm_source", "read"],
+			["utm_medium", "share"],
+			["utm_campaign", "read-permalink"],
+		];
+	return `/view/${encodeURIComponent(articleUrl)}?${new URLSearchParams(utmParams).toString()}`;
+}
 
 function readImportSkippedFlash(
 	req: Request,
@@ -201,7 +218,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			/** 302 (not 301) because the redirect is conditional on
 			 * auth/ownership — the same URL renders differently for the
 			 * owner, so caches must not pin a single response. */
-			res.redirect(302, `/view/${encodeURIComponent(articleUrl)}`);
+			res.redirect(302, buildShareRedirectUrl(articleUrl, req.query));
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
@@ -172,7 +172,11 @@ describe("Queue routes", () => {
 			const response = await request(harness.server).get(`/queue/${articleId}/read`);
 
 			expect(response.status).toBe(302);
-			expect(response.headers.location).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			const location = new URL(response.headers.location, TEST_APP_ORIGIN);
+			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			expect(location.searchParams.get("utm_source")).toBe("read");
+			expect(location.searchParams.get("utm_medium")).toBe("share");
+			expect(location.searchParams.get("utm_campaign")).toBe("read-permalink");
 		});
 
 		it("should redirect logged-in non-owners to the public /view permalink", async () => {
@@ -199,7 +203,37 @@ describe("Queue routes", () => {
 			const response = await guestAgent.get(`/queue/${articleId}/read`);
 
 			expect(response.status).toBe(302);
-			expect(response.headers.location).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			const location = new URL(response.headers.location, TEST_APP_ORIGIN);
+			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			expect(location.searchParams.get("utm_source")).toBe("read");
+			expect(location.searchParams.get("utm_medium")).toBe("share");
+			expect(location.searchParams.get("utm_campaign")).toBe("read-permalink");
+		});
+
+		it("should preserve incoming UTM params on the redirect so external campaign attribution survives", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const ownerAgent = await loginAgent(harness.server, auth);
+
+			const articleUrl = "https://example.com/utm-passthrough";
+			await ownerAgent.post("/queue/save").type("form").send({ url: articleUrl });
+
+			const queueResponse = await ownerAgent.get("/queue");
+			const articleId = new JSDOM(queueResponse.text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert.ok(articleId, "owner must see the saved article in their queue");
+
+			const response = await request(harness.server)
+				.get(`/queue/${articleId}/read`)
+				.query({ utm_source: "twitter", utm_medium: "social" });
+
+			expect(response.status).toBe(302);
+			const location = new URL(response.headers.location, TEST_APP_ORIGIN);
+			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			expect(location.searchParams.get("utm_source")).toBe("twitter");
+			expect(location.searchParams.get("utm_medium")).toBe("social");
+			expect(location.searchParams.get("utm_campaign")).toBeNull();
 		});
 
 		it("should link article title to reader view in queue when content exists", async () => {


### PR DESCRIPTION
## Summary

- The `/queue/:id/read` route redirects non-owners (anonymous visitors and logged-in non-owners) to `/view/<url>` so social-media previews unfurl, but until now it dropped all query params on the redirect.
- That left the analytics middleware on `/view` unable to distinguish traffic from a shared `/read` link from organic `/view` traffic.
- This PR adds UTM params to the redirect destination: incoming UTM params are preserved (so externally tagged share campaigns survive), and when none are present the redirect falls back to defaults `utm_source=read`, `utm_medium=share`, `utm_campaign=read-permalink`.

The owner-facing path (`ownedArticle` present) is unchanged — only the non-owner redirect branch is touched.

## Test plan

- [x] Updated existing `queue.route.test.ts` redirect tests to assert UTM defaults are set on the redirect for anonymous and logged-in non-owners.
- [x] Added new test verifying incoming UTM params (`utm_source=twitter&utm_medium=social`) pass through unchanged to the `/view` location.
- [x] `pnpm test --testPathPattern="queue.route"` — 111 tests pass.
- [x] `pnpm lint` — clean.
- [x] `pnpm test-with-coverage` — coverage thresholds met (99.69% statements globally; new helper has 100% function coverage with both ternary branches exercised).

https://claude.ai/code/session_01WeABuMS7fFKDZ1pjqAFcaK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeABuMS7fFKDZ1pjqAFcaK)_