### PR TITLE
perf(save-link): single-image PDF OCR chunks and same-key staged-PDF cache

### DIFF
--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -6,13 +6,15 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import type { InvokePdfPageOcr, StagePdfToS3 } from "./pdf-page-ocr-invoker.types";
 
 // Pages per page-Lambda invocation. Each Lambda downloads the staged PDF
-// once, rasterises this many pages, and sends them as a single multi-image
-// vision request. Multi-image batching amplifies DeepInfra TTFB — empirically
-// 5-image batches on math-heavy PDFs spend ≥120s waiting for first token,
-// so M is kept small. M=2 still halves S3 GET pressure and request count vs
-// M=1, without pushing per-chunk wall time past the OpenAI client's
-// per-attempt timeout budget.
-const DEFAULT_BATCH_SIZE = 2;
+// once, rasterises this many pages, and sends them as a single vision
+// request. Multi-image batching amplifies DeepInfra TTFB non-linearly:
+// 2-image chunks on yellowpaper-class content sit at 100-190s, while
+// the same pages as single-image calls land in ~25-76s. M=1 eliminates
+// that penalty at the cost of doubling S3 GETs and Lambda invokes — both
+// cheap compared to the OCR wall time we recover. The module-level
+// PDF cache in pdf-page-ocr.main.ts absorbs the extra GETs on warm
+// container reuse.
+const DEFAULT_BATCH_SIZE = 1;
 
 // In-flight page-Lambda invocations. Sized so the worst-case PDF
 // (`MAX_PDF_PAGES` pages, all in one wave at `DEFAULT_BATCH_SIZE` per chunk)

--- a/projects/save-link/src/runtime/pdf-page-ocr.main.ts
+++ b/projects/save-link/src/runtime/pdf-page-ocr.main.ts
@@ -6,26 +6,29 @@ import { requireEnv } from "../require-env";
 import { initPdfPageOcrHandler } from "./domain/pdf-page-ocr/pdf-page-ocr-handler";
 import { initCreateDeepInfraVisionMessage } from "./domain/article-parser/create-deepinfra-vision-message";
 import { initDownloadStagedPdf } from "./providers/pdf-page-ocr/init-download-staged-pdf";
+import { initLastPdfCache } from "./providers/pdf-page-ocr/init-last-pdf-cache";
 
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const deepInfraApiKey = requireEnv("DEEPINFRA_API_KEY");
 
 const s3Client = new S3Client({});
 
-// Per-attempt timeout sized for DeepInfra TTFB on multi-image dense-math
-// pages — empirically the first-token wait can sit at 100-200s under load,
-// so 120s was too aggressive (exhausted all retries, no successful response).
-// 240s gives each attempt real room. Budget: 2 attempts × 240s = 480s,
-// leaving 120s headroom under the 600s Lambda timeout for S3 download +
-// pdftoppm + final stitching.
+// Per-attempt timeout sized for DeepInfra single-image TTFB. With M=1 (see
+// DEFAULT_BATCH_SIZE in ocr-pdf.ts) observed P99 latency on the densest
+// pages we've seen — yellowpaper-class math — sits at ~80s. 90s gives
+// ~10s of headroom over P99 without slack. Three attempts × 90s = 270s
+// leaves ~330s under the 600s Lambda timeout for S3 download, pdftoppm,
+// and stitching, and absorbs DeepInfra 429s without exhausting the budget
+// on a single slow attempt.
 const deepInfraClient = new OpenAI({
 	apiKey: deepInfraApiKey,
 	baseURL: "https://api.deepinfra.com/v1/openai",
-	timeout: 240_000,
-	maxRetries: 1,
+	timeout: 90_000,
+	maxRetries: 2,
 });
 
-const { downloadStagedPdf } = initDownloadStagedPdf({ client: s3Client, bucketName: contentBucketName });
+const baseDownload = initDownloadStagedPdf({ client: s3Client, bucketName: contentBucketName });
+const { downloadStagedPdf } = initLastPdfCache({ downloadStagedPdf: baseDownload.downloadStagedPdf });
 const createVisionMessage = initCreateDeepInfraVisionMessage({
 	createChatCompletion: (params) => deepInfraClient.chat.completions.create(params),
 });

