### PR TITLE
fix(hutch): suppress share-balloon auto-open while article is loading or errored

### DIFF
--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	MinutesSchema,
+	ReaderArticleHashIdSchema,
+	SaveableUrlSchema,
+} from "@packages/domain/article";
+import type { SavedArticle } from "@packages/domain/article";
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import { UserIdSchema } from "@packages/domain/user";
+import { Base } from "../../base.component";
+import { ReaderPage } from "./reader.component";
+
+const userId = UserIdSchema.parse("00000000000000000000000000000001");
+const articleId = ReaderArticleHashIdSchema.parse(
+	"0123456789abcdef0123456789abcdef",
+);
+const url = SaveableUrlSchema.parse("https://example.com/post");
+
+function makeArticle(overrides: Partial<SavedArticle> = {}): SavedArticle {
+	return {
+		id: articleId,
+		userId,
+		url,
+		metadata: {
+			title: "Hello World",
+			siteName: "example.com",
+			excerpt: "A lovely article.",
+			wordCount: 500,
+		},
+		content: "<p>Body copy.</p>",
+		estimatedReadTime: MinutesSchema.parse(3),
+		status: "unread",
+		savedAt: new Date(),
+		...overrides,
+	};
+}
+
+function render(
+	article: SavedArticle,
+	options?: { crawl?: ArticleCrawl },
+): Document {
+	const html = Base(ReaderPage(article, { crawl: options?.crawl }), {
+		isAuthenticated: true,
+		emailVerified: undefined,
+	}).to("text/html").body;
+	return new JSDOM(html).window.document;
+}
+
+function autoOpenAttr(doc: Document): string | null {
+	const wrap = doc.querySelector("[data-test-share-balloon-wrap]");
+	assert(wrap, "share balloon wrap must be rendered");
+	return wrap.getAttribute("data-share-balloon-auto-open");
+}
+
+describe("ReaderPage — share balloon auto-open gating", () => {
+	it("enables auto-open when content is present and crawl is ready", () => {
+		const doc = render(makeArticle(), { crawl: { status: "ready" } });
+		expect(autoOpenAttr(doc)).toBe("true");
+	});
+
+	it("disables auto-open while the crawl is still pending (article loading)", () => {
+		const article = makeArticle({ content: undefined });
+		const doc = render(article, { crawl: { status: "pending" } });
+		expect(autoOpenAttr(doc)).toBe("false");
+	});
+
+	it("disables auto-open when the crawl has failed (article errored)", () => {
+		const article = makeArticle({ content: undefined });
+		const doc = render(article, {
+			crawl: { status: "failed", reason: "blocked" },
+		});
+		expect(autoOpenAttr(doc)).toBe("false");
+	});
+
+	it("disables auto-open when the crawl is unsupported (article errored)", () => {
+		const article = makeArticle({ content: undefined });
+		const doc = render(article, {
+			crawl: { status: "unsupported", reason: "non-html content type" },
+		});
+		expect(autoOpenAttr(doc)).toBe("false");
+	});
+
+	it("disables auto-open when content is missing on a legacy row (read-after-write race)", () => {
+		const article = makeArticle({ content: undefined });
+		const doc = render(article);
+		expect(autoOpenAttr(doc)).toBe("false");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -12,6 +12,7 @@ import {
 	SHARE_BALLOON_SCRIPT,
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
+import { isArticleReady } from "../../shared/article-state/is-article-ready";
 import { READER_STYLES } from "./reader.styles";
 
 const CANONICAL_BASE_URL = "https://readplace.com";
@@ -66,6 +67,10 @@ export function ReaderPage(
 		shareTitle: article.metadata.title,
 		shareHint: "Click here to share this post!",
 		shareSource: "reader-internal",
+		autoOpen: isArticleReady({
+			crawl: options?.crawl,
+			content: article.content,
+		}),
 	});
 	const content = render(READER_TEMPLATE, { innerContent, shareBalloon });
 

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -337,4 +337,48 @@ describe("ViewPage", () => {
 		assert(link, "cta action must still be rendered without content");
 	});
 
+	describe("share balloon auto-open gating", () => {
+		function autoOpenAttr(doc: Document): string | null {
+			const wrap = doc.querySelector("[data-test-share-balloon-wrap]");
+			assert(wrap, "share balloon wrap must be rendered");
+			return wrap.getAttribute("data-share-balloon-auto-open");
+		}
+
+		it("enables auto-open when content is present and crawl is ready", () => {
+			const doc = render({ ...baseInput, crawl: { status: "ready" } });
+			expect(autoOpenAttr(doc)).toBe("true");
+		});
+
+		it("disables auto-open while the crawl is still pending (article loading)", () => {
+			const doc = render({
+				...baseInput,
+				content: undefined,
+				crawl: { status: "pending" },
+			});
+			expect(autoOpenAttr(doc)).toBe("false");
+		});
+
+		it("disables auto-open when the crawl has failed (article errored)", () => {
+			const doc = render({
+				...baseInput,
+				content: undefined,
+				crawl: { status: "failed", reason: "blocked" },
+			});
+			expect(autoOpenAttr(doc)).toBe("false");
+		});
+
+		it("disables auto-open when the crawl is unsupported (article errored)", () => {
+			const doc = render({
+				...baseInput,
+				content: undefined,
+				crawl: { status: "unsupported", reason: "non-html content type" },
+			});
+			expect(autoOpenAttr(doc)).toBe("false");
+		});
+
+		it("disables auto-open when content is missing on a legacy row (read-after-write race)", () => {
+			const doc = render({ ...baseInput, content: undefined, crawl: undefined });
+			expect(autoOpenAttr(doc)).toBe("false");
+		});
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -16,6 +16,7 @@ import {
 	SHARE_BALLOON_SCRIPT,
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
+import { isArticleReady } from "../../shared/article-state/is-article-ready";
 import { VIEW_STYLES } from "./view.styles";
 
 const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
@@ -84,6 +85,10 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		shareTitle: input.metadata.title,
 		shareHint: "Click here to share this view!",
 		shareSource: "reader-public",
+		autoOpen: isArticleReady({
+			crawl: input.crawl,
+			content: input.content,
+		}),
 	});
 
 	const content = render(VIEW_TEMPLATE, {

--- a/projects/hutch/src/runtime/web/shared/article-state/is-article-ready.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-state/is-article-ready.test.ts
@@ -1,0 +1,65 @@
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+import { isArticleReady } from "./is-article-ready";
+
+const CONTENT = "<p>Body copy.</p>";
+
+describe("isArticleReady", () => {
+	it("returns true when content is present and crawl is undefined (legacy row)", () => {
+		expect(isArticleReady({ crawl: undefined, content: CONTENT })).toBe(true);
+	});
+
+	it("returns true when content is present and crawl status is ready", () => {
+		expect(
+			isArticleReady({ crawl: { status: "ready" }, content: CONTENT }),
+		).toBe(true);
+	});
+
+	it("returns false when content is missing (read-after-write race)", () => {
+		expect(isArticleReady({ crawl: undefined, content: undefined })).toBe(
+			false,
+		);
+	});
+
+	it("returns false when crawl status is pending", () => {
+		expect(
+			isArticleReady({ crawl: { status: "pending" }, content: CONTENT }),
+		).toBe(false);
+	});
+
+	it("returns false when crawl status is failed", () => {
+		expect(
+			isArticleReady({
+				crawl: { status: "failed", reason: "x" },
+				content: CONTENT,
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when crawl status is unsupported", () => {
+		expect(
+			isArticleReady({
+				crawl: { status: "unsupported", reason: "x" },
+				content: CONTENT,
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when crawl is ready but content is missing (worker-bug catch-all)", () => {
+		expect(
+			isArticleReady({ crawl: { status: "ready" }, content: undefined }),
+		).toBe(false);
+	});
+
+	it("covers every CrawlStatus variant — a new variant must break this test", () => {
+		const variants: Array<{ crawl: ArticleCrawl; expected: boolean }> = [
+			{ crawl: { status: "ready" }, expected: true },
+			{ crawl: { status: "pending" }, expected: false },
+			{ crawl: { status: "failed", reason: "x" }, expected: false },
+			{ crawl: { status: "unsupported", reason: "x" }, expected: false },
+		];
+
+		for (const { crawl, expected } of variants) {
+			expect(isArticleReady({ crawl, content: CONTENT })).toBe(expected);
+		}
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-state/is-article-ready.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-state/is-article-ready.test.ts
@@ -50,15 +50,21 @@ describe("isArticleReady", () => {
 		).toBe(false);
 	});
 
-	it("covers every CrawlStatus variant — a new variant must break this test", () => {
-		const variants: Array<{ crawl: ArticleCrawl; expected: boolean }> = [
-			{ crawl: { status: "ready" }, expected: true },
-			{ crawl: { status: "pending" }, expected: false },
-			{ crawl: { status: "failed", reason: "x" }, expected: false },
-			{ crawl: { status: "unsupported", reason: "x" }, expected: false },
-		];
+	it("covers every CrawlStatus variant — adding a new variant will cause a compile error", () => {
+		const variants = {
+			ready: { crawl: { status: "ready" }, expected: true },
+			pending: { crawl: { status: "pending" }, expected: false },
+			failed: { crawl: { status: "failed", reason: "x" }, expected: false },
+			unsupported: {
+				crawl: { status: "unsupported", reason: "x" },
+				expected: false,
+			},
+		} satisfies Record<
+			ArticleCrawl["status"],
+			{ crawl: ArticleCrawl; expected: boolean }
+		>;
 
-		for (const { crawl, expected } of variants) {
+		for (const { crawl, expected } of Object.values(variants)) {
 			expect(isArticleReady({ crawl, content: CONTENT })).toBe(expected);
 		}
 	});

--- a/projects/hutch/src/runtime/web/shared/article-state/is-article-ready.ts
+++ b/projects/hutch/src/runtime/web/shared/article-state/is-article-ready.ts
@@ -1,0 +1,10 @@
+import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
+
+export function isArticleReady(input: {
+	crawl: ArticleCrawl | undefined;
+	content: string | undefined;
+}): boolean {
+	if (input.content === undefined) return false;
+	if (input.crawl === undefined) return true;
+	return input.crawl.status === "ready";
+}

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.test.ts
@@ -10,10 +10,12 @@ const ARTICLE_URL_SHARE = "https://example.com/post?utm_medium=share";
 const ARTICLE_URL_COPY = "https://example.com/post?utm_medium=copy";
 const ARTICLE_TITLE = "Hello World";
 
-const FIXTURE = `<!DOCTYPE html><html><body>
+function buildFixture(options: { autoOpen?: "true" | "false" } = {}): string {
+	const autoOpen = options.autoOpen ?? "true";
+	return `<!DOCTYPE html><html><body>
 <span data-share-balloon-status></span>
 <div data-article-body></div>
-<div data-share-balloon-wrap hidden>
+<div data-share-balloon-wrap data-share-balloon-auto-open="${autoOpen}" hidden>
   <div data-share-balloon-buttons>
     <div data-share-balloon-chat></div>
     <button type="button" data-share-balloon-copy data-share-url="${ARTICLE_URL_COPY}"></button>
@@ -23,6 +25,7 @@ const FIXTURE = `<!DOCTYPE html><html><body>
   <span data-share-balloon-copied>Link copied!</span>
 </div>
 </body></html>`;
+}
 
 interface NavigatorStub {
 	share?: (data: { title: string; url: string }) => Promise<void>;
@@ -31,8 +34,8 @@ interface NavigatorStub {
 
 type TestWindow = ReturnType<typeof createDom>["window"];
 
-function createDom() {
-	const dom = new JSDOM(FIXTURE, { url: "https://readplace.com/" });
+function createDom(options: { autoOpen?: "true" | "false" } = {}) {
+	const dom = new JSDOM(buildFixture(options), { url: "https://readplace.com/" });
 	return { window: dom.window, document: dom.window.document };
 }
 
@@ -63,9 +66,10 @@ function setup(
 		dismissed?: boolean;
 		navigator?: NavigatorStub;
 		articleHeight?: number;
+		autoOpen?: "true" | "false";
 	} = {},
 ) {
-	const { window, document } = createDom();
+	const { window, document } = createDom({ autoOpen: options.autoOpen });
 	setScrollY(window, options.scrollY ?? 0);
 	setArticleHeight(document, options.articleHeight ?? 4000);
 	if (options.dismissed) {
@@ -152,6 +156,59 @@ describe("initShareBalloon — attach/dismiss flow", () => {
 		jest.advanceTimersByTime(1000);
 
 		expect(wrap.classList.contains(OPEN_CLASS)).toBe(true);
+	});
+});
+
+describe("initShareBalloon — autoOpen=false (article loading or errored)", () => {
+	it("does not attach the scroll listener so scrolling past the threshold never opens the balloon", () => {
+		const { window, document, ctrl } = setup({
+			articleHeight: 2000,
+			autoOpen: "false",
+		});
+		const wrap = element(document, "[data-share-balloon-wrap]");
+		ctrl.attach();
+
+		setScrollY(window, 1500);
+		fireScroll(window);
+		jest.advanceTimersByTime(5000);
+
+		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
+	});
+
+	it("does not auto-open even when the page was already scrolled past the threshold on attach", () => {
+		const { document, ctrl } = setup({
+			articleHeight: 2000,
+			scrollY: 1500,
+			autoOpen: "false",
+		});
+		const wrap = element(document, "[data-share-balloon-wrap]");
+
+		ctrl.attach();
+		jest.advanceTimersByTime(5000);
+
+		expect(wrap.classList.contains(OPEN_CLASS)).toBe(false);
+	});
+
+	it("still unhides the wrap so the share and copy buttons remain reachable", () => {
+		const { document, ctrl } = setup({ autoOpen: "false" });
+		const wrap = element(document, "[data-share-balloon-wrap]");
+
+		ctrl.attach();
+
+		expect(wrap.hasAttribute("hidden")).toBe(false);
+	});
+
+	it("still wires the copy button so the buttons keep working without the balloon", async () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({
+			autoOpen: "false",
+			navigator: { clipboard: { writeText } },
+		});
+		ctrl.attach();
+
+		fireEvent.click(element(document, "[data-share-balloon-copy]"));
+
+		expect(writeText).toHaveBeenCalledWith(ARTICLE_URL_COPY);
 	});
 });
 

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
@@ -85,6 +85,7 @@ export function initShareBalloon(
 	const shareUrl = pickAttribute(btn, "data-share-url");
 	const copyUrl = pickAttribute(copyBtn, "data-share-url");
 	const title = pickAttribute(btn, "data-share-title");
+	const autoOpen = pickAttribute(wrap, "data-share-balloon-auto-open") !== "false";
 
 	const canShare = typeof deps.navigator.share === "function";
 	const canCopy = deps.navigator.clipboard !== undefined;
@@ -171,7 +172,7 @@ export function initShareBalloon(
 		btn.hidden = !canShare;
 		copyBtn.hidden = !canCopy;
 
-		if (!readDismissed()) {
+		if (autoOpen && !readDismissed()) {
 			scrollListener = onScroll;
 			deps.window.addEventListener("scroll", scrollListener, { passive: true });
 			onScroll();

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
@@ -23,6 +23,13 @@ export interface ShareBalloonInput {
 	shareTitle: string;
 	shareHint: string;
 	shareSource: ShareBalloonSource;
+	/**
+	 * When false, the client skips the scroll-to-open listener so the chat
+	 * balloon stays closed. Used by reader/view pages while the article is
+	 * still loading or has errored, so we don't ask the user to share a
+	 * page that hasn't rendered yet.
+	 */
+	autoOpen: boolean;
 }
 
 function withUtm(
@@ -51,5 +58,6 @@ export function renderShareBalloon(input: ShareBalloonInput): string {
 		shareIconSvg: SHARE_ICON_SVG,
 		copyIconSvg: COPY_ICON_SVG,
 		founderAvatarUrl: FOUNDER_AVATAR_URL,
+		autoOpen: input.autoOpen ? "true" : "false",
 	});
 }

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
@@ -23,12 +23,7 @@ export interface ShareBalloonInput {
 	shareTitle: string;
 	shareHint: string;
 	shareSource: ShareBalloonSource;
-	/**
-	 * When false, the client skips the scroll-to-open listener so the chat
-	 * balloon stays closed. Used by reader/view pages while the article is
-	 * still loading or has errored, so we don't ask the user to share a
-	 * page that hasn't rendered yet.
-	 */
+	/** Avoids prompting the user to share a page that hasn't rendered yet. */
 	autoOpen: boolean;
 }
 

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html
@@ -1,5 +1,5 @@
 <span class="sr-only" role="status" aria-live="polite" data-share-balloon-status></span>
-<div class="share-balloon__wrap" data-share-balloon-wrap data-test-share-balloon-wrap hidden>
+<div class="share-balloon__wrap" data-share-balloon-wrap data-test-share-balloon-wrap data-share-balloon-auto-open="{{autoOpen}}" hidden>
   <div class="share-balloon__buttons" data-share-balloon-buttons>
     <div class="share-balloon__chat" data-share-balloon-chat>
       <img


### PR DESCRIPTION
## Summary

- On both the private (`/queue/:id/read`) and public (`/view/:url`) reader pages, the share balloon's auto-open chat ("Hi, I'm Fayner Brack. Click here to share this post!") no longer pops up while the article is still loading (`crawl.status === "pending"`, missing content) or has errored (`crawl.status === "failed" | "unsupported"`).
- The share/copy buttons themselves remain reachable in every state — only the scroll-triggered chat balloon is gated.
- Gating flows through a new `autoOpen` flag on the share-balloon component, surfaced as `data-share-balloon-auto-open` and read by the client (which skips wiring the scroll listener when `false`).
- New `isArticleReady` helper computes the state from `{ crawl, content }`, mirroring the exhaustive switch in `renderReaderSlot`.

## Test plan

- [x] `pnpm jest --testMatch='**/dist/runtime/web/**/*.test.js'` (1213 passed)
- [x] `pnpm nx run hutch:lint`
- [x] `pnpm nx run hutch:test-with-coverage` (all thresholds met)
- New unit tests cover every `CrawlStatus` × content combination in `is-article-ready.test.ts`, `reader.component.test.ts`, and `view.component.test.ts`.
- New client tests verify the scroll listener is not attached and the page does not open even when pre-scrolled past the threshold when `data-share-balloon-auto-open="false"`, while the copy button still wires up.

---
_Generated by [Claude Code](https://claude.ai/code/session_015P669XWCDatzVyYW3MZtGM)_