### PR TITLE
feat(hutch): expire public /view access 3 days after save unless shared

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -126,6 +126,22 @@ const BUNDLES = [
 			"});",
 		].join("\n"),
 	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/pages/view/expiry-counter.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "expiry-counter.client.js"),
+		globalName: "ExpiryCounter",
+		footer: [
+			"ExpiryCounter.initExpiryCounter({",
+			"  document: window.document,",
+			"  now: function () { return Date.now(); },",
+			"  setIntervalFn: function (cb, ms) { return window.setInterval(cb, ms); },",
+			"  clearIntervalFn: function (id) { window.clearInterval(id); }",
+			"});",
+		].join("\n"),
+	},
 ];
 
 function buildOptions(bundle) {

--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -50,6 +50,7 @@ const ArticleRow = z.object({
 	content: dynamoField(z.string()),
 	estimatedReadTime: MinutesSchema,
 	contentSourceTier: dynamoField(z.enum(["tier-0", "tier-1"])),
+	savedAt: z.string(),
 });
 /** Every ArticleRow attribute except `content`, derived so the list stays in sync with the schema. */
 const ArticleMetadataFields = ArticleRow.omit({ content: true }).keyof().options;
@@ -127,17 +128,13 @@ export function initDynamoDbArticleStore(deps: {
 		return row ?? null;
 	}
 
-	const ignoreDuplicate = (error: unknown) => {
-		if (error instanceof ConditionalCheckFailedException) return;
-		throw error;
-	};
-
 	const saveArticleGlobally: SaveArticleGlobally = async (params) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
 		const routeId = ReaderArticleHashId.from(params.url);
+		const savedAtIso = params.savedAt.toISOString();
 
-		await articles
-			.put({
+		try {
+			await articles.put({
 				Item: {
 					url: articleResourceUniqueId.value,
 					routeId: routeId.value,
@@ -148,12 +145,20 @@ export function initDynamoDbArticleStore(deps: {
 					wordCount: params.metadata.wordCount,
 					imageUrl: params.metadata.imageUrl,
 					estimatedReadTime: params.estimatedReadTime,
-					savedAt: params.savedAt.toISOString(),
+					savedAt: savedAtIso,
 				},
 				ConditionExpression: "attribute_not_exists(#url)",
 				ExpressionAttributeNames: { "#url": "url" },
-			})
-			.catch(ignoreDuplicate);
+			});
+		} catch (error) {
+			if (!(error instanceof ConditionalCheckFailedException)) throw error;
+			/** Row already exists — bump savedAt so the public /view expiry counter resets to the full 3-day window on every re-save. Metadata is left untouched so a stub re-save (the view fallback path passes hostname-only metadata) cannot clobber the real parsed metadata. */
+			await articles.update({
+				Key: { url: articleResourceUniqueId.value },
+				UpdateExpression: "SET savedAt = :savedAt",
+				ExpressionAttributeValues: { ":savedAt": savedAtIso },
+			});
+		}
 	};
 
 	const saveArticle: SaveArticle = async (params) => {
@@ -373,6 +378,7 @@ export function initDynamoDbArticleStore(deps: {
 					"imageUrl",
 					"estimatedReadTime",
 					"contentSourceTier",
+					"savedAt",
 				],
 			},
 		);
@@ -389,6 +395,7 @@ export function initDynamoDbArticleStore(deps: {
 			},
 			estimatedReadTime: row.estimatedReadTime,
 			contentSourceTier: row.contentSourceTier,
+			savedAt: new Date(row.savedAt),
 		};
 	};
 

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
@@ -1,15 +1,17 @@
+import assert from "node:assert/strict";
 import type { Minutes, SavedArticle } from "@packages/domain/article";
 import { ReaderArticleHashId } from "@packages/domain/article";
 import { UserIdSchema } from "@packages/domain/user";
 import { initReaderPermalink, type ReaderPermalinkDeps } from "./reader-permalink";
 
-const OWNER_ID = UserIdSchema.parse("owner-user");
-const STRANGER_ID = UserIdSchema.parse("stranger-user");
+const OWNER_ID = UserIdSchema.parse("a3f1c2deadbeef0123456789abcdef01");
+const STRANGER_ID = UserIdSchema.parse("b4c5d6abcdef0123456789abcdef0123");
 const ARTICLE_URL = "https://example.com/shared-article";
 const ARTICLE_ID = ReaderArticleHashId.from(ARTICLE_URL);
 const UNKNOWN_HASH = "0".repeat(32);
 
 const DEFAULT_UTM = "utm_source=read&utm_medium=share&utm_campaign=read-permalink";
+const STRANGER_UTM_CONTENT = "b4c5d6";
 
 function savedArticleFor(userId = OWNER_ID): SavedArticle {
 	return {
@@ -55,7 +57,7 @@ describe("resolveReaderPermalink", () => {
 		expect(result).toEqual({ kind: "article", article: owned });
 	});
 
-	it("redirects a logged-in non-owner to the public /view permalink with default UTM params", async () => {
+	it("redirects a logged-in non-owner to the public /view permalink with the requester's userId prefix stamped into utm_content so the receiving view treats it as a permanent share", async () => {
 		const resolve = initReaderPermalink(createDeps({
 			findArticleById: async () => null,
 			findArticleUrlById: async (id) =>
@@ -68,12 +70,12 @@ describe("resolveReaderPermalink", () => {
 			kind: "redirect",
 			redirect: {
 				statusCode: 302,
-				location: `/view/${encodeURIComponent(ARTICLE_URL)}?${DEFAULT_UTM}`,
+				location: `/view/${encodeURIComponent(ARTICLE_URL)}?${DEFAULT_UTM}&utm_content=${STRANGER_UTM_CONTENT}`,
 			},
 		});
 	});
 
-	it("redirects an anonymous visitor to the public /view permalink without consulting findArticleById", async () => {
+	it("redirects an anonymous visitor to the public /view permalink without a utm_content userId (no share-trace available) so the standard expiry applies", async () => {
 		let ownerLookupCalls = 0;
 		const resolve = initReaderPermalink(createDeps({
 			findArticleById: async () => {
@@ -113,6 +115,23 @@ describe("resolveReaderPermalink", () => {
 				location: `/view/${encodeURIComponent(ARTICLE_URL)}?utm_source=newsletter&utm_campaign=weekly`,
 			},
 		});
+	});
+
+	it("overrides incoming utm_content with the requester's userId prefix so a re-shared link still carries the latest sharer's trace", async () => {
+		const resolve = initReaderPermalink(createDeps({
+			findArticleUrlById: async () => ARTICLE_URL,
+		}));
+
+		const result = await resolve({
+			rawId: ARTICLE_ID.value,
+			requesterId: STRANGER_ID,
+			query: { utm_source: "newsletter", utm_content: "old-trace" },
+		});
+
+		assert(result.kind === "redirect", "result must be a redirect");
+		const location = new URL(result.redirect.location, "http://localhost");
+		expect(location.searchParams.get("utm_source")).toBe("newsletter");
+		expect(location.searchParams.get("utm_content")).toBe(STRANGER_UTM_CONTENT);
 	});
 
 	it("redirects to /queue when the hash is well-formed but no article matches", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
@@ -8,6 +8,7 @@ import type {
 } from "@packages/test-fixtures/providers/article-store";
 import type { Redirect } from "../../redirect.component";
 import { collectUtmParams } from "../../shared/utm";
+import { shareUserIdPrefix } from "../view/view-expiry";
 
 export interface ReaderPermalinkDeps {
 	findArticleById: FindArticleById;
@@ -32,17 +33,28 @@ const REDIRECT_TO_QUEUE: ReaderPermalinkResult = {
 /** UTM params on the /view redirect let analytics distinguish shared
  * /read clicks from organic /view traffic. Preserve any incoming UTM
  * (e.g. a campaign-tagged share URL) over the defaults so external
- * attribution survives the redirect. */
-function buildShareRedirectUrl(articleUrl: string, query: Request["query"]): string {
+ * attribution survives the redirect. When the requester is authenticated,
+ * stamp the first 6 chars of their userId into `utm_content` so the
+ * receiving public /view recognises the link as a logged-in user's share
+ * and skips the 3-day access expiry — see view-expiry.ts. */
+function buildShareRedirectUrl(
+	articleUrl: string,
+	query: Request["query"],
+	requesterId: UserId | undefined,
+): string {
 	const incomingUtm = collectUtmParams(query);
-	const utmParams: [string, string][] = incomingUtm.length > 0
+	const baseParams: [string, string][] = incomingUtm.length > 0
 		? incomingUtm
 		: [
 			["utm_source", "read"],
 			["utm_medium", "share"],
 			["utm_campaign", "read-permalink"],
 		];
-	return `/view/${encodeURIComponent(articleUrl)}?${new URLSearchParams(utmParams).toString()}`;
+	const params = new URLSearchParams(baseParams);
+	if (requesterId !== undefined) {
+		params.set("utm_content", shareUserIdPrefix(requesterId));
+	}
+	return `/view/${encodeURIComponent(articleUrl)}?${params.toString()}`;
 }
 
 export function initReaderPermalink(deps: ReaderPermalinkDeps) {
@@ -65,7 +77,10 @@ export function initReaderPermalink(deps: ReaderPermalinkDeps) {
 		 * owner, so caches must not pin a single response. */
 		return {
 			kind: "redirect",
-			redirect: { statusCode: 302, location: buildShareRedirectUrl(articleUrl, input.query) },
+			redirect: {
+				statusCode: 302,
+				location: buildShareRedirectUrl(articleUrl, input.query, input.requesterId),
+			},
 		};
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
@@ -46,4 +46,23 @@ describe("ReaderPage", () => {
 		const wrap = doc.querySelector("[data-test-share-balloon-wrap]");
 		assert(wrap, "share balloon wrap must be rendered");
 	});
+
+	it("stamps the share-balloon's utm_content with the article owner's first 6 userId chars so the public /view treats the link as permanent", () => {
+		const ownerId = UserIdSchema.parse("a3f1c2deadbeef0123456789abcdef01");
+		const html = Base(ReaderPage(makeArticle({ userId: ownerId })), {
+			isAuthenticated: true,
+			emailVerified: undefined,
+		}).to("text/html").body;
+		const doc = new JSDOM(html).window.document;
+
+		const shareBtn = doc.querySelector("[data-test-share-balloon]");
+		assert(shareBtn, "share button must be rendered");
+		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		expect(shareUrl.searchParams.get("utm_content")).toBe("a3f1c2");
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		expect(copyUrl.searchParams.get("utm_content")).toBe("a3f1c2");
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -12,6 +12,7 @@ import {
 	SHARE_BALLOON_SCRIPT,
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
+import { shareUserIdPrefix } from "../view/view-expiry";
 import { READER_STYLES } from "./reader.styles";
 
 const CANONICAL_BASE_URL = "https://readplace.com";
@@ -91,6 +92,7 @@ export function ReaderPage(
 		shareTitle: article.metadata.title,
 		shareHint: "Click here to share this post!",
 		shareSource: "reader-internal",
+		sharerUserIdPrefix: shareUserIdPrefix(article.userId),
 	});
 	const content = render(READER_TEMPLATE, { innerContent, shareBalloon });
 

--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	decomposeTimeLeftClient,
+	formatCounterText,
+	formatSaveUtmContentClient,
+	initExpiryCounter,
+	withSaveUtmContent,
+} from "./expiry-counter.client";
+
+const FIXED_NOW = new Date("2026-05-20T00:00:00.000Z").getTime();
+
+function buildDoc(html: string): { document: Document; window: Window } {
+	const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`);
+	return {
+		document: dom.window.document,
+		window: dom.window as unknown as Window,
+	};
+}
+
+interface FakeInterval {
+	id: number;
+	tick(): void;
+}
+
+function buildFakeInterval(): {
+	setIntervalFn: (cb: () => void, ms: number) => unknown;
+	clearIntervalFn: (id: unknown) => void;
+	intervals: FakeInterval[];
+} {
+	const intervals: FakeInterval[] = [];
+	return {
+		setIntervalFn(cb) {
+			const id = intervals.length + 1;
+			intervals.push({ id, tick: cb });
+			return id;
+		},
+		clearIntervalFn(id) {
+			const idx = intervals.findIndex((i) => i.id === id);
+			if (idx >= 0) intervals.splice(idx, 1);
+		},
+		intervals,
+	};
+}
+
+describe("decomposeTimeLeftClient", () => {
+	it("splits a duration into d/h/m/s using the same algorithm as the server helper", () => {
+		expect(decomposeTimeLeftClient(((24 + 2) * 3600 + 30) * 1000)).toEqual({
+			days: 1,
+			hours: 2,
+			minutes: 0,
+			seconds: 30,
+		});
+	});
+
+	it("clamps non-positive values to zero so the counter degrades to `0d 0h 0m 0s`", () => {
+		expect(decomposeTimeLeftClient(-1)).toEqual({
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+	});
+});
+
+describe("formatCounterText", () => {
+	it("matches the SSR copy so the first client tick does not replace the server text with a different format", () => {
+		expect(
+			formatCounterText({ days: 1, hours: 2, minutes: 3, seconds: 4 }),
+		).toBe("Public access will expire in 1d 2h 3m 4s");
+	});
+});
+
+describe("formatSaveUtmContentClient", () => {
+	it("matches the SSR utm_content so click-time and load-time analytics rows share the same value when no second has elapsed", () => {
+		expect(
+			formatSaveUtmContentClient({ days: 2, hours: 4, minutes: 5, seconds: 6 }),
+		).toBe("2d_4h_left");
+	});
+});
+
+describe("withSaveUtmContent", () => {
+	it("rewrites utm_content on a relative href while preserving other params and the path", () => {
+		expect(
+			withSaveUtmContent("/save?url=x&utm_content=2d_4h_left&foo=bar", "1d_5h_left"),
+		).toBe("/save?url=x&utm_content=1d_5h_left&foo=bar");
+	});
+
+	it("preserves the absolute origin when the href is fully qualified", () => {
+		expect(
+			withSaveUtmContent("https://readplace.com/save?utm_content=old", "0d_3h_left"),
+		).toBe("https://readplace.com/save?utm_content=0d_3h_left");
+	});
+
+	it("adds utm_content when none was present in the original href", () => {
+		expect(withSaveUtmContent("/save?url=x", "1d_5h_left")).toBe(
+			"/save?url=x&utm_content=1d_5h_left",
+		);
+	});
+});
+
+describe("initExpiryCounter", () => {
+	it("returns undefined when no expiry element exists (e.g. the landing page)", () => {
+		const { document } = buildDoc("");
+		const fake = buildFakeInterval();
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => FIXED_NOW,
+			...fake,
+		});
+
+		expect(controller).toBeUndefined();
+		expect(fake.intervals.length).toBe(0);
+	});
+
+	it("returns undefined when state='permanent' so the script becomes a no-op", () => {
+		const { document } = buildDoc(
+			`<p data-test-view-expiry data-expiry-state="permanent">Public access doesn't expire.</p>`,
+		);
+		const fake = buildFakeInterval();
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => FIXED_NOW,
+			...fake,
+		});
+
+		expect(controller).toBeUndefined();
+		expect(fake.intervals.length).toBe(0);
+	});
+
+	it("ticks the visible counter text and updates [data-expiry-save-link] anchors' utm_content on each interval", () => {
+		const expiresAt = new Date(FIXED_NOW + 90_000);
+		const { document } = buildDoc(`
+			<a data-expiry-save-link data-test-view-cta-action href="/save?url=x&utm_content=0d_0h_left">Save</a>
+			<p
+				data-test-view-expiry
+				data-expiry-state="counting"
+				data-expires-at="${expiresAt.toISOString()}"
+			>Public access will expire in 0d 0h 1m 30s</p>
+		`);
+		const fake = buildFakeInterval();
+		let nowMs = FIXED_NOW;
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => nowMs,
+			...fake,
+		});
+		assert(controller, "controller should be returned when counter is active");
+
+		const expiry = document.querySelector("[data-test-view-expiry]");
+		assert(expiry, "expiry element must exist");
+		expect(expiry.textContent).toContain("0d 0h 1m 30s");
+
+		nowMs += 60_000;
+		fake.intervals[0]?.tick();
+
+		expect(expiry.textContent).toContain("0d 0h 0m 30s");
+		const saveLink = document.querySelector("[data-expiry-save-link]");
+		assert(saveLink, "save link must exist");
+		const updatedHref = saveLink.getAttribute("href");
+		assert(updatedHref, "href must be set");
+		const updated = new URL(updatedHref, "http://placeholder.invalid");
+		expect(updated.searchParams.get("utm_content")).toBe("0d_0h_left");
+	});
+
+	it("flips state to 'expired' and stops ticking once the deadline passes so the interval doesn't keep firing forever", () => {
+		const expiresAt = new Date(FIXED_NOW + 1_000);
+		const { document } = buildDoc(
+			`<p data-test-view-expiry data-expiry-state="counting" data-expires-at="${expiresAt.toISOString()}">Public access will expire in 0d 0h 0m 1s</p>`,
+		);
+		const fake = buildFakeInterval();
+		let nowMs = FIXED_NOW;
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => nowMs,
+			...fake,
+		});
+		assert(controller, "controller should be returned");
+
+		nowMs += 2_000;
+		fake.intervals[0]?.tick();
+
+		const expiry = document.querySelector("[data-test-view-expiry]");
+		assert(expiry, "expiry element must exist");
+		expect(expiry.getAttribute("data-expiry-state")).toBe("expired");
+		expect(expiry.textContent?.trim()).toBe("Public access has expired.");
+		expect(fake.intervals.length).toBe(0);
+	});
+
+	it("returns undefined when data-expires-at is missing so a malformed render does not throw", () => {
+		const { document } = buildDoc(
+			`<p data-test-view-expiry data-expiry-state="counting">Public access will expire in 0d 0h 1m 30s</p>`,
+		);
+		const fake = buildFakeInterval();
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => FIXED_NOW,
+			...fake,
+		});
+
+		expect(controller).toBeUndefined();
+	});
+
+	it("returns undefined when data-expires-at is not a parseable ISO string", () => {
+		const { document } = buildDoc(
+			`<p data-test-view-expiry data-expiry-state="counting" data-expires-at="not-a-date">x</p>`,
+		);
+		const fake = buildFakeInterval();
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => FIXED_NOW,
+			...fake,
+		});
+
+		expect(controller).toBeUndefined();
+	});
+
+	it("stop() detaches the interval so callers can clean up without leaks", () => {
+		const expiresAt = new Date(FIXED_NOW + 60_000);
+		const { document } = buildDoc(
+			`<p data-test-view-expiry data-expiry-state="counting" data-expires-at="${expiresAt.toISOString()}">x</p>`,
+		);
+		const fake = buildFakeInterval();
+
+		const controller = initExpiryCounter({
+			document,
+			now: () => FIXED_NOW,
+			...fake,
+		});
+		assert(controller, "controller should be returned");
+		expect(fake.intervals.length).toBe(1);
+
+		controller.stop();
+		expect(fake.intervals.length).toBe(0);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
@@ -3,7 +3,7 @@
  * /view page.
  *
  * Reads:
- *   [data-test-view-expiry][data-expiry-state="counting"][data-expires-at]
+ *   [data-expiry-state="counting"][data-expires-at]
  *
  * The server renders the counter with the correct initial value so the page
  * is correct on first paint and remains correct without JS. This module
@@ -87,7 +87,7 @@ interface ExpiryCounterController {
 export function initExpiryCounter(
 	deps: ExpiryCounterDeps,
 ): ExpiryCounterController | undefined {
-	const el = deps.document.querySelector("[data-test-view-expiry]");
+	const el = deps.document.querySelector("[data-expiry-state]");
 	if (el === null) return undefined;
 	if (el.getAttribute("data-expiry-state") !== "counting") return undefined;
 	const expiresAtRaw = el.getAttribute("data-expires-at");

--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
@@ -1,0 +1,137 @@
+/**
+ * Tick the "Public access will expire in Xd Yh Zm Ws" counter on the public
+ * /view page.
+ *
+ * Reads:
+ *   [data-test-view-expiry][data-expiry-state="counting"][data-expires-at]
+ *
+ * The server renders the counter with the correct initial value so the page
+ * is correct on first paint and remains correct without JS. This module
+ * refreshes the visible text every second and, when the configured grace
+ * period elapses, swaps the state to "expired" so CSS can recolour it.
+ *
+ * It also rewrites every `[data-expiry-save-link]` anchor's `utm_content` to
+ * carry the current `Xd_Yh_left` value at click time, so the analytics row
+ * for a save click reflects how much time the visitor had left.
+ *
+ * Permanent links (state="permanent") and already-expired links
+ * (state="expired") need no client logic; the script becomes a no-op.
+ */
+
+interface ExpiryAnchor {
+	href: string;
+}
+
+interface ExpiryCounterElement {
+	textContent: string | null;
+	getAttribute(name: string): string | null;
+	setAttribute(name: string, value: string): void;
+}
+
+interface ExpiryDocument {
+	querySelector(selector: string): ExpiryCounterElement | null;
+	querySelectorAll(selector: string): ArrayLike<ExpiryAnchor>;
+}
+
+interface ExpiryCounterDeps {
+	document: ExpiryDocument;
+	now: () => number;
+	setIntervalFn: (cb: () => void, ms: number) => unknown;
+	clearIntervalFn: (id: unknown) => void;
+}
+
+export interface TimeLeftClient {
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+}
+
+export function decomposeTimeLeftClient(ms: number): TimeLeftClient {
+	if (ms <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+	const totalSeconds = Math.floor(ms / 1000);
+	return {
+		days: Math.floor(totalSeconds / 86400),
+		hours: Math.floor((totalSeconds % 86400) / 3600),
+		minutes: Math.floor((totalSeconds % 3600) / 60),
+		seconds: totalSeconds % 60,
+	};
+}
+
+export function formatCounterText(left: TimeLeftClient): string {
+	return `Public access will expire in ${left.days}d ${left.hours}h ${left.minutes}m ${left.seconds}s`;
+}
+
+export function formatSaveUtmContentClient(left: TimeLeftClient): string {
+	return `${left.days}d_${left.hours}h_left`;
+}
+
+/** Replace `utm_content` in an absolute or relative URL while preserving every other query parameter and the path. The server only ever renders well-formed save hrefs so a parse failure here would mean the DOM was tampered with — the `URL` constructor with a base URL is permissive enough that no realistic input throws. */
+export function withSaveUtmContent(
+	href: string,
+	utmContent: string,
+): string {
+	const parsed = new URL(href, "http://placeholder.invalid");
+	parsed.searchParams.set("utm_content", utmContent);
+	if (parsed.origin === "http://placeholder.invalid") {
+		return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+	}
+	return parsed.toString();
+}
+
+interface ExpiryCounterController {
+	tick(): void;
+	stop(): void;
+}
+
+export function initExpiryCounter(
+	deps: ExpiryCounterDeps,
+): ExpiryCounterController | undefined {
+	const el = deps.document.querySelector("[data-test-view-expiry]");
+	if (el === null) return undefined;
+	if (el.getAttribute("data-expiry-state") !== "counting") return undefined;
+	const expiresAtRaw = el.getAttribute("data-expires-at");
+	if (expiresAtRaw === null) return undefined;
+	const expiresAtMs = Date.parse(expiresAtRaw);
+	if (!Number.isFinite(expiresAtMs)) return undefined;
+
+	const saveLinks: ExpiryAnchor[] = Array.from(
+		deps.document.querySelectorAll("[data-expiry-save-link]"),
+	);
+	const originalHrefs = saveLinks.map((link) => link.href);
+
+	let intervalId: unknown;
+	let stopped = false;
+
+	function tick(): void {
+		if (stopped) return;
+		const msLeft = expiresAtMs - deps.now();
+		const left = decomposeTimeLeftClient(msLeft);
+		el?.setAttribute("data-expiry-state", msLeft <= 0 ? "expired" : "counting");
+		if (el !== null) {
+			el.textContent =
+				msLeft <= 0 ? "Public access has expired." : formatCounterText(left);
+		}
+		const utmContent = formatSaveUtmContentClient(left);
+		for (let i = 0; i < saveLinks.length; i += 1) {
+			saveLinks[i].href = withSaveUtmContent(originalHrefs[i], utmContent);
+		}
+		if (msLeft <= 0) {
+			stop();
+		}
+	}
+
+	function stop(): void {
+		if (stopped) return;
+		stopped = true;
+		if (intervalId !== undefined) {
+			deps.clearIntervalFn(intervalId);
+			intervalId = undefined;
+		}
+	}
+
+	tick();
+	intervalId = deps.setIntervalFn(tick, 1000);
+
+	return { tick, stop };
+}

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import type { UserId } from "@packages/domain/user";
+import {
+	PERMANENT_UTM_SOURCE,
+	PUBLIC_VIEW_ACCESS_WINDOW_MS,
+	SHARED_USER_ID_PREFIX_LENGTH,
+	computePublicViewExpiry,
+	decomposeTimeLeft,
+	formatCounter,
+	formatSaveUtmContent,
+	hasSharedUserIdPrefix,
+	shareUserIdPrefix,
+} from "./view-expiry";
+
+const SAVED_AT = new Date("2026-05-20T00:00:00.000Z");
+const EXPIRES_AT = new Date(
+	SAVED_AT.getTime() + PUBLIC_VIEW_ACCESS_WINDOW_MS,
+);
+
+describe("shareUserIdPrefix", () => {
+	it("returns the first 6 characters of the userId so the sharer can be traced without exposing the whole id", () => {
+		const userId = "a3f1c2deadbeef0123456789abcdef01" as UserId;
+
+		expect(shareUserIdPrefix(userId)).toBe("a3f1c2");
+		expect(shareUserIdPrefix(userId).length).toBe(SHARED_USER_ID_PREFIX_LENGTH);
+	});
+});
+
+describe("hasSharedUserIdPrefix", () => {
+	it("matches utm_content that starts with 6 hex chars (a logged-in sharer's id prefix)", () => {
+		expect(hasSharedUserIdPrefix("a3f1c2")).toBe(true);
+		expect(hasSharedUserIdPrefix("a3f1c2-some-suffix")).toBe(true);
+		expect(hasSharedUserIdPrefix("0000ff_more")).toBe(true);
+	});
+
+	it("rejects values that do not start with 6 hex chars so analytics-only utm_content like `paste-another-link` keeps the standard expiry", () => {
+		expect(hasSharedUserIdPrefix("paste-another-link")).toBe(false);
+		expect(hasSharedUserIdPrefix("a3f1c")).toBe(false);
+		expect(hasSharedUserIdPrefix("ZZZZZZ")).toBe(false);
+		expect(hasSharedUserIdPrefix("share-balloon-fallback")).toBe(false);
+	});
+
+	it("returns false when utm_content is undefined", () => {
+		expect(hasSharedUserIdPrefix(undefined)).toBe(false);
+	});
+});
+
+describe("computePublicViewExpiry", () => {
+	it("returns savedAt + 3 days for an organic visit (no utm_source, no utm_content)", () => {
+		const result = computePublicViewExpiry({
+			savedAt: SAVED_AT,
+			utmSource: undefined,
+			utmContent: undefined,
+		});
+
+		assert(result.expiresAt, "expiresAt must be set for organic visits");
+		expect(result.expiresAt.toISOString()).toBe(EXPIRES_AT.toISOString());
+	});
+
+	it("returns null (permanent) when utm_source = fagnerbrack.com so syndication from the founder's blog never expires", () => {
+		const result = computePublicViewExpiry({
+			savedAt: SAVED_AT,
+			utmSource: PERMANENT_UTM_SOURCE,
+			utmContent: undefined,
+		});
+
+		expect(result.expiresAt).toBeNull();
+	});
+
+	it("returns null (permanent) when utm_content carries a 6-hex-char userId prefix (share-balloon or /read redirect)", () => {
+		const result = computePublicViewExpiry({
+			savedAt: SAVED_AT,
+			utmSource: "share-balloon",
+			utmContent: "a3f1c2",
+		});
+
+		expect(result.expiresAt).toBeNull();
+	});
+
+	it("applies the standard expiry when utm_source is share-balloon but utm_content lacks the userId prefix (anonymous sharer fallback)", () => {
+		const result = computePublicViewExpiry({
+			savedAt: SAVED_AT,
+			utmSource: "share-balloon",
+			utmContent: "anonymous",
+		});
+
+		assert(result.expiresAt, "expiresAt must be set when no userId prefix");
+		expect(result.expiresAt.toISOString()).toBe(EXPIRES_AT.toISOString());
+	});
+});
+
+describe("decomposeTimeLeft", () => {
+	it("splits a duration into days/hours/minutes/seconds", () => {
+		const oneDayTenHoursFiveMinThirtyThreeSec =
+			((24 + 10) * 3600 + 5 * 60 + 33) * 1000;
+
+		expect(decomposeTimeLeft(oneDayTenHoursFiveMinThirtyThreeSec)).toEqual({
+			days: 1,
+			hours: 10,
+			minutes: 5,
+			seconds: 33,
+		});
+	});
+
+	it("returns all zeros for a zero or negative duration so the counter shows `0d 0h 0m 0s` at expiry", () => {
+		expect(decomposeTimeLeft(0)).toEqual({
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+		expect(decomposeTimeLeft(-1000)).toEqual({
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+	});
+});
+
+describe("formatCounter", () => {
+	it("formats the full days/hours/minutes/seconds tuple as `Xd Yh Zm Ws`", () => {
+		expect(
+			formatCounter({ days: 1, hours: 10, minutes: 5, seconds: 33 }),
+		).toBe("1d 10h 5m 33s");
+	});
+});
+
+describe("formatSaveUtmContent", () => {
+	it("formats as `Xd_Yh_left` at day/hour resolution so the analytics value is stable across short clicks", () => {
+		expect(
+			formatSaveUtmContent({ days: 2, hours: 4, minutes: 5, seconds: 33 }),
+		).toBe("2d_4h_left");
+		expect(
+			formatSaveUtmContent({ days: 0, hours: 3, minutes: 0, seconds: 0 }),
+		).toBe("0d_3h_left");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
@@ -1,0 +1,72 @@
+import type { UserId } from "@packages/domain/user";
+
+/** Hours a public /view article remains accessible after the first crawl (or any subsequent re-save). After this window the same URL still resolves but the page surfaces the expiration in the CTA strip. */
+export const PUBLIC_VIEW_ACCESS_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** When the visitor lands with `utm_source=fagnerbrack.com` the page bypasses the expiration counter — the founder hosts permanent links to public views from his own domain. */
+export const PERMANENT_UTM_SOURCE = "fagnerbrack.com";
+
+/** Length of the userId prefix embedded in `utm_content` when an authenticated user shares a public view. A match means the visitor arrived via a share-balloon click or `/queue/:id/read` redirect, so the page treats the link as permanent. */
+export const SHARED_USER_ID_PREFIX_LENGTH = 6;
+
+/** UserId hashes are produced from `randomBytes(16).toString("hex")` in dynamodb-auth.ts, so the share prefix is the same hex alphabet. */
+const SHARED_USER_ID_PREFIX_PATTERN = new RegExp(
+	`^[0-9a-f]{${SHARED_USER_ID_PREFIX_LENGTH}}`,
+);
+
+export function shareUserIdPrefix(userId: UserId): string {
+	return userId.slice(0, SHARED_USER_ID_PREFIX_LENGTH);
+}
+
+export function hasSharedUserIdPrefix(utmContent: string | undefined): boolean {
+	if (utmContent === undefined) return false;
+	return SHARED_USER_ID_PREFIX_PATTERN.test(utmContent);
+}
+
+export interface PublicViewExpiryInput {
+	savedAt: Date;
+	utmSource: string | undefined;
+	utmContent: string | undefined;
+}
+
+export interface PublicViewExpiry {
+	/** ISO timestamp when the public view stops being shareable, or `null` for permanent views (share-balloon / `/queue/:id/read` redirect / fagnerbrack.com). */
+	expiresAt: Date | null;
+}
+
+export function computePublicViewExpiry(
+	input: PublicViewExpiryInput,
+): PublicViewExpiry {
+	if (input.utmSource === PERMANENT_UTM_SOURCE) return { expiresAt: null };
+	if (hasSharedUserIdPrefix(input.utmContent)) return { expiresAt: null };
+	return {
+		expiresAt: new Date(input.savedAt.getTime() + PUBLIC_VIEW_ACCESS_WINDOW_MS),
+	};
+}
+
+export interface TimeLeft {
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+}
+
+/** Decompose `ms` into days/hours/minutes/seconds. Returns all-zero for non-positive durations so the counter degrades to "0d 0h 0m 0s" at expiry rather than wrapping to negatives. */
+export function decomposeTimeLeft(ms: number): TimeLeft {
+	if (ms <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+	const totalSeconds = Math.floor(ms / 1000);
+	const days = Math.floor(totalSeconds / 86400);
+	const hours = Math.floor((totalSeconds % 86400) / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	return { days, hours, minutes, seconds };
+}
+
+export function formatCounter(timeLeft: TimeLeft): string {
+	return `${timeLeft.days}d ${timeLeft.hours}h ${timeLeft.minutes}m ${timeLeft.seconds}s`;
+}
+
+/** Render the `utm_content` value the public-view "Save to my queue" link carries when the counter is active. Day/hour resolution only — minutes/seconds change too fast to be useful in analytics. Examples: `2d_4h_left`, `0d_3h_left`. */
+export function formatSaveUtmContent(timeLeft: TimeLeft): string {
+	return `${timeLeft.days}d_${timeLeft.hours}h_left`;
+}

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -23,6 +23,7 @@ const baseInput: ViewPageInput = {
 			variant: "primary",
 		},
 	],
+	expiresAt: null,
 };
 
 function render(input = baseInput) {
@@ -341,4 +342,91 @@ describe("ViewPage", () => {
 		assert(link, "cta action must still be rendered without content");
 	});
 
+	describe("Public access expiry counter", () => {
+		it("renders the counter element in state='permanent' (and no expires-at attribute) when the view does not expire", () => {
+			const doc = render({ ...baseInput, expiresAt: null });
+
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must always render so client JS can find it");
+			expect(expiry.getAttribute("data-expiry-state")).toBe("permanent");
+			expect(expiry.hasAttribute("data-expires-at")).toBe(false);
+			expect(expiry.classList.contains("view__expiry--permanent")).toBe(true);
+		});
+
+		it("renders the counter in state='counting' with the SSR-correct initial text and an ISO data-expires-at when the view will expire", () => {
+			const expiresAt = new Date(Date.now() + 60_000); // 1 minute in the future
+			const doc = render({ ...baseInput, expiresAt });
+
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must be rendered");
+			expect(expiry.getAttribute("data-expiry-state")).toBe("counting");
+			expect(expiry.getAttribute("data-expires-at")).toBe(expiresAt.toISOString());
+			expect(expiry.textContent?.trim()).toMatch(
+				/^Public access will expire in 0d 0h 0m 59s$|^Public access will expire in 0d 0h 1m 0s$/,
+			);
+		});
+
+		it("renders the counter in state='expired' with a terminal message when expiresAt is in the past", () => {
+			const expiresAt = new Date(Date.now() - 60_000);
+			const doc = render({ ...baseInput, expiresAt });
+
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must be rendered");
+			expect(expiry.getAttribute("data-expiry-state")).toBe("expired");
+			expect(expiry.textContent?.trim()).toBe("Public access has expired.");
+		});
+
+		it("marks any action with expirySaveLink=true via data-expiry-save-link so the client script can rewrite its utm_content as the counter ticks", () => {
+			const doc = render({
+				...baseInput,
+				expiresAt: new Date(Date.now() + 60_000),
+				actions: [
+					{
+						name: "Save to My Queue",
+						href: "/save?url=x&utm_content=2d_4h_left",
+						variant: "primary",
+						expirySaveLink: true,
+					},
+					{
+						name: "Paste another link",
+						href: "/view?utm_source=view-article",
+						variant: "secondary",
+					},
+				],
+			});
+
+			const links = doc.querySelectorAll("[data-test-view-cta-action]");
+			expect(links.length).toBe(2);
+			expect(links[0]?.hasAttribute("data-expiry-save-link")).toBe(true);
+			expect(links[1]?.hasAttribute("data-expiry-save-link")).toBe(false);
+		});
+
+		it("loads the expiry-counter client bundle so the SSR counter ticks down once the page hydrates", () => {
+			const doc = render({ ...baseInput, expiresAt: new Date(Date.now() + 60_000) });
+
+			const script = doc.querySelector(
+				'script[src$="/client-dist/expiry-counter.client.js"]',
+			);
+			assert(script, "expiry-counter client script must be rendered");
+			expect(script.hasAttribute("defer")).toBe(true);
+		});
+
+		it("stamps the share balloon's utm_content with the visitor's sharerUserIdPrefix when provided so receiving views treat the link as a logged-in user's share", () => {
+			const doc = render({ ...baseInput, sharerUserIdPrefix: "a3f1c2" });
+
+			const shareBtn = doc.querySelector("[data-test-share-balloon]");
+			assert(shareBtn, "share button must be rendered");
+			const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+			expect(shareUrl.searchParams.get("utm_content")).toBe("a3f1c2");
+		});
+
+		it("omits utm_content from the share balloon when no sharerUserIdPrefix is provided so anonymous shares fall back to standard expiry on the receiving page", () => {
+			const doc = render(baseInput);
+
+			const shareBtn = doc.querySelector("[data-test-share-balloon]");
+			assert(shareBtn, "share button must be rendered");
+			const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+			expect(shareUrl.searchParams.get("utm_content")).toBeNull();
+		});
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -17,10 +17,15 @@ import {
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
 import { VIEW_STYLES } from "./view.styles";
+import {
+	decomposeTimeLeft,
+	formatCounter,
+} from "./view-expiry";
 
 const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
+const EXPIRY_COUNTER_SCRIPT = `<script src="/client-dist/expiry-counter.client.js" defer></script>`;
 
 const CANONICAL_BASE_URL = "https://readplace.com";
 const DEFAULT_OG_IMAGE = `${STATIC_BASE_URL}/og-image-1200x630.png`;
@@ -37,6 +42,31 @@ export function formatViewDocumentTitle(articleTitle: string): string {
 	return `${articleTitle} | Reader View`;
 }
 
+interface ExpiryFields {
+	state: "permanent" | "counting" | "expired";
+	message: string;
+	expiresAtIso?: string;
+}
+
+function buildExpiryFields(expiresAt: Date | null, now: Date): ExpiryFields {
+	if (expiresAt === null) {
+		return { state: "permanent", message: "Public access doesn't expire." };
+	}
+	const msLeft = expiresAt.getTime() - now.getTime();
+	if (msLeft <= 0) {
+		return {
+			state: "expired",
+			message: "Public access has expired.",
+			expiresAtIso: expiresAt.toISOString(),
+		};
+	}
+	return {
+		state: "counting",
+		message: `Public access will expire in ${formatCounter(decomposeTimeLeft(msLeft))}`,
+		expiresAtIso: expiresAt.toISOString(),
+	};
+}
+
 const VIEW_TEMPLATE = readFileSync(
 	join(__dirname, "view.template.html"),
 	"utf-8",
@@ -46,6 +76,8 @@ export interface ViewAction {
 	name: string;
 	href: string;
 	variant: "primary" | "secondary";
+	/** When true the rendered link carries `data-expiry-save-link`, which the expiry-counter client uses to keep the link's `utm_content=Xd_Yh_left` value in sync with the countdown. Only set on the "Save to my queue" action. */
+	expirySaveLink?: boolean;
 }
 
 export interface ViewPageInput {
@@ -60,6 +92,12 @@ export interface ViewPageInput {
 	progress?: ProgressTick;
 	actions: ViewAction[];
 	extensionInstallUrl?: string;
+	/** ISO timestamp when public access to this view expires (3 days after the most recent crawl/re-save). `null` for permanent links — `utm_source=fagnerbrack.com` or `utm_content` carrying a 6-hex-char userId prefix from the share-balloon / `/queue/:id/read` redirect. */
+	expiresAt: Date | null;
+	/** First 6 chars of the visiting user's userId, when authenticated. Stamped into the share-balloon's outbound utm_content so the receiving public view recognises the link as a logged-in user's share. */
+	sharerUserIdPrefix?: string;
+	/** Clock used to compute the initial SSR counter text. The route passes its injected `now` provider so the SSR state stays consistent with the savedAt the same handler just wrote. Defaults to `new Date()` for callers (tests) that don't need clock control. */
+	now?: Date;
 }
 
 export function ViewPage(input: ViewPageInput): PageBody {
@@ -85,13 +123,19 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		shareTitle: input.metadata.title,
 		shareHint: "Click here to share this view!",
 		shareSource: "reader-public",
+		sharerUserIdPrefix: input.sharerUserIdPrefix,
 	});
+
+	const expiry = buildExpiryFields(input.expiresAt, input.now ?? new Date());
 
 	const content = render(VIEW_TEMPLATE, {
 		innerContent,
 		articleUrl: input.articleUrl,
 		actions: input.actions,
 		shareBalloon,
+		expiryState: expiry.state,
+		expiryMessage: expiry.message,
+		expiresAtIso: expiry.expiresAtIso,
 	});
 
 	const ogImage = input.metadata.imageUrl ?? DEFAULT_OG_IMAGE;
@@ -130,6 +174,6 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		styles: VIEW_STYLES,
 		bodyClass: "page-view",
 		content: { html: content },
-		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT,
+		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT + EXPIRY_COUNTER_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -43,6 +43,12 @@ import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "../save/save-error.component";
 import { ViewLandingPage } from "./view-landing.component";
 import { ViewPage, formatViewDocumentTitle, type ViewAction } from "./view.component";
+import {
+	computePublicViewExpiry,
+	decomposeTimeLeft,
+	formatSaveUtmContent,
+	shareUserIdPrefix,
+} from "./view-expiry";
 
 interface ViewDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
@@ -136,7 +142,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 					wordCount: 0,
 				},
 				estimatedReadTime: calculateReadTime(0),
-				savedAt: new Date(),
+				savedAt: deps.now(),
 			});
 			await deps.markCrawlPending({ url: articleUrl });
 			await deps.markSummaryPending({ url: articleUrl });
@@ -171,12 +177,28 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		}
 
 		const utmParams = collectUtmParams(req.query);
+		const utmSource = typeof req.query.utm_source === "string" ? req.query.utm_source : undefined;
+		const utmContent = typeof req.query.utm_content === "string" ? req.query.utm_content : undefined;
+
+		const expiry = computePublicViewExpiry({
+			savedAt: articleSnapshot.savedAt,
+			utmSource,
+			utmContent,
+		});
+
+		const saveHrefParams = new URLSearchParams([["url", articleUrl], ...utmParams]);
+		if (expiry.expiresAt !== null) {
+			/** Stamp the visitor's remaining-time snapshot into the Save link so the analytics row for a save click captures urgency. The client script re-stamps this on every tick so a click made hours later carries the latest day/hour value. */
+			const timeLeft = decomposeTimeLeft(expiry.expiresAt.getTime() - deps.now().getTime());
+			saveHrefParams.set("utm_content", formatSaveUtmContent(timeLeft));
+		}
 
 		const actions: ViewAction[] = [
 			{
 				name: "Save to My Queue",
-				href: `/save?${new URLSearchParams([["url", articleUrl], ...utmParams]).toString()}`,
+				href: `/save?${saveHrefParams.toString()}`,
 				variant: "primary",
+				expirySaveLink: expiry.expiresAt !== null,
 			},
 			{
 				name: "Paste another link",
@@ -205,6 +227,9 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 					progress: state.progress,
 					actions,
 					extensionInstallUrl: extensionInstallUrlIfMissing(req),
+					expiresAt: expiry.expiresAt,
+					sharerUserIdPrefix: req.userId ? shareUserIdPrefix(req.userId) : undefined,
+					now: deps.now(),
 				}),
 				{ ...bannerStateFromRequest(req), showExtensionSuggestionBanner, extensionInstalled: isExtensionInstalled(req) },
 			),

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@packages/article-parser";
 import type { FindArticleCrawlStatus } from "@packages/test-fixtures/providers/article-crawl";
 import type { FindGeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import type { Minutes } from "@packages/domain/article";
 import { useTestServer } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
@@ -1150,6 +1151,147 @@ describe("View routes", () => {
 				.set("If-None-Match", etag);
 			expect(second.status).toBe(304);
 			expect(second.text).toBe("");
+		});
+	});
+
+	describe("Public access expiry counter", () => {
+		function buildHarness(now: Date) {
+			const parseArticle: ParseArticle = async () => buildParseResult();
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			return useApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+				shared: { ...fixture.shared, now: () => now },
+			});
+		}
+
+		it("renders the counter in state='counting' with a 3-day deadline for an organic anonymous visit", async () => {
+			const fixedNow = new Date("2026-04-25T12:00:00.000Z");
+			const harness = buildHarness(fixedNow);
+
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must be rendered");
+			expect(expiry.getAttribute("data-expiry-state")).toBe("counting");
+			const expiresAt = expiry.getAttribute("data-expires-at");
+			assert(expiresAt, "data-expires-at must be set when counting");
+			const expectedExpiry = new Date(
+				fixedNow.getTime() + 3 * 24 * 60 * 60 * 1000,
+			);
+			expect(expiresAt).toBe(expectedExpiry.toISOString());
+		});
+
+		it("renders the counter in state='permanent' when the visitor arrives with utm_source=fagnerbrack.com so syndication links never expire", async () => {
+			const harness = buildHarness(new Date("2026-04-25T12:00:00.000Z"));
+
+			const response = await request(harness.server).get(
+				`/view/${ENCODED}?utm_source=fagnerbrack.com`,
+			);
+
+			const doc = new JSDOM(response.text).window.document;
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must be rendered");
+			expect(expiry.getAttribute("data-expiry-state")).toBe("permanent");
+			expect(expiry.hasAttribute("data-expires-at")).toBe(false);
+		});
+
+		it("renders the counter in state='permanent' when utm_content carries a 6-hex-char userId prefix (share-balloon or /read redirect)", async () => {
+			const harness = buildHarness(new Date("2026-04-25T12:00:00.000Z"));
+
+			const response = await request(harness.server).get(
+				`/view/${ENCODED}?utm_source=share-balloon&utm_content=a3f1c2`,
+			);
+
+			const doc = new JSDOM(response.text).window.document;
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must be rendered");
+			expect(expiry.getAttribute("data-expiry-state")).toBe("permanent");
+		});
+
+		it("stamps the Save action's utm_content with the time left in Xd_Yh_left format and marks the link with data-expiry-save-link so the client script keeps it in sync", async () => {
+			const harness = buildHarness(new Date("2026-04-25T12:00:00.000Z"));
+
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const saveLink = doc.querySelector("[data-expiry-save-link]");
+			assert(saveLink, "Save action must carry data-expiry-save-link when counting");
+			const href = saveLink.getAttribute("href");
+			assert(href, "save link must have an href");
+			const parsed = new URL(href, "http://localhost");
+			expect(parsed.searchParams.get("utm_content")).toBe("3d_0h_left");
+		});
+
+		it("omits the Save link's data-expiry-save-link marker for permanent views so the client script has nothing to keep in sync", async () => {
+			const harness = buildHarness(new Date("2026-04-25T12:00:00.000Z"));
+
+			const response = await request(harness.server).get(
+				`/view/${ENCODED}?utm_source=fagnerbrack.com`,
+			);
+
+			const doc = new JSDOM(response.text).window.document;
+			const saveLink = doc.querySelector("[data-expiry-save-link]");
+			expect(saveLink).toBeNull();
+		});
+
+		it("resets the counter to a full 3-day window when the article is re-saved (savedAt is bumped on saveArticleGlobally)", async () => {
+			const firstVisit = new Date("2026-04-20T00:00:00.000Z");
+			const reVisit = new Date("2026-04-22T00:00:00.000Z");
+			let currentNow = firstVisit;
+			const parseArticle: ParseArticle = async () => buildParseResult();
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const harness = useApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+				},
+				shared: { ...fixture.shared, now: () => currentNow },
+			});
+
+			await request(harness.server).get(`/view/${ENCODED}`);
+			currentNow = reVisit;
+			await harness.articleStore.saveArticleGlobally({
+				url: ARTICLE_URL,
+				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: 0 },
+				estimatedReadTime: 0 as Minutes,
+				savedAt: reVisit,
+			});
+
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const doc = new JSDOM(response.text).window.document;
+			const expiry = doc.querySelector("[data-test-view-expiry]");
+			assert(expiry, "expiry element must be rendered");
+			const expiresAt = expiry.getAttribute("data-expires-at");
+			const expected = new Date(reVisit.getTime() + 3 * 24 * 60 * 60 * 1000);
+			expect(expiresAt).toBe(expected.toISOString());
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.styles.css
+++ b/projects/hutch/src/runtime/web/pages/view/view.styles.css
@@ -74,3 +74,24 @@
   margin-top: 1.5rem;
   pointer-events: none;
 }
+
+.view__expiry {
+  margin: 0.5rem 0 0;
+  font-size: 0.8125rem;
+  text-align: center;
+  color: var(--color-text-muted, #5e5e5e);
+}
+
+/* purgecss-ignore-start: state suffix is interpolated from buildExpiryFields() in view.component.ts */
+.view__expiry--permanent {
+  display: none;
+}
+
+.view__expiry--expired {
+  color: var(--color-error, #b00020);
+}
+
+.view__expiry--counting {
+  /* default styling already covers counting state */
+}
+/* purgecss-ignore-end */

--- a/projects/hutch/src/runtime/web/pages/view/view.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view.template.html
@@ -9,7 +9,10 @@
     <aside class="view__cta" data-test-view-cta>
       <div class="view__cta-content">
         {{#each actions}}
-        <a class="view__cta-btn view__cta-btn--{{variant}}" href="{{href}}" data-test-view-cta-action>{{name}}</a>
+        <a class="view__cta-btn view__cta-btn--{{variant}}" href="{{href}}"{{#if expirySaveLink}} data-expiry-save-link{{/if}} data-test-view-cta-action>{{name}}</a>
         {{/each}}
       </div>
+      <p class="view__expiry view__expiry--{{expiryState}}" data-test-view-expiry data-expiry-state="{{expiryState}}"{{#if expiresAtIso}} data-expires-at="{{expiresAtIso}}"{{/if}}>
+        {{expiryMessage}}
+      </p>
     </aside>

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -56,6 +56,7 @@ function defaultFakeArticle(): GlobalArticleData {
 			wordCount: 100,
 		},
 		estimatedReadTime: 1 as Minutes,
+		savedAt: FIXED_NOW,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
@@ -23,16 +23,25 @@ export interface ShareBalloonInput {
 	shareTitle: string;
 	shareHint: string;
 	shareSource: ShareBalloonSource;
+	/** First 6 chars of the sharer's userId, stamped into `utm_content` so the receiving public /view treats the link as permanent (see view-expiry.ts). Omit for anonymous visitors — the standard expiry then applies on the receiving page. */
+	sharerUserIdPrefix?: string;
 }
 
 function withUtm(
 	baseUrl: string,
-	params: { medium: "copy" | "share"; campaign: ShareBalloonSource },
+	params: {
+		medium: "copy" | "share";
+		campaign: ShareBalloonSource;
+		sharerUserIdPrefix: string | undefined;
+	},
 ): string {
 	const url = new URL(baseUrl);
 	url.searchParams.set("utm_source", "share-balloon");
 	url.searchParams.set("utm_medium", params.medium);
 	url.searchParams.set("utm_campaign", params.campaign);
+	if (params.sharerUserIdPrefix !== undefined) {
+		url.searchParams.set("utm_content", params.sharerUserIdPrefix);
+	}
 	return url.toString();
 }
 
@@ -41,10 +50,12 @@ export function renderShareBalloon(input: ShareBalloonInput): string {
 		shareUrlCopy: withUtm(input.shareUrl, {
 			medium: "copy",
 			campaign: input.shareSource,
+			sharerUserIdPrefix: input.sharerUserIdPrefix,
 		}),
 		shareUrlShare: withUtm(input.shareUrl, {
 			medium: "share",
 			campaign: input.shareSource,
+			sharerUserIdPrefix: input.sharerUserIdPrefix,
 		}),
 		shareTitle: input.shareTitle,
 		shareHint: input.shareHint,

--- a/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
@@ -65,6 +65,8 @@ export interface GlobalArticleData {
 	metadata: SavedArticle["metadata"];
 	estimatedReadTime: SavedArticle["estimatedReadTime"];
 	contentSourceTier?: "tier-0" | "tier-1";
+	/** When this URL first entered the global article table. Re-saves of the same URL bump this so the public /view counter resets to the full 3-day window. */
+	savedAt: Date;
 }
 
 export type FindArticleByUrl = (

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
@@ -65,6 +65,52 @@ describe("initInMemoryArticleStore", () => {
 			expect(found?.url).toBe("https://example.com/article");
 			expect(found?.metadata.title).toBe("Test Article");
 		});
+
+		it("returns the global savedAt so the public /view expiry counter can compute (savedAt + 3 days)", async () => {
+			const store = initInMemoryArticleStore();
+			const firstSave = new Date("2026-05-20T00:00:00.000Z");
+			await store.saveArticleGlobally({
+				url: "https://example.com/article",
+				metadata: {
+					title: "Hello",
+					siteName: "example.com",
+					excerpt: "",
+					wordCount: 0,
+				},
+				estimatedReadTime: 0 as Minutes,
+				savedAt: firstSave,
+			});
+
+			const found = await store.findArticleByUrl("https://example.com/article");
+
+			expect(found?.savedAt.toISOString()).toBe(firstSave.toISOString());
+		});
+
+		it("bumps savedAt on re-save so the public /view counter resets to a full 3-day window each time the article is re-crawled", async () => {
+			const store = initInMemoryArticleStore();
+			const url = "https://example.com/article";
+			const firstSave = new Date("2026-05-20T00:00:00.000Z");
+			const reSave = new Date("2026-05-21T00:00:00.000Z");
+			await store.saveArticleGlobally({
+				url,
+				metadata: { title: "Hello", siteName: "example.com", excerpt: "", wordCount: 100 },
+				estimatedReadTime: 0 as Minutes,
+				savedAt: firstSave,
+			});
+
+			await store.saveArticleGlobally({
+				url,
+				metadata: { title: "stub-from-view", siteName: "example.com", excerpt: "", wordCount: 0 },
+				estimatedReadTime: 0 as Minutes,
+				savedAt: reSave,
+			});
+
+			const found = await store.findArticleByUrl(url);
+			expect(found?.savedAt.toISOString()).toBe(reSave.toISOString());
+			/** Stub metadata from the second call must not clobber the real parsed metadata. */
+			expect(found?.metadata.title).toBe("Hello");
+			expect(found?.metadata.wordCount).toBe(100);
+		});
 	});
 
 	describe("findArticleUrlById", () => {

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
@@ -93,16 +93,20 @@ export function initInMemoryArticleStore(): {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
 		const routeId = ReaderArticleHashId.from(params.url);
 
-		if (!articles.has(articleResourceUniqueId.value)) {
-			articles.set(articleResourceUniqueId.value, {
-				url: articleResourceUniqueId.value,
-				originalUrl: params.url,
-				routeId,
-				metadata: params.metadata,
-				estimatedReadTime: params.estimatedReadTime,
-				savedAt: params.savedAt,
-			});
+		const existing = articles.get(articleResourceUniqueId.value);
+		if (existing) {
+			/** Bump savedAt on re-save so the public /view expiry counter resets to the full 3-day window. Metadata is left untouched so a stub re-save can't clobber real parsed metadata. */
+			existing.savedAt = params.savedAt;
+			return;
 		}
+		articles.set(articleResourceUniqueId.value, {
+			url: articleResourceUniqueId.value,
+			originalUrl: params.url,
+			routeId,
+			metadata: params.metadata,
+			estimatedReadTime: params.estimatedReadTime,
+			savedAt: params.savedAt,
+		});
 	};
 
 	const saveArticle: SaveArticle = async (params) => {
@@ -161,6 +165,7 @@ export function initInMemoryArticleStore(): {
 
 			estimatedReadTime: article.estimatedReadTime,
 			contentSourceTier: article.contentSourceTier,
+			savedAt: article.savedAt,
 		};
 	};
 


### PR DESCRIPTION
## Summary

- Public `/view/<url>` pages now show a live "Public access will expire in Xd Yh Zm Ws" counter that starts at 3 days from the most recent crawl or re-save. When the deadline passes the strip flips to "Public access has expired."
- Shares stay permanent: `utm_content` carrying a 6-hex-char userId prefix (stamped by the share-balloon and the `/queue/:id/read` redirect) or `utm_source=fagnerbrack.com` (founder's syndicated links) bypass the counter and render `state="permanent"` instead.
- The Save action's `utm_content` is stamped with the current `Xd_Yh_left` value server-side and re-stamped by `expiry-counter.client.ts` on every tick so click-time analytics reflect the visitor's remaining urgency.
- The global article row's `savedAt` is bumped on every `saveArticleGlobally`, so re-saves reset the counter. Stub metadata from the `/view` fallback path never clobbers real parsed metadata (DynamoDB `UpdateExpression` only touches `savedAt`; in-memory store mirrors the same).

## Test plan

- [x] `view-expiry.test.ts` covers `computePublicViewExpiry`, `decomposeTimeLeft`, `formatCounter`, `formatSaveUtmContent`, `shareUserIdPrefix`, `hasSharedUserIdPrefix`.
- [x] `expiry-counter.client.test.ts` covers the SSR-to-client takeover (counting → expired flip, save-link `utm_content` rewriting, no-op for `permanent`/missing/malformed elements, `stop()` cleanup).
- [x] `view.component.test.ts` and `view.route.test.ts` assert the permanent/counting/expired markup, `data-expiry-save-link` toggling, share-balloon `utm_content` stamping, founder UTM bypass, and the `savedAt` bump after re-save.
- [x] `reader-permalink.test.ts` covers the userId-prefix override in the `/queue/:id/read → /view` redirect (including incoming `utm_content` overrides for re-shares).
- [x] `in-memory-article-store.test.ts` verifies the `savedAt` bump preserves real metadata on stub re-save.
- [x] Full `pnpm nx run hutch:test-with-coverage` passes — 100% function coverage, all coverage gates met.
- [x] Full `pnpm nx run hutch:lint` passes (tsc + biome + knip + check-unused-css).

https://claude.ai/code/session_01WmRAzGce1cXggEtM3Xsk2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmRAzGce1cXggEtM3Xsk2R)_