### PR TITLE
fix(hutch): fold trial days into signup CTA, trim hint to "Cancel any time."

### DIFF
--- a/projects/hutch/src/runtime/web/auth/auth.component.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.component.ts
@@ -99,7 +99,7 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		emailField: toFieldViewModel(errors, "email"),
 		passwordField: toFieldViewModel(errors, "password"),
 		confirmPasswordField: toFieldViewModel(errors, "confirmPassword"),
-		submitLabel: "Join Readplace",
+		submitLabel: `Join Readplace${trialSuffix}`,
 		googleLabel: `Sign up with Google${trialSuffix}`,
 		foundingProgressHtml: renderFoundingProgress({
 			userCount: data.userCount,
@@ -107,7 +107,6 @@ export function SignupPage(data: SignupFormData, options?: { statusCode?: number
 		}),
 		foundingMemberLimit: data.foundingAllocation.foundingMemberLimit,
 		foundingAvailable: !data.foundingAllocation.isFoundingAllocationExhausted(data.userCount),
-		trialDays: STRIPE_TRIAL_PERIOD_DAYS,
 	});
 
 	return {

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -1044,7 +1044,7 @@ describe("Auth routes", () => {
 			expect(signupDoc.querySelector("[data-test-founding-blurb]")).toBeNull();
 		}, 30000);
 
-		it("renders '14 days trial. Cancel any time.' trial hint on /signup when the founding allocation is exhausted", async () => {
+		it("renders 'Cancel any time.' trial hint on /signup when the founding allocation is exhausted", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const { auth } = harness;
 			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
@@ -1052,7 +1052,19 @@ describe("Auth routes", () => {
 			}
 
 			const doc = new JSDOM((await request(harness.server).get("/signup")).text).window.document;
-			expect(doc.querySelector("[data-test-trial-hint]")?.textContent).toBe("14 days trial. Cancel any time.");
+			expect(doc.querySelector("[data-test-trial-hint]")?.textContent).toBe("Cancel any time.");
+		}, 30000);
+
+		it("renders 'Join Readplace (14 days free)' submit button on /signup when the founding allocation is exhausted", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
+				await auth.createUser({ email: `user${i}@test.com`, password: "password123" });
+			}
+
+			const doc = new JSDOM((await request(harness.server).get("/signup")).text).window.document;
+			const submit = doc.querySelector('[data-test-form="signup"] button[type="submit"]');
+			expect(submit?.textContent).toBe("Join Readplace (14 days free)");
 		}, 30000);
 	});
 });

--- a/projects/hutch/src/runtime/web/auth/signup.template.html
+++ b/projects/hutch/src/runtime/web/auth/signup.template.html
@@ -27,7 +27,7 @@
             {{#if confirmPasswordField.error}}<p class="auth-form__error" data-test-error="confirmPassword">{{confirmPasswordField.error}}</p>{{/if}}
           </div>
           <button class="auth-form__submit" type="submit" data-test-action="signup">{{submitLabel}}</button>
-          {{#unless foundingAvailable}}<p class="auth-form__hint" data-test-trial-hint>{{trialDays}} days trial. Cancel any time.</p>{{/unless}}
+          {{#unless foundingAvailable}}<p class="auth-form__hint" data-test-trial-hint>Cancel any time.</p>{{/unless}}
         </form>
         <div class="auth-google-section" data-test-google-section>
           <div class="auth-divider">or</div>


### PR DESCRIPTION
## Summary

- Promote the trial duration into the signup submit button label so it mirrors the Google CTA — `"Join Readplace (14 days free)"` instead of a separate hint line.
- Shrink the hint underneath to just `"Cancel any time."`
- Both labels now share the same `trialSuffix` path, gated by whether the founding allocation is exhausted.

## Test plan

- [x] `pnpm nx test hutch --testPathPattern="auth.route"` — all 97 tests pass
- [x] `pnpm nx check hutch` — 100% coverage threshold met
- [x] Updated `auth.route.test.ts`:
  - Renamed trial-hint test to assert `"Cancel any time."`
  - Added a new test asserting `"Join Readplace (14 days free)"` submit label when founding allocation is exhausted


---
_Generated by [Claude Code](https://claude.ai/code/session_012gTNCX9E7SbeTR9kSogfeq)_