### PR TITLE
feat(hutch): stamp share balloon utm_content with sharer user id prefix

### DIFF
--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
@@ -46,4 +46,25 @@ describe("ReaderPage", () => {
 		const wrap = doc.querySelector("[data-test-share-balloon-wrap]");
 		assert(wrap, "share balloon wrap must be rendered");
 	});
+
+	it("stamps utm_content on the share balloon URLs with the first 6 chars of the article owner's user id", () => {
+		const article = makeArticle({
+			userId: UserIdSchema.parse("abcdef0123456789abcdef0123456789"),
+		});
+		const html = Base(ReaderPage(article), {
+			isAuthenticated: true,
+			emailVerified: undefined,
+		}).to("text/html").body;
+		const doc = new JSDOM(html).window.document;
+
+		const shareBtn = doc.querySelector("[data-test-share-balloon]");
+		assert(shareBtn, "share button must be rendered");
+		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		assert.equal(shareUrl.searchParams.get("utm_content"), "abcdef");
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		assert.equal(copyUrl.searchParams.get("utm_content"), "abcdef");
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
@@ -59,12 +59,16 @@ describe("ReaderPage", () => {
 
 		const shareBtn = doc.querySelector("[data-test-share-balloon]");
 		assert(shareBtn, "share button must be rendered");
-		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		const shareHref = shareBtn.getAttribute("data-share-url");
+		assert(shareHref, "share button must carry a data-share-url");
+		const shareUrl = new URL(shareHref);
 		assert.equal(shareUrl.searchParams.get("utm_content"), "abcdef");
 
 		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
 		assert(copyBtn, "copy button must be rendered");
-		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		const copyHref = copyBtn.getAttribute("data-share-url");
+		assert(copyHref, "copy button must carry a data-share-url");
+		const copyUrl = new URL(copyHref);
 		assert.equal(copyUrl.searchParams.get("utm_content"), "abcdef");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -12,6 +12,7 @@ import {
 	SHARE_BALLOON_SCRIPT,
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
+import { shareUserIdPrefix } from "../../shared/share-balloon/share-user-id-prefix";
 import { READER_STYLES } from "./reader.styles";
 
 const CANONICAL_BASE_URL = "https://readplace.com";
@@ -91,6 +92,7 @@ export function ReaderPage(
 		shareTitle: article.metadata.title,
 		shareHint: "Click here to share this post!",
 		shareSource: "reader-internal",
+		sharerUserIdPrefix: shareUserIdPrefix(article.userId),
 	});
 	const content = render(READER_TEMPLATE, { innerContent, shareBalloon });
 

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -341,4 +341,32 @@ describe("ViewPage", () => {
 		assert(link, "cta action must still be rendered without content");
 	});
 
+	it("stamps utm_content on the share balloon URLs when sharerUserIdPrefix is provided", () => {
+		const doc = render({ ...baseInput, sharerUserIdPrefix: "abcdef" });
+
+		const shareBtn = doc.querySelector("[data-test-share-balloon]");
+		assert(shareBtn, "share button must be rendered");
+		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		expect(shareUrl.searchParams.get("utm_content")).toBe("abcdef");
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		expect(copyUrl.searchParams.get("utm_content")).toBe("abcdef");
+	});
+
+	it("omits utm_content on the share balloon URLs when no sharerUserIdPrefix is provided", () => {
+		const doc = render();
+
+		const shareBtn = doc.querySelector("[data-test-share-balloon]");
+		assert(shareBtn, "share button must be rendered");
+		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		expect(shareUrl.searchParams.get("utm_content")).toBeNull();
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		expect(copyUrl.searchParams.get("utm_content")).toBeNull();
+	});
+
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -346,12 +346,16 @@ describe("ViewPage", () => {
 
 		const shareBtn = doc.querySelector("[data-test-share-balloon]");
 		assert(shareBtn, "share button must be rendered");
-		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		const shareHref = shareBtn.getAttribute("data-share-url");
+		assert(shareHref, "share button must carry a data-share-url");
+		const shareUrl = new URL(shareHref);
 		expect(shareUrl.searchParams.get("utm_content")).toBe("abcdef");
 
 		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
 		assert(copyBtn, "copy button must be rendered");
-		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		const copyHref = copyBtn.getAttribute("data-share-url");
+		assert(copyHref, "copy button must carry a data-share-url");
+		const copyUrl = new URL(copyHref);
 		expect(copyUrl.searchParams.get("utm_content")).toBe("abcdef");
 	});
 
@@ -360,12 +364,16 @@ describe("ViewPage", () => {
 
 		const shareBtn = doc.querySelector("[data-test-share-balloon]");
 		assert(shareBtn, "share button must be rendered");
-		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		const shareHref = shareBtn.getAttribute("data-share-url");
+		assert(shareHref, "share button must carry a data-share-url");
+		const shareUrl = new URL(shareHref);
 		expect(shareUrl.searchParams.get("utm_content")).toBeNull();
 
 		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
 		assert(copyBtn, "copy button must be rendered");
-		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		const copyHref = copyBtn.getAttribute("data-share-url");
+		assert(copyHref, "copy button must carry a data-share-url");
+		const copyUrl = new URL(copyHref);
 		expect(copyUrl.searchParams.get("utm_content")).toBeNull();
 	});
 

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -60,6 +60,7 @@ export interface ViewPageInput {
 	progress?: ProgressTick;
 	actions: ViewAction[];
 	extensionInstallUrl?: string;
+	sharerUserIdPrefix?: string;
 }
 
 export function ViewPage(input: ViewPageInput): PageBody {
@@ -85,6 +86,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		shareTitle: input.metadata.title,
 		shareHint: "Click here to share this view!",
 		shareSource: "reader-public",
+		sharerUserIdPrefix: input.sharerUserIdPrefix,
 	});
 
 	const content = render(VIEW_TEMPLATE, {

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -39,6 +39,7 @@ import type {
 	PollUrlBuilder,
 } from "../../shared/article-reader/article-reader.types";
 import { isFullyParsed } from "../../shared/article-state/is-fully-parsed";
+import { shareUserIdPrefix } from "../../shared/share-balloon/share-user-id-prefix";
 import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "../save/save-error.component";
 import { ViewLandingPage } from "./view-landing.component";
@@ -205,6 +206,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 					progress: state.progress,
 					actions,
 					extensionInstallUrl: extensionInstallUrlIfMissing(req),
+					sharerUserIdPrefix: req.userId ? shareUserIdPrefix(req.userId) : undefined,
 				}),
 				{ ...bannerStateFromRequest(req), showExtensionSuggestionBanner, extensionInstalled: isExtensionInstalled(req) },
 			),

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { renderShareBalloon } from "./share-balloon.component";
+
+function parse(html: string): Document {
+	return new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`).window
+		.document;
+}
+
+function shareUrl(doc: Document): URL {
+	const btn = doc.querySelector("[data-test-share-balloon]");
+	assert(btn, "share button must be rendered");
+	const href = btn.getAttribute("data-share-url");
+	assert(href, "share button must carry a data-share-url");
+	return new URL(href);
+}
+
+function copyUrl(doc: Document): URL {
+	const btn = doc.querySelector("[data-test-share-balloon-copy]");
+	assert(btn, "copy button must be rendered");
+	const href = btn.getAttribute("data-share-url");
+	assert(href, "copy button must carry a data-share-url");
+	return new URL(href);
+}
+
+describe("renderShareBalloon", () => {
+	it("stamps utm_content with the sharer prefix on both share and copy URLs when provided", () => {
+		const html = renderShareBalloon({
+			shareUrl: "https://readplace.com/view/x",
+			shareTitle: "A title",
+			shareHint: "share me",
+			shareSource: "reader-internal",
+			sharerUserIdPrefix: "abcdef",
+		});
+		const doc = parse(html);
+
+		assert.equal(shareUrl(doc).searchParams.get("utm_content"), "abcdef");
+		assert.equal(copyUrl(doc).searchParams.get("utm_content"), "abcdef");
+	});
+
+	it("omits utm_content when no sharer prefix is provided", () => {
+		const html = renderShareBalloon({
+			shareUrl: "https://readplace.com/view/x",
+			shareTitle: "A title",
+			shareHint: "share me",
+			shareSource: "reader-public",
+		});
+		const doc = parse(html);
+
+		assert.equal(shareUrl(doc).searchParams.get("utm_content"), null);
+		assert.equal(copyUrl(doc).searchParams.get("utm_content"), null);
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.component.ts
@@ -23,16 +23,24 @@ export interface ShareBalloonInput {
 	shareTitle: string;
 	shareHint: string;
 	shareSource: ShareBalloonSource;
+	sharerUserIdPrefix?: string;
 }
 
 function withUtm(
 	baseUrl: string,
-	params: { medium: "copy" | "share"; campaign: ShareBalloonSource },
+	params: {
+		medium: "copy" | "share";
+		campaign: ShareBalloonSource;
+		content?: string;
+	},
 ): string {
 	const url = new URL(baseUrl);
 	url.searchParams.set("utm_source", "share-balloon");
 	url.searchParams.set("utm_medium", params.medium);
 	url.searchParams.set("utm_campaign", params.campaign);
+	if (params.content !== undefined) {
+		url.searchParams.set("utm_content", params.content);
+	}
 	return url.toString();
 }
 
@@ -41,10 +49,12 @@ export function renderShareBalloon(input: ShareBalloonInput): string {
 		shareUrlCopy: withUtm(input.shareUrl, {
 			medium: "copy",
 			campaign: input.shareSource,
+			content: input.sharerUserIdPrefix,
 		}),
 		shareUrlShare: withUtm(input.shareUrl, {
 			medium: "share",
 			campaign: input.shareSource,
+			content: input.sharerUserIdPrefix,
 		}),
 		shareTitle: input.shareTitle,
 		shareHint: input.shareHint,

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-user-id-prefix.test.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-user-id-prefix.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
+import { shareUserIdPrefix } from "./share-user-id-prefix";
+
+describe("shareUserIdPrefix", () => {
+	it("returns the first 6 characters of a 32-char hex user id", () => {
+		const userId = UserIdSchema.parse("abcdef0123456789abcdef0123456789");
+		assert.equal(shareUserIdPrefix(userId), "abcdef");
+	});
+
+	it("returns the whole string when the user id is shorter than 6 characters", () => {
+		const userId = UserIdSchema.parse("ab12");
+		assert.equal(shareUserIdPrefix(userId), "ab12");
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-user-id-prefix.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-user-id-prefix.ts
@@ -1,0 +1,7 @@
+import type { UserId } from "@packages/domain/user";
+
+const PREFIX_LENGTH = 6;
+
+export function shareUserIdPrefix(userId: UserId): string {
+	return userId.slice(0, PREFIX_LENGTH);
+}


### PR DESCRIPTION
## Summary

Stamps outbound share-balloon URLs (Copy + Web Share API) with the first 6 hex chars of the sharer's userId in `utm_content`, enabling per-user share attribution in analytics and letting the receiving `/view` page recognise links that arrived via a real user's share (vs organic traffic).

- New `shareUserIdPrefix(userId)` helper (`userId.slice(0, 6)`) — 16^6 ≈ 16M combinations, enough for attribution without exposing the full id.
- `ShareBalloonInput` gains an optional `sharerUserIdPrefix`; `withUtm()` sets `utm_content` only when the prefix is provided, so anonymous visitors on `/view` get a clean URL with no userId trace.
- `ReaderPage` (private reader) passes the article owner's prefix; `view.page.ts` passes the logged-in viewer's prefix from `req.userId`, omitting it for anonymous traffic.

## Test plan

- [x] Unit: `shareUserIdPrefix` returns the first 6 characters
- [x] Unit: `renderShareBalloon` sets `utm_content` on share + copy URLs when prefix is present; omits it when undefined
- [x] Component: `ReaderPage` stamps the share balloon's `utm_content` with the owner's prefix
- [x] Component: `ViewPage` stamps when `sharerUserIdPrefix` is provided; omits when not provided
- [x] `pnpm test` — 1468/1468 pass
- [x] `pnpm lint` — clean
- [x] `pnpm test-with-coverage` — 100% on new/changed files, all thresholds met

---
_Generated by [Claude Code](https://claude.ai/code/session_01FT91k8931Bw4PNj9iZcSmk)_