### PR TITLE
docs: Stripe subscription management multi-phase plan

### DIFF
--- a/subscription-phase-0-providers-table.md
+++ b/subscription-phase-0-providers-table.md
@@ -1,0 +1,131 @@
+# Phase 0 — `subscription_providers` Table
+
+## Why
+
+Today the `users` table has no subscription linkage. The Stripe checkout
+success handler (`projects/hutch/src/runtime/web/auth/auth.page.ts` lines
+298-400) creates the user but discards `subscriptionId` and `customerId`
+from the checkout session. Without these IDs we cannot:
+
+- Operate on the subscription (cancel, resume, refund).
+- Tell apart founding members from paying users.
+- Add a second provider (Apple IAP, Paddle) later without rewriting access
+  logic.
+
+This phase creates a decoupled association table that maps `userId` to
+`{ provider, subscriptionId, customerId, status }`. The `users` table stays
+untouched. Provider polymorphism is enforced at the schema layer
+(`provider: z.literal("stripe")` for now, extensible to a union later).
+
+## Design
+
+### New DynamoDB table
+
+| Property             | Value                                                                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Logical name         | `subscription_providers`                                                                                                                           |
+| Hash key             | `userId` (String)                                                                                                                                  |
+| Range key            | none (one row per user)                                                                                                                            |
+| GSIs                 | `subscriptionId-index` (hashKey `subscriptionId`, projects `ALL`). Required for the Phase 1 webhook handler — given a Stripe `subscription.id`, find the user. |
+| Billing              | `PAY_PER_REQUEST`                                                                                                                                  |
+| PITR                 | enabled                                                                                                                                            |
+| Deletion protection  | matches `args.deletionProtection` (true in prod)                                                                                                   |
+
+### Row schema
+
+```ts
+// projects/hutch/src/runtime/providers/subscription-providers/
+//   dynamodb-subscription-providers.ts
+
+const SubscriptionProviderRow = z.object({
+  userId: UserIdSchema,
+  provider: z.literal("stripe"), // future: z.enum(["stripe", "apple", ...])
+  subscriptionId: z.string(),
+  customerId: z.string(),
+  status: z.enum(["active", "pending_cancellation", "cancelled"]),
+  cancellationEffectiveAt: dynamoField(z.string()), // ISO; set when status="pending_cancellation"
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+```
+
+Notes:
+
+- `subscriptionId` may change over the lifetime of a user. When a cancelled
+  user resumes (Phase 3), we create a NEW Stripe subscription and overwrite
+  the row's `subscriptionId`. The old `subscriptionId` is forgotten in our
+  store — Stripe remains the historical record.
+- `provider: z.literal("stripe")` — when we add a second provider it
+  becomes `z.enum([...])` and downstream code already destructures by
+  provider name.
+- Branded `UserIdSchema` from `@packages/domain/user` matches existing
+  convention (see `dynamodb-auth.ts` line 32).
+
+## Files to add
+
+| File | Purpose |
+| --- | --- |
+| `projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.ts` | Thin DynamoDB wrapper. Returns `{ findByUserId, findBySubscriptionId, upsertActive, markPendingCancellation, markCancelled, markActive }`. Mirrors the pattern in `dynamodb-auth.ts`. |
+| `projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.test.ts` | Unit test with `Partial<DynamoDBDocumentClient>` fake pattern (see test-driven-design skill, "Thin AWS SDK Wrappers"). |
+| `projects/hutch/src/runtime/domain/subscription/subscription.types.ts` | Domain types: `SubscriptionStatus`, `SubscriptionRecord`. |
+| `src/packages/test-fixtures/providers/subscription-providers/index.ts` | In-memory test double for use in route/page tests. |
+
+## Files to modify
+
+### Infrastructure (per infrastructure-design skill, Flavor A — config-derived)
+
+| File | Change |
+| --- | --- |
+| `projects/hutch/src/infra/hutch-storage.ts` | Add `subscriptionProvidersTable` field; add `subscriptionProviders: string` to `tableNames`; add new `aws.dynamodb.Table('hutch-subscription-providers', {...})` block following the `usersTable` shape on lines 76-93, plus the `subscriptionId-index` GSI. |
+| `projects/hutch/src/infra/index.ts` | Read `config.require("dynamodbSubscriptionProvidersTable")`; pass to `HutchStorage`; grant via `HutchDynamoDBAccess` (Query on the GSI included); add `DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE: requireEnv(...)` to the Lambda env block. |
+| `projects/hutch/Pulumi.prod.yaml` | Add `hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-prod`. |
+| `projects/hutch/Pulumi.staging.yaml` | Add `hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-staging`. |
+
+### Runtime composition root
+
+| File | Change |
+| --- | --- |
+| `projects/hutch/src/runtime/server.ts` (composition root) | Call `initDynamoDbSubscriptionProviders({ client, tableName: requireEnv("DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE") })`. Pass the result into the deps of the auth/checkout-success page handler. |
+
+### Stripe checkout flow (the connective tissue)
+
+| File | Change |
+| --- | --- |
+| `projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts` | Extend `retrieveCheckoutSession` to return `subscriptionId` (from `session.subscription`) and `customerId` (from `session.customer`). Both come back as strings when the session is in `mode: 'subscription'`. |
+| `projects/hutch/src/runtime/web/auth/auth.page.ts` (lines 338-400, `GET /auth/checkout/success`) | After successful `createUserWithPasswordHash` / `createGoogleUser`, call `subscriptionProviders.upsertActive({ userId, provider: 'stripe', subscriptionId, customerId })`. Fail loudly if the write fails — we must never have an orphaned paid user. |
+
+## Migration (manual)
+
+Only one existing paid user. After deploy, the user manually inserts a row
+via the AWS DynamoDB console (see Context section of the parent plan for the
+exact item).
+
+No script needed. All other users (free email signups) intentionally have
+no row — they're implicit founding members.
+
+## Architecture snapshot
+
+This phase adds **NO** `defineCommand` / `defineEvent` declarations. Per the
+infrastructure-design skill's snapshot rule, no `.architecture/<hash>/`
+snapshot is required.
+
+## Tests
+
+- Unit-test `dynamodb-subscription-providers.ts` with a
+  `Partial<DynamoDBDocumentClient>` fake — assert `UpdateExpression`,
+  `ConditionExpression`, and value shape using `toContain`.
+- Add an integration test for the checkout-success handler that asserts
+  the `subscription_providers` row is written with `status: 'active'`.
+- Update the existing checkout-success integration test if it asserts the
+  full set of side effects.
+
+## Verification
+
+1. `pnpm nx test hutch` — all unit tests green.
+2. `pnpm nx check-infra hutch` — Pulumi preview shows the new table and
+   GSI.
+3. Deploy to staging. Walk through Stripe checkout end-to-end. Verify a
+   row appears in the staging `subscription_providers` table with the
+   expected `subscriptionId` / `customerId` / `status: 'active'`.
+4. After production deploy, the user manually inserts the row for the one
+   existing paid account.

