### PR TITLE
fix(hutch): preserve ?page=N when toggling rows on import review

### DIFF
--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -305,6 +305,34 @@ describe("Import routes", () => {
 
 			expect(response.status).toBe(422);
 		});
+
+		it("preserves the current page in the redirect when posting to the rendered row form action", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
+			const { body, contentType } = multipartBody("many.txt", Buffer.from(urls.join("\n")));
+			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
+			const sessionPath = create.headers.location;
+
+			const page2 = await agent.get(`${sessionPath}?page=2`);
+			const doc2 = new JSDOM(page2.text).window.document;
+			const row = doc2.querySelector<HTMLElement>("[data-test-import-row]");
+			assert(row, "at least one row must be rendered on page 2");
+			const form = row.querySelector<HTMLFormElement>("form");
+			assert(form, "row toggle form must be rendered");
+			const action = form.getAttribute("action");
+			assert(action, "row form must have an action attribute");
+			const indexInput = form.querySelector<HTMLInputElement>('input[name="index"]');
+			assert(indexInput, "row form must have an index hidden input");
+
+			const toggleResp = await agent
+				.post(action)
+				.type("form")
+				.send({ index: indexInput.value, checked: "false" });
+
+			expect(toggleResp.status).toBe(303);
+			expect(toggleResp.headers.location).toBe(`${sessionPath}?page=2`);
+		});
 	});
 
 	describe("GET /import/:id master checkbox", () => {
@@ -435,7 +463,7 @@ describe("Import routes", () => {
 			}
 		});
 
-		it("preserves the current page in the redirect", async () => {
+		it("preserves the current page in the redirect when posting to the rendered toolbar form action", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 			const urls = Array.from({ length: 60 }, (_v, i) => `https://example.com/post-${i}`);
@@ -443,10 +471,14 @@ describe("Import routes", () => {
 			const create = await agent.post("/import").set("Content-Type", contentType).send(body);
 			const sessionPath = create.headers.location;
 
-			const toggleResp = await agent
-				.post(`${sessionPath}/toggle-all?page=2`)
-				.type("form")
-				.send({ checked: "false" });
+			const page2 = await agent.get(`${sessionPath}?page=2`);
+			const doc2 = new JSDOM(page2.text).window.document;
+			const form = doc2.querySelector<HTMLFormElement>('[data-test-form="import-toggle-all"]');
+			assert(form, "toggle-all form must be rendered on page 2");
+			const action = form.getAttribute("action");
+			assert(action, "toggle-all form must have an action attribute");
+
+			const toggleResp = await agent.post(action).type("form").send({ checked: "false" });
 
 			expect(toggleResp.status).toBe(303);
 			expect(toggleResp.headers.location).toBe(`${sessionPath}?page=2`);

--- a/projects/hutch/src/runtime/web/pages/import/import.url.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.url.ts
@@ -14,3 +14,13 @@ export function parseImportPage(query: Record<string, unknown>): number {
 export function buildImportUrl(sessionId: string, page: number): string {
 	return page > 1 ? `/import/${sessionId}?page=${page}` : `/import/${sessionId}`;
 }
+
+export function buildImportToggleUrl(sessionId: string, page: number): string {
+	const base = `/import/${sessionId}/toggle`;
+	return page > 1 ? `${base}?page=${page}` : base;
+}
+
+export function buildImportToggleAllUrl(sessionId: string, page: number): string {
+	const base = `/import/${sessionId}/toggle-all`;
+	return page > 1 ? `${base}?page=${page}` : base;
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -124,6 +124,30 @@ describe("toImportViewModel", () => {
 		expect(vm.someSelected).toBe(true);
 	});
 
+	it("omits the page query string on toggle URLs when viewing the first page", () => {
+		const session = makeSession({ totalUrls: 120 });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: [], page: 1, pageSize: 50 },
+			120,
+		);
+
+		expect(vm.toggleUrl).toBe(`/import/${session.id}/toggle`);
+		expect(vm.toggleAllUrl).toBe(`/import/${session.id}/toggle-all`);
+	});
+
+	it("carries the current page in toggle URLs when viewing a later page", () => {
+		const session = makeSession({ totalUrls: 200 });
+
+		const vm = toImportViewModel(
+			{ session, pageUrls: [], page: 3, pageSize: 50 },
+			200,
+		);
+
+		expect(vm.toggleUrl).toBe(`/import/${session.id}/toggle?page=3`);
+		expect(vm.toggleAllUrl).toBe(`/import/${session.id}/toggle-all?page=3`);
+	});
+
 	it("propagates the truncated flag and totalFoundInFile from the session header", () => {
 		const session = makeSession({ totalUrls: 2_000, totalFoundInFile: 2_345, truncated: true });
 

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -1,6 +1,6 @@
 import type { ImportSessionPage } from "@packages/domain/import-session";
 import type { ComponentError } from "../../shared/component-error.types";
-import { buildImportUrl } from "./import.url";
+import { buildImportToggleAllUrl, buildImportToggleUrl, buildImportUrl } from "./import.url";
 
 export interface ImportUploadViewModel {
 	readonly errors?: readonly ComponentError[];
@@ -68,8 +68,8 @@ export function toImportViewModel(
 		prevUrl: page > 1 ? buildImportUrl(sessionId, page - 1) : undefined,
 		nextUrl: page < totalPages ? buildImportUrl(sessionId, page + 1) : undefined,
 		commitUrl: `/import/${sessionId}/commit`,
-		toggleUrl: `/import/${sessionId}/toggle`,
-		toggleAllUrl: `/import/${sessionId}/toggle-all`,
+		toggleUrl: buildImportToggleUrl(sessionId, page),
+		toggleAllUrl: buildImportToggleAllUrl(sessionId, page),
 		allSelected,
 		noneSelected,
 		someSelected: !allSelected && !noneSelected,


### PR DESCRIPTION
## Summary

- Carry the current `?page=N` through the row-toggle and toolbar select-all `<form action="…">` URLs on `/import/{id}`, the same way `prevUrl` / `nextUrl` already do. Without this, every checkbox click on page 2+ posted to `/import/{id}/toggle`, fell through `parseImportPage(req.query) ?? 1`, and 303-redirected back to page 1 — making selective review of a paginated import unusable.
- Two new helpers in `import.url.ts` (`buildImportToggleUrl`, `buildImportToggleAllUrl`), wired into `toImportViewModel`. No template, handler, or domain change needed: the handlers already read `parseImportPage(req.query)` and only ever missed the page because the form action didn't carry it.
- Fix the misleading existing route test (`"preserves the current page in the redirect"`), which manually appended `?page=2` to the POST URL and so green-lit the buggy template. It now extracts the action attribute from the rendered HTML on page 2 and posts to that. Added the parallel row-toggle test that the suite was missing, plus two view-model tests pinning the URL shape at `page === 1` and `page > 1`.

## Test plan

- [x] `pnpm nx test hutch` — 47/47 import tests pass (including new ones)
- [x] `pnpm nx lint hutch` clean
- [x] `pnpm check` (full pre-commit) passes
- [ ] Manual: upload a 200+ URL file at `/queue`, navigate to page 2, click a row — URL stays at `?page=2`, summary updates
- [ ] Manual: same on page 3 with the toolbar "select all"
- [ ] Manual: with JavaScript disabled, the `<noscript>` submit button also lands on the same page
- [ ] Manual: "Import N selected" still redirects to `/queue` with the import banner

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJFDyAKTJbxWY45TedzbFW)_