### PR TITLE
feat(hutch): scale share balloon scroll threshold to article height

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/view-page-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/view-page-actions.ts
@@ -103,7 +103,11 @@ export function createAnonymousViewPageActions(
 				const shareWrap = page.locator('[data-test-share-balloon-wrap]')
 				await expect(shareWrap).toHaveCount(1)
 				await expect(shareWrap).not.toHaveClass(/share-balloon__wrap--open/)
-				await page.evaluate(() => window.scrollTo(0, 200))
+				await page.evaluate(() => {
+					const article = document.querySelector<HTMLElement>('[data-article-body]')
+					const height = article ? article.offsetHeight : 0
+					window.scrollTo(0, Math.ceil(height * 0.5) + 1)
+				})
 				await expect(shareWrap).toHaveClass(/share-balloon__wrap--open/, { timeout: 3000 })
 				await page.locator('[data-test-share-balloon-close]').click()
 				await expect(shareWrap).not.toHaveClass(/share-balloon__wrap--open/)
@@ -126,7 +130,11 @@ export function createAnonymousViewPageActions(
 				// Share dismiss persists across reload: scrolling past the threshold
 				// again must NOT re-open the balloon. Wait past the 1s OPEN_DELAY_MS
 				// so a would-be setTimeout has had its chance to fire.
-				await page.evaluate(() => window.scrollTo(0, 200))
+				await page.evaluate(() => {
+					const article = document.querySelector<HTMLElement>('[data-article-body]')
+					const height = article ? article.offsetHeight : 0
+					window.scrollTo(0, Math.ceil(height * 0.5) + 1)
+				})
 				await page.waitForTimeout(1500)
 				await expect(shareWrap).not.toHaveClass(/share-balloon__wrap--open/)
 

--- a/projects/hutch/src/runtime/web/pages/reader/reader.template.html
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.template.html
@@ -1,5 +1,7 @@
     <main class="reader">
-      {{{innerContent}}}
+      <div class="reader__article-body" data-article-body>
+        {{{innerContent}}}
+      </div>
       <div class="reader__share-row">
         {{{shareBalloon}}}
       </div>

--- a/projects/hutch/src/runtime/web/pages/view/view.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view.template.html
@@ -1,5 +1,5 @@
     <main class="view">
-      <article class="view__body">
+      <article class="view__body" data-article-body>
         {{{innerContent}}}
       </article>
       <div class="view__share-row">

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -12,6 +12,7 @@ const ARTICLE_TITLE = "Hello World";
 
 const FIXTURE = `<!DOCTYPE html><html><body>
 <span data-share-balloon-status></span>
+<div data-article-body></div>
 <div data-share-balloon-wrap hidden>
   <div data-share-balloon-buttons>
     <div data-share-balloon-chat></div>
@@ -43,6 +44,23 @@ function setScrollY(win: TestWindow, value: number): void {
 	});
 }
 
+function setViewportHeight(win: TestWindow, value: number): void {
+	Object.defineProperty(win, "innerHeight", {
+		value,
+		writable: true,
+		configurable: true,
+	});
+}
+
+function setArticleHeight(doc: Document, value: number): void {
+	const el = element(doc, "[data-article-body]");
+	Object.defineProperty(el, "offsetHeight", {
+		value,
+		writable: true,
+		configurable: true,
+	});
+}
+
 function fireScroll(win: TestWindow): void {
 	win.dispatchEvent(new win.Event("scroll"));
 }
@@ -52,10 +70,14 @@ function setup(
 		scrollY?: number;
 		dismissed?: boolean;
 		navigator?: NavigatorStub;
+		articleHeight?: number;
+		viewportHeight?: number;
 	} = {},
 ) {
 	const { window, document } = createDom();
 	setScrollY(window, options.scrollY ?? 0);
+	setViewportHeight(window, options.viewportHeight ?? 800);
+	setArticleHeight(document, options.articleHeight ?? 4000);
 	if (options.dismissed) {
 		window.localStorage.setItem(STORAGE_KEY, "1");
 	}
@@ -99,7 +121,7 @@ describe("initShareBalloon — attach/dismiss flow", () => {
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 
-		setScrollY(window, 150);
+		setScrollY(window, 2500);
 		fireScroll(window);
 		jest.advanceTimersByTime(5000);
 
@@ -121,7 +143,7 @@ describe("initShareBalloon — attach/dismiss flow", () => {
 		const wrap = element(document, "[data-share-balloon-wrap]");
 
 		ctrl.attach();
-		setScrollY(window, 150);
+		setScrollY(window, 2500);
 		fireScroll(window);
 		jest.advanceTimersByTime(5000);
 
@@ -135,7 +157,7 @@ describe("initShareBalloon — attach/dismiss flow", () => {
 
 		ctrl.attach();
 		ctrl.attach();
-		setScrollY(window, 150);
+		setScrollY(window, 2500);
 		fireScroll(window);
 		jest.advanceTimersByTime(1000);
 
@@ -144,24 +166,44 @@ describe("initShareBalloon — attach/dismiss flow", () => {
 });
 
 describe("initShareBalloon — scroll-to-open", () => {
-	it("does not schedule the open when scrollY is below the threshold", () => {
-		const { window, document, ctrl } = setup();
+	it("opens immediately when the article fits inside the viewport (no scroll required)", () => {
+		const { document, ctrl } = setup({
+			articleHeight: 600,
+			viewportHeight: 800,
+			scrollY: 0,
+		});
+		const wrap = element(document, "[data-share-balloon-wrap]");
+
+		ctrl.attach();
+		jest.advanceTimersByTime(1000);
+
+		expect(wrap.classList.contains(OPEN_CLASS)).toBe(true);
+	});
+
+	it("does not open while scrollY is below half the article height on a longer article", () => {
+		const { window, document, ctrl } = setup({
+			articleHeight: 2000,
+			viewportHeight: 800,
+		});
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 
-		setScrollY(window, 50);
+		setScrollY(window, 999);
 		fireScroll(window);
 		jest.advanceTimersByTime(5000);
 
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
 	});
 
-	it("opens the wrap one OPEN_DELAY_MS after scrollY crosses the threshold", () => {
-		const { window, document, ctrl } = setup();
+	it("opens one OPEN_DELAY_MS after scrollY crosses half the article height on a longer article", () => {
+		const { window, document, ctrl } = setup({
+			articleHeight: 2000,
+			viewportHeight: 800,
+		});
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 
-		setScrollY(window, 150);
+		setScrollY(window, 1000);
 		fireScroll(window);
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
 		jest.advanceTimersByTime(999);
@@ -171,11 +213,14 @@ describe("initShareBalloon — scroll-to-open", () => {
 	});
 
 	it("does not schedule a second open if another scroll fires after the threshold was crossed", () => {
-		const { window, document, ctrl } = setup();
+		const { window, document, ctrl } = setup({
+			articleHeight: 2000,
+			viewportHeight: 800,
+		});
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 
-		setScrollY(window, 150);
+		setScrollY(window, 1000);
 		fireScroll(window);
 		jest.advanceTimersByTime(1000);
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(true);
@@ -187,7 +232,11 @@ describe("initShareBalloon — scroll-to-open", () => {
 	});
 
 	it("honours an already-scrolled page on attach (synchronous open scheduling)", () => {
-		const { document, ctrl } = setup({ scrollY: 250 });
+		const { document, ctrl } = setup({
+			articleHeight: 2000,
+			viewportHeight: 800,
+			scrollY: 1500,
+		});
 		const wrap = element(document, "[data-share-balloon-wrap]");
 
 		ctrl.attach();
@@ -195,11 +244,44 @@ describe("initShareBalloon — scroll-to-open", () => {
 
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(true);
 	});
+
+	it("re-reads the article height on each scroll so dynamic-height content recomputes the threshold", () => {
+		const { window, document, ctrl } = setup({
+			articleHeight: 2000,
+			viewportHeight: 800,
+		});
+		const wrap = element(document, "[data-share-balloon-wrap]");
+		ctrl.attach();
+
+		setScrollY(window, 500);
+		fireScroll(window);
+		jest.advanceTimersByTime(5000);
+		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
+
+		setArticleHeight(document, 200);
+		fireScroll(window);
+		jest.advanceTimersByTime(1000);
+		expect(wrap.classList.contains(OPEN_CLASS)).toBe(true);
+	});
+
+	it("does not open even when the article fits the viewport if the dismiss flag is already set", () => {
+		const { document, ctrl } = setup({
+			articleHeight: 600,
+			viewportHeight: 800,
+			dismissed: true,
+		});
+		const wrap = element(document, "[data-share-balloon-wrap]");
+
+		ctrl.attach();
+		jest.advanceTimersByTime(5000);
+
+		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
+	});
 });
 
 describe("initShareBalloon — close button", () => {
 	it("removes the open class and persists the dismiss flag in storage", () => {
-		const { window, document, ctrl } = setup({ scrollY: 150 });
+		const { window, document, ctrl } = setup({ scrollY: 2500 });
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 		jest.advanceTimersByTime(1000);
@@ -212,7 +294,7 @@ describe("initShareBalloon — close button", () => {
 	});
 
 	it("cancels a pending open timer when closed before OPEN_DELAY_MS elapses", () => {
-		const { document, ctrl } = setup({ scrollY: 150 });
+		const { document, ctrl } = setup({ scrollY: 2500 });
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 
@@ -228,7 +310,7 @@ describe("initShareBalloon — close button", () => {
 		ctrl.attach();
 
 		fireEvent.click(element(document, "[data-share-balloon-close]"));
-		setScrollY(window, 150);
+		setScrollY(window, 2500);
 		fireScroll(window);
 		jest.advanceTimersByTime(5000);
 
@@ -388,7 +470,7 @@ describe("initShareBalloon — copy click", () => {
 
 describe("initShareBalloon — storage failures", () => {
 	it("treats a throwing getItem as not dismissed", () => {
-		const { window, document } = setup({ scrollY: 150 });
+		const { window, document } = setup({ scrollY: 2500 });
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		const storage = {
 			getItem: jest.fn((): string | null => {
@@ -437,7 +519,7 @@ describe("initShareBalloon — storage failures", () => {
 
 describe("initShareBalloon — detach()", () => {
 	it("cancels a pending open timer and stops later scrolls from opening", () => {
-		const { window, document, ctrl } = setup({ scrollY: 150 });
+		const { window, document, ctrl } = setup({ scrollY: 2500 });
 		const wrap = element(document, "[data-share-balloon-wrap]");
 		ctrl.attach();
 
@@ -445,7 +527,7 @@ describe("initShareBalloon — detach()", () => {
 		jest.advanceTimersByTime(5000);
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
 
-		setScrollY(window, 200);
+		setScrollY(window, 3000);
 		fireScroll(window);
 		jest.advanceTimersByTime(1000);
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
@@ -1,5 +1,6 @@
 interface ShareBalloonWindow {
 	readonly scrollY: number;
+	readonly innerHeight: number;
 	addEventListener(
 		type: "scroll",
 		listener: () => void,
@@ -38,7 +39,6 @@ export function initShareBalloon(
 	deps: ShareBalloonDeps,
 ): ShareBalloonController {
 	const STORAGE_KEY = "readplace.share-dismissed";
-	const SCROLL_THRESHOLD_PX = 100;
 	const OPEN_DELAY_MS = 1000;
 	const COPIED_FADE_MS = 3000;
 	const OPEN_CLASS = "share-balloon__wrap--open";
@@ -81,6 +81,7 @@ export function initShareBalloon(
 	const closeBtn = pickElement(wrap, "[data-share-balloon-close]");
 	const copiedLabel = pickElement(wrap, "[data-share-balloon-copied]");
 	const status = pickElement(deps.document, "[data-share-balloon-status]");
+	const articleEl = pickElement(deps.document, "[data-article-body]");
 
 	const shareUrl = pickAttribute(btn, "data-share-url");
 	const copyUrl = pickAttribute(copyBtn, "data-share-url");
@@ -117,7 +118,10 @@ export function initShareBalloon(
 	}
 
 	function onScroll() {
-		if (deps.window.scrollY < SCROLL_THRESHOLD_PX) return;
+		const articleHeight = articleEl.offsetHeight;
+		const viewportHeight = deps.window.innerHeight;
+		const threshold = articleHeight <= viewportHeight ? 0 : articleHeight * 0.5;
+		if (deps.window.scrollY < threshold) return;
 		if (scrollListener !== null) {
 			deps.window.removeEventListener("scroll", scrollListener);
 			scrollListener = null;


### PR DESCRIPTION
## Summary
- Replace the fixed 100 px scroll trigger for the share balloon with a per-article threshold: balloon opens once `scrollY` crosses half the article height on long posts, and immediately on posts that fit in one viewport (where there is no later moment to wait for).
- Add a stable `[data-article-body]` hook to the reader and view templates so `share-balloon.client.ts` has a single, semantic element to measure on both `/queue/:id/read` and `/view/:url`.
- Extend the JSDOM unit harness to drive `window.innerHeight` and `articleEl.offsetHeight` via `Object.defineProperty` (same pattern already used for `scrollY`) and add coverage for both branches of the new dynamic threshold.

The 1 s open delay, the dismiss-forever `localStorage` flag, and the click/copy/share behavior all stay unchanged — only the trigger condition moves.

## Test plan
- [x] `pnpm nx test hutch` — 1242 tests green (32 of them in `share-balloon.client.test.ts`).
- [x] `pnpm nx run hutch:check` — coverage gate green (project-wide 99.7% statements / 96.4% branches; share-balloon file at 98.6% / 97.43%, matching baseline).
- [x] `pnpm nx run hutch:lint` — `tsc`, biome, knip, and the unused-CSS check all clean (no rule for the new `reader__article-body` wrapper is required).
- [ ] Manual browser check (per the web skill):
  - Short post (< viewport) opened from `/queue` → balloon appears ~1 s after page load, no scroll required.
  - Long post (> 2 viewports) opened from `/queue` → balloon stays hidden until scrolled past ~½ article height, then appears ~1 s later.
  - Same long post opened via `/view/<url>` → same behavior.
  - Click ×, navigate away, navigate back → balloon stays dismissed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYKAkcq3MS7FPir9VkNifQ)_