### PR TITLE
feat(@packages/check-stuck-articles): surface summary.skipped("ai-unavailable") for manual recrawl

### DIFF
--- a/.github/workflows/stuck-articles-canary.md
+++ b/.github/workflows/stuck-articles-canary.md
@@ -1,10 +1,13 @@
 # Stuck Articles Canary Failure Investigation
 
-You have been triggered because the `Stuck articles canary` workflow failed on its scheduled run. One or more articles in the production DynamoDB articles table are stuck in a non-terminal state — `summaryStatus`/`crawlStatus` is `pending` or `failed`, or both are absent on a non-legacy row.
+You have been triggered because the `Stuck articles canary` workflow failed on its scheduled run. One or more articles in the production DynamoDB articles table are owed a manual retry — `summaryStatus`/`crawlStatus` is `pending` (worker never produced a terminal outcome), or `summaryStatus = "skipped"` with reason `ai-unavailable` (AI was down and no auto-heal fires for `skipped`).
 
 ## Your Task
 
-1. **Read the issue body and any follow-up comments.** Each stuck row is listed as `[<reasons>] <url> — fetched: <ts>; failure: <reason>; recrawl: <admin-url>`. The reasons (`summary-pending`, `summary-failed`, `crawl-pending`, `crawl-failed`, `legacy-stub`) tell you which state machine got stuck.
+1. **Read the issue body and any follow-up comments.** Each stuck row is listed as `[<reasons>] <url> — fetched: <ts>; failure: <reason>; recrawl: <admin-url>`. The reasons map to:
+   - `summary-pending` / `crawl-pending` — the worker never produced a terminal outcome on that axis.
+   - `summary-pending-after-aggregate-migration` / `crawl-pending-after-aggregate-migration` — same as above but the latest writer was a Phase 2 cross-axis transition that was supposed to flip both axes to terminal.
+   - `summary-skipped-ai-unavailable` — the summariser recorded the AI as down at the time the summary ran. The handler treats `skipped` as terminal and never re-runs, and the auto-heal only fires for `failed` rows — so the only recovery is a manual recrawl via the `/admin/recrawl/<url>` link in the row.
 2. **Find the change that introduced the state.** Run `git log --since='14 days ago' --format='%h %s'` and inspect commits touching:
    - `projects/save-link/src/generate-summary/**` (summary state machine)
    - `projects/save-link/src/article-crawl/**` and `projects/hutch/src/runtime/providers/article-crawl/**` (crawl state machine)

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
@@ -47,6 +47,7 @@ describe("checkTerminalState", () => {
 		assert.deepStrictEqual(result, {
 			terminal: false,
 			message: "summaryStatus is 'pending' — summary worker never produced a terminal outcome",
+			reasons: ["summary-pending"],
 		});
 	});
 

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.test.ts
@@ -8,17 +8,33 @@ describe("checkTerminalState", () => {
 			summaryStatus: "ready",
 			crawlStatus: "ready",
 			aggregateTransitionName: undefined,
+			summarySkippedReason: undefined,
 		});
 		assert.deepStrictEqual(result, { terminal: true });
 	});
 
