### PR TITLE
feat(hutch): record createdAt on new pending signups

### DIFF
--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
@@ -22,12 +22,14 @@ const PendingSignupRow = z.object({
 	passwordHash: dynamoField(z.string()),
 	userId: dynamoField(UserIdSchema),
 	returnUrl: dynamoField(z.string()),
+	createdAt: dynamoField(z.number()),
 	checkoutRecoveryEmailSentAt: dynamoField(z.number()),
 });
 
 const PendingSignupSummaryRow = z.object({
 	checkoutSessionId: CheckoutSessionIdSchema,
 	email: z.string(),
+	createdAt: dynamoField(z.number()),
 	checkoutRecoveryEmailSentAt: dynamoField(z.number()),
 });
 
@@ -52,12 +54,13 @@ export function initDynamoDbPendingSignup(deps: {
 		schema: PendingSignupSummaryRow,
 	});
 
-	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup }) => {
+	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup, createdAt }) => {
 		await table.put({
 			Item: {
 				checkoutSessionId,
 				method: signup.method,
 				email: signup.email,
+				createdAt,
 				...(signup.method === "email" ? { passwordHash: signup.passwordHash } : {}),
 				...(signup.method === "google" ? { userId: signup.userId } : {}),
 				...(signup.returnUrl ? { returnUrl: signup.returnUrl } : {})
@@ -102,13 +105,14 @@ export function initDynamoDbPendingSignup(deps: {
 		do {
 			const page = await summaryTable.scan({
 				ProjectionExpression:
-					"checkoutSessionId, email, checkoutRecoveryEmailSentAt",
+					"checkoutSessionId, email, createdAt, checkoutRecoveryEmailSentAt",
 				ExclusiveStartKey: lastEvaluatedKey,
 			});
 			for (const row of page.items) {
 				summaries.push({
 					checkoutSessionId: row.checkoutSessionId,
 					email: row.email,
+					...(row.createdAt !== undefined ? { createdAt: row.createdAt } : {}),
 					...(row.checkoutRecoveryEmailSentAt !== undefined
 						? { checkoutRecoveryEmailSentAt: row.checkoutRecoveryEmailSentAt }
 						: {}),

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -290,6 +290,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				passwordHash,
 				...(returnUrl ? { returnUrl } : {}),
 			},
+			createdAt: Math.floor(deps.now().getTime() / 1000),
 		});
 
 		res.redirect(303, checkout.url);

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -159,6 +159,7 @@ describe("GET /auth/checkout/success", () => {
 				email: "google-buyer@example.com",
 				userId: UserIdSchema.parse("u-google-checkout-1"),
 			},
+			createdAt: 1735000000,
 		});
 		stripe.markPaid(checkout.id);
 
@@ -192,6 +193,7 @@ describe("GET /auth/checkout/success", () => {
 				email: "google-welcome@example.com",
 				userId: UserIdSchema.parse("u-google-welcome-1"),
 			},
+			createdAt: 1735000000,
 		});
 		stripe.markPaid(checkout.id);
 
@@ -232,6 +234,7 @@ describe("GET /auth/checkout/success", () => {
 				email: "preexisting@example.com",
 				userId: UserIdSchema.parse("u-google-different"),
 			},
+			createdAt: 1735000000,
 		});
 		stripe.markPaid(checkout.id);
 
@@ -271,6 +274,7 @@ describe("GET /auth/checkout/success", () => {
 				email: "existing-welcome@example.com",
 				userId: UserIdSchema.parse("u-google-existing-welcome"),
 			},
+			createdAt: 1735000000,
 		});
 		stripe.markPaid(checkout.id);
 

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -239,6 +239,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 				userId: newUserId,
 				...(safeReturnUrl ? { returnUrl: safeReturnUrl } : {}),
 			},
+			createdAt: Math.floor(deps.now().getTime() / 1000),
 		});
 
 		res.redirect(303, checkout.url);

