### PR TITLE
feat(hutch): add subscription_providers table and 14-day no-card trial

### DIFF
--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -25,6 +25,7 @@ config:
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-prod
+  hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-prod
   hutch:contentBucketName: hutch-article-content-prod
   hutch:pendingHtmlBucketName: hutch-pending-html-prod
   hutch:userExportBucketName: hutch-user-exports-prod

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -17,6 +17,7 @@ config:
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-staging
+  hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-staging
   hutch:contentBucketName: hutch-article-content-staging
   hutch:pendingHtmlBucketName: hutch-pending-html-staging
   hutch:userExportBucketName: hutch-user-exports-staging

--- a/projects/hutch/src/e2e/queue-flow/auth-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/auth-actions.ts
@@ -45,7 +45,7 @@ export function createAuthActions(
         )
         await clickAndWaitForPageReload(
           page,
-          page.locator('[data-test-form="signup"] button[type="submit"]'),
+          page.locator('[data-test-action="signup-trial"]'),
         )
 
         const onQueue = await isOnPage(page, 'page-queue')

--- a/projects/hutch/src/e2e/queue-flow/auth-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/auth-actions.ts
@@ -45,7 +45,7 @@ export function createAuthActions(
         )
         await clickAndWaitForPageReload(
           page,
-          page.locator('[data-test-action="signup-trial"]'),
+          page.locator('[data-test-action="signup"]'),
         )
 
         const onQueue = await isOnPage(page, 'page-queue')

--- a/projects/hutch/src/infra/hutch-storage.ts
+++ b/projects/hutch/src/infra/hutch-storage.ts
@@ -11,6 +11,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 	public readonly passwordResetTokensTable: aws.dynamodb.Table;
 	public readonly pendingSignupsTable: aws.dynamodb.Table;
 	public readonly importSessionsTable: aws.dynamodb.Table;
