### PR TITLE
fix(article-parser): generalize authorPhoto selector to match wrapper elements

### DIFF
--- a/projects/save-link/src/runtime/domain/article-parser/medium-pre-parser.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/medium-pre-parser.test.ts
@@ -75,6 +75,19 @@ describe("mediumPreParser.extract — fingerprint gate", () => {
 		expect(result?.bodyHtml).toContain("This is filler body content");
 	});
 
+	it("activates and strips authorPhoto when data-testid is on a wrapper div (friends-link variant)", () => {
+		const html = buildHtml({
+			articleInner:
+				'<h1>Headline</h1><div data-testid="authorPhoto"><a href="/author"><img src="avatar.jpg"></a></div>',
+		});
+
+		const result = mediumPreParser.extract({ html });
+
+		expect(result?.bodyHtml).not.toContain("authorPhoto");
+		expect(result?.bodyHtml).not.toContain("avatar.jpg");
+		expect(result?.bodyHtml).toContain("This is filler body content");
+	});
+
 	it("activates when og:site_name is not 'Medium' but data-testid='storyReadTime' is present", () => {
 		const html = buildHtml({
 			ogSiteName: "Fagner Brack",
@@ -204,6 +217,19 @@ describe("mediumPreParser.extract — author photo / read time / publish date", 
 		const result = mediumPreParser.extract({ html });
 
 		expect(result?.bodyHtml).not.toContain("authorPhoto");
+	});
+
+	it("strips authorPhoto when data-testid is on a wrapper div instead of the img", () => {
+		const html = buildHtml({
+			ogSiteName: "Medium",
+			articleInner:
+				'<div data-testid="authorPhoto"><a href="/author"><img src="avatar.jpg" alt="Author"></a></div>',
+		});
+
+		const result = mediumPreParser.extract({ html });
+
+		expect(result?.bodyHtml).not.toContain("authorPhoto");
+		expect(result?.bodyHtml).not.toContain("avatar.jpg");
 	});
 });
 

--- a/projects/save-link/src/runtime/domain/article-parser/medium-pre-parser.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/medium-pre-parser.ts
@@ -58,11 +58,11 @@ export const mediumPreParser: SitePreParser = {
 		const container = findArticleContainer(document);
 		if (!container) return undefined;
 
-		const authorImg = container.querySelector('img[data-testid="authorPhoto"]');
+		const authorPhoto = container.querySelector('[data-testid="authorPhoto"]');
 
-		stripClapsSeparators({ container, anchorElement: authorImg });
-		authorImg?.closest("a")?.remove();
-		authorImg?.remove();
+		stripClapsSeparators({ container, anchorElement: authorPhoto });
+		authorPhoto?.closest("a")?.remove();
+		authorPhoto?.remove();
 
 		stripWithEnclosingParagraph({
 			container,

--- a/src/packages/test-fixtures/src/providers/article-parser/medium-pre-parser.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-parser/medium-pre-parser.test.ts
@@ -75,6 +75,19 @@ describe("mediumPreParser.extract — fingerprint gate", () => {
 		expect(result?.bodyHtml).toContain("This is filler body content");
 	});
 
+	it("activates and strips authorPhoto when data-testid is on a wrapper div (friends-link variant)", () => {
+		const html = buildHtml({
+			articleInner:
+				'<h1>Headline</h1><div data-testid="authorPhoto"><a href="/author"><img src="avatar.jpg"></a></div>',
+		});
+
+		const result = mediumPreParser.extract({ html });
+
+		expect(result?.bodyHtml).not.toContain("authorPhoto");
+		expect(result?.bodyHtml).not.toContain("avatar.jpg");
+		expect(result?.bodyHtml).toContain("This is filler body content");
+	});
+
 	it("activates when og:site_name is not 'Medium' but data-testid='storyReadTime' is present", () => {
 		const html = buildHtml({
 			ogSiteName: "Fagner Brack",
@@ -204,6 +217,19 @@ describe("mediumPreParser.extract — author photo / read time / publish date", 
 		const result = mediumPreParser.extract({ html });
 
 		expect(result?.bodyHtml).not.toContain("authorPhoto");
+	});
+
+	it("strips authorPhoto when data-testid is on a wrapper div instead of the img", () => {
+		const html = buildHtml({
+			ogSiteName: "Medium",
+			articleInner:
+				'<div data-testid="authorPhoto"><a href="/author"><img src="avatar.jpg" alt="Author"></a></div>',
+		});
+
+		const result = mediumPreParser.extract({ html });
+
+		expect(result?.bodyHtml).not.toContain("authorPhoto");
+		expect(result?.bodyHtml).not.toContain("avatar.jpg");
 	});
 });
 

--- a/src/packages/test-fixtures/src/providers/article-parser/medium-pre-parser.ts
+++ b/src/packages/test-fixtures/src/providers/article-parser/medium-pre-parser.ts
@@ -58,11 +58,11 @@ export const mediumPreParser: SitePreParser = {
 		const container = findArticleContainer(document);
 		if (!container) return undefined;
 
-		const authorImg = container.querySelector('img[data-testid="authorPhoto"]');
+		const authorPhoto = container.querySelector('[data-testid="authorPhoto"]');
 
-		stripClapsSeparators({ container, anchorElement: authorImg });
-		authorImg?.closest("a")?.remove();
-		authorImg?.remove();
+		stripClapsSeparators({ container, anchorElement: authorPhoto });
+		authorPhoto?.closest("a")?.remove();
+		authorPhoto?.remove();
 
 		stripWithEnclosingParagraph({
 			container,


### PR DESCRIPTION
Generalize the Medium pre-parser's authorPhoto stripping selector from `img[data-testid="authorPhoto"]` to `[data-testid="authorPhoto"]` so it matches both `<img>` and wrapper elements (e.g. `<div>`). Medium's friends-link pages render the `data-testid` on a wrapper instead of the `<img>` directly, causing the authorPhoto chrome to leak into the parsed output.

Closes #356

Generated with [Claude Code](https://claude.ai/code)