### PR TITLE
feat(hutch): tag header-nav Import Links with UTM params for funnel attribution

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -85,7 +85,7 @@ describe("Base component", () => {
 		expect(nav.getAttribute("data-test-nav-variant")).toBe("authenticated");
 	});
 
-	it("renders the Import Links nav item for an authenticated request", () => {
+	it("renders the Import Links nav item for an authenticated request, tagged for funnel attribution", () => {
 		const page = createTestPageBody();
 		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
@@ -93,7 +93,14 @@ describe("Base component", () => {
 		const link = doc.querySelector('[data-test-nav-item="import"]');
 		assert(link, "Import Links nav item must be rendered for authenticated users");
 		expect(link.textContent).toBe("Import Links");
-		expect(link.getAttribute("href")).toBe("/import");
+
+		const href = link.getAttribute("href");
+		assert(href, "Import Links nav item must have an href");
+		const url = new URL(href, "https://readplace.com");
+		expect(url.pathname).toBe("/import");
+		expect(url.searchParams.get("utm_source")).toBe("header-nav");
+		expect(url.searchParams.get("utm_medium")).toBe("internal");
+		expect(url.searchParams.get("utm_content")).toBe("import-link");
 	});
 
 	it("hides the Import Links nav item for unauthenticated requests", () => {

--- a/projects/hutch/src/runtime/web/header.template.html
+++ b/projects/hutch/src/runtime/web/header.template.html
@@ -11,7 +11,7 @@
           <ul class="nav__list" data-test-nav-variant="{{#if isAuthenticated}}authenticated{{else}}guest{{/if}}">
             {{#if isAuthenticated}}
             <li><a href="/queue" class="nav__link" data-test-nav-item="queue">Queue</a></li>
-            <li><a href="/import" class="nav__link" data-test-nav-item="import">Import Links</a></li>
+            <li><a href="/import?utm_source=header-nav&amp;utm_medium=internal&amp;utm_content=import-link" class="nav__link" data-test-nav-item="import">Import Links</a></li>
             <li><a href="/export" class="nav__link" data-test-nav-item="export">Export</a></li>
             <li>
               <form method="POST" action="/logout">

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.filters.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.filters.route.test.ts
@@ -242,7 +242,9 @@ describe("Queue routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			const navLink = doc.querySelector('[data-test-nav-item="import"]');
 			assert(navLink, "Import Links nav item must be rendered for authenticated users");
-			expect(navLink.getAttribute("href")).toBe("/import");
+			const navHref = navLink.getAttribute("href");
+			assert(navHref, "Import Links nav item must have an href");
+			expect(new URL(navHref, "https://readplace.com").pathname).toBe("/import");
 			expect(doc.querySelector("form.queue__import-form")).toBeNull();
 			expect(doc.querySelector('[data-test-form="import-file"]')).toBeNull();
 		});


### PR DESCRIPTION
## Why

The `/import` pageview event has no entry-point attribution today — a landing looks identical whether it came from typing the URL, a bookmark, or the nav menu. The server-side `import_uploaded` / `import_committed` events already carry fixed UTMs (`utm_source=import-feature`, see [`analytics.ts:21-48`](https://github.com/readplace/readplace.com/blob/main/projects/hutch/src/runtime/web/middleware/analytics.ts#L21-L48)), but the initial GET `/import` does not. That blind spot means we cannot measure the gap between "considered importing via the menu" and "actually uploaded a file" — the exact funnel slice the team wanted visibility on.

## What

Add a hardcoded UTM tuple to the authenticated-user "Import Links" header nav link:

- `utm_source=header-nav` (deliberately different from server events' `import-feature` so the two slices don't collide in the dashboard)
- `utm_medium=internal` (matches existing internal-nav pattern, e.g. `utm_content=back-top` on the reader-to-queue link)
- `utm_content=import-link` (specific identifier)

The analytics middleware already extracts all four standard UTM keys into the pageview log, so this lands on the existing CloudWatch dashboard with no infra work. Joining nav-tagged `/import` pageviews against same-visitor `import_uploaded` events via `visitor_hash` exposes the "clicked menu, never uploaded" drop-off.

The nav link already lives behind `{{#if isAuthenticated}}`, so "for authenticated users" required no extra plumbing — anonymous visitors never see the link.

## Files

- `projects/hutch/src/runtime/web/header.template.html` — one-line href change
- `projects/hutch/src/runtime/web/base.component.test.ts` — assertion now parses the URL and checks each UTM key independently (no string-ordering brittleness)
- `projects/hutch/src/runtime/web/pages/queue/queue.listing.filters.route.test.ts` — a peripheral assertion that hardcoded the old `/import` href; relaxed to assert the pathname only, leaving the UTM contract to the base component test

## Test plan

- [x] `pnpm nx test hutch` — full suite passes (1278/1278)
- [x] `pnpm nx lint hutch` — clean
- [ ] Manual: log in, click "Import Links" in the header nav, confirm the address bar shows `/import?utm_source=header-nav&utm_medium=internal&utm_content=import-link`
- [ ] Dashboard sanity post-deploy: filter pageviews by `path="/import" AND utm_source="header-nav"`, compare to same-visitor `import_uploaded` counts to surface the drop-off

https://claude.ai/code/session_01MJsrtwss69DmeJ8BRBAnYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJsrtwss69DmeJ8BRBAnYL)_