### PR TITLE
feat(hutch): show upload progress bar on /import

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -82,6 +82,11 @@ const BUNDLES = [
 			"    window.document.body.addEventListener('htmx:afterSwap', listener);",
 			"  }",
 			"});",
+			"ImportClient.initUploadProgress({",
+			"  document: window.document,",
+			"  formatBytes: ImportClient.formatBytes,",
+			"  nativeSubmit: function (form) { form.submit(); }",
+			"});",
 		].join("\n"),
 	},
 	{

--- a/projects/hutch/src/e2e/queue-flow/import-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/import-actions.ts
@@ -27,6 +27,8 @@ async function uploadUrlsAndOpenReview(
 		mimeType: 'text/plain',
 		buffer: Buffer.from(urls.join('\n'), 'utf-8'),
 	})
+	const form = page.locator('form.import__upload-form')
+	await expect(form).toHaveAttribute('data-import-state', 'uploading')
 	await page.waitForSelector('[data-test-import-list]')
 }
 

--- a/projects/hutch/src/runtime/web/pages/import/import.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.client.test.ts
@@ -1,12 +1,30 @@
 import { JSDOM } from "jsdom";
 import {
 	applyIndeterminate,
+	formatBytes,
 	initIndeterminateCheckboxes,
+	initUploadProgress,
 } from "./import.client";
 
 function makeDoc(html: string): Document {
 	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
 }
