### PR TITLE
test: pin pdf-save-flow contract end-to-end for the browser extension

### DIFF
--- a/projects/browser-extension-core/src/e2e/index.ts
+++ b/projects/browser-extension-core/src/e2e/index.ts
@@ -16,3 +16,8 @@ export type {
 	DriverNavigation,
 } from "./flow-state-handler.types";
 export type { ElementQueries } from "./element-queries.types";
+export {
+	obtainAccessToken,
+	runPdfSaveScenario,
+} from "./pdf-save-scenario";
+export type { PdfSaveScenarioConfig } from "./pdf-save-scenario";

--- a/projects/browser-extension-core/src/e2e/pdf-save-scenario.test.ts
+++ b/projects/browser-extension-core/src/e2e/pdf-save-scenario.test.ts
@@ -1,0 +1,440 @@
+import { obtainAccessToken, runPdfSaveScenario } from "./pdf-save-scenario";
+
+type Route = { status: number; body?: string; headers?: Record<string, string> };
+type RouteHandler = Route | ((init?: RequestInit) => Route);
+
+function createRoutingFetch(routes: Record<string, RouteHandler>): {
+	fetchFn: typeof fetch;
+	calls: string[];
+	bodies: string[];
+} {
+	const calls: string[] = [];
+	const bodies: string[] = [];
+	const fetchFn: typeof fetch = async (input, init) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+		const method = init?.method ?? "GET";
+		const key = `${method} ${url}`;
+		calls.push(key);
+		if (typeof init?.body === "string") bodies.push(init.body);
+		const handler = routes[key];
+		if (!handler) throw new Error(`Unexpected fetch: ${key}`);
+		const route = typeof handler === "function" ? handler(init) : handler;
+		const headers = new Headers(route.headers);
+		return new Response(route.body ?? null, {
+			status: route.status,
+			headers,
+		});
+	};
+	return { fetchFn, calls, bodies };
+}
+
+const SERVER = "http://server.test";
+
+function authRoutes(overrides?: Partial<Record<string, RouteHandler>>): Record<string, RouteHandler> {
+	return {
+		[`POST ${SERVER}/login`]: {
+			status: 303,
+			headers: {
+				location: "/queue",
+				"set-cookie": "rp_session=abc123; Path=/; HttpOnly, other=value",
+			},
+		},
+		[`POST ${SERVER}/oauth/authorize`]: {
+			status: 303,
+			headers: { location: "http://127.0.0.1:3000/oauth/callback?code=AUTH_CODE&state=xyz" },
+		},
+		[`POST ${SERVER}/oauth/token`]: {
+			status: 200,
+			body: JSON.stringify({ access_token: "OAUTH_BEARER" }),
+		},
+		...overrides,
+	};
+}
+
+describe("obtainAccessToken", () => {
+	it("returns the token from the oauth/token response after login + authorize", async () => {
+		const { fetchFn, calls, bodies } = createRoutingFetch(authRoutes());
+		const token = await obtainAccessToken({
+			serverUrl: SERVER,
+			email: "e@x.com",
+			password: "pw",
+			fetchFn,
+		});
+		expect(token).toBe("OAUTH_BEARER");
+		expect(calls[0]).toBe(`POST ${SERVER}/login`);
+		expect(bodies[0]).toContain("email=e%40x.com");
+		expect(bodies[0]).toContain("password=pw");
+		expect(calls[1]).toBe(`POST ${SERVER}/oauth/authorize`);
+		expect(bodies[1]).toContain("client_id=hutch-chrome-extension");
+		expect(bodies[1]).toContain("action=approve");
+		expect(calls[2]).toBe(`POST ${SERVER}/oauth/token`);
+		expect(bodies[2]).toContain("code=AUTH_CODE");
+		expect(bodies[2]).toContain("grant_type=authorization_code");
+	});
+
+	it("re-sends the session cookie on the oauth/authorize call", async () => {
+		let authorizeCookie: string | null = null;
+		const routes = authRoutes({
+			[`POST ${SERVER}/oauth/authorize`]: (init) => {
+				authorizeCookie = new Headers(init?.headers).get("cookie");
+				return {
+					status: 303,
+					headers: { location: "http://127.0.0.1:3000/oauth/callback?code=C&state=s" },
+				};
+			},
+		});
+		const { fetchFn } = createRoutingFetch(routes);
+		await obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn });
+		expect(authorizeCookie).toContain("rp_session=abc123");
+		expect(authorizeCookie).toContain("other=value");
+	});
+
+	it("uses globalThis.fetch when no fetchFn is provided", async () => {
+		const original = globalThis.fetch;
+		const { fetchFn } = createRoutingFetch(authRoutes());
+		globalThis.fetch = fetchFn;
+		try {
+			const token = await obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p" });
+			expect(token).toBe("OAUTH_BEARER");
+		} finally {
+			globalThis.fetch = original;
+		}
+	});
+
+	it("rejects when the login response status is outside 2xx/3xx", async () => {
+		const { fetchFn } = createRoutingFetch({
+			[`POST ${SERVER}/login`]: { status: 422, body: "invalid" },
+		});
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow(/POST \/login returned 422/);
+	});
+
+	it("rejects when /login does not return a session cookie", async () => {
+		const { fetchFn } = createRoutingFetch({
+			[`POST ${SERVER}/login`]: { status: 303, headers: { location: "/queue" } },
+		});
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow(/did not return a session cookie/);
+	});
+
+	it("rejects when /login set-cookie has no parseable name=value pairs", async () => {
+		const { fetchFn } = createRoutingFetch({
+			[`POST ${SERVER}/login`]: {
+				status: 303,
+				headers: { location: "/queue", "set-cookie": " " },
+			},
+		});
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow();
+	});
+
+	it("rejects when /oauth/authorize does not redirect", async () => {
+		const { fetchFn } = createRoutingFetch(
+			authRoutes({
+				[`POST ${SERVER}/oauth/authorize`]: { status: 400, body: "bad" },
+			}),
+		);
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow(/POST \/oauth\/authorize must redirect/);
+	});
+
+	it("rejects when the authorize redirect lacks a code parameter", async () => {
+		const { fetchFn } = createRoutingFetch(
+			authRoutes({
+				[`POST ${SERVER}/oauth/authorize`]: {
+					status: 303,
+					headers: { location: "http://127.0.0.1:3000/oauth/callback?state=s" },
+				},
+			}),
+		);
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow(/authorize redirect missing code/);
+	});
+
+	it("rejects when /oauth/token returns non-200", async () => {
+		const { fetchFn } = createRoutingFetch(
+			authRoutes({
+				[`POST ${SERVER}/oauth/token`]: { status: 401, body: "denied" },
+			}),
+		);
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow(/POST \/oauth\/token returned 401/);
+	});
+
+	it("rejects when /oauth/token response is missing access_token", async () => {
+		const { fetchFn } = createRoutingFetch(
+			authRoutes({
+				[`POST ${SERVER}/oauth/token`]: { status: 200, body: JSON.stringify({}) },
+			}),
+		);
+		await expect(
+			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
+		).rejects.toThrow(/token response missing access_token/);
+	});
+});
+
+const SIREN = "application/vnd.siren+json";
+const PDF_URL = "https://pdf.test/sample.pdf";
+const SAVED_ID = "saved-pdf-id";
+const STUB_TITLE = "Article from pdf.test";
+const READY_TITLE = "READPLACE_E2E_PDF_FIXTURE";
+
+function articleEntity(title: string) {
+	return {
+		class: ["article"],
+		rel: ["item"],
+		properties: { id: SAVED_ID, url: PDF_URL, title, savedAt: "2026-05-19T00:00:00.000Z" },
+		links: [{ rel: ["read"], href: `/queue/${SAVED_ID}/read` }],
+		actions: [{ name: "delete", href: `/queue/${SAVED_ID}/delete`, method: "POST" }],
+	};
+}
+
+function collectionResponse(items: unknown[]) {
+	return JSON.stringify({
+		class: ["collection", "articles"],
+		entities: items,
+		links: [{ rel: ["self"], href: "/queue" }],
+		actions: [
+			{
+				name: "save-article",
+				href: "/queue",
+				method: "POST",
+				type: "application/json",
+				fields: [{ name: "url", type: "url" }],
+			},
+			{
+				name: "search",
+				href: "/queue",
+				method: "GET",
+				fields: [{ name: "url", type: "url" }],
+			},
+		],
+	});
+}
+
+function sirenWalkerRoutes(opts: {
+	collectionResponses: string[];
+}): Record<string, RouteHandler> {
+	let walkerCallIndex = 0;
+	const handler: RouteHandler = () => {
+		const body = opts.collectionResponses[walkerCallIndex] ?? opts.collectionResponses[opts.collectionResponses.length - 1];
+		walkerCallIndex += 1;
+		return { status: 200, body, headers: { "content-type": SIREN } };
+	};
+	return {
+		[`GET ${SERVER}/`]: handler,
+		[`GET ${SERVER}/queue`]: handler,
+	};
+}
+
+describe("runPdfSaveScenario", () => {
+	it("polls until the saved article's title contains the expected substring", async () => {
+		const collections = [
+			collectionResponse([]),
+			collectionResponse([articleEntity(STUB_TITLE)]),
+			collectionResponse([articleEntity(STUB_TITLE)]),
+			collectionResponse([articleEntity(READY_TITLE)]),
+		];
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 201,
+				body: JSON.stringify(articleEntity(STUB_TITLE)),
+				headers: { "content-type": SIREN },
+			},
+		};
+		const { fetchFn } = createRoutingFetch(routes);
+		await runPdfSaveScenario({
+			serverUrl: SERVER,
+			email: "e",
+			password: "p",
+			pdfUrl: PDF_URL,
+			expectedTitleSubstring: "READPLACE_E2E_PDF",
+			fetchFn,
+			pollIntervalMs: 1,
+			pollTimeoutMs: 5_000,
+		});
+	});
+
+	it("times out when the title never converges to the expected substring", async () => {
+		const collections = [
+			collectionResponse([]),
+			collectionResponse([articleEntity(STUB_TITLE)]),
+		];
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 201,
+				body: JSON.stringify(articleEntity(STUB_TITLE)),
+				headers: { "content-type": SIREN },
+			},
+		};
+		const { fetchFn } = createRoutingFetch(routes);
+		await expect(
+			runPdfSaveScenario({
+				serverUrl: SERVER,
+				email: "e",
+				password: "p",
+				pdfUrl: PDF_URL,
+				expectedTitleSubstring: "WILL_NEVER_APPEAR",
+				fetchFn,
+				pollIntervalMs: 1,
+				pollTimeoutMs: 20,
+			}),
+		).rejects.toThrow(/Timed out after 20ms.*Last observed title: "Article from pdf\.test"/);
+	});
+
+	it("uses default poll interval/timeout when not provided", async () => {
+		const collections = [
+			collectionResponse([]),
+			collectionResponse([articleEntity(READY_TITLE)]),
+		];
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 201,
+				body: JSON.stringify(articleEntity(READY_TITLE)),
+				headers: { "content-type": SIREN },
+			},
+		};
+		const { fetchFn } = createRoutingFetch(routes);
+		await runPdfSaveScenario({
+			serverUrl: SERVER,
+			email: "e",
+			password: "p",
+			pdfUrl: PDF_URL,
+			expectedTitleSubstring: "READPLACE_E2E_PDF",
+			fetchFn,
+		});
+	});
+
+	it("uses globalThis.fetch when no fetchFn is provided", async () => {
+		const collections = [
+			collectionResponse([]),
+			collectionResponse([articleEntity(READY_TITLE)]),
+		];
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 201,
+				body: JSON.stringify(articleEntity(READY_TITLE)),
+				headers: { "content-type": SIREN },
+			},
+		};
+		const original = globalThis.fetch;
+		const { fetchFn } = createRoutingFetch(routes);
+		globalThis.fetch = fetchFn;
+		try {
+			await runPdfSaveScenario({
+				serverUrl: SERVER,
+				email: "e",
+				password: "p",
+				pdfUrl: PDF_URL,
+				expectedTitleSubstring: "READPLACE_E2E_PDF",
+				pollIntervalMs: 1,
+				pollTimeoutMs: 5_000,
+			});
+		} finally {
+			globalThis.fetch = original;
+		}
+	});
+
+	it("rejects when saveUrl returns ok:false", async () => {
+		const collections = [collectionResponse([])];
+		const collectionWithBlockedSave = JSON.stringify({
+			class: ["collection", "articles"],
+			properties: { warning: { code: "blocked", message: "no" } },
+			entities: [],
+			links: [{ rel: ["self"], href: "/queue" }],
+			actions: [],
+		});
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 422,
+				body: collectionWithBlockedSave,
+				headers: { "content-type": SIREN },
+			},
+		};
+		const { fetchFn } = createRoutingFetch(routes);
+		await expect(
+			runPdfSaveScenario({
+				serverUrl: SERVER,
+				email: "e",
+				password: "p",
+				pdfUrl: PDF_URL,
+				expectedTitleSubstring: "X",
+				fetchFn,
+				pollIntervalMs: 1,
+				pollTimeoutMs: 1_000,
+			}),
+		).rejects.toThrow(/saveUrl failed/);
+	});
+
+	it("rejects when the saved article disappears from the queue mid-poll", async () => {
+		const collections = [
+			collectionResponse([]),
+			collectionResponse([articleEntity(STUB_TITLE)]),
+			collectionResponse([]),
+		];
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 201,
+				body: JSON.stringify(articleEntity(STUB_TITLE)),
+				headers: { "content-type": SIREN },
+			},
+		};
+		const { fetchFn } = createRoutingFetch(routes);
+		await expect(
+			runPdfSaveScenario({
+				serverUrl: SERVER,
+				email: "e",
+				password: "p",
+				pdfUrl: PDF_URL,
+				expectedTitleSubstring: "X",
+				fetchFn,
+				pollIntervalMs: 1,
+				pollTimeoutMs: 5_000,
+			}),
+		).rejects.toThrow(/disappeared from the queue/);
+	});
+
+	it("propagates a 401 from a Siren call as Unauthorized", async () => {
+		const collections = [collectionResponse([])];
+		const routes = {
+			...authRoutes(),
+			...sirenWalkerRoutes({ collectionResponses: collections }),
+			[`POST ${SERVER}/queue`]: {
+				status: 401,
+				body: "",
+				headers: { "content-type": SIREN },
+			},
+		};
+		const { fetchFn } = createRoutingFetch(routes);
+		await expect(
+			runPdfSaveScenario({
+				serverUrl: SERVER,
+				email: "e",
+				password: "p",
+				pdfUrl: PDF_URL,
+				expectedTitleSubstring: "X",
+				fetchFn,
+				pollIntervalMs: 1,
+				pollTimeoutMs: 1_000,
+			}),
+		).rejects.toThrow(/Unauthorized while running pdf-save scenario/);
+	});
+});

