### PR TITLE
fix(hutch): give banner e2e two unique per-run URLs and anchor locator to body

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts
@@ -25,7 +25,7 @@ export type BannerOnReaderProgress = {
  * the client wiring, and the close-button affordance all line up. Route
  * tests cover the SSR side; this file covers the rendered state. */
 export function createBannerOnReaderActions(
-	config: { baseUrl: string; testUrl: string },
+	config: { baseUrl: string; publicViewTestUrl: string; privateReaderTestUrl: string },
 	cleanupProgress: CleanupProgress,
 	progress: BannerOnReaderProgress,
 ): (authProgress: AuthProgress) => Record<BannerOnReaderActionKey, PageAction> {
@@ -47,21 +47,25 @@ export function createBannerOnReaderActions(
 				}
 			},
 			execute: async (page) => {
-				// Unique URL so the first visit hits the not-fully-parsed path
-				// (summary still pending → banner data-show='true').
-				const target = `${config.baseUrl}/privacy?banner-on-public-view=${Date.now()}`
+				// Use the per-run unique URL the callsite supplies. API Gateway on
+				// staging strips arbitrary query strings, so a `?ts=${Date.now()}`
+				// trick collapses every run back to the same path and the cached
+				// row pins `summaryStatus='ready'` → banner never shows. The /e2e
+				// fixture URL pattern (used in run.e2e-staging.ts) avoids this by
+				// embedding the runId in the path itself.
 				await page.goto(
-					`${config.baseUrl}/view/${encodeURIComponent(target)}`,
+					`${config.baseUrl}/view/${encodeURIComponent(config.publicViewTestUrl)}`,
 					{ waitUntil: 'domcontentloaded' },
 				)
 				const onPublicView = await isOnPage(page, 'page-view')
 				assert.ok(onPublicView, '/view/<url> must render the public reader page')
 
-				// Scoped to .banner-area because saved Readplace-hosted pages (e.g.
-				// /privacy) keep the chrome banner in their stored HTML, so /view's
-				// reader slot can render a second banner inside <article> with the
-				// same data-test attribute. Strict-mode locator must match one element.
-				const banner = page.locator('.banner-area [data-test-extension-suggestion-banner]')
+				// Anchored to a body-direct child because saved Readplace-hosted
+				// HTML keeps the entire `<div class="banner-area"><banner></div>`
+				// chrome wrapper inside the article reader slot; a descendant
+				// selector would still match both copies. The outer banner-area
+				// is body's first DOM child per base.template.html.
+				const banner = page.locator('body > .banner-area [data-test-extension-suggestion-banner]')
 				await expect(banner).toHaveAttribute('data-show-extension-suggestion', 'true')
 				await expect(banner).toHaveClass(/extension-suggestion-banner--visible/)
 
@@ -94,7 +98,7 @@ export function createBannerOnReaderActions(
 			},
 			execute: async (page) => {
 				const input = page.locator('[data-test-form="save-article"] input[name="url"]')
-				await input.fill(config.testUrl)
+				await input.fill(config.privateReaderTestUrl)
 				await clickAndWaitForPageReload(
 					page,
 					page.locator('[data-test-form="save-article"] button[type="submit"]'),
@@ -111,9 +115,9 @@ export function createBannerOnReaderActions(
 				const onReader = await isOnPage(page, 'page-reader')
 				assert.ok(onReader, 'clicking the saved article must navigate to the owner reader')
 
-				// See verify-banner-on-public-view for why the locator is scoped to
-				// .banner-area: the saved Readplace HTML duplicates the banner inside <article>.
-				const banner = page.locator('.banner-area [data-test-extension-suggestion-banner]')
+				// Same body-direct-child anchor as verify-banner-on-public-view —
+				// the saved article's reader slot replays the chrome wrapper too.
+				const banner = page.locator('body > .banner-area [data-test-extension-suggestion-banner]')
 				await expect(banner).toHaveAttribute('data-show-extension-suggestion', 'true')
 				await expect(banner).toHaveClass(/extension-suggestion-banner--visible/)
 

--- a/projects/hutch/src/e2e/queue-flow/run.e2e-local.ts
+++ b/projects/hutch/src/e2e/queue-flow/run.e2e-local.ts
@@ -82,7 +82,11 @@ test.describe('Queue management flow (local)', () => {
           savePermalinkProgress,
         ),
         bannerOnReader: createBannerOnReaderActions(
-          { baseUrl: BASE_URL, testUrl: `${BASE_URL}/privacy?banner-on-reader=1` },
+          {
+            baseUrl: BASE_URL,
+            publicViewTestUrl: `${BASE_URL}/privacy?banner-on-public-view=${Date.now()}`,
+            privateReaderTestUrl: `${BASE_URL}/privacy?banner-on-private-reader=${Date.now()}`,
+          },
           cleanupProgress,
           bannerOnReaderProgress,
         ),

--- a/projects/hutch/src/e2e/queue-flow/run.e2e-staging.ts
+++ b/projects/hutch/src/e2e/queue-flow/run.e2e-staging.ts
@@ -133,7 +133,11 @@ test.describe('Queue management flow (staging)', () => {
           savePermalinkProgress,
         ),
         bannerOnReader: createBannerOnReaderActions(
-          { baseUrl: baseURL, testUrl: fixtureUrl('banner-on-reader') },
+          {
+            baseUrl: baseURL,
+            publicViewTestUrl: fixtureUrl('banner-on-public-view'),
+            privateReaderTestUrl: fixtureUrl('banner-on-private-reader'),
+          },
           cleanupProgress,
           bannerOnReaderProgress,
         ),


### PR DESCRIPTION
## Summary

Follow-up to #338, which tried to fix the staging-deploy failure but didn't go far enough. I verified the failure mode by inspecting the post-merge run (job 76474561570) and the downloaded artifact:

- My \`.banner-area\`-scoped locator from #338 **still** matched two elements (\`strict mode violation: ... resolved to 2 elements\`). The saved Readplace HTML keeps the entire \`<div class="banner-area"><banner></div>\` wrapper inside the reader slot, not just the banner element.
- Both matched elements had \`data-show-extension-suggestion="false"\` — including the outer chrome banner. That confirmed my second theory: API Gateway on staging strips \`?banner-on-public-view=<ts>\`, so every run collapses to the same \`/privacy\` URL whose article state is permanently \`ready/ready\` from the first ever test run.

This PR addresses both:

1. **Locator anchored to body-direct child**: \`body > .banner-area [data-test-extension-suggestion-banner]\`. The saved-HTML banner-area is nested inside \`<article>\` and is never a body-direct child.

2. **Two distinct per-run URLs**: the action now takes \`publicViewTestUrl\` and \`privateReaderTestUrl\` separately from the callsite. On staging both resolve to \`fixtureUrl('banner-on-public-view')\` / \`fixtureUrl('banner-on-private-reader')\` — i.e., \`/e2e/article/<runId>-banner-on-{...}\`. Path-based, so API Gateway can't strip them.

## Test plan

- [x] \`pnpm test:e2e\` (run.e2e-local.ts → queue-flow) — 1 passed in 1.1m
- [ ] Tried to run \`pnpm test:e2e:staging\` against \`https://hkncrxpii6.execute-api.ap-southeast-2.amazonaws.com\` directly. It failed at a *different* step (\`queue-actions.ts:418\`, expected 1 article got 2) — residual state from the prior failed CI runs left \`e2e-test@example.com\`'s store dirty, so the banner action never executed. The next post-deploy will trigger its own \`cleanup\` action before the banner step, so CI is the cleanest verification.
- [ ] CI all-tests
- [ ] hutch / deploy-staging post-deploy (the actual fix proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)