### PR TITLE
feat(@packages/check-failed-articles): exclude browser-internal scheme URLs from canary

### DIFF
--- a/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
@@ -63,6 +63,25 @@ describe("EXCLUDE_PATTERNS — internal-network hostnames", () => {
 	}
 });
 
+describe("EXCLUDE_PATTERNS — browser-internal schemes", () => {
+	const cases: ReadonlyArray<{ url: string; excluded: boolean; label: string }> = [
+		{ url: "chrome://extensions/", excluded: true, label: "chrome:// with path" },
+		{ url: "chrome://newtab", excluded: true, label: "chrome:// newtab" },
+		{ url: "CHROME://SETTINGS", excluded: true, label: "chrome:// uppercase" },
+		{ url: "about:home", excluded: true, label: "about:home" },
+		{ url: "about:newtab", excluded: true, label: "about:newtab" },
+		{ url: "about:blank", excluded: true, label: "about:blank" },
+		{ url: "ABOUT:HOME", excluded: true, label: "about: uppercase" },
+		{ url: "https://example.org/about:home", excluded: false, label: "about: inside a path — should NOT match" },
+		{ url: "https://chrome.google.com/webstore", excluded: false, label: "chrome in hostname — should NOT match" },
+	];
+	for (const { url, excluded, label } of cases) {
+		it(`${excluded ? "excludes" : "keeps"}: ${label} — ${url}`, () => {
+			assert.equal(isExcluded(url, EXCLUDE_PATTERNS), excluded);
+		});
+	}
+});
+
 describe("EXCLUDE_PATTERNS — nhttps typo'd-scheme entry", () => {
 	const cases: ReadonlyArray<{ url: string; excluded: boolean; label: string }> = [
 		{ url: "nhttps://example.org/foo", excluded: true, label: "nhttps scheme on a normal host" },

--- a/src/packages/check-failed-articles/scripts/exclude-patterns.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.ts
@@ -34,6 +34,11 @@ export const EXCLUDE_PATTERNS: readonly RegExp[] = [
 	// fails on it; there's nothing to crawl. The whole URL is unusable, not
 	// just unreachable, so an operator re-save is the only resolution.
 	/^nhttps:\/\//i,
+	// Browser-internal schemes (`chrome://`, `about:`, etc.) — legacy rows
+	// saved before `validateSaveableUrl` added the `unsupported_scheme`
+	// rejection. The crawler can never fetch these; intake now blocks them.
+	/^chrome:\/\//i,
+	/^about:/i,
 ];
 
 export function isExcluded(url: string, patterns: readonly RegExp[]): boolean {


### PR DESCRIPTION
Closes #344

Adds exclude patterns for `chrome://` and `about:` browser-internal scheme URLs in the failed-articles canary. These are legacy rows saved before `validateSaveableUrl` added `unsupported_scheme` rejection. The crawler can never fetch browser-internal URLs; intake now blocks them.

See issue comment for the full report on all 9 rows and recommended operator actions.

Generated with [Claude Code](https://claude.ai/code)