+	public readonly subscriptionProvidersTable: aws.dynamodb.Table;
 
 	constructor(name: string, args: { deletionProtection: boolean; tableNames: {
 		articles: string;
@@ -22,6 +23,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 		passwordResetTokens: string;
 		pendingSignups: string;
 		importSessions: string;
+		subscriptionProviders: string;
 	} }, opts?: pulumi.ComponentResourceOptions) {
 		super("hutch:infra:HutchStorage", name, {}, opts);
 
@@ -159,6 +161,25 @@ export class HutchStorage extends pulumi.ComponentResource {
 				enabled: true,
 			},
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+
+		this.subscriptionProvidersTable = new aws.dynamodb.Table(`hutch-subscription-providers`, {
+			name: args.tableNames.subscriptionProviders,
+			billingMode: "PAY_PER_REQUEST",
+			deletionProtectionEnabled: args.deletionProtection,
+			pointInTimeRecovery: { enabled: true },
+			hashKey: "userId",
+			attributes: [
+				{ name: "userId", type: "S" },
+				{ name: "subscriptionId", type: "S" },
+			],
+			globalSecondaryIndexes: [
+				{
+					name: "subscriptionId-index",
+					hashKey: "subscriptionId",
+					projectionType: "ALL",
+				},
+			],
+		}, { parent: this });
 
 		this.registerOutputs();
 	}

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -33,6 +33,7 @@ const tableNames = {
 	passwordResetTokens: config.require("dynamodbPasswordResetTokensTable"),
 	pendingSignups: config.require("dynamodbPendingSignupsTable"),
 	importSessions: config.require("dynamodbImportSessionsTable"),
+	subscriptionProviders: config.require("dynamodbSubscriptionProvidersTable"),
 };
 
 const storage = new HutchStorage("hutch", {
@@ -101,6 +102,7 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 		{ arn: storage.passwordResetTokensTable.arn, includeIndexes: false },
 		{ arn: storage.pendingSignupsTable.arn, includeIndexes: false },
 		{ arn: storage.importSessionsTable.arn, includeIndexes: false },
+		{ arn: storage.subscriptionProvidersTable.arn, includeIndexes: true },
 	],
 	actions: [
 		"dynamodb:GetItem",
@@ -147,6 +149,7 @@ const lambda = new HutchLambda("hutch", {
 		DYNAMODB_PASSWORD_RESET_TOKENS_TABLE: storage.passwordResetTokensTable.name,
 		DYNAMODB_PENDING_SIGNUPS_TABLE: storage.pendingSignupsTable.name,
 		DYNAMODB_IMPORT_SESSIONS_TABLE: storage.importSessionsTable.name,
+		DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE: storage.subscriptionProvidersTable.name,
 		GOOGLE_LOGIN_CLIENT_ID: requireEnv("GOOGLE_LOGIN_CLIENT_ID"),
 		GOOGLE_LOGIN_CLIENT_SECRET: requireEnv("GOOGLE_LOGIN_CLIENT_SECRET"),
 		RESEND_API_KEY: requireEnv("RESEND_API_KEY"),

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -57,6 +57,8 @@ import { initInMemoryStripeCheckout } from "@packages/test-fixtures/providers/st
 import { initStripeCheckout } from "./providers/stripe-checkout/stripe-checkout";
 import { initInMemoryPendingSignup } from "@packages/test-fixtures/providers/pending-signup";
 import { initDynamoDbPendingSignup } from "./providers/pending-signup/dynamodb-pending-signup";
+import { initInMemorySubscriptionProviders } from "@packages/test-fixtures/providers/subscription-providers";
+import { initDynamoDbSubscriptionProviders } from "./providers/subscription-providers/dynamodb-subscription-providers";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initLogParseError, type ParseErrorEvent } from "@packages/hutch-infra-components";
 import { validateSaveableUrl } from "@packages/domain/article";
@@ -114,6 +116,7 @@ function initProviders() {
 		const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 		const pendingHtmlBucketName = requireEnv("PENDING_HTML_BUCKET_NAME");
 		const importSessionsTable = requireEnv("DYNAMODB_IMPORT_SESSIONS_TABLE");
+		const subscriptionProvidersTable = requireEnv("DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE");
 		const client = createDynamoDocumentClient();
 		const s3Client = new S3Client({});
 
@@ -179,6 +182,11 @@ function initProviders() {
 			fetch: globalThis.fetch,
 		});
 		const pendingSignup = initDynamoDbPendingSignup({ client, tableName: pendingSignupsTable });
+		const subscriptionProviders = initDynamoDbSubscriptionProviders({
+			client,
+			tableName: subscriptionProvidersTable,
+			now: () => new Date(),
+		});
 		const importSessionStore = initDynamoDbImportSession({
 			client,
 			tableName: importSessionsTable,
@@ -190,6 +198,7 @@ function initProviders() {
 			articleStore,
 			readArticleContent,
 			importSessionStore,
+			subscriptionProviders,
 
 			...initResendEmail(resendApiKey),
 			...initDynamoDbEmailVerification({ client, tableName: verificationTokensTable }),
@@ -221,6 +230,7 @@ function initProviders() {
 	const oauthModel = createOAuthModel(initInMemoryOAuthModel());
 	const devStripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() });
 	const devPendingSignup = initInMemoryPendingSignup();
+	const devSubscriptionProviders = initInMemorySubscriptionProviders({ now: () => new Date() });
 	const devGoogleClientId = getEnv("GOOGLE_LOGIN_CLIENT_ID");
 	const devGoogleClientSecret = getEnv("GOOGLE_LOGIN_CLIENT_SECRET");
 	assert(
@@ -338,6 +348,7 @@ function initProviders() {
 			logError,
 		}),
 		importSessionStore,
+		subscriptionProviders: devSubscriptionProviders,
 
 		...initLogEmail(),
 		...initInMemoryEmailVerification(),

--- a/projects/hutch/src/runtime/conversions.test.ts
+++ b/projects/hutch/src/runtime/conversions.test.ts
@@ -50,6 +50,27 @@ describe("emitUserCreated", () => {
 		expect(JSON.stringify(captured[0])).not.toContain("stripe_checkout_session_id");
 	});
 
+	it("emits a trial signup event without a stripe checkout session id", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "trial@example.com",
+				method: "email",
+				tier: "trial",
+				attribution: undefined,
+			},
+		);
+
+		expect(captured[0]).toMatchObject({
+			tier: "trial",
+			method: "email",
+		});
+		expect(JSON.stringify(captured[0])).not.toContain("stripe_checkout_session_id");
+	});
+
 	it("includes stripe_checkout_session_id for paid signups so the event can be joined to Stripe payment data downstream", () => {
 		const { logger, captured } = createCapturingLogger();
 

--- a/projects/hutch/src/runtime/conversions.ts
+++ b/projects/hutch/src/runtime/conversions.ts
@@ -24,7 +24,7 @@ export function emitUserCreated(
 		userId: UserId;
 		email: string;
 		method: "email" | "google";
-		tier: "free" | "paid";
+		tier: "free" | "paid" | "trial";
 		stripeCheckoutSessionId?: string;
 		attribution: ClickAttribution | undefined;
 	},

--- a/projects/hutch/src/runtime/domain/subscription/trial-config.ts
+++ b/projects/hutch/src/runtime/domain/subscription/trial-config.ts
@@ -1,1 +1,0 @@
-export const TRIAL_DURATION_DAYS = 14;

--- a/projects/hutch/src/runtime/domain/subscription/trial-config.ts
+++ b/projects/hutch/src/runtime/domain/subscription/trial-config.ts
@@ -1,0 +1,1 @@
+export const TRIAL_DURATION_DAYS = 14;

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -20,6 +20,8 @@ const RetrieveSessionResponse = z.object({
 	payment_status: z.enum(["paid", "unpaid", "no_payment_required"]),
 	status: z.enum(["open", "complete", "expired"]),
 	created: z.number(),
+	subscription: z.string().nullish(),
+	customer: z.string().nullish(),
 });
 
 const StripeErrorResponse = z.object({
@@ -107,6 +109,8 @@ export function initStripeCheckout(deps: {
 			customerEmail,
 			status: parsed.status,
 			created: parsed.created,
+			...(parsed.subscription ? { subscriptionId: parsed.subscription } : {}),
+			...(parsed.customer ? { customerId: parsed.customer } : {}),
 		};
 	};
 

--- a/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.test.ts
+++ b/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.test.ts
@@ -1,0 +1,400 @@
+import assert from "node:assert/strict";
+import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
+import { UserIdSchema } from "@packages/domain/user";
+import { initDynamoDbSubscriptionProviders } from "./dynamodb-subscription-providers";
+
+type SendFn = DynamoDBDocumentClient["send"];
+
+function createFakeClient(
+	impl: (input: unknown) => unknown,
+): Partial<DynamoDBDocumentClient> {
+	return {
+		send: (async (input: unknown) => impl(input)) as unknown as SendFn,
+	};
+}
+
+const TABLE = "test-subscription-providers";
+const NOW = () => new Date("2026-05-22T10:00:00.000Z");
+const USER_ID = UserIdSchema.parse("u-1");
+
+describe("initDynamoDbSubscriptionProviders", () => {
+	describe("findByUserId", () => {
+		it("returns undefined when no row exists", async () => {
+			const client = createFakeClient(() => ({ Item: undefined }));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			expect(await subs.findByUserId(USER_ID)).toBeUndefined();
+		});
+
+		it("returns a parsed trialing record when a row exists with trialEndsAt", async () => {
+			const client = createFakeClient(() => ({
+				Item: {
+					userId: USER_ID,
+					provider: "stripe",
+					status: "trialing",
+					trialEndsAt: "2026-06-05T00:00:00.000Z",
+					createdAt: "2026-05-22T10:00:00.000Z",
+					updatedAt: "2026-05-22T10:00:00.000Z",
+				},
+			}));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			const row = await subs.findByUserId(USER_ID);
+			assert(row, "row must be returned");
+			expect(row.status).toBe("trialing");
+			expect(row.trialEndsAt).toBe("2026-06-05T00:00:00.000Z");
+			expect(row.subscriptionId).toBeUndefined();
+			expect(row.customerId).toBeUndefined();
+			expect(row.cancellationEffectiveAt).toBeUndefined();
+		});
+
+		it("returns a parsed active record with subscriptionId and customerId", async () => {
+			const client = createFakeClient(() => ({
+				Item: {
+					userId: USER_ID,
+					provider: "stripe",
+					status: "active",
+					subscriptionId: "sub_123",
+					customerId: "cus_123",
+					createdAt: "2026-05-20T10:00:00.000Z",
+					updatedAt: "2026-05-22T10:00:00.000Z",
+				},
+			}));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			const row = await subs.findByUserId(USER_ID);
+			assert(row, "row must be returned");
+			expect(row.status).toBe("active");
+			expect(row.subscriptionId).toBe("sub_123");
+			expect(row.customerId).toBe("cus_123");
+			expect(row.trialEndsAt).toBeUndefined();
+		});
+
+		it("returns a parsed pending_cancellation record with cancellationEffectiveAt", async () => {
+			const client = createFakeClient(() => ({
+				Item: {
+					userId: USER_ID,
+					provider: "stripe",
+					status: "pending_cancellation",
+					subscriptionId: "sub_pc",
+					customerId: "cus_pc",
+					cancellationEffectiveAt: "2026-06-22T00:00:00.000Z",
+					createdAt: "2026-05-20T10:00:00.000Z",
+					updatedAt: "2026-05-22T10:00:00.000Z",
+				},
+			}));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			const row = await subs.findByUserId(USER_ID);
+			assert(row, "row must be returned");
+			expect(row.status).toBe("pending_cancellation");
+			expect(row.cancellationEffectiveAt).toBe("2026-06-22T00:00:00.000Z");
+		});
+	});
+
+	describe("findBySubscriptionId", () => {
+		it("issues a Query against subscriptionId-index", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {
+					Items: [
+						{
+							userId: USER_ID,
+							provider: "stripe",
+							status: "active",
+							subscriptionId: "sub_x",
+							customerId: "cus_x",
+							createdAt: "2026-05-20T10:00:00.000Z",
+							updatedAt: "2026-05-22T10:00:00.000Z",
+						},
+					],
+					Count: 1,
+				};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			const row = await subs.findBySubscriptionId("sub_x");
+			assert(row, "row must be returned");
+			expect(row.userId).toBe(USER_ID);
+			expect(row.subscriptionId).toBe("sub_x");
+
+			const command = received as {
+				input: {
+					IndexName?: string;
+					KeyConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+					Limit?: number;
+				};
+			};
+			expect(command.input.IndexName).toBe("subscriptionId-index");
+			expect(command.input.KeyConditionExpression).toContain("subscriptionId = :sid");
+			expect(command.input.ExpressionAttributeValues?.[":sid"]).toBe("sub_x");
+			expect(command.input.Limit).toBe(1);
+		});
+
+		it("returns undefined when the GSI query returns no items", async () => {
+			const client = createFakeClient(() => ({ Items: [], Count: 0 }));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			expect(await subs.findBySubscriptionId("sub_missing")).toBeUndefined();
+		});
+	});
+
+	describe("upsertTrialing", () => {
+		it("issues an Update that sets status=trialing, trialEndsAt, and removes Stripe ids", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await subs.upsertTrialing({ userId: USER_ID, trialEndsAt: "2026-06-05T00:00:00.000Z" });
+
+			const command = received as {
+				input: {
+					Key?: Record<string, unknown>;
+					UpdateExpression?: string;
+					ExpressionAttributeNames?: Record<string, string>;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.Key).toEqual({ userId: USER_ID });
+			expect(command.input.UpdateExpression).toContain("SET");
+			expect(command.input.UpdateExpression).toContain("#status = :status");
+			expect(command.input.UpdateExpression).toContain("trialEndsAt = :trialEndsAt");
+			expect(command.input.UpdateExpression).toContain("#provider = :provider");
+			expect(command.input.UpdateExpression).toContain("if_not_exists(createdAt, :now)");
+			expect(command.input.UpdateExpression).toContain("updatedAt = :now");
+			expect(command.input.UpdateExpression).toContain("REMOVE");
+			expect(command.input.UpdateExpression).toContain("subscriptionId");
+			expect(command.input.UpdateExpression).toContain("customerId");
+			expect(command.input.UpdateExpression).toContain("cancellationEffectiveAt");
+			expect(command.input.ExpressionAttributeNames?.["#status"]).toBe("status");
+			expect(command.input.ExpressionAttributeNames?.["#provider"]).toBe("provider");
+			expect(command.input.ExpressionAttributeValues?.[":status"]).toBe("trialing");
+			expect(command.input.ExpressionAttributeValues?.[":provider"]).toBe("stripe");
+			expect(command.input.ExpressionAttributeValues?.[":trialEndsAt"]).toBe(
+				"2026-06-05T00:00:00.000Z",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":now"]).toBe(
+				"2026-05-22T10:00:00.000Z",
+			);
+		});
+	});
+
+	describe("upsertActive", () => {
+		it("issues an Update that sets status=active, Stripe ids, and removes trialEndsAt", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await subs.upsertActive({
+				userId: USER_ID,
+				subscriptionId: "sub_abc",
+				customerId: "cus_abc",
+			});
+
+			const command = received as {
+				input: {
+					Key?: Record<string, unknown>;
+					UpdateExpression?: string;
+					ExpressionAttributeNames?: Record<string, string>;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.Key).toEqual({ userId: USER_ID });
+			expect(command.input.UpdateExpression).toContain("#status = :status");
+			expect(command.input.UpdateExpression).toContain("subscriptionId = :subscriptionId");
+			expect(command.input.UpdateExpression).toContain("customerId = :customerId");
+			expect(command.input.UpdateExpression).toContain("REMOVE");
+			expect(command.input.UpdateExpression).toContain("trialEndsAt");
+			expect(command.input.UpdateExpression).toContain("cancellationEffectiveAt");
+			expect(command.input.ExpressionAttributeValues?.[":status"]).toBe("active");
+			expect(command.input.ExpressionAttributeValues?.[":subscriptionId"]).toBe("sub_abc");
+			expect(command.input.ExpressionAttributeValues?.[":customerId"]).toBe("cus_abc");
+		});
+	});
+
+	describe("markPendingCancellation", () => {
+		it("issues a guarded Update that sets pending_cancellation and effective date", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await subs.markPendingCancellation({
+				userId: USER_ID,
+				cancellationEffectiveAt: "2026-06-22T00:00:00.000Z",
+			});
+
+			const command = received as {
+				input: {
+					Key?: Record<string, unknown>;
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.Key).toEqual({ userId: USER_ID });
+			expect(command.input.UpdateExpression).toContain("#status = :status");
+			expect(command.input.UpdateExpression).toContain(
+				"cancellationEffectiveAt = :effectiveAt",
+			);
+			expect(command.input.UpdateExpression).toContain("updatedAt = :now");
+			expect(command.input.ConditionExpression).toContain("attribute_exists(userId)");
+			expect(command.input.ExpressionAttributeValues?.[":status"]).toBe(
+				"pending_cancellation",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":effectiveAt"]).toBe(
+				"2026-06-22T00:00:00.000Z",
+			);
+		});
+	});
+
+	describe("markCancelled", () => {
+		it("queries the GSI, then issues a guarded Update keyed on the found userId", async () => {
+			const received: unknown[] = [];
+			let call = 0;
+			const client = createFakeClient((input) => {
+				received.push(input);
+				call++;
+				if (call === 1) {
+					return {
+						Items: [
+							{
+								userId: USER_ID,
+								provider: "stripe",
+								status: "active",
+								subscriptionId: "sub_cancel",
+								customerId: "cus_cancel",
+								createdAt: "2026-05-20T10:00:00.000Z",
+								updatedAt: "2026-05-22T10:00:00.000Z",
+							},
+						],
+						Count: 1,
+					};
+				}
+				return {};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await subs.markCancelled({ subscriptionId: "sub_cancel" });
+
+			const queryCommand = received[0] as {
+				input: { IndexName?: string; KeyConditionExpression?: string };
+			};
+			expect(queryCommand.input.IndexName).toBe("subscriptionId-index");
+			expect(queryCommand.input.KeyConditionExpression).toContain(
+				"subscriptionId = :sid",
+			);
+
+			const updateCommand = received[1] as {
+				input: {
+					Key?: Record<string, unknown>;
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(updateCommand.input.Key).toEqual({ userId: USER_ID });
+			expect(updateCommand.input.UpdateExpression).toContain("#status = :status");
+			expect(updateCommand.input.ConditionExpression).toContain(
+				"attribute_exists(userId)",
+			);
+			expect(updateCommand.input.ExpressionAttributeValues?.[":status"]).toBe(
+				"cancelled",
+			);
+		});
+
+		it("throws when the subscriptionId is not present in the GSI", async () => {
+			const client = createFakeClient(() => ({ Items: [], Count: 0 }));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await expect(subs.markCancelled({ subscriptionId: "sub_unknown" })).rejects.toThrow(
+				/No subscription row/,
+			);
+		});
+	});
+
+	describe("markActive", () => {
+		it("issues a guarded Update that sets status=active and removes cancellationEffectiveAt", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await subs.markActive({ userId: USER_ID });
+
+			const command = received as {
+				input: {
+					Key?: Record<string, unknown>;
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.Key).toEqual({ userId: USER_ID });
+			expect(command.input.UpdateExpression).toContain("#status = :status");
+			expect(command.input.UpdateExpression).toContain("REMOVE cancellationEffectiveAt");
+			expect(command.input.ConditionExpression).toContain("attribute_exists(userId)");
+			expect(command.input.ExpressionAttributeValues?.[":status"]).toBe("active");
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.ts
+++ b/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.ts
@@ -1,0 +1,177 @@
+import {
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+	dynamoField,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { UserIdSchema } from "@packages/domain/user";
+import type {
+	FindSubscriptionBySubscriptionId,
+	FindSubscriptionByUserId,
+	MarkSubscriptionActive,
+	MarkSubscriptionCancelled,
+	MarkSubscriptionPendingCancellation,
+	SubscriptionRecord,
+	UpsertActiveSubscription,
+	UpsertTrialingSubscription,
+} from "@packages/test-fixtures/providers/subscription-providers";
+
+const SubscriptionProviderRow = z.object({
+	userId: UserIdSchema,
+	provider: z.literal("stripe"),
+	subscriptionId: dynamoField(z.string()),
+	customerId: dynamoField(z.string()),
+	status: z.enum(["trialing", "active", "pending_cancellation", "cancelled"]),
+	trialEndsAt: dynamoField(z.string()),
+	cancellationEffectiveAt: dynamoField(z.string()),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+});
+
+function toRecord(row: z.infer<typeof SubscriptionProviderRow>): SubscriptionRecord {
+	return {
+		userId: row.userId,
+		provider: row.provider,
+		...(row.subscriptionId !== undefined ? { subscriptionId: row.subscriptionId } : {}),
+		...(row.customerId !== undefined ? { customerId: row.customerId } : {}),
+		status: row.status,
+		...(row.trialEndsAt !== undefined ? { trialEndsAt: row.trialEndsAt } : {}),
+		...(row.cancellationEffectiveAt !== undefined ? { cancellationEffectiveAt: row.cancellationEffectiveAt } : {}),
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+	};
+}
+
+export function initDynamoDbSubscriptionProviders(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	now: () => Date;
+}): {
+	findByUserId: FindSubscriptionByUserId;
+	findBySubscriptionId: FindSubscriptionBySubscriptionId;
+	upsertTrialing: UpsertTrialingSubscription;
+	upsertActive: UpsertActiveSubscription;
+	markPendingCancellation: MarkSubscriptionPendingCancellation;
+	markCancelled: MarkSubscriptionCancelled;
+	markActive: MarkSubscriptionActive;
+} {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: SubscriptionProviderRow,
+	});
+
+	const findByUserId: FindSubscriptionByUserId = async (userId) => {
+		const row = await table.get({ userId });
+		return row ? toRecord(row) : undefined;
+	};
+
+	const findBySubscriptionId: FindSubscriptionBySubscriptionId = async (subscriptionId) => {
+		const { items } = await table.query({
+			IndexName: "subscriptionId-index",
+			KeyConditionExpression: "subscriptionId = :sid",
+			ExpressionAttributeValues: { ":sid": subscriptionId },
+			Limit: 1,
+		});
+		const row = items[0];
+		return row ? toRecord(row) : undefined;
+	};
+
+	const upsertTrialing: UpsertTrialingSubscription = async ({ userId, trialEndsAt }) => {
+		const nowIso = deps.now().toISOString();
+		await table.update({
+			Key: { userId },
+			UpdateExpression:
+				"SET #provider = :provider, #status = :status, trialEndsAt = :trialEndsAt, createdAt = if_not_exists(createdAt, :now), updatedAt = :now REMOVE subscriptionId, customerId, cancellationEffectiveAt",
+			ExpressionAttributeNames: {
+				"#provider": "provider",
+				"#status": "status",
+			},
+			ExpressionAttributeValues: {
+				":provider": "stripe",
+				":status": "trialing",
+				":trialEndsAt": trialEndsAt,
+				":now": nowIso,
+			},
+		});
+	};
+
+	const upsertActive: UpsertActiveSubscription = async ({ userId, subscriptionId, customerId }) => {
+		const nowIso = deps.now().toISOString();
+		await table.update({
+			Key: { userId },
+			UpdateExpression:
+				"SET #provider = :provider, #status = :status, subscriptionId = :subscriptionId, customerId = :customerId, createdAt = if_not_exists(createdAt, :now), updatedAt = :now REMOVE trialEndsAt, cancellationEffectiveAt",
+			ExpressionAttributeNames: {
+				"#provider": "provider",
+				"#status": "status",
+			},
+			ExpressionAttributeValues: {
+				":provider": "stripe",
+				":status": "active",
+				":subscriptionId": subscriptionId,
+				":customerId": customerId,
+				":now": nowIso,
+			},
+		});
+	};
+
+	const markPendingCancellation: MarkSubscriptionPendingCancellation = async ({ userId, cancellationEffectiveAt }) => {
+		await table.update({
+			Key: { userId },
+			UpdateExpression:
+				"SET #status = :status, cancellationEffectiveAt = :effectiveAt, updatedAt = :now",
+			ConditionExpression: "attribute_exists(userId)",
+			ExpressionAttributeNames: { "#status": "status" },
+			ExpressionAttributeValues: {
+				":status": "pending_cancellation",
+				":effectiveAt": cancellationEffectiveAt,
+				":now": deps.now().toISOString(),
+			},
+		});
+	};
+
+	const markCancelled: MarkSubscriptionCancelled = async ({ subscriptionId }) => {
+		const { items } = await table.query({
+			IndexName: "subscriptionId-index",
+			KeyConditionExpression: "subscriptionId = :sid",
+			ExpressionAttributeValues: { ":sid": subscriptionId },
+			Limit: 1,
+		});
+		const row = items[0];
+		if (!row) throw new Error(`No subscription row for subscriptionId ${subscriptionId}`);
+		await table.update({
+			Key: { userId: row.userId },
+			UpdateExpression: "SET #status = :status, updatedAt = :now",
+			ConditionExpression: "attribute_exists(userId)",
+			ExpressionAttributeNames: { "#status": "status" },
+			ExpressionAttributeValues: {
+				":status": "cancelled",
+				":now": deps.now().toISOString(),
+			},
+		});
+	};
+
+	const markActive: MarkSubscriptionActive = async ({ userId }) => {
+		await table.update({
+			Key: { userId },
+			UpdateExpression: "SET #status = :status, updatedAt = :now REMOVE cancellationEffectiveAt",
+			ConditionExpression: "attribute_exists(userId)",
+			ExpressionAttributeNames: { "#status": "status" },
+			ExpressionAttributeValues: {
+				":status": "active",
+				":now": deps.now().toISOString(),
+			},
+		});
+	};
+
+	return {
+		findByUserId,
+		findBySubscriptionId,
+		upsertTrialing,
+		upsertActive,
+		markPendingCancellation,
+		markCancelled,
+		markActive,
+	};
+}

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -31,7 +31,6 @@ import type {
 } from "@packages/test-fixtures/providers/pending-signup";
 import type {
 	UpsertActiveSubscription,
-	UpsertTrialingSubscription,
 } from "@packages/test-fixtures/providers/subscription-providers";
 import type { ExchangeGoogleCode } from "@packages/test-fixtures/providers/google-auth";
 import type {
@@ -183,7 +182,6 @@ interface AppDependencies {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
 	subscriptionProviders: {
-		upsertTrialing: UpsertTrialingSubscription;
 		upsertActive: UpsertActiveSubscription;
 	};
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -29,6 +29,10 @@ import type {
 	ConsumePendingSignup,
 	StorePendingSignup,
 } from "@packages/test-fixtures/providers/pending-signup";
+import type {
+	UpsertActiveSubscription,
+	UpsertTrialingSubscription,
+} from "@packages/test-fixtures/providers/subscription-providers";
 import type { ExchangeGoogleCode } from "@packages/test-fixtures/providers/google-auth";
 import type {
 	DeleteArticle,
@@ -178,6 +182,10 @@ interface AppDependencies {
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+	subscriptionProviders: {
+		upsertTrialing: UpsertTrialingSubscription;
+		upsertActive: UpsertActiveSubscription;
+	};
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
 	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
@@ -442,6 +450,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		retrieveCheckoutSession: deps.retrieveCheckoutSession,
 		storePendingSignup: deps.storePendingSignup,
 		consumePendingSignup: deps.consumePendingSignup,
+		subscriptionProviders: deps.subscriptionProviders,
 		appOrigin,
 		baseUrl: deps.baseUrl,
 		staticBaseUrl,

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -65,6 +65,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			shared: fixture.shared,
 			stripe: fixture.stripe,
 			pendingSignup: fixture.pendingSignup,
+			subscriptionProviders: fixture.subscriptionProviders,
 			botDefense: fixture.botDefense,
 			conversions: fixture.conversions,
 			foundingAllocation: fixture.foundingAllocation,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -57,6 +57,15 @@ import type {
 	StorePendingSignup,
 } from "@packages/test-fixtures/providers/pending-signup";
 import type {
+	FindSubscriptionBySubscriptionId,
+	FindSubscriptionByUserId,
+	MarkSubscriptionActive,
+	MarkSubscriptionCancelled,
+	MarkSubscriptionPendingCancellation,
+	UpsertActiveSubscription,
+	UpsertTrialingSubscription,
+} from "@packages/test-fixtures/providers/subscription-providers";
+import type {
 	ArticleMetadata,
 	Minutes,
 } from "@packages/domain/article";
@@ -124,6 +133,16 @@ export interface StripeCheckoutBundle {
 export interface PendingSignupBundle {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+}
+
+export interface SubscriptionProvidersBundle {
+	findByUserId: FindSubscriptionByUserId;
+	findBySubscriptionId: FindSubscriptionBySubscriptionId;
+	upsertTrialing: UpsertTrialingSubscription;
+	upsertActive: UpsertActiveSubscription;
+	markPendingCancellation: MarkSubscriptionPendingCancellation;
+	markCancelled: MarkSubscriptionCancelled;
+	markActive: MarkSubscriptionActive;
 }
 
 export interface ArticleStoreBundle {
@@ -269,6 +288,7 @@ export interface TestAppFixture {
 	shared: SharedBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
+	subscriptionProviders: SubscriptionProvidersBundle;
 	botDefense: BotDefenseBundle;
 	conversions: ConversionsBundle;
 	foundingAllocation: FoundingAllocationBundle;
@@ -291,6 +311,7 @@ export interface TestAppResult {
 	passwordReset: PasswordResetBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
+	subscriptionProviders: SubscriptionProvidersBundle;
 	botDefense: BotDefenseBundle;
 	conversions: ConversionsBundle;
 	analytics: AnalyticsBundle;
@@ -362,6 +383,10 @@ function flattenFixtureToAppDependencies(
 		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,
 		storePendingSignup: fixture.pendingSignup.storePendingSignup,
 		consumePendingSignup: fixture.pendingSignup.consumePendingSignup,
+		subscriptionProviders: {
+			upsertTrialing: fixture.subscriptionProviders.upsertTrialing,
+			upsertActive: fixture.subscriptionProviders.upsertActive,
+		},
 		botDefenseLogger: fixture.botDefense.logger,
 		conversionLogger: fixture.conversions.logger,
 		analytics: analyticsBundle.logger,
@@ -392,6 +417,7 @@ export function createTestApp(fixture: TestAppFixture): TestAppResult {
 		passwordReset: fixture.passwordReset,
 		stripe: fixture.stripe,
 		pendingSignup: fixture.pendingSignup,
+		subscriptionProviders: fixture.subscriptionProviders,
 		botDefense: fixture.botDefense,
 		conversions: fixture.conversions,
 		analytics: analyticsBundle,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -384,7 +384,6 @@ function flattenFixtureToAppDependencies(
 		storePendingSignup: fixture.pendingSignup.storePendingSignup,
 		consumePendingSignup: fixture.pendingSignup.consumePendingSignup,
 		subscriptionProviders: {
-			upsertTrialing: fixture.subscriptionProviders.upsertTrialing,
 			upsertActive: fixture.subscriptionProviders.upsertActive,
 		},
 		botDefenseLogger: fixture.botDefense.logger,

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -99,7 +99,7 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		emailField: toFieldViewModel(errors, "email"),
 		passwordField: toFieldViewModel(errors, "password"),
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
-		paidSubmitLabel: "Subscribe — $3.99/month",
+		submitLabel: "Join Readplace",
 		googleLabel: `Sign up with Google${trialSuffix}`,
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -99,7 +99,7 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		emailField: toFieldViewModel(errors, "email"),
 		passwordField: toFieldViewModel(errors, "password"),
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
-		submitLabel: `Join Readplace${trialSuffix}`,
+		paidSubmitLabel: "Subscribe — $3.99/month",
 		googleLabel: `Sign up with Google${trialSuffix}`,
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,

--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -107,6 +107,7 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		}),
 		foundingMemberLimit: data.foundingAllocation.foundingMemberLimit,
 		foundingAvailable: !data.foundingAllocation.isFoundingAllocationExhausted(data.userCount),
+		trialDays: STRIPE_TRIAL_PERIOD_DAYS,
 	});
 
 	return {

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -25,11 +25,7 @@ import type {
 	ConsumePendingSignup,
 	StorePendingSignup,
 } from "@packages/test-fixtures/providers/pending-signup";
-import type {
-	UpsertActiveSubscription,
-	UpsertTrialingSubscription,
-} from "@packages/test-fixtures/providers/subscription-providers";
-import { TRIAL_DURATION_DAYS } from "../../domain/subscription/trial-config";
+import type { UpsertActiveSubscription } from "@packages/test-fixtures/providers/subscription-providers";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import type {
 	CreateCheckoutSession,
@@ -57,8 +53,6 @@ import { emitUserCreated } from "../../conversions";
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
 const SignupQuerySchema = z.object({ email: z.string().email() }).passthrough();
-const SignupIntentSchema = z.enum(["trial", "paid"]);
-const MS_PER_DAY = 86400000;
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
 
@@ -84,7 +78,6 @@ interface AuthDependencies {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
 	subscriptionProviders: {
-		upsertTrialing: UpsertTrialingSubscription;
 		upsertActive: UpsertActiveSubscription;
 	};
 	appOrigin: string;
@@ -219,7 +212,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const returnUrl = extractReturnUrl(req.query);
 		const body = (req.body ?? {}) as Record<string, unknown>;
 
-		const renderFailure = async (email: string | undefined, errors: ComponentError[], statusCode = 422) => {
+		const renderFailure = async (email: string | undefined, errors: ComponentError[]) => {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				req, res,
@@ -232,7 +225,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						email,
 						errors,
 					},
-					{ statusCode },
+					{ statusCode: 422 },
 				), bannerStateFromRequest(req)),
 			);
 		};
@@ -261,43 +254,8 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			return;
 		}
 
-		const intentResult = SignupIntentSchema.safeParse(body.intent);
-		if (!intentResult.success) {
-			await renderFailure(result.email, [{ message: "Please choose Start free trial or Subscribe." }], 400);
-			return;
-		}
-		const intent = intentResult.data;
-
 		const { email, password } = result;
 		const passwordHash = await deps.hashPassword(password);
-
-		if (intent === "trial") {
-			const created = await deps.createUserWithPasswordHash({ email, passwordHash });
-			if (!created.ok) {
-				await renderFailure(email, [{ message: "An account with this email already exists" }]);
-				return;
-			}
-
-			const trialEndsAt = new Date(deps.now().getTime() + TRIAL_DURATION_DAYS * MS_PER_DAY).toISOString();
-			await deps.subscriptionProviders.upsertTrialing({ userId: created.userId, trialEndsAt });
-
-			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
-			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
-			sendVerificationEmail(created.userId, email);
-			emitUserCreated(
-				{ logger: deps.conversionLogger, now: deps.now },
-				{
-					userId: created.userId,
-					email,
-					method: "email",
-					tier: "trial",
-					attribution: readClickAttribution(req),
-				},
-			);
-			res.redirect(303, parseReturnUrl({ return: returnUrl }));
-			return;
-		}
-
 		const userCount = await fetchUserCount();
 
 		if (!deps.foundingAllocation.isFoundingAllocationExhausted(userCount)) {

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -20,10 +20,16 @@ import type {
 	VerifyEmailToken,
 } from "@packages/test-fixtures/providers/email-verification";
 import { VerificationTokenSchema } from "@packages/test-fixtures/providers/email-verification";
+import assert from "node:assert";
 import type {
 	ConsumePendingSignup,
 	StorePendingSignup,
 } from "@packages/test-fixtures/providers/pending-signup";
+import type {
+	UpsertActiveSubscription,
+	UpsertTrialingSubscription,
+} from "@packages/test-fixtures/providers/subscription-providers";
+import { TRIAL_DURATION_DAYS } from "../../domain/subscription/trial-config";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import type {
 	CreateCheckoutSession,
@@ -51,6 +57,8 @@ import { emitUserCreated } from "../../conversions";
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
 const SignupQuerySchema = z.object({ email: z.string().email() }).passthrough();
+const SignupIntentSchema = z.enum(["trial", "paid"]);
+const MS_PER_DAY = 86400000;
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
 
@@ -75,6 +83,10 @@ interface AuthDependencies {
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+	subscriptionProviders: {
+		upsertTrialing: UpsertTrialingSubscription;
+		upsertActive: UpsertActiveSubscription;
+	};
 	appOrigin: string;
 	baseUrl: string;
 	staticBaseUrl: string;
@@ -207,7 +219,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const returnUrl = extractReturnUrl(req.query);
 		const body = (req.body ?? {}) as Record<string, unknown>;
 
-		const renderFailure = async (email: string | undefined, errors: ComponentError[]) => {
+		const renderFailure = async (email: string | undefined, errors: ComponentError[], statusCode = 422) => {
 			const userCount = await fetchUserCount();
 			sendComponent(
 				req, res,
@@ -220,7 +232,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						email,
 						errors,
 					},
-					{ statusCode: 422 },
+					{ statusCode },
 				), bannerStateFromRequest(req)),
 			);
 		};
@@ -249,8 +261,43 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			return;
 		}
 
+		const intentResult = SignupIntentSchema.safeParse(body.intent);
+		if (!intentResult.success) {
+			await renderFailure(result.email, [{ message: "Please choose Start free trial or Subscribe." }], 400);
+			return;
+		}
+		const intent = intentResult.data;
+
 		const { email, password } = result;
 		const passwordHash = await deps.hashPassword(password);
+
+		if (intent === "trial") {
+			const created = await deps.createUserWithPasswordHash({ email, passwordHash });
+			if (!created.ok) {
+				await renderFailure(email, [{ message: "An account with this email already exists" }]);
+				return;
+			}
+
+			const trialEndsAt = new Date(deps.now().getTime() + TRIAL_DURATION_DAYS * MS_PER_DAY).toISOString();
+			await deps.subscriptionProviders.upsertTrialing({ userId: created.userId, trialEndsAt });
+
+			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
+			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			sendVerificationEmail(created.userId, email);
+			emitUserCreated(
+				{ logger: deps.conversionLogger, now: deps.now },
+				{
+					userId: created.userId,
+					email,
+					method: "email",
+					tier: "trial",
+					attribution: readClickAttribution(req),
+				},
+			);
+			res.redirect(303, parseReturnUrl({ return: returnUrl }));
+			return;
+		}
+
 		const userCount = await fetchUserCount();
 
 		if (!deps.foundingAllocation.isFoundingAllocationExhausted(userCount)) {
@@ -337,6 +384,10 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			return;
 		}
 
+		const { subscriptionId, customerId } = session;
+		assert(subscriptionId, "Stripe checkout session must carry a subscriptionId for a paid signup");
+		assert(customerId, "Stripe checkout session must carry a customerId for a paid signup");
+
 		const pending = await deps.consumePendingSignup(checkoutSessionId);
 		if (!pending) {
 			await renderFailure(409, "This checkout link has already been used.");
@@ -355,6 +406,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				return;
 			}
 
+			await deps.subscriptionProviders.upsertActive({ userId: created.userId, subscriptionId, customerId });
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 			sendVerificationEmail(created.userId, pending.email);
@@ -386,12 +438,14 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			if (!lookup.emailVerified) {
 				await deps.markEmailVerified(pending.email);
 			}
+			await deps.subscriptionProviders.upsertActive({ userId: lookup.userId, subscriptionId, customerId });
 			const sessionId = await deps.createSession({ userId: lookup.userId, emailVerified: true });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 			res.redirect(303, returnPath);
 			return;
 		}
 
+		await deps.subscriptionProviders.upsertActive({ userId: created.userId, subscriptionId, customerId });
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
 		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
 		sendWelcomeEmail(pending.email);

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -308,7 +308,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -337,7 +336,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -358,7 +356,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -374,7 +371,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -393,7 +389,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -431,7 +426,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(422);
@@ -451,7 +445,6 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -619,159 +612,6 @@ describe("Auth routes", () => {
 			expect(doc.querySelector('[data-test-error="password"]')?.textContent).toBe("Password must be at least 8 characters");
 		});
 
-		it("returns 400 when intent is missing from a valid signup payload", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "missing-intent@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-			});
-
-			expect(response.status).toBe(400);
-			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("Start free trial");
-		});
-
-		it("returns 400 when intent is unknown", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "bad-intent@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-				intent: "premium",
-			});
-
-			expect(response.status).toBe(400);
-		});
-	});
-
-	describe("POST /signup — trial intent", () => {
-		it("creates a trialing subscription row with trialEndsAt ~14 days out and redirects to /queue", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const { auth, subscriptionProviders } = harness;
-
-			const before = Date.now();
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "trial@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-				intent: "trial",
-			});
-			const after = Date.now();
-
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
-			expect(response.headers["set-cookie"].length).toBeGreaterThan(0);
-
-			const lookup = await auth.findUserByEmail("trial@example.com");
-			assert(lookup, "trial signup must persist a user");
-
-			const subRow = await subscriptionProviders.findByUserId(lookup.userId);
-			assert(subRow, "subscription_providers row must be written for the trial user");
-			expect(subRow.status).toBe("trialing");
-			expect(subRow.provider).toBe("stripe");
-			expect(subRow.subscriptionId).toBeUndefined();
-			expect(subRow.customerId).toBeUndefined();
-
-			assert(subRow.trialEndsAt, "trialEndsAt must be set on a trialing row");
-			const trialEndsMs = new Date(subRow.trialEndsAt).getTime();
-			const expectedEndsMin = before + 14 * 86400000;
-			const expectedEndsMax = after + 14 * 86400000;
-			expect(trialEndsMs).toBeGreaterThanOrEqual(expectedEndsMin);
-			expect(trialEndsMs).toBeLessThanOrEqual(expectedEndsMax);
-		}, 30000);
-
-		it("emits a user_created conversion event with tier=trial on trial signup", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const { conversions } = harness;
-
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "trial-convert@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-				intent: "trial",
-			});
-
-			expect(response.status).toBe(303);
-			expect(conversions.events).toHaveLength(1);
-			expect(conversions.events[0]).toMatchObject({
-				stream: "conversions",
-				event: "user_created",
-				method: "email",
-				tier: "trial",
-			});
-		});
-
-		it("does not create a Stripe checkout when intent=trial", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const { pendingSignup } = harness;
-
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "trial-no-stripe@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-				intent: "trial",
-			});
-
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
-
-			const consumed = await pendingSignup.consumePendingSignup(
-				CheckoutSessionIdSchema.parse("cs_test_never_created"),
-			);
-			expect(consumed).toBeNull();
-		});
-
-		it("creates a trialing row even when the founding allocation is exhausted", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const { auth, subscriptionProviders } = harness;
-			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
-				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
-			}
-
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "trial-after-limit@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-				intent: "trial",
-			});
-
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/queue");
-			const lookup = await auth.findUserByEmail("trial-after-limit@example.com");
-			assert(lookup, "user must be persisted");
-			const subRow = await subscriptionProviders.findByUserId(lookup.userId);
-			assert(subRow, "trial row must be written even after the founding limit");
-			expect(subRow.status).toBe("trialing");
-		}, 30000);
-
-		it("rejects a trial signup that targets an email that already exists", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const { auth } = harness;
-			await auth.createUser({ email: "already@example.com", password: "existing-password" });
-
-			const response = await request(harness.server).post("/signup").type("form").send({
-				email: "already@example.com",
-				password: "password123",
-				confirmPassword: "password123",
-				loadedAt: freshLoadedAt(),
-				intent: "trial",
-			});
-
-			expect(response.status).toBe(422);
-			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain(
-				"already exists",
-			);
-		});
 	});
 
 	describe("POST /signup — bot defense", () => {
@@ -956,7 +796,6 @@ describe("Auth routes", () => {
 				confirmPassword: "password123",
 				loadedAt: String(Date.now() - 5000),
 				website: "",
-				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -1130,6 +969,27 @@ describe("Auth routes", () => {
 			const blurb = doc.querySelector("[data-test-founding-blurb]");
 			expect(blurb?.textContent).toBe(`Free account for the first ${TEST_FOUNDING_MEMBER_LIMIT} readers`);
 		});
+
+		it("hides the trial hint on /signup when the founding allocation is available", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
+			const doc = new JSDOM(response.text).window.document;
+
+			expect(doc.querySelector("[data-test-trial-hint]")).toBeNull();
+		});
+	});
+
+	describe("Signup submit button", () => {
+		it("renders a single 'Join Readplace' submit button (no intent attribute)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/signup");
+			const doc = new JSDOM(response.text).window.document;
+
+			const submits = doc.querySelectorAll('[data-test-form="signup"] button[type="submit"]');
+			expect(submits).toHaveLength(1);
+			expect(submits[0]?.textContent).toBe("Join Readplace");
+			expect(submits[0]?.getAttribute("name")).toBeNull();
+		});
 	});
 
 	describe("Founding members progress — exhausted allocation", () => {
@@ -1143,6 +1003,17 @@ describe("Auth routes", () => {
 			const signupDoc = new JSDOM((await request(harness.server).get("/signup")).text).window.document;
 			expect(signupDoc.querySelector("[data-test-founding-progress]")).toBeNull();
 			expect(signupDoc.querySelector("[data-test-founding-blurb]")).toBeNull();
+		}, 30000);
+
+		it("renders '14 days. Cancel any time.' trial hint on /signup when the founding allocation is exhausted", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
+				await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
+			}
+
+			const doc = new JSDOM((await request(harness.server).get("/signup")).text).window.document;
+			expect(doc.querySelector("[data-test-trial-hint]")?.textContent).toBe("14 days. Cancel any time.");
 		}, 30000);
 	});
 });

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -308,6 +308,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -336,6 +337,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -356,6 +358,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -371,6 +374,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -389,6 +393,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -426,6 +431,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(422);
@@ -445,6 +451,7 @@ describe("Auth routes", () => {
 				password: "password123",
 				confirmPassword: "password123",
 				loadedAt: freshLoadedAt(),
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);
@@ -610,6 +617,160 @@ describe("Auth routes", () => {
 			expect(response.status).toBe(422);
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector('[data-test-error="password"]')?.textContent).toBe("Password must be at least 8 characters");
+		});
+
+		it("returns 400 when intent is missing from a valid signup payload", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "missing-intent@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(400);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("Start free trial");
+		});
+
+		it("returns 400 when intent is unknown", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "bad-intent@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				intent: "premium",
+			});
+
+			expect(response.status).toBe(400);
+		});
+	});
+
+	describe("POST /signup — trial intent", () => {
+		it("creates a trialing subscription row with trialEndsAt ~14 days out and redirects to /queue", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, subscriptionProviders } = harness;
+
+			const before = Date.now();
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "trial@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				intent: "trial",
+			});
+			const after = Date.now();
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+			expect(response.headers["set-cookie"].length).toBeGreaterThan(0);
+
+			const lookup = await auth.findUserByEmail("trial@example.com");
+			assert(lookup, "trial signup must persist a user");
+
+			const subRow = await subscriptionProviders.findByUserId(lookup.userId);
+			assert(subRow, "subscription_providers row must be written for the trial user");
+			expect(subRow.status).toBe("trialing");
+			expect(subRow.provider).toBe("stripe");
+			expect(subRow.subscriptionId).toBeUndefined();
+			expect(subRow.customerId).toBeUndefined();
+
+			assert(subRow.trialEndsAt, "trialEndsAt must be set on a trialing row");
+			const trialEndsMs = new Date(subRow.trialEndsAt).getTime();
+			const expectedEndsMin = before + 14 * 86400000;
+			const expectedEndsMax = after + 14 * 86400000;
+			expect(trialEndsMs).toBeGreaterThanOrEqual(expectedEndsMin);
+			expect(trialEndsMs).toBeLessThanOrEqual(expectedEndsMax);
+		}, 30000);
+
+		it("emits a user_created conversion event with tier=trial on trial signup", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { conversions } = harness;
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "trial-convert@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				intent: "trial",
+			});
+
+			expect(response.status).toBe(303);
+			expect(conversions.events).toHaveLength(1);
+			expect(conversions.events[0]).toMatchObject({
+				stream: "conversions",
+				event: "user_created",
+				method: "email",
+				tier: "trial",
+			});
+		});
+
+		it("does not create a Stripe checkout when intent=trial", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { pendingSignup } = harness;
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "trial-no-stripe@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				intent: "trial",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+
+			const consumed = await pendingSignup.consumePendingSignup(
+				CheckoutSessionIdSchema.parse("cs_test_never_created"),
+			);
+			expect(consumed).toBeNull();
+		});
+
+		it("creates a trialing row even when the founding allocation is exhausted", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, subscriptionProviders } = harness;
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
+				await auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "trial-after-limit@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				intent: "trial",
+			});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+			const lookup = await auth.findUserByEmail("trial-after-limit@example.com");
+			assert(lookup, "user must be persisted");
+			const subRow = await subscriptionProviders.findByUserId(lookup.userId);
+			assert(subRow, "trial row must be written even after the founding limit");
+			expect(subRow.status).toBe("trialing");
+		}, 30000);
+
+		it("rejects a trial signup that targets an email that already exists", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			await auth.createUser({ email: "already@example.com", password: "existing-password" });
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "already@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+				intent: "trial",
+			});
+
+			expect(response.status).toBe(422);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain(
+				"already exists",
+			);
 		});
 	});
 
