### PR TITLE
test(hutch): assert UTM count instead of negative null check

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
@@ -233,7 +233,7 @@ describe("Queue routes", () => {
 			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
 			expect(location.searchParams.get("utm_source")).toBe("twitter");
 			expect(location.searchParams.get("utm_medium")).toBe("social");
-			expect(location.searchParams.get("utm_campaign")).toBeNull();
+			expect([...location.searchParams.keys()].filter((k) => k.startsWith("utm_"))).toHaveLength(2);
 		});
 
 		it("should link article title to reader view in queue when content exists", async () => {


### PR DESCRIPTION
## Summary

- Replace `expect(searchParams.get("utm_campaign")).toBeNull()` with a count-based assertion on UTM keys in the "preserve incoming UTM params" test in `queue.reader.route.test.ts`.
- The negative null assertion would pass spuriously if a future refactor renamed the default key (e.g. `utm_campaign` → `utm_campaign_id`) or added a new default UTM that leaked through — exactly the regressions the test exists to catch.
- The new assertion bounds the total UTM count to the two incoming params (`utm_source`, `utm_medium`), so any extra default leaking onto the redirect fails the test for the right reason. The existing positive value assertions on lines 234–235 are untouched.

## Test plan

- [x] `pnpm nx test hutch --testPathPattern=queue.reader.route.test.js` — all 19 tests pass, including "should preserve incoming UTM params".
- [x] Verified regression detection: temporarily edited `reader-permalink.ts` to unconditionally append `utm_campaign=read-permalink` when incoming UTMs are present; the new `toHaveLength(2)` assertion failed with `Received length: 3, Received array: ["utm_source", "utm_medium", "utm_campaign"]`. Reverted before committing.
- [x] No production code changes — only the one-line test refactor.

---
_Generated by [Claude Code](https://claude.ai/code/session_015th3GeUEitT5d7xuhx4Z1T)_