--- a/projects/browser-extension-core/src/e2e/pdf-save-scenario.test.ts
+++ b/projects/browser-extension-core/src/e2e/pdf-save-scenario.test.ts
@@ -175,7 +175,7 @@ describe("obtainAccessToken", () => {
 		);
 		await expect(
 			obtainAccessToken({ serverUrl: SERVER, email: "e", password: "p", fetchFn }),
-		).rejects.toThrow(/token response missing access_token/);
+		).rejects.toThrow(/expected string, received undefined/);
 	});
 });
 

--- a/projects/browser-extension-core/src/e2e/pdf-save-scenario.ts
+++ b/projects/browser-extension-core/src/e2e/pdf-save-scenario.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { createHash, randomBytes } from "node:crypto";
+import { initSirenReadingList } from "../reading-list/siren-reading-list";
+
+/**
+ * Pinned OAuth client for the e2e PDF scenario. The Chrome extension registers
+ * under the same id, and the test-fixtures provider has a corresponding entry
+ * (src/packages/test-fixtures/src/providers/oauth/oauth-clients.ts).
+ */
+const CLIENT_ID = "hutch-chrome-extension";
+
+/**
+ * Any 127.0.0.1:* callback passes validateRedirectUri (oauth-clients.ts:40), so
+ * a fixed port works against both the local e2e server (which binds 127.0.0.1)
+ * and staging (which never sees the callback — we extract the code from the
+ * authorize response's Location header without following the redirect).
+ */
+const REDIRECT_URI = "http://127.0.0.1:3000/oauth/callback";
+
+function generatePkce(): { codeVerifier: string; codeChallenge: string } {
+	const codeVerifier = randomBytes(32).toString("base64url");
+	const codeChallenge = createHash("sha256")
+		.update(codeVerifier)
+		.digest("base64url");
+	return { codeVerifier, codeChallenge };
+}
+
+/**
+ * Splits a `set-cookie` response header (Node's `fetch` joins multiple cookies
+ * with `, ` even though commas are legal in cookie attribute values like
+ * `expires=Wed, 09 Jun 2027`). Splits on `, ` only when followed by a token=,
+ * which is the leading shape of a new cookie. Returns just the `name=value`
+ * pair of each cookie, suitable for re-sending via the `Cookie` header.
+ */
+function parseSetCookieHeader(setCookieHeader: string): string[] {
+	const cookies: string[] = [];
+	const parts = setCookieHeader.split(/,(?=\s*[A-Za-z0-9_-]+=)/);
+	for (const part of parts) {
+		const semiIndex = part.indexOf(";");
+		const nameValue = semiIndex === -1 ? part.trim() : part.slice(0, semiIndex).trim();
+		if (nameValue.length > 0) cookies.push(nameValue);
+	}
+	return cookies;
+}
+
+/**
+ * Logs in via the SSR /login form and exchanges the session for an OAuth
+ * access token via the same authorize → token flow the extension's
+ * background script runs. Returns a Bearer token suitable for
+ * `Authorization: Bearer …` on Siren routes.
+ *
+ * Mirrors projects/hutch/src/runtime/web/api/save-article-via-oauth.integration.ts
+ * but uses node's global fetch (no supertest) so it works against any base URL,
+ * local or staging.
+ */
+export async function obtainAccessToken(params: {
+	serverUrl: string;
+	email: string;
+	password: string;
+	fetchFn?: typeof fetch;
+}): Promise<string> {
+	const fetchFn = params.fetchFn ?? globalThis.fetch;
+
+	const loginResponse = await fetchFn(`${params.serverUrl}/login`, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			email: params.email,
+			password: params.password,
+		}).toString(),
+		redirect: "manual",
+	});
+	assert(
+		loginResponse.status >= 200 && loginResponse.status < 400,
+		`POST /login returned ${loginResponse.status}`,
+	);
+	const setCookie = loginResponse.headers.get("set-cookie");
+	assert(setCookie, "POST /login did not return a session cookie");
+	const cookieHeader = parseSetCookieHeader(setCookie).join("; ");
+
+	const { codeVerifier, codeChallenge } = generatePkce();
+	const state = randomBytes(16).toString("base64url");
+	const authorizeResponse = await fetchFn(`${params.serverUrl}/oauth/authorize`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Cookie: cookieHeader,
+		},
+		body: new URLSearchParams({
+			client_id: CLIENT_ID,
+			redirect_uri: REDIRECT_URI,
+			response_type: "code",
+			code_challenge: codeChallenge,
+			code_challenge_method: "S256",
+			state,
+			action: "approve",
+		}).toString(),
+		redirect: "manual",
+	});
+	const location = authorizeResponse.headers.get("location");
+	assert(
+		location,
+		`POST /oauth/authorize must redirect (got ${authorizeResponse.status})`,
+	);
+	const code = new URL(location).searchParams.get("code");
+	assert(code, `authorize redirect missing code: ${location}`);
+
+	const tokenResponse = await fetchFn(`${params.serverUrl}/oauth/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "authorization_code",
+			code,
+			redirect_uri: REDIRECT_URI,
+			client_id: CLIENT_ID,
+			code_verifier: codeVerifier,
+		}).toString(),
+	});
+	assert.equal(
+		tokenResponse.status,
+		200,
+		`POST /oauth/token returned ${tokenResponse.status}`,
+	);
+	const tokenBody = (await tokenResponse.json()) as { access_token?: string };
+	assert(tokenBody.access_token, "token response missing access_token");
+	return tokenBody.access_token;
+}
+
+export interface PdfSaveScenarioConfig {
+	/** Origin of the readplace.com server under test (local e2e or staging). */
+	serverUrl: string;
+	/** Pre-provisioned test user; local harness creates this via POST /e2e/users. */
+	email: string;
+	password: string;
+	/** A URL that responds with Content-Type: application/pdf. The extension's
+	 * save-article path (no rawHtml) will be invoked with this URL. */
+	pdfUrl: string;
+	/** Substring expected in the saved article's title after ComprehensiveCrawl
+	 * extracts the PDF (local: the stub's marker; staging: a fragment of the
+	 * real document title from vision OCR). */
+	expectedTitleSubstring: string;
+	/** Override globalThis.fetch — useful for staging tests that need to disable
+	 * keep-alive or add a proxy. Defaults to global fetch. */
+	fetchFn?: typeof fetch;
+	/** How long to poll for the extracted title before failing. PDF OCR via
+	 * DeepInfra in staging can take 20–30s; default of 90s leaves headroom. */
+	pollTimeoutMs?: number;
+	/** Interval between polls of the Siren collection. */
+	pollIntervalMs?: number;
+}
+
+/**
+ * End-to-end contract test for the extension's save flow on PDF URLs.
+ *
+ * Drives the same `initSirenReadingList` walker the production extension uses,
+ * exercising the URL-only `save-article` fallback (no rawHtml) that fires
+ * every time the popup is opened on a tab whose body the content script can't
+ * capture — which is every PDF tab, because browsers render PDFs in a native
+ * viewer where `document.documentElement.outerHTML` is unreachable.
+ *
+ * The scenario pins the contract:
+ *   - extension follows Siren entry point and discovers `save-article` by name
+ *   - server accepts the URL, kicks off SimpleCrawl → ComprehensiveCrawl
+ *   - PDF branch (crawl-article.ts:190) runs extractPdf
+ *   - selector promotes the article to `ready` and updates the title
+ *   - re-walking Siren shows the updated title within the poll window
+ */
+export async function runPdfSaveScenario(
+	config: PdfSaveScenarioConfig,
+): Promise<void> {
+	const fetchFn = config.fetchFn ?? globalThis.fetch;
+	const pollTimeoutMs = config.pollTimeoutMs ?? 90_000;
+	const pollIntervalMs = config.pollIntervalMs ?? 1_000;
+
+	const accessToken = await obtainAccessToken({
+		serverUrl: config.serverUrl,
+		email: config.email,
+		password: config.password,
+		fetchFn,
+	});
+
+	const { saveUrl, getAllItems } = initSirenReadingList({
+		serverUrl: config.serverUrl,
+		getAccessToken: async () => accessToken,
+		fetchFn,
+		onUnauthorized: async () => {
+			throw new Error("Unauthorized while running pdf-save scenario");
+		},
+	});
+
+	const saveResult = await saveUrl({
+		url: config.pdfUrl,
+		title: "",
+	});
+	assert(saveResult.ok, `saveUrl failed: ${JSON.stringify(saveResult)}`);
+	const savedId = saveResult.item.id;
+
+	const deadline = Date.now() + pollTimeoutMs;
+	let lastTitle = saveResult.item.title;
+	while (Date.now() < deadline) {
+		const items = await getAllItems();
+		const current = items.find((item) => item.id === savedId);
+		assert(
+			current,
+			`Saved article id ${savedId} disappeared from the queue mid-poll`,
+		);
+		lastTitle = current.title;
+		if (current.title.includes(config.expectedTitleSubstring)) return;
+		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+	}
+
+	throw new Error(
+		`Timed out after ${pollTimeoutMs}ms waiting for extracted title to contain "${config.expectedTitleSubstring}". Last observed title: "${lastTitle}"`,
+	);
+}

--- a/projects/browser-extension-core/src/e2e/pdf-save-scenario.ts
+++ b/projects/browser-extension-core/src/e2e/pdf-save-scenario.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash, randomBytes } from "node:crypto";
+import { z } from "zod";
 import { initSirenReadingList } from "../reading-list/siren-reading-list";
 
 /**
@@ -121,8 +122,8 @@ export async function obtainAccessToken(params: {
 		200,
 		`POST /oauth/token returned ${tokenResponse.status}`,
 	);
-	const tokenBody = (await tokenResponse.json()) as { access_token?: string };
-	assert(tokenBody.access_token, "token response missing access_token");
+	const TokenResponse = z.object({ access_token: z.string() });
+	const tokenBody = TokenResponse.parse(await tokenResponse.json());
 	return tokenBody.access_token;
 }
 

--- a/projects/extensions/chrome-extension/knip.config.ts
+++ b/projects/extensions/chrome-extension/knip.config.ts
@@ -42,5 +42,6 @@ export default {
 		"src/runtime/offscreen/offscreen.browser.ts",
 		// E2E test entry points (run via node --test)
 		"src/e2e/**/run.e2e-local.main.ts",
+		"src/e2e/**/run.e2e-staging.main.ts",
 	],
 } satisfies KnipConfig;

--- a/projects/extensions/chrome-extension/package.json
+++ b/projects/extensions/chrome-extension/package.json
@@ -13,6 +13,7 @@
     "test:sequential": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000 --runInBand --passWithNoTests",
     "test-with-coverage": "pnpm compile && c8 node scripts/run-tests-with-coverage.js && node enforce-coverage.config.js",
     "test:e2e": "E2E_PORT=3001 HUTCH_SERVER_URL=http://127.0.0.1:3001 node scripts/build-extension.js && E2E_PORT=3001 node --test dist/e2e/login-flow/run.e2e-local.main.js",
+    "test:e2e:pdf-save-staging": "node --test dist/e2e/pdf-save-flow/run.e2e-staging.main.js",
     "deploy-infra": "nx run deploy-infra",
     "post-deploy": "echo 'No post-deploy steps'",
     "check-infra": "PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack \"${PULUMI_STACK:?PULUMI_STACK is not set}\"",

--- a/projects/extensions/chrome-extension/run-tests.config.js
+++ b/projects/extensions/chrome-extension/run-tests.config.js
@@ -40,5 +40,13 @@ module.exports = {
       env: { HEADLESS: 'true', E2E_PORT: port },
       e2e: true,
     },
+    {
+      type: 'node-test',
+      name: 'Running PDF save E2E (local, stubbed PDF extractor)',
+      files: ['dist/e2e/pdf-save-flow/run.e2e-local.main.js'],
+      timeout: 90000,
+      env: { E2E_PORT: port },
+      e2e: true,
+    },
   ],
 };

--- a/projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-local.main.ts
+++ b/projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-local.main.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { runPdfSaveScenario } from "browser-extension-core/e2e";
+
+const TEST_EMAIL = "pdf-e2e-test@example.com";
+const TEST_PASSWORD = "testpassword123";
+assert(process.env.E2E_PORT, "E2E_PORT is required");
+const TEST_PORT = Number(process.env.E2E_PORT);
+const ORIGIN = `http://127.0.0.1:${TEST_PORT}`;
+
+async function waitForServer(port: number, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+			return;
+		} catch {
+			await new Promise((r) => setTimeout(r, 100));
+		}
+	}
+	throw new Error(`e2e server did not start on port ${port} within ${timeoutMs}ms`);
+}
+
+async function startTestServer(): Promise<ChildProcess> {
+	// Same pnpm-nx invocation as the login-flow harness: see
+	// projects/extensions/chrome-extension/src/e2e/login-flow/run.e2e-local.main.ts
+	// for the rationale on NX_DAEMON=false and detached:true (process-group
+	// cleanup so the e2e-server is killed when the harness exits).
+	const child = spawn("pnpm", ["nx", "run", "hutch:e2e-server"], {
+		env: {
+			...process.env,
+			E2E_PORT: String(TEST_PORT),
+			NODE_ENV: "test",
+			NX_DAEMON: "false",
+		},
+		stdio: "inherit",
+		detached: true,
+	});
+	child.on("error", () => {});
+	await waitForServer(TEST_PORT, 30_000);
+	const userRes = await fetch(`${ORIGIN}/e2e/users`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+	});
+	assert.equal(
+		userRes.status,
+		201,
+		`POST /e2e/users returned ${userRes.status} (expected 201)`,
+	);
+	return child;
+}
+
+async function stopTestServer(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.pid === undefined) return;
+	const pid = child.pid;
+	const killGroup = (signal: NodeJS.Signals) => {
+		try {
+			process.kill(-pid, signal);
+		} catch {
+			child.kill(signal);
+		}
+	};
+	await new Promise<void>((resolve) => {
+		const cleanExit = () => resolve();
+		child.once("exit", cleanExit);
+		killGroup("SIGTERM");
+		setTimeout(() => {
+			killGroup("SIGKILL");
+			child.off("exit", cleanExit);
+			resolve();
+		}, 5_000).unref();
+	});
+}
+
+test("extension should save a PDF URL end-to-end via the Siren walker", async () => {
+	const server = await startTestServer();
+	try {
+		await runPdfSaveScenario({
+			serverUrl: ORIGIN,
+			email: TEST_EMAIL,
+			password: TEST_PASSWORD,
+			pdfUrl: `${ORIGIN}/e2e/fixtures/sample.pdf`,
+			expectedTitleSubstring: "READPLACE_E2E_PDF_FIXTURE",
+			pollTimeoutMs: 30_000,
+		});
+	} finally {
+		await stopTestServer(server);
+	}
+});

