### PR TITLE
feat(hutch): dismissible extension-suggestion banner for web saves

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -84,6 +84,22 @@ const BUNDLES = [
 			"});",
 		].join("\n"),
 	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "extension-suggestion-banner.client.js"),
+		globalName: "ExtensionSuggestionBanner",
+		footer: [
+			"document.addEventListener('DOMContentLoaded', function () {",
+			"  ExtensionSuggestionBanner.initExtensionSuggestionBanner({",
+			"    document: window.document,",
+			"    storage: window.localStorage",
+			"  }).attach();",
+			"});",
+		].join("\n"),
+	},
 ];
 
 function buildOptions(bundle) {

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -8,6 +8,11 @@ export interface BannerStateSource {
 export interface BannerState {
 	isAuthenticated: boolean;
 	emailVerified: boolean | undefined;
+	/** When true, the SSR markup carries data-show-extension-suggestion="true"
+	 * so the banner client can reveal the dismissible extension-suggestion banner
+	 * (subject to its own localStorage dismissal). Defaults to false; the queue
+	 * and view page handlers set it when the latest article is not fully parsed. */
+	showExtensionSuggestionBanner?: boolean;
 }
 
 export function bannerStateFromRequest(source: BannerStateSource): BannerState {

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -122,6 +122,42 @@ describe("Base component", () => {
 		expect(banner?.getAttribute("aria-hidden")).toBe("true");
 	});
 
+	it("renders the extension suggestion banner element with data-show='false' by default", () => {
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-extension-suggestion-banner]");
+		assert(banner, "extension suggestion banner must always be in the DOM");
+		expect(banner.getAttribute("data-show-extension-suggestion")).toBe("false");
+	});
+
+	it("sets data-show='true' on the extension suggestion banner when state asks for it", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			isAuthenticated: true,
+			emailVerified: true,
+			showExtensionSuggestionBanner: true,
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-extension-suggestion-banner]");
+		assert(banner, "extension suggestion banner must always be in the DOM");
+		expect(banner.getAttribute("data-show-extension-suggestion")).toBe("true");
+	});
+
+	it("loads the extension suggestion banner client bundle", () => {
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const script = doc.querySelector(
+			'script[src$="/client-dist/extension-suggestion-banner.client.js"]',
+		);
+		assert(script, "extension suggestion banner client script must be rendered");
+		expect(script.hasAttribute("defer")).toBe(true);
+	});
+
 	it("should set meta description from seo", () => {
 		const page = createTestPageBody({ seo: { title: "T", description: "My desc", canonicalUrl: "https://readplace.com" } });
 		const result = Base(page, GUEST_STATE).to("text/html");

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -21,6 +21,11 @@ import { MarkdownPage } from "./markdown-page";
 import { buildMarkdownFrontmatter } from "./markdown-frontmatter";
 import type { PageBody, SeoMetadata } from "./page-body.types";
 import { render } from "./render";
+import {
+	EXTENSION_SUGGESTION_BANNER_SCRIPT,
+	renderExtensionSuggestionBanner,
+} from "./shared/extension-suggestion-banner/extension-suggestion-banner.component";
+import { EXTENSION_SUGGESTION_BANNER_STYLES } from "./shared/extension-suggestion-banner/extension-suggestion-banner.styles";
 import { getEnv, requireEnv } from "../domain/require-env";
 
 const HEADER_TEMPLATE = readFileSync(join(__dirname, "header.template.html"), "utf-8");
@@ -195,14 +200,22 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		footerStyles: FOOTER_STYLES,
 		offlineBannerStyles: OFFLINE_BANNER_STYLES,
 		verifyBannerStyles: VERIFY_BANNER_STYLES,
+		extensionSuggestionBannerStyles: EXTENSION_SUGGESTION_BANNER_STYLES,
 		showVerificationBanner: state.isAuthenticated && state.emailVerified === false,
+		extensionSuggestionBanner: renderExtensionSuggestionBanner({
+			show: state.showExtensionSuggestionBanner ?? false,
+		}),
 		bodyClass: body.bodyClass,
 		header: renderHeader(headerVariant, { isAuthenticated: state.isAuthenticated }),
 		content: injectPageStylesIntoMain(body.content.html, body.styles),
 		footer: renderFooter(),
 		navScript: NAV_SCRIPT,
 		offlineScript: OFFLINE_INDICATOR_SCRIPT,
-		scripts: HTMX_SCRIPTS + (body.scripts ?? "") + LIVERELOAD_SCRIPT,
+		scripts:
+			HTMX_SCRIPTS +
+			EXTENSION_SUGGESTION_BANNER_SCRIPT +
+			(body.scripts ?? "") +
+			LIVERELOAD_SCRIPT,
 	});
 }
 

