### PR TITLE
feat(@packages/crawl-article,save-link): add residential-proxy persona for IP-blocked origins

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -129,9 +129,10 @@ const contentMediaCdn = new HutchS3ContentMediaCDN("content-media", {
 const deepseekApiKey = pulumi.secret(requireEnv("DEEPSEEK_API_KEY"));
 const deepInfraApiKey = pulumi.secret(requireEnv("DEEPINFRA_API_KEY"));
 /**
- * Residential-proxy egress URL (Bright Data PAYG zone) consumed by the
- * crawler when the in-AWS direct egress hits an IP-class block. Same
- * GitHub-Actions-secret → requireEnv pattern as DEEPINFRA_API_KEY. Empty
+ * Residential-proxy egress URL (any HTTP(S) residential proxy — current
+ * provider: Webshare Rotating Residential, `http://USER:PASS@p.webshare.io:80`)
+ * consumed by the crawler when the in-AWS direct egress hits an IP-class block.
+ * Same GitHub-Actions-secret → requireEnv pattern as DEEPINFRA_API_KEY. Empty
  * value disables the residential-proxy persona at runtime (the runtime's
  * `getEnv` returns undefined for empty strings).
  */

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -128,6 +128,14 @@ const contentMediaCdn = new HutchS3ContentMediaCDN("content-media", {
 
 const deepseekApiKey = pulumi.secret(requireEnv("DEEPSEEK_API_KEY"));
 const deepInfraApiKey = pulumi.secret(requireEnv("DEEPINFRA_API_KEY"));
+/**
+ * Residential-proxy egress URL (Bright Data PAYG zone) consumed by the
+ * crawler when the in-AWS direct egress hits an IP-class block. Same
+ * GitHub-Actions-secret → requireEnv pattern as DEEPINFRA_API_KEY. Empty
+ * value disables the residential-proxy persona at runtime (the runtime's
+ * `getEnv` returns undefined for empty strings).
+ */
+const residentialProxyUrl = pulumi.secret(requireEnv("RESIDENTIAL_PROXY_URL"));
 
 const eventBus = HutchEventBus.fromPlatformStack(config);
 
@@ -217,6 +225,7 @@ const saveLinkCommandLambda = new HutchLambda("save-link-command", {
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		RESIDENTIAL_PROXY_URL: residentialProxyUrl,
 	},
 	policies: [
 		...saveLinkCommandDynamodb.policies,
@@ -274,6 +283,7 @@ const saveLinkRawHtmlCommandLambda = new HutchLambda("save-link-raw-html-command
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		RESIDENTIAL_PROXY_URL: residentialProxyUrl,
 	},
 	policies: [
 		...saveLinkRawHtmlCommandDynamodb.policies,
@@ -332,6 +342,7 @@ const saveAnonymousLinkCommandLambda = new HutchLambda("save-anonymous-link-comm
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		RESIDENTIAL_PROXY_URL: residentialProxyUrl,
 	},
 	policies: [
 		...saveAnonymousLinkCommandDynamodb.policies,
@@ -526,6 +537,7 @@ const comprehensiveCrawlCommandLambda = new HutchLambda("comprehensive-crawl-com
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 		PDF_PAGE_OCR_FUNCTION_NAME: pdfPageOcrLambda.functionName,
+		RESIDENTIAL_PROXY_URL: residentialProxyUrl,
 	},
 	policies: [
 		...comprehensiveCrawlCommandDynamodb.policies,
@@ -599,6 +611,7 @@ const staleCheckRequestedLambda = new HutchLambda("stale-check-requested", {
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
 		PENDING_HTML_BUCKET_NAME: pendingHtmlBucketName,
+		RESIDENTIAL_PROXY_URL: residentialProxyUrl,
 	},
 	policies: [
 		...staleCheckRequestedDynamodb.policies,
@@ -832,6 +845,7 @@ const recrawlLinkInitiatedLambda = new HutchLambda("recrawl-link-initiated", {
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,
 		GENERATE_SUMMARY_QUEUE_URL: generateSummaryQueue.queueUrl,
+		RESIDENTIAL_PROXY_URL: residentialProxyUrl,
 	},
 	policies: [
 		...recrawlLinkInitiatedDynamodb.policies,

--- a/projects/save-link/src/runtime/dep-bundles/parser.ts
+++ b/projects/save-link/src/runtime/dep-bundles/parser.ts
@@ -10,6 +10,7 @@ import {
 	initCrawlFetch,
 	initSimpleCrawl,
 	CRAWL_PERSONAS,
+	appendResidentialProxyPersona,
 } from "@packages/crawl-article";
 import {
 	initReadabilityParser,
@@ -17,6 +18,7 @@ import {
 	theInformationPreParser,
 } from "@packages/article-parser";
 import type { ParseHtml } from "@packages/article-parser";
+import { getEnv } from "../../require-env";
 import type { LogError } from "./observability";
 
 export type ParserDepBundle = {
@@ -38,7 +40,7 @@ export function initParserDepBundle(deps: {
 }): ParserDepBundle {
 	const crawlFetch = initCrawlFetch({
 		fetch: globalThis.fetch,
-		personas: CRAWL_PERSONAS,
+		personas: appendResidentialProxyPersona(CRAWL_PERSONAS, getEnv("RESIDENTIAL_PROXY_URL")),
 	});
 	const simpleCrawl = initSimpleCrawl({ crawlFetch, logError: deps.logError });
 	const { parseHtml } = initReadabilityParser({
@@ -72,7 +74,7 @@ export function initComprehensiveParserDepBundle(deps: {
 }): ComprehensiveParserDepBundle {
 	const crawlFetch = initCrawlFetch({
 		fetch: globalThis.fetch,
-		personas: CRAWL_PERSONAS,
+		personas: appendResidentialProxyPersona(CRAWL_PERSONAS, getEnv("RESIDENTIAL_PROXY_URL")),
 	});
 	const simpleCrawl = initSimpleCrawl({ crawlFetch, logError: deps.logError });
 	const comprehensiveCrawl = initComprehensiveCrawl({

--- a/src/packages/crawl-article/scripts/health-sources.ts
+++ b/src/packages/crawl-article/scripts/health-sources.ts
@@ -192,7 +192,7 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		// after both free personas fail and egresses via a non-AWS IP, which
 		// Akamai treats as a real browser. If this entry fails, the
 		// residential-proxy persona is broken (missing env var, proxy
-		// credentials rotated, Bright Data zone disabled) — fix the proxy, do
+		// credentials rotated, Webshare account suspended / quota exhausted) — fix the proxy, do
 		// not delete the entry.
 		label: "PDF (USDA via Akamai — AWS-IP gated)",
 		url: "https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf",

--- a/src/packages/crawl-article/scripts/health-sources.ts
+++ b/src/packages/crawl-article/scripts/health-sources.ts
@@ -185,14 +185,35 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		expectedContent: "Attention Is All You Need",
 		expectsThumbnail: false,
 	},
-	// USDA (https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf) is
-	// fronted by Akamai BotManager, which RSTs HTTP/2 streams from AWS-range
-	// IPs regardless of HTTP-header persona (confirmed via prod Lambda logs
-	// after CRAWL_PERSONAS landed: both `default-browser` and `honest-bot`
-	// produced curl exit 92 INTERNAL_ERROR). The same default-browser persona
-	// returns 200 from a residential IP. Re-adding this entry requires a
-	// non-AWS egress path (residential proxy as a third persona, or
-	// equivalent) — not a new HTTP-header variation.
+	{
+		// Akamai BotManager RSTs HTTP/2 streams from AWS-range IPs regardless of
+		// HTTP-header persona — both `default-browser` and `honest-bot` get a
+		// curl exit 92 INTERNAL_ERROR. The `residential-proxy` persona engages
+		// after both free personas fail and egresses via a non-AWS IP, which
+		// Akamai treats as a real browser. If this entry fails, the
+		// residential-proxy persona is broken (missing env var, proxy
+		// credentials rotated, Bright Data zone disabled) — fix the proxy, do
+		// not delete the entry.
+		label: "PDF (USDA via Akamai — AWS-IP gated)",
+		url: "https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf",
+		expectedContent: "Dummy PDF",
+		expectsThumbnail: false,
+	},
+	{
+		// CIA reading-room's edge 302-loops back to /readingroom for AWS-range
+		// source IPs, producing curl exit 47 ("Maximum (5) redirects followed").
+		// Same headers + curl args succeed from a residential IP, which is what
+		// the `residential-proxy` persona routes through. Exercises a different
+		// IP-class signature than USDA (302 redirect-loop vs. h2 RST_STREAM) AND
+		// keeps `--globoff` + WHATWG URL re-encoding under canary coverage via
+		// the bracketed path segment `[16505689]`. expectedContent anchors on a
+		// phrase from the dossier body (the Kennedy assassination commission
+		// report, despite the misleading filename) that survives OCR.
+		label: "PDF (CIA reading room — AWS-IP gated + bracketed URL)",
+		url: "https://www.cia.gov/readingroom/docs/COMPUTERS%20AND%20AUTOMATION%20[16505689].pdf",
+		expectedContent: "Warren Commission",
+		expectsThumbnail: false,
+	},
 	{
 		// Adobe-class fingerprint-strict origin. Sent today's partial Chrome
 		// headers and Adobe's edge RSTs the h2 stream (curl exit 92,

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -961,7 +961,7 @@ describe("appendResidentialProxyPersona", () => {
 	});
 
 	it("appends a residential-proxy persona at the end when proxyUrl is set", () => {
-		const proxyUrl = "http://user:pass@brd.superproxy.io:22225";
+		const proxyUrl = "http://user:pass@p.webshare.io:80";
 		const result = appendResidentialProxyPersona(CRAWL_PERSONAS, proxyUrl);
 		expect(result).toHaveLength(CRAWL_PERSONAS.length + 1);
 		const last = result[result.length - 1];

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert";
 import {
+	appendResidentialProxyPersona,
+	CRAWL_PERSONAS,
 	initComprehensiveCrawl,
 	initCrawlArticle,
 	initSimpleCrawl,
@@ -949,5 +951,35 @@ describe("initCrawlArticle — composed (simple ▸ comprehensive)", () => {
 
 		expect(result).toEqual({ status: "unsupported", reason: "non-pdf content type: application/json" });
 		expect(extractPdf).not.toHaveBeenCalled();
+	});
+});
+
+describe("appendResidentialProxyPersona", () => {
+	it("returns the persona list unchanged when proxyUrl is undefined", () => {
+		const result = appendResidentialProxyPersona(CRAWL_PERSONAS, undefined);
+		expect(result).toBe(CRAWL_PERSONAS);
+	});
+
+	it("appends a residential-proxy persona at the end when proxyUrl is set", () => {
+		const proxyUrl = "http://user:pass@brd.superproxy.io:22225";
+		const result = appendResidentialProxyPersona(CRAWL_PERSONAS, proxyUrl);
+		expect(result).toHaveLength(CRAWL_PERSONAS.length + 1);
+		const last = result[result.length - 1];
+		expect(last.name).toBe("residential-proxy");
+		expect(last.proxy).toBe(proxyUrl);
+	});
+
+	it("gives the proxy persona browser-shaped headers (Sec-Fetch-* + sec-ch-ua-*)", () => {
+		const result = appendResidentialProxyPersona(CRAWL_PERSONAS, "http://proxy:22225");
+		const proxyPersona = result[result.length - 1];
+		expect(proxyPersona.headers["user-agent"]).toContain("Chrome");
+		expect(proxyPersona.headers["sec-fetch-dest"]).toBe("document");
+		expect(proxyPersona.headers["sec-ch-ua-platform"]).toBe('"macOS"');
+	});
+
+	it("keeps the existing personas in their original order — proxy is appended, not inserted", () => {
+		const result = appendResidentialProxyPersona(CRAWL_PERSONAS, "http://proxy:22225");
+		expect(result[0].name).toBe(CRAWL_PERSONAS[0].name);
+		expect(result[1].name).toBe(CRAWL_PERSONAS[1].name);
 	});
 });

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -13,6 +13,7 @@ import { headerOrUndefined } from "./header-utils";
 import { isPdfContentType, isPdfMagicBytes } from "./pdf-detect";
 import { MAX_PDF_BYTES } from "./pdf-page-limits";
 import type { ExtractPdf } from "./pdf-extract.types";
+import type { Persona } from "./persona-fallback";
 import { initFetchTweetViaOembed, isTweetUrl } from "./x-twitter-preprocessor";
 
 const FETCH_TIMEOUT_MS = 10000;
@@ -32,6 +33,25 @@ export const DEFAULT_CRAWL_HEADERS = {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
 	accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 	"accept-language": "en-US,en;q=0.9",
+} as const;
+
+/**
+ * Coherent "real Chrome navigating to a document" header set. Reused by the
+ * `default-browser` persona and (when an egress proxy is configured) the
+ * `residential-proxy` persona — both want the same browser-shaped fingerprint,
+ * they differ only in the outbound IP.
+ */
+const BROWSER_PERSONA_HEADERS = {
+	...DEFAULT_CRAWL_HEADERS,
+	"sec-ch-ua":
+		'"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
+	"sec-ch-ua-mobile": "?0",
+	"sec-ch-ua-platform": '"macOS"',
+	"sec-fetch-dest": "document",
+	"sec-fetch-mode": "navigate",
+	"sec-fetch-site": "none",
+	"sec-fetch-user": "?1",
+	"upgrade-insecure-requests": "1",
 } as const;
 
 /**
@@ -56,22 +76,15 @@ export const DEFAULT_CRAWL_HEADERS = {
  *    origins that explicitly allow disclosed bots and reject any browser-
  *    shaped client they can't fingerprint (verified: Adobe accepts this;
  *    default-curl UA also works but ReadplaceBot is the polite-bot signal).
+ *
+ * Optional 3rd persona (`residential-proxy`) is appended at the composition
+ * root via `appendResidentialProxyPersona` when the runtime is configured
+ * with an egress proxy URL — see that helper for the IP-class-block rationale.
  */
 export const CRAWL_PERSONAS = [
 	{
 		name: "default-browser",
-		headers: {
-			...DEFAULT_CRAWL_HEADERS,
-			"sec-ch-ua":
-				'"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
-			"sec-ch-ua-mobile": "?0",
-			"sec-ch-ua-platform": '"macOS"',
-			"sec-fetch-dest": "document",
-			"sec-fetch-mode": "navigate",
-			"sec-fetch-site": "none",
-			"sec-fetch-user": "?1",
-			"upgrade-insecure-requests": "1",
-		},
+		headers: BROWSER_PERSONA_HEADERS,
 	},
 	{
 		name: "honest-bot",
@@ -82,6 +95,34 @@ export const CRAWL_PERSONAS = [
 		},
 	},
 ] as const;
+
+/**
+ * Returns `personas` with a `residential-proxy` persona appended when
+ * `proxyUrl` is set; otherwise returns `personas` unchanged. The proxy
+ * persona always lands LAST so the free direct-egress attempts run first —
+ * each blocked URL costs at most one residential-proxy request.
+ *
+ * Why a separate persona rather than wiring the proxy into every persona:
+ * the free personas are the bulk of traffic (Wikipedia, Medium, …) and must
+ * stay on direct egress to avoid bandwidth spend on the working majority.
+ * The residential-proxy persona engages only when the prior personas hit a
+ * block-class outcome (403/406/451, h2 RST_STREAM, curl exit 47 redirect
+ * loop, …) — the persona-fallback wrapper enforces that ordering.
+ */
+export function appendResidentialProxyPersona(
+	personas: ReadonlyArray<Persona>,
+	proxyUrl: string | undefined,
+): ReadonlyArray<Persona> {
+	if (!proxyUrl) return personas;
+	return [
+		...personas,
+		{
+			name: "residential-proxy",
+			headers: BROWSER_PERSONA_HEADERS,
+			proxy: proxyUrl,
+		},
+	];
+}
 
 function initConditionalFetch(deps: {
 	crawlFetch: CrawlFetch;

--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -152,6 +152,23 @@ describe("fetchCurl argument construction", () => {
 		);
 	});
 
+	it("appends --proxy <url> when init.proxy is set", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await fetchCurl("https://example.com", { proxy: "http://user:pass@brd.superproxy.io:22225" });
+		const args = fake.calls[0].args;
+		const proxyIdx = args.indexOf("--proxy");
+		expect(proxyIdx).toBeGreaterThan(0);
+		expect(args[proxyIdx + 1]).toBe("http://user:pass@brd.superproxy.io:22225");
+	});
+
+	it("omits --proxy when init.proxy is not set", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
+		await fetchCurl("https://example.com");
+		expect(fake.calls[0].args).not.toContain("--proxy");
+	});
+
 	it("title-cases header names per Cloudflare JA3 fingerprinting", async () => {
 		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
 		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });

--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -155,11 +155,11 @@ describe("fetchCurl argument construction", () => {
 	it("appends --proxy <url> when init.proxy is set", async () => {
 		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
 		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl });
-		await fetchCurl("https://example.com", { proxy: "http://user:pass@brd.superproxy.io:22225" });
+		await fetchCurl("https://example.com", { proxy: "http://user:pass@p.webshare.io:80" });
 		const args = fake.calls[0].args;
 		const proxyIdx = args.indexOf("--proxy");
 		expect(proxyIdx).toBeGreaterThan(0);
-		expect(args[proxyIdx + 1]).toBe("http://user:pass@brd.superproxy.io:22225");
+		expect(args[proxyIdx + 1]).toBe("http://user:pass@p.webshare.io:80");
 	});
 
 	it("omits --proxy when init.proxy is not set", async () => {

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -7,6 +7,12 @@ const DEFAULT_TIMEOUT_MS = 10000;
 type CurlFetchInit = {
 	headers?: Record<string, string>;
 	signal?: AbortSignal;
+	/**
+	 * Optional egress proxy URL. When set, `--proxy <url>` is added to the
+	 * curl argv so the request egresses via that proxy (e.g. a residential
+	 * IP) instead of the host's outbound address.
+	 */
+	proxy?: string;
 };
 
 type CurlChild = {
@@ -53,7 +59,7 @@ export function createCurlFetch(deps: { execCurl: ExecCurl }): CurlFetch {
 	const { execCurl } = deps;
 	return function fetchCurl(url, init) {
 		return new Promise((resolve, reject) => {
-			const args = buildCurlArgs({ url, headers: init?.headers });
+			const args = buildCurlArgs({ url, headers: init?.headers, proxy: init?.proxy });
 			const timeoutMs = init?.signal ? undefined : DEFAULT_TIMEOUT_MS;
 			const child = execCurl(args, { timeoutMs }, (error, stdout) => {
 				if (error) {
@@ -83,7 +89,7 @@ export function createCurlFetch(deps: { execCurl: ExecCurl }): CurlFetch {
 
 export const fetchCurl: CurlFetch = createCurlFetch({ execCurl: defaultExecCurl });
 
-function buildCurlArgs(params: { url: string; headers?: Record<string, string> }): string[] {
+function buildCurlArgs(params: { url: string; headers?: Record<string, string>; proxy?: string }): string[] {
 	const args = [
 		"--http2",
 		// Disable curl's URL globbing so `[…]` and `{…}` in real URLs (e.g.
@@ -102,6 +108,9 @@ function buildCurlArgs(params: { url: string; headers?: Record<string, string> }
 		"-",
 		"--compressed",
 	];
+	if (params.proxy) {
+		args.push("--proxy", params.proxy);
+	}
 	if (params.headers) {
 		for (const [key, value] of Object.entries(params.headers)) {
 			args.push("--header", `${toTitleCase(key)}: ${value}`);

--- a/src/packages/crawl-article/src/h2-fetch.test.ts
+++ b/src/packages/crawl-article/src/h2-fetch.test.ts
@@ -532,6 +532,31 @@ describe("withH2Fallback", () => {
 		});
 	});
 
+	it("short-circuits to curl with --proxy when init carries a proxy, skipping baseFetch and h2", async () => {
+		const baseFetch = jest.fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>();
+		const h2Impl = jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>();
+		const curlImpl = jest.fn<ReturnType<typeof fetchCurl>, Parameters<typeof fetchCurl>>(async () =>
+			new Response("<html>via-proxy</html>", { status: 200, headers: { "content-type": "text/html" } }),
+		);
+		const wrapped = withH2Fallback(baseFetch, h2Impl, curlImpl);
+
+		const response = await wrapped("https://example.com/page", {
+			headers: { "user-agent": "Test/1.0" },
+			proxy: "http://user:pass@proxy.example:22225",
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<html>via-proxy</html>");
+		expect(baseFetch).not.toHaveBeenCalled();
+		expect(h2Impl).not.toHaveBeenCalled();
+		expect(curlImpl).toHaveBeenCalledTimes(1);
+		expect(curlImpl).toHaveBeenCalledWith("https://example.com/page", {
+			headers: { "user-agent": "Test/1.0" },
+			signal: undefined,
+			proxy: "http://user:pass@proxy.example:22225",
+		});
+	});
+
 	it("succeeds via h2 when baseFetch throws (e.g. Akamai RST_STREAM) and h2 bypasses the block", async () => {
 		const rstError = new Error("INTERNAL_ERROR: HTTP/2 stream closed");
 		const baseFetch: typeof fetch = async () => {

--- a/src/packages/crawl-article/src/h2-fetch.ts
+++ b/src/packages/crawl-article/src/h2-fetch.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import http2 from "node:http2";
 import { fetchCurl } from "./curl-fetch";
+import type { PersonaFetch } from "./persona-fallback";
 
 const MAX_REDIRECTS = 5;
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
@@ -127,8 +128,20 @@ export function withH2Fallback(
 	baseFetch: typeof fetch,
 	h2FetchImpl: typeof fetchH2 = fetchH2,
 	curlFetchImpl: typeof fetchCurl = fetchCurl,
-): typeof fetch {
+): PersonaFetch {
 	return async (input, init) => {
+		// Persona carries a proxy: skip baseFetch and h2 (neither honours it
+		// and the proxy persona is reserved for IP-class blocks where direct
+		// egress is the failing path). Curl is the only transport that
+		// threads `--proxy`, so route straight there.
+		if (init?.proxy) {
+			const url = urlFromInput(input);
+			return curlFetchImpl(url, {
+				headers: toPlainHeaders(init.headers),
+				signal: init.signal ?? undefined,
+				proxy: init.proxy,
+			});
+		}
 		let response: Response;
 		try {
 			response = await baseFetch(input, init);

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -5,6 +5,7 @@ export {
 	initComprehensiveCrawl,
 	DEFAULT_CRAWL_HEADERS,
 	CRAWL_PERSONAS,
+	appendResidentialProxyPersona,
 } from "./crawl-article";
 export type { Persona } from "./persona-fallback";
 export { extensionFromContentType } from "./extension-from-content-type";

--- a/src/packages/crawl-article/src/persona-fallback.test.ts
+++ b/src/packages/crawl-article/src/persona-fallback.test.ts
@@ -200,13 +200,13 @@ describe("withPersonaFallback", () => {
 		const proxyPersona: Persona = {
 			name: "with-proxy",
 			headers: { "user-agent": "Test/1.0" },
-			proxy: "http://user:pass@brd.superproxy.io:22225",
+			proxy: "http://user:pass@p.webshare.io:80",
 		};
 		const wrapped = withPersonaFallback(inner as typeof fetch, [proxyPersona]);
 
 		await wrapped("https://example.com");
 
-		expect(captured[0].proxy).toBe("http://user:pass@brd.superproxy.io:22225");
+		expect(captured[0].proxy).toBe("http://user:pass@p.webshare.io:80");
 	});
 
 	it("omits proxy from the inner init for personas that don't carry one", async () => {

--- a/src/packages/crawl-article/src/persona-fallback.test.ts
+++ b/src/packages/crawl-article/src/persona-fallback.test.ts
@@ -31,6 +31,8 @@ describe("isBlockClassError", () => {
 		"NGHTTP2_INTERNAL_ERROR",
 		"ERR_HTTP2_STREAM_ERROR: RST_STREAM",
 		"ERR_HTTP2_PROTOCOL_ERROR",
+		"fetchCurl failed for https://example.com: curl: (47) Maximum (5) redirects followed",
+		"undici fetch failed: max_redirects exceeded",
 	])("treats %j as block-class error", (message) => {
 		expect(isBlockClassError(new Error(message))).toBe(true);
 	});
@@ -187,5 +189,59 @@ describe("withPersonaFallback", () => {
 
 		expect(captured[0].input).toBe("https://example.com/path");
 		expect(captured[0].signal).toBe(controller.signal);
+	});
+
+	it("threads persona.proxy through to the inner fetch init", async () => {
+		const captured: { proxy: string | undefined }[] = [];
+		const inner = async (_input: unknown, init?: { proxy?: string }) => {
+			captured.push({ proxy: init?.proxy });
+			return new Response("ok", { status: 200 });
+		};
+		const proxyPersona: Persona = {
+			name: "with-proxy",
+			headers: { "user-agent": "Test/1.0" },
+			proxy: "http://user:pass@brd.superproxy.io:22225",
+		};
+		const wrapped = withPersonaFallback(inner as typeof fetch, [proxyPersona]);
+
+		await wrapped("https://example.com");
+
+		expect(captured[0].proxy).toBe("http://user:pass@brd.superproxy.io:22225");
+	});
+
+	it("omits proxy from the inner init for personas that don't carry one", async () => {
+		const captured: { hasProxyKey: boolean; proxy: unknown }[] = [];
+		const inner = async (_input: unknown, init?: Record<string, unknown>) => {
+			captured.push({ hasProxyKey: init !== undefined && "proxy" in init, proxy: init?.proxy });
+			return new Response("ok", { status: 200 });
+		};
+		const wrapped = withPersonaFallback(inner as typeof fetch, [personaPrimary]);
+
+		await wrapped("https://example.com");
+
+		expect(captured[0].hasProxyKey).toBe(false);
+		expect(captured[0].proxy).toBeUndefined();
+	});
+
+	it("advances to a proxy-bearing persona after a free persona returns block-class, and the proxy reaches the inner init", async () => {
+		const captured: { proxy: string | undefined }[] = [];
+		const inner = async (_input: unknown, init?: { proxy?: string }) => {
+			captured.push({ proxy: init?.proxy });
+			if (captured.length === 1) return new Response("blocked", { status: 403 });
+			return new Response("ok", { status: 200 });
+		};
+		const proxyPersona: Persona = {
+			name: "with-proxy",
+			headers: { "user-agent": "Test/1.0" },
+			proxy: "http://proxy.example:22225",
+		};
+		const wrapped = withPersonaFallback(inner as typeof fetch, [personaPrimary, proxyPersona]);
+
+		const response = await wrapped("https://example.com");
+
+		expect(response.status).toBe(200);
+		expect(captured).toHaveLength(2);
+		expect(captured[0].proxy).toBeUndefined();
+		expect(captured[1].proxy).toBe("http://proxy.example:22225");
 	});
 });

--- a/src/packages/crawl-article/src/persona-fallback.ts
+++ b/src/packages/crawl-article/src/persona-fallback.ts
@@ -1,8 +1,9 @@
 /**
  * Iterate through a list of request "personas" — coherent sets of headers
- * that together look like a single client to the origin — when the inner
- * fetch returns a block-class response (403/406/451) or throws a
- * block-class error (HTTP/2 RST_STREAM INTERNAL_ERROR, curl exit 92, etc.).
+ * (and optionally an egress proxy) that together look like a single client
+ * to the origin — when the inner fetch returns a block-class response
+ * (403/406/451) or throws a block-class error (HTTP/2 RST_STREAM
+ * INTERNAL_ERROR, curl exit 92, curl exit 47 redirect-loop, etc.).
  *
  * The wrapper is intentionally domain- and tool-agnostic: it never names
  * an origin, never names a fetcher implementation. Each persona's headers
@@ -15,11 +16,20 @@
  * below this wrapper. The right shape for those is a deeper persona that
  * swaps the TLS client (e.g. curl-impersonate); slot it in by adding a
  * persona whose inner fetcher uses that client, not by extending this
- * wrapper.
+ * wrapper. IP-class blocks (AWS-range gates) are the same shape — slot in
+ * a persona that carries an egress `proxy` URL; the inner fetcher routes
+ * the request through it via curl's `--proxy` flag.
  */
 export type Persona = {
 	readonly name: string;
 	readonly headers: Readonly<Record<string, string>>;
+	/**
+	 * Optional egress proxy URL (e.g. `http://user:pass@host:port`). When
+	 * set, the inner fetcher short-circuits to the curl transport with
+	 * `--proxy <url>` — fetch and h2 are not proxy-aware and would just
+	 * replay the failure from the same outbound IP.
+	 */
+	readonly proxy?: string;
 };
 
 const BLOCK_STATUS_CODES = new Set([403, 406, 451]);
@@ -29,6 +39,8 @@ const BLOCK_ERROR_SIGNATURES = [
 	"rst_stream", /* explicit ERR_HTTP2_STREAM_ERROR from undici / Node's http2 */
 	"not closed cleanly", /* curl exit 92 — server killed the h2 stream mid-request */
 	"err_http2_protocol_error", /* undici's mapping of generic h2 protocol errors */
+	"maximum (5) redirects followed", /* curl exit 47 — AWS-IP-gated origin loops 302 back to home */
+	"max_redirects", /* undici's mapping of redirect-loop failures */
 ];
 
 export function isBlockClassResponse(response: Response): boolean {
@@ -44,6 +56,18 @@ export function isBlockClassError(error: unknown): boolean {
 type FetchInput = Parameters<typeof fetch>[0];
 type FetchInit = Parameters<typeof fetch>[1];
 
+/**
+ * Inner-layer init shape — same as `RequestInit` plus an optional `proxy`
+ * URL the persona-fallback wrapper injects per-persona. The proxy field is
+ * internal to the fallback chain and never appears on the public
+ * `CrawlFetchInit` surface; only the curl transport reads it.
+ */
+export type PersonaFetchInit = NonNullable<FetchInit> & { proxy?: string };
+export type PersonaFetch = (
+	input: FetchInput,
+	init?: PersonaFetchInit,
+) => Promise<Response>;
+
 function callerHeaderOverrides(headers: NonNullable<FetchInit>["headers"]): Record<string, string> {
 	const out: Record<string, string> = {};
 	if (!headers) return out;
@@ -54,7 +78,7 @@ function callerHeaderOverrides(headers: NonNullable<FetchInit>["headers"]): Reco
 }
 
 export function withPersonaFallback(
-	innerFetch: typeof fetch,
+	innerFetch: PersonaFetch,
 	personas: ReadonlyArray<Persona>,
 ): typeof fetch {
 	if (personas.length === 0) {
@@ -66,8 +90,11 @@ export function withPersonaFallback(
 		let lastResponse: Response | undefined;
 		for (const persona of personas) {
 			const headers = { ...persona.headers, ...callerOverrides };
+			const personaInit: PersonaFetchInit = persona.proxy
+				? { ...init, headers, proxy: persona.proxy }
+				: { ...init, headers };
 			try {
-				const response = await innerFetch(input, { ...init, headers });
+				const response = await innerFetch(input, personaInit);
 				if (isBlockClassResponse(response)) {
 					lastResponse = response;
 					continue;


### PR DESCRIPTION
## Summary

AWS Lambda's outbound IPs are gated by some origins regardless of HTTP-header persona:

- **USDA via Akamai BotManager** — RSTs HTTP/2 streams from AWS-range IPs (`curl exit 92 INTERNAL_ERROR`).
- **CIA reading room** — edges 302-loop back to `/readingroom` for AWS-range source IPs (`curl exit 47 "Maximum (5) redirects followed"`).

Neither failure has an HTTP-header fix. The right shape is a third persona that egresses via a residential IP through Webshare's Rotating Residential endpoint (`http://user:pass@p.webshare.io:80`), engaging only after the two free direct-egress personas exhaust.

## What changes

- **`Persona` gains an optional `proxy?: string`.** When set, the persona-fallback wrapper threads it into the inner init; `withH2Fallback` short-circuits straight to `curl --proxy <url>` (fetch and h2 aren't proxy-aware, would just replay the same AWS-IP failure). The public `CrawlFetchInit` surface is unchanged — the proxy field is internal to the fallback chain.
- **`appendResidentialProxyPersona(personas, proxyUrl?)`** helper on the package boundary. Returns `personas` unchanged when `proxyUrl` is undefined; otherwise appends a third `residential-proxy` persona (full browser headers + proxy URL) at the end of the chain. The static `CRAWL_PERSONAS` const stays pure.
- **Save-link parser dep bundle** reads `getEnv("RESIDENTIAL_PROXY_URL")` at composition time. Six Lambdas pick it up (`save-link-command`, `save-anonymous-link-command`, `save-link-raw-html-command`, `recrawl-link-initiated`, `comprehensive-crawl-command`, `stale-check`) via the existing single dep-bundle call site.
- **Infra wiring** mirrors `DEEPINFRA_API_KEY`: `pulumi.secret(requireEnv("RESIDENTIAL_PROXY_URL"))` added to all six Lambda environment blocks.
- **BLOCK_ERROR_SIGNATURES** gains `maximum (5) redirects followed` and `max_redirects` so curl exit 47 / undici redirect-loop failures advance the persona chain to the proxy.
- **Health canary** — re-enabled USDA entry (exercises h2 RST_STREAM block class via proxy) and added CIA reading-room entry (exercises 302 redirect-loop block class + keeps `--globoff` + WHATWG URL re-encoding under canary coverage via the bracketed path segment `[16505689]`).

## Hard ordering guarantee

- The proxy persona is **always last** in the persona array — personas 1 and 2 (free direct egress) must produce a block-class outcome before persona 3 is even tried.
- Within persona 3, `withH2Fallback` short-circuits to curl-with-proxy only — fetch and h2 are skipped because they ignore the proxy URL and would replay the AWS-IP failure.
- Net effect: each blocked URL costs **exactly one** residential-proxy request, after up to four free attempts.

## Deployment requirement

Before this PR can deploy:

1. Create the GitHub Actions secret `RESIDENTIAL_PROXY_URL` in both `staging` and `prod` environments.
2. Value format: `http://USERNAME:PASSWORD@p.webshare.io:80` (Webshare Rotating Residential endpoint — single endpoint, auto-rotates a residential IP pool per request). For initial smoke-testing, a single static Webshare proxy row (`http://USER:PASS@IP:PORT` from the account's free proxy list) can be dropped into the secret first — same URL shape, same wiring, just no rotation — then swap to `p.webshare.io:80` once the wiring is confirmed.
3. The runtime's `getEnv` returns `undefined` for empty strings, so an empty placeholder keeps the persona inert until the secret holds a real credential.

`infra/index.ts` uses `requireEnv("RESIDENTIAL_PROXY_URL")` (matching `DEEPINFRA_API_KEY`), so the secret **must** be set before `check-infra` / `pulumi up` runs in CI.

## Out of scope

- Pre-existing failing test `crawl-article.test.ts > returns status 'unsupported' with the byte count when PDF body exceeds 25 MiB` — the test expects a 25 MiB threshold but `MAX_PDF_BYTES.bytes` is 500 MiB. Unrelated to this PR; flagged for separate fix. `pnpm check` is unaffected (crawl-article's check target is `pnpm lint`, not `pnpm test-with-coverage`).
- Per-call proxy field on the public `CrawlFetchInit` — could be added later if a caller needs to force the proxy for a specific URL. No concrete use case yet.

## Test plan

- [x] `pnpm nx run @packages/crawl-article:compile` — clean
- [x] `pnpm nx run @packages/crawl-article:lint` — clean
- [x] `pnpm nx run save-link:compile` — clean (infra type-checks)
- [x] `pnpm nx run save-link:lint` — clean
- [x] `pnpm nx run save-link:test` — 362 / 362 passing (includes parser dep bundle)
- [x] `pnpm nx affected --target=check` — all affected projects pass, 100% coverage threshold met
- [x] New unit tests: 4 in `crawl-article.test.ts` (helper), 3 in `persona-fallback.test.ts` (proxy + redirect-loop signatures), 1 in `h2-fetch.test.ts` (short-circuit), 2 in `curl-fetch.test.ts` (--proxy arg construction). All passing.
- [x] `git grep -i 'bright ?data\|brd\.superproxy'` — zero hits in tracked files
- [ ] Post-deploy: trigger a recrawl of the CIA URL; tail `recrawl-link-initiated-handler` for the new request ID and expect `[persona-fallback] advanced to residential-proxy` followed by `200 application/pdf`.
- [ ] Post-deploy: tier-1+ canary green with the new USDA + CIA entries.

---
_Generated by [Claude Code](https://claude.ai/code)_