### PR TITLE
feat(hutch): global live-ticking trial countdown in the header

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -126,6 +126,25 @@ const BUNDLES = [
 			"});",
 		].join("\n"),
 	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/trial-countdown.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "trial-countdown.client.js"),
+		globalName: "TrialCountdown",
+		footer: [
+			"document.addEventListener('DOMContentLoaded', function () {",
+			"  TrialCountdown.initTrialCountdown({",
+			"    document: window.document,",
+			"    now: function () { return Date.now(); },",
+			"    setIntervalFn: function (cb, ms) { return window.setInterval(cb, ms); },",
+			"    clearIntervalFn: function (id) { window.clearInterval(id); },",
+			"    addSwapListener: function (cb) { document.body.addEventListener('htmx:afterSwap', cb); }",
+			"  }).attach();",
+			"});",
+		].join("\n"),
+	},
 ];
 
 function buildOptions(bundle) {

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -94,7 +94,7 @@ import { initDualAuth, type ValidateAccessToken } from "./web/dual-auth.middlewa
 import { initMarkExtensionInstalled } from "./web/mark-extension-installed.middleware";
 import { initOAuthRoutes } from "./web/oauth/oauth.routes";
 import { Base } from "./web/base.component";
-import { bannerStateFromRequest } from "./web/banner-state";
+import { initBuildBannerState } from "./web/banner-state";
 import { sendComponent } from "./web/send-component";
 import { wantsMarkdown, wantsSiren } from "./web/content-negotiation";
 import { contentSignalMiddleware } from "./web/content-signal.middleware";
@@ -241,6 +241,16 @@ export function createApp(dependencies: AppDependencies): Express {
 	const markExtensionInstalled = initMarkExtensionInstalled();
 	app.use(markExtensionInstalled);
 
+	const getEffectiveAccess = initGetEffectiveAccess({
+		findSubscriptionByUserId: deps.subscriptionProviders.findByUserId,
+		now: deps.now,
+	});
+	const requireWriteAccess = initRequireWriteAccess({ getEffectiveAccess });
+	const buildBannerState = initBuildBannerState({
+		getEffectiveAccess,
+		now: deps.now,
+	});
+
 	app.get("/favicon.ico", (_req: Request, res: Response) => {
 		res.redirect(301, `${staticBaseUrl}/favicon.ico`);
 	});
@@ -365,19 +375,20 @@ export function createApp(dependencies: AppDependencies): Express {
 			: ua.includes("Chrome/") ? "chrome"
 			: "other";
 		const userCount = await countUsers().catch(() => 0);
+		const banner = await buildBannerState(req);
 		sendComponent(
 			req,
 			res,
-			Base(HomePage({ userCount, staticBaseUrl, browser, foundingAllocation }), bannerStateFromRequest(req)),
+			Base(HomePage({ userCount, staticBaseUrl, browser, foundingAllocation }), banner),
 		);
 	});
 
-	app.get("/privacy", (req: Request, res: Response) => {
-		sendComponent(req, res, Base(PrivacyPage(), bannerStateFromRequest(req)));
+	app.get("/privacy", async (req: Request, res: Response) => {
+		sendComponent(req, res, Base(PrivacyPage(), await buildBannerState(req)));
 	});
 
-	app.get("/terms", (req: Request, res: Response) => {
-		sendComponent(req, res, Base(TermsPage(), bannerStateFromRequest(req)));
+	app.get("/terms", async (req: Request, res: Response) => {
+		sendComponent(req, res, Base(TermsPage(), await buildBannerState(req)));
 	});
 
 	// Path-uniqued article fixture for staging e2e tests. The :id segment is
@@ -388,8 +399,8 @@ export function createApp(dependencies: AppDependencies): Express {
 	// Lambda; tests (NODE_ENV=test via Jest) and local dev (NODE_ENV unset)
 	// both expose it.
 	if (getEnv("NODE_ENV") !== "production") {
-		app.get("/e2e/article/:id", (req: Request, res: Response) => {
-			sendComponent(req, res, Base(E2EFixturePage(), bannerStateFromRequest(req)));
+		app.get("/e2e/article/:id", async (req: Request, res: Response) => {
+			sendComponent(req, res, Base(E2EFixturePage(), await buildBannerState(req)));
 		});
 
 		/**
@@ -414,10 +425,10 @@ export function createApp(dependencies: AppDependencies): Express {
 			fetchFirefoxDownloadUrl(),
 			fetchChromeDownloadUrl(),
 		]);
-		sendComponent(req, res, Base(InstallPage({ firefox, chrome, browser }), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(InstallPage({ firefox, chrome, browser }), await buildBannerState(req)));
 	});
 
-	const blogRouter = initBlogRoutes({ blogPosts });
+	const blogRouter = initBlogRoutes({ blogPosts, buildBannerState });
 	app.use("/blog", (req: Request, res: Response, next: NextFunction) => {
 		if (req.headers.host === "hutch-app.com") {
 			res.redirect(301, `${appOrigin}${req.originalUrl}`);
@@ -427,12 +438,6 @@ export function createApp(dependencies: AppDependencies): Express {
 	});
 	app.use("/blog", blogRouter);
 	app.use("/embed", initEmbedRoutes({ appOrigin }));
-
-	const getEffectiveAccess = initGetEffectiveAccess({
-		findSubscriptionByUserId: deps.subscriptionProviders.findByUserId,
-		now: deps.now,
-	});
-	const requireWriteAccess = initRequireWriteAccess({ getEffectiveAccess });
 
 	const authRouter = initAuthRoutes({
 		hashPassword: deps.hashPassword,
@@ -461,6 +466,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		botDefenseLogger: deps.botDefenseLogger,
 		conversionLogger: deps.conversionLogger,
 		foundingAllocation,
+		buildBannerState,
 	});
 	app.use(authRouter);
 
@@ -527,6 +533,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		dualAuth: dualAuthMiddleware,
 		requireWriteAccess,
 		getEffectiveAccess,
+		buildBannerState,
 		logError: deps.logError,
 		logParseError: deps.logParseError,
 		now: deps.now,
@@ -553,10 +560,11 @@ export function createApp(dependencies: AppDependencies): Express {
 		analytics: deps.analytics,
 		salt: deps.salt,
 		now: deps.now,
+		buildBannerState,
 	});
 	app.use("/import", requireAuth, requireWriteAccess, importRouter);
 
-	const saveRouter = initSaveRoutes();
+	const saveRouter = initSaveRoutes({ buildBannerState });
 	app.use("/save", saveRouter);
 
 	const viewRouter = initViewRoutes({
@@ -571,6 +579,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		publishSaveAnonymousLink: deps.publishSaveAnonymousLink,
 		publishStaleCheckRequested: deps.publishStaleCheckRequested,
 		now: deps.now,
+		buildBannerState,
 	});
 	app.use("/view", viewRouter);
 
@@ -586,6 +595,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		adminEmails: deps.adminEmails,
 		serviceToken: deps.recrawlServiceToken,
 		now: deps.now,
+		buildBannerState,
 	});
 	app.use("/admin/recrawl", adminRecrawlRouter);
 
@@ -594,18 +604,20 @@ export function createApp(dependencies: AppDependencies): Express {
 		findEmailByUserId: deps.findEmailByUserId,
 		logError: deps.logError,
 		now: () => new Date(),
+		buildBannerState,
 	});
 	app.use("/export", requireAuth, exportRouter);
 
 	const oauthRouter = initOAuthRoutes({
 		model: deps.oauthModel,
+		buildBannerState,
 	});
 	app.use("/oauth/token", extensionCors);
 	app.use("/oauth/revoke", extensionCors);
 	app.use("/oauth", oauthRouter);
 
-	app.use((req: Request, res: Response) => {
-		sendComponent(req, res, Base(NotFoundPage(), bannerStateFromRequest(req)));
+	app.use(async (req: Request, res: Response) => {
+		sendComponent(req, res, Base(NotFoundPage(), await buildBannerState(req)));
 	});
 
 	return app;

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -30,7 +30,7 @@ import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/strip
 import type { RetrieveCheckoutSession } from "@packages/test-fixtures/providers/stripe-checkout";
 import { STRIPE_TRIAL_PERIOD_DAYS } from "../../domain/stripe/stripe-trial-config";
 import { Base } from "../base.component";
-import { bannerStateFromRequest } from "../banner-state";
+import { bannerStateFromRequest, type BuildBannerState } from "../banner-state";
 import { sendComponent } from "../send-component";
 import type { ComponentError } from "../shared/component-error.types";
 import { LoginSchema } from "./auth.schema";
@@ -84,6 +84,7 @@ interface AuthDependencies {
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
 	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	foundingAllocation: FoundingAllocation;
+	buildBannerState: BuildBannerState;
 }
 
 export function initAuthRoutes(deps: AuthDependencies): Router {
@@ -425,7 +426,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				Base(VerifyEmailPage({
 					success: false,
 					error: "No verification token provided.",
-				}), bannerStateFromRequest(req)),
+				}), await deps.buildBannerState(req)),
 			);
 			return;
 		}
@@ -438,7 +439,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				Base(VerifyEmailPage({
 					success: false,
 					error: "This verification link is invalid or has already been used.",
-				}), bannerStateFromRequest(req)),
+				}), await deps.buildBannerState(req)),
 			);
 			return;
 		}
@@ -451,7 +452,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			await deps.markSessionEmailVerified(sessionId);
 		}
 
-		sendComponent(req, res, Base(VerifyEmailPage({ success: true }), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(VerifyEmailPage({ success: true }), await deps.buildBannerState(req)));
 	});
 
 	router.post("/logout", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -1,7 +1,13 @@
 import { UserIdSchema } from "@packages/domain/user";
-import { bannerStateFromRequest } from "./banner-state";
+import {
+	bannerStateFromRequest,
+	initBuildBannerState,
+} from "./banner-state";
+import type { EffectiveAccess } from "../domain/access/effective-access";
 
 const USER_ID = UserIdSchema.parse("user-1");
+const ONE_DAY_MS = 86_400_000;
+const FIXED_NOW = new Date("2026-01-01T00:00:00.000Z");
 
 describe("bannerStateFromRequest", () => {
 	it("maps a present userId to isAuthenticated=true", () => {
@@ -20,5 +26,125 @@ describe("bannerStateFromRequest", () => {
 		expect(bannerStateFromRequest({ emailVerified: true }).emailVerified).toBe(true);
 		expect(bannerStateFromRequest({ emailVerified: false }).emailVerified).toBe(false);
 		expect(bannerStateFromRequest({}).emailVerified).toBeUndefined();
+	});
+});
+
+describe("initBuildBannerState", () => {
+	it("returns isAuthenticated=false with no trial for an unauthenticated request and never fetches access", async () => {
+		const getEffectiveAccess = jest.fn();
+		const buildBannerState = initBuildBannerState({
+			getEffectiveAccess,
+			now: () => FIXED_NOW,
+		});
+
+		const result = await buildBannerState({});
+
+		expect(result).toEqual({ isAuthenticated: false, emailVerified: undefined });
+		expect(getEffectiveAccess).not.toHaveBeenCalled();
+	});
+
+	it("populates trial.state='active' with the remaining window and escalation for a trialing user", async () => {
+		const trialEndsAt = new Date(FIXED_NOW.getTime() + 3 * ONE_DAY_MS).toISOString();
+		const access: EffectiveAccess = {
+			tier: "trial",
+			access: "full",
+			banner: "trial-countdown",
+			trialEndsAt,
+		};
+		const buildBannerState = initBuildBannerState({
+			getEffectiveAccess: async () => access,
+			now: () => FIXED_NOW,
+		});
+
+		const result = await buildBannerState({ userId: USER_ID });
+
+		expect(result.trial).toEqual({
+			state: "active",
+			endsAtIso: trialEndsAt,
+			serverNowIso: FIXED_NOW.toISOString(),
+			remaining: expect.objectContaining({ days: 3 }),
+			escalation: "moderate",
+		});
+	});
+
+	it("populates trial.state='expired' for both trial-expired and subscription-cancelled inactive users", async () => {
+		const trialExpired: EffectiveAccess = {
+			tier: "inactive",
+			access: "read-only",
+			banner: "inactive",
+			reason: "trial-expired",
+		};
+		const cancelled: EffectiveAccess = {
+			tier: "inactive",
+			access: "read-only",
+			banner: "inactive",
+			reason: "subscription-cancelled",
+		};
+
+		const buildExpired = initBuildBannerState({
+			getEffectiveAccess: async () => trialExpired,
+			now: () => FIXED_NOW,
+		});
+		const buildCancelled = initBuildBannerState({
+			getEffectiveAccess: async () => cancelled,
+			now: () => FIXED_NOW,
+		});
+
+		expect((await buildExpired({ userId: USER_ID })).trial).toEqual({
+			state: "expired",
+		});
+		expect((await buildCancelled({ userId: USER_ID })).trial).toEqual({
+			state: "expired",
+		});
+	});
+
+	it("leaves trial undefined for founding members, paid users, and users with a pending cancellation", async () => {
+		const founding: EffectiveAccess = {
+			tier: "founding",
+			access: "full",
+			banner: "none",
+		};
+		const paid: EffectiveAccess = {
+			tier: "paid",
+			access: "full",
+			banner: "none",
+		};
+		const pendingCancellation: EffectiveAccess = {
+			tier: "paid",
+			access: "full",
+			banner: "pending-cancellation",
+			cancellationEffectiveAt: "2026-02-01T00:00:00.000Z",
+		};
+
+		for (const access of [founding, paid, pendingCancellation]) {
+			const build = initBuildBannerState({
+				getEffectiveAccess: async () => access,
+				now: () => FIXED_NOW,
+			});
+			expect((await build({ userId: USER_ID })).trial).toBeUndefined();
+		}
+	});
+
+	it("honors a preFetchedAccess without re-invoking getEffectiveAccess (queue page already fetched it)", async () => {
+		const trialEndsAt = new Date(FIXED_NOW.getTime() + ONE_DAY_MS).toISOString();
+		const preFetchedAccess: EffectiveAccess = {
+			tier: "trial",
+			access: "full",
+			banner: "trial-countdown",
+			trialEndsAt,
+		};
+		const getEffectiveAccess = jest.fn();
+		const buildBannerState = initBuildBannerState({
+			getEffectiveAccess,
+			now: () => FIXED_NOW,
+		});
+
+		const result = await buildBannerState(
+			{ userId: USER_ID },
+			{ preFetchedAccess },
+		);
+
+		expect(result.trial?.state).toBe("active");
+		expect(getEffectiveAccess).not.toHaveBeenCalled();
 	});
 });

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -1,4 +1,9 @@
 import type { UserId } from "@packages/domain/user";
+import type {
+	EffectiveAccess,
+	GetEffectiveAccess,
+} from "../domain/access/effective-access";
+import { toTrialDisplay, type TrialDisplay } from "./trial-countdown.format";
 
 export interface BannerStateSource {
 	userId?: UserId;
@@ -17,11 +22,37 @@ export interface BannerState {
 	 * the article with their already-installed extension; when false (or unset) it
 	 * pitches the install. Sourced from the extension liveness cookie. */
 	extensionInstalled?: boolean;
+	/** Drives the global trial countdown rendered below the brand in the header.
+	 * Undefined for guests, founding members, paid users, and users with a
+	 * pending cancellation; "active" for trialing users; "expired" for users
+	 * whose trial has lapsed or whose subscription was cancelled. */
+	trial?: TrialDisplay;
 }
 
 export function bannerStateFromRequest(source: BannerStateSource): BannerState {
 	return {
 		isAuthenticated: Boolean(source.userId),
 		emailVerified: source.emailVerified,
+	};
+}
+
+export type BuildBannerState = (
+	source: BannerStateSource,
+	options?: { preFetchedAccess?: EffectiveAccess },
+) => Promise<BannerState>;
+
+export function initBuildBannerState(deps: {
+	getEffectiveAccess: GetEffectiveAccess;
+	now: () => Date;
+}): BuildBannerState {
+	return async (source, options) => {
+		const base = bannerStateFromRequest(source);
+		const userId: UserId | undefined = source.userId;
+		if (!userId) return base;
+		const access =
+			options?.preFetchedAccess ?? (await deps.getEffectiveAccess(userId));
+		const trial = toTrialDisplay(access, deps.now());
+		if (!trial) return base;
+		return { ...base, trial };
 	};
 }

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -313,6 +313,99 @@ describe("Base component", () => {
 		).toBe("https://readplace.com/queue");
 	});
 
+	it("does not render the trial countdown when state.trial is undefined", () => {
+		const page = createTestPageBody();
+		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
+		expect(
+			doc.querySelector('script[src$="/client-dist/trial-countdown.client.js"]'),
+		).toBeNull();
+	});
+
+	it("renders the trial countdown with text/data-attrs and includes the client script when trial.state='active'", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			isAuthenticated: true,
+			emailVerified: true,
+			trial: {
+				state: "active",
+				endsAtIso: "2026-01-15T00:00:00.000Z",
+				serverNowIso: "2026-01-01T00:00:00.000Z",
+				remaining: {
+					days: 13,
+					hours: 12,
+					minutes: 33,
+					seconds: 22,
+					totalMs: 1,
+				},
+				escalation: "moderate",
+			},
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown must be rendered when trial.state='active'");
+		expect(countdown.textContent).toBe("13d 12h 33m 22s in your free trial");
+		expect(countdown.getAttribute("data-trial-state")).toBe("active");
+		expect(countdown.getAttribute("data-trial-ends-at-iso")).toBe("2026-01-15T00:00:00.000Z");
+		expect(countdown.getAttribute("data-server-now-iso")).toBe("2026-01-01T00:00:00.000Z");
+		expect(countdown.classList.contains("trial-countdown--moderate")).toBe(true);
+		expect(countdown.getAttribute("role")).toBe("timer");
+		expect(countdown.getAttribute("aria-live")).toBe("off");
+
+		const script = doc.querySelector(
+			'script[src$="/client-dist/trial-countdown.client.js"]',
+		);
+		assert(script, "trial countdown client script must load when state='active'");
+		expect(script.hasAttribute("defer")).toBe(true);
+	});
+
+	it("renders the trial countdown as 'Free trial is over!' and skips the client script when trial.state='expired'", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			isAuthenticated: true,
+			emailVerified: true,
+			trial: { state: "expired" },
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown must be rendered when trial.state='expired'");
+		expect(countdown.textContent).toBe("Free trial is over!");
+		expect(countdown.getAttribute("data-trial-state")).toBe("expired");
+		expect(countdown.classList.contains("trial-countdown--expired")).toBe(true);
+
+		expect(
+			doc.querySelector('script[src$="/client-dist/trial-countdown.client.js"]'),
+		).toBeNull();
+	});
+
+	it("places the trial countdown directly after the header brand inside .header__content", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			isAuthenticated: true,
+			emailVerified: true,
+			trial: {
+				state: "active",
+				endsAtIso: "2026-01-15T00:00:00.000Z",
+				serverNowIso: "2026-01-01T00:00:00.000Z",
+				remaining: { days: 13, hours: 12, minutes: 33, seconds: 22, totalMs: 1 },
+				escalation: "soft",
+			},
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const headerContent = doc.querySelector(".header__content");
+		assert(headerContent, "header content container must exist");
+		const brand = headerContent.querySelector(".header__brand");
+		assert(brand, "brand link must exist");
+		const next = brand.nextElementSibling;
+		assert(next, "an element must follow the brand inside .header__content");
+		expect(next.hasAttribute("data-test-trial-countdown")).toBe(true);
+	});
+
 	it("should preserve query string when normalizing canonical URLs", () => {
 		const page = createTestPageBody({
 			seo: {

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -10,10 +10,12 @@ import {
 	HEADER_STYLES,
 	NAV_STYLES,
 	OFFLINE_BANNER_STYLES,
+	TRIAL_COUNTDOWN_STYLES,
 	VERIFY_BANNER_STYLES,
 	UTILITY_STYLES,
 } from "./base.styles";
 import type { BannerState } from "./banner-state";
+import { formatTrialDisplay, type TrialDisplay } from "./trial-countdown.format";
 import type { Component, ParsedComponent } from "./component.types";
 import { HtmlPage } from "./html-page";
 import { htmlToMarkdown } from "./html-to-markdown";
@@ -34,11 +36,19 @@ const BASE_TEMPLATE = readFileSync(join(__dirname, "base.template.html"), "utf-8
 
 function renderHeader(
 	variant: "default" | "transparent",
-	options: { isAuthenticated: boolean },
+	options: { isAuthenticated: boolean; trial: TrialDisplay | undefined },
 ): string {
+	const trial = options.trial;
 	return render(HEADER_TEMPLATE, {
 		transparent: variant === "transparent",
 		isAuthenticated: options.isAuthenticated,
+		trial: Boolean(trial),
+		trialDisplayText: trial ? formatTrialDisplay(trial) : "",
+		trialState: trial?.state ?? "",
+		trialEscalationClass:
+			trial?.state === "active" ? trial.escalation : "expired",
+		trialEndsAtIso: trial?.state === "active" ? trial.endsAtIso : "",
+		serverNowIso: trial?.state === "active" ? trial.serverNowIso : "",
 	});
 }
 
@@ -85,6 +95,8 @@ const LIVERELOAD_SCRIPT = getEnv("LIVERELOAD")
 	: "";
 
 const HTMX_SCRIPTS = `<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js" integrity="sha384-/TgkGk7p307TH7EXJDuUlgG3Ce1UVolAOFopFekQkkXihi5u/6OCvVKyz1W+idaz" crossorigin="anonymous"></script><script>htmx.config.scrollBehavior='smooth';</script>`;
+
+const TRIAL_COUNTDOWN_SCRIPT = `<script src="/client-dist/trial-countdown.client.js" defer></script>`;
 
 const OFFLINE_INDICATOR_SCRIPT = `
 <script>
@@ -200,6 +212,7 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		footerStyles: FOOTER_STYLES,
 		offlineBannerStyles: OFFLINE_BANNER_STYLES,
 		verifyBannerStyles: VERIFY_BANNER_STYLES,
+		trialCountdownStyles: TRIAL_COUNTDOWN_STYLES,
 		extensionSuggestionBannerStyles: EXTENSION_SUGGESTION_BANNER_STYLES,
 		showVerificationBanner: state.isAuthenticated && state.emailVerified === false,
 		extensionSuggestionBanner: renderExtensionSuggestionBanner({
@@ -207,7 +220,10 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 			extensionInstalled: state.extensionInstalled ?? false,
 		}),
 		bodyClass: body.bodyClass,
-		header: renderHeader(headerVariant, { isAuthenticated: state.isAuthenticated }),
+		header: renderHeader(headerVariant, {
+			isAuthenticated: state.isAuthenticated,
+			trial: state.trial,
+		}),
 		content: injectPageStylesIntoMain(body.content.html, body.styles),
 		footer: renderFooter(),
 		navScript: NAV_SCRIPT,
@@ -215,6 +231,7 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		scripts:
 			HTMX_SCRIPTS +
 			EXTENSION_SUGGESTION_BANNER_SCRIPT +
+			(state.trial?.state === "active" ? TRIAL_COUNTDOWN_SCRIPT : "") +
 			(body.scripts ?? "") +
 			LIVERELOAD_SCRIPT,
 	});

--- a/projects/hutch/src/runtime/web/base.styles.ts
+++ b/projects/hutch/src/runtime/web/base.styles.ts
@@ -372,6 +372,85 @@ export const NAV_STYLES = `
   }
 `;
 
+export const TRIAL_COUNTDOWN_STYLES = `
+  .trial-countdown {
+    margin: 0;
+    padding: 0 12px;
+    color: var(--color-error);
+    font-weight: 600;
+    font-size: 0.875rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.01em;
+    transition: color 0.3s ease, background 0.3s ease, font-weight 0.3s ease;
+  }
+
+  /* purgecss-ignore-start: modifier suffix is interpolated from BannerState.trial.escalation in header.template.html */
+  .trial-countdown--soft {
+    font-weight: 500;
+    opacity: 0.85;
+  }
+
+  .trial-countdown--moderate {
+    font-weight: 600;
+  }
+
+  .trial-countdown--urgent {
+    font-weight: 700;
+    padding: 2px 10px;
+    background: var(--error-bg);
+    border-radius: var(--radius-sm);
+  }
+
+  .trial-countdown--critical {
+    font-weight: 700;
+    padding: 2px 10px;
+    background: var(--color-error);
+    color: var(--error-foreground);
+    border-radius: var(--radius-sm);
+    animation: trial-countdown-pulse 1.5s ease-in-out infinite;
+  }
+
+  .trial-countdown--expired {
+    font-weight: 700;
+    padding: 2px 10px;
+    background: var(--color-error);
+    color: var(--error-foreground);
+    border-radius: var(--radius-sm);
+    animation: trial-countdown-shake 0.5s ease-in-out 1;
+  }
+  /* purgecss-ignore-end */
+
+  @keyframes trial-countdown-pulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.04); }
+  }
+
+  @keyframes trial-countdown-shake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-2px); }
+    75% { transform: translateX(2px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .trial-countdown {
+      transition: none;
+      animation: none !important;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .header__content {
+      flex-wrap: wrap;
+    }
+
+    .trial-countdown {
+      flex-basis: 100%;
+      padding: 4px 0 0;
+      order: 99;
+    }
+  }
+`;
+
 export const VERIFY_BANNER_STYLES = `
   .verify-banner {
     background: var(--color-warning);

--- a/projects/hutch/src/runtime/web/base.template.html
+++ b/projects/hutch/src/runtime/web/base.template.html
@@ -78,6 +78,7 @@
     {{{footerStyles}}}
     {{{offlineBannerStyles}}}
     {{{verifyBannerStyles}}}
+    {{{trialCountdownStyles}}}
     {{{extensionSuggestionBannerStyles}}}
   </style>
 </head>

--- a/projects/hutch/src/runtime/web/header.template.html
+++ b/projects/hutch/src/runtime/web/header.template.html
@@ -1,6 +1,16 @@
   <header class="header{{#if transparent}} header--transparent{{/if}}">
     <div class="header__content">
       <a href="/" class="header__brand">Read<span class="header__brand-mark">place</span></a>
+      {{#if trial}}
+      <p class="trial-countdown trial-countdown--{{trialEscalationClass}}"
+         data-trial-ends-at-iso="{{trialEndsAtIso}}"
+         data-server-now-iso="{{serverNowIso}}"
+         data-trial-state="{{trialState}}"
+         role="timer"
+         aria-live="off"
+         aria-atomic="true"
+         data-test-trial-countdown>{{trialDisplayText}}</p>
+      {{/if}}
       <nav class="nav">
         <button class="nav__toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-menu">
           <span class="nav__toggle-bar"></span>

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -5,7 +5,7 @@ import ExpressOAuthServer from "@node-oauth/express-oauth-server";
 import type { OAuthModel } from "@packages/test-fixtures/providers/oauth";
 import { getClient, validateRedirectUri } from "@packages/test-fixtures/providers/oauth";
 import { Base } from "../base.component";
-import { bannerStateFromRequest } from "../banner-state";
+import type { BuildBannerState } from "../banner-state";
 import { sendComponent } from "../send-component";
 import { OAuthAuthorizePage, OAuthCallbackPage } from "./oauth.component";
 
@@ -26,6 +26,7 @@ const denyBodySchema = z.object({
 
 interface OAuthRouteDeps {
 	model: OAuthModel;
+	buildBannerState: BuildBannerState;
 }
 
 export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
@@ -40,7 +41,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 		},
 	});
 
-	router.get("/authorize", (req: Request, res: Response) => {
+	router.get("/authorize", async (req: Request, res: Response) => {
 		const parsed = authorizeQuerySchema.safeParse(req.query);
 		if (!parsed.success) {
 			res.status(400).json({
@@ -83,7 +84,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 				redirectUri: redirect_uri,
 				codeChallenge: parsed.data.code_challenge,
 				state,
-			}), bannerStateFromRequest(req)),
+			}), await deps.buildBannerState(req)),
 		);
 	});
 
@@ -163,8 +164,8 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 		res.status(200).json({});
 	});
 
-	router.get("/callback", (req: Request, res: Response) => {
-		sendComponent(req, res, Base(OAuthCallbackPage(), bannerStateFromRequest(req)));
+	router.get("/callback", async (req: Request, res: Response) => {
+		sendComponent(req, res, Base(OAuthCallbackPage(), await deps.buildBannerState(req)));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -15,7 +15,7 @@ import type {
 import type { PublishRecrawlLinkInitiated } from "@packages/test-fixtures/providers/events";
 import type { FindUserByEmail } from "@packages/test-fixtures/providers/auth";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { extensionInstallUrlIfMissing } from "../../onboarding/extension-install";
 import { initArticleReader } from "../../shared/article-reader/article-reader";
 import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.types";
@@ -38,6 +38,7 @@ export interface AdminRecrawlDependencies {
 	adminEmails: readonly string[];
 	serviceToken: string;
 	now: () => Date;
+	buildBannerState: BuildBannerState;
 }
 
 function pollUrlBuilderFor(articleUrl: string): PollUrlBuilder {
@@ -54,28 +55,34 @@ function noStore(_req: Request, res: Response, next: NextFunction): void {
 	next();
 }
 
-function renderNotFound(req: Request, res: Response) {
+async function renderNotFound(
+	deps: AdminRecrawlDependencies,
+	req: Request,
+	res: Response,
+): Promise<void> {
 	const html = Base(SaveErrorPage({
 		redirectUrl: "/admin/recrawl",
 		linkLabel: "Back to recrawl",
-	}), bannerStateFromRequest(req)).to("text/html");
+	}), await deps.buildBannerState(req)).to("text/html");
 	res.status(404).type("html").send(html.body);
 }
 
-function handleLanding(req: Request, res: Response): void {
-	const submittedUrl =
-		typeof req.query.url === "string" ? req.query.url : undefined;
-	if (submittedUrl === undefined) {
-		const html = Base(AdminRecrawlLandingPage(), bannerStateFromRequest(req)).to("text/html");
-		res.status(html.statusCode).type("html").send(html.body);
-		return;
-	}
-	const parsed = RecrawlUrlSchema.safeParse(submittedUrl);
-	if (!parsed.success) {
-		renderNotFound(req, res);
-		return;
-	}
-	res.redirect(302, `/admin/recrawl/${encodeURIComponent(parsed.data)}`);
+function handleLanding(deps: AdminRecrawlDependencies) {
+	return async (req: Request, res: Response): Promise<void> => {
+		const submittedUrl =
+			typeof req.query.url === "string" ? req.query.url : undefined;
+		if (submittedUrl === undefined) {
+			const html = Base(AdminRecrawlLandingPage(), await deps.buildBannerState(req)).to("text/html");
+			res.status(html.statusCode).type("html").send(html.body);
+			return;
+		}
+		const parsed = RecrawlUrlSchema.safeParse(submittedUrl);
+		if (!parsed.success) {
+			await renderNotFound(deps, req, res);
+			return;
+		}
+		res.redirect(302, `/admin/recrawl/${encodeURIComponent(parsed.data)}`);
+	};
 }
 
 function handleRecrawlArticle(
@@ -92,7 +99,7 @@ function handleRecrawlArticle(
 		const normalizedUrl = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
 		const parsed = RecrawlUrlSchema.safeParse(normalizedUrl);
 		if (!parsed.success) {
-			renderNotFound(req, res);
+			await renderNotFound(deps, req, res);
 			return;
 		}
 		const articleUrl = parsed.data;
@@ -101,7 +108,7 @@ function handleRecrawlArticle(
 		if (!existing) {
 			// The endpoint is explicitly for human intervention on an existing
 			// saved URL. Do not create a stub; surface 404.
-			renderNotFound(req, res);
+			await renderNotFound(deps, req, res);
 			return;
 		}
 
@@ -136,7 +143,7 @@ function handleRecrawlArticle(
 			progress: state.progress,
 			contentSourceTier: existing.contentSourceTier,
 			extensionInstallUrl: extensionInstallUrlIfMissing(req),
-		}), bannerStateFromRequest(req)).to("text/html");
+		}), await deps.buildBannerState(req)).to("text/html");
 		assert(
 			state.crawl?.status === "pending",
 			"force-pending + resolveReaderState must leave the crawl in 'pending'",
@@ -205,7 +212,7 @@ export function initAdminRecrawlRoutes(deps: AdminRecrawlDependencies): Router {
 	router.use(noStore);
 	router.use(requireAdmin);
 
-	router.get("/", handleLanding);
+	router.get("/", handleLanding(deps));
 	router.get("/summary", handleSummaryPoll(reader));
 	router.get("/reader", handleReaderPoll(reader));
 	router.get<string, Record<string, string>>(

--- a/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.page.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, Router } from "express";
 import express from "express";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { BlogIndexPage } from "./blog-index.component";
 import { BlogPostPage } from "./blog-post.component";
@@ -14,16 +14,16 @@ const SLUG_REDIRECTS: Record<string, string> = {
 	"hutch-vs-karakeep-hosted-vs-self-hosted-read-it-later": "readplace-vs-karakeep-hosted-vs-self-hosted-read-it-later",
 };
 
-export function initBlogRoutes(deps: { blogPosts: BlogPosts }): Router {
+export function initBlogRoutes(deps: { blogPosts: BlogPosts; buildBannerState: BuildBannerState }): Router {
 	const router = express.Router();
-	const { blogPosts } = deps;
+	const { blogPosts, buildBannerState } = deps;
 
-	router.get("/", (req: Request, res: Response) => {
+	router.get("/", async (req: Request, res: Response) => {
 		const posts = blogPosts.getAllPosts();
-		sendComponent(req, res, Base(BlogIndexPage({ posts }), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(BlogIndexPage({ posts }), await buildBannerState(req)));
 	});
 
-	router.get("/:slug", (req: Request, res: Response) => {
+	router.get("/:slug", async (req: Request, res: Response) => {
 		const newSlug = SLUG_REDIRECTS[req.params.slug];
 		if (newSlug) {
 			res.redirect(301, `/blog/${newSlug}`);
@@ -31,10 +31,10 @@ export function initBlogRoutes(deps: { blogPosts: BlogPosts }): Router {
 		}
 		const post = blogPosts.findPostBySlug(req.params.slug);
 		if (!post) {
-			sendComponent(req, res, Base(NotFoundPage(), bannerStateFromRequest(req)));
+			sendComponent(req, res, Base(NotFoundPage(), await buildBannerState(req)));
 			return;
 		}
-		sendComponent(req, res, Base(BlogPostPage({ post }), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(BlogPostPage({ post }), await buildBannerState(req)));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/export/export.page.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.page.ts
@@ -4,7 +4,7 @@ import express from "express";
 import type { FindEmailByUserId } from "@packages/test-fixtures/providers/auth";
 import type { PublishExportUserDataCommand } from "@packages/test-fixtures/providers/events";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { ExportPage } from "./export.component";
 
@@ -13,14 +13,15 @@ interface ExportDependencies {
 	findEmailByUserId: FindEmailByUserId;
 	logError: (message: string, error?: Error) => void;
 	now: () => Date;
+	buildBannerState: BuildBannerState;
 }
 
 export function initExportRoutes(deps: ExportDependencies): Router {
 	const router = express.Router();
 
-	router.get("/", (req: Request, res: Response) => {
+	router.get("/", async (req: Request, res: Response) => {
 		const status = req.query.status === "preparing" ? "preparing" : "idle";
-		sendComponent(req, res, Base(ExportPage({ status }), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(ExportPage({ status }), await deps.buildBannerState(req)));
 	});
 
 	router.post("/start", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -14,7 +14,7 @@ import type { ImportSessionStore } from "@packages/domain/import-session";
 import type { ValidateSaveableUrl, SaveableUrl, SaveableUrlErrorCode } from "@packages/domain/article";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { saveArticleFromUrl, type SaveArticleFromUrlDependencies } from "../../shared/save-article/save-article-from-url";
 import type { AnalyticsEvent } from "../../middleware/analytics";
@@ -36,6 +36,7 @@ interface ImportRouteDependencies extends SaveArticleFromUrlDependencies {
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
 	salt: string;
 	now: () => Date;
+	buildBannerState: BuildBannerState;
 }
 
 const UPLOAD_ERROR_REDIRECT = {
@@ -56,13 +57,13 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		next(err);
 	};
 
-	router.get("/", (req: Request, res: Response) => {
+	router.get("/", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const errorMessage = importErrorMessageMapping(req.query);
 		const vm = toImportUploadViewModel({
 			errors: errorMessage ? [{ message: errorMessage }] : undefined,
 		});
-		sendComponent(req, res, Base(ImportUploadPage(vm), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(ImportUploadPage(vm), await deps.buildBannerState(req)));
 	});
 
 	router.post("/", rawBodyParser, sizeLimitHandler, async (req: Request, res: Response) => {
@@ -125,7 +126,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		const totalSelected =
 			pageResult.session.totalUrls - pageResult.session.deselected.size;
 		const vm = toImportViewModel(pageResult, totalSelected);
-		sendComponent(req, res, Base(ImportPage(vm), bannerStateFromRequest(req)));
+		sendComponent(req, res, Base(ImportPage(vm), await deps.buildBannerState(req)));
 	});
 
 	router.post("/:id/toggle", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -38,11 +38,7 @@ interface QueueDisplayModel {
 	currentPage: number;
 	totalPages: number;
 	subscriptionBannerStateClass: string;
-	subscriptionBannerIsTrialCountdown: boolean;
 	subscriptionBannerIsPendingCancellation: boolean;
-	subscriptionBannerIsInactive: boolean;
-	trialDaysLeft?: number;
-	trialDaysLeftWord?: string;
 	cancellationEffectiveAtIso?: string;
 	cancellationEffectiveAtFormatted?: string;
 	accessIsReadOnly: boolean;
@@ -101,11 +97,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		currentPage: vm.currentPage,
 		totalPages: vm.totalPages,
 		subscriptionBannerStateClass: `queue-banner--${banner.state}`,
-		subscriptionBannerIsTrialCountdown: banner.state === "trial-countdown",
 		subscriptionBannerIsPendingCancellation: banner.state === "pending-cancellation",
-		subscriptionBannerIsInactive: banner.state === "inactive",
-		trialDaysLeft: banner.state === "trial-countdown" ? banner.daysLeft : undefined,
-		trialDaysLeftWord: banner.state === "trial-countdown" ? banner.daysLeftWord : undefined,
 		cancellationEffectiveAtIso:
 			banner.state === "pending-cancellation" ? banner.cancellationEffectiveAtIso : undefined,
 		cancellationEffectiveAtFormatted:

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -45,7 +45,7 @@ import type { PublishSaveLinkRawHtmlCommand } from "@packages/test-fixtures/prov
 import type { PutPendingHtml } from "@packages/test-fixtures/providers/pending-html";
 import { saveArticleFromUrl } from "../../shared/save-article/save-article-from-url";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { RedirectComponent } from "../../redirect.component";
 import { CacheableComponent } from "../../conditional-get";
@@ -135,6 +135,7 @@ interface QueueDependencies {
 	 * mark-as-read, and delete remain reachable for read-only users. */
 	requireWriteAccess: RequestHandler;
 	getEffectiveAccess: GetEffectiveAccess;
+	buildBannerState: BuildBannerState;
 	logError: (message: string, error?: Error) => void;
 	logParseError: LogParseError;
 	now: () => Date;
@@ -253,7 +254,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				audioEnabled,
 				extensionInstallUrl: extensionInstallUrlIfMissing(req),
 			}), {
-				...bannerStateFromRequest(req),
+				...(await deps.buildBannerState(req)),
 				showExtensionSuggestionBanner,
 				extensionInstalled: isExtensionInstalled(req),
 			}),
@@ -332,7 +333,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			req, res,
 			Base(
 				QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed }),
-				bannerStateFromRequest(req),
+				await deps.buildBannerState(req, { preFetchedAccess: effectiveAccess }),
 			),
 		);
 	});
@@ -520,7 +521,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				summaryByUrl,
 				crawlByUrl,
 			});
-			sendComponent(req, res, Base(QueuePage(vm, { statusCode: 422 }), bannerStateFromRequest(req)));
+			sendComponent(req, res, Base(QueuePage(vm, { statusCode: 422 }), await deps.buildBannerState(req)));
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -29,14 +29,8 @@
   display: none;
 }
 
-.queue-banner--trial-countdown,
-.queue-banner--pending-cancellation,
-.queue-banner--inactive {
+.queue-banner--pending-cancellation {
   display: flex;
-}
-
-.queue-banner--inactive {
-  border-left-color: var(--error);
 }
 /* purgecss-ignore-end */
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
@@ -17,8 +17,8 @@ async function loginUser(harness: ReturnType<ReturnType<typeof useTestServer>>, 
 	return { agent, userId: lookup.userId };
 }
 
-describe("Queue subscription banner", () => {
-	it("renders the banner with state class `queue-banner--none` for a founding member (no row)", async () => {
+describe("Queue page banner state", () => {
+	it("renders the aside with state class `queue-banner--none` and no header countdown for a founding member (no row)", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { auth } = harness;
 		const agent = await loginAgent(harness.server, auth);
@@ -26,15 +26,15 @@ describe("Queue subscription banner", () => {
 		const response = await agent.get("/queue");
 		const doc = new JSDOM(response.text).window.document;
 		const banner = doc.querySelector("[data-test-subscription-banner]");
-		assert(banner, "queue banner must always be rendered");
+		assert(banner, "queue banner aside must always be rendered");
 		expect(banner.classList.contains("queue-banner--none")).toBe(true);
+		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
 	});
 
-	it("renders the trial-countdown banner with the days-left text for a trialing user", async () => {
+	it("renders the header trial countdown with `Xd Xh Xm Xs in your free trial` for a trialing user, while the queue aside stays in the `none` state", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "trialing@example.com");
-		// 7 days remaining (rounded to days via Math.ceil on remaining ms).
 		await subscriptionProviders.upsertTrialing({
 			userId,
 			trialEndsAt: new Date(Date.now() + 7 * ONE_DAY_MS).toISOString(),
@@ -42,27 +42,16 @@ describe("Queue subscription banner", () => {
 
 		const response = await agent.get("/queue");
 		const doc = new JSDOM(response.text).window.document;
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "global trial countdown must be rendered for a trialing user");
+		expect(countdown.getAttribute("data-trial-state")).toBe("active");
+		expect(countdown.textContent).toMatch(/^\d+d \d+h \d+m \d+s in your free trial$/);
 		const banner = doc.querySelector("[data-test-subscription-banner]");
-		assert(banner, "queue banner must always be rendered");
-		expect(banner.classList.contains("queue-banner--trial-countdown")).toBe(true);
-		expect(doc.querySelector("[data-test-trial-days-left]")?.textContent).toBe("7 days left");
+		assert(banner, "queue banner aside must still be rendered");
+		expect(banner.classList.contains("queue-banner--none")).toBe(true);
 	});
 
-	it("uses singular 'day' when one day remains in the trial window", async () => {
-		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const { subscriptionProviders } = harness;
-		const { agent, userId } = await loginUser(harness, "one-day@example.com");
-		await subscriptionProviders.upsertTrialing({
-			userId,
-			trialEndsAt: new Date(Date.now() + 12 * 60 * 60 * 1000).toISOString(),
-		});
-
-		const response = await agent.get("/queue");
-		const doc = new JSDOM(response.text).window.document;
-		expect(doc.querySelector("[data-test-trial-days-left]")?.textContent).toBe("1 day left");
-	});
-
-	it("flips to inactive banner with read-only save form after the trial window ends", async () => {
+	it("flips the header countdown to 'Free trial is over!' and disables the save form after the trial window ends", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "expired-trial@example.com");
@@ -73,18 +62,22 @@ describe("Queue subscription banner", () => {
 
 		const response = await agent.get("/queue");
 		const doc = new JSDOM(response.text).window.document;
-		const banner = doc.querySelector("[data-test-subscription-banner]");
-		assert(banner, "queue banner must always be rendered");
-		expect(banner.classList.contains("queue-banner--inactive")).toBe(true);
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "global trial countdown must be rendered for an expired-trial user");
+		expect(countdown.getAttribute("data-trial-state")).toBe("expired");
+		expect(countdown.textContent).toBe("Free trial is over!");
 		const saveForm = doc.querySelector('[data-test-form="save-article"]');
 		assert(saveForm, "save form must still be rendered");
 		expect(saveForm.classList.contains("queue__save-form--disabled")).toBe(true);
 		const submitButton = saveForm.querySelector("button[type='submit']");
 		assert(submitButton, "save button must still be rendered");
 		expect(submitButton.hasAttribute("disabled")).toBe(true);
+		const banner = doc.querySelector("[data-test-subscription-banner]");
+		assert(banner, "queue banner aside must still be rendered (it's now empty for inactive)");
+		expect(banner.classList.contains("queue-banner--none")).toBe(true);
 	});
 
-	it("renders the pending-cancellation banner with the formatted effective date for users mid-cancellation", async () => {
+	it("renders the pending-cancellation aside with the formatted effective date for users mid-cancellation, and no header countdown", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "pending-cancel@example.com");
@@ -102,13 +95,14 @@ describe("Queue subscription banner", () => {
 		const response = await agent.get("/queue");
 		const doc = new JSDOM(response.text).window.document;
 		const banner = doc.querySelector("[data-test-subscription-banner]");
-		assert(banner, "queue banner must always be rendered");
+		assert(banner, "queue banner aside must always be rendered");
 		expect(banner.classList.contains("queue-banner--pending-cancellation")).toBe(true);
 		expect(banner.querySelector("time")?.getAttribute("datetime")).toBe(effectiveAt);
 		expect(banner.querySelector(".queue-banner__cta")?.getAttribute("href")).toBe("/account");
+		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
 	});
 
-	it("renders the inactive banner with identical wording for a cancelled user (no leak of the internal 'reason' state)", async () => {
+	it("flips the header countdown to 'Free trial is over!' for a cancelled user too, with the same wording as trial-expired", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "cancelled-user@example.com");
@@ -121,11 +115,10 @@ describe("Queue subscription banner", () => {
 
 		const response = await agent.get("/queue");
 		const doc = new JSDOM(response.text).window.document;
-		const banner = doc.querySelector("[data-test-subscription-banner]");
-		assert(banner, "queue banner must always be rendered");
-		expect(banner.classList.contains("queue-banner--inactive")).toBe(true);
-		// Same wording as the trial-expired banner — reason is internal only.
-		expect(banner.textContent).toContain("Subscription not active.");
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "global trial countdown must be rendered for a cancelled user");
+		expect(countdown.getAttribute("data-trial-state")).toBe("expired");
+		expect(countdown.textContent).toBe("Free trial is over!");
 	});
 });
 
@@ -170,5 +163,4 @@ describe("POST /queue/save read-only gating", () => {
 		expect(response.status).toBe(303);
 		expect(response.headers.location).toBe("/queue#latest-saved");
 	});
-
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -4,17 +4,9 @@
         <h1 class="queue__title">My Queue</h1>
       </div>
       <aside class="queue-banner {{subscriptionBannerStateClass}}" aria-live="polite" data-test-subscription-banner>
-        {{#if subscriptionBannerIsTrialCountdown}}
-        <p class="queue-banner__message"><strong data-test-trial-days-left>{{trialDaysLeft}} {{trialDaysLeftWord}} left</strong> in your free trial.</p>
-        <a class="queue-banner__cta" href="/account">Subscribe — $3.99/month</a>
-        {{/if}}
         {{#if subscriptionBannerIsPendingCancellation}}
         <p class="queue-banner__message">Your subscription will end on <time datetime="{{cancellationEffectiveAtIso}}">{{cancellationEffectiveAtFormatted}}</time>.</p>
         <a class="queue-banner__cta" href="/account">Manage subscription →</a>
-        {{/if}}
-        {{#if subscriptionBannerIsInactive}}
-        <p class="queue-banner__message"><strong>Subscription not active.</strong> Your saved articles are still here.</p>
-        <a class="queue-banner__cta" href="/account">Subscribe — $3.99/month</a>
         {{/if}}
       </aside>
       <form class="{{saveFormClass}}" method="POST" action="/queue/save" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -13,9 +13,7 @@ import type { EffectiveAccess } from "../../../domain/access/effective-access";
 
 export type SubscriptionBannerState =
 	| { state: "none" }
-	| { state: "trial-countdown"; daysLeft: number; daysLeftWord: "day" | "days" }
-	| { state: "pending-cancellation"; cancellationEffectiveAtIso: string; cancellationEffectiveAtFormatted: string }
-	| { state: "inactive" };
+	| { state: "pending-cancellation"; cancellationEffectiveAtIso: string; cancellationEffectiveAtFormatted: string };
 
 export interface ArticleActionField {
 	name: string;
@@ -90,12 +88,6 @@ export interface QueueViewModel {
 	accessIsReadOnly: boolean;
 }
 
-function formatTrialDaysLeft(trialEndsAt: string, now: Date): { daysLeft: number; daysLeftWord: "day" | "days" } {
-	const remaining = new Date(trialEndsAt).getTime() - now.getTime();
-	const daysLeft = Math.max(1, Math.ceil(remaining / 86_400_000));
-	return { daysLeft, daysLeftWord: daysLeft === 1 ? "day" : "days" };
-}
-
 function formatCancellationDate(iso: string): string {
 	return new Date(iso).toLocaleDateString("en-AU", {
 		day: "numeric",
@@ -104,22 +96,18 @@ function formatCancellationDate(iso: string): string {
 	});
 }
 
-function toSubscriptionBannerState(access: EffectiveAccess, now: Date): SubscriptionBannerState {
+function toSubscriptionBannerState(access: EffectiveAccess): SubscriptionBannerState {
 	switch (access.banner) {
 		case "none":
+		case "trial-countdown":
+		case "inactive":
 			return { state: "none" };
-		case "trial-countdown": {
-			const { daysLeft, daysLeftWord } = formatTrialDaysLeft(access.trialEndsAt, now);
-			return { state: "trial-countdown", daysLeft, daysLeftWord };
-		}
 		case "pending-cancellation":
 			return {
 				state: "pending-cancellation",
 				cancellationEffectiveAtIso: access.cancellationEffectiveAt,
 				cancellationEffectiveAtFormatted: formatCancellationDate(access.cancellationEffectiveAt),
 			};
-		case "inactive":
-			return { state: "inactive" };
 	}
 }
 
@@ -287,7 +275,7 @@ export function toQueueViewModel(
 		saveErrorCode: options?.saveErrorCode,
 		importFlash: options?.importFlash,
 		importSkipped: options?.importSkipped,
-		subscriptionBanner: toSubscriptionBannerState(access, now),
+		subscriptionBanner: toSubscriptionBannerState(access),
 		accessIsReadOnly: access.access === "read-only",
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/save/save.page.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.page.ts
@@ -2,7 +2,7 @@ import type { Router } from "express";
 import express from "express";
 import { z } from "zod";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "./save-error.component";
@@ -15,16 +15,16 @@ function parseUrl(raw: unknown): string | undefined {
 	return parsed.success ? parsed.data : undefined;
 }
 
-export function initSaveRoutes(): Router {
+export function initSaveRoutes(deps: { buildBannerState: BuildBannerState }): Router {
 	const router = express.Router();
 
-	router.get("/", (req, res) => {
+	router.get("/", async (req, res) => {
 		const url = parseUrl(typeof req.query.url === "string" ? req.query.url : undefined);
 
 		if (!url) {
 			const redirectUrl = req.userId ? "/queue" : "/";
 			const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
-			sendComponent(req, res, Base(SaveErrorPage({ redirectUrl, linkLabel }), bannerStateFromRequest(req)));
+			sendComponent(req, res, Base(SaveErrorPage({ redirectUrl, linkLabel }), await deps.buildBannerState(req)));
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -30,7 +30,7 @@ import { htmlToMarkdown } from "../../html-to-markdown";
 import { buildMarkdownFrontmatter } from "../../markdown-frontmatter";
 import { MarkdownPage } from "../../markdown-page";
 import { Base } from "../../base.component";
-import { bannerStateFromRequest } from "../../banner-state";
+import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "../../send-component";
 import { extensionInstallUrlIfMissing, isExtensionInstalled } from "../../onboarding/extension-install";
 import { initArticleReader } from "../../shared/article-reader/article-reader";
@@ -56,12 +56,13 @@ interface ViewDependencies {
 	publishSaveAnonymousLink: PublishSaveAnonymousLink;
 	publishStaleCheckRequested: PublishStaleCheckRequested;
 	now: () => Date;
+	buildBannerState: BuildBannerState;
 }
 
-function renderError(req: Request, res: Response) {
+async function renderError(deps: ViewDependencies, req: Request, res: Response): Promise<void> {
 	const redirectUrl = req.userId ? "/queue" : "/";
 	const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
-	sendComponent(req, res, Base(SaveErrorPage({ redirectUrl, linkLabel }), bannerStateFromRequest(req)));
+	sendComponent(req, res, Base(SaveErrorPage({ redirectUrl, linkLabel }), await deps.buildBannerState(req)));
 }
 
 function hostnameFrom(validatedUrl: string): string {
@@ -87,16 +88,16 @@ function buildArticleReaderDeps(deps: ViewDependencies): ArticleReaderDeps {
 }
 
 function handleViewLanding(deps: ViewDependencies) {
-	return (req: Request, res: Response) => {
+	return async (req: Request, res: Response) => {
 		const submittedUrl =
 			typeof req.query.url === "string" ? req.query.url : undefined;
 		if (submittedUrl === undefined) {
-			sendComponent(req, res, Base(ViewLandingPage(), bannerStateFromRequest(req)));
+			sendComponent(req, res, Base(ViewLandingPage(), await deps.buildBannerState(req)));
 			return;
 		}
 		const validation = deps.validateSaveableUrl(submittedUrl);
 		if (validation.status === "ERROR") {
-			renderError(req, res);
+			await renderError(deps, req, res);
 			return;
 		}
 		res.redirect(302, `/view/${encodeURIComponent(validation.url)}`);
@@ -115,7 +116,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		const normalizedUrl = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
 		const validation = deps.validateSaveableUrl(normalizedUrl);
 		if (validation.status === "ERROR") {
-			renderError(req, res);
+			await renderError(deps, req, res);
 			return;
 		}
 		const articleUrl = validation.url;
@@ -206,7 +207,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 					actions,
 					extensionInstallUrl: extensionInstallUrlIfMissing(req),
 				}),
-				{ ...bannerStateFromRequest(req), showExtensionSuggestionBanner, extensionInstalled: isExtensionInstalled(req) },
+				{ ...(await deps.buildBannerState(req)), showExtensionSuggestionBanner, extensionInstalled: isExtensionInstalled(req) },
 			),
 		);
 	};

--- a/projects/hutch/src/runtime/web/trial-countdown.client.test.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.client.test.ts
@@ -1,0 +1,412 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { initTrialCountdown } from "./trial-countdown.client";
+
+const ONE_SECOND_MS = 1000;
+const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
+interface FakeTimer {
+	id: number;
+	cb: () => void;
+}
+
+function buildFixture(opts: {
+	endsAtIso: string;
+	serverNowIso: string;
+	state: "active" | "expired";
+	escalation: string;
+	text: string;
+}): string {
+	return `<!DOCTYPE html><html><body>
+		<p class="trial-countdown trial-countdown--${opts.escalation}"
+		   data-trial-ends-at-iso="${opts.endsAtIso}"
+		   data-server-now-iso="${opts.serverNowIso}"
+		   data-trial-state="${opts.state}"
+		   role="timer"
+		   aria-live="off"
+		   data-test-trial-countdown>${opts.text}</p>
+	</body></html>`;
+}
+
+function createDom(html: string) {
+	const dom = new JSDOM(html, { url: "https://readplace.com/queue" });
+	return { window: dom.window, document: dom.window.document };
+}
+
+interface FakeClock {
+	now: number;
+	timers: Map<number, FakeTimer>;
+	nextId: number;
+	deps: {
+		document: Document;
+		now: () => number;
+		setIntervalFn: (cb: () => void, ms: number) => number;
+		clearIntervalFn: (id: number) => void;
+		addSwapListener: (cb: () => void) => void;
+	};
+	swapListener: (() => void) | undefined;
+}
+
+function createFakeClock(doc: Document, initialNowMs: number): FakeClock {
+	const state: FakeClock = {
+		now: initialNowMs,
+		timers: new Map(),
+		nextId: 1,
+		swapListener: undefined,
+		deps: {
+			document: doc,
+			now: () => state.now,
+			setIntervalFn: (cb) => {
+				const id = state.nextId++;
+				state.timers.set(id, { id, cb });
+				return id;
+			},
+			clearIntervalFn: (id) => {
+				state.timers.delete(id);
+			},
+			addSwapListener: (cb) => {
+				state.swapListener = cb;
+			},
+		},
+	};
+	return state;
+}
+
+function advanceClock(clock: FakeClock, ms: number): void {
+	const ticksToFire = Math.floor(ms / ONE_SECOND_MS);
+	for (let i = 0; i < ticksToFire; i += 1) {
+		clock.now += ONE_SECOND_MS;
+		for (const timer of Array.from(clock.timers.values())) {
+			timer.cb();
+		}
+	}
+	const remainder = ms - ticksToFire * ONE_SECOND_MS;
+	clock.now += remainder;
+}
+
+function getCountdownElement(doc: Document): Element {
+	const el = doc.querySelector("[data-test-trial-countdown]");
+	assert(el, "trial countdown element must exist in fixture");
+	return el;
+}
+
+describe("initTrialCountdown — tick updates the text every second using a clock-skew-corrected now", () => {
+	it("rewrites the textContent every 1000ms with the new Xd Xh Xm Xs string", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + 2 * ONE_HOUR_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "urgent",
+				text: "placeholder",
+			}),
+		);
+
+		const clientNow = Date.parse(serverNow);
+		const clock = createFakeClock(document, clientNow);
+		initTrialCountdown(clock.deps).attach();
+
+		const el = getCountdownElement(document);
+		expect(el.textContent).toBe("0d 2h 0m 0s in your free trial");
+
+		advanceClock(clock, ONE_SECOND_MS);
+		expect(el.textContent).toBe("0d 1h 59m 59s in your free trial");
+
+		advanceClock(clock, ONE_SECOND_MS);
+		expect(el.textContent).toBe("0d 1h 59m 58s in your free trial");
+	});
+
+	it("corrects for client clock skew so a client clock that's 10 minutes ahead still produces the server-relative countdown", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + 5 * ONE_HOUR_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "urgent",
+				text: "placeholder",
+			}),
+		);
+
+		const skewedClientNow = Date.parse(serverNow) + 10 * ONE_MINUTE_MS;
+		const clock = createFakeClock(document, skewedClientNow);
+		initTrialCountdown(clock.deps).attach();
+
+		expect(getCountdownElement(document).textContent).toBe(
+			"0d 5h 0m 0s in your free trial",
+		);
+	});
+});
+
+describe("initTrialCountdown — escalation class transitions as the deadline approaches", () => {
+	it("swaps from --moderate to --urgent when crossing the one-day threshold during a tick", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + ONE_DAY_MS + 2 * ONE_SECOND_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "moderate",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		initTrialCountdown(clock.deps).attach();
+
+		const el = getCountdownElement(document);
+		expect(el.classList.contains("trial-countdown--moderate")).toBe(true);
+		expect(el.classList.contains("trial-countdown--urgent")).toBe(false);
+
+		advanceClock(clock, 3 * ONE_SECOND_MS);
+
+		expect(el.classList.contains("trial-countdown--moderate")).toBe(false);
+		expect(el.classList.contains("trial-countdown--urgent")).toBe(true);
+	});
+});
+
+describe("initTrialCountdown — expiration", () => {
+	it("swaps the text to 'Free trial is over!', sets data-trial-state=expired, aria-live=polite, and clears the interval", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + 2 * ONE_SECOND_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "critical",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		initTrialCountdown(clock.deps).attach();
+
+		expect(clock.timers.size).toBe(1);
+
+		advanceClock(clock, 3 * ONE_SECOND_MS);
+
+		const el = getCountdownElement(document);
+		expect(el.textContent).toBe("Free trial is over!");
+		expect(el.getAttribute("data-trial-state")).toBe("expired");
+		expect(el.getAttribute("aria-live")).toBe("polite");
+		expect(el.classList.contains("trial-countdown--expired")).toBe(true);
+		expect(clock.timers.size).toBe(0);
+	});
+});
+
+describe("initTrialCountdown — visibility changes", () => {
+	it("clears the interval when the document becomes hidden and re-arms it when it becomes visible again", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + ONE_HOUR_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "urgent",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		initTrialCountdown(clock.deps).attach();
+
+		expect(clock.timers.size).toBe(1);
+
+		Object.defineProperty(document, "hidden", { configurable: true, value: true });
+		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
+		expect(clock.timers.size).toBe(0);
+
+		Object.defineProperty(document, "hidden", { configurable: true, value: false });
+		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
+		expect(clock.timers.size).toBe(1);
+	});
+});
+
+describe("initTrialCountdown — htmx swaps", () => {
+	it("invokes the swap listener callback so a re-rendered header can be picked up on tick", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + ONE_HOUR_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "urgent",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		initTrialCountdown(clock.deps).attach();
+		assert(clock.swapListener, "swap listener must be registered");
+
+		// Simulate an htmx swap that re-renders the countdown to a different remaining value
+		const el = getCountdownElement(document);
+		el.textContent = "stale text";
+
+		clock.swapListener();
+
+		expect(el.textContent).toBe("0d 1h 0m 0s in your free trial");
+	});
+});
+
+describe("initTrialCountdown — absent element", () => {
+	it("returns a no-op controller when the page has no countdown element (guest pages)", () => {
+		const { document } = createDom("<!DOCTYPE html><html><body></body></html>");
+		const clock = createFakeClock(document, Date.now());
+
+		const ctrl = initTrialCountdown(clock.deps);
+		expect(() => ctrl.attach()).not.toThrow();
+		expect(() => ctrl.stop()).not.toThrow();
+		expect(clock.timers.size).toBe(0);
+	});
+});
+
+describe("initTrialCountdown — already-expired initial state", () => {
+	it("does not start the interval when data-trial-state='expired' is set in the SSR markup", () => {
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: "2026-01-01T00:00:00.000Z",
+				serverNowIso: "2026-01-02T00:00:00.000Z",
+				state: "expired",
+				escalation: "expired",
+				text: "Free trial is over!",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse("2026-01-02T00:00:00.000Z"));
+		initTrialCountdown(clock.deps).attach();
+
+		expect(clock.timers.size).toBe(0);
+		const el = getCountdownElement(document);
+		expect(el.textContent).toBe("Free trial is over!");
+	});
+});
+
+describe("initTrialCountdown — clock skew fallback", () => {
+	it("treats a missing data-server-now-iso attribute as skewMs=0 so the countdown still ticks against the client clock", () => {
+		const endsAt = new Date(Date.parse("2026-01-01T00:00:00.000Z") + ONE_HOUR_MS).toISOString();
+		const { document } = createDom(`<!DOCTYPE html><html><body>
+			<p class="trial-countdown trial-countdown--urgent"
+			   data-trial-ends-at-iso="${endsAt}"
+			   data-server-now-iso=""
+			   data-trial-state="active"
+			   role="timer"
+			   aria-live="off"
+			   data-test-trial-countdown>placeholder</p>
+		</body></html>`);
+
+		const clock = createFakeClock(document, Date.parse("2026-01-01T00:00:00.000Z"));
+		initTrialCountdown(clock.deps).attach();
+
+		expect(getCountdownElement(document).textContent).toBe(
+			"0d 1h 0m 0s in your free trial",
+		);
+	});
+
+	it("treats a non-parseable data-server-now-iso as skewMs=0", () => {
+		const endsAt = new Date(Date.parse("2026-01-01T00:00:00.000Z") + 30 * ONE_MINUTE_MS).toISOString();
+		const { document } = createDom(`<!DOCTYPE html><html><body>
+			<p class="trial-countdown trial-countdown--urgent"
+			   data-trial-ends-at-iso="${endsAt}"
+			   data-server-now-iso="not-a-date"
+			   data-trial-state="active"
+			   role="timer"
+			   aria-live="off"
+			   data-test-trial-countdown>placeholder</p>
+		</body></html>`);
+
+		const clock = createFakeClock(document, Date.parse("2026-01-01T00:00:00.000Z"));
+		initTrialCountdown(clock.deps).attach();
+
+		expect(getCountdownElement(document).textContent).toBe(
+			"0d 0h 30m 0s in your free trial",
+		);
+	});
+});
+
+describe("initTrialCountdown — idempotent state transitions", () => {
+	it("is a no-op when visibilitychange fires twice while the document stays hidden", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + ONE_HOUR_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "urgent",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		initTrialCountdown(clock.deps).attach();
+		expect(clock.timers.size).toBe(1);
+
+		Object.defineProperty(document, "hidden", { configurable: true, value: true });
+		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
+		expect(clock.timers.size).toBe(0);
+
+		// Second hidden event — interval already cleared, must stay 0
+		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
+		expect(clock.timers.size).toBe(0);
+	});
+
+	it("does not re-arm the interval when the trial has already expired and visibility flips back to visible", () => {
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: "2026-01-01T00:00:00.000Z",
+				serverNowIso: "2026-01-02T00:00:00.000Z",
+				state: "expired",
+				escalation: "expired",
+				text: "Free trial is over!",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse("2026-01-02T00:00:00.000Z"));
+		initTrialCountdown(clock.deps).attach();
+		expect(clock.timers.size).toBe(0);
+
+		Object.defineProperty(document, "hidden", { configurable: true, value: false });
+		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
+
+		expect(clock.timers.size).toBe(0);
+	});
+});
+
+describe("initTrialCountdown — stop()", () => {
+	it("removes the visibilitychange listener and clears the interval so the controller can be torn down for tests", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + ONE_HOUR_MS).toISOString();
+		const { document } = createDom(
+			buildFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "urgent",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		const ctrl = initTrialCountdown(clock.deps);
+		ctrl.attach();
+		expect(clock.timers.size).toBe(1);
+
+		ctrl.stop();
+		expect(clock.timers.size).toBe(0);
+
+		// After stop(), a visibilitychange event should not re-arm the interval.
+		Object.defineProperty(document, "hidden", { configurable: true, value: false });
+		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
+		expect(clock.timers.size).toBe(0);
+	});
+});

--- a/projects/hutch/src/runtime/web/trial-countdown.client.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.client.ts
@@ -1,0 +1,131 @@
+import {
+	deriveTrialEscalation,
+	formatTrialDisplay,
+	formatTrialRemaining,
+	type TrialDisplay,
+	type TrialEscalation,
+} from "./trial-countdown.format";
+
+interface TrialCountdownDeps {
+	document: Document;
+	now: () => number;
+	setIntervalFn: (cb: () => void, ms: number) => number;
+	clearIntervalFn: (id: number) => void;
+	addSwapListener: (cb: () => void) => void;
+}
+
+interface TrialCountdownController {
+	attach(): void;
+	stop(): void;
+}
+
+const SELECTOR = "[data-test-trial-countdown]";
+const TICK_INTERVAL_MS = 1000;
+const ESCALATIONS: readonly TrialEscalation[] = [
+	"soft",
+	"moderate",
+	"urgent",
+	"critical",
+];
+
+function assert(cond: unknown, message: string): asserts cond {
+	if (!cond) throw new Error(message);
+}
+
+function readSkewMs(deps: TrialCountdownDeps, el: Element): number {
+	const serverNowIso = el.getAttribute("data-server-now-iso");
+	if (serverNowIso === null || serverNowIso === "") return 0;
+	const serverNowMs = Date.parse(serverNowIso);
+	if (!Number.isFinite(serverNowMs)) return 0;
+	return serverNowMs - deps.now();
+}
+
+function setEscalationClass(el: Element, escalation: TrialEscalation | "expired"): void {
+	for (const e of ESCALATIONS) {
+		el.classList.remove(`trial-countdown--${e}`);
+	}
+	el.classList.remove("trial-countdown--expired");
+	el.classList.add(`trial-countdown--${escalation}`);
+}
+
+export function initTrialCountdown(
+	deps: TrialCountdownDeps,
+): TrialCountdownController {
+	const root = deps.document.querySelector(SELECTOR);
+	if (!root) return { attach() {}, stop() {} };
+	const el: Element = root;
+
+	const endsAtIso = el.getAttribute("data-trial-ends-at-iso");
+	assert(endsAtIso, `${SELECTOR} must carry data-trial-ends-at-iso`);
+	const skewMs = readSkewMs(deps, el);
+
+	let intervalId: number | undefined;
+	let expired = el.getAttribute("data-trial-state") === "expired";
+
+	function tick(): void {
+		const skewedNow = new Date(deps.now() + skewMs);
+		const remaining = formatTrialRemaining(endsAtIso ?? "", skewedNow);
+		if (remaining.totalMs <= 0) {
+			if (!expired) {
+				const display: TrialDisplay = { state: "expired" };
+				el.textContent = formatTrialDisplay(display);
+				el.setAttribute("data-trial-state", "expired");
+				el.setAttribute("aria-live", "polite");
+				setEscalationClass(el, "expired");
+				expired = true;
+			}
+			if (intervalId !== undefined) {
+				deps.clearIntervalFn(intervalId);
+				intervalId = undefined;
+			}
+			return;
+		}
+		const escalation = deriveTrialEscalation(remaining);
+		const display: TrialDisplay = {
+			state: "active",
+			endsAtIso: endsAtIso ?? "",
+			serverNowIso: skewedNow.toISOString(),
+			remaining,
+			escalation,
+		};
+		el.textContent = formatTrialDisplay(display);
+		setEscalationClass(el, escalation);
+	}
+
+	function startInterval(): void {
+		if (intervalId !== undefined) return;
+		if (expired) return;
+		intervalId = deps.setIntervalFn(tick, TICK_INTERVAL_MS);
+	}
+
+	function stopInterval(): void {
+		if (intervalId === undefined) return;
+		deps.clearIntervalFn(intervalId);
+		intervalId = undefined;
+	}
+
+	function onVisibilityChange(): void {
+		if (deps.document.hidden) {
+			stopInterval();
+			return;
+		}
+		tick();
+		startInterval();
+	}
+
+	function attach(): void {
+		tick();
+		startInterval();
+		deps.document.addEventListener("visibilitychange", onVisibilityChange);
+		deps.addSwapListener(() => {
+			tick();
+		});
+	}
+
+	function stop(): void {
+		stopInterval();
+		deps.document.removeEventListener("visibilitychange", onVisibilityChange);
+	}
+
+	return { attach, stop };
+}

--- a/projects/hutch/src/runtime/web/trial-countdown.format.test.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.format.test.ts
@@ -1,0 +1,168 @@
+import {
+	deriveTrialEscalation,
+	formatTrialDisplay,
+	formatTrialRemaining,
+	toTrialDisplay,
+} from "./trial-countdown.format";
+import type { EffectiveAccess } from "../domain/access/effective-access";
+
+const ONE_SECOND_MS = 1000;
+const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
+describe("formatTrialRemaining", () => {
+	it("breaks the remaining window into days/hours/minutes/seconds", () => {
+		const now = new Date("2026-01-01T00:00:00.000Z");
+		const endsAt = new Date(
+			now.getTime() + 13 * ONE_DAY_MS + 12 * ONE_HOUR_MS + 33 * ONE_MINUTE_MS + 22 * ONE_SECOND_MS,
+		).toISOString();
+		expect(formatTrialRemaining(endsAt, now)).toEqual({
+			days: 13,
+			hours: 12,
+			minutes: 33,
+			seconds: 22,
+			totalMs:
+				13 * ONE_DAY_MS + 12 * ONE_HOUR_MS + 33 * ONE_MINUTE_MS + 22 * ONE_SECOND_MS,
+		});
+	});
+
+	it("clamps a past endsAt to zero remaining so an expired trial reports totalMs=0", () => {
+		const now = new Date("2026-01-01T00:00:00.000Z");
+		const endsAt = new Date(now.getTime() - ONE_DAY_MS).toISOString();
+		expect(formatTrialRemaining(endsAt, now)).toEqual({
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+			totalMs: 0,
+		});
+	});
+
+	it("reports exactly zero across the boundary so the client sees totalMs<=0 once and only once", () => {
+		const now = new Date("2026-01-01T00:00:00.000Z");
+		expect(formatTrialRemaining(now.toISOString(), now).totalMs).toBe(0);
+	});
+});
+
+describe("deriveTrialEscalation", () => {
+	const baseRemaining = { days: 0, hours: 0, minutes: 0, seconds: 0 };
+
+	it("returns 'soft' when more than seven days remain", () => {
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: 8 * ONE_DAY_MS }),
+		).toBe("soft");
+	});
+
+	it("returns 'moderate' when between one and seven days remain", () => {
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: 3 * ONE_DAY_MS }),
+		).toBe("moderate");
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: 7 * ONE_DAY_MS }),
+		).toBe("moderate");
+	});
+
+	it("returns 'urgent' when between one hour and one day remain", () => {
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: 5 * ONE_HOUR_MS }),
+		).toBe("urgent");
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: ONE_DAY_MS }),
+		).toBe("urgent");
+	});
+
+	it("returns 'critical' when less than one hour remains", () => {
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: 30 * ONE_MINUTE_MS }),
+		).toBe("critical");
+		expect(
+			deriveTrialEscalation({ ...baseRemaining, totalMs: 0 }),
+		).toBe("critical");
+	});
+});
+
+describe("formatTrialDisplay", () => {
+	it("renders the active countdown as `Xd Xh Xm Xs in your free trial`", () => {
+		expect(
+			formatTrialDisplay({
+				state: "active",
+				endsAtIso: "2026-01-15T00:00:00.000Z",
+				serverNowIso: "2026-01-01T00:00:00.000Z",
+				remaining: {
+					days: 13,
+					hours: 12,
+					minutes: 33,
+					seconds: 22,
+					totalMs: 1,
+				},
+				escalation: "soft",
+			}),
+		).toBe("13d 12h 33m 22s in your free trial");
+	});
+
+	it("renders the expired state as the standalone 'Free trial is over!' message", () => {
+		expect(formatTrialDisplay({ state: "expired" })).toBe("Free trial is over!");
+	});
+});
+
+describe("toTrialDisplay", () => {
+	const now = new Date("2026-01-01T00:00:00.000Z");
+
+	it("maps an active trial banner to a state=active TrialDisplay carrying the ISO end time and serverNowIso", () => {
+		const trialEndsAt = new Date(now.getTime() + 3 * ONE_DAY_MS).toISOString();
+		const access: EffectiveAccess = {
+			tier: "trial",
+			access: "full",
+			banner: "trial-countdown",
+			trialEndsAt,
+		};
+		const result = toTrialDisplay(access, now);
+		expect(result).toEqual({
+			state: "active",
+			endsAtIso: trialEndsAt,
+			serverNowIso: now.toISOString(),
+			remaining: expect.objectContaining({ days: 3 }),
+			escalation: "moderate",
+		});
+	});
+
+	it("maps an inactive banner (trial-expired or cancelled) to a state=expired TrialDisplay", () => {
+		const trialExpired: EffectiveAccess = {
+			tier: "inactive",
+			access: "read-only",
+			banner: "inactive",
+			reason: "trial-expired",
+		};
+		const cancelled: EffectiveAccess = {
+			tier: "inactive",
+			access: "read-only",
+			banner: "inactive",
+			reason: "subscription-cancelled",
+		};
+		expect(toTrialDisplay(trialExpired, now)).toEqual({ state: "expired" });
+		expect(toTrialDisplay(cancelled, now)).toEqual({ state: "expired" });
+	});
+
+	it("returns undefined for founding/paid/pending-cancellation so the countdown is hidden", () => {
+		const founding: EffectiveAccess = {
+			tier: "founding",
+			access: "full",
+			banner: "none",
+		};
+		const paid: EffectiveAccess = {
+			tier: "paid",
+			access: "full",
+			banner: "none",
+		};
+		const pendingCancellation: EffectiveAccess = {
+			tier: "paid",
+			access: "full",
+			banner: "pending-cancellation",
+			cancellationEffectiveAt: "2026-02-01T00:00:00.000Z",
+		};
+		expect(toTrialDisplay(founding, now)).toBeUndefined();
+		expect(toTrialDisplay(paid, now)).toBeUndefined();
+		expect(toTrialDisplay(pendingCancellation, now)).toBeUndefined();
+	});
+});

--- a/projects/hutch/src/runtime/web/trial-countdown.format.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.format.ts
@@ -1,0 +1,78 @@
+import type { EffectiveAccess } from "../domain/access/effective-access";
+
+export interface TrialRemaining {
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+	totalMs: number;
+}
+
+export type TrialEscalation = "soft" | "moderate" | "urgent" | "critical";
+
+export type TrialDisplay =
+	| {
+			state: "active";
+			endsAtIso: string;
+			serverNowIso: string;
+			remaining: TrialRemaining;
+			escalation: TrialEscalation;
+		}
+	| { state: "expired" };
+
+const ONE_SECOND_MS = 1000;
+const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
+
+export function formatTrialRemaining(
+	endsAtIso: string,
+	now: Date,
+): TrialRemaining {
+	const endsAtMs = Date.parse(endsAtIso);
+	const totalMs = Math.max(0, endsAtMs - now.getTime());
+	const days = Math.floor(totalMs / ONE_DAY_MS);
+	const hours = Math.floor((totalMs % ONE_DAY_MS) / ONE_HOUR_MS);
+	const minutes = Math.floor((totalMs % ONE_HOUR_MS) / ONE_MINUTE_MS);
+	const seconds = Math.floor((totalMs % ONE_MINUTE_MS) / ONE_SECOND_MS);
+	return { days, hours, minutes, seconds, totalMs };
+}
+
+export function deriveTrialEscalation(
+	remaining: TrialRemaining,
+): TrialEscalation {
+	if (remaining.totalMs > SEVEN_DAYS_MS) return "soft";
+	if (remaining.totalMs > ONE_DAY_MS) return "moderate";
+	if (remaining.totalMs > ONE_HOUR_MS) return "urgent";
+	return "critical";
+}
+
+export function formatTrialDisplay(trial: TrialDisplay): string {
+	if (trial.state === "expired") return "Free trial is over!";
+	const { days, hours, minutes, seconds } = trial.remaining;
+	return `${days}d ${hours}h ${minutes}m ${seconds}s in your free trial`;
+}
+
+export function toTrialDisplay(
+	access: EffectiveAccess,
+	now: Date,
+): TrialDisplay | undefined {
+	switch (access.banner) {
+		case "trial-countdown": {
+			const remaining = formatTrialRemaining(access.trialEndsAt, now);
+			return {
+				state: "active",
+				endsAtIso: access.trialEndsAt,
+				serverNowIso: now.toISOString(),
+				remaining,
+				escalation: deriveTrialEscalation(remaining),
+			};
+		}
+		case "inactive":
+			return { state: "expired" };
+		case "none":
+		case "pending-cancellation":
+			return undefined;
+	}
+}


### PR DESCRIPTION
## Summary

- Replace the queue-only "14 days left in your free trial" aside with a global, red, live-ticking countdown rendered below the brand on every authenticated page (`Xd Xh Xm Xs in your free trial`). Once the trial ends — whether by expiry or subscription cancellation — the same element flips to `Free trial is over!`, so the read-only state has a single ever-visible signal instead of relying on a banner only visible on `/queue`.
- Add `buildBannerState(req, deps)` that wraps the existing sync `bannerStateFromRequest` and resolves trial state from `EffectiveAccess` for authenticated requests. Every authenticated route now passes through this factory; `/queue` reuses the `EffectiveAccess` it already fetches to avoid double-fetching.
- New shared `trial-countdown.format.ts` formatter is used by both the server-rendered string and the browser-side `trial-countdown.client.ts` tick. The client corrects for client-clock skew using a `data-server-now-iso` attribute, pauses the interval on `visibilitychange`, and swaps to `Free trial is over!` (with `aria-live="polite"` so screen readers announce the expiration once) when the deadline passes.
- Escalation class on the element shifts from `--soft` (>7d) → `--moderate` (1–7d) → `--urgent` (1h–1d) → `--critical` (<1h) → `--expired`, with a subtle pulse at critical and a shake at expired. Honors `prefers-reduced-motion`.
- Drop the trial-countdown and inactive branches from the queue aside. The pending-cancellation aside stays for paid users with an upcoming end date.

## Test plan

- [x] `pnpm nx run hutch:compile` — passes
- [x] `pnpm nx run hutch:lint` — passes (biome, knip, css-purge, tsc lint)
- [x] `pnpm test` (hutch jest suite) — 1489/1489 pass
- [x] `pnpm nx run hutch:test-with-coverage` — 99.7% statements / 96.23% branches / 100% functions / 99.7% lines (all above thresholds)
- [ ] Local smoke (fresh trial user, expired trial, cancelled subscription, founding, paid) — recommended before merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV1sThU1eQcshAsbdYVeFz)_