-	it("returns terminal:true when the summary was deliberately skipped (content-too-short etc.)", () => {
+	it("returns terminal:true when the summary was deliberately skipped for content-too-short (PR #320 tie path is the recovery)", () => {
 		const result = checkTerminalState({
 			summaryStatus: "skipped",
 			crawlStatus: "ready",
 			aggregateTransitionName: undefined,
+			summarySkippedReason: "content-too-short",
 		});
 		assert.deepStrictEqual(result, { terminal: true });
+	});
+
+	it("returns terminal:false with the ai-unavailable message when the summariser recorded AI as down", () => {
+		const result = checkTerminalState({
+			summaryStatus: "skipped",
+			crawlStatus: "ready",
+			aggregateTransitionName: undefined,
+			summarySkippedReason: "ai-unavailable",
+		});
+		assert.equal(result.terminal, false);
+		assert.match(
+			result.terminal === false ? result.message : "",
+			/ai-unavailable.*no auto-heal fires for skipped/,
+		);
 	});
 
 	it("returns terminal:false with the summary-pending message when summaryStatus=pending", () => {
@@ -26,6 +42,7 @@ describe("checkTerminalState", () => {
 			summaryStatus: "pending",
 			crawlStatus: "ready",
 			aggregateTransitionName: undefined,
+			summarySkippedReason: undefined,
 		});
 		assert.deepStrictEqual(result, {
 			terminal: false,
@@ -38,6 +55,7 @@ describe("checkTerminalState", () => {
 			summaryStatus: "pending",
 			crawlStatus: "pending",
 			aggregateTransitionName: undefined,
+			summarySkippedReason: undefined,
 		});
 		assert.equal(result.terminal, false);
 		assert.equal(
@@ -51,6 +69,7 @@ describe("checkTerminalState", () => {
 			summaryStatus: "ready",
 			crawlStatus: "failed",
 			aggregateTransitionName: undefined,
+			summarySkippedReason: undefined,
 		});
 		assert.deepStrictEqual(failedCrawl, { terminal: true });
 
@@ -58,6 +77,7 @@ describe("checkTerminalState", () => {
 			summaryStatus: "skipped",
 			crawlStatus: "unsupported",
 			aggregateTransitionName: undefined,
+			summarySkippedReason: "crawl-unsupported",
 		});
 		assert.deepStrictEqual(unsupportedCrawl, { terminal: true });
 	});
@@ -67,6 +87,7 @@ describe("checkTerminalState", () => {
 			summaryStatus: undefined,
 			crawlStatus: undefined,
 			aggregateTransitionName: undefined,
+			summarySkippedReason: undefined,
 		});
 		assert.deepStrictEqual(result, { terminal: true });
 	});
@@ -76,6 +97,7 @@ describe("checkTerminalState", () => {
 			summaryStatus: "ready",
 			crawlStatus: "pending",
 			aggregateTransitionName: "recrawlTieKeptCanonical",
+			summarySkippedReason: undefined,
 		});
 		assert.equal(result.terminal, false);
 		assert.match(

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
@@ -8,7 +8,9 @@ type ArticleStateFields = {
 	summarySkippedReason: string | undefined;
 };
 
-type TerminalCheckResult = { terminal: true } | { terminal: false; message: string };
+type TerminalCheckResult =
+	| { terminal: true }
+	| { terminal: false; message: string; reasons: StuckReason[] };
 
 const REASON_MESSAGES: Record<StuckReason, string> = {
 	"summary-pending": "summaryStatus is 'pending' — summary worker never produced a terminal outcome",
@@ -25,5 +27,5 @@ export function checkTerminalState(fields: ArticleStateFields): TerminalCheckRes
 	const reasons = classifyRow(fields);
 	if (reasons.length === 0) return { terminal: true };
 	const message = reasons.map((reason) => REASON_MESSAGES[reason]).join("; ");
-	return { terminal: false, message };
+	return { terminal: false, message, reasons };
 }

--- a/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
+++ b/src/packages/check-stuck-articles/scripts/check-terminal-state.ts
@@ -5,6 +5,7 @@ type ArticleStateFields = {
 	summaryStatus: SummaryStatus | undefined;
 	crawlStatus: CrawlStatus | undefined;
 	aggregateTransitionName: string | undefined;
+	summarySkippedReason: string | undefined;
 };
 
 type TerminalCheckResult = { terminal: true } | { terminal: false; message: string };
@@ -16,6 +17,8 @@ const REASON_MESSAGES: Record<StuckReason, string> = {
 		"summaryStatus is 'pending' after a Phase 2 aggregate transition wrote this row — the migration was supposed to flip both axes to terminal in one save; non-zero counts here falsify the Phase 2 hypothesis",
 	"crawl-pending-after-aggregate-migration":
 		"crawlStatus is 'pending' after a Phase 2 aggregate transition wrote this row — the migration was supposed to flip the crawl axis to terminal/ready in one save; non-zero counts here falsify the Phase 2 hypothesis",
+	"summary-skipped-ai-unavailable":
+		"summaryStatus is 'skipped' with reason 'ai-unavailable' — AI was down when summarisation ran; no auto-heal fires for skipped rows, recrawl via /admin/recrawl now that AI is back",
 };
 
 export function checkTerminalState(fields: ArticleStateFields): TerminalCheckResult {

--- a/src/packages/check-stuck-articles/scripts/classify-row.test.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.test.ts
@@ -9,6 +9,7 @@ describe("classifyRow", () => {
 				summaryStatus: "pending",
 				crawlStatus: "ready",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, ["summary-pending"]);
 		});
@@ -18,6 +19,7 @@ describe("classifyRow", () => {
 				summaryStatus: "failed",
 				crawlStatus: "ready",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -27,15 +29,37 @@ describe("classifyRow", () => {
 				summaryStatus: "ready",
 				crawlStatus: "ready",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
 
-		it("returns no reason for skipped", () => {
+		it("returns no reason for skipped with content-too-short (PR #320 tie path is the recovery; pure retry no-ops)", () => {
 			const reasons = classifyRow({
 				summaryStatus: "skipped",
 				crawlStatus: "ready",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: "content-too-short",
+			});
+			assert.deepStrictEqual(reasons, []);
+		});
+
+		it("returns no reason for skipped with crawl-unsupported (URL type unsupported, retry never helps)", () => {
+			const reasons = classifyRow({
+				summaryStatus: "skipped",
+				crawlStatus: "unsupported",
+				aggregateTransitionName: undefined,
+				summarySkippedReason: "crawl-unsupported",
+			});
+			assert.deepStrictEqual(reasons, []);
+		});
+
+		it("returns no reason for skipped with no recorded reason (legacy row, defaults to no retry-owed signal)", () => {
+			const reasons = classifyRow({
+				summaryStatus: "skipped",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -47,6 +71,7 @@ describe("classifyRow", () => {
 				summaryStatus: "ready",
 				crawlStatus: "pending",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, ["crawl-pending"]);
 		});
@@ -56,6 +81,7 @@ describe("classifyRow", () => {
 				summaryStatus: "ready",
 				crawlStatus: "failed",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -65,6 +91,7 @@ describe("classifyRow", () => {
 				summaryStatus: "skipped",
 				crawlStatus: "unsupported",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: "crawl-unsupported",
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -74,6 +101,29 @@ describe("classifyRow", () => {
 				summaryStatus: "ready",
 				crawlStatus: "ready",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
+			});
+			assert.deepStrictEqual(reasons, []);
+		});
+	});
+
+	describe("summary skipped ai-unavailable", () => {
+		it("returns summary-skipped-ai-unavailable when the summariser recorded the AI as down (no auto-heal fires for skipped, manual recrawl is the only recovery)", () => {
+			const reasons = classifyRow({
+				summaryStatus: "skipped",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+				summarySkippedReason: "ai-unavailable",
+			});
+			assert.deepStrictEqual(reasons, ["summary-skipped-ai-unavailable"]);
+		});
+
+		it("does NOT emit ai-unavailable when summaryStatus is ready (defensive — reason attribute should be cleared on transition out of skipped)", () => {
+			const reasons = classifyRow({
+				summaryStatus: "ready",
+				crawlStatus: "ready",
+				aggregateTransitionName: undefined,
+				summarySkippedReason: "ai-unavailable",
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -85,6 +135,7 @@ describe("classifyRow", () => {
 				summaryStatus: "pending",
 				crawlStatus: "pending",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, ["summary-pending", "crawl-pending"]);
 		});
@@ -94,17 +145,32 @@ describe("classifyRow", () => {
 				summaryStatus: "failed",
 				crawlStatus: "failed",
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
+		});
+
+		it("returns crawl-pending and summary-skipped-ai-unavailable when crawl is in flight while a prior summary attempt was skipped on AI down", () => {
+			const reasons = classifyRow({
+				summaryStatus: "skipped",
+				crawlStatus: "pending",
+				aggregateTransitionName: undefined,
+				summarySkippedReason: "ai-unavailable",
+			});
+			assert.deepStrictEqual(reasons, [
+				"crawl-pending",
+				"summary-skipped-ai-unavailable",
+			]);
 		});
 	});
 
 	describe("undefined statuses", () => {
-		it("returns no reasons when both statuses are undefined (canary only flags pending — terminal absence is not stuck)", () => {
+		it("returns no reasons when both statuses are undefined (canary only flags pending and skipped-ai-unavailable — terminal absence is not stuck)", () => {
 			const reasons = classifyRow({
 				summaryStatus: undefined,
 				crawlStatus: undefined,
 				aggregateTransitionName: undefined,
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -116,6 +182,7 @@ describe("classifyRow", () => {
 				summaryStatus: "pending",
 				crawlStatus: "ready",
 				aggregateTransitionName: "markCrawlExhausted",
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, [
 				"summary-pending-after-aggregate-migration",
@@ -127,6 +194,7 @@ describe("classifyRow", () => {
 				summaryStatus: "ready",
 				crawlStatus: "pending",
 				aggregateTransitionName: "recrawlTieKeptCanonical",
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, [
 				"crawl-pending-after-aggregate-migration",
@@ -138,6 +206,7 @@ describe("classifyRow", () => {
 				summaryStatus: "ready",
 				crawlStatus: "pending",
 				aggregateTransitionName: "recrawlPromoteTier",
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, [
 				"crawl-pending-after-aggregate-migration",
@@ -149,6 +218,7 @@ describe("classifyRow", () => {
 				summaryStatus: "pending",
 				crawlStatus: "ready",
 				aggregateTransitionName: "refreshContent",
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, ["summary-pending"]);
 		});
@@ -158,6 +228,7 @@ describe("classifyRow", () => {
 				summaryStatus: "failed",
 				crawlStatus: "failed",
 				aggregateTransitionName: "markCrawlExhausted",
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, []);
 		});
@@ -167,6 +238,7 @@ describe("classifyRow", () => {
 				summaryStatus: "pending",
 				crawlStatus: "pending",
 				aggregateTransitionName: "markCrawlExhausted",
+				summarySkippedReason: undefined,
 			});
 			assert.deepStrictEqual(reasons, [
 				"summary-pending-after-aggregate-migration",

--- a/src/packages/check-stuck-articles/scripts/classify-row.ts
+++ b/src/packages/check-stuck-articles/scripts/classify-row.ts
@@ -4,7 +4,8 @@ export type StuckReason =
 	| "summary-pending"
 	| "crawl-pending"
 	| "summary-pending-after-aggregate-migration"
-	| "crawl-pending-after-aggregate-migration";
+	| "crawl-pending-after-aggregate-migration"
+	| "summary-skipped-ai-unavailable";
 
 const PHASE_2_MIGRATED_TRANSITIONS: ReadonlySet<string> = new Set([
 	"markCrawlExhausted",
@@ -14,15 +15,21 @@ const PHASE_2_MIGRATED_TRANSITIONS: ReadonlySet<string> = new Set([
 
 /**
  * Map a row to the reasons it is "stuck". Empty array = the row is healthy
- * (both state machines reached a terminal value: ready / failed / unsupported
- * / skipped). Only `pending` is non-terminal — the canary's job is to surface
- * rows that the workers never moved past `pending`, not to grade legacy data
- * or writer-contract violations.
+ * and no manual retry is owed. The canary surfaces:
+ *   - `pending` on either axis (worker never moved past in-flight).
+ *   - `summary.skipped("ai-unavailable")` — AI was down when summarisation
+ *     ran. The generate-summary handler treats `skipped` as a terminal cache
+ *     hit and never re-runs the AI, and `decideSummaryAutoHeal` only re-primes
+ *     `failed` rows, so without this signal the row sits skipped forever.
+ * `failed` rows are intentionally excluded — the DLQ alarm is their signal.
+ * Other `skipped` reasons (`content-too-short`, `crawl-unsupported`) are not
+ * surfaced: a pure retry cannot change the input that produced the skip.
  */
 export function classifyRow(row: {
 	summaryStatus: SummaryStatus | undefined;
 	crawlStatus: CrawlStatus | undefined;
 	aggregateTransitionName: string | undefined;
+	summarySkippedReason: string | undefined;
 }): StuckReason[] {
 	const migratedWriter =
 		row.aggregateTransitionName !== undefined &&
@@ -42,6 +49,12 @@ export function classifyRow(row: {
 				? "crawl-pending-after-aggregate-migration"
 				: "crawl-pending",
 		);
+	}
+	if (
+		row.summaryStatus === "skipped" &&
+		row.summarySkippedReason === "ai-unavailable"
+	) {
+		reasons.push("summary-skipped-ai-unavailable");
 	}
 	return reasons;
 }

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.test.ts
@@ -76,7 +76,17 @@ describe("buildScanInput", () => {
 		);
 	});
 
-	it("only emits the two pending disjuncts — no legacy-stub or writer-contract clauses", () => {
+	it("emits a skipped-ai-unavailable disjunct gated on contentFetchedAt (summary axis has no pendingSince once skipped)", () => {
+		const input = buildScanInput(NOW);
+		assert.match(
+			input.FilterExpression,
+			/summaryStatus = :skipped AND summarySkippedReason = :aiUnavailable AND \(contentFetchedAt < :summaryMinAge OR \(attribute_not_exists\(contentFetchedAt\) AND savedAt < :summaryMinAge\)\)/,
+		);
+		assert.equal(input.ExpressionAttributeValues[":skipped"], "skipped");
+		assert.equal(input.ExpressionAttributeValues[":aiUnavailable"], "ai-unavailable");
+	});
+
+	it("only emits the pending and ai-unavailable disjuncts — no legacy-stub or writer-contract clauses", () => {
 		const input = buildScanInput(NOW);
 		assert.ok(
 			!input.FilterExpression.includes("attribute_not_exists(summaryStatus)"),
@@ -101,6 +111,10 @@ describe("buildScanInput", () => {
 		assert.ok(
 			input.ProjectionExpression.includes("savedAt"),
 			"savedAt remains projected for the legacy fallback diagnostics",
+		);
+		assert.ok(
+			input.ProjectionExpression.includes("summarySkippedReason"),
+			"summarySkippedReason must be projected so the classifier can distinguish ai-unavailable from other skip reasons",
 		);
 	});
 
@@ -149,6 +163,7 @@ describe("collectStuckRows", () => {
 			"summaryPendingSince",
 			"savedAt",
 			"aggregateTransitionName",
+			"summarySkippedReason",
 		]) {
 			assert.ok(projection.includes(attr), `ProjectionExpression must include ${attr}`);
 		}
@@ -311,5 +326,55 @@ describe("collectStuckRows", () => {
 		assert.deepEqual(stuck[0]?.reasons, [
 			"crawl-pending-after-aggregate-migration",
 		]);
+	});
+
+	it("surfaces a summary.skipped('ai-unavailable') row as summary-skipped-ai-unavailable (the AI was down, manual recrawl needed)", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/ai-was-down",
+					originalUrl: "https://example.test/ai-was-down",
+					summaryStatus: "skipped",
+					summarySkippedReason: "ai-unavailable",
+					crawlStatus: "ready",
+					contentFetchedAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+					savedAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+		});
+		assert.equal(stuck.length, 1);
+		assert.deepEqual(stuck[0]?.reasons, ["summary-skipped-ai-unavailable"]);
+		assert.match(stuck[0]?.terminalCheckMessage ?? "", /ai-unavailable/);
+	});
+
+	it("does NOT surface a summary.skipped('content-too-short') row (PR #320 tie path is the recovery; pure retry no-ops)", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "example.test/stub-content",
+					originalUrl: "https://example.test/stub-content",
+					summaryStatus: "skipped",
+					summarySkippedReason: "content-too-short",
+					crawlStatus: "ready",
+					contentFetchedAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+					savedAt: new Date(NOW.getTime() - 30 * 60_000).toISOString(),
+				},
+			],
+			Count: 1,
+		}));
+		const stuck = await collectStuckRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+		});
+		assert.deepEqual(stuck, []);
 	});
 });

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
@@ -15,7 +15,7 @@ import {
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import { checkTerminalState } from "./check-terminal-state";
-import { type StuckReason, classifyRow } from "./classify-row";
+import type { StuckReason } from "./classify-row";
 
 /* `dynamoField` normalises DDB's `null` for absent attributes to `undefined`. */
 const StuckArticleRow = z.object({
@@ -144,11 +144,10 @@ export async function collectStuckRows(deps: {
 		for (const row of page.items) {
 			const verdict = checkTerminalState(row);
 			if (verdict.terminal) continue;
-			const reasons = classifyRow(row);
 			const effectiveUrl = row.originalUrl ?? row.url;
 			stuck.push({
 				originalUrl: effectiveUrl,
-				reasons,
+				reasons: verdict.reasons,
 				contentFetchedAt: row.contentFetchedAt,
 				recrawlUrl: `${deps.origin}/admin/recrawl/${encodeURIComponent(effectiveUrl)}`,
 				terminalCheckMessage: verdict.message,

--- a/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
+++ b/src/packages/check-stuck-articles/scripts/collect-stuck-rows.ts
@@ -28,6 +28,7 @@ const StuckArticleRow = z.object({
 	summaryPendingSince: dynamoField(z.string()),
 	savedAt: z.string(),
 	aggregateTransitionName: dynamoField(z.string()),
+	summarySkippedReason: dynamoField(z.string()),
 });
 
 export interface StuckRow {
@@ -77,6 +78,13 @@ export const SUMMARY_MIN_AGE_MS = 20 * 60_000; /* 1 */
  *   2. Legacy disjunct on contentFetchedAt/savedAt — covers rows saved
  *      before pendingSince existed. Dropped once the canary scan reports
  *      zero rows hitting this branch.
+ *   3. `summaryStatus = "skipped" AND summarySkippedReason = "ai-unavailable"`
+ *      — `summaryPendingSince` is removed when the summary transitions to
+ *      skipped (see `dynamodb-article-store.ts` REMOVE clause), so the
+ *      pending-age gates above can never match this state. Anchor the gate
+ *      to `contentFetchedAt` (set by the freshness writer immediately
+ *      before the summariser ran, so it bounds when the skip happened),
+ *      falling back to `savedAt` for legacy rows missing contentFetchedAt.
  */
 export function buildScanInput(now: Date) {
 	const crawlMinAge = new Date(now.getTime() - CRAWL_MIN_AGE_MS).toISOString();
@@ -90,13 +98,18 @@ export function buildScanInput(now: Date) {
 			`(summaryStatus = :pending AND ` +
 			`(summaryPendingSince < :summaryMinAge OR ${legacyAgeGate(":summaryMinAge")})) ` +
 			`OR (crawlStatus = :pending AND ` +
-			`(crawlPendingSince < :crawlMinAge OR ${legacyAgeGate(":crawlMinAge")}))`,
+			`(crawlPendingSince < :crawlMinAge OR ${legacyAgeGate(":crawlMinAge")})) ` +
+			`OR (summaryStatus = :skipped AND summarySkippedReason = :aiUnavailable AND ` +
+			`(contentFetchedAt < :summaryMinAge OR (attribute_not_exists(contentFetchedAt) AND savedAt < :summaryMinAge)))`,
 		ProjectionExpression:
 			"originalUrl, #u, summaryStatus, crawlStatus, contentFetchedAt, " +
-			"crawlPendingSince, summaryPendingSince, savedAt, aggregateTransitionName",
+			"crawlPendingSince, summaryPendingSince, savedAt, aggregateTransitionName, " +
+			"summarySkippedReason",
 		ExpressionAttributeNames: { "#u": "url" },
 		ExpressionAttributeValues: {
 			":pending": "pending",
+			":skipped": "skipped",
+			":aiUnavailable": "ai-unavailable",
 			":crawlMinAge": crawlMinAge,
 			":summaryMinAge": summaryMinAge,
 		},


### PR DESCRIPTION
## Summary

The stuck-articles canary is the operator's only retry-needed signal for terminal states that don't go through the DLQ. Today `summary.skipped("ai-unavailable")` silently sits forever after an AI outage:

- `generate-summary-handler.ts:38-48` treats every `skipped` reason as a terminal cache hit and short-circuits — no re-run of the AI.
- `decideSummaryAutoHeal` only re-primes `summary.failed` rows, never `skipped`.
- The handler returns gracefully on AI unavailability (`link-summariser.ts:113-115`), so the DLQ never fires.

This PR adds a third FilterExpression disjunct that surfaces those rows on the daily canary, alongside the existing `pending`-axis checks. The operator hits the `/admin/recrawl/<url>` link in the issue body once the AI is back.

## Why nothing else was added

Walked every terminal value across `CrawlStatus` × `SummaryStatus` and their reason unions:

| State | Existing recovery | Add to canary? |
|---|---|---|
| `summary.skipped("ai-unavailable")` | None | **YES** (this PR) |
| `summary.skipped("content-too-short")` | PR #320 tie-path re-save | No — pure retry no-ops when content has not changed |
| `summary.skipped("crawl-unsupported")` | None | No — URL type unsupported, retry never helps |
| `summary.failed(*)` | DLQ email + auto-heal 3×/24h | No — covered |
| `crawl.failed(*)` | DLQ email per source queue | No — covered |
| `crawl.unsupported(*)` | None | No — deterministic, retry never helps |

## Implementation notes

- **Age gate.** `summaryPendingSince` is removed when the summary transitions to `skipped` (see `dynamodb-article-store.ts:237`), so the existing pending-age gates can never match the new state. The new disjunct anchors on `contentFetchedAt` (set by the freshness writer immediately before the summariser ran, so it bounds when the skip happened), with a `savedAt` fallback for legacy rows — same shape as the legacy fallback the pending disjuncts use.
- **No `-after-aggregate-migration` variant.** `markSummarySkipped` is not in the `PHASE_2_MIGRATED_TRANSITIONS` set, so a skipped row will never carry one of those transition names on its latest writer.

## Test plan

- [x] `pnpm nx run @packages/check-stuck-articles:check` — 60 tests pass (added 6 new cases: ai-unavailable classification, content-too-short non-classification, the new FilterExpression disjunct, the new `summarySkippedReason` projection, plus the integration "surfaces a `skipped('ai-unavailable')` row" / "does NOT surface a `skipped('content-too-short')` row" pair on `collectStuckRows`).
- [x] Workspace `pnpm check` — clean, 100% function coverage, 99.7% lines/branches.
- [ ] Next scheduled canary run (06:30 AEST) — if any prod row currently sits in `skipped("ai-unavailable")`, expect the GitHub issue to list it with the new `[summary-skipped-ai-unavailable]` reason tag and the `/admin/recrawl/<url>` link to manually retry.

---
_Generated by [Claude Code](https://claude.ai/code/session_016q6piCysgyzDuZ4byhFCcc)_