--- a/projects/save-link/src/runtime/providers/pdf-page-ocr/init-last-pdf-cache.test.ts
+++ b/projects/save-link/src/runtime/providers/pdf-page-ocr/init-last-pdf-cache.test.ts
@@ -1,0 +1,72 @@
+import { initLastPdfCache } from "./init-last-pdf-cache";
+
+describe("initLastPdfCache", () => {
+	it("returns the underlying download on a cold call", async () => {
+		const calls: string[] = [];
+		const { downloadStagedPdf } = initLastPdfCache({
+			downloadStagedPdf: async ({ key }) => {
+				calls.push(key);
+				return Buffer.from(`pdf:${key}`);
+			},
+		});
+
+		const buf = await downloadStagedPdf({ key: "pdf-rasterise-staging/abc/source.pdf" });
+
+		expect(buf.toString()).toBe("pdf:pdf-rasterise-staging/abc/source.pdf");
+		expect(calls).toEqual(["pdf-rasterise-staging/abc/source.pdf"]);
+	});
+
+	it("returns the cached buffer without calling the underlying download on a same-key re-read", async () => {
+		const calls: string[] = [];
+		const { downloadStagedPdf } = initLastPdfCache({
+			downloadStagedPdf: async ({ key }) => {
+				calls.push(key);
+				return Buffer.from(`pdf:${key}`);
+			},
+		});
+
+		const first = await downloadStagedPdf({ key: "pdf-rasterise-staging/abc/source.pdf" });
+		const second = await downloadStagedPdf({ key: "pdf-rasterise-staging/abc/source.pdf" });
+
+		expect(first.equals(second)).toBe(true);
+		expect(first).toBe(second);
+		expect(calls).toEqual(["pdf-rasterise-staging/abc/source.pdf"]);
+	});
+
+	it("evicts the previous entry and re-downloads when the key changes", async () => {
+		const calls: string[] = [];
+		const { downloadStagedPdf } = initLastPdfCache({
+			downloadStagedPdf: async ({ key }) => {
+				calls.push(key);
+				return Buffer.from(`pdf:${key}`);
+			},
+		});
+
+		await downloadStagedPdf({ key: "pdf-rasterise-staging/abc/source.pdf" });
+		await downloadStagedPdf({ key: "pdf-rasterise-staging/xyz/source.pdf" });
+		await downloadStagedPdf({ key: "pdf-rasterise-staging/abc/source.pdf" });
+
+		expect(calls).toEqual([
+			"pdf-rasterise-staging/abc/source.pdf",
+			"pdf-rasterise-staging/xyz/source.pdf",
+			"pdf-rasterise-staging/abc/source.pdf",
+		]);
+	});
+
+	it("does not cache a failed underlying download — the next call re-issues", async () => {
+		let attempt = 0;
+		const { downloadStagedPdf } = initLastPdfCache({
+			downloadStagedPdf: async ({ key }) => {
+				attempt += 1;
+				if (attempt === 1) throw new Error("S3 transient");
+				return Buffer.from(`pdf:${key}`);
+			},
+		});
+
+		await expect(downloadStagedPdf({ key: "k" })).rejects.toThrow("S3 transient");
+		const buf = await downloadStagedPdf({ key: "k" });
+
+		expect(buf.toString()).toBe("pdf:k");
+		expect(attempt).toBe(2);
+	});
+});