+
+const UPLOAD_FORM_HTML = `
+<form class="import__upload-form" method="POST" action="/import" enctype="multipart/form-data"
+      data-import-state="idle" hx-post="/import">
+  <div class="import__idle" data-import-region="idle">
+    <input type="file" name="file" required>
+    <button type="submit">Upload</button>
+  </div>
+  <div class="import__uploading" data-import-region="uploading">
+    <div class="import__progress-bar" data-import-progress-bar>
+      <div class="import__progress-fill" data-import-progress-fill style="width: 0%"></div>
+    </div>
+    <p class="import__progress-label" data-import-progress-label>Preparing upload&hellip;</p>
+  </div>
+</form>
+`;
 
 describe("applyIndeterminate", () => {
 	it("sets the indeterminate property on every checkbox carrying the marker", () => {
@@ -50,5 +68,147 @@ describe("initIndeterminateCheckboxes", () => {
 		if (target) target.indeterminate = false;
 		registered?.();
 		expect(target?.indeterminate).toBe(true);
+	});
+});
+
+describe("formatBytes", () => {
+	it.each([
+		[0, "0 KB"],
+		[1024, "1 KB"],
+		[10 * 1024, "10 KB"],
+		[600_000, "0.6 MB"],
+		[1_500_000, "1.4 MB"],
+		[3 * 1024 * 1024, "3.0 MB"],
+	])("formats %i bytes as %s", (bytes, expected) => {
+		expect(formatBytes(bytes)).toBe(expected);
+	});
+
+	it("clamps a negative byte count to 0 KB", () => {
+		expect(formatBytes(-1)).toBe("0 KB");
+	});
+
+	it("clamps a NaN byte count to 0 KB", () => {
+		expect(formatBytes(Number.NaN)).toBe("0 KB");
+	});
+});
+
+describe("initUploadProgress", () => {
+	function makeUploadDom(): JSDOM {
+		return new JSDOM(`<!doctype html><html><body>${UPLOAD_FORM_HTML}</body></html>`);
+	}
+
+	function dispatch(dom: JSDOM, form: HTMLFormElement, type: string, detail?: object | null): void {
+		form.dispatchEvent(new dom.window.CustomEvent(type, { detail }));
+	}
+
+	it("is a no-op when no .import__upload-form is present", () => {
+		const doc = makeDoc('<main>no form here</main>');
+		expect(() =>
+			initUploadProgress({
+				document: doc,
+				formatBytes,
+				nativeSubmit: () => undefined,
+			}),
+		).not.toThrow();
+	});
+
+	it("flips data-import-state to uploading on htmx:beforeRequest", () => {
+		const dom = makeUploadDom();
+		const doc = dom.window.document;
+		initUploadProgress({ document: doc, formatBytes, nativeSubmit: () => undefined });
+		const form = doc.querySelector<HTMLFormElement>("form.import__upload-form");
+		if (!form) throw new Error("form must be present");
+
+		expect(form.dataset.importState).toBe("idle");
+		dispatch(dom, form, "htmx:beforeRequest");
+		expect(form.dataset.importState).toBe("uploading");
+	});
+
+	it("updates the progress fill width and label on htmx:xhr:progress", () => {
+		const dom = makeUploadDom();
+		const doc = dom.window.document;
+		initUploadProgress({ document: doc, formatBytes, nativeSubmit: () => undefined });
+		const form = doc.querySelector<HTMLFormElement>("form.import__upload-form");
+		if (!form) throw new Error("form must be present");
+
+		dispatch(dom, form, "htmx:beforeRequest");
+		dispatch(dom, form, "htmx:xhr:progress", { loaded: 600_000, total: 1_500_000 });
+
+		const fill = doc.querySelector<HTMLElement>("[data-import-progress-fill]");
+		const label = doc.querySelector<HTMLElement>("[data-import-progress-label]");
+		expect(fill?.style.width).toBe("40%");
+		expect(label?.textContent).toBe("Uploading 0.6 MB of 1.4 MB (40%)");
+	});
+
+	it("ignores a progress event with no total", () => {
+		const dom = makeUploadDom();
+		const doc = dom.window.document;
+		initUploadProgress({ document: doc, formatBytes, nativeSubmit: () => undefined });
+		const form = doc.querySelector<HTMLFormElement>("form.import__upload-form");
+		if (!form) throw new Error("form must be present");
+
+		dispatch(dom, form, "htmx:xhr:progress", { loaded: 100 });
+
+		const fill = doc.querySelector<HTMLElement>("[data-import-progress-fill]");
+		const label = doc.querySelector<HTMLElement>("[data-import-progress-label]");
+		expect(fill?.style.width).toBe("0%");
+		expect(label?.textContent).toBe("Preparing upload…");
+	});
+
+	it("ignores a non-CustomEvent progress event with no detail", () => {
+		const dom = makeUploadDom();
+		const doc = dom.window.document;
+		initUploadProgress({ document: doc, formatBytes, nativeSubmit: () => undefined });
+		const form = doc.querySelector<HTMLFormElement>("form.import__upload-form");
+		if (!form) throw new Error("form must be present");
+
+		form.dispatchEvent(new dom.window.Event("htmx:xhr:progress"));
+
+		const fill = doc.querySelector<HTMLElement>("[data-import-progress-fill]");
+		expect(fill?.style.width).toBe("0%");
+	});
+
+	it("ignores a progress event whose detail is null", () => {
+		const dom = makeUploadDom();
+		const doc = dom.window.document;
+		initUploadProgress({ document: doc, formatBytes, nativeSubmit: () => undefined });
+		const form = doc.querySelector<HTMLFormElement>("form.import__upload-form");
+		if (!form) throw new Error("form must be present");
+
+		dispatch(dom, form, "htmx:xhr:progress", null);
+
+		const fill = doc.querySelector<HTMLElement>("[data-import-progress-fill]");
+		expect(fill?.style.width).toBe("0%");
+	});
+
+	it.each([
+		["htmx:sendError"],
+		["htmx:responseError"],
+		["htmx:timeout"],
+		["htmx:swapError"],
+	])("reverts to idle and falls back to native submit on %s", (eventType) => {
+		const dom = makeUploadDom();
+		const doc = dom.window.document;
+		const calls: HTMLFormElement[] = [];
+		const removedHxPostBeforeSubmit: boolean[] = [];
+		initUploadProgress({
+			document: doc,
+			formatBytes,
+			nativeSubmit: (form) => {
+				removedHxPostBeforeSubmit.push(!form.hasAttribute("hx-post"));
+				calls.push(form);
+			},
+		});
+		const form = doc.querySelector<HTMLFormElement>("form.import__upload-form");
+		if (!form) throw new Error("form must be present");
+		dispatch(dom, form, "htmx:beforeRequest");
+		expect(form.dataset.importState).toBe("uploading");
+
+		dispatch(dom, form, eventType);
+
+		expect(form.dataset.importState).toBe("idle");
+		expect(form.hasAttribute("hx-post")).toBe(false);
+		expect(calls).toEqual([form]);
+		expect(removedHxPostBeforeSubmit).toEqual([true]);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.client.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.client.ts
@@ -37,3 +37,73 @@ export function initIndeterminateCheckboxes(deps: IndeterminateDeps): void {
 	deps.addSwapListener(run);
 	run();
 }
+
+/**
+ * Render an upload byte count with one decimal place when the value rounds
+ * up to less than 10 MB. The label is read aloud during a slow upload, so
+ * the precision tracks the bar's perceived movement rather than the raw
+ * byte total.
+ */
+export function formatBytes(bytes: number): string {
+	const clamped = bytes > 0 ? bytes : 0;
+	const mb = clamped / (1024 * 1024);
+	if (mb < 0.1) {
+		const kb = Math.round(clamped / 1024);
+		return `${kb} KB`;
+	}
+	const rounded = Math.round(mb * 10) / 10;
+	return `${rounded.toFixed(1)} MB`;
+}
+
+function assert(cond: unknown, message: string): asserts cond {
+	if (!cond) throw new Error(message);
+}
+
+interface UploadProgressDeps {
+	document: Document;
+	formatBytes: (bytes: number) => string;
+	nativeSubmit: (form: HTMLFormElement) => void;
+}
+
+function readNumberField(obj: object, key: string): number {
+	const value: unknown = Reflect.get(obj, key);
+	return typeof value === "number" ? value : 0;
+}
+
+export function initUploadProgress(deps: UploadProgressDeps): void {
+	const form = deps.document.querySelector<HTMLFormElement>(
+		"form.import__upload-form",
+	);
+	if (!form) return;
+
+	const fill = form.querySelector<HTMLElement>("[data-import-progress-fill]");
+	const label = form.querySelector<HTMLElement>("[data-import-progress-label]");
+	assert(fill, "upload form must contain [data-import-progress-fill]");
+	assert(label, "upload form must contain [data-import-progress-label]");
+
+	form.addEventListener("htmx:beforeRequest", () => {
+		form.dataset.importState = "uploading";
+	});
+
+	form.addEventListener("htmx:xhr:progress", (event) => {
+		const detail: unknown = Reflect.get(event, "detail");
+		if (typeof detail !== "object" || detail === null) return;
+		const loaded = readNumberField(detail, "loaded");
+		const total = readNumberField(detail, "total");
+		if (total <= 0) return;
+		const pct = Math.min(100, Math.max(0, Math.round((loaded / total) * 100)));
+		fill.style.width = `${pct}%`;
+		label.textContent = `Uploading ${deps.formatBytes(loaded)} of ${deps.formatBytes(total)} (${pct}%)`;
+	});
+
+	const fallback = (): void => {
+		form.dataset.importState = "idle";
+		form.removeAttribute("hx-post");
+		deps.nativeSubmit(form);
+	};
+
+	form.addEventListener("htmx:sendError", fallback);
+	form.addEventListener("htmx:responseError", fallback);
+	form.addEventListener("htmx:timeout", fallback);
+	form.addEventListener("htmx:swapError", fallback);
+}

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -98,6 +98,6 @@ export function ImportUploadPage(vm: ImportUploadViewModel): PageBody {
 		styles: IMPORT_STYLES,
 		bodyClass: "page-import",
 		content: { html: content },
-		scripts: UPLOAD_AUTO_SUBMIT_SCRIPT,
+		scripts: `${IMPORT_CLIENT_SCRIPT}${UPLOAD_AUTO_SUBMIT_SCRIPT}`,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -59,6 +59,39 @@ describe("Import routes", () => {
 			expect(button.textContent).toBe("Upload");
 		});
 
+		it("renders the upload form in idle state with both idle and uploading regions", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/import");
+
+			const doc = new JSDOM(response.text).window.document;
+			const form = doc.querySelector<HTMLFormElement>('[data-test-form="import-file"]');
+			assert(form, "upload form must be rendered");
+			expect(form.getAttribute("data-import-state")).toBe("idle");
+			expect(form.getAttribute("hx-post")).toBe("/import");
+			expect(form.getAttribute("hx-encoding")).toBe("multipart/form-data");
+			const idle = form.querySelector('[data-import-region="idle"]');
+			const uploading = form.querySelector('[data-import-region="uploading"]');
+			assert(idle, "idle region must always be rendered");
+			assert(uploading, "uploading region must always be rendered");
+			const fill = uploading.querySelector('[data-import-progress-fill]');
+			const label = uploading.querySelector('[data-import-progress-label]');
+			assert(fill, "progress fill must be rendered inside the uploading region");
+			assert(label, "progress label must be rendered inside the uploading region");
+		});
+
+		it("includes the import client bundle on the upload page", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/import");
+
+			const doc = new JSDOM(response.text).window.document;
+			const script = doc.querySelector('script[src="/client-dist/import.client.js"]');
+			assert(script, "import.client.js bundle must be loaded on the upload page");
+		});
+
 		it("renders the import_no_urls message when error_code=import_no_urls", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.css
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.css
@@ -52,6 +52,45 @@
   margin: 0 0 24px;
 }
 
+.import__idle {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.import__upload-form .import__uploading {
+  display: none;
+}
+
+.import__upload-form[data-import-state="uploading"] .import__idle {
+  display: none;
+}
+
+.import__upload-form[data-import-state="uploading"] .import__uploading {
+  display: block;
+}
+
+.import__progress-bar {
+  height: 8px;
+  background: var(--muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.import__progress-fill {
+  height: 100%;
+  background: var(--color-brand);
+  width: 0%;
+  transition: width 150ms linear;
+}
+
+.import__progress-label {
+  margin: 12px 0 0;
+  font-size: 0.9375rem;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
 .import__file-input {
   position: absolute;
   width: 1px;

--- a/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
@@ -8,23 +8,34 @@
       {{#if errorMessage}}
       <p class="import__upload-error" role="alert" data-test-import-error>{{errorMessage}}</p>
       {{/if}}
-      <form class="import__upload-form" method="POST" action="{{uploadAction}}" enctype="multipart/form-data" data-test-form="import-file">
-        <label class="import__dropzone" data-import-dropzone>
-          <input type="file" name="file" required class="import__file-input" data-test-import-file-input>
-          <span class="import__dropzone-icon" aria-hidden="true">
-            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="17 8 12 3 7 8"></polyline>
-              <line x1="12" y1="3" x2="12" y2="15"></line>
-            </svg>
-          </span>
-          <span class="import__dropzone-primary">
-            <span class="import__dropzone-link">Choose a file</span>
-            <span class="import__dropzone-or"> or drag it here</span>
-          </span>
-          <span class="import__dropzone-meta" data-import-dropzone-meta>HTML, JSON, or plain text &middot; up to 5&nbsp;MiB &middot; up to 2,000 links</span>
-        </label>
-        <button class="import__upload-btn" type="submit" data-test-action="import-upload">Upload</button>
+      <form class="import__upload-form" method="POST" action="{{uploadAction}}" enctype="multipart/form-data"
+            data-import-state="idle" data-test-form="import-file"
+            hx-post="{{uploadAction}}" hx-encoding="multipart/form-data"
+            hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
+        <div class="import__idle" data-import-region="idle">
+          <label class="import__dropzone" data-import-dropzone>
+            <input type="file" name="file" required class="import__file-input" data-test-import-file-input>
+            <span class="import__dropzone-icon" aria-hidden="true">
+              <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="17 8 12 3 7 8"></polyline>
+                <line x1="12" y1="3" x2="12" y2="15"></line>
+              </svg>
+            </span>
+            <span class="import__dropzone-primary">
+              <span class="import__dropzone-link">Choose a file</span>
+              <span class="import__dropzone-or"> or drag it here</span>
+            </span>
+            <span class="import__dropzone-meta" data-import-dropzone-meta>HTML, JSON, or plain text &middot; up to 5&nbsp;MiB &middot; up to 2,000 links</span>
+          </label>
+          <button class="import__upload-btn" type="submit" data-test-action="import-upload">Upload</button>
+        </div>
+        <div class="import__uploading" data-import-region="uploading" aria-live="polite">
+          <div class="import__progress-bar" data-import-progress-bar>
+            <div class="import__progress-fill" data-import-progress-fill style="width: 0%"></div>
+          </div>
+          <p class="import__progress-label" data-import-progress-label>Preparing upload&hellip;</p>
+        </div>
       </form>
       <p class="import__fallback">
         Larger files or more than 2,000 links? Email


### PR DESCRIPTION
## Summary

- Render an idle region (existing dropzone + Upload button) and an uploading region (progress bar + label) into the `/import` form, switched by `data-import-state` on the form root.
- Wire the upload form for htmx (`hx-post`, `hx-encoding`, `hx-target="main"`) and add `initUploadProgress` to `import.client.ts` so:
  - `htmx:beforeRequest` flips state to `uploading` before the first byte leaves.
  - `htmx:xhr:progress` drives the fill width and the `Uploading X.X MB of Y.Y MB (NN%)` label.
  - `htmx:sendError` / `responseError` / `timeout` / `swapError` revert to `idle`, drop `hx-post`, and call the native submit fallback.
- Ship `import.client.js` alongside the existing inline auto-submit script on the upload page; bundle footer wires `initUploadProgress` with `formatBytes` and `form.submit()` as the native-submit fallback.

The wire time is unchanged; what changes is whether the user can see the upload happening. The state flips synchronously inside htmx's submit handler, so the dropzone disappears before the first TCP byte leaves — a slow first-byte connection no longer leaves the user staring at the old form.

Without JavaScript, the form still posts as a plain multipart submission via `method="POST" action="/import" enctype="multipart/form-data"`.

## Test plan

- [x] `pnpm exec jest dist/runtime/web/pages/import/` — 91 tests pass (21 client-side covering state flip, progress label, error fallback, no-form no-op, NaN/negative formatBytes; 3 new route assertions for the rendered markup + bundle tag)
- [x] `pnpm exec nx run hutch:lint` — biome / tsc / knip / check-unused-css all clean
- [x] `pnpm exec nx run hutch:test` — full suite (1321 tests) green
- [x] Coverage gate met (global branches 96.49% ≥ 96% threshold; `import.client.ts` at 100/94/100/100)
- [ ] Manual: throttle DevTools to "Slow 3G", drop a 2–3 MB file on `/import`, verify the dropzone disappears immediately, label transitions `Preparing upload… → Uploading … (NN%)`, then the review page swaps in
- [ ] Manual: throttle to "Offline" mid-upload, verify the form reverts to `idle` and the native submit fallback fires
- [ ] Manual without JS: choose a file and click Upload, verify the plain multipart POST still creates a session

https://claude.ai/code/session_017fY1bdwuRe8kiFAMBQjCbt

---
_Generated by [Claude Code](https://claude.ai/code/session_017fY1bdwuRe8kiFAMBQjCbt)_