--- a/subscription-phase-1-cancellation-gating.md
+++ b/subscription-phase-1-cancellation-gating.md
@@ -60,7 +60,7 @@ Read-only means:
 | `projects/hutch/src/runtime/domain/access/effective-access.test.ts` | Unit tests for all four states. |
 | `projects/hutch/src/runtime/web/middleware/require-write-access.middleware.ts` | Express middleware. Loads access for `req.userId`; if read-only, returns 402 with HTML for browser routes or 402 JSON for the extension OAuth route. |
 | `projects/hutch/src/runtime/web/middleware/require-write-access.middleware.test.ts` | Integration test using supertest against a minimal app. |
-| `projects/hutch/src/runtime/web/pages/webhooks/stripe-webhook.page.ts` | `POST /webhooks/stripe`. Verifies signature using `STRIPE_WEBHOOK_SECRET`. Handles `customer.subscription.deleted` → `subscriptionProviders.markCancelled({ subscriptionId })`. Idempotent — re-deliveries are no-ops. Returns 200 on signature failure with logging (per Stripe docs, return non-2xx only when we genuinely want a retry). |
+| `projects/hutch/src/runtime/web/pages/webhooks/stripe-webhook.page.ts` | `POST /webhooks/stripe`. Verifies signature using `STRIPE_WEBHOOK_SECRET`. Handles `customer.subscription.deleted` → `subscriptionProviders.markCancelled({ subscriptionId })`. Idempotent — re-deliveries are no-ops. Returns 400 on signature failure with error-level logging — an invalid signature means the request is not from Stripe and must be rejected. |
 | `projects/hutch/src/runtime/web/pages/webhooks/stripe-webhook.route.test.ts` | Integration tests: valid signature + known event → row updated; valid signature + unknown event type → 200 no-op; invalid signature → 400; redelivery of same event → idempotent. |
 
 ### Files to modify