--- a/projects/save-link/src/runtime/providers/pdf-page-ocr/init-last-pdf-cache.ts
+++ b/projects/save-link/src/runtime/providers/pdf-page-ocr/init-last-pdf-cache.ts
@@ -1,0 +1,25 @@
+import type { DownloadStagedPdf } from "../../domain/pdf-page-ocr/pdf-page-ocr-handler.types";
+
+/**
+ * Wraps a `DownloadStagedPdf` with a single-slot cache keyed by S3 key.
+ * Lambda execution environments are reused across invocations, so chunks
+ * of the same PDF that land on the same warm container avoid re-issuing
+ * a GetObject for the (multi-MB) staged PDF. A new key replaces the
+ * cached entry; GC reclaims the previous buffer on assignment. No LRU,
+ * no /tmp, no eviction signals — the container itself bounds lifetime.
+ */
+export function initLastPdfCache(deps: {
+	downloadStagedPdf: DownloadStagedPdf;
+}): { downloadStagedPdf: DownloadStagedPdf } {
+	const { downloadStagedPdf: underlying } = deps;
+	let cached: { key: string; buffer: Buffer } | undefined;
+
+	const downloadStagedPdf: DownloadStagedPdf = async ({ key }) => {
+		if (cached?.key === key) return cached.buffer;
+		const buffer = await underlying({ key });
+		cached = { key, buffer };
+		return buffer;
+	};
+
+	return { downloadStagedPdf };
+}


### PR DESCRIPTION
## Summary

Optimises the PDF OCR pipeline for the "every PDF in roughly 30s" goal at the existing `DEFAULT_CONCURRENCY=150` ceiling.

- **`DEFAULT_BATCH_SIZE: 2 → 1`** in `ocr-pdf.ts`. DeepInfra's multi-image TTFB scales non-linearly: 2-image chunks on yellowpaper-class content sit at 100–190 s, while the same pages as single-image calls land in ~25–76 s. M=1 eliminates the penalty at the cost of doubling S3 GETs and Lambda invokes — both cheap relative to the OCR wall time recovered.
- **OpenAI client retuned** in `pdf-page-ocr.main.ts`: `timeout 240 s → 90 s`, `maxRetries 1 → 2`. 90 s covers observed P99 single-image latency on dense-math pages with ~10 s headroom; 3 attempts × 90 s = 270 s absorbs DeepInfra 429s without exhausting the 600 s Lambda budget.
- **`initLastPdfCache`** (new, in `providers/pdf-page-ocr/`): single-slot key cache wrapping `downloadStagedPdf`. Lambda execution environments are reused; chunks of the same PDF landing on the same warm container skip the S3 GET of the multi-MB staged PDF. New key replaces the cached entry; GC reclaims the previous buffer on assignment.

`DEFAULT_CONCURRENCY = 150` is unchanged.

### Predicted wall-time impact (vs the table in the plan)

| Pages | Today (M=2, C=150) | After (M=1, C=150) |
| --- | --- | --- |
| 3 (sample-local-pdf) | 54 s | ~30–40 s |
| 42 (yellowpaper) | 190 s | ~30–50 s (single wave) |
| 212 (mythical-man-month) | 166 s | ~60–100 s (two waves) |

### Deliberately deferred

- **JPEG output from `pdftoppm`.** The plan called for a live DeepInfra probe against `google/gemma-4-31B-it` with a `data:image/jpeg;base64,...` payload before flipping the format. That probe can't run from this sandbox, so the PNG path is unchanged here. Worth a follow-up.

## Test plan

- [x] `pnpm nx run save-link:lint` — clean
- [x] `pnpm test` — 344/344 pass (including new `initLastPdfCache` suite: cold call, warm same-key reuse, key-change eviction, no-cache-on-failure)
- [x] `pnpm test-with-coverage` — 100% statements / branches / functions / lines across all 78 files (incl. the new `init-last-pdf-cache.ts`)
- [x] `pnpm nx run save-link:check` — all 12 dependent tasks pass
- [x] Pre-commit hook (`nx run-many --target=check --all`, 21 projects, 23 dependent tasks) — pass
- [ ] After merge: `pnpm check-infra` to confirm the page Lambda's `imageUri` bumps (constants and OpenAI client wrapper change the bundle hash); `pnpm deploy-infra`; recrawl the three reference PDFs from the plan and compare `[ocr-pdf] chunk … dt=Nms` log lines against the predicted table; if any yellowpaper-class chunk exceeds 80 s in practice, bump the 90 s OpenAI timeout to 120 s.

https://claude.ai/code/session_01Wfpe1ffWF7yDGZB267jD9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wfpe1ffWF7yDGZB267jD9b)_