### PR TITLE
perf(hutch): parallelise Done-tab unread-count fetch

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -266,15 +266,15 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			return;
 		}
 
-		const unreadCount = urlState.tab === "queue"
-			? result.total
-			: (await deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 })).total;
 		const saveError = deps.httpErrorMessageMapping(req.query);
 		const importFlash = importFlashMapping(req.query);
 		const importSkipped = readImportSkippedFlash(req, res);
-		const [summaryByUrl, crawlByUrl] = await Promise.all([
+		const [summaryByUrl, crawlByUrl, unreadCount] = await Promise.all([
 			loadSummaries(deps.findGeneratedSummary, result.articles),
 			loadCrawls(deps.findArticleCrawlStatus, result.articles),
+			urlState.tab === "queue"
+				? Promise.resolve(result.total)
+				: deps.findArticlesByUser({ userId, status: "unread", page: 1, pageSize: 1 }).then(r => r.total),
 		]);
 		const vm = toQueueViewModel(result, urlState, {
 			unreadCount,


### PR DESCRIPTION
## Summary

- `GET /queue?tab=done` was paying for one extra serial DynamoDB round-trip — a `Select: "COUNT"` pagination loop on `userId-savedAt-index` filtered by `status="unread"` — before the existing `Promise.all` that fans out `loadSummaries` / `loadCrawls`. That made the Done tab visibly slower than the To-read tab even though both render against the same handler.
- Fold the unread-count promise into the existing `Promise.all` in `queue.page.ts:272` so the count round-trip overlaps with the per-article fan-out instead of adding to the critical path. The `?tab=queue` branch resolves synchronously from `result.total` (the listing query is already filtered to `status="unread"`, so `total` is the count of every unread row, not just the current page). The `?tab=done` branch issues the count call alongside the summary/crawl loads.
- Contract-preserving: pure reads, no new types, no provider changes, no caller-visible behaviour change beyond wall-clock latency. The sibling serial-await in the `POST /save` 422 validation-error handler is intentionally left alone — different (cold, error) path; expanding the diff there would pull in `queue.mutations.route.test.ts`.

## Test plan

- [x] `pnpm jest --testMatch='**/dist/**/*.test.js' --testPathPattern='queue\.(listing|listing\.filters|freshness|reader|reader\.advanced|mutations|viewmodel)'` — 7 suites, 130 tests, all green.
- [x] `pnpm check` (root: lint + test-with-coverage across all 19 projects) — green. Coverage thresholds held at 100/100/100/100 for the enforced files; the `queue.page.ts` branch percentage is unchanged from main.
- [ ] Manual smoke: load `/queue`, click **Done**, confirm the page renders, the **To read (N)** badge shows the correct unread total, pagination still works, and the htmx-boosted nav swaps `<main>` cleanly.
- [ ] Optional perf check: seed a user with a few hundred read + unread articles, `curl -w '%{time_total}\n'` against `?tab=queue` vs `?tab=done`, n=10 — Done should now match To-read within noise.

https://claude.ai/code/session_01DGNzuV6bSMLdWNxt5tGWG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNzuV6bSMLdWNxt5tGWG9)_