--- a/subscription-phase-1-cancellation-gating.md
+++ b/subscription-phase-1-cancellation-gating.md
@@ -1,0 +1,149 @@
+# Phase 1 — Cancellation Gating + Stripe Webhook
+
+> Assumes Phase 0 has shipped: the `subscription_providers` table exists
+> and is populated on new Stripe checkouts.
+
+## Why
+
+We sold a paid product. When a paying user cancels, Stripe's standard
+contract is "keep paid access until the period ends, then deactivate."
+Phase 1 makes that contract real:
+
+1. The Stripe webhook tells us when the billing period actually ends.
+2. The row flips to `status='cancelled'`.
+3. Write access disappears; read + export survive forever.
+
+We never lose the user's data — they paid for it, they own it. Read access
+and export must always remain available. This builds trust and creates a
+clean offboarding ramp + frictionless resume path (delivered fully in
+Phase 3).
+
+Founding members (users with no `subscription_providers` row) are
+grandfathered: they get full access forever, regardless of subscription
+state. They predate the paid model. The original task asked for a backfill
+script setting `type = 'FOUNDING_MEMBER' | 'REGULAR_USER'`. After
+clarification with the user, no `type` field exists and no script is
+needed: the implicit model (row absent = founding member; row present +
+status = derives access) handles every case naturally.
+
+## Access model — derived state
+
+```
+findSubscription(userId):
+  row = subscription_providers.get(userId)
+  if !row:                                 return { tier: 'founding',    access: 'full' }
+  if row.status == 'active':               return { tier: 'paid',        access: 'full' }
+  if row.status == 'pending_cancellation': return { tier: 'paid',        access: 'full' }
+  if row.status == 'cancelled':            return { tier: 'paid',        access: 'read-only' }
+```
+
+`pending_cancellation` keeps full access — the user paid through the
+period; we honour it. Only at the period-end webhook do we flip to read-
+only.
+
+Read-only means:
+
+- Can view saved articles (`GET /queue`, `GET /view/:id`)
+- Can export data (`GET /export`, `POST /export/start`)
+- Can resume subscription (`POST /account/resume` — Phase 3)
+- Cannot save new articles (`POST /queue/save`)
+- Cannot use the browser-extension save endpoint
+- Cannot import (`POST /import/*`)
+
+## Design
+
+### Files to add
+
+| File | Purpose |
+| --- | --- |
+| `projects/hutch/src/runtime/domain/access/effective-access.ts` | Pure function `initGetEffectiveAccess({ findSubscriptionByUserId }) => (userId) => Promise<{ tier, access }>`. No I/O of its own — fully unit-testable. |
+| `projects/hutch/src/runtime/domain/access/effective-access.test.ts` | Unit tests for all four states. |
+| `projects/hutch/src/runtime/web/middleware/require-write-access.middleware.ts` | Express middleware. Loads access for `req.userId`; if read-only, returns 402 with HTML for browser routes or 402 JSON for the extension OAuth route. |
+| `projects/hutch/src/runtime/web/middleware/require-write-access.middleware.test.ts` | Integration test using supertest against a minimal app. |
+| `projects/hutch/src/runtime/web/pages/webhooks/stripe-webhook.page.ts` | `POST /webhooks/stripe`. Verifies signature using `STRIPE_WEBHOOK_SECRET`. Handles `customer.subscription.deleted` → `subscriptionProviders.markCancelled({ subscriptionId })`. Idempotent — re-deliveries are no-ops. Returns 200 on signature failure with logging (per Stripe docs, return non-2xx only when we genuinely want a retry). |
+| `projects/hutch/src/runtime/web/pages/webhooks/stripe-webhook.route.test.ts` | Integration tests: valid signature + known event → row updated; valid signature + unknown event type → 200 no-op; invalid signature → 400; redelivery of same event → idempotent. |
+
+### Files to modify
+
+| File | Change |
+| --- | --- |
+| `projects/hutch/src/runtime/server.ts` | (a) Wire `requireWriteAccess` onto each write route group: `POST /queue/save`, `POST /import/*`, the extension OAuth save endpoint. Do NOT apply to `GET /queue`, `GET /view`, `GET /export`, `POST /export/start`, `GET /account`, `POST /account/*`, or the webhook route. (b) Mount `POST /webhooks/stripe` BEFORE the JSON body parser middleware so the raw body is available for signature verification — use `express.raw({ type: 'application/json' })` scoped to this route. |
+| `projects/hutch/src/runtime/web/pages/queue/queue.page.ts` and `queue.component.ts` / template | When the view model carries `access: 'read-only'`, render a banner above the save bar: "Your subscription is cancelled. Your saved articles are still here. [Resume subscription] [Export your data]." Reuse the existing email-verification banner pattern (`banner-state.ts`). |
+| `projects/hutch/src/infra/index.ts` | Add `STRIPE_WEBHOOK_SECRET: requireEnv("STRIPE_WEBHOOK_SECRET")` to the Lambda `environment:` block. |
+| `.github/workflows/project-deployment.yaml` (or whichever workflow deploys hutch) | Forward `STRIPE_WEBHOOK_SECRET` into both `deploy-staging` and `deploy-prod` jobs: `STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}`. This is the most commonly missed step per the infrastructure-design skill, Flavor B. |
+| Local `.envrc` / `.env` | Add `STRIPE_WEBHOOK_SECRET` for local dev with Stripe CLI's `stripe listen --forward-to localhost:.../webhooks/stripe`. |
+
+### Stripe webhook setup (operational, not code)
+
+Owner must, in the Stripe dashboard:
+
+1. Create a webhook endpoint pointing at `https://<host>/webhooks/stripe`.
+2. Subscribe to events: `customer.subscription.deleted` (and
+   `customer.subscription.updated` if we later want to detect external
+   cancellations — Phase 1 doesn't require it).
+3. Copy the signing secret into the repo's GitHub Actions secrets
+   (`STRIPE_WEBHOOK_SECRET`) for both staging and prod environments.
+4. Verify both secrets are visible via
+   `gh secret list --env staging --repo <org>/<repo>` and the prod
+   equivalent.
+
+Per the infrastructure-design skill, document this in the secret's
+deployment workflow alongside the existing `STRIPE_SECRET_KEY` setup.
+
+### Per web skill compliance
+
+- The read-only banner is unconditionally rendered as part of the queue
+  page; visibility is toggled via a state class
+  (`.queue-banner--cancelled`), never via `querySelector(...).toBeNull()`
+  checks in tests (see test-driven-design skill, "Never Rely on
+  `querySelector(...).toBeNull()`").
+- The save form remains in the DOM in read-only mode but is disabled and
+  paired with the banner. Submitting it still 402s server-side — defense
+  in depth, never trust the client.
+
+### Per test-driven-design skill compliance
+
+- `initGetEffectiveAccess` uses partial application (`init*` prefix,
+  returns the effective access function).
+- No mocks: the middleware test injects a fake
+  `findSubscriptionByUserId` via the existing dependency-injection
+  pattern.
+- Stripe webhook signature verification uses the official
+  `stripe.webhooks.constructEvent(rawBody, signature, secret)` helper;
+  tests use Stripe's test signature generator (see Stripe's official docs
+  for the helper).
+
+## Architecture snapshot
+
+No new `defineCommand` / `defineEvent` declarations — the webhook is a
+synchronous request/response Lambda fronted by Express (the allowed
+exception in the infrastructure-design skill). Snapshot not required.
+
+If future work moves this onto SQS for retry semantics, add a snapshot at
+that point.
+
+## Tests
+
+- Unit: `effective-access.test.ts` covers all four states (founding,
+  active, pending_cancellation, cancelled).
+- Integration: middleware returns 402 on write routes for cancelled
+  users, 200 for active / pending_cancellation / founding.
+- Integration: `GET /queue` renders the read-only banner with the
+  correct state class when `status='cancelled'`.
+- Integration: webhook flow — `customer.subscription.deleted` with a
+  valid signature flips the row to `status='cancelled'`; second
+  delivery is a no-op; bad signature → 400.
+- E2E (`e2e/`): a cancelled user logs in, sees the banner; attempting
+  to save shows the same banner state — no save persisted.
+
+## Verification
+
+1. `pnpm nx test hutch` — green.
+2. Local: use `stripe listen --forward-to localhost:3000/webhooks/stripe`
+   to relay test events. Trigger a `customer.subscription.deleted` and
+   confirm the local DynamoDB row flips to `status='cancelled'`.
+3. Local: as that user, attempt to save a link → see the banner and
+   the 402 response.
+4. Manually flip back to `active` in DynamoDB Local → save works again.
+5. Sign up a brand-new user (no row in `subscription_providers` because
+   you skipped checkout) — observe full access (founding-member path).

--- a/subscription-phase-2-account-menu.md
+++ b/subscription-phase-2-account-menu.md
@@ -1,0 +1,116 @@
+# Phase 2 — Account Menu for Subscription Management
+
+> Assumes Phases 0 and 1 have shipped: the table exists, access gating
+> works, the webhook reacts to Stripe.
+
+## Why
+
+The user has no surface inside the app today to act on their subscription.
+A logged-in user can't see their plan, can't cancel, can't resume. We need
+this inside the app for two reasons:
+
+1. Lower support load — users self-serve instead of emailing us.
+2. Control the framing — we own the cancellation copy (delivered in
+   Phase 3). If we redirected to the Stripe Billing Portal we'd lose the
+   chance to soften the moment with "your data is still here, you can
+   resume any time with no new card."
+
+## Re the question about pausing instead of cancelling
+
+The user's words are **cancel** — the in-app button says "Cancel
+subscription." The Stripe primitive is `cancel_at_period_end: true`.
+This is Stripe's standard "graceful cancellation" pattern:
+
+- The subscription stays active until the current period ends
+  (`current_period_end`, typically ~30 days away).
+- During that window the user keeps full paid access (we honour
+  `status='pending_cancellation'` as full-access in Phase 1).
+- At period end, Stripe fires `customer.subscription.deleted` — handled
+  by the Phase 1 webhook, which flips the row to `cancelled`.
+- The user can clear the cancellation flag at any time before period end
+  with a single click — Phase 3 handles "resume before period end."
+
+The "resume after period end" path (Phase 3) creates a NEW subscription
+on the same customer using their saved payment method — no checkout UI,
+one click — exactly the "no additional credit card required" behaviour
+requested. The old subscription remains `canceled` in Stripe forever.
+
+## Design
+
+### Files to add
+
+| File | Purpose |
+| --- | --- |
+| `projects/hutch/src/runtime/web/pages/account/account.page.ts` | Page handler. `GET /account` renders summary; `POST /account/cancel` calls Stripe `subscriptions.update(id, { cancel_at_period_end: true })` + flips row to `pending_cancellation`. (Resume = Phase 3.) |
+| `projects/hutch/src/runtime/web/pages/account/account.component.ts` | Component assembly. |
+| `projects/hutch/src/runtime/web/pages/account/account.template.html` | Template with four branches: founding-member, active, pending_cancellation, cancelled. (Cancelled state is a thin Phase 2 placeholder; Phase 3 fleshes it out.) |
+| `projects/hutch/src/runtime/web/pages/account/account.view-model.ts` | View-model builder. |
+| `projects/hutch/src/runtime/web/pages/account/account.styles.ts` | BEM-scoped styles (`.account-card`, `.account-card__status`, etc.). |
+| `projects/hutch/src/runtime/web/pages/account/account.url.ts` | URL builder. |
+| `projects/hutch/src/runtime/web/pages/account/account.route.test.ts` | Integration tests for all four states + cancel action. |
+| `projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.ts` | New thin wrapper: `initStripeSubscriptions({ stripeClient }) => { scheduleCancellation, clearCancellation, createSubscription, retrieveSubscription }`. Mirrors the shape of `stripe-checkout.ts`. |
+| `projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.test.ts` | Unit test with a fake Stripe client asserting exact API payloads. |
+
+### Files to modify
+
+| File | Change |
+| --- | --- |
+| `projects/hutch/src/runtime/web/header.template.html` | Add `<li><a href="/account">Account</a></li>` in the logged-in branch, immediately before the Sign-out form (line 9-14 region). |
+| `projects/hutch/src/runtime/server.ts` | Mount `/account` routes behind `requireAuth` only (NOT `requireWriteAccess` — cancelled users must still reach `/account` to resume). |
+
+### Page behaviour by state
+
+| State | Page renders (Phase 2 — minimal; Phase 3 finalises copy) |
+| --- | --- |
+| Founding member (no row) | "You're a founding member." Static, no buttons. |
+| Active (`status='active'`) | "Subscription: Active." Button: **Cancel subscription** → `POST /account/cancel`. |
+| Pending cancellation (`status='pending_cancellation'`) | "Subscription: Active until `<cancellationEffectiveAt>`. Cancelled — won't renew." Button: **Keep subscription** → `POST /account/resume` (Phase 3). |
+| Cancelled (`status='cancelled'`) | "Subscription: Cancelled." Button: **Resume subscription** → `POST /account/resume` (Phase 3 wires both paths). |
+
+The Phase 2 deliverable is the Cancel button + the state-aware page. Phase 3
+adds the confirmation step, the final copy, and the Resume button.
+
+### `POST /account/cancel` handler
+
+1. Load `req.userId`'s subscription row.
+2. If absent → 400 ("nothing to cancel" — founding members shouldn't reach
+   this route).
+3. If `status !== 'active'` → redirect 303 to `/account` (idempotent).
+4. Call `stripeSubscriptions.scheduleCancellation({ subscriptionId })` —
+   wraps `stripe.subscriptions.update(id, { cancel_at_period_end: true })`.
+   Capture `result.current_period_end` from the response.
+5. `subscriptionProviders.markPendingCancellation({ userId, cancellationEffectiveAt: new Date(current_period_end * 1000).toISOString() })`.
+6. Redirect 303 to `/account`.
+
+### Per web skill compliance
+
+- All actions are HTML `<form method="POST">` first.
+- The nav and the forms get `hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none"` for SPA feel.
+- No custom `*.client.js`.
+- POST-Redirect-GET for state changes.
+
+## Architecture snapshot
+
+No new commands/events. The Stripe call is synchronous request-scoped,
+fronted by Express. Snapshot not required.
+
+## Tests
+
+- Unit: `stripe-subscriptions.test.ts` asserts the exact
+  `subscriptions.update` payload (`{ cancel_at_period_end: true }`).
+- Integration: `account.route.test.ts` covers GET for all four states +
+  POST `/cancel` transitioning active → pending_cancellation, with
+  `cancellationEffectiveAt` correctly captured from the (faked) Stripe
+  response.
+- Integration: nav link renders for logged-in users (extend
+  `header.template` tests).
+
+## Verification
+
+1. `pnpm nx test hutch` — green.
+2. Local: log in as the (manually-seeded) active paid user → visit
+   `/account` → click **Cancel** → observe redirect to `/account` showing
+   "Active until `<date>`" state → confirm Stripe dashboard shows the
+   subscription with `cancel_at_period_end: true`.
+3. Per Phase 1 verification: even after cancel scheduled, save still
+   works until the webhook flips status to `cancelled`.

--- a/subscription-phase-3-cancellation-copy-and-resume.md
+++ b/subscription-phase-3-cancellation-copy-and-resume.md
@@ -1,0 +1,212 @@
+# Phase 3 — Cancellation Copy + One-Click Resume
+
+> Assumes Phases 0, 1, 2 have shipped: table exists, gating works, the
+> webhook reacts, `/account` renders all four states, Cancel works.
+
+## Why
+
+When a user clicks "Cancel subscription," two things must land
+immediately:
+
+1. **Trust** — they keep their data. They can export. Nothing is lost.
+2. **Frictionless return** — resume is one click, no card re-entry. This
+   is the single highest-leverage churn reducer Stripe offers.
+
+The current Phase 2 page does the mechanics. Phase 3 wraps the mechanics
+in copy that reduces fear at the moment of cancellation and removes
+friction at the moment of return.
+
+## Design
+
+### Files to modify
+
+| File | Change |
+| --- | --- |
+| `projects/hutch/src/runtime/web/pages/account/account.template.html` | Replace the bare Phase 2 buttons with the copy below. Add a confirmation step on cancel. |
+| `projects/hutch/src/runtime/web/pages/account/account.page.ts` | Add `POST /account/resume` handler with two code paths: `pending_cancellation` → clear `cancel_at_period_end`; `cancelled` → create new subscription on existing customer. |
+| `projects/hutch/src/runtime/web/pages/account/account.route.test.ts` | Add tests for both resume paths and for the new copy strings. |
+| `projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.ts` | Confirm `clearCancellation({ subscriptionId })` and `createSubscription({ customerId, priceId })` are present. (Phase 2 added the wrapper; Phase 3 may add the create-subscription path.) |
+| `projects/hutch/src/runtime/web/pages/queue/queue.template.html` | The read-only banner (Phase 1) gets the final copy alignment: prominent **Resume** button, secondary **Export** link, "Your subscription is cancelled — your saved articles are still here" phrasing. |
+
+### Copy
+
+**Active state — primary screen:**
+
+> ## Your subscription
+>
+> Active — billed monthly.
+>
+> [ Cancel subscription ]   (secondary button; navigates to confirmation step)
+
+**Cancel confirmation step** (rendered when `?confirm=cancel` query param
+is present, per the URL-as-state convention in the web skill):
+
+> ## Cancel your subscription?
+>
+> Your saved articles stay exactly where they are. You'll be able to
+> export your data after cancellation — visit the Export page any time.
+>
+> You'll keep full access until your current period ends (your next
+> billing date). After that, you'll switch to read-only mode — you can
+> still view and export your saved articles, but you won't be able to
+> save new ones or use the browser extension.
+>
+> Resuming later is one click. Your card on file stays put, so you won't
+> need to re-enter payment details.
+>
+> [ Cancel subscription ]   [ Keep my subscription ]
+
+**Pending-cancellation state:**
+
+> ## Your subscription will end on `<formatted cancellationEffectiveAt>`
+>
+> You still have full access until then. Your saved articles will stay
+> available after — you'll switch to read-only mode at that point.
+>
+> Changed your mind?
+>
+> [ Resume subscription ]   (clears cancellation; same card, no checkout)
+
+**Cancelled state:**
+
+> ## Your subscription is cancelled
+>
+> Your saved articles are still here. Resume to start saving again —
+> your card on file still works, no new payment method needed.
+>
+> [ Resume subscription ]   (creates a fresh subscription on your
+> existing card — one click, no checkout)
+>
+> [ Export your data → ]    (link to `/export`)
+
+### URL-as-state for the confirmation step
+
+Per the web skill: the confirmation step is a `GET` to
+`/account?confirm=cancel`, NOT a JavaScript modal. The view model branches
+on `confirm === 'cancel'` and renders the confirmation copy + a
+`<form method="POST" action="/account/cancel">` with `hx-boost`. "Keep my
+subscription" is an `<a href="/account">` link.
+
+This means:
+
+- Bookmarkable.
+- Works without JS.
+- Back button cancels naturally.
+
+### Resume handler
+
+```
+// POST /account/resume
+1. Load subscription row for req.userId.
+2. If row absent → 400 ("nothing to resume").
+3. If row.status === 'active' → redirect 303 (idempotent).
+4. If row.status === 'pending_cancellation':
+     a. stripeSubscriptions.clearCancellation({ subscriptionId: row.subscriptionId })
+        // stripe.subscriptions.update(id, { cancel_at_period_end: false })
+     b. subscriptionProviders.markActive({ userId })
+5. If row.status === 'cancelled':
+     a. created = stripeSubscriptions.createSubscription({
+          customerId: row.customerId,
+          priceId: requireEnv("STRIPE_PRICE_ID"),
+        })
+        // stripe.subscriptions.create({ customer, items: [{ price }] })
+        // No payment confirmation needed — customer has a default payment
+        // method from the original checkout. If the card has expired or
+        // was removed, this throws and we render an error page asking
+        // the user to update their card via Stripe Billing Portal (out
+        // of scope for Phase 3 — caught and rendered as a friendly
+        // message linking to support).
+     b. subscriptionProviders.upsertActive({
+          userId: row.userId,
+          provider: "stripe",
+          subscriptionId: created.id,
+          customerId: row.customerId,
+        })
+        // Overwrites the row — new subscriptionId, old one is forgotten
+        // in our store. Stripe keeps the old one in `canceled` state
+        // forever as the historical record.
+6. Redirect 303 to /account.
+```
+
+After resume, the queue page's read-only banner from Phase 1 disappears
+automatically (because effective access is now full).
+
+### Card-on-file failure mode
+
+If `createSubscription` throws because the customer's default payment
+method has expired or was removed, render an error page on `/account`
+explaining "your card on file is no longer valid — contact support" with
+a mailto link. We don't ship in-app card update in this phase. The Stripe
+error is logged at error level for ops visibility.
+
+### Per web skill compliance
+
+- Confirmation is a server-rendered page state, not a JS modal.
+- All buttons are inside `<form method="POST">` or `<a href>`.
+- `hx-boost="true"` on the form and nav link container delivers the SPA
+  feel.
+- No custom `*.client.js` introduced.
+
+## Tests
+
+- Integration: `POST /account/resume` covers all three branches:
+  `pending_cancellation` → `active` (cleared in Stripe, no new sub),
+  `cancelled` → `active` (new sub created with the same customer),
+  `active` → noop redirect, missing row → 400.
+- Integration: `GET /account?confirm=cancel` renders the confirmation
+  copy and a form posting to `/account/cancel`.
+- Integration: `GET /account` for cancelled user contains both
+  "Resume subscription" and an `<a href="/export">` link, asserted via
+  semantic CSS classes (`.account-card__resume`,
+  `.account-card__export`) per the web skill's
+  no-`data-test-*`-in-CSS rule.
+- Unit: `stripe-subscriptions.test.ts` covers `clearCancellation` and
+  `createSubscription` payloads.
+- E2E: cancelled user sees banner → clicks Resume → banner disappears
+  → save works again. Verify the new `subscriptionId` in DynamoDB
+  differs from the original.
+
+## Verification
+
+1. `pnpm nx test hutch` — green.
+2. Local: as the seeded user → visit `/account` (state=active) → click
+   **Cancel** → land on confirmation → click **Cancel subscription** → see
+   pending-cancellation copy with the correct date → confirm Stripe
+   dashboard shows `cancel_at_period_end: true`.
+3. Click **Resume** (still pending) → state returns to active → Stripe
+   dashboard shows `cancel_at_period_end: false`.
+4. To exercise the "cancelled → resume" path: in Stripe test mode use
+   `stripe trigger customer.subscription.deleted` against the
+   subscription → webhook flips row to `cancelled` → click **Resume** on
+   `/account` → confirm a NEW `subscriptionId` lands in DynamoDB and
+   Stripe shows two subscriptions for the customer (one `canceled`,
+   one `active`).
+5. As a cancelled user (before clicking Resume): visit `/queue`,
+   confirm banner; visit `/export` and trigger an export to confirm
+   read access still works.
+
+---
+
+## Cross-phase notes (recap)
+
+- **Webhook scope**: Phase 1 adds `POST /webhooks/stripe` handling
+  `customer.subscription.deleted`. We may extend later to handle
+  `customer.subscription.updated` (for external dashboard changes) and
+  `invoice.payment_failed` (for dunning) but those are out of scope.
+- **No new EventBridge commands/events.** No architecture snapshots
+  required for any phase. (Webhook handler is a synchronous request/
+  response Lambda fronted by Express — allowed exception.)
+- **One-time manual migration** for the single existing paid user is the
+  only data change to production.
+- **Order is strict**: Phase 1 depends on Phase 0's table; Phase 2
+  depends on the access middleware existing (so `/account` doesn't get
+  gated incorrectly); Phase 3 depends on `/account` existing.
+- **Env vars added**:
+  - `DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE` (Flavor A, config-derived) —
+    Phase 0.
+  - `STRIPE_WEBHOOK_SECRET` (Flavor B, external secret) — Phase 1.
+  - `STRIPE_PRICE_ID` may already exist for Phase 0; if not, add as
+    Flavor B in Phase 3 for the create-subscription call.
+- **Stripe Billing Portal is NOT integrated.** Phase 3's error path for
+  expired cards links to a `mailto`. If we ever want self-serve card
+  update, that's a separate piece of work.

