### PR TITLE
fix(@packages/domain): reset stale crawl-failed summary on recrawl success

### DIFF
--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
@@ -259,7 +259,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 		expect(writeCanonicalContent).not.toHaveBeenCalled();
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
 			url: "https://example.com/a",
-			input: undefined,
+			input: { now: FIXED_NOW.toISOString() },
 		});
 	});
 
@@ -327,7 +327,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 		expect(writeCanonicalContent).not.toHaveBeenCalled();
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
 			url: "https://example.com/a",
-			input: undefined,
+			input: { now: FIXED_NOW.toISOString() },
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -161,7 +161,7 @@ export function initRecrawlContentExtractedHandler(deps: {
 				} else {
 					await transitionAndPersist(recrawlTieKeptCanonical, {
 						url: detail.url,
-						input: undefined,
+						input: { now: now().toISOString() },
 					});
 					logger.info("[RecrawlContentExtracted] tie kept canonical unchanged", {
 						url: detail.url,

--- a/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
@@ -178,6 +178,16 @@ describe("EXCLUDE_PATTERNS — operator-curated exact-URL entries", () => {
 			excluded: false,
 			label: "psychologywod blocked-practice article missing trailing slash",
 		},
+		{
+			url: "https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf",
+			excluded: true,
+			label: "USDA PDF exact (Akamai BotManager IP block)",
+		},
+		{
+			url: "https://www.rd.usda.gov/sites/default/files/other.pdf",
+			excluded: false,
+			label: "USDA different PDF path — should NOT match",
+		},
 	];
 	for (const { url, excluded, label } of cases) {
 		it(`${excluded ? "excludes" : "keeps"}: ${label} — ${url}`, () => {

--- a/src/packages/check-failed-articles/scripts/exclude-patterns.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.ts
@@ -61,6 +61,10 @@ export const EXCLUDE_PATTERNS: readonly RegExp[] = [
 	/^https:\/\/cutlefish\.substack\.com\/p\/tbm-1352-asking-better-questions\?utm_source=substack&utm_medium=email$/i,
 	/^https:\/\/cutlefish\.substack\.com\/p\/tbm-410-dancing-with-problems\?utm_source=post-email-title&publication_id=24711&post_id=190590408&utm_campaign=email-post-title&isFreemail=true&r=5ik6xc&triedRedirect=true&utm_medium=email$/i,
 	/^https:\/\/psychologywod\.com\/2013\/08\/18\/blocked-practice-vs-random-practice-shake-things-up-in-your-training-and-in-your-life\/$/i,
+	// Akamai BotManager RSTs HTTP/2 from AWS-range IPs at the TLS layer —
+	// both `default-browser` and `honest-bot` personas fail. Requires a
+	// non-AWS egress path (residential proxy) to resolve.
+	/^https:\/\/www\.rd\.usda\.gov\/sites\/default\/files\/pdf-sample_0\.pdf$/i,
 ];
 
 export function isExcluded(url: string, patterns: readonly RegExp[]): boolean {

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
@@ -138,6 +138,104 @@ describe("recrawlPromoteTier", () => {
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 	});
 
+	it("resets summary to pending when the canonical hash is unchanged but summary is failed(crawl-failed) — the cross-axis pairing from markCrawlExhausted is stale", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: {
+				kind: "failed",
+				reason: { kind: "crawl-failed" },
+			},
+		});
+
+		const { article } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
+	});
+
+	it("emits generate-summary when canonical hash is unchanged but summary is failed(crawl-failed)", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: {
+				kind: "failed",
+				reason: { kind: "crawl-failed" },
+			},
+		});
+
+		const { effects } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{ kind: "publish-recrawl-completed", url: "https://example.com/post" },
+		]);
+	});
+
+	it("includes summary in writes when canonical hash is unchanged but summary is failed(crawl-failed)", () => {
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: {
+				kind: "failed",
+				reason: { kind: "crawl-failed" },
+			},
+		});
+
+		const { writes } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual([...writes].sort(), [
+			"crawl",
+			"freshness",
+			"metadata",
+			"summary",
+		]);
+	});
+
+	it("preserves failed(exhausted-retries) summary when canonical hash is unchanged — only crawl-failed is stale", () => {
+		const existingSummary = {
+			kind: "failed" as const,
+			reason: { kind: "exhausted-retries" as const, receiveCount: 4 },
+		};
+		const before = buildArticle({
+			freshness: {
+				etag: '"old-etag"',
+				lastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+				contentFetchedAt: "2026-01-01T00:00:00.000Z",
+				canonicalContentHash: HASH_A,
+			},
+			summary: existingSummary,
+		});
+
+		const { article } = recrawlPromoteTier(
+			before,
+			buildInput({ canonicalContentHash: HASH_A }),
+		);
+
+		assert.deepEqual(article.summary, existingSummary);
+	});
+
 	it("preserves the cached ready summary when the canonical hash is unchanged (cacheability gate)", () => {
 		const existingSummary = {
 			kind: "ready" as const,

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
@@ -16,8 +16,10 @@ export interface RecrawlPromoteTierInput {
 }
 
 /* Recrawl promotion: writes metadata + freshness + crawl=ready. The summary
- * axis is only regenerated when the canonical content hash actually changed
- * (lazy backfill: a row without a prior hash is treated as changed). */
+ * axis is regenerated when the canonical content hash changed (lazy backfill:
+ * a row without a prior hash is treated as changed), OR when the existing
+ * summary is failed(crawl-failed) — that cross-axis pairing from
+ * markCrawlExhausted is stale now that the crawl succeeded. */
 export function recrawlPromoteTier(
 	article: Article,
 	input: RecrawlPromoteTierInput,
@@ -30,9 +32,16 @@ export function recrawlPromoteTier(
 	const contentChanged =
 		previousHash === undefined || previousHash !== input.canonicalContentHash;
 
+	const staleCrawlFailedSummary =
+		!contentChanged &&
+		article.summary.kind === "failed" &&
+		article.summary.reason.kind === "crawl-failed";
+
+	const needsSummaryReset = contentChanged || staleCrawlFailedSummary;
+
 	const writes: AggregateField[] = ["metadata", "freshness", "crawl"];
 	const effects: Effect[] = [];
-	if (contentChanged) {
+	if (needsSummaryReset) {
 		effects.push({ kind: "generate-summary", url: article.url });
 	}
 	effects.push({ kind: "publish-recrawl-completed", url: article.url });
@@ -44,7 +53,7 @@ export function recrawlPromoteTier(
 	};
 
 	let nextSummary: Article["summary"];
-	if (contentChanged) {
+	if (needsSummaryReset) {
 		nextSummary = { kind: "pending", pendingSince: input.now };
 		writes.push("summary");
 	} else {

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import type { Article } from "../article.types";
-import { recrawlTieKeptCanonical } from "./recrawl-tie-kept-canonical";
+import {
+	recrawlTieKeptCanonical,
+	type RecrawlTieKeptCanonicalInput,
+} from "./recrawl-tie-kept-canonical";
+
+const NOW = "2026-05-13T12:00:00.000Z";
 
 function buildArticle(overrides: Partial<Article> = {}): Article {
 	return {
@@ -20,19 +25,23 @@ function buildArticle(overrides: Partial<Article> = {}): Article {
 	};
 }
 
+function buildInput(overrides: Partial<RecrawlTieKeptCanonicalInput> = {}): RecrawlTieKeptCanonicalInput {
+	return { now: NOW, ...overrides };
+}
+
 describe("recrawlTieKeptCanonical", () => {
 	it("flips crawl from pending to ready (unsticks the row admin/recrawl wrote pending)", () => {
-		const { article } = recrawlTieKeptCanonical(buildArticle(), undefined);
+		const { article } = recrawlTieKeptCanonical(buildArticle(), buildInput());
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
 	});
 
-	it("preserves the existing summary by not transitioning summary state at all", () => {
+	it("preserves the existing ready summary by not transitioning summary state at all", () => {
 		const before = buildArticle({
 			summary: { kind: "ready", summary: "kept", excerpt: "kept excerpt" },
 		});
 
-		const { article } = recrawlTieKeptCanonical(before, undefined);
+		const { article } = recrawlTieKeptCanonical(before, buildInput());
 
 		assert.deepEqual(article.summary, {
 			kind: "ready",
@@ -41,10 +50,10 @@ describe("recrawlTieKeptCanonical", () => {
 		});
 	});
 
-	it("does not emit generate-summary so identical canonical content does not burn DeepSeek tokens on re-summarise", () => {
+	it("does not emit generate-summary when summary is ready (identical canonical content does not burn DeepSeek tokens)", () => {
 		const { effects } = recrawlTieKeptCanonical(
 			buildArticle({ url: "https://example.com/post" }),
-			undefined,
+			buildInput(),
 		);
 
 		assert.ok(
@@ -53,10 +62,10 @@ describe("recrawlTieKeptCanonical", () => {
 		);
 	});
 
-	it("emits only publish-recrawl-completed to settle the recrawl pipeline", () => {
+	it("emits only publish-recrawl-completed when summary is healthy", () => {
 		const { effects } = recrawlTieKeptCanonical(
 			buildArticle({ url: "https://example.com/post" }),
-			undefined,
+			buildInput(),
 		);
 
 		assert.deepEqual(effects, [
@@ -64,17 +73,72 @@ describe("recrawlTieKeptCanonical", () => {
 		]);
 	});
 
-	it("declares writes for crawl only (canonical is preserved by definition of this branch)", () => {
-		const { writes } = recrawlTieKeptCanonical(buildArticle(), undefined);
+	it("declares writes for crawl only when summary is healthy", () => {
+		const { writes } = recrawlTieKeptCanonical(buildArticle(), buildInput());
 
 		assert.deepEqual([...writes], ["crawl"]);
+	});
+
+	it("resets summary to pending when summary is failed(crawl-failed) — the cross-axis pairing from markCrawlExhausted is stale", () => {
+		const before = buildArticle({
+			summary: {
+				kind: "failed",
+				reason: { kind: "crawl-failed" },
+			},
+		});
+
+		const { article } = recrawlTieKeptCanonical(before, buildInput());
+
+		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
+	});
+
+	it("emits generate-summary when summary is failed(crawl-failed)", () => {
+		const before = buildArticle({
+			url: "https://example.com/post",
+			summary: {
+				kind: "failed",
+				reason: { kind: "crawl-failed" },
+			},
+		});
+
+		const { effects } = recrawlTieKeptCanonical(before, buildInput());
+
+		assert.deepEqual(effects, [
+			{ kind: "generate-summary", url: "https://example.com/post" },
+			{ kind: "publish-recrawl-completed", url: "https://example.com/post" },
+		]);
+	});
+
+	it("includes summary in writes when summary is failed(crawl-failed)", () => {
+		const before = buildArticle({
+			summary: {
+				kind: "failed",
+				reason: { kind: "crawl-failed" },
+			},
+		});
+
+		const { writes } = recrawlTieKeptCanonical(before, buildInput());
+
+		assert.deepEqual([...writes].sort(), ["crawl", "summary"]);
+	});
+
+	it("preserves failed(exhausted-retries) summary — only crawl-failed is stale", () => {
+		const existingSummary = {
+			kind: "failed" as const,
+			reason: { kind: "exhausted-retries" as const, receiveCount: 4 },
+		};
+		const before = buildArticle({ summary: existingSummary });
+
+		const { article } = recrawlTieKeptCanonical(before, buildInput());
+
+		assert.deepEqual(article.summary, existingSummary);
 	});
 
 	it("does not mutate the input article (pure function)", () => {
 		const before = buildArticle();
 		const snapshot = JSON.parse(JSON.stringify(before));
 
-		recrawlTieKeptCanonical(before, undefined);
+		recrawlTieKeptCanonical(before, buildInput());
 
 		assert.deepEqual(before, snapshot);
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-tie-kept-canonical.ts
@@ -2,26 +2,48 @@ import type { Article } from "../article.types";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
+export interface RecrawlTieKeptCanonicalInput {
+	now: string;
+}
+
 /* Tie kept canonical: the selector returned a tie and a canonical already
- * exists on disk. No tier flip, no metadata refresh, no summary reset. The
- * crawl axis flips to ready to unstick the row, and no generate-summary
- * effect is emitted — re-summarising identical canonical content would
- * burn DeepSeek tokens for no value. */
+ * exists on disk. No tier flip, no metadata refresh. The crawl axis flips
+ * to ready to unstick the row, and no generate-summary effect is emitted
+ * — re-summarising identical canonical content would burn DeepSeek tokens
+ * for no value. Exception: a failed(crawl-failed) summary is a cross-axis
+ * pairing from markCrawlExhausted that is stale now that crawl succeeded;
+ * that gets reset to pending so the summary worker retries. */
 export function recrawlTieKeptCanonical(
 	article: Article,
-	_input: undefined,
+	input: RecrawlTieKeptCanonicalInput,
 ): {
 	article: Article;
 	effects: readonly Effect[];
 	writes: readonly AggregateField[];
 } {
+	const staleCrawlFailedSummary =
+		article.summary.kind === "failed" &&
+		article.summary.reason.kind === "crawl-failed";
+
+	const effects: Effect[] = [];
+	if (staleCrawlFailedSummary) {
+		effects.push({ kind: "generate-summary", url: article.url });
+	}
+	effects.push({ kind: "publish-recrawl-completed", url: article.url });
+
+	const writes: AggregateField[] = ["crawl"];
+	let nextSummary: Article["summary"];
+	if (staleCrawlFailedSummary) {
+		nextSummary = { kind: "pending", pendingSince: input.now };
+		writes.push("summary");
+	} else {
+		nextSummary = article.summary;
+	}
+
 	const next: Article = {
 		...article,
 		crawl: { kind: "ready" },
+		summary: nextSummary,
 	};
-	const effects: readonly Effect[] = [
-		{ kind: "publish-recrawl-completed", url: article.url },
-	];
-	const writes: readonly AggregateField[] = ["crawl"];
 	return { article: next, effects, writes };
 }


### PR DESCRIPTION
Fixes #363

When `markCrawlExhausted` cross-axis pairs summary to `failed(crawl-failed)`, a subsequent recrawl that succeeds with the same content hash left the summary stuck in failed state. Now both `recrawlPromoteTier` and `recrawlTieKeptCanonical` detect the stale summary and reset it to pending.

Also adds the USDA PDF URL to the failed-articles exclude list (Akamai BotManager IP block).

Generated with [Claude Code](https://claude.ai/code)