--- a/src/packages/test-fixtures/src/providers/pending-signup/in-memory-pending-signup.test.ts
+++ b/src/packages/test-fixtures/src/providers/pending-signup/in-memory-pending-signup.test.ts
@@ -16,6 +16,7 @@ describe("initInMemoryPendingSignup", () => {
 		await storePendingSignup({
 			checkoutSessionId,
 			signup: { method: "email", email: "buyer@example.com", passwordHash: "hash:hex" },
+			createdAt: 1735000000,
 		});
 
 		const first = await consumePendingSignup(checkoutSessionId);
@@ -37,6 +38,7 @@ describe("initInMemoryPendingSignup", () => {
 		await storePendingSignup({
 			checkoutSessionId,
 			signup: { method: "google", email: "google@example.com", userId, returnUrl: "/save" },
+			createdAt: 1735000000,
 		});
 
 		const first = await consumePendingSignup(checkoutSessionId);
@@ -64,10 +66,12 @@ describe("initInMemoryPendingSignup", () => {
 		await storePendingSignup({
 			checkoutSessionId: emailId,
 			signup: { method: "email", email: "a@example.com", passwordHash: "hash" },
+			createdAt: 1734000000,
 		});
 		await storePendingSignup({
 			checkoutSessionId: googleId,
 			signup: { method: "google", email: "b@example.com", userId },
+			createdAt: 1734000001,
 		});
 
 		const before = await listAllPendingSignups();
@@ -75,6 +79,7 @@ describe("initInMemoryPendingSignup", () => {
 		const emailRow = before.find((r) => r.checkoutSessionId === emailId);
 		assert(emailRow, "email row must be present");
 		expect(emailRow.email).toBe("a@example.com");
+		expect(emailRow.createdAt).toBe(1734000000);
 		expect(emailRow.checkoutRecoveryEmailSentAt).toBeUndefined();
 
 		await markCheckoutRecoveryEmailSent({

--- a/src/packages/test-fixtures/src/providers/pending-signup/in-memory-pending-signup.ts
+++ b/src/packages/test-fixtures/src/providers/pending-signup/in-memory-pending-signup.ts
@@ -9,6 +9,7 @@ import type {
 
 interface StoredEntry {
 	signup: PendingSignup;
+	createdAt?: number;
 	checkoutRecoveryEmailSentAt?: number;
 }
 
@@ -20,8 +21,8 @@ export function initInMemoryPendingSignup(): {
 } {
 	const store = new Map<CheckoutSessionId, StoredEntry>();
 
-	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup }) => {
-		store.set(checkoutSessionId, { signup });
+	const storePendingSignup: StorePendingSignup = async ({ checkoutSessionId, signup, createdAt }) => {
+		store.set(checkoutSessionId, { signup, createdAt });
 	};
 
 	const consumePendingSignup: ConsumePendingSignup = async (checkoutSessionId) => {
@@ -35,6 +36,7 @@ export function initInMemoryPendingSignup(): {
 		Array.from(store.entries()).map(([checkoutSessionId, entry]) => ({
 			checkoutSessionId,
 			email: entry.signup.email,
+			...(entry.createdAt !== undefined ? { createdAt: entry.createdAt } : {}),
 			...(entry.checkoutRecoveryEmailSentAt !== undefined
 				? { checkoutRecoveryEmailSentAt: entry.checkoutRecoveryEmailSentAt }
 				: {}),

--- a/src/packages/test-fixtures/src/providers/pending-signup/pending-signup.types.ts
+++ b/src/packages/test-fixtures/src/providers/pending-signup/pending-signup.types.ts
@@ -9,12 +9,14 @@ export type PendingSignup =
 export interface PendingSignupSummary {
 	checkoutSessionId: CheckoutSessionId;
 	email: string;
+	createdAt?: number;
 	checkoutRecoveryEmailSentAt?: number;
 }
 
 export type StorePendingSignup = (params: {
 	checkoutSessionId: CheckoutSessionId;
 	signup: PendingSignup;
+	createdAt: number;
 }) => Promise<void>;
 
 export type ConsumePendingSignup = (


### PR DESCRIPTION
## Summary
- Add optional `createdAt` (epoch seconds) to the `hutch-pending-signups` DynamoDB row and to the `PendingSignupSummary` projection.
- Callers (`auth.page.ts`, `google-auth.page.ts`) now pass `createdAt: Math.floor(deps.now().getTime() / 1000)` when calling `storePendingSignup`, matching the existing explicit-clock pattern used by `markCheckoutRecoveryEmailSent({ sentAt })`.
- Schema uses `dynamoField(z.number())` so existing rows without the attribute continue to deserialize as `undefined` — no backfill, no migration.

## Test plan
- [x] `pnpm nx run @packages/test-fixtures:check` (all 215 tests pass, coverage thresholds met)
- [x] `pnpm test-with-coverage` in `projects/hutch` (1301 tests pass, coverage thresholds met)
- [x] Pre-commit hook ran full `nx run-many --target=check --all` and passed
- [ ] Manual: verify a new sign-up writes `createdAt` to DynamoDB after deploy
- [ ] Manual: verify the checkout-recovery CLI continues to scan rows that pre-date this change (rows with no `createdAt`)

https://claude.ai/code/session_01AH6JSaQehLAuRJHjGLiXHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AH6JSaQehLAuRJHjGLiXHD)_