### PR TITLE
feat(infra): custom domains for content-media and static-assets CDNs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       PULUMI_STACK: staging
       PULUMI_CONFIG_PASSPHRASE: ''
       PERSISTENCE: development
-      STATIC_BASE_URL: 'https://d2uoxssv1ey7em.cloudfront.net'
+      STATIC_BASE_URL: 'https://static-staging.readplace.com'
     steps:
       - uses: actions/checkout@v6
 

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -6,7 +6,7 @@ config:
   hutch:platformStack: organization/platform/staging
   hutch:deletionProtection: false
   hutch:staticDomains:
-    - d2uoxssv1ey7em.cloudfront.net
+    - static-staging.readplace.com
   hutch:staticBucketName: hutch-static-assets-staging
   hutch:dynamodbArticlesTable: hutch-articles-cda0a08
   hutch:dynamodbUserArticlesTable: hutch-user-articles-8226beb

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -76,9 +76,16 @@ if (redirectDomains.length > 0) {
 const staticDomainEntries = staticDomains.map((staticDomain) => {
 	const parentIndex = domains.findIndex((d) => staticDomain.endsWith(`.${d}`));
 	const parentRegistration = parentIndex >= 0 ? allDomainRegistrations[parentIndex] : undefined;
-	return parentRegistration?.zoneId
-		? { domain: staticDomain, zoneId: parentRegistration.zoneId }
-		: { domain: staticDomain };
+	if (parentRegistration?.zoneId) {
+		return { domain: staticDomain, zoneId: parentRegistration.zoneId };
+	}
+	const parts = staticDomain.split(".");
+	if (parts.length < 3) {
+		return { domain: staticDomain };
+	}
+	const parent = parts.slice(1).join(".");
+	const zoneId = aws.route53.getZone({ name: parent }).then((z) => z.zoneId);
+	return { domain: staticDomain, zoneId };
 });
 
 const staticAssets = new HutchStaticAssets("hutch-static", {

--- a/projects/save-link/Pulumi.prod.yaml
+++ b/projects/save-link/Pulumi.prod.yaml
@@ -8,5 +8,6 @@ config:
   save-link:articlesTableArn: arn:aws:dynamodb:ap-southeast-2:278728209435:table/hutch-articles-cda0a08
   save-link:contentBucketName: hutch-article-content-prod
   save-link:pendingHtmlBucketName: hutch-pending-html-prod
+  save-link:contentMediaCdnDomain: cdn.readplace.com
 
 encryptionsalt: v1:wtDgBy80qGM=:v1:blQ7pAjXgW+f/NKU:eQnkrsxqXh9Nnvo+fQ/ofy4bxQK7/Q==

--- a/projects/save-link/Pulumi.staging.yaml
+++ b/projects/save-link/Pulumi.staging.yaml
@@ -8,5 +8,6 @@ config:
   save-link:articlesTableArn: arn:aws:dynamodb:ap-southeast-2:572337278115:table/hutch-articles-cda0a08
   save-link:contentBucketName: hutch-article-content-staging
   save-link:pendingHtmlBucketName: hutch-pending-html-staging
+  save-link:contentMediaCdnDomain: cdn-staging.readplace.com
 
 encryptionsalt: v1:UOuPAPopzKA=:v1:R9v//2alhEYfLugF:HuZRBtgwdPawWU7VHPvdJ9bsYqJR9w==

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import assert from "node:assert";
 import { z } from "zod";
 import {
 	HutchEventBus,
@@ -50,6 +52,7 @@ const articlesTableName = config.require("articlesTableName");
 const articlesTableArn = config.require("articlesTableArn");
 const contentBucketName = config.require("contentBucketName");
 const pendingHtmlBucketName = config.require("pendingHtmlBucketName");
+const contentMediaCdnDomain = config.get("contentMediaCdnDomain");
 
 /**
  * Image URI for the comprehensive-crawl-command container Lambda, written by
@@ -78,8 +81,19 @@ const pendingHtmlBucket = new HutchS3ReadWrite("pending-html-bucket", {
 
 // --- Content Images CDN ---
 
+const contentMediaCustomDomain = contentMediaCdnDomain
+	? (() => {
+		const parts = contentMediaCdnDomain.split(".");
+		assert(parts.length >= 2, `contentMediaCdnDomain ${contentMediaCdnDomain} must have a parent zone`);
+		const parent = parts.slice(1).join(".");
+		const zoneId = aws.route53.getZone({ name: parent }).then((z) => z.zoneId);
+		return { domain: contentMediaCdnDomain, zoneId };
+	})()
+	: undefined;
+
 const contentMediaCdn = new HutchS3ContentMediaCDN("content-media", {
 	contentBucket,
+	customDomain: contentMediaCustomDomain,
 });
 
 const deepseekApiKey = pulumi.secret(requireEnv("DEEPSEEK_API_KEY"));

--- a/src/packages/hutch-infra-components/src/infra/hutch-s3-content-media-cdn.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-s3-content-media-cdn.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import type { HutchS3ReadWrite } from "./hutch-s3-read-write";
+import { HutchCertificate } from "./hutch-certificate";
 
 export class HutchS3ContentMediaCDN extends pulumi.ComponentResource {
 	public readonly baseUrl: pulumi.Output<string>;
@@ -9,6 +10,7 @@ export class HutchS3ContentMediaCDN extends pulumi.ComponentResource {
 		name: string,
 		args: {
 			contentBucket: HutchS3ReadWrite;
+			customDomain?: { domain: string; zoneId: pulumi.Input<string> };
 		},
 		opts?: pulumi.ComponentResourceOptions,
 	) {
@@ -30,8 +32,40 @@ export class HutchS3ContentMediaCDN extends pulumi.ComponentResource {
 			signingProtocol: "sigv4",
 		}, { parent: this });
 
+		let viewerCertificate: aws.types.input.cloudfront.DistributionViewerCertificate;
+		let aliases: pulumi.Input<string>[] | undefined;
+
+		if (args.customDomain) {
+			const usEast1 = new aws.Provider(
+				`${name}-us-east-1`,
+				{ region: "us-east-1" },
+				{ parent: this },
+			);
+
+			const cert = new HutchCertificate(
+				name,
+				{
+					primaryDomain: args.customDomain.domain,
+					altDomains: [],
+					zoneId: args.customDomain.zoneId,
+					provider: usEast1,
+				},
+				{ parent: this },
+			);
+
+			viewerCertificate = {
+				acmCertificateArn: cert.certificateArn,
+				sslSupportMethod: "sni-only",
+				minimumProtocolVersion: "TLSv1.2_2021",
+			};
+			aliases = [args.customDomain.domain];
+		} else {
+			viewerCertificate = { cloudfrontDefaultCertificate: true };
+		}
+
 		const distribution = new aws.cloudfront.Distribution(`${name}-cdn`, {
 			enabled: true,
+			aliases,
 			origins: [{
 				originId: "content-s3",
 				domainName: args.contentBucket.bucketRegionalDomainName,
@@ -47,9 +81,7 @@ export class HutchS3ContentMediaCDN extends pulumi.ComponentResource {
 			restrictions: {
 				geoRestriction: { restrictionType: "none" },
 			},
-			viewerCertificate: {
-				cloudfrontDefaultCertificate: true,
-			},
+			viewerCertificate,
 			priceClass: "PriceClass_100",
 			loggingConfig: {
 				bucket: logsBucket.bucketDomainName,
@@ -73,7 +105,23 @@ export class HutchS3ContentMediaCDN extends pulumi.ComponentResource {
 			),
 		}, { parent: this });
 
-		this.baseUrl = pulumi.interpolate`https://${distribution.domainName}`;
+		if (args.customDomain) {
+			new aws.route53.Record(`${name}-record`, {
+				zoneId: args.customDomain.zoneId,
+				name: args.customDomain.domain,
+				type: "A",
+				aliases: [
+					{
+						name: distribution.domainName,
+						zoneId: distribution.hostedZoneId,
+						evaluateTargetHealth: false,
+					},
+				],
+			}, { parent: this });
+			this.baseUrl = pulumi.output(`https://${args.customDomain.domain}`);
+		} else {
+			this.baseUrl = pulumi.interpolate`https://${distribution.domainName}`;
+		}
 		this.registerOutputs();
 	}
 }


### PR DESCRIPTION
## Summary

Replace AWS-generated `*.cloudfront.net` URLs with custom hostnames on both CDN distributions:

| CDN | Prod | Staging |
|-----|------|---------|
| Content-media | `cdn.readplace.com` | `cdn-staging.readplace.com` |
| Static-assets | `static.readplace.com` (unchanged) | `static-staging.readplace.com` |

The original `*.cloudfront.net` URLs stay alive for the lifetime of the distributions, so previously saved articles whose HTML embeds those hostnames keep working — no DDB backfill required. Only newly saved articles store URLs under the new hostname.

## Changes

- **`hutch-s3-content-media-cdn.ts`** — add optional `customDomain` arg; conditionally provision a us-east-1 ACM cert via `HutchCertificate`, set distribution aliases, add a Route53 A-record alias.
- **`save-link/src/infra/index.ts`** — read new `save-link:contentMediaCdnDomain` config; derive parent zone via `aws.route53.getZone` and pass through to the component.
- **`save-link/Pulumi.{prod,staging}.yaml`** — set `contentMediaCdnDomain`.
- **`hutch/src/infra/index.ts`** — extend the static-domain → zoneId map with a fallback to direct `aws.route53.getZone(parent)` when no in-stack `DomainRegistration` matches. Unblocks `static-staging.readplace.com` without forcing staging to register `readplace.com`.
- **`hutch/Pulumi.staging.yaml`** — `staticDomains: [static-staging.readplace.com]`.
- **`.github/workflows/ci.yml`** — `STATIC_BASE_URL: https://static-staging.readplace.com`.

## Test plan

- [x] `pnpm nx run save-link:lint` (typecheck + biome + knip)
- [x] `pnpm nx run hutch:lint`
- [x] `pnpm nx run @packages/hutch-infra-components:lint`
- [x] `pnpm nx run save-link:test` — 364 tests pass
- [x] `pnpm nx run hutch:test` — 1239 tests pass
- [ ] `pulumi preview --stack staging` from `projects/save-link` — expect new ACM cert (us-east-1) + validation records, in-place distribution update for aliases/viewerCertificate, new Route53 A-record
- [ ] `pulumi preview --stack staging` from `projects/hutch` — expect in-place static distribution update with aliases + ACM cert, new Route53 record for `static-staging.readplace.com`
- [ ] After staging deploy: save a new article and confirm `<img src>` uses `cdn-staging.readplace.com`; reload an older article and confirm legacy `*.cloudfront.net` URLs still resolve; confirm CSS/JS load from `static-staging.readplace.com`
- [ ] Promote to prod, repeat smoke test against `cdn.readplace.com` / `static.readplace.com`

## Out of scope

- Backfilling old `*.cloudfront.net` URLs already embedded in saved-article HTML (default URL still resolves)
- Removing the default `*.cloudfront.net` URL (not supported by AWS)
- Cache invalidation (content-media keys are content-hashed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUaJzJeZSEMjZngDR6RhPD)_