--- a/projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-local.main.ts
+++ b/projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-local.main.ts
@@ -37,7 +37,7 @@ async function startTestServer(): Promise<ChildProcess> {
 		stdio: "inherit",
 		detached: true,
 	});
-	child.on("error", () => {});
+	child.on("error", () => {}); // waitForServer will throw on its own timeout
 	await waitForServer(TEST_PORT, 30_000);
 	const userRes = await fetch(`${ORIGIN}/e2e/users`, {
 		method: "POST",

--- a/projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-staging.main.ts
+++ b/projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-staging.main.ts
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runPdfSaveScenario } from "browser-extension-core/e2e";
+
+const STAGING_URL = process.env.STAGING_URL;
+const STAGING_TEST_EMAIL = process.env.STAGING_TEST_EMAIL;
+const STAGING_TEST_PASSWORD = process.env.STAGING_TEST_PASSWORD;
+
+/** Known-good small PDF from the production health canary
+ * (src/packages/crawl-article/scripts/health-sources.ts:174). The canary keeps
+ * this URL working for the real OCR pipeline; reusing it here means the
+ * staging variant of the pdf-save-flow scenario fails for the same reasons
+ * the canary fails, not for unrelated PDF-source rot. */
+const STAGING_PDF_URL = "https://arxiv.org/pdf/1706.03762v7";
+const STAGING_EXPECTED_TITLE_SUBSTRING = "Attention";
+
+test("extension should save a PDF URL end-to-end against staging", async (t) => {
+	if (!STAGING_URL || !STAGING_TEST_EMAIL || !STAGING_TEST_PASSWORD) {
+		t.skip("STAGING_URL, STAGING_TEST_EMAIL, STAGING_TEST_PASSWORD must be set");
+		return;
+	}
+	assert(STAGING_URL && STAGING_TEST_EMAIL && STAGING_TEST_PASSWORD);
+	await runPdfSaveScenario({
+		serverUrl: STAGING_URL,
+		email: STAGING_TEST_EMAIL,
+		password: STAGING_TEST_PASSWORD,
+		pdfUrl: STAGING_PDF_URL,
+		expectedTitleSubstring: STAGING_EXPECTED_TITLE_SUBSTRING,
+		pollTimeoutMs: 120_000,
+	});
+});

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -33,11 +33,27 @@ const logger = HutchLogger.from(consoleLogger)
 
 const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }))
 const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, personas: CRAWL_PERSONAS })
