### PR TITLE
fix(save-link): regenerate summary when canonical ties an inadequate prior

### DIFF
--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
@@ -1,5 +1,6 @@
 import { noopLogger } from "@packages/hutch-logger";
 import {
+	type Article,
 	recrawlPromoteTier,
 	recrawlTieKeptCanonical,
 	type TransitionAndPersist,
@@ -72,6 +73,18 @@ function createSqsEvent(detail: { url: string }): SQSEvent {
 
 type HandlerDeps = Parameters<typeof initRecrawlContentExtractedHandler>[0];
 
+function articleWithSummary(url: string, summary: Article["summary"]): Article {
+	return {
+		url,
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary,
+		summaryAutoHeal: { attempts: 0 },
+	};
+}
+
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 	const deps: HandlerDeps = {
@@ -79,6 +92,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		selectMostCompleteContent: jest.fn<ReturnType<SelectMostCompleteContent>, Parameters<SelectMostCompleteContent>>().mockResolvedValue({ winner: "tie", reason: "" }),
 		writeCanonicalContent: jest.fn<ReturnType<WriteCanonicalContent>, Parameters<WriteCanonicalContent>>().mockResolvedValue(undefined),
 		findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
+		loadArticle: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist,
 		imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
 		now: () => FIXED_NOW,
@@ -207,6 +221,79 @@ describe("initRecrawlContentExtractedHandler", () => {
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary("https://example.com/a", {
+					kind: "ready",
+					summary: "ok",
+				}),
+			),
+			writeCanonicalContent,
+			transitionAndPersist,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(writeCanonicalContent).not.toHaveBeenCalled();
+		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
+			url: "https://example.com/a",
+			input: undefined,
+		});
+	});
+
+	it("on a tie with an existing canonical whose summary is skipped(content-too-short), falls through to the deterministic tiebreaker and dispatches recrawlPromoteTier so the stuck row regenerates against the new canonical", async () => {
+		const tier0 = tierSource("tier-0");
+		const tier1 = tierSource("tier-1");
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
+			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary("https://example.com/a", {
+					kind: "skipped",
+					reason: "content-too-short",
+				}),
+			),
+			writeCanonicalContent,
+			transitionAndPersist,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-1",
+		});
+		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlPromoteTier, {
+			url: "https://example.com/a",
+			input: {
+				winnerTier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				now: FIXED_NOW.toISOString(),
+			},
+		});
+	});
+
+	it("on a tie with an existing canonical whose summary is skipped for a non-too-short reason (e.g. ai-unavailable), keeps the existing canonical and dispatches recrawlTieKeptCanonical", async () => {
+		const tier0 = tierSource("tier-0");
+		const tier1 = tierSource("tier-1");
+		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
+			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary("https://example.com/a", {
+					kind: "skipped",
+					reason: "ai-unavailable",
+				}),
+			),
 			writeCanonicalContent,
 			transitionAndPersist,
 		});

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -104,10 +104,11 @@ export function initRecrawlContentExtractedHandler(deps: {
 						const summaryStuckOnTooShort =
 							existingArticle?.summary.kind === "skipped" &&
 							existingArticle.summary.reason === "content-too-short";
+						const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
 						if (cdnTie) {
 							winnerTier = cdnTie.tier;
 							reason = cdnTie.reason;
-						} else if (existingTier && !summaryStuckOnTooShort) {
+						} else if (canonicalIsHealthy) {
 							winnerTier = undefined;
 							reason = decision.reason;
 						} else {

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -7,6 +7,7 @@ import type {
 } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
 import {
+	type LoadArticle,
 	type TransitionAndPersist,
 	recrawlPromoteTier,
 	recrawlTieKeptCanonical,
@@ -23,6 +24,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 	selectMostCompleteContent: SelectMostCompleteContent;
 	writeCanonicalContent: WriteCanonicalContent;
 	findContentSourceTier: FindContentSourceTier;
+	loadArticle: LoadArticle;
 	transitionAndPersist: TransitionAndPersist;
 	imagesCdnBaseUrl: string;
 	now: () => Date;
@@ -33,6 +35,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 		selectMostCompleteContent,
 		writeCanonicalContent,
 		findContentSourceTier,
+		loadArticle,
 		transitionAndPersist,
 		imagesCdnBaseUrl,
 		now,
@@ -95,25 +98,33 @@ export function initRecrawlContentExtractedHandler(deps: {
 						 * of the CDN host than the others. */
 						const cdnTie = breakTieByCdnRewriteCount(sources, cdnHost);
 						const existingTier = cdnTie ? undefined : await findContentSourceTier(detail.url);
+						const existingArticle = existingTier
+							? await loadArticle(detail.url)
+							: undefined;
+						const summaryStuckOnTooShort =
+							existingArticle?.summary.kind === "skipped" &&
+							existingArticle.summary.reason === "content-too-short";
 						if (cdnTie) {
 							winnerTier = cdnTie.tier;
 							reason = cdnTie.reason;
-						} else if (existingTier) {
+						} else if (existingTier && !summaryStuckOnTooShort) {
 							winnerTier = undefined;
 							reason = decision.reason;
 						} else {
-							/* Tie with no canonical yet — i.e. recovering a row that
-							 * the user-save flow left stuck because of the same tie
-							 * pathology. Default to tier-1 (Readability) when present,
-							 * else tier-0; both candidates carry identical content by
-							 * definition of "tie", so this is a deterministic
-							 * tiebreaker rather than a quality call. */
+							/* Either tie with no canonical yet (recovering a stuck
+							 * row), OR canonical exists but its summary is
+							 * skipped("content-too-short") — the previous canonical's
+							 * content was inadequate. By definition of "tie" both
+							 * tiers carry equivalent content; prefer tier-1
+							 * (Readability) when present, else tier-0. */
 							const fallback =
 								sources.find((source) => source.tier === "tier-1") ??
 								sources.find((source) => source.tier === "tier-0");
 							assert(fallback, "tie with no candidate tiers should be unreachable");
 							winnerTier = fallback.tier;
-							reason = `tie on recrawl recovery; defaulted to ${fallback.tier}`;
+							reason = summaryStuckOnTooShort
+								? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
+								: `tie on recrawl recovery; defaulted to ${fallback.tier}`;
 						}
 					} else {
 						winnerTier = decision.winner;

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
@@ -1,5 +1,6 @@
 import { noopLogger } from "@packages/hutch-logger";
 import {
+	type Article,
 	promoteTier,
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
@@ -71,6 +72,18 @@ function createSqsEvent(detail: { url: string; tier: "tier-0" | "tier-1"; userId
 
 type HandlerDeps = Parameters<typeof initSelectMostCompleteContentHandler>[0];
 
+function articleWithSummary(url: string, summary: Article["summary"]): Article {
+	return {
+		url,
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary,
+		summaryAutoHeal: { attempts: 0 },
+	};
+}
+
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
 	const deps: HandlerDeps = {
@@ -78,6 +91,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		selectMostCompleteContent: jest.fn<ReturnType<SelectMostCompleteContent>, Parameters<SelectMostCompleteContent>>().mockResolvedValue({ winner: "tie", reason: "" }),
 		writeCanonicalContent: jest.fn<ReturnType<WriteCanonicalContent>, Parameters<WriteCanonicalContent>>().mockResolvedValue(undefined),
 		findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
+		loadArticle: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist,
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: () => FIXED_NOW,
@@ -227,6 +241,77 @@ describe("initSelectMostCompleteContentHandler", () => {
 			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary("https://example.com/a", {
+					kind: "ready",
+					summary: "ok",
+				}),
+			),
+			publishEvent,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+
+		expect(deps.writeCanonicalContent).not.toHaveBeenCalled();
+		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
+		const events = publishEvent.mock.calls.map((call: [{ detailType: string }]) => call[0].detailType);
+		expect(events).toEqual(["CrawlArticleCompleted"]);
+	});
+
+	it("tie with an existing canonical whose summary is skipped(content-too-short) falls through to the deterministic tiebreaker and promotes so the row exits the stuck skipped state", async () => {
+		const tier0 = tierSource("tier-0");
+		const tier1 = tierSource("tier-1");
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
+			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary("https://example.com/a", {
+					kind: "skipped",
+					reason: "content-too-short",
+				}),
+			),
+			publishEvent,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+
+		expect(publishEvent).not.toHaveBeenCalled();
+		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-1",
+		});
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
+			url: "https://example.com/a",
+			input: {
+				tier: "tier-1",
+				metadata: tier1.metadata,
+				estimatedReadTime: tier1.metadata.estimatedReadTime,
+				contentFetchedAt: FIXED_NOW.toISOString(),
+				now: FIXED_NOW.toISOString(),
+				canonicalChanged: true,
+				userId: "user-1",
+			},
+		});
+	});
+
+	it("tie with an existing canonical whose summary is skipped for a non-too-short reason (e.g. ai-unavailable) keeps the existing skip — does not promote", async () => {
+		const tier0 = tierSource("tier-0");
+		const tier1 = tierSource("tier-1");
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "equally complete" }),
+			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary("https://example.com/a", {
+					kind: "skipped",
+					reason: "ai-unavailable",
+				}),
+			),
 			publishEvent,
 		});
 

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -97,7 +97,8 @@ export function initSelectMostCompleteContentHandler(deps: {
 						const summaryStuckOnTooShort =
 							existingArticle?.summary.kind === "skipped" &&
 							existingArticle.summary.reason === "content-too-short";
-						if (existingTier && !summaryStuckOnTooShort) {
+						const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
+						if (canonicalIsHealthy) {
 							/* Recrawl tie: a canonical already exists. Promoting the
 							 * same content again would be a no-op write but a real
 							 * summary regeneration — wasted Deepseek tokens. Emit

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -3,6 +3,7 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
+	type LoadArticle,
 	type TransitionAndPersist,
 	promoteTier,
 } from "@packages/domain/article-aggregate";
@@ -22,6 +23,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 	selectMostCompleteContent: SelectMostCompleteContent;
 	writeCanonicalContent: WriteCanonicalContent;
 	findContentSourceTier: FindContentSourceTier;
+	loadArticle: LoadArticle;
 	transitionAndPersist: TransitionAndPersist;
 	publishEvent: PublishEvent;
 	now: () => Date;
@@ -32,6 +34,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 		selectMostCompleteContent,
 		writeCanonicalContent,
 		findContentSourceTier,
+		loadArticle,
 		transitionAndPersist,
 		publishEvent,
 		now,
@@ -88,7 +91,13 @@ export function initSelectMostCompleteContentHandler(deps: {
 					});
 					if (decision.winner === "tie") {
 						const existingTier = await findContentSourceTier(detail.url);
-						if (existingTier) {
+						const existingArticle = existingTier
+							? await loadArticle(detail.url)
+							: undefined;
+						const summaryStuckOnTooShort =
+							existingArticle?.summary.kind === "skipped" &&
+							existingArticle.summary.reason === "content-too-short";
+						if (existingTier && !summaryStuckOnTooShort) {
 							/* Recrawl tie: a canonical already exists. Promoting the
 							 * same content again would be a no-op write but a real
 							 * summary regeneration — wasted Deepseek tokens. Emit
@@ -102,19 +111,21 @@ export function initSelectMostCompleteContentHandler(deps: {
 							});
 							continue;
 						}
-						/* First save: tie with no canonical yet. By definition of
-						 * "tie" both tiers carry equivalent content, so picking
-						 * one is a deterministic tiebreaker rather than a quality
-						 * call. Prefer tier-1 (Readability-parsed) when present,
-						 * else tier-0 (raw HTML). Without this default the row
-						 * sits at crawlStatus=pending forever — promoteTier
-						 * is the only writer of crawlStatus="ready". */
+						/* Either first save (no canonical yet) OR canonical exists
+						 * but its summary is skipped("content-too-short") — i.e.
+						 * the previous canonical's content was inadequate. In both
+						 * cases, by definition of "tie" both tiers carry equivalent
+						 * content; prefer tier-1 (Readability-parsed) when present,
+						 * else tier-0. promoteTier resets summary to pending and
+						 * re-fires generate-summary against the new canonical. */
 						const fallback =
 							sources.find((source) => source.tier === "tier-1") ??
 							sources.find((source) => source.tier === "tier-0");
 						assert(fallback, "tie with no candidate tiers should be unreachable");
 						winnerTier = fallback.tier;
-						reason = `tie on first save; defaulted to ${fallback.tier}`;
+						reason = summaryStuckOnTooShort
+							? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
+							: `tie on first save; defaulted to ${fallback.tier}`;
 					} else {
 						winnerTier = decision.winner;
 						reason = decision.reason;

--- a/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
@@ -42,6 +42,7 @@ const selectContent = initSelectContentDepBundle({
 export const handler = initRecrawlContentExtractedHandler({
 	...selectContent,
 	...articleAggregate,
+	loadArticle: articleAggregate.store.load,
 	imagesCdnBaseUrl,
 	now: () => new Date(),
 	logger: consoleLogger,

--- a/projects/save-link/src/runtime/select-most-complete-content.main.ts
+++ b/projects/save-link/src/runtime/select-most-complete-content.main.ts
@@ -92,6 +92,7 @@ export const handler = initSelectMostCompleteContentHandler({
 	selectMostCompleteContent,
 	writeCanonicalContent,
 	findContentSourceTier,
+	loadArticle: store.load,
 	transitionAndPersist,
 	publishEvent,
 	now: () => new Date(),


### PR DESCRIPTION
## Summary

A reader could see "This article is too short to summarise." on an article that clearly has full content. Reproduction:

1. User saves a URL via the Chrome extension while the page is still rendering — extension submits a stub-HTML tier-0 source.
2. Summariser sees `cleanedText.length <= MAX_SUMMARY_LENGTH * 3` and returns `{kind:"skipped", reason:"content-too-short"}`.
3. Later the user re-saves (or an admin recrawl runs) and a tier-1 source with full content arrives.
4. The selector returns "tie" against the stub canonical. Both tie-handling paths short-circuit — the user-save path emits `CrawlArticleCompleted` directly and skips the aggregate transition; the recrawl path dispatches `recrawlTieKeptCanonical` which does not reset summary. The skipped state persists.

## Fix

Read the existing summary state in both tie branches. When the prior canonical's summary is `skipped("content-too-short")` — an auditable per-event record that the previous canonical's content was inadequate — fall through to the existing deterministic tier-1-else-tier-0 tiebreaker and dispatch `promoteTier` / `recrawlPromoteTier`. Those transitions reset summary to pending and re-fire `generate-summary` against the new canonical, so the UI exits the stuck "too short to summarise" message.

The override only fires for this specific recorded failure signal — any other summary state (`ready`, `failed`, `pending`, or `skipped` for `ai-unavailable`/`crawl-unsupported`) keeps the existing cache-hit / kept-canonical short-circuit, so Deepseek cost is unchanged on healthy ties.

## Test plan

- [x] `pnpm nx test save-link` — 368 tests pass, including 4 new tests covering the override on both handlers and 2 negative tests confirming non-`content-too-short` skipped states still hit the existing short-circuit
- [x] `pnpm nx test-with-coverage save-link` — 100% statements/branches/functions/lines maintained
- [x] `pnpm nx lint save-link` — clean
- [x] `pnpm check` — all 19 projects pass during the pre-commit hook
- [ ] Manual reproduction against dev stack: save a stub URL, confirm `summary={kind:"skipped",reason:"content-too-short"}` and the "too short" UI; re-save with full HTML; confirm the new override log line and `summary={kind:"ready",...}` with the new excerpt
- [ ] Manual reproduction via `/admin/recrawl/<url>` for the symmetric recrawl path


---
_Generated by [Claude Code](https://claude.ai/code/session_017xu7wNVC7U5TU2RHNg47z2)_