@@ -795,6 +956,7 @@ describe("Auth routes", () => {
 				confirmPassword: "password123",
 				loadedAt: String(Date.now() - 5000),
 				website: "",
+				intent: "paid",
 			});
 
 			expect(response.status).toBe(303);

--- a/projects/hutch/src/runtime/web/auth/auth.styles.css
+++ b/projects/hutch/src/runtime/web/auth/auth.styles.css
@@ -122,6 +122,24 @@
   opacity: 0.9;
 }
 
+.auth-form__submit--secondary {
+  background: var(--card);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.auth-form__submit--secondary:hover {
+  background: var(--background);
+  opacity: 1;
+}
+
+.auth-form__hint {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  text-align: center;
+  margin: 0;
+}
+
 .auth-form__global-error {
   background: var(--error-bg);
   border: 1px solid var(--error);

--- a/projects/hutch/src/runtime/web/auth/auth.styles.css
+++ b/projects/hutch/src/runtime/web/auth/auth.styles.css
@@ -122,17 +122,6 @@
   opacity: 0.9;
 }
 
-.auth-form__submit--secondary {
-  background: var(--card);
-  color: var(--foreground);
-  border: 1px solid var(--border);
-}
-
-.auth-form__submit--secondary:hover {
-  background: var(--background);
-  opacity: 1;
-}
-
 .auth-form__hint {
   font-size: 0.8125rem;
   color: var(--muted-foreground);

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -50,7 +50,6 @@ describe("GET /auth/checkout/success", () => {
 			password: "password123",
 			confirmPassword: "password123",
 			loadedAt: String(Date.now() - 5000),
-			intent: "paid",
 		});
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),
@@ -148,7 +147,6 @@ describe("GET /auth/checkout/success", () => {
 			password: "password123",
 			confirmPassword: "password123",
 			loadedAt: String(Date.now() - 5000),
-			intent: "paid",
 		});
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -50,6 +50,7 @@ describe("GET /auth/checkout/success", () => {
 			password: "password123",
 			confirmPassword: "password123",
 			loadedAt: String(Date.now() - 5000),
+			intent: "paid",
 		});
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),
@@ -114,6 +115,29 @@ describe("GET /auth/checkout/success", () => {
 		expect(credentials.ok).toBe(true);
 	});
 
