### PR TITLE
feat(hutch): block naive scripted-client UAs site-wide

### DIFF
--- a/projects/hutch/src/runtime/lambda.main.ts
+++ b/projects/hutch/src/runtime/lambda.main.ts
@@ -8,6 +8,7 @@ import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { logger as requestLogger } from "./domain/logger";
 import { createAnalyticsMiddleware, hashIp } from "./web/middleware/analytics";
 import { createBanMiddleware } from "./web/middleware/ban";
+import { type BotBlockEvent, createBlockNaiveBotMiddleware } from "./web/middleware/naive-bot";
 import { logAndRespondOnError } from "./web/middleware/error-handler";
 import { createHutchApp, localServer } from "./app";
 import { getEnv, requireEnv } from "./domain/require-env";
@@ -21,6 +22,9 @@ const log = requestLogger();
 const logger = HutchLogger.from(consoleLogger);
 const salt = requireEnv("ANALYTICS_SALT");
 const ban = createBanMiddleware({ salt, hashIp });
+const blockNaiveBot = createBlockNaiveBotMiddleware({
+	logger: HutchLogger.fromJSON<BotBlockEvent>(),
+});
 const analytics = createAnalyticsMiddleware({
 	logger: analyticsLogger,
 	salt,
@@ -37,6 +41,7 @@ const application = express()
 		}),
 	)
 	.use(ban)
+	.use(blockNaiveBot)
 	.use(analytics)
 	.use(app)
 	.use(logAndRespondOnError(logger));

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -233,6 +233,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					deps.botDefenseLogger.info(createBotDefenseEvent({
 						trip: { reason: result.reason, timeToSubmitMs: result.timeToSubmitMs },
 						ip: req.ip,
+						userAgent: req.get("user-agent"),
 						body,
 						now: deps.now(),
 					}));

--- a/projects/hutch/src/runtime/web/auth/bot-defense-event.test.ts
+++ b/projects/hutch/src/runtime/web/auth/bot-defense-event.test.ts
@@ -7,6 +7,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
@@ -22,6 +23,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: "203.0.113.1",
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
@@ -32,6 +34,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
@@ -42,16 +45,63 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: "",
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
 		expect(event).not.toHaveProperty("ip");
 	});
 
+	it("includes user_agent when provided", () => {
+		const event = createBotDefenseEvent({
+			trip: { reason: "honeypot" },
+			ip: undefined,
+			userAgent: "Mozilla/5.0 (compatible; FakeBot/1.0)",
+			body: {},
+			now: REJECT_AT,
+		});
+		expect(event.user_agent).toBe("Mozilla/5.0 (compatible; FakeBot/1.0)");
+	});
+
+	it("truncates user_agent to 200 characters", () => {
+		const longUA = "A".repeat(300);
+		const event = createBotDefenseEvent({
+			trip: { reason: "honeypot" },
+			ip: undefined,
+			userAgent: longUA,
+			body: {},
+			now: REJECT_AT,
+		});
+		expect(event.user_agent).toBe("A".repeat(200));
+	});
+
+	it("omits user_agent when undefined", () => {
+		const event = createBotDefenseEvent({
+			trip: { reason: "honeypot" },
+			ip: undefined,
+			userAgent: undefined,
+			body: {},
+			now: REJECT_AT,
+		});
+		expect(event).not.toHaveProperty("user_agent");
+	});
+
+	it("omits user_agent when empty string", () => {
+		const event = createBotDefenseEvent({
+			trip: { reason: "honeypot" },
+			ip: undefined,
+			userAgent: "",
+			body: {},
+			now: REJECT_AT,
+		});
+		expect(event).not.toHaveProperty("user_agent");
+	});
+
 	it("derives email_domain from body.email, lowercased", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: { email: "Bot@Example.COM" },
 			now: REJECT_AT,
 		});