-// E2E exercises HTML pages only — PDFs are not part of the e2e flow today,
-// and OCR (canvas + DeepInfra) is deliberately out of scope for tests. The
-// stub returns failed so crawlArticle reports "unsupported" if a PDF ever
-// reaches this path.
-const extractPdf: ExtractPdf = async () => ({ kind: "failed", reason: "PDF extraction not supported in e2e server" })
+/** Deterministic PDF extractor for the e2e harness: emits the same synthetic
+ * HTML the prod vision pipeline would produce for the bundled /e2e/fixtures/sample.pdf
+ * fixture, so the pdf-save-flow e2e test can pin the extension's Siren contract
+ * for "save a URL that returns application/pdf" without depending on DeepInfra
+ * or the pdftoppm rasterizer. The marker title is what the test polls for to
+ * detect that ComprehensiveCrawl ran the PDF branch and the selector promoted
+ * the article from `unsupported` (SimpleCrawl) to `ready`.
+ *
+ * The body needs to be long enough that Mozilla Readability classifies it as a
+ * real article (the parser falls back to title = "Article from <hostname>" if
+ * Readability returns null, which would leave the marker out of the title and
+ * the e2e poll would never converge). Repeating the body paragraph clears the
+ * character-threshold heuristic without making the synthetic HTML noisy. */
+const E2E_PDF_TITLE = "READPLACE_E2E_PDF_FIXTURE"
+const E2E_PDF_BODY = "Readplace e2e pdf fixture body — this string is asserted on by the pdf-save-flow scenario."
+const E2E_PDF_BODY_PARAGRAPHS = Array.from({ length: 12 }, () => `<p>${E2E_PDF_BODY}</p>`).join("")
+const extractPdf: ExtractPdf = async () => ({
+  kind: "fetched",
+  title: E2E_PDF_TITLE,
+  html: `<!DOCTYPE html><html><head><title>${E2E_PDF_TITLE}</title></head><body><article><h1>${E2E_PDF_TITLE}</h1>${E2E_PDF_BODY_PARAGRAPHS}</article></body></html>`,
+})
 const simpleCrawl = initSimpleCrawl({ crawlFetch, logError })
 const comprehensiveCrawl = initComprehensiveCrawl({ crawlFetch, extractPdf, logError })
 const crawlArticle = initCrawlArticle({ simpleCrawl, comprehensiveCrawl })
