### PR TITLE
feat(hutch): add view-expiry pure functions for public view access window

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       '@packages/retriable':
         specifier: workspace:*
         version: link:../../src/packages/retriable
+      '@packages/time-left':
+        specifier: workspace:*
+        version: link:../../src/packages/time-left
       browser-extension-core:
         specifier: workspace:*
         version: link:../browser-extension-core
@@ -838,6 +841,24 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  src/packages/time-left:
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      c8:
+        specifier: 10.1.3
+        version: 10.1.3
+      concurrently:
+        specifier: 9.2.1
+        version: 9.2.1
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@22.19.1)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
 packages:
 
   '@11ty/posthtml-urls@1.0.3':
@@ -1268,24 +1289,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.8':
     resolution: {integrity: sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.8':
     resolution: {integrity: sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.8':
     resolution: {integrity: sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.8':
     resolution: {integrity: sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==}
@@ -1989,21 +2014,25 @@ packages:
     resolution: {integrity: sha512-4ZSjvCjnBT0WpGdF12hvgLWmok4WftaE09fOWWrMm4b2m8F/5yKgU6usPFTehQa5oqTp08KW60kZMLaOQHOJQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@21.6.10':
     resolution: {integrity: sha512-lNzlTsgr7nY56ddIpLTzYZTuNA3FoeWb9Ald07pCWc0EHSZ0W4iatJ+NNnj/QLINW8HWUehE9mAV5qZlhVFBmg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@21.6.10':
     resolution: {integrity: sha512-nJxUtzcHwk8TgDdcqUmbJnEMV3baQxmdWn77d1NTP4cG677A7jdV93hbnCcw+AQonaFLUzDwJOIX8eIPZ32GLw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@21.6.10':
     resolution: {integrity: sha512-+VwITTQW9wswP7EvFzNOucyaU86l2UcO6oYxFiwNvRioTlDOE5U7lxYmCgj3OHeGCmy9jhXlujdD+t3OhOT3gQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@21.6.10':
     resolution: {integrity: sha512-kkK/0GNVs7pdcgksLfoMBT8k92XGfcePPuhhS1Tsyq+zc3gpsPo+vNIGfeIf2FumKBsUdWUHuChfpxBmjcVFVw==}
@@ -2130,41 +2159,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}

--- a/projects/hutch/knip.config.ts
+++ b/projects/hutch/knip.config.ts
@@ -40,6 +40,7 @@ export default {
 		"@packages/domain",
 		"@packages/onboarding-extension-signal",
 		"@packages/retriable",
+		"@packages/time-left",
 		"@packages/test-fixtures",
 	],
 	ignoreBinaries: [

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -55,6 +55,7 @@
     "@packages/hutch-storage-client": "workspace:*",
     "@packages/onboarding-extension-signal": "workspace:*",
     "@packages/retriable": "workspace:*",
+    "@packages/time-left": "workspace:*",
     "browser-extension-core": "workspace:*",
     "compression": "1.8.1",
     "cookie-parser": "1.4.7",

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
@@ -1,45 +1,58 @@
 import assert from "node:assert/strict";
 import { UserIdSchema } from "@packages/domain/user";
 import {
-	PERMANENT_UTM_SOURCE,
+	PERMANENT_UTM_SOURCES,
 	PUBLIC_VIEW_ACCESS_WINDOW_MS,
-	SHARED_USER_ID_PREFIX_LENGTH,
 	computePublicViewExpiry,
-	decomposeTimeLeft,
-	formatCounter,
 	formatSaveUtmContent,
-	hasSharedUserIdPrefix,
-	shareUserIdPrefix,
+	sharedUserIdFrom,
+	sharedUserIdFromQueryParams,
 } from "./view-expiry";
 
-describe("shareUserIdPrefix", () => {
-	it("returns the first SHARED_USER_ID_PREFIX_LENGTH chars of the user id", () => {
+describe("sharedUserIdFrom", () => {
+	it("returns the first 6 chars of the user id, lowercased", () => {
 		const userId = UserIdSchema.parse("abc123deadbeef1234567890abcdef01");
-		const prefix = shareUserIdPrefix(userId);
-		expect(prefix).toBe("abc123");
-		expect(prefix.length).toBe(SHARED_USER_ID_PREFIX_LENGTH);
+		const prefix = sharedUserIdFrom(userId);
+		assert.equal(prefix, "abc123");
+		assert.equal(prefix.length, 6);
+	});
+
+	it("normalises uppercase hex to lowercase", () => {
+		const userId = UserIdSchema.parse("ABCDEF1234567890abcdef0123456789");
+		const prefix = sharedUserIdFrom(userId);
+		assert.equal(prefix, "abcdef");
 	});
 });
 
-describe("hasSharedUserIdPrefix", () => {
-	it("returns true when utm_content starts with 6 hex chars", () => {
-		expect(hasSharedUserIdPrefix("abc123")).toBe(true);
+describe("sharedUserIdFromQueryParams", () => {
+	it("returns SharedUserId when utm_content starts with 6 hex chars", () => {
+		const result = sharedUserIdFromQueryParams("abc123");
+		assert(result !== null);
+		assert.equal(result, "abc123");
 	});
 
-	it("returns true when 6 hex chars are followed by more characters", () => {
-		expect(hasSharedUserIdPrefix("abc123-share")).toBe(true);
+	it("returns SharedUserId when 6 hex chars are followed by more characters", () => {
+		const result = sharedUserIdFromQueryParams("abc123-share");
+		assert(result !== null);
+		assert.equal(result, "abc123-share");
 	});
 
-	it("returns false for non-hex values like 'paste-another-link'", () => {
-		expect(hasSharedUserIdPrefix("paste-another-link")).toBe(false);
+	it("normalises uppercase hex in utm_content", () => {
+		const result = sharedUserIdFromQueryParams("ABCDEF");
+		assert(result !== null);
+		assert.equal(result, "abcdef");
 	});
 
-	it("returns false when fewer than 6 hex chars are present", () => {
-		expect(hasSharedUserIdPrefix("abcde")).toBe(false);
+	it("returns null for non-hex values like 'paste-another-link'", () => {
+		assert.equal(sharedUserIdFromQueryParams("paste-another-link"), null);
 	});
 
-	it("returns false when utm_content is undefined", () => {
-		expect(hasSharedUserIdPrefix(undefined)).toBe(false);
+	it("returns null when fewer than 6 hex chars are present", () => {
+		assert.equal(sharedUserIdFromQueryParams("abcde"), null);
+	});
+
+	it("returns null when utm_content is undefined", () => {
+		assert.equal(sharedUserIdFromQueryParams(undefined), null);
 	});
 });
 
@@ -53,19 +66,17 @@ describe("computePublicViewExpiry", () => {
 			utmContent: undefined,
 		});
 		assert(result.expiresAt, "expiresAt must be set for organic visits");
-		expect(result.expiresAt.toISOString()).toBe("2026-05-04T00:00:00.000Z");
-		expect(result.expiresAt.getTime() - savedAt.getTime()).toBe(
-			PUBLIC_VIEW_ACCESS_WINDOW_MS,
-		);
+		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
+		assert.equal(result.expiresAt.getTime() - savedAt.getTime(), PUBLIC_VIEW_ACCESS_WINDOW_MS);
 	});
 
 	it("returns null for utm_source=fagnerbrack.com", () => {
 		const result = computePublicViewExpiry({
 			savedAt,
-			utmSource: PERMANENT_UTM_SOURCE,
+			utmSource: PERMANENT_UTM_SOURCES[0],
 			utmContent: undefined,
 		});
-		expect(result.expiresAt).toBeNull();
+		assert.equal(result.expiresAt, null);
 	});
 
 	it("returns null when utm_content carries a 6-hex-char prefix", () => {
@@ -74,7 +85,7 @@ describe("computePublicViewExpiry", () => {
 			utmSource: undefined,
 			utmContent: "abc123-share",
 		});
-		expect(result.expiresAt).toBeNull();
+		assert.equal(result.expiresAt, null);
 	});
 
 	it("applies the standard expiry when utm_content is non-hex like 'paste-another-link'", () => {
@@ -84,56 +95,15 @@ describe("computePublicViewExpiry", () => {
 			utmContent: "paste-another-link",
 		});
 		assert(result.expiresAt, "expiresAt must be set for analytics-only utm_content");
-		expect(result.expiresAt.toISOString()).toBe("2026-05-04T00:00:00.000Z");
-	});
-});
-
-describe("decomposeTimeLeft", () => {
-	it("splits 1d 10h 5m 33s into components", () => {
-		const ms =
-			1 * 24 * 60 * 60 * 1000 +
-			10 * 60 * 60 * 1000 +
-			5 * 60 * 1000 +
-			33 * 1000;
-		expect(decomposeTimeLeft(ms)).toEqual({
-			days: 1,
-			hours: 10,
-			minutes: 5,
-			seconds: 33,
-		});
-	});
-
-	it("returns all zeros for zero input", () => {
-		expect(decomposeTimeLeft(0)).toEqual({
-			days: 0,
-			hours: 0,
-			minutes: 0,
-			seconds: 0,
-		});
-	});
-
-	it("clamps negative input to zero", () => {
-		expect(decomposeTimeLeft(-1000)).toEqual({
-			days: 0,
-			hours: 0,
-			minutes: 0,
-			seconds: 0,
-		});
-	});
-});
-
-describe("formatCounter", () => {
-	it("renders '1d 10h 5m 33s'", () => {
-		expect(
-			formatCounter({ days: 1, hours: 10, minutes: 5, seconds: 33 }),
-		).toBe("1d 10h 5m 33s");
+		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
 	});
 });
 
 describe("formatSaveUtmContent", () => {
 	it("renders '2d_4h_left' at day/hour resolution only", () => {
-		expect(
+		assert.equal(
 			formatSaveUtmContent({ days: 2, hours: 4, minutes: 30, seconds: 15 }),
-		).toBe("2d_4h_left");
+			"2d_4h_left",
+		);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
+import {
+	PERMANENT_UTM_SOURCE,
+	PUBLIC_VIEW_ACCESS_WINDOW_MS,
+	SHARED_USER_ID_PREFIX_LENGTH,
+	computePublicViewExpiry,
+	decomposeTimeLeft,
+	formatCounter,
+	formatSaveUtmContent,
+	hasSharedUserIdPrefix,
+	shareUserIdPrefix,
+} from "./view-expiry";
+
+describe("shareUserIdPrefix", () => {
+	it("returns the first SHARED_USER_ID_PREFIX_LENGTH chars of the user id", () => {
+		const userId = UserIdSchema.parse("abc123deadbeef1234567890abcdef01");
+		const prefix = shareUserIdPrefix(userId);
+		expect(prefix).toBe("abc123");
+		expect(prefix.length).toBe(SHARED_USER_ID_PREFIX_LENGTH);
+	});
+});
+
+describe("hasSharedUserIdPrefix", () => {
+	it("returns true when utm_content starts with 6 hex chars", () => {
+		expect(hasSharedUserIdPrefix("abc123")).toBe(true);
+	});
+
+	it("returns true when 6 hex chars are followed by more characters", () => {
+		expect(hasSharedUserIdPrefix("abc123-share")).toBe(true);
+	});
+
+	it("returns false for non-hex values like 'paste-another-link'", () => {
+		expect(hasSharedUserIdPrefix("paste-another-link")).toBe(false);
+	});
+
+	it("returns false when fewer than 6 hex chars are present", () => {
+		expect(hasSharedUserIdPrefix("abcde")).toBe(false);
+	});
+
+	it("returns false when utm_content is undefined", () => {
+		expect(hasSharedUserIdPrefix(undefined)).toBe(false);
+	});
+});
+
+describe("computePublicViewExpiry", () => {
+	const savedAt = new Date("2026-05-01T00:00:00.000Z");
+
+	it("returns savedAt + 3 days for organic visits", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			utmSource: undefined,
+			utmContent: undefined,
+		});
+		assert(result.expiresAt, "expiresAt must be set for organic visits");
+		expect(result.expiresAt.toISOString()).toBe("2026-05-04T00:00:00.000Z");
+		expect(result.expiresAt.getTime() - savedAt.getTime()).toBe(
+			PUBLIC_VIEW_ACCESS_WINDOW_MS,
+		);
+	});
+
+	it("returns null for utm_source=fagnerbrack.com", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			utmSource: PERMANENT_UTM_SOURCE,
+			utmContent: undefined,
+		});
+		expect(result.expiresAt).toBeNull();
+	});
+
+	it("returns null when utm_content carries a 6-hex-char prefix", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			utmSource: undefined,
+			utmContent: "abc123-share",
+		});
+		expect(result.expiresAt).toBeNull();
+	});
+
+	it("applies the standard expiry when utm_content is non-hex like 'paste-another-link'", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			utmSource: undefined,
+			utmContent: "paste-another-link",
+		});
+		assert(result.expiresAt, "expiresAt must be set for analytics-only utm_content");
+		expect(result.expiresAt.toISOString()).toBe("2026-05-04T00:00:00.000Z");
+	});
+});
+
+describe("decomposeTimeLeft", () => {
+	it("splits 1d 10h 5m 33s into components", () => {
+		const ms =
+			1 * 24 * 60 * 60 * 1000 +
+			10 * 60 * 60 * 1000 +
+			5 * 60 * 1000 +
+			33 * 1000;
+		expect(decomposeTimeLeft(ms)).toEqual({
+			days: 1,
+			hours: 10,
+			minutes: 5,
+			seconds: 33,
+		});
+	});
+
+	it("returns all zeros for zero input", () => {
+		expect(decomposeTimeLeft(0)).toEqual({
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+	});
+
+	it("clamps negative input to zero", () => {
+		expect(decomposeTimeLeft(-1000)).toEqual({
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+	});
+});
+
+describe("formatCounter", () => {
+	it("renders '1d 10h 5m 33s'", () => {
+		expect(
+			formatCounter({ days: 1, hours: 10, minutes: 5, seconds: 33 }),
+		).toBe("1d 10h 5m 33s");
+	});
+});
+
+describe("formatSaveUtmContent", () => {
+	it("renders '2d_4h_left' at day/hour resolution only", () => {
+		expect(
+			formatSaveUtmContent({ days: 2, hours: 4, minutes: 30, seconds: 15 }),
+		).toBe("2d_4h_left");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
@@ -1,0 +1,74 @@
+import type { UserId } from "@packages/domain/user";
+
+/** Public /view pages remain accessible for 3 days after the most recent
+ * save. The window creates urgency for organic visitors ("save it before it
+ * disappears") while authenticated sharers and the founder's syndication
+ * bypass the expiry — see {@link computePublicViewExpiry}. */
+export const PUBLIC_VIEW_ACCESS_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** Visits stamped with this utm_source skip the expiry window. Traffic from
+ * the founder's blog is a syndication channel we want to encourage, not
+ * penalise. */
+export const PERMANENT_UTM_SOURCE = "fagnerbrack.com";
+
+/** Hex prefix length taken from the sharer's UserId and stamped into
+ * utm_content when an authenticated user shares a link. Long enough to be
+ * collision-resistant for share attribution; short enough that the full
+ * UserId is never exposed. */
+export const SHARED_USER_ID_PREFIX_LENGTH = 6;
+
+const SHARED_USER_ID_PREFIX_PATTERN = /^[0-9a-f]{6}/;
+
+export function shareUserIdPrefix(userId: UserId): string {
+	return userId.slice(0, SHARED_USER_ID_PREFIX_LENGTH);
+}
+
+export function hasSharedUserIdPrefix(utmContent: string | undefined): boolean {
+	if (utmContent === undefined) return false;
+	return SHARED_USER_ID_PREFIX_PATTERN.test(utmContent);
+}
+
+export type ComputePublicViewExpiryInput = {
+	savedAt: Date;
+	utmSource: string | undefined;
+	utmContent: string | undefined;
+};
+
+export function computePublicViewExpiry(
+	input: ComputePublicViewExpiryInput,
+): { expiresAt: Date | null } {
+	if (input.utmSource === PERMANENT_UTM_SOURCE) return { expiresAt: null };
+	if (hasSharedUserIdPrefix(input.utmContent)) return { expiresAt: null };
+	return {
+		expiresAt: new Date(input.savedAt.getTime() + PUBLIC_VIEW_ACCESS_WINDOW_MS),
+	};
+}
+
+export type TimeLeft = {
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+};
+
+export function decomposeTimeLeft(ms: number): TimeLeft {
+	if (ms <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+	const totalSeconds = Math.floor(ms / 1000);
+	const seconds = totalSeconds % 60;
+	const totalMinutes = Math.floor(totalSeconds / 60);
+	const minutes = totalMinutes % 60;
+	const totalHours = Math.floor(totalMinutes / 60);
+	const hours = totalHours % 24;
+	const days = Math.floor(totalHours / 24);
+	return { days, hours, minutes, seconds };
+}
+
+export function formatCounter(timeLeft: TimeLeft): string {
+	return `${timeLeft.days}d ${timeLeft.hours}h ${timeLeft.minutes}m ${timeLeft.seconds}s`;
+}
+
+/** Day/hour resolution only. Minute/second values change too fast to be
+ * useful for analytics aggregation, so they are intentionally dropped. */
+export function formatSaveUtmContent(timeLeft: TimeLeft): string {
+	return `${timeLeft.days}d_${timeLeft.hours}h_left`;
+}

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
@@ -1,5 +1,6 @@
 import type { UserId } from "@packages/domain/user";
 import type { TimeLeft } from "@packages/time-left";
+import { z } from "zod";
 
 /** Public /view pages remain accessible for 3 days after the most recent
  * save. The window creates urgency for organic visitors ("save it before it
@@ -22,15 +23,19 @@ const SHARED_USER_ID_PREFIX_PATTERN = /^[0-9a-f]{6}/;
 
 export type SharedUserId = string & { readonly __brand: "SharedUserId" };
 
+const SharedUserIdSchema = z
+	.string()
+	.regex(SHARED_USER_ID_PREFIX_PATTERN)
+	.transform((s): SharedUserId => s as SharedUserId);
+
 export function sharedUserIdFrom(userId: UserId): SharedUserId {
-	return userId.slice(0, SHARED_USER_ID_PREFIX_LENGTH).toLowerCase() as SharedUserId;
+	return SharedUserIdSchema.parse(userId.slice(0, SHARED_USER_ID_PREFIX_LENGTH).toLowerCase());
 }
 
 export function sharedUserIdFromQueryParams(utmContent: string | undefined): SharedUserId | null {
 	if (utmContent === undefined) return null;
-	const normalized = utmContent.toLowerCase();
-	if (!SHARED_USER_ID_PREFIX_PATTERN.test(normalized)) return null;
-	return normalized as SharedUserId;
+	const result = SharedUserIdSchema.safeParse(utmContent.toLowerCase());
+	return result.success ? result.data : null;
 }
 
 export type ComputePublicViewExpiryInput = {

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
@@ -1,4 +1,5 @@
 import type { UserId } from "@packages/domain/user";
+import type { TimeLeft } from "@packages/time-left";
 
 /** Public /view pages remain accessible for 3 days after the most recent
  * save. The window creates urgency for organic visitors ("save it before it
@@ -6,26 +7,30 @@ import type { UserId } from "@packages/domain/user";
  * bypass the expiry — see {@link computePublicViewExpiry}. */
 export const PUBLIC_VIEW_ACCESS_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
 
-/** Visits stamped with this utm_source skip the expiry window. Traffic from
- * the founder's blog is a syndication channel we want to encourage, not
- * penalise. */
-export const PERMANENT_UTM_SOURCE = "fagnerbrack.com";
+/** Visits stamped with any of these utm_source values skip the expiry
+ * window. Traffic from the founder's blog is a syndication channel we want
+ * to encourage, not penalise. */
+export const PERMANENT_UTM_SOURCES: readonly string[] = ["fagnerbrack.com"];
 
 /** Hex prefix length taken from the sharer's UserId and stamped into
  * utm_content when an authenticated user shares a link. Long enough to be
  * collision-resistant for share attribution; short enough that the full
  * UserId is never exposed. */
-export const SHARED_USER_ID_PREFIX_LENGTH = 6;
+const SHARED_USER_ID_PREFIX_LENGTH = 6;
 
 const SHARED_USER_ID_PREFIX_PATTERN = /^[0-9a-f]{6}/;
 
-export function shareUserIdPrefix(userId: UserId): string {
-	return userId.slice(0, SHARED_USER_ID_PREFIX_LENGTH);
+export type SharedUserId = string & { readonly __brand: "SharedUserId" };
+
+export function sharedUserIdFrom(userId: UserId): SharedUserId {
+	return userId.slice(0, SHARED_USER_ID_PREFIX_LENGTH).toLowerCase() as SharedUserId;
 }
 
-export function hasSharedUserIdPrefix(utmContent: string | undefined): boolean {
-	if (utmContent === undefined) return false;
-	return SHARED_USER_ID_PREFIX_PATTERN.test(utmContent);
+export function sharedUserIdFromQueryParams(utmContent: string | undefined): SharedUserId | null {
+	if (utmContent === undefined) return null;
+	const normalized = utmContent.toLowerCase();
+	if (!SHARED_USER_ID_PREFIX_PATTERN.test(normalized)) return null;
+	return normalized as SharedUserId;
 }
 
 export type ComputePublicViewExpiryInput = {
@@ -37,34 +42,11 @@ export type ComputePublicViewExpiryInput = {
 export function computePublicViewExpiry(
 	input: ComputePublicViewExpiryInput,
 ): { expiresAt: Date | null } {
-	if (input.utmSource === PERMANENT_UTM_SOURCE) return { expiresAt: null };
-	if (hasSharedUserIdPrefix(input.utmContent)) return { expiresAt: null };
+	if (input.utmSource !== undefined && PERMANENT_UTM_SOURCES.includes(input.utmSource)) return { expiresAt: null };
+	if (sharedUserIdFromQueryParams(input.utmContent) !== null) return { expiresAt: null };
 	return {
 		expiresAt: new Date(input.savedAt.getTime() + PUBLIC_VIEW_ACCESS_WINDOW_MS),
 	};
-}
-
-export type TimeLeft = {
-	days: number;
-	hours: number;
-	minutes: number;
-	seconds: number;
-};
-
-export function decomposeTimeLeft(ms: number): TimeLeft {
-	if (ms <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
-	const totalSeconds = Math.floor(ms / 1000);
-	const seconds = totalSeconds % 60;
-	const totalMinutes = Math.floor(totalSeconds / 60);
-	const minutes = totalMinutes % 60;
-	const totalHours = Math.floor(totalMinutes / 60);
-	const hours = totalHours % 24;
-	const days = Math.floor(totalHours / 24);
-	return { days, hours, minutes, seconds };
-}
-
-export function formatCounter(timeLeft: TimeLeft): string {
-	return `${timeLeft.days}d ${timeLeft.hours}h ${timeLeft.minutes}m ${timeLeft.seconds}s`;
 }
 
 /** Day/hour resolution only. Minute/second values change too fast to be

--- a/src/packages/time-left/biome.json
+++ b/src/packages/time-left/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../../../biome.config.base.json"]
+}

--- a/src/packages/time-left/enforce-coverage.config.js
+++ b/src/packages/time-left/enforce-coverage.config.js
@@ -1,0 +1,21 @@
+const baseConfig = require('../../../enforce-coverage.config.base');
+const path = require('path');
+
+const config = {
+  ...baseConfig,
+  thresholds: {
+    statements: 100,
+    branches: 100,
+    functions: 100,
+    lines: 100,
+  },
+};
+
+config.enforceCoverage({
+  projectRoot: path.resolve(__dirname),
+  thresholds: config.thresholds,
+  showTextTable: true,
+  extraExcludePatterns: [
+    ...(config.extraExcludePatterns || [])
+  ],
+});

--- a/src/packages/time-left/knip.config.ts
+++ b/src/packages/time-left/knip.config.ts
@@ -1,0 +1,9 @@
+import type { KnipConfig } from "knip";
+
+export default {
+	entry: ["src/index.ts"],
+	ignoreBinaries: ["knip", "biome"],
+	jest: {
+		entry: ["src/**/*.test.ts"],
+	},
+} satisfies KnipConfig;

--- a/src/packages/time-left/package.json
+++ b/src/packages/time-left/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@packages/time-left",
+  "version": "1.0.0",
+  "description": "Decompose and format a millisecond duration into days/hours/minutes/seconds",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "private": true,
+  "scripts": {
+    "compile": "rm -rf dist && tsc",
+    "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
+    "test": "jest --testMatch='**/dist/src/**/*.test.js'",
+    "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",
+    "check": "pnpm lint",
+    "check-infra": "echo 'No infrastructure — shared library'"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.14",
+    "c8": "10.1.3",
+    "concurrently": "9.2.1",
+    "jest": "29.7.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/src/packages/time-left/project.json
+++ b/src/packages/time-left/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "@packages/time-left",
+  "targets": {
+    "check": {
+      "command": "pnpm lint",
+      "options": { "cwd": "{projectRoot}" }
+    }
+  }
+}

--- a/src/packages/time-left/src/index.test.ts
+++ b/src/packages/time-left/src/index.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { decomposeTimeLeft, formatCounter } from "./index";
+
+describe("decomposeTimeLeft", () => {
+	it("splits 1d 10h 5m 33s into components", () => {
+		const ms =
+			1 * 24 * 60 * 60 * 1000 +
+			10 * 60 * 60 * 1000 +
+			5 * 60 * 1000 +
+			33 * 1000;
+		assert.deepStrictEqual(decomposeTimeLeft(ms), {
+			days: 1,
+			hours: 10,
+			minutes: 5,
+			seconds: 33,
+		});
+	});
+
+	it("returns all zeros for zero input", () => {
+		assert.deepStrictEqual(decomposeTimeLeft(0), {
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+	});
+
+	it("clamps negative input to zero", () => {
+		assert.deepStrictEqual(decomposeTimeLeft(-1000), {
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+		});
+	});
+});
+
+describe("formatCounter", () => {
+	it("renders '1d 10h 5m 33s'", () => {
+		assert.equal(
+			formatCounter({ days: 1, hours: 10, minutes: 5, seconds: 33 }),
+			"1d 10h 5m 33s",
+		);
+	});
+
+	it("skips leading zero-unit segments", () => {
+		assert.equal(
+			formatCounter({ days: 0, hours: 0, minutes: 0, seconds: 5 }),
+			"5s",
+		);
+	});
+
+	it("keeps trailing zeros after the first nonzero segment", () => {
+		assert.equal(
+			formatCounter({ days: 1, hours: 0, minutes: 0, seconds: 0 }),
+			"1d 0h 0m 0s",
+		);
+	});
+
+	it("renders hours onward when days is zero", () => {
+		assert.equal(
+			formatCounter({ days: 0, hours: 2, minutes: 0, seconds: 15 }),
+			"2h 0m 15s",
+		);
+	});
+
+	it("renders minutes onward when days and hours are zero", () => {
+		assert.equal(
+			formatCounter({ days: 0, hours: 0, minutes: 3, seconds: 0 }),
+			"3m 0s",
+		);
+	});
+});

--- a/src/packages/time-left/src/index.ts
+++ b/src/packages/time-left/src/index.ts
@@ -1,0 +1,27 @@
+export type TimeLeft = {
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+};
+
+export function decomposeTimeLeft(ms: number): TimeLeft {
+	if (ms <= 0) return { days: 0, hours: 0, minutes: 0, seconds: 0 };
+	const totalSeconds = Math.floor(ms / 1000);
+	const seconds = totalSeconds % 60;
+	const totalMinutes = Math.floor(totalSeconds / 60);
+	const minutes = totalMinutes % 60;
+	const totalHours = Math.floor(totalMinutes / 60);
+	const hours = totalHours % 24;
+	const days = Math.floor(totalHours / 24);
+	return { days, hours, minutes, seconds };
+}
+
+export function formatCounter(timeLeft: TimeLeft): string {
+	const parts: string[] = [];
+	if (timeLeft.days > 0) parts.push(`${timeLeft.days}d`);
+	if (timeLeft.days > 0 || timeLeft.hours > 0) parts.push(`${timeLeft.hours}h`);
+	if (timeLeft.days > 0 || timeLeft.hours > 0 || timeLeft.minutes > 0) parts.push(`${timeLeft.minutes}m`);
+	parts.push(`${timeLeft.seconds}s`);
+	return parts.join(" ");
+}

--- a/src/packages/time-left/tsconfig.json
+++ b/src/packages/time-left/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.config.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/packages/time-left/tsconfig.lint.json
+++ b/src/packages/time-left/tsconfig.lint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `projects/hutch/src/runtime/web/pages/view/view-expiry.ts` with the pure-function rules for the public `/view` 3-day access window: organic visits expire at `savedAt + 3 days`, while `utm_source=fagnerbrack.com` (founder syndication) and a `utm_content` carrying a 6-hex-char sharer prefix bypass expiry entirely.
- Exposes the helpers downstream callers will need: `shareUserIdPrefix`, `hasSharedUserIdPrefix`, `computePublicViewExpiry`, `decomposeTimeLeft`, `formatCounter`, and `formatSaveUtmContent` (day/hour resolution only — minutes/seconds change too fast to be useful for analytics aggregation).
- `hasSharedUserIdPrefix` uses `/^[0-9a-f]{6}/` so analytics-only `utm_content` values like `paste-another-link` fall back to the standard expiry instead of accidentally becoming permanent.

## Test plan

- [x] `view-expiry.test.ts` covers all 6 exports across 15 cases (organic expiry, fagnerbrack permanence, 6-hex prefix permanence, non-hex fallback, zero/negative `decomposeTimeLeft` clamping, counter and save-utm formatting).
- [x] `npx jest --testMatch='**/dist/**/view-expiry.test.js'` — 15/15 passing locally.
- [x] `npx biome lint` — clean.
- [x] `npx tsc --noEmit` — no errors on the new files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuDUFEedZZ5ZoxTXN1nF5d)_