### PR TITLE
fix(hutch): scope banner-on-reader e2e locator to .banner-area

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts
@@ -57,7 +57,11 @@ export function createBannerOnReaderActions(
 				const onPublicView = await isOnPage(page, 'page-view')
 				assert.ok(onPublicView, '/view/<url> must render the public reader page')
 
-				const banner = page.locator('[data-test-extension-suggestion-banner]')
+				// Scoped to .banner-area because saved Readplace-hosted pages (e.g.
+				// /privacy) keep the chrome banner in their stored HTML, so /view's
+				// reader slot can render a second banner inside <article> with the
+				// same data-test attribute. Strict-mode locator must match one element.
+				const banner = page.locator('.banner-area [data-test-extension-suggestion-banner]')
 				await expect(banner).toHaveAttribute('data-show-extension-suggestion', 'true')
 				await expect(banner).toHaveClass(/extension-suggestion-banner--visible/)
 
@@ -107,14 +111,16 @@ export function createBannerOnReaderActions(
 				const onReader = await isOnPage(page, 'page-reader')
 				assert.ok(onReader, 'clicking the saved article must navigate to the owner reader')
 
-				const banner = page.locator('[data-test-extension-suggestion-banner]')
+				// See verify-banner-on-public-view for why the locator is scoped to
+				// .banner-area: the saved Readplace HTML duplicates the banner inside <article>.
+				const banner = page.locator('.banner-area [data-test-extension-suggestion-banner]')
 				await expect(banner).toHaveAttribute('data-show-extension-suggestion', 'true')
 				await expect(banner).toHaveClass(/extension-suggestion-banner--visible/)
 
 				// Verify the banner stays put until the user dismisses it, then
 				// confirm the close button removes it and persists the dismiss
 				// flag so it doesn't re-appear on subsequent visits.
-				await page.locator('[data-extension-suggestion-close]').click()
+				await banner.locator('[data-extension-suggestion-close]').click()
 				await expect(banner).not.toHaveClass(/extension-suggestion-banner--visible/)
 				const dismissed = await page.evaluate(() =>
 					window.localStorage.getItem('readplace.extension-suggestion-dismissed'),


### PR DESCRIPTION
## Summary

Fixes the staging-deploy e2e failure on https://github.com/Readplace/readplace.com/actions/runs/26016620655/job/76468601698 (\`strict mode violation: locator('[data-test-extension-suggestion-banner]') resolved to 2 elements\`).

The test target URL is \`\${baseUrl}/privacy\` (or another Readplace endpoint via \`fixtureUrl\`). When the crawler captures that URL, the saved HTML retains the chrome banner from \`base.template.html\`. \`/view/<url>\` and \`/queue/:id/read\` then render the saved HTML inside \`<article>\`, so the rendered page has two elements with \`data-test-extension-suggestion-banner\`: the outer page banner (from \`.banner-area\`) and the inner banner from the saved article copy.

The fix scopes the locator (and the close-button click derived from it) to \`.banner-area\`, which only contains the page-chrome banner. Both \`/view\` and \`/queue/:id/read\` assertions are updated.

## Test plan

- [x] Local e2e: \`pnpm test:e2e\` (run.e2e-local.ts → queue-flow) — 1 passed (48.2s)
- [ ] CI all-tests (PR CI)
- [ ] Once merged: hutch / deploy-staging post-deploy on the staging stack
- [ ] Once merged: hutch / deploy-prod post-deploy

## Why it slipped to CI

The author of \`e5532b0f feat(hutch): trigger extension-suggestion banner on owner reader\` ran \`pnpm check\` locally — which runs the **local** Playwright config against the **e2e-server fixture**. The e2e-server fakes most of the save pipeline, so the same Readplace-hosted URL produces a saved-HTML payload that **doesn't include the chrome banner** (Readability extracts only article content, no full-page chrome). Locally there's only one banner element, the locator is unambiguous, and the test passes. On staging, the real \`crawl-article\` fetcher pulls the live \`/privacy\` HTML — full chrome included — and the saved HTML retains the inner banner. Test sees two elements, strict mode fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)