@@ -62,6 +112,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
@@ -72,6 +123,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: { email: 123 },
 			now: REJECT_AT,
 		});
@@ -82,6 +134,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: { email: "no-at-sign" },
 			now: REJECT_AT,
 		});
@@ -92,6 +145,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: { email: "trailing@" },
 			now: REJECT_AT,
 		});
@@ -102,6 +156,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "submit_too_fast", timeToSubmitMs: 1234 },
 			ip: undefined,
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
@@ -112,6 +167,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "submit_too_fast", timeToSubmitMs: 0 },
 			ip: undefined,
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});
@@ -122,6 +178,7 @@ describe("createBotDefenseEvent", () => {
 		const event = createBotDefenseEvent({
 			trip: { reason: "honeypot" },
 			ip: undefined,
+			userAgent: undefined,
 			body: {},
 			now: REJECT_AT,
 		});

--- a/projects/hutch/src/runtime/web/auth/bot-defense-event.ts
+++ b/projects/hutch/src/runtime/web/auth/bot-defense-event.ts
@@ -20,16 +20,19 @@ function extractEmailDomain(body: Record<string, unknown>): string | undefined {
 export function createBotDefenseEvent(input: {
 	trip: BotDefenseTrip;
 	ip: string | undefined;
+	userAgent: string | undefined;
 	body: Record<string, unknown>;
 	now: Date;
 }): BotDefenseEvent {
 	const emailDomain = extractEmailDomain(input.body);
+	const ua = input.userAgent?.slice(0, 200);
 	return {
 		stream: "bot-defense",
 		event: "signup_rejected",
 		reason: input.trip.reason,
 		timestamp: input.now.toISOString(),
 		...(input.ip ? { ip: input.ip } : {}),
+		...(ua ? { user_agent: ua } : {}),
 		...(emailDomain ? { email_domain: emailDomain } : {}),
 		...(input.trip.timeToSubmitMs !== undefined
 			? { time_to_submit_ms: input.trip.timeToSubmitMs }

--- a/projects/hutch/src/runtime/web/middleware/naive-bot.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/naive-bot.test.ts
@@ -1,0 +1,208 @@
+import type { NextFunction, Request, Response } from "express";
+import type { HutchLogger } from "@packages/hutch-logger";
+import { type BotBlockEvent, createBlockNaiveBotMiddleware } from "./naive-bot";
+
+interface RunResult {
+	status?: number;
+	nextCalled: boolean;
+	logged: BotBlockEvent[];
+}
+
+function run({ ua, path = "/" }: { ua?: string; path?: string }): RunResult {
+	let status: number | undefined;
+	const res = {
+		status: (code: number) => {
+			status = code;
+			return res;
+		},
+		end: jest.fn(),
+	} as unknown as Response;
+
+	const headers: Record<string, string | undefined> = { "user-agent": ua };
+	const req = {
+		path,
+		get(name: string): string | undefined {
+			return headers[name.toLowerCase()];
+		},
+	} as unknown as Request;
+
+	const logged: BotBlockEvent[] = [];
+	const logger: HutchLogger.Typed<BotBlockEvent> = {
+		info: (data) => { logged.push(data); },
+		error: () => {},
+		warn: () => {},
+		debug: () => {},
+	};
+
+	const next = jest.fn() as unknown as NextFunction;
+	createBlockNaiveBotMiddleware({ logger })(req, res, next);
+	return {
+		status,
+		nextCalled: (next as jest.Mock).mock.calls.length > 0,
+		logged,
+	};
+}
+
+describe("createBlockNaiveBotMiddleware", () => {
+	it("allows a modern browser UA", () => {
+		const result = run({
+			ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+		});
+		expect(result.nextCalled).toBe(true);
+		expect(result.status).toBeUndefined();
+		expect(result.logged).toEqual([]);
+	});
+
+	it("allows Googlebot — the policy must not block any legitimate crawler, including ones isbot() would flag", () => {
+		const result = run({
+			ua: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+		});
+		expect(result.nextCalled).toBe(true);
+		expect(result.status).toBeUndefined();
+	});
+
+	it("allows GPTBot — robots.txt at projects/hutch/src/runtime/server.ts:258-259 explicitly allows it", () => {
+		const result = run({
+			ua: "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot",
+		});
+		expect(result.nextCalled).toBe(true);
+	});
+
+	it("allows ClaudeBot — robots.txt at projects/hutch/src/runtime/server.ts:264-265 explicitly allows it", () => {
+		const result = run({
+			ua: "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
+		});
+		expect(result.nextCalled).toBe(true);
+	});
+
+	it("allows PerplexityBot — robots.txt at projects/hutch/src/runtime/server.ts:261-262 explicitly allows it", () => {
+		const result = run({
+			ua: "Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)",
+		});
+		expect(result.nextCalled).toBe(true);
+	});
+
+	it("allows an unknown crawler — the policy assumes good faith for any UA not on the explicit block-list, so a future search engine we have never heard of still gets to index us", () => {
+		const result = run({
+			ua: "Mozilla/5.0 (compatible; FlimsyBot/1.0; +https://flimsy.example/bot)",
+		});
+		expect(result.nextCalled).toBe(true);
+	});
+
+	it("allows empty UA — missing UA is not a high-confidence bot signal (could be a misconfigured legit client) so we err on the side of allow", () => {
+		const result = run({ ua: "" });
+		expect(result.nextCalled).toBe(true);
+		expect(result.status).toBeUndefined();
+	});
+
+	it("allows missing UA header — same reasoning as empty UA", () => {
+		const result = run({ ua: undefined });
+		expect(result.nextCalled).toBe(true);
+		expect(result.status).toBeUndefined();
+	});
+
+	it("blocks curl with 403 and logs one bot-block event", () => {
+		const result = run({ ua: "curl/7.88.1" });
+		expect(result.status).toBe(403);
+		expect(result.nextCalled).toBe(false);
+		expect(result.logged).toEqual([
+			{ stream: "bot-block", event: "blocked", path: "/", user_agent: "curl/7.88.1" },
+		]);
+	});
+
+	it("blocks Wget", () => {
+		expect(run({ ua: "Wget/1.21.3" }).status).toBe(403);
+	});
+
+	it("blocks libcurl", () => {
+		expect(run({ ua: "libcurl/7.88.0 mbedTLS/3.0.0" }).status).toBe(403);
+	});
+
+	it("blocks python-requests", () => {
+		expect(run({ ua: "python-requests/2.31.0" }).status).toBe(403);
+	});
+
+	it("blocks Python-urllib", () => {
+		expect(run({ ua: "Python-urllib/3.11" }).status).toBe(403);
+	});
+
+	it("blocks aiohttp", () => {
+		expect(run({ ua: "aiohttp/3.9.1" }).status).toBe(403);
+	});
+
+	it("blocks Go-http-client", () => {
+		expect(run({ ua: "Go-http-client/1.1" }).status).toBe(403);
+	});
+
+	it("blocks Java default UA", () => {
+		expect(run({ ua: "Java/17.0.2" }).status).toBe(403);
+	});
+
+	it("blocks okhttp", () => {
+		expect(run({ ua: "okhttp/4.10.0" }).status).toBe(403);
+	});
+
+	it("blocks Apache-HttpClient", () => {
+		expect(run({ ua: "Apache-HttpClient/4.5.13 (Java/11.0.16)" }).status).toBe(403);
+	});
+
+	it("blocks node-fetch", () => {
+		expect(run({ ua: "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" }).status).toBe(403);
+	});
+
+	it("blocks axios", () => {
+		expect(run({ ua: "axios/1.6.2" }).status).toBe(403);
+	});
+
+	it("blocks Ruby default", () => {
+		expect(run({ ua: "Ruby" }).status).toBe(403);
+	});
+
+	it("blocks Faraday", () => {
+		expect(run({ ua: "Faraday v2.7.10" }).status).toBe(403);
+	});
+
+	it("blocks PHP default", () => {
+		expect(run({ ua: "PHP/8.2.0" }).status).toBe(403);
+	});
+
+	it("blocks GuzzleHttp", () => {
+		expect(run({ ua: "GuzzleHttp/7.5.0 curl/7.81.0 PHP/8.1.0" }).status).toBe(403);
+	});
+
+	it("blocks Scrapy", () => {
+		expect(run({ ua: "Scrapy/2.11.0 (+https://scrapy.org)" }).status).toBe(403);
+	});
+
+	it("bypasses the block for /robots.txt so crawlers can always read the crawl policy", () => {
+		const result = run({ ua: "curl/7.88.1", path: "/robots.txt" });
+		expect(result.nextCalled).toBe(true);
+		expect(result.status).toBeUndefined();
+		expect(result.logged).toEqual([]);
+	});
+
+	it("bypasses the block for /sitemap.xml", () => {
+		expect(run({ ua: "curl/7.88.1", path: "/sitemap.xml" }).nextCalled).toBe(true);
+	});
+
+	it("bypasses the block for /llms.txt", () => {
+		expect(run({ ua: "curl/7.88.1", path: "/llms.txt" }).nextCalled).toBe(true);
+	});
+
+	it("bypasses the block for /llms-full.txt", () => {
+		expect(run({ ua: "curl/7.88.1", path: "/llms-full.txt" }).nextCalled).toBe(true);
+	});
+
+	it("bypasses the block for /favicon.ico", () => {
+		expect(run({ ua: "curl/7.88.1", path: "/favicon.ico" }).nextCalled).toBe(true);
+	});
+
+	it("truncates logged user_agent to 200 chars so a malicious 10KB UA cannot blow up the log line size", () => {
+		const longUa = `curl/${"x".repeat(500)}`;
+		const result = run({ ua: longUa });
+		expect(result.status).toBe(403);
+		expect(result.logged).toHaveLength(1);
+		expect(result.logged[0]?.user_agent.length).toBe(200);
+		expect(result.logged[0]?.user_agent.startsWith("curl/xxx")).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/middleware/naive-bot.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/naive-bot.test.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from "express";
+import type { Request, Response } from "express";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { type BotBlockEvent, createBlockNaiveBotMiddleware } from "./naive-bot";
 
@@ -10,13 +10,14 @@ interface RunResult {
 
 function run({ ua, path = "/" }: { ua?: string; path?: string }): RunResult {
 	let status: number | undefined;
+	let nextCalled = false;
 	const res = {
-		status: (code: number) => {
+		status(code: number) {
 			status = code;
 			return res;
 		},
-		end: jest.fn(),
-	} as unknown as Response;
+		end() {},
+	};
 
 	const headers: Record<string, string | undefined> = { "user-agent": ua };
 	const req = {
@@ -24,7 +25,7 @@ function run({ ua, path = "/" }: { ua?: string; path?: string }): RunResult {
 		get(name: string): string | undefined {
 			return headers[name.toLowerCase()];
 		},
-	} as unknown as Request;
+	};
 
 	const logged: BotBlockEvent[] = [];
 	const logger: HutchLogger.Typed<BotBlockEvent> = {
@@ -34,13 +35,9 @@ function run({ ua, path = "/" }: { ua?: string; path?: string }): RunResult {
 		debug: () => {},
 	};
 
-	const next = jest.fn() as unknown as NextFunction;
-	createBlockNaiveBotMiddleware({ logger })(req, res, next);
-	return {
-		status,
-		nextCalled: (next as jest.Mock).mock.calls.length > 0,
-		logged,
-	};
+	const next = () => { nextCalled = true; };
+	createBlockNaiveBotMiddleware({ logger })(req as Request, res as Response, next);
+	return { status, nextCalled, logged };
 }
 
 describe("createBlockNaiveBotMiddleware", () => {

--- a/projects/hutch/src/runtime/web/middleware/naive-bot.ts
+++ b/projects/hutch/src/runtime/web/middleware/naive-bot.ts
@@ -1,0 +1,72 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { HutchLogger } from "@packages/hutch-logger";
+
+export interface BotBlockEvent {
+	stream: "bot-block";
+	event: "blocked";
+	path: string;
+	user_agent: string;
+}
+
+/**
+ * Default User-Agent strings of common scripted HTTP clients. Each pattern must
+ * be unambiguous — no plausible browser or legitimate crawler shares it.
+ * Allow-listing legit crawlers is intentionally avoided: an unknown new crawler
+ * (e.g. a future search engine) should pass through, not be silently blocked.
+ */
+const NAIVE_BOT_UA_PATTERNS: readonly RegExp[] = [
+	/^curl\//i,
+	/^libcurl\//i,
+	/^Wget\//i,
+	/^python-requests\//i,
+	/^Python-urllib\//i,
+	/^aiohttp\//i,
+	/^Go-http-client\//i,
+	/^Java\//i,
+	/^okhttp\//i,
+	/^Apache-HttpClient\//i,
+	/^node-fetch\//i,
+	/^axios\//i,
+	/^Ruby\b/i,
+	/^Faraday\b/i,
+	/^PHP\//i,
+	/^GuzzleHttp\//i,
+	/^Scrapy\//i,
+];
+
+const BOT_BYPASS_PATHS: ReadonlySet<string> = new Set([
+	"/robots.txt",
+	"/sitemap.xml",
+	"/llms.txt",
+	"/llms-full.txt",
+	"/favicon.ico",
+]);
+
+const MAX_LOGGED_UA_LENGTH = 200;
+
+export function createBlockNaiveBotMiddleware(deps: {
+	logger: HutchLogger.Typed<BotBlockEvent>;
+}): RequestHandler {
+	return (req: Request, res: Response, next: NextFunction) => {
+		if (BOT_BYPASS_PATHS.has(req.path)) {
+			next();
+			return;
+		}
+		const ua = req.get("user-agent");
+		if (!ua) {
+			next();
+			return;
+		}
+		if (NAIVE_BOT_UA_PATTERNS.some((pattern) => pattern.test(ua))) {
+			deps.logger.info({
+				stream: "bot-block",
+				event: "blocked",
+				path: req.path,
+				user_agent: ua.slice(0, MAX_LOGGED_UA_LENGTH),
+			});
+			res.status(403).end();
+			return;
+		}
+		next();
+	};
+}

--- a/src/packages/test-fixtures/src/providers/auth/bot-defense.types.ts
+++ b/src/packages/test-fixtures/src/providers/auth/bot-defense.types.ts
@@ -10,6 +10,7 @@ export interface BotDefenseEvent {
 	reason: BotDefenseRejectReason;
 	timestamp: string;
 	ip?: string;
+	user_agent?: string;
 	email_domain?: string;
 	time_to_submit_ms?: number;
 }


### PR DESCRIPTION
## Summary

Adds an Express middleware that returns `403` to requests whose `User-Agent` matches a narrow block-list of default scripted-HTTP-client UAs (curl, wget, python-requests, Python-urllib, aiohttp, Go-http-client, Java, okhttp, Apache-HttpClient, node-fetch, axios, Ruby, Faraday, PHP, GuzzleHttp, Scrapy, libcurl).

- Real browsers, Googlebot, GPTBot, ClaudeBot, PerplexityBot, and any unknown-but-legit crawler (e.g. a future search engine we have never heard of) all pass through.
- This is a curated **block-list**, not an `isbot()` allow-list — the latter risks silently blocking a legitimate crawler we forgot to enumerate, which is worse than letting an extra scraper through.
- `/robots.txt`, `/sitemap.xml`, `/llms.txt`, `/llms-full.txt`, `/favicon.ico` bypass the check so every client can read the crawl policy.
- Empty/missing `User-Agent` is allowed (not a high-confidence bot signal).
- Each rejection emits one `{ stream: "bot-block", event: "blocked", path, user_agent }` info log (UA truncated to 200 chars).

## Why

Three production pains that share one root cause:

1. **Failed-checkout emails go to harvested addresses.** Bots that post `/signup` and start a Stripe checkout abandon, land in `pending_signups` with `paid === false`, and the checkout-recovery worker (`projects/hutch/src/runtime/domain/checkout-recovery/select-recipients.ts`) then emails them a "come back" reminder via Resend → spam complaints, Resend deliverability damage, PII pollution.
2. **The honeypot is a single fragile line of defense.** `validate-signup.ts` only catches bots that fill hidden fields or post too fast. Anything running headless Chrome trivially passes. Honeypot stays as belt-and-suspenders but stops being the *primary* defense.
3. **CloudWatch `readplace-analytics` utm_ widgets are polluted by bot traffic.** `analytics.ts:63` already does `if (isbot(...)) return false` — but that only *skips the log emission*; the request still hits the Lambda. Catching bots one middleware earlier means they never reach the pageview emitter at all, so utm_ widgets drop their bot tail.

### Why not WAF (despite the branch name)

AWS WAF cannot attach to API Gateway v2 HTTP APIs — only CloudFront, ALB, REST APIs, AppSync, Cognito, App Runner, Verified Access, Amplify. Adding WAF would require fronting API Gateway with a new CloudFront distribution, migrating apex DNS, rewriting real-client-IP handling to read `CloudFront-Viewer-Address`, and paying ~$8/mo baseline. The app-layer block-list is free and reverses cleanly if it ever needs to come out.

## Test plan

- [x] `pnpm nx run hutch:test-with-coverage` — 100% coverage on new file, all thresholds met
- [x] `pnpm nx run hutch:lint` — biome/knip/tsc clean
- [x] `pnpm nx run-many --target=check --all` (via pre-commit hook) — passes
- [ ] **Manual smoke (after deploy to prod):**
  - `curl -sS -o /dev/null -w "%{http_code}\n" https://readplace.com/` → expect `403`
  - `curl -sS -A "Mozilla/5.0 (compatible; Googlebot/2.1)" -o /dev/null -w "%{http_code}\n" https://readplace.com/` → expect `200`
  - `curl -sS -A "Mozilla/5.0 (compatible; GPTBot/1.2)" -o /dev/null -w "%{http_code}\n" https://readplace.com/` → expect `200`
  - `curl -sS -o /dev/null -w "%{http_code}\n" https://readplace.com/robots.txt` → expect `200`
  - Browser-load https://readplace.com/ → renders normally
- [ ] **Post-deploy observability:** CloudWatch Logs Insights against `/aws/lambda/hutch-handler`:
  ```
  fields @timestamp, user_agent | filter stream = "bot-block" | stats count(*) as blocks by user_agent | sort blocks desc | limit 20
  ```
  Confirms which UAs are being rejected; no legitimate UA should appear.
- [ ] Watch `readplace-analytics` "Pageviews by utm_source" widget over 24h — bot-tagged utm sources should drop.

## Out of scope (follow-ups)

- No CloudWatch metric filter on `stream = "bot-block"` yet. Easy to add to `projects/hutch/src/infra/index.ts` alongside `imports-completed-filter` if a dashboard widget is wanted.
- No removal of the honeypot / `loadedAt` / `submit_too_fast` checks — they stay as defense-in-depth against sophisticated bots that fake a Chrome UA.
- No infra changes (no CloudFront, no WAF, no Pulumi diff).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1FzncsxNhakWmEfKtzLro)_