### PR TITLE
feat: savedAt on GlobalArticleData with bump-on-re-save

### DIFF
--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -15,6 +15,7 @@ import { ReaderArticleHashId, ReaderArticleHashIdSchema } from "@packages/domain
 import { UserIdSchema } from "@packages/domain/user";
 import type { UserId } from "@packages/domain/user";
 import type {
+	BumpArticleSavedAt,
 	DeleteArticle,
 	FindArticleById,
 	FindArticleByUrl,
@@ -37,7 +38,13 @@ const ArticleFreshnessRow = z.object({
 	contentFetchedAt: dynamoField(z.string()),
 });
 
-/** `routeId` column holds the `ReaderArticleHashId.value` (32-char hex). The Zod schema rehydrates it into a `ReaderArticleHashId` instance on read. */
+/** `routeId` column holds the `ReaderArticleHashId.value` (32-char hex). The Zod schema rehydrates it into a `ReaderArticleHashId` instance on read.
+ *
+ * `savedAt` is the public-row freshness anchor: when the row is first created
+ * it records the original save; on every re-save the domain bumps it via
+ * `bumpArticleSavedAt` so downstream consumers (expiry counter, freshness
+ * policies) can compute time-based behaviour from a single timestamp. Stored
+ * as ISO-8601 to match the column convention used by `UserArticleRow`. */
 const ArticleRow = z.object({
 	url: z.string(),
 	routeId: ReaderArticleHashIdSchema,
@@ -49,6 +56,7 @@ const ArticleRow = z.object({
 	imageUrl: dynamoField(z.string()),
 	content: dynamoField(z.string()),
 	estimatedReadTime: MinutesSchema,
+	savedAt: z.string(),
 	contentSourceTier: dynamoField(z.enum(["tier-0", "tier-1"])),
 });
 /** Every ArticleRow attribute except `content`, derived so the list stays in sync with the schema. */
@@ -92,6 +100,7 @@ export function initDynamoDbArticleStore(deps: {
 }): {
 	saveArticle: SaveArticle;
 	saveArticleGlobally: SaveArticleGlobally;
+	bumpArticleSavedAt: BumpArticleSavedAt;
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
 	findArticleUrlById: FindArticleUrlById;
@@ -127,17 +136,12 @@ export function initDynamoDbArticleStore(deps: {
 		return row ?? null;
 	}
 
-	const ignoreDuplicate = (error: unknown) => {
-		if (error instanceof ConditionalCheckFailedException) return;
-		throw error;
-	};
-
 	const saveArticleGlobally: SaveArticleGlobally = async (params) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
 		const routeId = ReaderArticleHashId.from(params.url);
 
-		await articles
-			.put({
+		try {
+			await articles.put({
 				Item: {
 					url: articleResourceUniqueId.value,
 					routeId: routeId.value,
@@ -152,21 +156,52 @@ export function initDynamoDbArticleStore(deps: {
 				},
 				ConditionExpression: "attribute_not_exists(#url)",
 				ExpressionAttributeNames: { "#url": "url" },
-			})
-			.catch(ignoreDuplicate);
+			});
+			return { created: true };
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) {
+				return { created: false };
+			}
+			throw error;
+		}
+	};
+
+	const bumpArticleSavedAt: BumpArticleSavedAt = async (params) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
+		try {
+			await articles.update({
+				Key: { url: articleResourceUniqueId.value },
+				UpdateExpression: "SET savedAt = :savedAt",
+				ConditionExpression: "attribute_exists(#url)",
+				ExpressionAttributeNames: { "#url": "url" },
+				ExpressionAttributeValues: {
+					":savedAt": params.savedAt.toISOString(),
+				},
+			});
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) return;
+			throw error;
+		}
 	};
 
 	const saveArticle: SaveArticle = async (params) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
 		const now = new Date();
 
-		await Promise.all([
-			saveArticleGlobally({
+		const upsertGlobal = async () => {
+			const { created } = await saveArticleGlobally({
 				url: params.url,
 				metadata: params.metadata,
 				estimatedReadTime: params.estimatedReadTime,
 				savedAt: now,
-			}),
+			});
+			if (!created) {
+				await bumpArticleSavedAt({ url: params.url, savedAt: now });
+			}
+		};
+
+		await Promise.all([
+			upsertGlobal(),
 			userArticles.update({
 				Key: { userId: params.userId, url: articleResourceUniqueId.value },
 				UpdateExpression:
@@ -372,6 +407,7 @@ export function initDynamoDbArticleStore(deps: {
 					"wordCount",
 					"imageUrl",
 					"estimatedReadTime",
+					"savedAt",
 					"contentSourceTier",
 				],
 			},
@@ -388,6 +424,7 @@ export function initDynamoDbArticleStore(deps: {
 				imageUrl: row.imageUrl,
 			},
 			estimatedReadTime: row.estimatedReadTime,
+			savedAt: new Date(row.savedAt),
 			contentSourceTier: row.contentSourceTier,
 		};
 	};
@@ -404,6 +441,7 @@ export function initDynamoDbArticleStore(deps: {
 	return {
 		saveArticle,
 		saveArticleGlobally,
+		bumpArticleSavedAt,
 		findArticleById,
 		findArticleByUrl,
 		findArticleUrlById,

--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -56,7 +56,7 @@ const ArticleRow = z.object({
 	imageUrl: dynamoField(z.string()),
 	content: dynamoField(z.string()),
 	estimatedReadTime: MinutesSchema,
-	savedAt: z.string(),
+	savedAt: dynamoField(z.string()),
 	contentSourceTier: dynamoField(z.enum(["tier-0", "tier-1"])),
 });
 /** Every ArticleRow attribute except `content`, derived so the list stays in sync with the schema. */
@@ -424,7 +424,7 @@ export function initDynamoDbArticleStore(deps: {
 				imageUrl: row.imageUrl,
 			},
 			estimatedReadTime: row.estimatedReadTime,
-			savedAt: new Date(row.savedAt),
+			savedAt: row.savedAt ? new Date(row.savedAt) : new Date(0),
 			contentSourceTier: row.contentSourceTier,
 		};
 	};

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -56,6 +56,7 @@ function defaultFakeArticle(): GlobalArticleData {
 			wordCount: 100,
 		},
 		estimatedReadTime: 1 as Minutes,
+		savedAt: FIXED_NOW,
 	};
 }
 

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -68,6 +68,7 @@ import type {
 	UpsertTrialingSubscription,
 } from "./providers/subscription-providers/subscription-providers.types";
 import type {
+	BumpArticleSavedAt,
 	DeleteArticle,
 	FindArticleById,
 	FindArticleByUrl,
@@ -153,6 +154,7 @@ export interface ArticleStoreBundle {
 	findArticlesByUser: FindArticlesByUser;
 	saveArticle: SaveArticle;
 	saveArticleGlobally: SaveArticleGlobally;
+	bumpArticleSavedAt: BumpArticleSavedAt;
 	deleteArticle: DeleteArticle;
 	updateArticleStatus: UpdateArticleStatus;
 	readArticleContent: ReadArticleContent;

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -261,6 +261,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 			findArticlesByUser: articleStoreMemory.findArticlesByUser,
 			saveArticle: articleStoreMemory.saveArticle,
 			saveArticleGlobally: articleStoreMemory.saveArticleGlobally,
+			bumpArticleSavedAt: articleStoreMemory.bumpArticleSavedAt,
 			deleteArticle: articleStoreMemory.deleteArticle,
 			updateArticleStatus: articleStoreMemory.updateArticleStatus,
 			readArticleContent: (url) =>

--- a/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
@@ -42,8 +42,21 @@ export interface SaveArticleGloballyParams {
 	savedAt: Date;
 }
 
+/** Returned `{ created }` lets the caller distinguish a fresh insert from a
+ * no-op upsert on an existing row. The store performs the conditional put
+ * only; whether to bump `savedAt` (or take any other follow-up) is a
+ * domain decision the caller layers on top via `bumpArticleSavedAt`. */
 export type SaveArticleGlobally = (
 	params: SaveArticleGloballyParams,
+) => Promise<{ created: boolean }>;
+
+export interface BumpArticleSavedAtParams {
+	url: string;
+	savedAt: Date;
+}
+
+export type BumpArticleSavedAt = (
+	params: BumpArticleSavedAtParams,
 ) => Promise<void>;
 
 export type FindArticleById = (
@@ -64,6 +77,7 @@ export interface GlobalArticleData {
 	url: string;
 	metadata: SavedArticle["metadata"];
 	estimatedReadTime: SavedArticle["estimatedReadTime"];
+	savedAt: Date;
 	contentSourceTier?: "tier-0" | "tier-1";
 }
 

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import { ReaderArticleHashId } from "@packages/domain/article";
 import type { Minutes } from "@packages/domain/article";
@@ -64,6 +65,115 @@ describe("initInMemoryArticleStore", () => {
 
 			expect(found?.url).toBe("https://example.com/article");
 			expect(found?.metadata.title).toBe("Test Article");
+		});
+
+		it("should return the global savedAt so downstream consumers can compute time-based policies", async () => {
+			const store = initInMemoryArticleStore();
+			const savedAt = new Date("2026-04-01T12:00:00.000Z");
+			await store.saveArticleGlobally({
+				url: "https://example.com/article",
+				metadata: { title: "T", siteName: "example.com", excerpt: "", wordCount: 0 },
+				estimatedReadTime: 0 as Minutes,
+				savedAt,
+			});
+
+			const found = await store.findArticleByUrl("https://example.com/article");
+
+			expect(found?.savedAt).toEqual(savedAt);
+		});
+	});
+
+	describe("saveArticleGlobally savedAt semantics", () => {
+		it("reports created=true on the first insert and created=false on subsequent calls", async () => {
+			const store = initInMemoryArticleStore();
+			const url = "https://example.com/article";
+			const baseMetadata = { title: "T", siteName: "example.com", excerpt: "", wordCount: 0 };
+
+			const first = await store.saveArticleGlobally({
+				url,
+				metadata: baseMetadata,
+				estimatedReadTime: 0 as Minutes,
+				savedAt: new Date("2026-04-01T12:00:00.000Z"),
+			});
+			const second = await store.saveArticleGlobally({
+				url,
+				metadata: baseMetadata,
+				estimatedReadTime: 0 as Minutes,
+				savedAt: new Date("2026-04-02T12:00:00.000Z"),
+			});
+
+			expect(first).toEqual({ created: true });
+			expect(second).toEqual({ created: false });
+		});
+
+		it("does not clobber real parsed metadata when a stub re-save lands on an existing row", async () => {
+			// Simulates the /view fallback path landing on a row that already
+			// holds parsed metadata: title/excerpt/wordCount must stay intact;
+			// only savedAt is allowed to advance (via bumpArticleSavedAt).
+			const store = initInMemoryArticleStore();
+			const url = "https://example.com/article";
+			const realMetadata = {
+				title: "Real Parsed Title",
+				siteName: "example.com",
+				excerpt: "Real parsed excerpt.",
+				wordCount: 500,
+			};
+			const firstSavedAt = new Date("2026-04-01T12:00:00.000Z");
+			const stubSavedAt = new Date("2026-04-02T12:00:00.000Z");
+
+			await store.saveArticleGlobally({
+				url,
+				metadata: realMetadata,
+				estimatedReadTime: 3 as Minutes,
+				savedAt: firstSavedAt,
+			});
+
+			const stubResult = await store.saveArticleGlobally({
+				url,
+				metadata: { title: "example.com", siteName: "example.com", excerpt: "", wordCount: 0 },
+				estimatedReadTime: 0 as Minutes,
+				savedAt: stubSavedAt,
+			});
+			expect(stubResult.created).toBe(false);
+
+			await store.bumpArticleSavedAt({ url, savedAt: stubSavedAt });
+
+			const found = await store.findArticleByUrl(url);
+			expect(found?.metadata).toEqual(realMetadata);
+			expect(found?.estimatedReadTime).toBe(3);
+			expect(found?.savedAt).toEqual(stubSavedAt);
+		});
+
+		it("bumps the global savedAt when the same user re-saves the article", async () => {
+			const store = initInMemoryArticleStore();
+			await store.saveArticle(makeArticleParams());
+			const firstFound = await store.findArticleByUrl(
+				"https://example.com/article",
+			);
+			assert(firstFound, "article must exist after first save");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			await store.saveArticle(makeArticleParams());
+			const secondFound = await store.findArticleByUrl(
+				"https://example.com/article",
+			);
+			assert(secondFound, "article must still exist after re-save");
+
+			expect(secondFound.savedAt.getTime()).toBeGreaterThan(
+				firstFound.savedAt.getTime(),
+			);
+		});
+
+		it("ignores a bumpArticleSavedAt call for a URL that has never been saved", async () => {
+			const store = initInMemoryArticleStore();
+
+			await store.bumpArticleSavedAt({
+				url: "https://example.com/missing",
+				savedAt: new Date("2026-04-02T12:00:00.000Z"),
+			});
+
+			const found = await store.findArticleByUrl("https://example.com/missing");
+			expect(found).toBeNull();
 		});
 	});
 

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
@@ -9,6 +9,7 @@ import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import { ReaderArticleHashId } from "@packages/domain/article";
 import type { UserId } from "@packages/domain/user";
 import type {
+	BumpArticleSavedAt,
 	DeleteArticle,
 	FindArticleById,
 	FindArticleByUrl,
@@ -63,6 +64,7 @@ function toSavedArticle(article: GlobalArticle, userArticle: UserArticle): Saved
 export function initInMemoryArticleStore(): {
 	saveArticle: SaveArticle;
 	saveArticleGlobally: SaveArticleGlobally;
+	bumpArticleSavedAt: BumpArticleSavedAt;
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
 	findArticleUrlById: FindArticleUrlById;
@@ -91,28 +93,39 @@ export function initInMemoryArticleStore(): {
 
 	const saveArticleGlobally: SaveArticleGlobally = async (params) => {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
-		const routeId = ReaderArticleHashId.from(params.url);
-
-		if (!articles.has(articleResourceUniqueId.value)) {
-			articles.set(articleResourceUniqueId.value, {
-				url: articleResourceUniqueId.value,
-				originalUrl: params.url,
-				routeId,
-				metadata: params.metadata,
-				estimatedReadTime: params.estimatedReadTime,
-				savedAt: params.savedAt,
-			});
+		if (articles.has(articleResourceUniqueId.value)) {
+			return { created: false };
 		}
+		const routeId = ReaderArticleHashId.from(params.url);
+		articles.set(articleResourceUniqueId.value, {
+			url: articleResourceUniqueId.value,
+			originalUrl: params.url,
+			routeId,
+			metadata: params.metadata,
+			estimatedReadTime: params.estimatedReadTime,
+			savedAt: params.savedAt,
+		});
+		return { created: true };
+	};
+
+	const bumpArticleSavedAt: BumpArticleSavedAt = async (params) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
+		const article = articles.get(articleResourceUniqueId.value);
+		if (!article) return;
+		article.savedAt = params.savedAt;
 	};
 
 	const saveArticle: SaveArticle = async (params) => {
 		const now = new Date();
-		await saveArticleGlobally({
+		const { created } = await saveArticleGlobally({
 			url: params.url,
 			metadata: params.metadata,
 			estimatedReadTime: params.estimatedReadTime,
 			savedAt: now,
 		});
+		if (!created) {
+			await bumpArticleSavedAt({ url: params.url, savedAt: now });
+		}
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(params.url);
 
 		const uaKey = userArticleKey(params.userId, articleResourceUniqueId.value);
@@ -160,6 +173,7 @@ export function initInMemoryArticleStore(): {
 			content: article.content,
 
 			estimatedReadTime: article.estimatedReadTime,
+			savedAt: article.savedAt,
 			contentSourceTier: article.contentSourceTier,
 		};
 	};
@@ -273,6 +287,7 @@ export function initInMemoryArticleStore(): {
 	return {
 		saveArticle,
 		saveArticleGlobally,
+		bumpArticleSavedAt,
 		findArticleById,
 		findArticleByUrl,
 		findArticleUrlById,


### PR DESCRIPTION
## Summary

- Adds `savedAt: Date` to `GlobalArticleData` so downstream consumers (expiry counter, freshness policies, analytics) can compute time-based behaviour from a single authoritative timestamp on the global article row.
- Changes `SaveArticleGlobally` to return `{ created: boolean }` and adds a new `BumpArticleSavedAt` operation. The store performs the atomic conditional-put only; the domain decides whether to advance `savedAt` on conflict, which keeps "real parsed metadata is preserved on stub re-save" and "user re-save bumps the clock" as separate concerns at the call site.
- The `saveArticle` wrapper in both in-memory and DynamoDB stores composes `saveArticleGlobally + bumpArticleSavedAt`, so a user re-save (via `saveArticle`) refreshes the timestamp. `view.page.ts` continues to call `saveArticleGlobally` only inside the `!existing` branch and deliberately does not bump on revisit — viewing a stale article doesn't reset its expiry clock.
- DynamoDB: `ArticleRow` gets a `savedAt` column (ISO-8601); `findArticleByUrl` projects and returns it; `bumpArticleSavedAt` uses `UpdateExpression: "SET savedAt = :savedAt"` with `attribute_exists` so a missing row is a no-op rather than creating a fields-less ghost.

## Why

The original plan calls for "expiration of the public view happens 3 days after the first crawl or after each subsequent re-save". This change provides the `savedAt` anchor that makes "3 days after" computable, and ensures the clock resets on each user re-save.

## Test plan

- [x] `pnpm nx run @packages/test-fixtures:check` (lint + unit tests + coverage)
- [x] `pnpm nx run hutch:check` (lint + unit tests + coverage)
- [x] New unit tests in `in-memory-article-store.test.ts`:
  - [x] `findArticleByUrl` returns the global `savedAt` so downstream consumers can read it
  - [x] `saveArticleGlobally` reports `created: true` on first insert, `created: false` on subsequent calls
  - [x] Stub re-save lands on an existing row without clobbering real parsed metadata; only `savedAt` advances when the domain follows up with `bumpArticleSavedAt`
  - [x] Re-save via `saveArticle` bumps the global `savedAt` to the new timestamp
  - [x] `bumpArticleSavedAt` on a never-saved URL is a no-op

https://claude.ai/code/session_0117rdvv9CqFpXUXdimNXveA

---
_Generated by [Claude Code](https://claude.ai/code/session_0117rdvv9CqFpXUXdimNXveA)_