--- a/subscription-phase-3-cancellation-copy-and-resume.md
+++ b/subscription-phase-3-cancellation-copy-and-resume.md
@@ -103,6 +103,12 @@ This means:
 4. If row.status === 'pending_cancellation':
      a. stripeSubscriptions.clearCancellation({ subscriptionId: row.subscriptionId })
         // stripe.subscriptions.update(id, { cancel_at_period_end: false })
+        // Race window: if the `customer.subscription.deleted` webhook fires
+        // between the row read (step 1) and this Stripe API call, the
+        // subscription no longer exists in Stripe and the update throws.
+        // Catch the Stripe error (resource_missing / 404) and fall through
+        // to step 5 (cancelled path: create a new subscription on the
+        // existing customer). This avoids surfacing a 500 to the user.
      b. subscriptionProviders.markActive({ userId })
 5. If row.status === 'cancelled':
      a. created = stripeSubscriptions.createSubscription({


### PR DESCRIPTION
## Summary

Adds four phase-plan markdown documents that sequence the move from one-shot Stripe checkout to managed subscriptions:

- **Phase 0** — `subscription_providers` DynamoDB table + GSI; wire `checkout-success` to persist `subscriptionId` / `customerId` / `status='active'`. No `users`-table change; founding members are implicit (no row).
- **Phase 1** — `effective-access` derivation, `requireWriteAccess` middleware (read + export always survive), `POST /webhooks/stripe` handling `customer.subscription.deleted`. Read-only banner on `/queue` when status flips to `cancelled`.
- **Phase 2** — `/account` page with state-aware rendering for founding / active / pending_cancellation / cancelled. Cancel button calls `stripe.subscriptions.update(id, { cancel_at_period_end: true })`.
- **Phase 3** — Final cancellation copy, URL-as-state confirmation step (`?confirm=cancel`), one-click Resume covering both branches (clear `cancel_at_period_end` for pending; `subscriptions.create` on existing customer for cancelled — no checkout UI).

Status enum: `'active' | 'pending_cancellation' | 'cancelled'`. Provider-polymorphism enforced at the schema layer (`provider: z.literal("stripe")` extensible to a union).

These are planning artifacts only — no source code is modified by this PR.

## Test plan

- [ ] Reviewer reads the four phase files and confirms the sequencing, access model, and Stripe-primitive choices match expectations.
- [ ] Reviewer confirms the one-time manual migration plan (single existing paid user, manual DynamoDB insert) is acceptable vs. a backfill script.
- [ ] Reviewer confirms no architecture snapshot is required (webhook is sync request/response via Express — allowed exception).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TC377zuBqDDCMBbNcreQxi)_