### PR TITLE
fix: gate summary regeneration on canonical content hash

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -190,7 +190,6 @@ function initProviders() {
 			putPendingHtml,
 			findGeneratedSummary: summaryStore.findGeneratedSummary,
 			markSummaryPending: summaryStore.markSummaryPending,
-			forceMarkSummaryPending: summaryStore.forceMarkSummaryPending,
 			findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
 			markCrawlPending: crawlStore.markCrawlPending,
 			forceMarkCrawlPending: crawlStore.forceMarkCrawlPending,
@@ -290,7 +289,6 @@ function initProviders() {
 	const { putPendingHtml } = initInMemoryPendingHtml();
 	const stubFindGeneratedSummary = async (_url: string) => undefined;
 	const stubMarkSummaryPending = async (_params: { url: string }) => {};
-	const stubForceMarkSummaryPending = async (_params: { url: string }) => {};
 	const { refreshArticleIfStale } = initRefreshArticleIfStale({
 		findArticleFreshness: articleStore.findArticleFreshness,
 		findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
@@ -333,7 +331,6 @@ function initProviders() {
 		putPendingHtml,
 		findGeneratedSummary: stubFindGeneratedSummary,
 		markSummaryPending: stubMarkSummaryPending,
-		forceMarkSummaryPending: stubForceMarkSummaryPending,
 		findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
 		markCrawlPending: crawlStore.markCrawlPending,
 		forceMarkCrawlPending: crawlStore.forceMarkCrawlPending,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -546,7 +546,6 @@ export function createApp(dependencies: AppDependencies): Express {
 		findArticleByUrl: deps.findArticleByUrl,
 		readArticleContent: deps.readArticleContent,
 		findGeneratedSummary: deps.findGeneratedSummary,
-		markSummaryPending: deps.markSummaryPending,
 		findArticleCrawlStatus: deps.findArticleCrawlStatus,
 		markCrawlPending: deps.markCrawlPending,
 		forceMarkCrawlPending: deps.forceMarkCrawlPending,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -50,7 +50,6 @@ import type {
 } from "@packages/test-fixtures/providers/article-crawl";
 import type {
 	FindGeneratedSummary,
-	ForceMarkSummaryPending,
 	MarkSummaryPending,
 } from "@packages/test-fixtures/providers/article-summary";
 import type { PublishLinkSaved } from "@packages/test-fixtures/providers/events";
@@ -161,7 +160,6 @@ interface AppDependencies {
 	putPendingHtml: PutPendingHtml;
 	findGeneratedSummary: FindGeneratedSummary;
 	markSummaryPending: MarkSummaryPending;
-	forceMarkSummaryPending: ForceMarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -547,7 +547,6 @@ export function createApp(dependencies: AppDependencies): Express {
 		readArticleContent: deps.readArticleContent,
 		findGeneratedSummary: deps.findGeneratedSummary,
 		markSummaryPending: deps.markSummaryPending,
-		forceMarkSummaryPending: deps.forceMarkSummaryPending,
 		findArticleCrawlStatus: deps.findArticleCrawlStatus,
 		markCrawlPending: deps.markCrawlPending,
 		forceMarkCrawlPending: deps.forceMarkCrawlPending,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -337,7 +337,6 @@ function flattenFixtureToAppDependencies(
 		putPendingHtml: fixture.pendingHtml.putPendingHtml,
 		findGeneratedSummary: fixture.summary.findGeneratedSummary,
 		markSummaryPending: fixture.summary.markSummaryPending,
-		forceMarkSummaryPending: fixture.summary.forceMarkSummaryPending,
 		refreshArticleIfStale: fixture.freshness.refreshArticleIfStale,
 		oauthModel: fixture.oauth.oauthModel,
 		validateAccessToken: fixture.oauth.validateAccessToken,

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -11,7 +11,6 @@ import type { FindArticleByUrl } from "@packages/test-fixtures/providers/article
 import type { ReadArticleContent } from "@packages/test-fixtures/providers/article-store";
 import type {
 	FindGeneratedSummary,
-	MarkSummaryPending,
 } from "@packages/test-fixtures/providers/article-summary";
 import type { PublishRecrawlLinkInitiated } from "@packages/test-fixtures/providers/events";
 import type { FindUserByEmail } from "@packages/test-fixtures/providers/auth";
@@ -31,7 +30,6 @@ export interface AdminRecrawlDependencies {
 	findArticleByUrl: FindArticleByUrl;
 	readArticleContent: ReadArticleContent;
 	findGeneratedSummary: FindGeneratedSummary;
-	markSummaryPending: MarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -11,7 +11,6 @@ import type { FindArticleByUrl } from "@packages/test-fixtures/providers/article
 import type { ReadArticleContent } from "@packages/test-fixtures/providers/article-store";
 import type {
 	FindGeneratedSummary,
-	ForceMarkSummaryPending,
 	MarkSummaryPending,
 } from "@packages/test-fixtures/providers/article-summary";
 import type { PublishRecrawlLinkInitiated } from "@packages/test-fixtures/providers/events";
@@ -33,7 +32,6 @@ export interface AdminRecrawlDependencies {
 	readArticleContent: ReadArticleContent;
 	findGeneratedSummary: FindGeneratedSummary;
 	markSummaryPending: MarkSummaryPending;
-	forceMarkSummaryPending: ForceMarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;
@@ -109,13 +107,14 @@ function handleRecrawlArticle(
 			return;
 		}
 
-		// Always recrawl. No cache, no TTL. Force both crawl and summary state
-		// back to pending (even if currently `ready`) so the reader slot shows
-		// the "recrawl in progress" skeleton AND the summary worker regenerates
-		// the AI excerpt instead of short-circuiting on its cached "ready" row,
-		// then publish the command.
+		// Always recrawl. No cache, no TTL. Force crawl back to pending (even if
+		// currently `ready`) so the reader slot shows the "recrawl in progress"
+		// skeleton. Summary state is owned by the recrawl pipeline — the
+		// canonicalContentHash gate inside recrawlPromoteTier /
+		// recrawlTieKeptCanonical decides whether to regenerate the AI excerpt,
+		// so wiping summary here would mean a guaranteed regen even when the
+		// canonical readable content has not actually changed.
 		await deps.forceMarkCrawlPending({ url: articleUrl });
-		await deps.forceMarkSummaryPending({ url: articleUrl });
 		await deps.publishRecrawlLinkInitiated({ url: articleUrl });
 
 		const state = await reader.resolveReaderState({

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
@@ -284,7 +284,7 @@ describe("Admin recrawl routes", () => {
 			);
 		});
 
-		it("force-flips a previously ready summary back to pending so the worker regenerates the AI excerpt", async () => {
+		it("preserves the existing ready summary on the admin recrawl trigger — summary regeneration is decided downstream by the canonicalContentHash gate, not by wiping state up front", async () => {
 			const harness = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await harness.auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
 			await harness.articleStore.saveArticleGlobally({
@@ -298,13 +298,14 @@ describe("Admin recrawl routes", () => {
 				estimatedReadTime: MinutesSchema.parse(1),
 				savedAt: new Date(),
 			});
-			// Summary was generated on a prior crawl. Without the force-pending
-			// path, the save-link summarizer's cache short-circuits on `ready`
-			// and the AI excerpt is never regenerated.
+			// Summary was generated on a prior crawl. Wiping it here would mean
+			// a guaranteed DeepSeek call on every admin recrawl regardless of
+			// whether the readable content actually changed. The hash gate in
+			// recrawlPromoteTier / recrawlTieKeptCanonical now owns that decision.
 			harness.summary.markSummaryReady({
 				url: ARTICLE_URL,
-				summary: "Stale summary",
-				excerpt: "Stale excerpt blurb",
+				summary: "Existing summary",
+				excerpt: "Existing summary blurb",
 			});
 
 			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
@@ -313,7 +314,11 @@ describe("Admin recrawl routes", () => {
 
 			expect(response.status).toBe(200);
 			const summaryAfter = await harness.summary.findGeneratedSummary(ARTICLE_URL);
-			expect(summaryAfter).toEqual({ status: "pending" });
+			expect(summaryAfter).toEqual({
+				status: "ready",
+				summary: "Existing summary",
+				excerpt: "Existing summary blurb",
+			});
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/generate-summary/generate-summary-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/generate-summary-handler.test.ts
@@ -8,6 +8,7 @@ import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
 import { initGenerateSummaryHandler } from "./generate-summary-handler";
 import type { SummarizeArticle } from "./link-summariser";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
@@ -74,8 +75,9 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 }
 
 describe("initGenerateSummaryHandler", () => {
-	it("fires markSummaryReady with summary/excerpt/inputTokens/outputTokens on the happy path", async () => {
+	it("fires markSummaryReady with summary/excerpt/inputTokens/outputTokens + sourceContentHash on the happy path", async () => {
 		const URL = "https://example.com/article";
+		const html = "<p>article content</p>";
 		const { handler, deps } = createHandler({
 			summarizeArticle: jest.fn<ReturnType<SummarizeArticle>, Parameters<SummarizeArticle>>().mockResolvedValue({
 				kind: "ready",
@@ -84,6 +86,7 @@ describe("initGenerateSummaryHandler", () => {
 				inputTokens: 100,
 				outputTokens: 50,
 			}),
+			findArticleContent: jest.fn<ReturnType<FindArticleContent>, Parameters<FindArticleContent>>().mockResolvedValue({ content: html }),
 			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
 		});
 
@@ -97,6 +100,7 @@ describe("initGenerateSummaryHandler", () => {
 				excerpt: "A blurb.",
 				inputTokens: 100,
 				outputTokens: 50,
+				sourceContentHash: computeCanonicalContentHash(html),
 			},
 		});
 	});

--- a/projects/save-link/src/runtime/domain/generate-summary/generate-summary-handler.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/generate-summary-handler.ts
@@ -10,6 +10,7 @@ import {
 import { GenerateSummaryCommand } from "./index";
 import type { SummarizeArticle } from "./link-summariser";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 
 interface GenerateSummaryHandlerDeps {
 	summarizeArticle: SummarizeArticle;
@@ -56,6 +57,10 @@ export function initGenerateSummaryHandler(deps: GenerateSummaryHandlerDeps): Ha
 				});
 
 				if (result.kind === "ready") {
+					/* Tag the persisted ready summary with the hash of the canonical
+					 * content it was generated against so a future caller can compare
+					 * hashes and short-circuit on cacheability. */
+					const sourceContentHash = computeCanonicalContentHash(article.content);
 					await transitionAndPersist(markSummaryReady, {
 						url: command.url,
 						input: {
@@ -63,6 +68,7 @@ export function initGenerateSummaryHandler(deps: GenerateSummaryHandlerDeps): Ha
 							excerpt: result.excerpt,
 							inputTokens: result.inputTokens,
 							outputTokens: result.outputTokens,
+							sourceContentHash,
 						},
 					});
 					logger.info("[GenerateSummary] completed", {

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
@@ -9,6 +9,7 @@ import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -138,8 +139,30 @@ describe("initRecrawlContentExtractedHandler", () => {
 				estimatedReadTime: tier1.metadata.estimatedReadTime,
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
+				canonicalContentHash: computeCanonicalContentHash(tier1.html),
 			},
 		});
+	});
+
+	it("computes a canonical content hash from the winner HTML and threads it through so the aggregate's hash gate can suppress redundant summary regeneration", async () => {
+		const tier1 = tierSource("tier-1", { html: "<article><p>Distinctive recrawl body.</p></article>" });
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
+			transitionAndPersist,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		const expectedHash = computeCanonicalContentHash(tier1.html);
+		expect(transitionAndPersist).toHaveBeenCalledWith(
+			recrawlPromoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({ canonicalContentHash: expectedHash }),
+			}),
+		);
+		expect(expectedHash.length).toBe(64);
 	});
 
 	it("refreshes user-facing metadata (title/excerpt/wordCount/imageUrl) into the aggregate input on a recrawl — bug-fix coverage for the previously-frozen card", async () => {
@@ -276,6 +299,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 				estimatedReadTime: tier1.metadata.estimatedReadTime,
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
+				canonicalContentHash: computeCanonicalContentHash(tier1.html),
 			},
 		});
 	});
@@ -327,6 +351,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 				estimatedReadTime: tier1.metadata.estimatedReadTime,
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
+				canonicalContentHash: computeCanonicalContentHash(tier1.html),
 			},
 		});
 	});

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -16,6 +16,7 @@ import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { TierSource } from "./tier-source.types";
 
 export function initRecrawlContentExtractedHandler(deps: {
@@ -124,6 +125,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 				if (winnerTier !== undefined) {
 					const winnerSource = sources.find((source) => source.tier === winnerTier);
 					assert(winnerSource, `winner tier ${winnerTier} missing from candidate set`);
+					const canonicalContentHash = computeCanonicalContentHash(winnerSource.html);
 
 					await writeCanonicalContent({ url: detail.url, tier: winnerTier });
 
@@ -135,6 +137,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 							estimatedReadTime: winnerSource.metadata.estimatedReadTime,
 							contentFetchedAt: now().toISOString(),
 							now: now().toISOString(),
+							canonicalContentHash,
 						},
 					});
 

--- a/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.test.ts
@@ -6,6 +6,7 @@ import {
 import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
 import { initRefreshContentExtractedHandler } from "./refresh-content-extracted-handler";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
@@ -124,9 +125,31 @@ describe("initRefreshContentExtractedHandler", () => {
 					metadata: expect.objectContaining({ title: "Title" }),
 					freshness: FRESHNESS,
 					now: FIXED_NOW.toISOString(),
+					canonicalContentHash: computeCanonicalContentHash(tier1.html),
 				}),
 			}),
 		);
+	});
+
+	it("computes a canonical content hash from the winner HTML and threads it through the refresh transition input", async () => {
+		const tier1 = tierSource("tier-1", { html: "<article><p>Refresh body.</p></article>" });
+		const transitionAndPersist: TransitionAndPersist = jest.fn().mockResolvedValue(undefined);
+
+		const { handler } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
+			transitionAndPersist,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		const expectedHash = computeCanonicalContentHash(tier1.html);
+		expect(transitionAndPersist).toHaveBeenCalledWith(
+			refreshContent,
+			expect.objectContaining({
+				input: expect.objectContaining({ canonicalContentHash: expectedHash }),
+			}),
+		);
+		expect(expectedHash.length).toBe(64);
 	});
 
 	it("preserves the existing canonical tier when the selector calls a tie and the row already has a canonical (key invariant: refresh must not silently flip to tier-1)", async () => {

--- a/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.ts
@@ -9,6 +9,7 @@ import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "a
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { SelectMostCompleteContent } from "./select-content";
 
 /**
@@ -93,6 +94,7 @@ export function initRefreshContentExtractedHandler(deps: {
 
 				const winnerSource = sources.find((source) => source.tier === winnerTier);
 				assert(winnerSource, `winner tier ${winnerTier} missing from candidate set`);
+				const canonicalContentHash = computeCanonicalContentHash(winnerSource.html);
 
 				const existingTier = await findContentSourceTier(detail.url);
 				if (existingTier !== winnerTier) {
@@ -116,6 +118,7 @@ export function initRefreshContentExtractedHandler(deps: {
 						},
 						estimatedReadTime: winnerSource.metadata.estimatedReadTime,
 						now: now().toISOString(),
+						canonicalContentHash,
 					},
 				});
 

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
@@ -8,6 +8,7 @@ import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -135,6 +136,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
 				canonicalChanged: true,
+				canonicalContentHash: computeCanonicalContentHash(tier1.html),
 				userId: "user-1",
 			},
 		});
@@ -187,6 +189,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
 				canonicalChanged: true,
+				canonicalContentHash: computeCanonicalContentHash(tier0.html),
 				userId: "user-1",
 			},
 		});
@@ -213,9 +216,30 @@ describe("initSelectMostCompleteContentHandler", () => {
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
 				canonicalChanged: true,
+				canonicalContentHash: computeCanonicalContentHash(tier1.html),
 				userId: undefined,
 			},
 		});
+	});
+
+	it("computes and passes a canonical content hash derived from the winning source HTML so the aggregate's hash gate can detect content equality", async () => {
+		const tier1 = tierSource("tier-1", { html: "<article><p>Distinctive winner body.</p></article>" });
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier1]),
+			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+
+		const expectedHash = computeCanonicalContentHash(tier1.html);
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			promoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({ canonicalContentHash: expectedHash }),
+			}),
+		);
+		expect(expectedHash.length).toBe(64);
 	});
 
 	it("tie with an existing canonical keeps it unchanged — emits CrawlArticleCompleted directly and skips the aggregate transition entirely", async () => {
@@ -263,6 +287,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
 				canonicalChanged: true,
+				canonicalContentHash: computeCanonicalContentHash(tier1.html),
 				userId: "user-1",
 			},
 		});
@@ -318,6 +343,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 				contentFetchedAt: FIXED_NOW.toISOString(),
 				now: FIXED_NOW.toISOString(),
 				canonicalChanged: false,
+				canonicalContentHash: computeCanonicalContentHash(tier0.html),
 				userId: "user-1",
 			},
 		});

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -14,6 +14,7 @@ import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { SelectMostCompleteContent } from "./select-content";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
+import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { TierSource } from "./tier-source.types";
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
@@ -131,6 +132,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 
 				const currentTier = await findContentSourceTier(detail.url);
 				const canonicalChanged = currentTier !== winnerTier;
+				const canonicalContentHash = computeCanonicalContentHash(winnerSource.html);
 
 				await writeCanonicalContent({ url: detail.url, tier: winnerTier });
 
@@ -143,6 +145,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 						contentFetchedAt: now().toISOString(),
 						now: now().toISOString(),
 						canonicalChanged,
+						canonicalContentHash,
 						userId: detail.userId,
 					},
 				});

--- a/projects/save-link/src/runtime/providers/article-store/compute-canonical-content-hash.test.ts
+++ b/projects/save-link/src/runtime/providers/article-store/compute-canonical-content-hash.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { computeCanonicalContentHash } from "./compute-canonical-content-hash";
+
+describe("computeCanonicalContentHash", () => {
+	it("returns the same hash for identical canonical HTML", () => {
+		const html = "<p>Hello world.</p>";
+
+		assert.equal(computeCanonicalContentHash(html), computeCanonicalContentHash(html));
+	});
+
+	it("returns the same hash when only ad/tracking markup differs but readable text is identical (server-decoy resistance)", () => {
+		const withoutAds = "<article><p>Hello world.</p></article>";
+		const withAds =
+			"<article><p>Hello world.</p><script src=\"https://tracker.example/pixel.js\"></script><div class=\"ad\"></div></article>";
+
+		assert.equal(
+			computeCanonicalContentHash(withoutAds),
+			computeCanonicalContentHash(withAds),
+		);
+	});
+
+	it("returns different hashes when the readable text differs", () => {
+		const a = "<p>Hello world.</p>";
+		const b = "<p>Hello universe.</p>";
+
+		assert.notEqual(computeCanonicalContentHash(a), computeCanonicalContentHash(b));
+	});
+
+	it("returns a 64-character lowercase hex sha256 string", () => {
+		const hash = computeCanonicalContentHash("<p>Hello world.</p>");
+
+		assert.equal(hash.length, 64);
+		assert.match(hash, /^[0-9a-f]{64}$/);
+	});
+});

--- a/projects/save-link/src/runtime/providers/article-store/compute-canonical-content-hash.ts
+++ b/projects/save-link/src/runtime/providers/article-store/compute-canonical-content-hash.ts
@@ -1,0 +1,15 @@
+import { createHash } from "node:crypto";
+import { stripHtml } from "../../domain/generate-summary/strip-html";
+
+/**
+ * Hash the readable text of canonical HTML. Hashing the stripped text rather
+ * than raw HTML means rotating ads/tracking scripts on the origin do not flip
+ * the hash, so a re-crawl of the same article does not trigger a summary
+ * regeneration. The stripping logic mirrors what the summariser feeds to
+ * DeepSeek (`generate-summary.main.ts`'s `cleanContent: stripHtml`) so the
+ * hash space lines up with the input the summary was actually generated from.
+ */
+export function computeCanonicalContentHash(canonicalHtml: string): string {
+	const text = stripHtml(canonicalHtml);
+	return createHash("sha256").update(text, "utf8").digest("hex");
+}

--- a/src/packages/article-store/src/dynamodb-article-store.test.ts
+++ b/src/packages/article-store/src/dynamodb-article-store.test.ts
@@ -70,12 +70,14 @@ describe("initDynamoDbArticleStore (unit)", () => {
 					etag: '"old-etag"',
 					lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
 					contentFetchedAt: "2026-01-01T00:00:00.000Z",
+					canonicalContentHash: "a".repeat(64),
 					crawlStatus: "ready",
 					summaryStatus: "ready",
 					summary: "Old summary",
 					summaryExcerpt: "Old summary excerpt",
 					summaryInputTokens: 1234,
 					summaryOutputTokens: 567,
+					summarySourceContentHash: "a".repeat(64),
 				},
 			}));
 			const { store } = initDynamoDbArticleStore({
@@ -98,6 +100,7 @@ describe("initDynamoDbArticleStore (unit)", () => {
 					etag: '"old-etag"',
 					lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
 					contentFetchedAt: "2026-01-01T00:00:00.000Z",
+					canonicalContentHash: "a".repeat(64),
 				},
 				estimatedReadTime: 1,
 				crawl: { kind: "ready" },
@@ -107,9 +110,29 @@ describe("initDynamoDbArticleStore (unit)", () => {
 					excerpt: "Old summary excerpt",
 					inputTokens: 1234,
 					outputTokens: 567,
+					sourceContentHash: "a".repeat(64),
 				},
 				summaryAutoHeal: { attempts: 0 },
 			});
+		});
+
+		it("leaves canonicalContentHash undefined for legacy rows that pre-date the hash column", async () => {
+			const client = createFakeClient(() => ({
+				Item: {
+					contentFetchedAt: "2026-01-01T00:00:00.000Z",
+					crawlStatus: "ready",
+					summaryStatus: "ready",
+					summary: "Old summary",
+				},
+			}));
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			const article = await store.load(URL);
+
+			expect(article?.freshness.canonicalContentHash).toBeUndefined();
 		});
 
 		it("maps a crawl-failed row with JSON-encoded tagged-union reason", async () => {
@@ -800,6 +823,131 @@ describe("initDynamoDbArticleStore (unit)", () => {
 			expect(
 				command.input.ExpressionAttributeValues?.[":summarySkippedReason"],
 			).toBeUndefined();
+		});
+
+		it("writes the canonicalContentHash on freshness when present so subsequent runs can compare hashes", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					freshness: {
+						etag: '"e"',
+						lastModified: "lm",
+						contentFetchedAt: "2026-05-10T12:00:00.000Z",
+						canonicalContentHash: "a".repeat(64),
+					},
+				}),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
+
+			const command = received as {
+				input: {
+					UpdateExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"canonicalContentHash = :cch",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":cch"]).toBe(
+				"a".repeat(64),
+			);
+		});
+
+		it("writes canonicalContentHash as null when omitted (legacy rows + first write after deploy)", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					freshness: { contentFetchedAt: "2026-05-10T12:00:00.000Z" },
+				}),
+				transitionName: "refreshContent",
+				writes: REFRESH_WRITES,
+			});
+
+			const command = received as {
+				input: { ExpressionAttributeValues?: Record<string, unknown> };
+			};
+			expect(command.input.ExpressionAttributeValues?.[":cch"]).toBeNull();
+		});
+
+		it("writes summarySourceContentHash on a ready summary so the summariser can short-circuit on hash equality", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					summary: {
+						kind: "ready",
+						summary: "abc",
+						sourceContentHash: "a".repeat(64),
+					},
+				}),
+				transitionName: "markSummaryReady",
+				writes: ["summary"],
+			});
+
+			const command = received as {
+				input: {
+					UpdateExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.UpdateExpression).toContain(
+				"summarySourceContentHash = :summarySourceContentHash",
+			);
+			expect(
+				command.input.ExpressionAttributeValues?.[":summarySourceContentHash"],
+			).toBe("a".repeat(64));
+		});
+
+		it("removes summarySourceContentHash when summary transitions to pending so a stale hash does not leak into a freshly-pending row", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const { store } = initDynamoDbArticleStore({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			await store.save({
+				article: buildArticle({
+					summary: { kind: "pending", pendingSince: PENDING_SINCE },
+				}),
+				transitionName: "promoteTier",
+				writes: ["summary"],
+			});
+
+			const command = received as { input: { UpdateExpression?: string } };
+			expect(command.input.UpdateExpression).toMatch(
+				/REMOVE.*summarySourceContentHash/,
+			);
 		});
 
 		it("encodes missing freshness fields as nulls so DynamoDB stores them as null (not the prior value)", async () => {

--- a/src/packages/article-store/src/dynamodb-article-store.ts
+++ b/src/packages/article-store/src/dynamodb-article-store.ts
@@ -41,6 +41,7 @@ const ArticleAggregateRow = z.object({
 	etag: dynamoField(z.string()),
 	lastModified: dynamoField(z.string()),
 	contentFetchedAt: dynamoField(z.string()),
+	canonicalContentHash: dynamoField(z.string()),
 	crawlStatus: dynamoField(CrawlStatusSchema),
 	crawlFailureReason: dynamoField(z.string()),
 	crawlUnsupportedReason: dynamoField(z.string()),
@@ -51,6 +52,7 @@ const ArticleAggregateRow = z.object({
 	summaryExcerpt: dynamoField(z.string()),
 	summaryInputTokens: dynamoField(z.number()),
 	summaryOutputTokens: dynamoField(z.number()),
+	summarySourceContentHash: dynamoField(z.string()),
 	summaryFailureReason: dynamoField(z.string()),
 	summarySkippedReason: dynamoField(z.string()),
 	summaryAutoHealAttempts: dynamoField(z.number()),
@@ -129,6 +131,8 @@ function rowToSummaryState(row: RowShape): SummaryState {
 			ready.inputTokens = row.summaryInputTokens;
 		if (row.summaryOutputTokens !== undefined)
 			ready.outputTokens = row.summaryOutputTokens;
+		if (row.summarySourceContentHash !== undefined)
+			ready.sourceContentHash = row.summarySourceContentHash;
 		return ready;
 	}
 	if (row.summaryStatus === "failed") {
@@ -172,6 +176,7 @@ function rowToArticle(url: string, row: RowShape): Article {
 			contentFetchedAt: row.contentFetchedAt ?? "",
 			etag: row.etag,
 			lastModified: row.lastModified,
+			canonicalContentHash: row.canonicalContentHash,
 		},
 		estimatedReadTime: row.estimatedReadTime ?? 0,
 		crawl: rowToCrawlState(row),
@@ -210,10 +215,12 @@ function appendFreshnessClauses(
 		"contentFetchedAt = :cfa",
 		"etag = :etag",
 		"lastModified = :lm",
+		"canonicalContentHash = :cch",
 	);
 	values[":cfa"] = article.freshness.contentFetchedAt;
 	values[":etag"] = article.freshness.etag ?? null;
 	values[":lm"] = article.freshness.lastModified ?? null;
+	values[":cch"] = article.freshness.canonicalContentHash ?? null;
 }
 
 function appendSummaryClauses(
@@ -232,6 +239,7 @@ function appendSummaryClauses(
 			"summaryExcerpt",
 			"summaryInputTokens",
 			"summaryOutputTokens",
+			"summarySourceContentHash",
 			"summaryStage",
 			"summaryFailureReason",
 			"summarySkippedReason",
@@ -244,12 +252,14 @@ function appendSummaryClauses(
 			"summaryExcerpt = :summaryExcerpt",
 			"summaryInputTokens = :summaryInputTokens",
 			"summaryOutputTokens = :summaryOutputTokens",
+			"summarySourceContentHash = :summarySourceContentHash",
 		);
 		values[":summaryStatus"] = "ready";
 		values[":summary"] = article.summary.summary;
 		values[":summaryExcerpt"] = article.summary.excerpt ?? null;
 		values[":summaryInputTokens"] = article.summary.inputTokens ?? null;
 		values[":summaryOutputTokens"] = article.summary.outputTokens ?? null;
+		values[":summarySourceContentHash"] = article.summary.sourceContentHash ?? null;
 		removes.push(
 			"summaryFailureReason",
 			"summarySkippedReason",

--- a/src/packages/domain/src/article-aggregate/article.types.ts
+++ b/src/packages/domain/src/article-aggregate/article.types.ts
@@ -12,6 +12,10 @@ export interface ArticleFreshness {
 	etag?: string;
 	lastModified?: string;
 	contentFetchedAt: string;
+	/* Optional for lazy backfill: legacy rows have no hash; first canonical write after
+	 * deploy populates it. Once present, hash equality drives summary regeneration —
+	 * same readable text → no regen, even across re-crawls or refreshes. */
+	canonicalContentHash?: string;
 }
 
 export type CrawlState =
@@ -28,6 +32,10 @@ export type SummaryState =
 			excerpt?: string;
 			inputTokens?: number;
 			outputTokens?: number;
+			/* Records the canonicalContentHash the summary was generated against, so
+			 * a later caller (admin recrawl, refresh) can compare to the current
+			 * canonical hash and detect "content is unchanged — keep this summary". */
+			sourceContentHash?: string;
 	  }
 	| { kind: "failed"; reason: SummaryFailureReason }
 	| { kind: "skipped"; reason?: string };

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.test.ts
@@ -33,6 +33,8 @@ describe("markSummaryReady", () => {
 			kind: "ready",
 			summary: "AI-generated summary",
 			excerpt: "AI-generated excerpt",
+			inputTokens: 1234,
+			outputTokens: 567,
 		});
 	});
 
@@ -51,6 +53,8 @@ describe("markSummaryReady", () => {
 			kind: "ready",
 			summary: "AI-generated summary",
 			excerpt: "AI-generated excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
 			sourceContentHash: hash,
 		});
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.test.ts
@@ -36,6 +36,39 @@ describe("markSummaryReady", () => {
 		});
 	});
 
+	it("records the supplied sourceContentHash on the ready summary so subsequent runs can compare against the canonical hash and skip regeneration", () => {
+		const hash = "a".repeat(64);
+
+		const { article } = markSummaryReady(buildArticle(), {
+			summary: "AI-generated summary",
+			excerpt: "AI-generated excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
+			sourceContentHash: hash,
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "ready",
+			summary: "AI-generated summary",
+			excerpt: "AI-generated excerpt",
+			sourceContentHash: hash,
+		});
+	});
+
+	it("omits sourceContentHash from the ready summary when none was supplied (legacy fallback for callers that have not threaded the hash)", () => {
+		const { article } = markSummaryReady(buildArticle(), {
+			summary: "AI-generated summary",
+			excerpt: "AI-generated excerpt",
+			inputTokens: 1,
+			outputTokens: 1,
+		});
+
+		assert.equal(
+			article.summary.kind === "ready" ? article.summary.sourceContentHash : "present",
+			undefined,
+		);
+	});
+
 	it("emits a publish-summary-generated effect carrying url and token counts", () => {
 		const { effects } = markSummaryReady(
 			buildArticle({ url: "https://example.com/post" }),

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.ts
@@ -7,6 +7,10 @@ export interface MarkSummaryReadyInput {
 	excerpt: string;
 	inputTokens: number;
 	outputTokens: number;
+	/** Optional: hash of the canonical readable text the summary was generated
+	 * against. Recorded on the ready summary so a future caller can detect
+	 * "content unchanged since last summary" and skip regeneration. */
+	sourceContentHash?: string;
 }
 
 /* `writes` covers summary + summaryAutoHeal so a successful regen resets the
@@ -19,13 +23,17 @@ export function markSummaryReady(
 	effects: readonly Effect[];
 	writes: readonly AggregateField[];
 } {
+	const summary: Extract<Article["summary"], { kind: "ready" }> = {
+		kind: "ready",
+		summary: input.summary,
+		excerpt: input.excerpt,
+	};
+	if (input.sourceContentHash !== undefined) {
+		summary.sourceContentHash = input.sourceContentHash;
+	}
 	const next: Article = {
 		...article,
-		summary: {
-			kind: "ready",
-			summary: input.summary,
-			excerpt: input.excerpt,
-		},
+		summary,
 		summaryAutoHeal: { attempts: 0 },
 	};
 	const effects: readonly Effect[] = [

--- a/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-summary-ready.ts
@@ -27,6 +27,8 @@ export function markSummaryReady(
 		kind: "ready",
 		summary: input.summary,
 		excerpt: input.excerpt,
+		inputTokens: input.inputTokens,
+		outputTokens: input.outputTokens,
 	};
 	if (input.sourceContentHash !== undefined) {
 		summary.sourceContentHash = input.sourceContentHash;

--- a/src/packages/domain/src/article-aggregate/transitions/promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/promote-tier.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import type { Article } from "../article.types";
-import { promoteTier } from "./promote-tier";
+import { promoteTier, type PromoteTierInput } from "./promote-tier";
 
 const FIXED_PENDING = "2026-01-01T00:00:00.000Z";
 const NOW = "2026-05-13T12:00:00.000Z";
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
 
 function buildArticle(overrides: Partial<Article> = {}): Article {
 	return {
@@ -26,22 +28,28 @@ function buildArticle(overrides: Partial<Article> = {}): Article {
 	};
 }
 
+function buildInput(overrides: Partial<PromoteTierInput> = {}): PromoteTierInput {
+	return {
+		tier: "tier-0",
+		metadata: {
+			title: "New title",
+			siteName: "New site",
+			excerpt: "New excerpt",
+			wordCount: 250,
+			imageUrl: "https://example.com/image.jpg",
+		},
+		estimatedReadTime: 2,
+		contentFetchedAt: "2026-05-10T12:00:00.000Z",
+		now: NOW,
+		canonicalChanged: true,
+		canonicalContentHash: HASH_A,
+		...overrides,
+	};
+}
+
 describe("promoteTier", () => {
 	it("overwrites metadata with the supplied values", () => {
-		const { article } = promoteTier(buildArticle(), {
-			tier: "tier-0",
-			metadata: {
-				title: "New title",
-				siteName: "New site",
-				excerpt: "New excerpt",
-				wordCount: 250,
-				imageUrl: "https://example.com/image.jpg",
-			},
-			estimatedReadTime: 2,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
-		});
+		const { article } = promoteTier(buildArticle(), buildInput());
 
 		assert.equal(article.metadata.title, "New title");
 		assert.equal(article.metadata.wordCount, 250);
@@ -57,48 +65,50 @@ describe("promoteTier", () => {
 			},
 		});
 
-		const { article } = promoteTier(before, {
-			tier: "tier-0",
-			metadata: before.metadata,
-			estimatedReadTime: 2,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
-		});
+		const { article } = promoteTier(
+			before,
+			buildInput({ metadata: before.metadata, estimatedReadTime: 2 }),
+		);
 
 		assert.equal(article.freshness.contentFetchedAt, "2026-05-10T12:00:00.000Z");
 		assert.equal(article.freshness.etag, '"kept-etag"');
 		assert.equal(article.freshness.lastModified, "Thu, 01 Jan 2026 00:00:00 GMT");
 	});
 
+	it("writes the new canonicalContentHash onto freshness so subsequent runs can compare against it", () => {
+		const { article } = promoteTier(
+			buildArticle(),
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.equal(article.freshness.canonicalContentHash, HASH_A);
+	});
+
 	it("overwrites estimatedReadTime with the supplied value", () => {
-		const { article } = promoteTier(buildArticle(), {
-			tier: "tier-0",
-			metadata: buildArticle().metadata,
-			estimatedReadTime: 7,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
-		});
+		const { article } = promoteTier(
+			buildArticle(),
+			buildInput({ estimatedReadTime: 7, metadata: buildArticle().metadata }),
+		);
 
 		assert.equal(article.estimatedReadTime, 7);
 	});
 
 	it("flips crawl to ready", () => {
-		const { article } = promoteTier(buildArticle(), {
-			tier: "tier-0",
-			metadata: buildArticle().metadata,
-			estimatedReadTime: 1,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
-		});
+		const { article } = promoteTier(
+			buildArticle(),
+			buildInput({ metadata: buildArticle().metadata, estimatedReadTime: 1 }),
+		);
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
 	});
 
-	it("resets summary to pending so the worker regenerates the cached text against the freshly-selected canonical", () => {
+	it("resets summary to pending when the canonical hash changed so the worker regenerates against the new canonical", () => {
 		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
 			summary: {
 				kind: "ready",
 				summary: "stale summary",
@@ -106,27 +116,84 @@ describe("promoteTier", () => {
 			},
 		});
 
-		const { article } = promoteTier(before, {
-			tier: "tier-0",
-			metadata: before.metadata,
-			estimatedReadTime: 1,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
-		});
+		const { article } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalContentHash: HASH_B,
+			}),
+		);
 
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 	});
 
-	it("stamps pendingSince with the provided now so the canary can age-gate the summary axis", () => {
-		const { article } = promoteTier(buildArticle(), {
-			tier: "tier-0",
-			metadata: buildArticle().metadata,
-			estimatedReadTime: 1,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
+	it("preserves the cached ready summary when the canonical hash is unchanged (cacheability gate)", () => {
+		const existingSummary = {
+			kind: "ready" as const,
+			summary: "cached summary",
+			excerpt: "cached excerpt",
+		};
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: existingSummary,
 		});
+
+		const { article } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalContentHash: HASH_A,
+			}),
+		);
+
+		assert.deepEqual(article.summary, existingSummary);
+	});
+
+	it("treats a missing previous canonicalContentHash as content-changed (lazy backfill on first run after deploy)", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+			},
+			summary: { kind: "ready", summary: "stale" },
+		});
+
+		const { article, writes } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalContentHash: HASH_A,
+			}),
+		);
+
+		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
+		assert.ok(writes.includes("summary"));
+	});
+
+	it("stamps pendingSince with the provided now so the canary can age-gate the summary axis", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
+
+		const { article } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalContentHash: HASH_B,
+			}),
+		);
 
 		assert.equal(
 			article.summary.kind === "pending" ? article.summary.pendingSince : "",
@@ -137,15 +204,12 @@ describe("promoteTier", () => {
 	it("emits generate-summary and publish-crawl-article-completed in that order, plus publish-link-saved when canonicalChanged + userId is supplied", () => {
 		const { effects } = promoteTier(
 			buildArticle({ url: "https://example.com/post" }),
-			{
-				tier: "tier-0",
+			buildInput({
 				metadata: buildArticle().metadata,
 				estimatedReadTime: 1,
-				contentFetchedAt: "2026-05-10T12:00:00.000Z",
-				now: NOW,
 				canonicalChanged: true,
 				userId: "user-123",
-			},
+			}),
 		);
 
 		assert.deepEqual(effects, [
@@ -165,14 +229,11 @@ describe("promoteTier", () => {
 	it("emits publish-anonymous-link-saved when canonicalChanged is true and userId is absent", () => {
 		const { effects } = promoteTier(
 			buildArticle({ url: "https://example.com/post" }),
-			{
-				tier: "tier-0",
+			buildInput({
 				metadata: buildArticle().metadata,
 				estimatedReadTime: 1,
-				contentFetchedAt: "2026-05-10T12:00:00.000Z",
-				now: NOW,
 				canonicalChanged: true,
-			},
+			}),
 		);
 
 		assert.deepEqual(effects, [
@@ -191,15 +252,12 @@ describe("promoteTier", () => {
 	it("omits the user-facing event when canonicalChanged is false (re-pick of the same tier must not re-fire link-saved notifications)", () => {
 		const { effects } = promoteTier(
 			buildArticle({ url: "https://example.com/post" }),
-			{
-				tier: "tier-0",
+			buildInput({
 				metadata: buildArticle().metadata,
 				estimatedReadTime: 1,
-				contentFetchedAt: "2026-05-10T12:00:00.000Z",
-				now: NOW,
 				canonicalChanged: false,
 				userId: "user-123",
-			},
+			}),
 		);
 
 		assert.deepEqual(effects, [
@@ -211,15 +269,53 @@ describe("promoteTier", () => {
 		]);
 	});
 
-	it("declares writes for metadata, freshness, crawl, and summary so the aggregate save scopes to the four axes the transition mutated", () => {
-		const { writes } = promoteTier(buildArticle(), {
-			tier: "tier-0",
-			metadata: buildArticle().metadata,
-			estimatedReadTime: 1,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
+	it("omits the generate-summary effect when canonical hash is unchanged (cacheability gate prevents wasted DeepSeek tokens)", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: { kind: "ready", summary: "kept" },
 		});
+
+		const { effects } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalChanged: false,
+				canonicalContentHash: HASH_A,
+				userId: "user-123",
+			}),
+		);
+
+		assert.deepEqual(effects, [
+			{
+				kind: "publish-crawl-article-completed",
+				url: "https://example.com/post",
+			},
+		]);
+	});
+
+	it("declares writes for metadata, freshness, crawl, and summary when the hash changed so the aggregate save scopes to the four mutated axes", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
+
+		const { writes } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalContentHash: HASH_B,
+			}),
+		);
 
 		assert.deepEqual([...writes].sort(), [
 			"crawl",
@@ -229,23 +325,45 @@ describe("promoteTier", () => {
 		]);
 	});
 
+	it("declares writes for metadata, freshness, and crawl only (no summary) when the canonical hash is unchanged", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: { kind: "ready", summary: "kept" },
+		});
+
+		const { writes } = promoteTier(
+			before,
+			buildInput({
+				metadata: before.metadata,
+				estimatedReadTime: 1,
+				canonicalContentHash: HASH_A,
+			}),
+		);
+
+		assert.deepEqual([...writes].sort(), ["crawl", "freshness", "metadata"]);
+	});
+
 	it("does not mutate the input article (pure function)", () => {
 		const before = buildArticle();
 		const snapshot = JSON.parse(JSON.stringify(before));
 
-		promoteTier(before, {
-			tier: "tier-1",
-			metadata: {
-				title: "Different",
-				siteName: "Example",
-				excerpt: "Different",
-				wordCount: 200,
-			},
-			estimatedReadTime: 3,
-			contentFetchedAt: "2026-05-10T12:00:00.000Z",
-			now: NOW,
-			canonicalChanged: true,
-		});
+		promoteTier(
+			before,
+			buildInput({
+				tier: "tier-1",
+				metadata: {
+					title: "Different",
+					siteName: "Example",
+					excerpt: "Different",
+					wordCount: 200,
+				},
+				estimatedReadTime: 3,
+			}),
+		);
 
 		assert.deepEqual(before, snapshot);
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/promote-tier.ts
@@ -10,13 +10,20 @@ export interface PromoteTierInput {
 	now: string;
 	/** True when the canonical tier flipped this run; gates the publish-link-saved / publish-anonymous-link-saved effect so a re-pick of the same tier does not re-fire user-facing notifications. */
 	canonicalChanged: boolean;
+	/** Hash of the new canonical readable text. Compared to the row's existing
+	 * `freshness.canonicalContentHash` to gate summary regeneration — equal
+	 * hashes mean the readable content is unchanged and the cached summary
+	 * stays valid. */
+	canonicalContentHash: string;
 	/** Authenticated save: emits publish-link-saved. Absent: emits publish-anonymous-link-saved. */
 	userId?: string;
 }
 
-/* Selector promotion: writes metadata + freshness + crawl=ready + summary=pending.
- * `canonicalChanged` gates the user-facing event so a re-pick of the same tier
- * does not re-fire link-saved / anonymous-link-saved notifications. */
+/* Selector promotion: writes metadata + freshness + crawl=ready. The summary
+ * axis is only written + regenerated when the canonical content hash actually
+ * changes (lazy backfill: if the row has no prior hash, treat as changed and
+ * record the new one). `canonicalChanged` continues to gate the user-facing
+ * notification so a re-pick of the same tier does not re-fire link-saved. */
 export function promoteTier(
 	article: Article,
 	input: PromoteTierInput,
@@ -25,18 +32,16 @@ export function promoteTier(
 	effects: readonly Effect[];
 	writes: readonly AggregateField[];
 } {
-	const next: Article = {
-		...article,
-		metadata: input.metadata,
-		freshness: { ...article.freshness, contentFetchedAt: input.contentFetchedAt },
-		estimatedReadTime: input.estimatedReadTime,
-		crawl: { kind: "ready" },
-		summary: { kind: "pending", pendingSince: input.now },
-	};
-	const effects: Effect[] = [
-		{ kind: "generate-summary", url: article.url },
-		{ kind: "publish-crawl-article-completed", url: article.url },
-	];
+	const previousHash = article.freshness.canonicalContentHash;
+	const contentChanged =
+		previousHash === undefined || previousHash !== input.canonicalContentHash;
+
+	const writes: AggregateField[] = ["metadata", "freshness", "crawl"];
+	const effects: Effect[] = [];
+	if (contentChanged) {
+		effects.push({ kind: "generate-summary", url: article.url });
+	}
+	effects.push({ kind: "publish-crawl-article-completed", url: article.url });
 	if (input.canonicalChanged) {
 		effects.push(
 			input.userId
@@ -44,11 +49,29 @@ export function promoteTier(
 				: { kind: "publish-anonymous-link-saved", url: article.url },
 		);
 	}
-	const writes: readonly AggregateField[] = [
-		"metadata",
-		"freshness",
-		"crawl",
-		"summary",
-	];
+
+	const nextFreshness: Article["freshness"] = {
+		...article.freshness,
+		contentFetchedAt: input.contentFetchedAt,
+		canonicalContentHash: input.canonicalContentHash,
+	};
+
+	let nextSummary: Article["summary"];
+	if (contentChanged) {
+		nextSummary = { kind: "pending", pendingSince: input.now };
+		writes.push("summary");
+	} else {
+		nextSummary = article.summary;
+	}
+
+	const next: Article = {
+		...article,
+		metadata: input.metadata,
+		freshness: nextFreshness,
+		estimatedReadTime: input.estimatedReadTime,
+		crawl: { kind: "ready" },
+		summary: nextSummary,
+	};
+
 	return { article: next, effects, writes };
 }

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
@@ -7,6 +7,8 @@ import {
 
 const FIXED_PENDING = "2026-01-01T00:00:00.000Z";
 const NOW = "2026-05-13T12:00:00.000Z";
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
 
 function buildArticle(overrides: Partial<Article> = {}): Article {
 	return {
@@ -43,6 +45,7 @@ function buildInput(overrides: Partial<RecrawlPromoteTierInput> = {}): RecrawlPr
 		estimatedReadTime: 3,
 		contentFetchedAt: "2026-05-10T12:00:00.000Z",
 		now: NOW,
+		canonicalContentHash: HASH_A,
 		...overrides,
 	};
 }
@@ -94,6 +97,15 @@ describe("recrawlPromoteTier", () => {
 		assert.equal(article.freshness.lastModified, "Thu, 01 Jan 2026 00:00:00 GMT");
 	});
 
+	it("writes the new canonicalContentHash onto freshness so subsequent runs can compare against it", () => {
+		const { article } = recrawlPromoteTier(
+			buildArticle(),
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.equal(article.freshness.canonicalContentHash, HASH_A);
+	});
+
 	it("overwrites estimatedReadTime with the supplied value", () => {
 		const { article } = recrawlPromoteTier(
 			buildArticle(),
@@ -103,8 +115,14 @@ describe("recrawlPromoteTier", () => {
 		assert.equal(article.estimatedReadTime, 7);
 	});
 
-	it("resets summary to pending so the regenerate fires against the new canonical body", () => {
+	it("resets summary to pending when the canonical hash changed so the regenerate fires against the new canonical body", () => {
 		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
 			summary: {
 				kind: "ready",
 				summary: "stale summary",
@@ -112,13 +130,71 @@ describe("recrawlPromoteTier", () => {
 			},
 		});
 
-		const { article } = recrawlPromoteTier(before, buildInput());
+		const { article } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_B }),
+		);
 
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 	});
 
+	it("preserves the cached ready summary when the canonical hash is unchanged (cacheability gate)", () => {
+		const existingSummary = {
+			kind: "ready" as const,
+			summary: "cached summary",
+			excerpt: "cached excerpt",
+		};
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: existingSummary,
+		});
+
+		const { article } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual(article.summary, existingSummary);
+	});
+
+	it("treats a missing previous canonicalContentHash as content-changed (lazy backfill on first run after deploy)", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+			},
+			summary: { kind: "ready", summary: "stale" },
+		});
+
+		const { article, writes } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
+		assert.ok(writes.includes("summary"));
+	});
+
 	it("stamps pendingSince with the provided now so the canary can age-gate the summary axis", () => {
-		const { article } = recrawlPromoteTier(buildArticle(), buildInput());
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
+
+		const { article } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_B }),
+		);
 
 		assert.equal(
 			article.summary.kind === "pending" ? article.summary.pendingSince : "",
@@ -126,10 +202,20 @@ describe("recrawlPromoteTier", () => {
 		);
 	});
 
-	it("emits generate-summary and publish-recrawl-completed effects in that order", () => {
+	it("emits generate-summary and publish-recrawl-completed effects in that order when content changed", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
+
 		const { effects } = recrawlPromoteTier(
-			buildArticle({ url: "https://example.com/post" }),
-			buildInput(),
+			before,
+			buildInput({ canonicalContentHash: HASH_B }),
 		);
 
 		assert.deepEqual(effects, [
@@ -138,8 +224,42 @@ describe("recrawlPromoteTier", () => {
 		]);
 	});
 
-	it("declares writes for metadata, freshness, crawl, summary so the aggregate save scopes to the four axes the transition mutated", () => {
-		const { writes } = recrawlPromoteTier(buildArticle(), buildInput());
+	it("omits generate-summary when the canonical hash is unchanged — only emits publish-recrawl-completed to settle the pipeline", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: { kind: "ready", summary: "kept" },
+		});
+
+		const { effects } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "publish-recrawl-completed", url: "https://example.com/post" },
+		]);
+	});
+
+	it("declares writes for metadata, freshness, crawl, summary when the hash changed so the aggregate save scopes to the four mutated axes", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
+
+		const { writes } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_B }),
+		);
 
 		assert.deepEqual([...writes].sort(), [
 			"crawl",
@@ -147,6 +267,25 @@ describe("recrawlPromoteTier", () => {
 			"metadata",
 			"summary",
 		]);
+	});
+
+	it("declares writes for metadata, freshness, and crawl only (no summary) when the canonical hash is unchanged", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: { kind: "ready", summary: "kept" },
+		});
+
+		const { writes } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual([...writes].sort(), ["crawl", "freshness", "metadata"]);
 	});
 
 	it("does not mutate the input article (pure function)", () => {

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
@@ -8,8 +8,16 @@ export interface RecrawlPromoteTierInput {
 	estimatedReadTime: number;
 	contentFetchedAt: string;
 	now: string;
+	/** Hash of the new canonical readable text. Compared to the row's existing
+	 * `freshness.canonicalContentHash` to gate summary regeneration — equal
+	 * hashes mean the recrawl produced identical readable content and the cached
+	 * summary remains valid. */
+	canonicalContentHash: string;
 }
 
+/* Recrawl promotion: writes metadata + freshness + crawl=ready. The summary
+ * axis is only regenerated when the canonical content hash actually changed
+ * (lazy backfill: a row without a prior hash is treated as changed). */
 export function recrawlPromoteTier(
 	article: Article,
 	input: RecrawlPromoteTierInput,
@@ -18,26 +26,39 @@ export function recrawlPromoteTier(
 	effects: readonly Effect[];
 	writes: readonly AggregateField[];
 } {
+	const previousHash = article.freshness.canonicalContentHash;
+	const contentChanged =
+		previousHash === undefined || previousHash !== input.canonicalContentHash;
+
+	const writes: AggregateField[] = ["metadata", "freshness", "crawl"];
+	const effects: Effect[] = [];
+	if (contentChanged) {
+		effects.push({ kind: "generate-summary", url: article.url });
+	}
+	effects.push({ kind: "publish-recrawl-completed", url: article.url });
+
+	const nextFreshness: Article["freshness"] = {
+		...article.freshness,
+		contentFetchedAt: input.contentFetchedAt,
+		canonicalContentHash: input.canonicalContentHash,
+	};
+
+	let nextSummary: Article["summary"];
+	if (contentChanged) {
+		nextSummary = { kind: "pending", pendingSince: input.now };
+		writes.push("summary");
+	} else {
+		nextSummary = article.summary;
+	}
+
 	const next: Article = {
 		...article,
 		metadata: input.metadata,
-		freshness: {
-			...article.freshness,
-			contentFetchedAt: input.contentFetchedAt,
-		},
+		freshness: nextFreshness,
 		estimatedReadTime: input.estimatedReadTime,
 		crawl: { kind: "ready" },
-		summary: { kind: "pending", pendingSince: input.now },
+		summary: nextSummary,
 	};
-	const effects: readonly Effect[] = [
-		{ kind: "generate-summary", url: article.url },
-		{ kind: "publish-recrawl-completed", url: article.url },
-	];
-	const writes: readonly AggregateField[] = [
-		"metadata",
-		"freshness",
-		"crawl",
-		"summary",
-	];
+
 	return { article: next, effects, writes };
 }

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.test.ts
@@ -27,7 +27,7 @@ describe("recrawlTieKeptCanonical", () => {
 		assert.deepEqual(article.crawl, { kind: "ready" });
 	});
 
-	it("preserves summary so a freshly-generated AI excerpt is not invalidated by the recrawl no-op", () => {
+	it("preserves the existing summary by not transitioning summary state at all", () => {
 		const before = buildArticle({
 			summary: { kind: "ready", summary: "kept", excerpt: "kept excerpt" },
 		});
@@ -41,29 +41,25 @@ describe("recrawlTieKeptCanonical", () => {
 		});
 	});
 
-	it("emits a generate-summary effect so the operator always sees a freshly-regenerated excerpt", () => {
+	it("does not emit generate-summary so identical canonical content does not burn DeepSeek tokens on re-summarise", () => {
 		const { effects } = recrawlTieKeptCanonical(
 			buildArticle({ url: "https://example.com/post" }),
 			undefined,
 		);
 
 		assert.ok(
-			effects.some(
-				(e) =>
-					e.kind === "generate-summary" && e.url === "https://example.com/post",
-			),
-			"generate-summary effect must be emitted on every recrawl",
+			!effects.some((e) => e.kind === "generate-summary"),
+			"generate-summary effect must not be emitted when canonical is unchanged",
 		);
 	});
 
-	it("emits a publish-recrawl-completed effect after the generate-summary effect", () => {
+	it("emits only publish-recrawl-completed to settle the recrawl pipeline", () => {
 		const { effects } = recrawlTieKeptCanonical(
 			buildArticle({ url: "https://example.com/post" }),
 			undefined,
 		);
 
 		assert.deepEqual(effects, [
-			{ kind: "generate-summary", url: "https://example.com/post" },
 			{ kind: "publish-recrawl-completed", url: "https://example.com/post" },
 		]);
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
@@ -3,9 +3,10 @@ import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
 /* Tie kept canonical: the selector returned a tie and a canonical already
- * exists on disk. No tier flip, no metadata refresh, no summary reset — but
- * crawl still flips to ready and generate-summary still fires (the summariser
- * short-circuits on cache hit) so the row exits pending. */
+ * exists on disk. No tier flip, no metadata refresh, no summary reset. The
+ * crawl axis flips to ready to unstick the row, and no generate-summary
+ * effect is emitted — re-summarising identical canonical content would
+ * burn DeepSeek tokens for no value. */
 export function recrawlTieKeptCanonical(
 	article: Article,
 	_input: undefined,
@@ -19,7 +20,6 @@ export function recrawlTieKeptCanonical(
 		crawl: { kind: "ready" },
 	};
 	const effects: readonly Effect[] = [
-		{ kind: "generate-summary", url: article.url },
 		{ kind: "publish-recrawl-completed", url: article.url },
 	];
 	const writes: readonly AggregateField[] = ["crawl"];

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import type { Article } from "../article.types";
 import { refreshContent } from "./refresh-content";
 
+const NOW = "2026-05-13T12:00:00.000Z";
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
 function buildArticle(overrides: Partial<Article> = {}): Article {
 	return {
 		url: "https://example.com/article",
@@ -28,8 +32,6 @@ function buildArticle(overrides: Partial<Article> = {}): Article {
 	};
 }
 
-const NOW = "2026-05-13T12:00:00.000Z";
-
 describe("refreshContent", () => {
 	it("overwrites metadata, freshness, and estimated read time with the fetched values", () => {
 		const before = buildArticle();
@@ -49,6 +51,7 @@ describe("refreshContent", () => {
 			},
 			estimatedReadTime: 2,
 			now: NOW,
+			canonicalContentHash: HASH_A,
 		});
 
 		assert.equal(article.metadata.title, "New title");
@@ -59,8 +62,28 @@ describe("refreshContent", () => {
 		assert.equal(article.estimatedReadTime, 2);
 	});
 
-	it("resets summary to pending so the worker regenerates the cached text", () => {
+	it("writes the new canonicalContentHash onto freshness so subsequent runs can compare against it", () => {
+		const before = buildArticle();
+
+		const { article } = refreshContent(before, {
+			metadata: before.metadata,
+			freshness: before.freshness,
+			estimatedReadTime: before.estimatedReadTime,
+			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
+
+		assert.equal(article.freshness.canonicalContentHash, HASH_A);
+	});
+
+	it("resets summary to pending when the canonical hash changed so the worker regenerates the cached text", () => {
 		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
 			summary: {
 				kind: "ready",
 				summary: "stale summary",
@@ -75,19 +98,72 @@ describe("refreshContent", () => {
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
+			canonicalContentHash: HASH_B,
 		});
 
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 	});
 
-	it("stamps pendingSince with the provided now so the canary can age-gate the row", () => {
-		const before = buildArticle();
+	it("preserves the cached ready summary when the canonical hash is unchanged (cacheability gate prevents wasted regeneration)", () => {
+		const existingSummary = {
+			kind: "ready" as const,
+			summary: "kept summary",
+			excerpt: "kept excerpt",
+		};
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: existingSummary,
+		});
 
 		const { article } = refreshContent(before, {
 			metadata: before.metadata,
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
+
+		assert.deepEqual(article.summary, existingSummary);
+	});
+
+	it("treats a missing previous canonicalContentHash as content-changed (lazy backfill on first run after deploy)", () => {
+		const before = buildArticle({
+			summary: { kind: "ready", summary: "stale" },
+		});
+
+		const { article, writes } = refreshContent(before, {
+			metadata: before.metadata,
+			freshness: before.freshness,
+			estimatedReadTime: before.estimatedReadTime,
+			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
+
+		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
+		assert.ok(writes.includes("summary"));
+	});
+
+	it("stamps pendingSince with the provided now so the canary can age-gate the row", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
+
+		const { article } = refreshContent(before, {
+			metadata: before.metadata,
+			freshness: before.freshness,
+			estimatedReadTime: before.estimatedReadTime,
+			now: NOW,
+			canonicalContentHash: HASH_B,
 		});
 
 		assert.equal(
@@ -104,19 +180,29 @@ describe("refreshContent", () => {
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
+			canonicalContentHash: HASH_A,
 		});
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
 	});
 
-	it("emits a generate-summary effect so the worker is invoked after persistence", () => {
-		const before = buildArticle({ url: "https://example.com/post" });
+	it("emits a generate-summary effect when canonical hash changed", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
 
 		const { effects } = refreshContent(before, {
 			metadata: before.metadata,
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
+			canonicalContentHash: HASH_B,
 		});
 
 		assert.deepEqual(effects, [
@@ -124,18 +210,73 @@ describe("refreshContent", () => {
 		]);
 	});
 
-	it("declares writes for metadata, freshness, and summary so crawl-state is not clobbered by a concurrent inline writer", () => {
-		const before = buildArticle();
+	it("emits no effects when canonical hash is unchanged (refresh that produced identical content must not regenerate)", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: { kind: "ready", summary: "kept" },
+		});
+
+		const { effects } = refreshContent(before, {
+			metadata: before.metadata,
+			freshness: before.freshness,
+			estimatedReadTime: before.estimatedReadTime,
+			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
+
+		assert.deepEqual(effects, []);
+	});
+
+	it("declares writes for metadata, freshness, and summary when hash changed so crawl is not clobbered by a concurrent inline writer", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+		});
 
 		const { writes } = refreshContent(before, {
 			metadata: before.metadata,
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
+			canonicalContentHash: HASH_B,
 		});
 
 		assert.deepEqual([...writes].sort(), ["freshness", "metadata", "summary"]);
 		assert.ok(!writes.includes("crawl"), "refresh must not declare crawl writes");
+	});
+
+	it("declares writes for metadata and freshness only (no summary) when canonical hash is unchanged", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: { kind: "ready", summary: "kept" },
+		});
+
+		const { writes } = refreshContent(before, {
+			metadata: before.metadata,
+			freshness: before.freshness,
+			estimatedReadTime: before.estimatedReadTime,
+			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
+
+		assert.deepEqual([...writes].sort(), ["freshness", "metadata"]);
+		assert.ok(!writes.includes("summary"));
+		assert.ok(!writes.includes("crawl"));
 	});
 
 	it("does not mutate the input article (pure function)", () => {
@@ -155,6 +296,7 @@ describe("refreshContent", () => {
 			},
 			estimatedReadTime: 3,
 			now: NOW,
+			canonicalContentHash: HASH_A,
 		});
 
 		assert.deepEqual(before, beforeSnapshot);

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
@@ -11,10 +11,16 @@ export interface RefreshContentInput {
 	freshness: ArticleFreshness;
 	estimatedReadTime: number;
 	now: string;
+	/** Hash of the new canonical readable text. Compared against the row's
+	 * existing `freshness.canonicalContentHash` to gate summary regeneration. */
+	canonicalContentHash: string;
 }
 
 /* `writes` excludes "crawl" — a concurrent inline crawl writer must not be
- * clobbered by the refresh aggregate save when the crawl is still in flight. */
+ * clobbered by the refresh aggregate save when the crawl is still in flight.
+ * The summary axis is only written + regenerated when the canonical content
+ * hash actually changed (lazy backfill: a row without a prior hash is treated
+ * as changed). */
 export function refreshContent(
 	article: Article,
 	input: RefreshContentInput,
@@ -23,16 +29,34 @@ export function refreshContent(
 	effects: readonly Effect[];
 	writes: readonly AggregateField[];
 } {
+	const previousHash = article.freshness.canonicalContentHash;
+	const contentChanged =
+		previousHash === undefined || previousHash !== input.canonicalContentHash;
+
+	const nextFreshness: Article["freshness"] = {
+		...input.freshness,
+		canonicalContentHash: input.canonicalContentHash,
+	};
+
+	const writes: AggregateField[] = ["metadata", "freshness"];
+	const effects: Effect[] = [];
+
+	let nextSummary: Article["summary"];
+	if (contentChanged) {
+		nextSummary = { kind: "pending", pendingSince: input.now };
+		writes.push("summary");
+		effects.push({ kind: "generate-summary", url: article.url });
+	} else {
+		nextSummary = article.summary;
+	}
+
 	const next: Article = {
 		...article,
 		metadata: input.metadata,
-		freshness: input.freshness,
+		freshness: nextFreshness,
 		estimatedReadTime: input.estimatedReadTime,
-		summary: { kind: "pending", pendingSince: input.now },
+		summary: nextSummary,
 	};
-	const effects: readonly Effect[] = [
-		{ kind: "generate-summary", url: article.url },
-	];
-	const writes: readonly AggregateField[] = ["metadata", "freshness", "summary"];
+
 	return { article: next, effects, writes };
 }


### PR DESCRIPTION
## Problem

A recrawl or refresh that did **not** change the canonical readable content still regenerated the article summary, burning DeepSeek tokens. Three unconditional regen sources in production code:

1. **`recrawl.page.ts`** called `forceMarkSummaryPending`, wiping the cached `summary.kind === "ready"` state to `"pending"` before the recrawl ran. The summariser's cache check only short‑circuits on `"ready"` or `"skipped"`, so once pending the handler always re‑invoked DeepSeek.
2. **`recrawlTieKeptCanonical`** emitted `generate-summary` even though it explicitly preserved canonical and even though its header comment claimed "the summariser short‑circuits on cache hit."
3. **`refreshContent`** unconditionally set `summary: { kind: "pending" }` and emitted `generate-summary`, so any refresh — even one that produced identical readable text — wiped summary and regenerated.

The system had **no content fingerprint** anywhere: summary freshness was decided entirely by the `summary.kind` enum, which the recrawl pre‑step destroyed.

## Approach

**Cacheability of the canonical content drives summary regeneration.** Same readable text → no regeneration. Different readable text → regeneration.

### Part A — Stop the three unconditional regen sources
- Removed the `forceMarkSummaryPending` call (and its dep wiring) from `recrawl.page.ts`. Crawl still flips to pending so the reader skeleton renders; summary state is now owned by the recrawl pipeline.
- Dropped the `generate-summary` effect from `recrawlTieKeptCanonical`. The transition now only emits `publish-recrawl-completed` and preserves the existing summary.
- Added a `canonicalContentHash` gate to `refreshContent` so a refresh that produced identical content does not touch the summary axis.

### Part B — Canonical content hash as the cache key
- New `compute-canonical-content-hash.ts` helper: `sha256(stripHtml(canonicalHtml))`. Hashing the **stripped text** rather than HTML means rotating ads/tracking on the origin do not flip the hash (server‑decoy resistance verified by unit test).
- Added `canonicalContentHash?: string` to `ArticleFreshness` and `sourceContentHash?: string` to the `ready` variant of `SummaryState`.
- The three promotion transitions (`promoteTier`, `recrawlPromoteTier`, `refreshContent`) now take a `canonicalContentHash` input. When it matches the row's existing `freshness.canonicalContentHash`, the transition preserves the cached ready summary and skips both the `generate-summary` effect and the `summary` write. A missing previous hash (legacy rows / first run after deploy) is treated as content‑changed, so the field backfills lazily on the next canonical write.
- The three handlers compute the hash from the winner source HTML and thread it through to the transition input.
- `markSummaryReady` now records `sourceContentHash` so the ready row knows which canonical content produced its summary; `generate-summary-handler` computes that hash from the article content it just fed DeepSeek.
- DynamoDB article-store schema persists `canonicalContentHash` on freshness and `summarySourceContentHash` on the ready summary; the pending summary write clears `summarySourceContentHash` so a stale hash never leaks into a freshly‑pending row.

### Adversarial check
- **Server‑decoy** (origin rotates ads/tracking but readable text identical) → text‑level hash collapses to the same digest, no spurious regen. Covered by `computeCanonicalContentHash` test.
- **Client abuse** (attacker re‑POSTs the same URL hoping to drain tokens) → repeated saves of identical content never reach the summariser regardless of frequency.

### Notes
- The plan's optional "defence in depth" (summariser short‑circuit when pending matches a previous ready hash) is **not implemented** in this PR. Making it work would require preserving the previous summary text through the pending state, which expands the state machine beyond what the three primary gates need. The three primary gates eliminate the real regen sources.

## Test plan
- [x] Unit / transition tests assert: `recrawlTieKeptCanonical` no longer emits `generate-summary`; the three promotion transitions skip summary writes + effect when hash equals; lazy backfill (no prior hash) regenerates.
- [x] Handler tests verify hash is computed from winner HTML and threaded into the transition input.
- [x] Generate‑summary handler stamps `sourceContentHash` on `markSummaryReady`.
- [x] Admin recrawl route test: `preserves the existing ready summary on the admin recrawl trigger — summary regeneration is decided downstream by the canonicalContentHash gate, not by wiping state up front`.
- [x] DynamoDB article-store: persists `canonicalContentHash` + `summarySourceContentHash`; clears `summarySourceContentHash` on transition to pending; hydrates both on load.
- [x] `pnpm nx run-many --target=test --all` — 18/18 projects (the one unrelated failure in `@packages/article-resource-unique-id` reproduces on clean `main`).
- [x] `pnpm nx run-many --target=lint --all` — all green.
- [x] 100% function + branch + line coverage on `@packages/domain`, `@packages/article-store`, `save-link`, and `hutch` (no new `c8 ignore`, no exclude patterns).

https://claude.ai/code/session_019Kp5uUTuqHa7jFLKfsKs2e

---
_Generated by [Claude Code](https://claude.ai/code/session_019Kp5uUTuqHa7jFLKfsKs2e)_