@@ -167,6 +183,19 @@ server.get('/e2e/stripe-checkout/:id', (req, res) => {
 // fail regardless of network conditions.
 server.get('/e2e/unfetchable', (_req, res) => {
   res.status(500).type('text/plain').send('e2e: intentional crawl failure')
+})
+
+/** Minimal valid PDF (single empty page, ~300 bytes). The extractor stub above
+ * never parses these bytes — it short-circuits to deterministic HTML. The
+ * fixture's only job is to make the upstream HTTP response Content-Type and
+ * magic bytes match `application/pdf` so SimpleCrawl reports `unsupported` and
+ * ComprehensiveCrawl takes the PDF branch (crawl-article.ts:190). */
+const E2E_SAMPLE_PDF = Buffer.from(
+  '%PDF-1.1\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000052 00000 n \n0000000099 00000 n \ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n149\n%%EOF\n',
+  'utf-8',
+)
+server.get('/e2e/fixtures/sample.pdf', (_req, res) => {
+  res.type('application/pdf').send(E2E_SAMPLE_PDF)
 })
 
 server.use(hutchApp)


### PR DESCRIPTION
## Summary

Pins the contract that the browser extension can save a URL returning `application/pdf` end-to-end. Adds:

- A shared `runPdfSaveScenario` in `browser-extension-core/src/e2e/` that drives `initSirenReadingList` — the same client the production extension ships — through the Siren entry point, invokes `save-article` with no `rawHtml` (the fallback path every PDF tab takes), and polls until the saved article's title contains the extracted marker.
- A **local** harness (`projects/extensions/chrome-extension/src/e2e/pdf-save-flow/run.e2e-local.main.ts`) that spawns the hutch e2e server (now ships a deterministic `extractPdf` stub and a `/e2e/fixtures/sample.pdf` route) and runs alongside the existing login-flow E2E.
- A **staging** harness gated on `STAGING_URL` / `STAGING_TEST_EMAIL` / `STAGING_TEST_PASSWORD` that runs the same scenario against the real DeepInfra OCR pipeline using the arXiv canary URL.
- 100% coverage on the scenario via mocked-fetch unit tests in `pdf-save-scenario.test.ts`.

## Why

The server pipeline already handles PDFs end-to-end (SimpleCrawl → `unsupported` → ComprehensiveCrawl → vision OCR → selector promotes to `ready`), and the prod health canary covers three PDF sources. But the **extension save path** was implicit and untested. When a popup opens on a PDF tab the content script can't reach `document.documentElement` (native PDF viewer), so HTML capture times out and the Siren walker silently falls back from `save-html` to `save-article` URL-only. A regression in that fallback would only surface in production — breaking the exact users the canary entries exist to protect (per CLAUDE.md's *Crawler Health Canary Is Load-Bearing*).

This PR pins that contract at the Siren-walker level so the next person who refactors the Siren actions, the crawl router, or the OCR pipeline gets a loud test failure instead of a silent regression that the canary only catches in prod.

## Test plan

- [x] `pnpm nx run-many --target=check --all` passes (pre-commit hook ran the full sweep)
- [x] Local PDF E2E passes in ~3s: `E2E_PORT=3002 node --test dist/e2e/pdf-save-flow/run.e2e-local.main.js` → `ok 1`
- [x] Staging harness skips cleanly when env vars are unset: `node --test dist/e2e/pdf-save-flow/run.e2e-staging.main.js` → `# SKIP`
- [x] Browser-extension-core coverage stays at 100% (now 23 files, including `pdf-save-scenario.ts`)
- [x] Hutch coverage thresholds met (no regression from the e2e-server changes)
- [ ] Run against real staging via `pnpm --filter chrome-extension test:e2e:pdf-save-staging` once `STAGING_URL` / `STAGING_TEST_EMAIL` / `STAGING_TEST_PASSWORD` are wired into the staging CI environment

---
_Generated by [Claude Code](https://claude.ai/code/session_012gdj7msRU7SqHe8mZUboRF)_