### PR TITLE
Drop browser-extension < v1.0.127 back-compat

### DIFF
--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
@@ -610,7 +610,7 @@ describe("initExtension", () => {
 			).rejects.toThrow("Save failed: 422");
 		});
 
-		it("sends Prefer: return=representation to opt into the collection-on-rejection flow", async () => {
+		it("sends Prefer: return=representation on save (RFC 7240)", async () => {
 			let capturedPrefer: string | null = null;
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({
@@ -801,8 +801,7 @@ describe("initExtension", () => {
 			).rejects.toThrow("Delete failed: 404");
 		});
 
-		/** Without this header the server falls back to a 204 No Content response to keep chrome-extension v1.0.66 (still in the web store) working — that build can only observe 204s because it sets `redirect: "manual"`, which masks 303 status codes as opaqueredirect/0. */
-		it("sends Prefer: return=representation so the server returns the refreshed Siren collection (and not the v1.0.66 backwards-compat 204)", async () => {
+		it("sends Prefer: return=representation on delete (RFC 7240)", async () => {
 			let observedPrefer: string | null = null;
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
@@ -161,11 +161,8 @@ export function initSaveArticleUnderstanding(): Map<string, ActionHandler> {
 					method: sirenAction.method,
 					headers: {
 						"Content-Type": sirenAction.type ?? "application/json",
-						/** Opt into the collection-on-rejection flow for non-saveable
-						 * URL schemes (RFC 7240, mirroring the delete route). Without
-						 * this the server falls back to a stub-save for backward
-						 * compatibility with extensions that can't interpret a
-						 * collection body on POST. */
+						/** Signal that the client will process a representation in
+						 * the response (RFC 7240). */
 						Prefer: "return=representation",
 					},
 					body: JSON.stringify({ url: fields.url }),
@@ -267,7 +264,8 @@ export function initDeleteArticleUnderstanding(): Map<string, ActionHandler> {
 	const handlers = new Map<string, ActionHandler>();
 	handlers.set("delete", (sirenAction, context) => {
 		return async () => {
-			/** Opt into the 303-redirect-then-collection flow. Without this the server falls back to a 204 No Content response for backwards compatibility with chrome-extension v1.0.66, whose delete handler can only observe 204s (it sets `redirect: "manual"`, which masks 303 status codes as opaqueredirect/0). */
+			/** Signal that the client will process a representation in the
+			 * response (RFC 7240). */
 			const response = await context.doFetch(
 				`${context.serverUrl}${sirenAction.href}`,
 				{

--- a/projects/extensions/chrome-extension/src/runtime/content/shortcut.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/content/shortcut.browser.ts
@@ -1,12 +1,5 @@
 /* c8 ignore start -- content script, runs in browser page context only */
 import browser from "webextension-polyfill";
-import { markExtensionInstalled } from "@packages/onboarding-extension-signal";
-
-declare const __APP_DOMAINS__: string[];
-
-if (__APP_DOMAINS__.includes(location.hostname)) {
-	try { markExtensionInstalled(); } catch (_e) { /* cookies may be disabled */ }
-}
 
 // Chrome won't let extensions override Cmd+D via the commands API — it silently
 // refuses to assign shortcuts that conflict with native browser shortcuts.

--- a/projects/extensions/firefox-extension/src/runtime/content/shortcut.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/content/shortcut.browser.ts
@@ -1,11 +1,4 @@
 /* c8 ignore start -- content script, runs in browser page context only */
-import { markExtensionInstalled } from "@packages/onboarding-extension-signal";
-
-declare const __APP_DOMAINS__: string[];
-
-if (__APP_DOMAINS__.includes(location.hostname)) {
-	try { markExtensionInstalled(); } catch (_e) { /* cookies may be disabled */ }
-}
 
 // Firefox won't let extensions override Cmd+D via the commands API — it silently
 // refuses to assign shortcuts that conflict with native browser shortcuts.

--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -241,7 +241,7 @@ describe("POST /queue (Siren save article)", () => {
 		expect(response.body.properties.code).toBe("invalid-url");
 	});
 
-	it("returns the article collection for a non-saveable scheme when client opts in via Prefer", async () => {
+	it("returns the article collection for a non-saveable scheme", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const accessToken = await createAccessToken(harness);
 
@@ -257,7 +257,6 @@ describe("POST /queue (Siren save article)", () => {
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
-			.set("Prefer", "return=representation")
 			.send({ url: "chrome://newtab/" });
 
 		expect(response.status).toBe(422);
@@ -281,7 +280,6 @@ describe("POST /queue (Siren save article)", () => {
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
-			.set("Prefer", "return=representation")
 			.send({ url: "http://localhost:3000/queue" });
 
 		expect(response.status).toBe(422);
@@ -301,27 +299,10 @@ describe("POST /queue (Siren save article)", () => {
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
-			.set("Prefer", "return=representation")
 			.send({ url: "http://router.home.arpa/" });
 
 		expect(response.status).toBe(422);
 		expect(response.body.properties.warning.code).toBe("private_network");
-	});
-
-	it("preserves the legacy stub-save behaviour for a non-saveable scheme without Prefer", async () => {
-		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(harness);
-
-		const response = await request(harness.server)
-			.post("/queue")
-			.set("Accept", SIREN_MEDIA_TYPE)
-			.set("Authorization", `Bearer ${accessToken}`)
-			.set("Content-Type", "application/json")
-			.send({ url: "chrome://newtab/" });
-
-		expect(response.status).toBe(201);
-		expect(response.body.class).toContain("article");
-		expect(response.body.properties.url).toBe("chrome://newtab/");
 	});
 
 	it("returns 401 without token", async () => {
@@ -453,7 +434,7 @@ describe("POST /queue (Siren re-save read article)", () => {
 });
 
 describe("POST /queue/:id/delete (Siren)", () => {
-	it("redirects to collection via 303 after deleting when client opts in via Prefer header", async () => {
+	it("redirects to collection via 303 after deleting", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const accessToken = await createAccessToken(harness);
 
@@ -506,30 +487,6 @@ describe("POST /queue/:id/delete (Siren)", () => {
 		expect(collectionResponse.status).toBe(200);
 		expect(collectionResponse.body.class).toContain("collection");
 		expect(collectionResponse.body.properties.total).toBe(0);
-	});
-
-	/** Chrome extension v1.0.66 (still in the web store) sets `redirect: "manual"` on its delete fetch and only treats `status === 204` as success — a 303 surfaces to JS as an opaqueredirect with status 0, leaving the deleted row visible in the popup until reopened. The server keeps returning 204 for Siren clients that don't opt into the new representation flow until v1.0.66 ages out of the wild. */
-	it("returns 204 No Content for legacy Siren clients without Prefer header (chrome-extension v1.0.66 backwards compat)", async () => {
-		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const accessToken = await createAccessToken(harness);
-
-		const saveResponse = await request(harness.server)
-			.post("/queue")
-			.set("Accept", SIREN_MEDIA_TYPE)
-			.set("Authorization", `Bearer ${accessToken}`)
-			.set("Content-Type", "application/json")
-			.send({ url: "https://example.com/article" });
-
-		const articleId = saveResponse.body.properties.id;
-
-		const deleteResponse = await request(harness.server)
-			.post(`/queue/${articleId}/delete`)
-			.set("Accept", SIREN_MEDIA_TYPE)
-			.set("Authorization", `Bearer ${accessToken}`)
-			.redirects(0);
-
-		expect(deleteResponse.status).toBe(204);
-		expect(deleteResponse.text).toBe("");
 	});
 });
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
@@ -3,8 +3,6 @@ import { JSDOM } from "jsdom";
 import {
 	ALIVE_COOKIE_NAME,
 	ALIVE_COOKIE_VALUE,
-	COOKIE_NAME,
-	COOKIE_VALUE,
 	DISMISS_COOKIE_NAME,
 	SAVE_COOKIE_NAME,
 	SAVE_COOKIE_VALUE,
@@ -90,25 +88,6 @@ describe("Queue onboarding", () => {
 		const step = doc.querySelector('[data-test-onboarding-step="install-extension"]');
 		assert(step, "install-extension step must be rendered");
 		expect(step.getAttribute("data-test-onboarding-complete")).toBe("true");
-	});
-
-	/** The legacy hutch_ext_installed cookie is writable from the extension's
-	 * content script and persists for a year, so its presence does not prove
-	 * the extension is currently installed. The server must ignore it for
-	 * onboarding purposes — only the httpOnly hutch_ext_alive cookie counts. */
-	it("does not mark install-extension complete when only the legacy hutch_ext_installed cookie is present", async () => {
-		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const { auth } = harness;
-		const agent = await loginAgent(harness.server, auth);
-
-		const response = await agent
-			.get("/queue")
-			.set("Cookie", `${COOKIE_NAME}=${COOKIE_VALUE}`);
-
-		const doc = new JSDOM(response.text).window.document;
-		const step = doc.querySelector('[data-test-onboarding-step="install-extension"]');
-		assert(step, "install-extension step must be rendered");
-		expect(step.getAttribute("data-test-onboarding-complete")).toBe("false");
 	});
 
 	it("shows success message when both the alive and extension-save cookies are present", async () => {
@@ -210,12 +189,10 @@ describe("Queue onboarding", () => {
 	 *     stops being renewed and lapses; the dismiss should not silently
 	 *     suppress the prompt to reinstall once that happens.
 	 *
-	 * The three tests below pin all directions of the rule:
+	 * The two tests below pin both directions of the rule:
 	 *   1. Both cookies present → onboarding stays hidden (the happy path).
 	 *   2. Dismiss cookie alone → onboarding re-renders with install-extension
 	 *      marked incomplete, so the user is prompted to install in this browser.
-	 *   3. Dismiss + legacy hutch_ext_installed without alive → onboarding
-	 *      re-renders, proving the legacy cookie does not satisfy dismissal.
 	 */
 	it("does not render onboarding when dismiss cookie matches current version and extension is alive", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -243,29 +220,6 @@ describe("Queue onboarding", () => {
 		const doc = new JSDOM(response.text).window.document;
 		const onboarding = doc.querySelector("[data-test-onboarding]");
 		assert(onboarding, "onboarding must re-render so the user can install the extension in this browser");
-		expect(onboarding.classList.contains("onboarding--visible")).toBe(true);
-		const installStep = doc.querySelector('[data-test-onboarding-step="install-extension"]');
-		assert(installStep);
-		expect(installStep.getAttribute("data-test-onboarding-complete")).toBe("false");
-	});
-
-	/** The exact bug this branch fixes: user installs the extension, completes
-	 * onboarding, dismisses it, then uninstalls the extension. The legacy
-	 * hutch_ext_installed cookie persists in the browser jar (1-year TTL,
-	 * written by the content script) but the httpOnly hutch_ext_alive lapses
-	 * once Siren requests stop. Onboarding must come back. */
-	it("re-renders onboarding after uninstall (dismiss + legacy cookie present, alive cookie missing)", async () => {
-		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const { auth } = harness;
-		const agent = await loginAgent(harness.server, auth);
-
-		const response = await agent
-			.get("/queue")
-			.set("Cookie", `${DISMISS_COOKIE_NAME}=${ONBOARDING_VERSION}; ${COOKIE_NAME}=${COOKIE_VALUE}`);
-
-		const doc = new JSDOM(response.text).window.document;
-		const onboarding = doc.querySelector("[data-test-onboarding]");
-		assert(onboarding, "onboarding must re-render once the extension stops renewing the alive cookie");
 		expect(onboarding.classList.contains("onboarding--visible")).toBe(true);
 		const installStep = doc.querySelector('[data-test-onboarding-step="install-extension"]');
 		assert(installStep);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -43,7 +43,7 @@ import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.
 import type { PublishLinkSaved } from "@packages/test-fixtures/providers/events";
 import type { PublishSaveLinkRawHtmlCommand } from "@packages/test-fixtures/providers/events";
 import type { PutPendingHtml } from "@packages/test-fixtures/providers/pending-html";
-import { saveArticleFromUrl, saveUnsaveableUrlStub } from "../../shared/save-article/save-article-from-url";
+import { saveArticleFromUrl } from "../../shared/save-article/save-article-from-url";
 import { Base } from "../../base.component";
 import { bannerStateFromRequest } from "../../banner-state";
 import { sendComponent } from "../../send-component";
@@ -327,7 +327,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const userId = req.userId;
 		const submittedUrl = typeof req.body?.url === "string" ? req.body.url : "";
 		const validation = deps.validateSaveableUrl(submittedUrl);
-		const prefersRepresentation = req.get("Prefer") === "return=representation";
 
 		if (validation.status === "ERROR") {
 			if (validation.error.code === "malformed_url") {
@@ -336,37 +335,26 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				);
 				return;
 			}
-			if (prefersRepresentation) {
-				/** Scheme/host that the crawler can't reach (chrome://, file:,
-				 * localhost, *.home.arpa, ...). Return the current collection so
-				 * the extension can drop the user back into the list view, and
-				 * surface a `warning` property carrying the failure code + a
-				 * human-readable message that the client can render as a warning
-				 * banner alongside the list. */
-				const collection = await deps.findArticlesByUser({ userId });
-				res.status(422).type(SIREN_MEDIA_TYPE).json(
-					toArticleCollectionEntity(
-						collection,
-						{ page: collection.page, pageSize: collection.pageSize },
-						{ warning: { code: validation.error.code, message: validation.error.message } },
-					),
-				);
-				return;
-			}
-			/** Legacy extension without Prefer header — fall through to the
-			 * pre-validator stub-save behaviour for backwards compatibility. */
+			/** Scheme/host that the crawler can't reach (chrome://, file:,
+			 * localhost, *.home.arpa, ...). Return the current collection so
+			 * the extension can drop the user back into the list view, and
+			 * surface a `warning` property carrying the failure code + a
+			 * human-readable message that the client can render as a warning
+			 * banner alongside the list. */
+			const collection = await deps.findArticlesByUser({ userId });
+			res.status(422).type(SIREN_MEDIA_TYPE).json(
+				toArticleCollectionEntity(
+					collection,
+					{ page: collection.page, pageSize: collection.pageSize },
+					{ warning: { code: validation.error.code, message: validation.error.message } },
+				),
+			);
+			return;
 		}
 
 		try {
-			if (validation.status === "SUCCESS") {
-				const freshness = await deps.refreshArticleIfStale({ url: validation.url });
-				const result = await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
-				markExtensionSavedArticle(res);
-				res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
-				return;
-			}
-			const freshness = await deps.refreshArticleIfStale({ url: submittedUrl });
-			const result = await saveUnsaveableUrlStub(deps, { userId, url: submittedUrl, freshness });
+			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
+			const result = await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
 			markExtensionSavedArticle(res);
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
@@ -639,13 +627,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 		if (parsedId.success) {
 			await deps.deleteArticle(parsedId.data, userId);
-		}
-
-		/** Chrome extension v1.0.66 (in the web store) sends this request with `redirect: "manual"` and only treats `status === 204` as success — a 303 surfaces to JS as an opaqueredirect with status 0, leaving the deleted row on screen until the popup is reopened. Newer extensions opt into the redirect-and-follow flow with `Prefer: return=representation` (RFC 7240) so they receive the refreshed Siren collection. Drop the 204 branch once v1.0.66 ages out of the wild. */
-		const prefersRepresentation = req.get("Prefer") === "return=representation";
-		if (wantsSiren(req) && !prefersRepresentation) {
-			res.status(204).send();
-			return;
 		}
 
 		res.redirect(303, buildQueueUrl(parseQueueUrl(req.query)));

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
@@ -79,16 +79,3 @@ export function saveArticleFromUrl(
 ): Promise<{ saved: SavedArticle }> {
 	return saveByFreshness(deps, params);
 }
-
-/** Back-compat shim for chrome-extension v1.0.66 (and earlier) which POSTs
- * non-saveable URLs to /queue without the Prefer: return=representation
- * header. The crawler can't fetch the URL, but old extensions expect a 201
- * with an article body — so we save a hostname-only stub via the same code
- * path that runs for valid URLs. Do NOT call this from new entry points;
- * route through validateSaveableUrl + saveArticleFromUrl instead. */
-export function saveUnsaveableUrlStub(
-	deps: SaveArticleFromUrlDependencies,
-	params: { userId: UserId; url: string; freshness: ContentFreshnessResult },
-): Promise<{ saved: SavedArticle }> {
-	return saveByFreshness(deps, params);
-}

--- a/src/packages/onboarding-extension-signal/src/index.ts
+++ b/src/packages/onboarding-extension-signal/src/index.ts
@@ -1,8 +1,3 @@
-/** Legacy cookie written by deployed extension content scripts. The server
- * ignores it for onboarding — see ALIVE_COOKIE_NAME. */
-export const COOKIE_NAME = "hutch_ext_installed";
-export const COOKIE_VALUE = "1";
-
 /** httpOnly cookie set by the server on every Siren request. Only the
  * extension makes Siren requests, so when it's uninstalled the cookie
  * lapses and the onboarding "install" step flips back to incomplete. */
@@ -20,10 +15,3 @@ export const SAVE_COOKIE_NAME = "hutch_ext_saved";
 export const SAVE_COOKIE_VALUE = "1";
 
 export const DISMISS_COOKIE_NAME = "hutch_onboarding_dismissed";
-
-/** Kept for compatibility with deployed extension versions that bundle
- * this function. The cookie it writes is not used for onboarding. */
-export function markExtensionInstalled(): void {
-	// biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API is unavailable in Firefox/Safari content scripts; document.cookie is the cross-browser path
-	document.cookie = `${COOKIE_NAME}=${COOKIE_VALUE}; path=/; max-age=31536000; SameSite=Lax`;
-}


### PR DESCRIPTION
## Summary

- Server stops gating on `Prefer: return=representation`. POST `/queue` always returns the collection-with-warning for non-saveable URLs, and `/queue/:id/delete` always 303-redirects. `saveUnsaveableUrlStub` is gone.
- Legacy `hutch_ext_installed` cookie thread removed end-to-end: the `COOKIE_NAME`/`COOKIE_VALUE` exports + `markExtensionInstalled()` in `@packages/onboarding-extension-signal`, the content-script writers in both Chrome and Firefox extensions, and the two tests that pinned the legacy behaviour. Only the httpOnly `hutch_ext_alive` cookie tracks extension liveness.
- Extension still sends `Prefer: return=representation` on save + delete per RFC 7240; comments updated to drop the v1.0.66 framing.

## Risk

A surviving v1.0.66 install (outside the v1.0.127+ assumption) will see:
- Delete: 303 instead of 204 → `redirect: "manual"` surfaces `opaqueredirect`; the row stays on screen until popup reopen (delete still succeeds server-side).
- POST `/queue` with `chrome://`-style URL: 422 with collection+warning instead of a silent 201 stub.

## Test plan

- [x] `pnpm nx run-many --target=test --projects=hutch,browser-extension-core,chrome-extension,firefox-extension,@packages/onboarding-extension-signal` (1235 unit tests pass)
- [x] `pnpm nx run hutch:test-integration` (2 integration tests pass)
- [x] `pnpm nx run-many --target=lint` (all green)
- [x] `pnpm nx run-many --target=check` (100% coverage thresholds met on touched files)
- [ ] Manual: load popup against local server, exercise save → delete loop end-to-end (regression check; extension behaviour unchanged)

https://claude.ai/code/session_01EKHFVD8NQdd2R8LjtUPU6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKHFVD8NQdd2R8LjtUPU6C)_