--- a/projects/hutch/src/runtime/web/base.template.html
+++ b/projects/hutch/src/runtime/web/base.template.html
@@ -78,6 +78,7 @@
     {{{footerStyles}}}
     {{{offlineBannerStyles}}}
     {{{verifyBannerStyles}}}
+    {{{extensionSuggestionBannerStyles}}}
   </style>
 </head>
 <body{{#if bodyClass}} class="{{bodyClass}}"{{/if}}>
@@ -88,6 +89,7 @@
     <div class="verify-banner {{#if showVerificationBanner}}verify-banner--visible{{else}}verify-banner--hidden{{/if}}" role="alert" data-test-verify-banner>
       Please verify your email. Check your inbox or spam folder.
     </div>
+    {{{extensionSuggestionBanner}}}
   </div>
   <script>
     (function() {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.extension-suggestion-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.extension-suggestion-banner.route.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { useTestServer, loginAgent } from "../../../test-app";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+	createFakeApplyParseResult,
+	createFakePublishLinkSaved,
+	createFakePublishRecrawlLinkInitiated,
+	createFakePublishSaveAnonymousLink,
+	createNoopLogError,
+	initReadabilityParser,
+} from "@packages/test-fixtures";
+import type { FindArticleCrawlStatus } from "@packages/test-fixtures/providers/article-crawl";
+import type { FindGeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+
+const useApp = useTestServer();
+
+function bannerAttr(html: string): string | null {
+	const doc = new JSDOM(html).window.document;
+	const banner = doc.querySelector("[data-test-extension-suggestion-banner]");
+	assert(banner, "extension suggestion banner element must always be present");
+	return banner.getAttribute("data-show-extension-suggestion");
+}
+
+describe("GET /queue — extension suggestion banner", () => {
+	it("sets data-show='false' for an empty queue (no saves to evaluate)", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const agent = await loginAgent(harness.server, harness.auth);
+
+		const response = await agent.get("/queue");
+
+		expect(response.status).toBe(200);
+		expect(bannerAttr(response.text)).toBe("false");
+	});
+
+	it("sets data-show='true' when the most recent save is still pending", async () => {
+		const findArticleCrawlStatus: FindArticleCrawlStatus = async () => ({
+			status: "pending",
+		});
+		const findGeneratedSummary: FindGeneratedSummary = async () => ({
+			status: "pending",
+		});
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp({
+			...fixture,
+			articleCrawl: { ...fixture.articleCrawl, findArticleCrawlStatus },
+			summary: { ...fixture.summary, findGeneratedSummary },
+		});
+		const agent = await loginAgent(harness.server, harness.auth);
+
+		await agent
+			.post("/queue/save")
+			.type("form")
+			.send({ url: "https://example.com/pending" });
+
+		const response = await agent.get("/queue");
+
+		expect(bannerAttr(response.text)).toBe("true");
+	});
+
+	it("sets data-show='false' when the most recent save has both crawl and summary ready", async () => {
+		const articleHtml = `<html><head><title>Post</title></head><body><article><p>Body.</p></article></body></html>`;
+		const crawlArticle = async () => ({
+			status: "fetched" as const,
+			html: articleHtml,
+		});
+		const findGeneratedSummary: FindGeneratedSummary = async () => ({
+			status: "ready",
+			summary: "Done.",
+		});
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const { parseArticle } = initReadabilityParser({
+			crawlArticle,
+			sitePreParsers: [],
+			logError: createNoopLogError(),
+		});
+		const applyParseResult = createFakeApplyParseResult({
+			articleStore: fixture.articleStore,
+			articleCrawl: fixture.articleCrawl,
+			parseArticle,
+		});
+		const harness = useApp({
+			...fixture,
+			parser: { parseArticle, crawlArticle },
+			events: {
+				...fixture.events,
+				publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+				publishRecrawlLinkInitiated:
+					createFakePublishRecrawlLinkInitiated(applyParseResult),
+				publishSaveAnonymousLink:
+					createFakePublishSaveAnonymousLink(applyParseResult),
+			},
+			summary: { ...fixture.summary, findGeneratedSummary },
+		});
+		const agent = await loginAgent(harness.server, harness.auth);
+
+		await agent
+			.post("/queue/save")
+			.type("form")
+			.send({ url: "https://example.com/parsed" });
+
+		const response = await agent.get("/queue");
+
+		expect(bannerAttr(response.text)).toBe("false");
+	});
+
+	it("sets data-show='true' when the crawl is ready but summary generation failed", async () => {
+		const articleHtml = `<html><head><title>Post</title></head><body><article><p>Body.</p></article></body></html>`;
+		const crawlArticle = async () => ({
+			status: "fetched" as const,
+			html: articleHtml,
+		});
+		const findGeneratedSummary: FindGeneratedSummary = async () => ({
+			status: "failed",
+			reason: "model timeout",
+		});
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const { parseArticle } = initReadabilityParser({
+			crawlArticle,
+			sitePreParsers: [],
+			logError: createNoopLogError(),
+		});
+		const applyParseResult = createFakeApplyParseResult({
+			articleStore: fixture.articleStore,
+			articleCrawl: fixture.articleCrawl,
+			parseArticle,
+		});
+		const harness = useApp({
+			...fixture,
+			parser: { parseArticle, crawlArticle },
+			events: {
+				...fixture.events,
+				publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+				publishRecrawlLinkInitiated:
+					createFakePublishRecrawlLinkInitiated(applyParseResult),
+				publishSaveAnonymousLink:
+					createFakePublishSaveAnonymousLink(applyParseResult),
+			},
+			summary: { ...fixture.summary, findGeneratedSummary },
+		});
+		const agent = await loginAgent(harness.server, harness.auth);
+
+		await agent
+			.post("/queue/save")
+			.type("form")
+			.send({ url: "https://example.com/summary-failed" });
+
+		const response = await agent.get("/queue");
+
+		expect(bannerAttr(response.text)).toBe("true");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -49,6 +49,7 @@ import { bannerStateFromRequest } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { RedirectComponent } from "../../redirect.component";
 import { CacheableComponent } from "../../conditional-get";
+import { isFullyParsed } from "../../shared/article-state/is-fully-parsed";
 import { initReaderPermalink } from "./reader-permalink";
 import { wantsSiren } from "../../content-negotiation";
 import type { QuerystringFeatureToggle } from "../../feature-toggle";
@@ -293,9 +294,22 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		 * again so they can install the extension here. */
 		const onboardingDismissed = extensionInstalled && req.cookies?.[DISMISS_COOKIE_NAME] === ONBOARDING_VERSION;
 		const browser = detectBrowser(req);
+		/** Most recent save in the listing is at index 0 (queue defaults to
+		 * sort=savedAt order=desc). Re-use the already-loaded crawl/summary
+		 * snapshots — no extra DynamoDB roundtrip. Empty queue → no banner. */
+		const mostRecent = result.articles[0];
+		const showExtensionSuggestionBanner = mostRecent
+			? !isFullyParsed({
+					crawlStatus: crawlByUrl.get(mostRecent.url)?.status,
+					summaryStatus: summaryByUrl.get(mostRecent.url)?.status,
+				})
+			: false;
 		sendComponent(
 			req, res,
-			Base(QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed }), bannerStateFromRequest(req)),
+			Base(
+				QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed }),
+				{ ...bannerStateFromRequest(req), showExtensionSuggestionBanner },
+			),
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/view/view.extension-suggestion-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.extension-suggestion-banner.route.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import type {
+	ParseArticle,
+	ParseArticleResult,
+} from "@packages/test-fixtures/providers/article-parser";
+import type { FindArticleCrawlStatus } from "@packages/test-fixtures/providers/article-crawl";
+import type { FindGeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import { useTestServer } from "../../../test-app";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+	createFakeApplyParseResult,
+	createFakePublishLinkSaved,
+	createFakePublishRecrawlLinkInitiated,
+	createFakePublishSaveAnonymousLink,
+} from "@packages/test-fixtures";
+
+const ARTICLE_URL = "https://example.com/post";
+const ENCODED = encodeURIComponent(ARTICLE_URL);
+
+type OkParseResult = Extract<ParseArticleResult, { ok: true }>;
+type ParsedArticle = OkParseResult["article"];
+
+function buildParseResult(
+	overrides: Partial<ParsedArticle> = {},
+): ParseArticleResult {
+	return {
+		ok: true,
+		article: {
+			title: "Hello World",
+			siteName: "example.com",
+			excerpt: "A lovely article.",
+			wordCount: 500,
+			content: "<p>Body copy.</p>",
+			imageUrl: "https://cdn.example.com/hero.jpg",
+			...overrides,
+		},
+	};
+}
+
+function bannerAttr(html: string): string | null {
+	const doc = new JSDOM(html).window.document;
+	const banner = doc.querySelector("[data-test-extension-suggestion-banner]");
+	assert(banner, "extension suggestion banner element must always be present");
+	return banner.getAttribute("data-show-extension-suggestion");
+}
+
+const useApp = useTestServer();
+
+describe("GET /view/{url} — extension suggestion banner", () => {
+	it("sets data-show='true' when no crawl/summary exists yet (anonymous first hit)", async () => {
+		const parseArticle: ParseArticle = async () => buildParseResult();
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const findArticleCrawlStatus: FindArticleCrawlStatus = async () => undefined;
+		const findGeneratedSummary: FindGeneratedSummary = async () => undefined;
+		const harness = useApp({
+			...fixture,
+			parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+			articleCrawl: { ...fixture.articleCrawl, findArticleCrawlStatus },
+			summary: { ...fixture.summary, findGeneratedSummary },
+		});
+
+		const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+		expect(response.status).toBe(200);
+		expect(bannerAttr(response.text)).toBe("true");
+	});
+
+	it("sets data-show='false' when both crawl and summary are ready (fully parsed)", async () => {
+		const parseArticle: ParseArticle = async () => buildParseResult();
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const applyParseResult = createFakeApplyParseResult({
+			articleStore: fixture.articleStore,
+			articleCrawl: fixture.articleCrawl,
+			parseArticle,
+		});
+		const findGeneratedSummary: FindGeneratedSummary = async () => ({
+			status: "ready",
+			summary: "TLDR.",
+		});
+		const harness = useApp({
+			...fixture,
+			parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+			events: {
+				...fixture.events,
+				publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+				publishRecrawlLinkInitiated:
+					createFakePublishRecrawlLinkInitiated(applyParseResult),
+				publishSaveAnonymousLink:
+					createFakePublishSaveAnonymousLink(applyParseResult),
+			},
+			summary: { ...fixture.summary, findGeneratedSummary },
+		});
+
+		const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+		expect(bannerAttr(response.text)).toBe("false");
+	});
+
+	it("sets data-show='true' when crawl is ready but summary is still pending", async () => {
+		const parseArticle: ParseArticle = async () => buildParseResult();
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const applyParseResult = createFakeApplyParseResult({
+			articleStore: fixture.articleStore,
+			articleCrawl: fixture.articleCrawl,
+			parseArticle,
+		});
+		const findGeneratedSummary: FindGeneratedSummary = async () => ({
+			status: "pending",
+		});
+		const harness = useApp({
+			...fixture,
+			parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+			events: {
+				...fixture.events,
+				publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+				publishRecrawlLinkInitiated:
+					createFakePublishRecrawlLinkInitiated(applyParseResult),
+				publishSaveAnonymousLink:
+					createFakePublishSaveAnonymousLink(applyParseResult),
+			},
+			summary: { ...fixture.summary, findGeneratedSummary },
+		});
+
+		const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+		expect(bannerAttr(response.text)).toBe("true");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -38,6 +38,7 @@ import type {
 	ArticleReaderDeps,
 	PollUrlBuilder,
 } from "../../shared/article-reader/article-reader.types";
+import { isFullyParsed } from "../../shared/article-state/is-fully-parsed";
 import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "../save/save-error.component";
 import { ViewLandingPage } from "./view-landing.component";
@@ -184,21 +185,29 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 			},
 		];
 
+		const showExtensionSuggestionBanner = !isFullyParsed({
+			crawlStatus: state.crawl?.status,
+			summaryStatus: state.summary?.status,
+		});
+
 		sendComponent(
 			req, res,
-			Base(ViewPage({
-				articleUrl,
-				metadata,
-				estimatedReadTime,
-				content: state.content,
-				crawl: state.crawl,
-				readerPollUrl: state.readerPollUrl,
-				summary: state.summary,
-				summaryPollUrl: state.summaryPollUrl,
-				progress: state.progress,
-				actions,
-				extensionInstallUrl: extensionInstallUrlIfMissing(req),
-			}), bannerStateFromRequest(req)),
+			Base(
+				ViewPage({
+					articleUrl,
+					metadata,
+					estimatedReadTime,
+					content: state.content,
+					crawl: state.crawl,
+					readerPollUrl: state.readerPollUrl,
+					summary: state.summary,
+					summaryPollUrl: state.summaryPollUrl,
+					progress: state.progress,
+					actions,
+					extensionInstallUrl: extensionInstallUrlIfMissing(req),
+				}),
+				{ ...bannerStateFromRequest(req), showExtensionSuggestionBanner },
+			),
 		);
 	};
 }

--- a/projects/hutch/src/runtime/web/shared/article-state/is-fully-parsed.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-state/is-fully-parsed.test.ts
@@ -1,0 +1,29 @@
+import type { CrawlStatus, SummaryStatus } from "@packages/article-state-types";
+import { isFullyParsed } from "./is-fully-parsed";
+
+const CRAWL_STATUSES: ReadonlyArray<CrawlStatus | undefined> = [
+	"pending",
+	"ready",
+	"failed",
+	"unsupported",
+	undefined,
+];
+
+const SUMMARY_STATUSES: ReadonlyArray<SummaryStatus | undefined> = [
+	"pending",
+	"ready",
+	"failed",
+	"skipped",
+	undefined,
+];
+
+describe("isFullyParsed", () => {
+	it("returns true only when both crawl and summary statuses are ready", () => {
+		for (const crawlStatus of CRAWL_STATUSES) {
+			for (const summaryStatus of SUMMARY_STATUSES) {
+				const expected = crawlStatus === "ready" && summaryStatus === "ready";
+				expect(isFullyParsed({ crawlStatus, summaryStatus })).toBe(expected);
+			}
+		}
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-state/is-fully-parsed.ts
+++ b/projects/hutch/src/runtime/web/shared/article-state/is-fully-parsed.ts
@@ -1,0 +1,8 @@
+import type { CrawlStatus, SummaryStatus } from "@packages/article-state-types";
+
+export function isFullyParsed(input: {
+	crawlStatus: CrawlStatus | undefined;
+	summaryStatus: SummaryStatus | undefined;
+}): boolean {
+	return input.crawlStatus === "ready" && input.summaryStatus === "ready";
+}

--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { fireEvent } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
+import { initExtensionSuggestionBanner } from "./extension-suggestion-banner.client";
+
+const STORAGE_KEY = "readplace.extension-suggestion-dismissed";
+const VISIBLE_CLASS = "extension-suggestion-banner--visible";
+
+function buildFixture(showAttr: "true" | "false"): string {
+	return `<!DOCTYPE html><html><body>
+    <div class="extension-suggestion-banner" data-show-extension-suggestion="${showAttr}">
+      <span class="extension-suggestion-banner__message">Tip</span>
+      <a class="extension-suggestion-banner__cta" href="/install">Get the extension</a>
+      <button type="button" class="extension-suggestion-banner__close" data-extension-suggestion-close>
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  </body></html>`;
+}
+
+function createDom(showAttr: "true" | "false") {
+	const dom = new JSDOM(buildFixture(showAttr), {
+		url: "https://readplace.com/queue",
+	});
+	return { window: dom.window, document: dom.window.document };
+}
+
+function banner(doc: Document): HTMLElement {
+	const el = doc.querySelector<HTMLElement>(".extension-suggestion-banner");
+	assert(el, "banner element must exist in fixture");
+	return el;
+}
+
+function closeBtn(doc: Document): HTMLElement {
+	const el = doc.querySelector<HTMLElement>("[data-extension-suggestion-close]");
+	assert(el, "close button must exist in fixture");
+	return el;
+}
+
+describe("initExtensionSuggestionBanner — attach", () => {
+	it("adds the visible class when show=true and the dismiss flag is not set", () => {
+		const { window, document } = createDom("true");
+
+		initExtensionSuggestionBanner({
+			document,
+			storage: window.localStorage,
+		}).attach();
+
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(true);
+	});
+
+	it("leaves the banner hidden when show=false", () => {
+		const { window, document } = createDom("false");
+
+		initExtensionSuggestionBanner({
+			document,
+			storage: window.localStorage,
+		}).attach();
+
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(false);
+	});
+
+	it("leaves the banner hidden when the dismiss flag is already set", () => {
+		const { window, document } = createDom("true");
+		window.localStorage.setItem(STORAGE_KEY, "1");
+
+		initExtensionSuggestionBanner({
+			document,
+			storage: window.localStorage,
+		}).attach();
+
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(false);
+	});
+});
+
+describe("initExtensionSuggestionBanner — dismiss", () => {
+	it("removes the visible class and persists the dismiss flag when the close button is clicked", () => {
+		const { window, document } = createDom("true");
+
+		initExtensionSuggestionBanner({
+			document,
+			storage: window.localStorage,
+		}).attach();
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(true);
+
+		fireEvent.click(closeBtn(document));
+
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(false);
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1");
+	});
+
+	it("keeps the banner hidden on a subsequent attach after dismissal", () => {
+		const { window, document } = createDom("true");
+
+		initExtensionSuggestionBanner({
+			document,
+			storage: window.localStorage,
+		}).attach();
+		fireEvent.click(closeBtn(document));
+
+		// Simulate a second page load by re-attaching with the same storage.
+		const { document: doc2 } = createDom("true");
+		initExtensionSuggestionBanner({
+			document: doc2,
+			storage: window.localStorage,
+		}).attach();
+
+		expect(banner(doc2).classList.contains(VISIBLE_CLASS)).toBe(false);
+	});
+});
+
+describe("initExtensionSuggestionBanner — storage failures", () => {
+	it("treats a throwing getItem as not dismissed and still shows the banner", () => {
+		const { document } = createDom("true");
+		const storage = {
+			getItem: jest.fn((): string | null => {
+				throw new Error("access denied");
+			}),
+			setItem: jest.fn(),
+		};
+
+		initExtensionSuggestionBanner({ document, storage }).attach();
+
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(true);
+	});
+
+	it("swallows a throwing setItem when the user dismisses", () => {
+		const { document } = createDom("true");
+		const storage = {
+			getItem: jest.fn((): string | null => null),
+			setItem: jest.fn((_k: string, _v: string): void => {
+				throw new Error("quota");
+			}),
+		};
+
+		initExtensionSuggestionBanner({ document, storage }).attach();
+
+		expect(() => fireEvent.click(closeBtn(document))).not.toThrow();
+		expect(banner(document).classList.contains(VISIBLE_CLASS)).toBe(false);
+	});
+});
+
+describe("initExtensionSuggestionBanner — missing elements", () => {
+	it("throws a descriptive error when the banner element is absent", () => {
+		const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+			url: "https://readplace.com/",
+		});
+
+		expect(() =>
+			initExtensionSuggestionBanner({
+				document: dom.window.document,
+				storage: dom.window.localStorage,
+			}),
+		).toThrow(/missing element \.extension-suggestion-banner/);
+	});
+
+	it("throws a descriptive error when the close button is absent", () => {
+		const dom = new JSDOM(
+			`<!DOCTYPE html><html><body>
+        <div class="extension-suggestion-banner" data-show-extension-suggestion="true"></div>
+      </body></html>`,
+			{ url: "https://readplace.com/" },
+		);
+
+		const ctrl = initExtensionSuggestionBanner({
+			document: dom.window.document,
+			storage: dom.window.localStorage,
+		});
+
+		expect(() => ctrl.attach()).toThrow(
+			/missing element \[data-extension-suggestion-close\]/,
+		);
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts
@@ -1,0 +1,68 @@
+interface ExtensionSuggestionBannerStorage {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+}
+
+interface ExtensionSuggestionBannerDeps {
+	document: Document;
+	storage: ExtensionSuggestionBannerStorage;
+}
+
+interface ExtensionSuggestionBannerController {
+	attach(): void;
+}
+
+const STORAGE_KEY = "readplace.extension-suggestion-dismissed";
+const BANNER_SELECTOR = ".extension-suggestion-banner";
+const CLOSE_SELECTOR = "[data-extension-suggestion-close]";
+const VISIBLE_CLASS = "extension-suggestion-banner--visible";
+
+export function initExtensionSuggestionBanner(
+	deps: ExtensionSuggestionBannerDeps,
+): ExtensionSuggestionBannerController {
+	function ensure<T>(value: T | null | undefined, description: string): T {
+		if (value === null || value === undefined) {
+			throw new Error(`extension-suggestion-banner: ${description}`);
+		}
+		return value;
+	}
+
+	function readDismissed(): boolean {
+		try {
+			return deps.storage.getItem(STORAGE_KEY) === "1";
+		} catch {
+			return false;
+		}
+	}
+
+	function writeDismissed(): void {
+		try {
+			deps.storage.setItem(STORAGE_KEY, "1");
+		} catch {
+			/* storage may throw in private mode — swallow */
+		}
+	}
+
+	const banner = ensure(
+		deps.document.querySelector<HTMLElement>(BANNER_SELECTOR),
+		`missing element ${BANNER_SELECTOR}`,
+	);
+
+	function attach(): void {
+		if (banner.dataset.showExtensionSuggestion !== "true") return;
+		if (readDismissed()) return;
+
+		banner.classList.add(VISIBLE_CLASS);
+
+		const closeBtn = ensure(
+			banner.querySelector<HTMLElement>(CLOSE_SELECTOR),
+			`missing element ${CLOSE_SELECTOR}`,
+		);
+		closeBtn.addEventListener("click", () => {
+			banner.classList.remove(VISIBLE_CLASS);
+			writeDismissed();
+		});
+	}
+
+	return { attach };
+}

--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { renderExtensionSuggestionBanner } from "./extension-suggestion-banner.component";
+
+function parse(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window
+		.document;
+}
+
+describe("renderExtensionSuggestionBanner", () => {
+	it("always renders the banner element regardless of the show flag", () => {
+		const shown = parse(renderExtensionSuggestionBanner({ show: true }));
+		const hidden = parse(renderExtensionSuggestionBanner({ show: false }));
+
+		assert(
+			shown.querySelector(".extension-suggestion-banner"),
+			"banner must be rendered when show=true",
+		);
+		assert(
+			hidden.querySelector(".extension-suggestion-banner"),
+			"banner must always be rendered so the client can locate it",
+		);
+	});
+
+	it("sets data-show-extension-suggestion='true' when show=true", () => {
+		const doc = parse(renderExtensionSuggestionBanner({ show: true }));
+
+		const banner = doc.querySelector(".extension-suggestion-banner");
+		assert(banner, "banner must be rendered");
+		expect(banner.getAttribute("data-show-extension-suggestion")).toBe("true");
+	});
+
+	it("sets data-show-extension-suggestion='false' when show=false", () => {
+		const doc = parse(renderExtensionSuggestionBanner({ show: false }));
+
+		const banner = doc.querySelector(".extension-suggestion-banner");
+		assert(banner, "banner must be rendered");
+		expect(banner.getAttribute("data-show-extension-suggestion")).toBe("false");
+	});
+
+	it("renders a close button with an accessible label and the dismiss data attribute", () => {
+		const doc = parse(renderExtensionSuggestionBanner({ show: true }));
+
+		const closeBtn = doc.querySelector("[data-extension-suggestion-close]");
+		assert(closeBtn, "close button must be rendered");
+		expect(closeBtn.getAttribute("aria-label")).toBe(
+			"Dismiss extension suggestion",
+		);
+	});
+
+	it("renders a CTA pointing to the extension install page", () => {
+		const doc = parse(renderExtensionSuggestionBanner({ show: true }));
+
+		const cta = doc.querySelector("[data-test-extension-suggestion-cta]");
+		assert(cta, "cta must be rendered");
+		expect(cta.getAttribute("href")).toBe("/install");
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.component.ts
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.component.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render } from "../../render";
+
+const EXTENSION_SUGGESTION_BANNER_TEMPLATE = readFileSync(
+	join(__dirname, "extension-suggestion-banner.template.html"),
+	"utf-8",
+);
+
+export const EXTENSION_SUGGESTION_BANNER_SCRIPT = `<script src="/client-dist/extension-suggestion-banner.client.js" defer></script>`;
+
+export function renderExtensionSuggestionBanner(input: { show: boolean }): string {
+	return render(EXTENSION_SUGGESTION_BANNER_TEMPLATE, {
+		show: input.show ? "true" : "false",
+	});
+}

--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.styles.ts
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.styles.ts
@@ -1,0 +1,56 @@
+export const EXTENSION_SUGGESTION_BANNER_STYLES = `
+  .extension-suggestion-banner {
+    background: var(--color-brand-light);
+    color: var(--color-text-primary);
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease, padding 0.3s ease;
+    padding: 0 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .extension-suggestion-banner--visible {
+    max-height: 120px;
+    padding: 8px 16px;
+  }
+
+  .extension-suggestion-banner__message {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: left;
+  }
+
+  .extension-suggestion-banner__cta {
+    flex: 0 0 auto;
+    color: var(--color-brand-dark);
+    font-weight: 600;
+    text-decoration: underline;
+  }
+
+  .extension-suggestion-banner__cta:hover {
+    color: var(--color-brand);
+  }
+
+  .extension-suggestion-banner__close {
+    flex: 0 0 auto;
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+  }
+
+  .extension-suggestion-banner__close:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
+`;

--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.template.html
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.template.html
@@ -1,0 +1,21 @@
+<div
+  class="extension-suggestion-banner"
+  role="status"
+  aria-live="polite"
+  data-show-extension-suggestion="{{show}}"
+  data-test-extension-suggestion-banner
+>
+  <span class="extension-suggestion-banner__message">
+    Tip: install the Readplace browser extension to save articles with their full content. Some sites block our server-side fetch with paywalls, login walls, or anti-bot defences — when that happens we can only save the link itself.
+  </span>
+  <a class="extension-suggestion-banner__cta" href="/install" data-test-extension-suggestion-cta>Get the extension</a>
+  <button
+    type="button"
+    class="extension-suggestion-banner__close"
+    data-extension-suggestion-close
+    data-test-extension-suggestion-close
+    aria-label="Dismiss extension suggestion"
+  >
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>


### PR DESCRIPTION
## Summary

- New dismissible banner shown on `/queue` (after a save) and `/view/{url}` whenever the canonical article row is **not** fully parsed (`crawlStatus === "ready" && summaryStatus === "ready"`). It explains the tier-1 fetch limitation and points at the browser extension.
- Banner markup is rendered unconditionally inside `.banner-area` (next to the existing offline / verify banners) so tests can assert-existence; visibility is gated by `data-show-extension-suggestion="true"` plus a per-device `localStorage["readplace.extension-suggestion-dismissed"]` flag set by the close button.
- No edits to the save pipeline, crawl state machine, or per-page view models — open/closed shape: new files + one prop threaded through `Base`.

## What changed

- **New predicate** — `shared/article-state/is-fully-parsed.ts` (+ exhaustive cross-product test).
- **New module** — `shared/extension-suggestion-banner/{component,client,styles,template}` with both component and client tests (jsdom + `@testing-library/dom`). Mirrors the share-balloon `localStorage` try/catch pattern.
- **Base wiring** — `BannerState.showExtensionSuggestionBanner?: boolean`; the base template now renders the banner element, includes its CSS, and loads `/client-dist/extension-suggestion-banner.client.js` (added to `build-client-bundles.js`).
- **Page-handler wiring** — `/queue` evaluates the most-recent save against the already-loaded `crawlByUrl`/`summaryByUrl` maps (no extra DDB roundtrip); `/view/{url}` reuses `state.crawl`/`state.summary` from `resolveReaderState`.
- **Integration tests** beside both page files cover the four interesting cases (empty queue, pending, fully ready, summary failed but crawl ready).

## Caveat to flag

The predicate is `crawl === "ready" && summary === "ready"` (chosen by product). That means a successful capture whose summary later failed still shows the banner — banner copy is about content capture, not summaries, so there's a minor copy/condition mismatch. Surfaced here per the task; do not narrow without product confirmation.

## Test plan

- [x] `pnpm nx run hutch:check` — green (1264 tests; 100% coverage on every new file).
- [x] New unit tests: `is-fully-parsed`, `extension-suggestion-banner.component`, `extension-suggestion-banner.client` (attach / dismiss / storage failures / missing elements).
- [x] New integration tests for `/queue` and `/view/{url}` asserting `data-show-extension-suggestion` flips correctly across the predicate cross-product.
- [x] Build pipeline updated and verified — `extension-suggestion-banner.client.js` ships under `/client-dist/`.

https://claude.ai/code/session_012FQiQgR27vCDeZmEEgnURy

---
_Generated by [Claude Code](https://claude.ai/code/session_012FQiQgR27vCDeZmEEgnURy)_