+	it("writes an active subscription_providers row with the Stripe ids on first paid visit", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, stripe, subscriptionProviders } = harness;
+
+		await completeStripeSignup({
+			server: harness.server,
+			auth,
+			stripe,
+			email: "sub-active@example.com",
+			password: "password123",
+		});
+
+		const lookup = await auth.findUserByEmail("sub-active@example.com");
+		assert(lookup, "user must exist after paid signup");
+		const subRow = await subscriptionProviders.findByUserId(lookup.userId);
+		assert(subRow, "subscription_providers row must be written for the paid user");
+		expect(subRow.status).toBe("active");
+		expect(subRow.provider).toBe("stripe");
+		expect(subRow.subscriptionId).toMatch(/^sub_test_[0-9a-f]+$/);
+		expect(subRow.customerId).toMatch(/^cus_test_[0-9a-f]+$/);
+		expect(subRow.trialEndsAt).toBeUndefined();
+	});
+
 	it("renders 409 when the email has been claimed since the Stripe redirect started", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { auth, stripe } = harness;
@@ -124,6 +148,7 @@ describe("GET /auth/checkout/success", () => {
 			password: "password123",
 			confirmPassword: "password123",
 			loadedAt: String(Date.now() - 5000),
+			intent: "paid",
 		});
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(
 			new URL(signup.headers.location).pathname.replace(/^\//, ""),

--- a/projects/hutch/src/runtime/web/auth/signup.template.html
+++ b/projects/hutch/src/runtime/web/auth/signup.template.html
@@ -27,7 +27,7 @@
             {{#if confirmPasswordField.error}}<p class="auth-form__error" data-test-error="confirmPassword">{{confirmPasswordField.error}}</p>{{/if}}
           </div>
           <button class="auth-form__submit" type="submit" data-test-action="signup">{{submitLabel}}</button>
-          {{#unless foundingAvailable}}<p class="auth-form__hint" data-test-trial-hint>14 days. Cancel any time.</p>{{/unless}}
+          {{#unless foundingAvailable}}<p class="auth-form__hint" data-test-trial-hint>{{trialDays}} days. Cancel any time.</p>{{/unless}}
         </form>
         <div class="auth-google-section" data-test-google-section>
           <div class="auth-divider">or</div>

--- a/projects/hutch/src/runtime/web/auth/signup.template.html
+++ b/projects/hutch/src/runtime/web/auth/signup.template.html
@@ -26,7 +26,9 @@
             <input class="auth-form__input{{confirmPasswordField.errorClass}}" type="password" id="confirmPassword" name="confirmPassword" required autocomplete="new-password">
             {{#if confirmPasswordField.error}}<p class="auth-form__error" data-test-error="confirmPassword">{{confirmPasswordField.error}}</p>{{/if}}
           </div>
-          <button class="auth-form__submit" type="submit">{{submitLabel}}</button>
+          <button class="auth-form__submit" type="submit" name="intent" value="trial" data-test-action="signup-trial">Start free trial</button>
+          <p class="auth-form__hint" data-test-trial-hint>14 days, no credit card required. Cancel any time.</p>
+          <button class="auth-form__submit auth-form__submit--secondary" type="submit" name="intent" value="paid" data-test-action="signup-paid">{{paidSubmitLabel}}</button>
         </form>
         <div class="auth-google-section" data-test-google-section>
           <div class="auth-divider">or</div>

--- a/projects/hutch/src/runtime/web/auth/signup.template.html
+++ b/projects/hutch/src/runtime/web/auth/signup.template.html
@@ -26,9 +26,8 @@
             <input class="auth-form__input{{confirmPasswordField.errorClass}}" type="password" id="confirmPassword" name="confirmPassword" required autocomplete="new-password">
             {{#if confirmPasswordField.error}}<p class="auth-form__error" data-test-error="confirmPassword">{{confirmPasswordField.error}}</p>{{/if}}
           </div>
-          <button class="auth-form__submit" type="submit" name="intent" value="trial" data-test-action="signup-trial">Start free trial</button>
-          <p class="auth-form__hint" data-test-trial-hint>14 days, no credit card required. Cancel any time.</p>
-          <button class="auth-form__submit auth-form__submit--secondary" type="submit" name="intent" value="paid" data-test-action="signup-paid">{{paidSubmitLabel}}</button>
+          <button class="auth-form__submit" type="submit" data-test-action="signup">{{submitLabel}}</button>
+          {{#unless foundingAvailable}}<p class="auth-form__hint" data-test-trial-hint>14 days. Cancel any time.</p>{{/unless}}
         </form>
         <div class="auth-google-section" data-test-google-section>
           <div class="auth-divider">or</div>

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -55,7 +55,6 @@ export async function completeStripeSignup(params: {
 			password: params.password,
 			confirmPassword: params.password,
 			loadedAt: String(Date.now() - 5000),
-			intent: "paid",
 		});
 
 	assert.equal(signupResponse.status, 303, "signup should redirect to Stripe");

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -55,6 +55,7 @@ export async function completeStripeSignup(params: {
 			password: params.password,
 			confirmPassword: params.password,
 			loadedAt: String(Date.now() - 5000),
+			intent: "paid",
 		});
 
 	assert.equal(signupResponse.status, 303, "signup should redirect to Stripe");

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -65,6 +65,10 @@
       "types": "./dist/providers/stripe-checkout/index.d.ts",
       "default": "./dist/providers/stripe-checkout/index.js"
     },
+    "./providers/subscription-providers": {
+      "types": "./dist/providers/subscription-providers/index.d.ts",
+      "default": "./dist/providers/subscription-providers/index.js"
+    },
     "./providers/import-session": {
       "types": "./dist/providers/import-session/index.d.ts",
       "default": "./dist/providers/import-session/index.js"
@@ -98,6 +102,7 @@
       "providers/refresh-html": ["./dist/providers/refresh-html/index.d.ts"],
       "providers/pending-signup": ["./dist/providers/pending-signup/index.d.ts"],
       "providers/stripe-checkout": ["./dist/providers/stripe-checkout/index.d.ts"],
+      "providers/subscription-providers": ["./dist/providers/subscription-providers/index.d.ts"],
       "providers/import-session": ["./dist/providers/import-session/index.d.ts"],
       "providers/oauth": ["./dist/providers/oauth/index.d.ts"],
       "providers/events": ["./dist/providers/events/index.d.ts"],

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -59,6 +59,15 @@ import type {
 	StorePendingSignup,
 } from "./providers/pending-signup/pending-signup.types";
 import type {
+	FindSubscriptionBySubscriptionId,
+	FindSubscriptionByUserId,
+	MarkSubscriptionActive,
+	MarkSubscriptionCancelled,
+	MarkSubscriptionPendingCancellation,
+	UpsertActiveSubscription,
+	UpsertTrialingSubscription,
+} from "./providers/subscription-providers/subscription-providers.types";
+import type {
 	DeleteArticle,
 	FindArticleById,
 	FindArticleByUrl,
@@ -124,6 +133,16 @@ export interface StripeCheckoutBundle {
 export interface PendingSignupBundle {
 	storePendingSignup: StorePendingSignup;
 	consumePendingSignup: ConsumePendingSignup;
+}
+
+export interface SubscriptionProvidersBundle {
+	findByUserId: FindSubscriptionByUserId;
+	findBySubscriptionId: FindSubscriptionBySubscriptionId;
+	upsertTrialing: UpsertTrialingSubscription;
+	upsertActive: UpsertActiveSubscription;
+	markPendingCancellation: MarkSubscriptionPendingCancellation;
+	markCancelled: MarkSubscriptionCancelled;
+	markActive: MarkSubscriptionActive;
 }
 
 export interface ArticleStoreBundle {
@@ -269,6 +288,7 @@ export interface TestAppFixture {
 	shared: SharedBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;
+	subscriptionProviders: SubscriptionProvidersBundle;
 	botDefense: BotDefenseBundle;
 	conversions: ConversionsBundle;
 	foundingAllocation: FoundingAllocationBundle;

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -16,6 +16,7 @@ import { initInMemoryPasswordReset } from "./providers/password-reset/in-memory-
 import { initInMemoryPendingHtml } from "./providers/pending-html/in-memory-pending-html";
 import { initInMemoryPendingSignup } from "./providers/pending-signup/in-memory-pending-signup";
 import { initInMemoryStripeCheckout } from "./providers/stripe-checkout/in-memory-stripe-checkout";
+import { initInMemorySubscriptionProviders } from "./providers/subscription-providers/in-memory-subscription-providers";
 import { initInMemoryImportSession } from "./providers/import-session/in-memory-import-session";
 import { initInMemorySaveLinkRawHtmlCommand } from "./providers/events/in-memory-save-link-raw-html-command";
 import { initInMemoryExportUserDataCommand } from "./providers/events/in-memory-export-user-data-command";
@@ -227,6 +228,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 	const oauthModel = createOAuthModel(initInMemoryOAuthModel(), { appOrigin });
 	const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => new Date() });
 	const pendingSignup = initInMemoryPendingSignup();
+	const subscriptionProviders = initInMemorySubscriptionProviders({ now: () => new Date() });
 
 	const botDefenseEvents: BotDefenseEvent[] = [];
 	/** Shared capture handler for every level — production code only ever calls
@@ -319,6 +321,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		},
 		stripe,
 		pendingSignup,
+		subscriptionProviders,
 		botDefense: { logger: botDefenseLogger, events: botDefenseEvents },
 		conversions: { logger: conversionLogger, events: conversionEvents },
 		/** Small enough that founding-allocation seed loops finish in

--- a/src/packages/test-fixtures/src/providers/auth/conversion.types.ts
+++ b/src/packages/test-fixtures/src/providers/auth/conversion.types.ts
@@ -7,7 +7,7 @@ export interface ConversionEvent {
 	user_id: UserId;
 	email_hash: string;
 	method: "email" | "google";
-	tier: "free" | "paid";
+	tier: "free" | "paid" | "trial";
 	utm_source?: string;
 	utm_medium?: string;
 	utm_campaign?: string;

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
@@ -60,6 +60,22 @@ describe("initInMemoryStripeCheckout", () => {
 		}
 	});
 
+	it("returns generated subscriptionId and customerId for a created session", async () => {
+		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
+		const session = await stripe.createCheckoutSession({
+			customerEmail: "buyer@example.com",
+			successUrl: "https://app.test/ok",
+			cancelUrl: "https://app.test/cancel",
+		});
+
+		const retrieved = await stripe.retrieveCheckoutSession(session.id);
+		assert.equal(retrieved.ok, true);
+		if (retrieved.ok) {
+			expect(retrieved.subscriptionId).toMatch(/^sub_test_[0-9a-f]+$/);
+			expect(retrieved.customerId).toMatch(/^cus_test_[0-9a-f]+$/);
+		}
+	});
+
 	it("uses the injected clock for created timestamp", async () => {
 		const fixedDate = new Date("2026-06-15T10:00:00Z");
 		const stripe = initInMemoryStripeCheckout({ checkoutBaseUrl: "https://checkout.stripe.test", now: () => fixedDate });

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.ts
@@ -12,6 +12,8 @@ interface StoredSession {
 	paid: boolean;
 	status: CheckoutSessionStatus;
 	created: number;
+	subscriptionId: string;
+	customerId: string;
 }
 
 export function initInMemoryStripeCheckout(opts: {
@@ -29,11 +31,14 @@ export function initInMemoryStripeCheckout(opts: {
 
 	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl }) => {
 		const id = CheckoutSessionIdSchema.parse(`cs_test_${randomBytes(12).toString("hex")}`);
+		const sessionSuffix = randomBytes(8).toString("hex");
 		sessions.set(id, {
 			customerEmail,
 			paid: false,
 			status: "open",
 			created: Math.floor(opts.now().getTime() / 1000),
+			subscriptionId: `sub_test_${sessionSuffix}`,
+			customerId: `cus_test_${sessionSuffix}`,
 		});
 		const url = `${opts.checkoutBaseUrl}/${id}?next=${encodeURIComponent(successUrl)}`;
 		urls.set(id, url);
@@ -49,6 +54,8 @@ export function initInMemoryStripeCheckout(opts: {
 			customerEmail: session.customerEmail,
 			status: session.status,
 			created: session.created,
+			subscriptionId: session.subscriptionId,
+			customerId: session.customerId,
 		};
 	};
 

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.types.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.types.ts
@@ -21,6 +21,8 @@ export type RetrieveCheckoutSession = (id: CheckoutSessionId) => Promise<
 			customerEmail: string;
 			status: CheckoutSessionStatus;
 			created: number;
+			subscriptionId?: string;
+			customerId?: string;
 	  }
 	| { ok: false; reason: "not-found" }
 >;

--- a/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.test.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
+import { initInMemorySubscriptionProviders } from "./in-memory-subscription-providers";
+
+describe("initInMemorySubscriptionProviders", () => {
+	const userId = UserIdSchema.parse("u-1");
+	const otherUserId = UserIdSchema.parse("u-2");
+
+	function fixedNow(iso: string) {
+		return () => new Date(iso);
+	}
+
+	it("returns undefined for an unknown userId", async () => {
+		const { findByUserId } = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+		expect(await findByUserId(userId)).toBeUndefined();
+	});
+
+	it("returns undefined for an unknown subscriptionId", async () => {
+		const { findBySubscriptionId } = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+		expect(await findBySubscriptionId("sub_missing")).toBeUndefined();
+	});
+
+	it("writes a trialing row with trialEndsAt and no Stripe ids", async () => {
+		const { upsertTrialing, findByUserId } = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+
+		await upsertTrialing({ userId, trialEndsAt: "2026-06-05T00:00:00.000Z" });
+
+		const row = await findByUserId(userId);
+		assert(row, "trialing row must exist");
+		expect(row.status).toBe("trialing");
+		expect(row.provider).toBe("stripe");
+		expect(row.trialEndsAt).toBe("2026-06-05T00:00:00.000Z");
+		expect(row.subscriptionId).toBeUndefined();
+		expect(row.customerId).toBeUndefined();
+		expect(row.createdAt).toBe("2026-05-22T00:00:00.000Z");
+		expect(row.updatedAt).toBe("2026-05-22T00:00:00.000Z");
+	});
+
+	it("writes an active row with Stripe ids and clears trialEndsAt", async () => {
+		const { upsertActive, findByUserId, findBySubscriptionId } = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+
+		await upsertActive({ userId, subscriptionId: "sub_123", customerId: "cus_123" });
+
+		const row = await findByUserId(userId);
+		assert(row, "active row must exist");
+		expect(row.status).toBe("active");
+		expect(row.subscriptionId).toBe("sub_123");
+		expect(row.customerId).toBe("cus_123");
+		expect(row.trialEndsAt).toBeUndefined();
+
+		const byId = await findBySubscriptionId("sub_123");
+		expect(byId?.userId).toBe(userId);
+	});
+
+	it("preserves createdAt when upserting active over a trialing row", async () => {
+		const clock = { iso: "2026-05-22T00:00:00.000Z" };
+		const subs = initInMemorySubscriptionProviders({ now: () => new Date(clock.iso) });
+		await subs.upsertTrialing({ userId, trialEndsAt: "2026-06-05T00:00:00.000Z" });
+
+		clock.iso = "2026-05-24T00:00:00.000Z";
+		await subs.upsertActive({ userId, subscriptionId: "sub_abc", customerId: "cus_abc" });
+
+		const row = await subs.findByUserId(userId);
+		assert(row, "row must exist after upsert");
+		expect(row.status).toBe("active");
+		expect(row.trialEndsAt).toBeUndefined();
+		expect(row.createdAt).toBe("2026-05-22T00:00:00.000Z");
+		expect(row.updatedAt).toBe("2026-05-24T00:00:00.000Z");
+	});
+
+	it("marks a subscription as pending_cancellation with effective date", async () => {
+		const clock = { iso: "2026-05-22T00:00:00.000Z" };
+		const subs = initInMemorySubscriptionProviders({ now: () => new Date(clock.iso) });
+		await subs.upsertActive({ userId, subscriptionId: "sub_x", customerId: "cus_x" });
+
+		clock.iso = "2026-05-30T00:00:00.000Z";
+		await subs.markPendingCancellation({ userId, cancellationEffectiveAt: "2026-06-22T00:00:00.000Z" });
+
+		const row = await subs.findByUserId(userId);
+		assert(row, "row must exist");
+		expect(row.status).toBe("pending_cancellation");
+		expect(row.cancellationEffectiveAt).toBe("2026-06-22T00:00:00.000Z");
+		expect(row.subscriptionId).toBe("sub_x");
+		expect(row.updatedAt).toBe("2026-05-30T00:00:00.000Z");
+	});
+
+	it("throws when markPendingCancellation is called for an unknown user", async () => {
+		const subs = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+		await expect(
+			subs.markPendingCancellation({ userId, cancellationEffectiveAt: "2026-06-22T00:00:00.000Z" }),
+		).rejects.toThrow(/No subscription row/);
+	});
+
+	it("marks a subscription as cancelled by subscriptionId", async () => {
+		const clock = { iso: "2026-05-22T00:00:00.000Z" };
+		const subs = initInMemorySubscriptionProviders({ now: () => new Date(clock.iso) });
+		await subs.upsertActive({ userId, subscriptionId: "sub_a", customerId: "cus_a" });
+		await subs.upsertActive({ userId: otherUserId, subscriptionId: "sub_b", customerId: "cus_b" });
+
+		clock.iso = "2026-06-01T00:00:00.000Z";
+		await subs.markCancelled({ subscriptionId: "sub_a" });
+
+		const a = await subs.findByUserId(userId);
+		const b = await subs.findByUserId(otherUserId);
+		assert(a && b, "both rows must exist");
+		expect(a.status).toBe("cancelled");
+		expect(a.updatedAt).toBe("2026-06-01T00:00:00.000Z");
+		expect(b.status).toBe("active");
+	});
+
+	it("throws when markCancelled cannot find the subscriptionId", async () => {
+		const subs = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+		await expect(subs.markCancelled({ subscriptionId: "sub_missing" })).rejects.toThrow(/No subscription row/);
+	});
+
+	it("marks a pending_cancellation row back to active when resumed", async () => {
+		const clock = { iso: "2026-05-22T00:00:00.000Z" };
+		const subs = initInMemorySubscriptionProviders({ now: () => new Date(clock.iso) });
+		await subs.upsertActive({ userId, subscriptionId: "sub_r", customerId: "cus_r" });
+		await subs.markPendingCancellation({ userId, cancellationEffectiveAt: "2026-06-22T00:00:00.000Z" });
+
+		clock.iso = "2026-05-28T00:00:00.000Z";
+		await subs.markActive({ userId });
+
+		const row = await subs.findByUserId(userId);
+		assert(row, "row must exist");
+		expect(row.status).toBe("active");
+		expect(row.updatedAt).toBe("2026-05-28T00:00:00.000Z");
+	});
+
+	it("throws when markActive is called for an unknown user", async () => {
+		const subs = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+		await expect(subs.markActive({ userId })).rejects.toThrow(/No subscription row/);
+	});
+});

--- a/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.test.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.test.ts
@@ -125,6 +125,7 @@ describe("initInMemorySubscriptionProviders", () => {
 		const row = await subs.findByUserId(userId);
 		assert(row, "row must exist");
 		expect(row.status).toBe("active");
+		expect(row.cancellationEffectiveAt).toBeUndefined();
 		expect(row.updatedAt).toBe("2026-05-28T00:00:00.000Z");
 	});
 

--- a/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.ts
@@ -88,8 +88,9 @@ export function initInMemorySubscriptionProviders(opts: {
 	const markActive: MarkSubscriptionActive = async ({ userId }) => {
 		const existing = rows.get(userId);
 		assert(existing, `No subscription row for user ${userId}`);
+		const { cancellationEffectiveAt: _ca, ...rest } = existing;
 		rows.set(userId, {
-			...existing,
+			...rest,
 			status: "active",
 			updatedAt: opts.now().toISOString(),
 		});

--- a/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert";
+import type { UserId } from "@packages/domain/user";
+import type {
+	FindSubscriptionBySubscriptionId,
+	FindSubscriptionByUserId,
+	MarkSubscriptionActive,
+	MarkSubscriptionCancelled,
+	MarkSubscriptionPendingCancellation,
+	SubscriptionRecord,
+	UpsertActiveSubscription,
+	UpsertTrialingSubscription,
+} from "./subscription-providers.types";
+
+export function initInMemorySubscriptionProviders(opts: {
+	now: () => Date;
+}): {
+	findByUserId: FindSubscriptionByUserId;
+	findBySubscriptionId: FindSubscriptionBySubscriptionId;
+	upsertTrialing: UpsertTrialingSubscription;
+	upsertActive: UpsertActiveSubscription;
+	markPendingCancellation: MarkSubscriptionPendingCancellation;
+	markCancelled: MarkSubscriptionCancelled;
+	markActive: MarkSubscriptionActive;
+} {
+	const rows = new Map<UserId, SubscriptionRecord>();
+
+	const findByUserId: FindSubscriptionByUserId = async (userId) => rows.get(userId);
+
+	const findBySubscriptionId: FindSubscriptionBySubscriptionId = async (subscriptionId) => {
+		for (const row of rows.values()) {
+			if (row.subscriptionId === subscriptionId) return row;
+		}
+		return undefined;
+	};
+
+	const upsertTrialing: UpsertTrialingSubscription = async ({ userId, trialEndsAt }) => {
+		const existing = rows.get(userId);
+		const nowIso = opts.now().toISOString();
+		rows.set(userId, {
+			userId,
+			provider: "stripe",
+			status: "trialing",
+			trialEndsAt,
+			createdAt: existing?.createdAt ?? nowIso,
+			updatedAt: nowIso,
+		});
+	};
+
+	const upsertActive: UpsertActiveSubscription = async ({ userId, subscriptionId, customerId }) => {
+		const existing = rows.get(userId);
+		const nowIso = opts.now().toISOString();
+		rows.set(userId, {
+			userId,
+			provider: "stripe",
+			subscriptionId,
+			customerId,
+			status: "active",
+			createdAt: existing?.createdAt ?? nowIso,
+			updatedAt: nowIso,
+		});
+	};
+
+	const markPendingCancellation: MarkSubscriptionPendingCancellation = async ({ userId, cancellationEffectiveAt }) => {
+		const existing = rows.get(userId);
+		assert(existing, `No subscription row for user ${userId}`);
+		rows.set(userId, {
+			...existing,
+			status: "pending_cancellation",
+			cancellationEffectiveAt,
+			updatedAt: opts.now().toISOString(),
+		});
+	};
+
+	const markCancelled: MarkSubscriptionCancelled = async ({ subscriptionId }) => {
+		for (const [userId, row] of rows.entries()) {
+			if (row.subscriptionId === subscriptionId) {
+				rows.set(userId, {
+					...row,
+					status: "cancelled",
+					updatedAt: opts.now().toISOString(),
+				});
+				return;
+			}
+		}
+		throw new Error(`No subscription row for subscriptionId ${subscriptionId}`);
+	};
+
+	const markActive: MarkSubscriptionActive = async ({ userId }) => {
+		const existing = rows.get(userId);
+		assert(existing, `No subscription row for user ${userId}`);
+		rows.set(userId, {
+			...existing,
+			status: "active",
+			updatedAt: opts.now().toISOString(),
+		});
+	};
+
+	return {
+		findByUserId,
+		findBySubscriptionId,
+		upsertTrialing,
+		upsertActive,
+		markPendingCancellation,
+		markCancelled,
+		markActive,
+	};
+}

--- a/src/packages/test-fixtures/src/providers/subscription-providers/index.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/index.ts
@@ -1,0 +1,2 @@
+export * from "./subscription-providers.types";
+export * from "./in-memory-subscription-providers";

--- a/src/packages/test-fixtures/src/providers/subscription-providers/subscription-providers.types.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/subscription-providers.types.ts
@@ -1,0 +1,51 @@
+/* c8 ignore start -- type-only file, no runtime code */
+import type { UserId } from "@packages/domain/user";
+
+export type SubscriptionStatus =
+	| "trialing"
+	| "active"
+	| "pending_cancellation"
+	| "cancelled";
+
+export interface SubscriptionRecord {
+	userId: UserId;
+	provider: "stripe";
+	subscriptionId?: string;
+	customerId?: string;
+	status: SubscriptionStatus;
+	trialEndsAt?: string;
+	cancellationEffectiveAt?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export type FindSubscriptionByUserId = (
+	userId: UserId,
+) => Promise<SubscriptionRecord | undefined>;
+
+export type FindSubscriptionBySubscriptionId = (
+	subscriptionId: string,
+) => Promise<SubscriptionRecord | undefined>;
+
+export type UpsertTrialingSubscription = (input: {
+	userId: UserId;
+	trialEndsAt: string;
+}) => Promise<void>;
+
+export type UpsertActiveSubscription = (input: {
+	userId: UserId;
+	subscriptionId: string;
+	customerId: string;
+}) => Promise<void>;
+
+export type MarkSubscriptionPendingCancellation = (input: {
+	userId: UserId;
+	cancellationEffectiveAt: string;
+}) => Promise<void>;
+
+export type MarkSubscriptionCancelled = (input: {
+	subscriptionId: string;
+}) => Promise<void>;
+
+export type MarkSubscriptionActive = (input: { userId: UserId }) => Promise<void>;
+/* c8 ignore stop */


### PR DESCRIPTION
## Summary

Phase 0 of the subscription rework: decouple our domain "subscription"
from Stripe by introducing a dedicated `subscription_providers`
DynamoDB table, and add a 14-day no-card trial in parallel to the
existing paid path. Same table powers both.

- New `subscription_providers` table keyed by `userId` with a
  `status` enum (`trialing | active | pending_cancellation |
  cancelled`) and a `subscriptionId-index` GSI so future webhook
  handlers can look up users without scanning. Wired through
  `HutchStorage`, `HutchDynamoDBAccess`, and the SSR Lambda's env
  block via a new `DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE` var sourced
  from Pulumi config.
- `GET /auth/checkout/success` now captures `subscriptionId` /
  `customerId` from the Stripe session — previously dropped on the
  floor — and writes them onto an `active` row. The production Stripe
  wrapper was extended to surface `subscription` and `customer`
  alongside the existing fields; the in-memory fixture mirrors that.
- `POST /signup` now reads `req.body.intent` (`"trial"` or `"paid"`,
  validated via Zod). The trial branch creates the user immediately,
  writes a `trialing` row with `trialEndsAt = signup + 14 days` (no
  Stripe IDs), and redirects to `/queue`. The paid branch runs the
  existing founding-allocation + checkout flow unchanged. Signup page
  surfaces both as separate submit buttons inside the same form.
- Adds `tier: "trial"` to the conversion event so downstream
  attribution queries can split out the no-card path.

A user with no row in `subscription_providers` is treated as a
grandfathered founding member, so every account that existed before
this phase deploys keeps full access without a backfill script.

## Test plan
- [x] `pnpm nx run hutch:test` — 1342 passing (added trial-intent,
  intent-validation, active-row-on-paid, and trial conversion tests)
- [x] `pnpm nx run @packages/test-fixtures:test` — 227 passing
  (covers the in-memory subscription store end-to-end)
- [x] `pnpm nx run-many --target test-with-coverage` — 100%
  thresholds met, including the new dynamodb wrapper
- [x] `pnpm nx run-many --target lint` — clean
- [ ] `pnpm nx run hutch:check-infra` — Pulumi not available in this
  sandbox; runs in CI
- [ ] After staging deploy: visit `/signup`, confirm both CTAs;
  click trial → land on `/queue` with a `trialing` row in
  `hutch-subscription-providers-staging` and `trialEndsAt` ~14 days
  out; complete a Stripe test checkout from the other branch and
  confirm an `active` row with the IDs

https://claude.ai/code/session_01QwkJLk7ecLLj586V7JRmBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwkJLk7ecLLj586V7JRmBE)_