### PR TITLE
fix(hutch): scale trial countdown by largest non-zero unit

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -374,7 +374,7 @@ describe("Base component", () => {
 
 		const countdown = doc.querySelector("[data-test-trial-countdown]");
 		assert(countdown, "trial countdown must be rendered when trial.state='active'");
-		expect(countdown.textContent).toBe("13d 12h 33m 22s in your free trial");
+		expect(countdown.textContent).toBe("13d 12h left in your free trial");
 		expect(countdown.getAttribute("data-trial-state")).toBe("active");
 		expect(countdown.getAttribute("data-trial-ends-at-iso")).toBe("2026-01-15T00:00:00.000Z");
 		expect(countdown.getAttribute("data-server-now-iso")).toBe("2026-01-01T00:00:00.000Z");

--- a/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
@@ -45,7 +45,9 @@ describe("Queue page banner state", () => {
 		const countdown = doc.querySelector("[data-test-trial-countdown]");
 		assert(countdown, "global trial countdown must be rendered for a trialing user");
 		expect(countdown.getAttribute("data-trial-state")).toBe("active");
-		expect(countdown.textContent).toMatch(/^\d+d \d+h \d+m \d+s in your free trial$/);
+		expect(countdown.textContent).toMatch(
+			/^(\d+d \d+h|\d+h \d+m|\d+m \d+s|\d+s) left in your free trial$/,
+		);
 		const banner = doc.querySelector("[data-test-subscription-banner]");
 		assert(banner, "queue banner aside must be rendered");
 		expect(banner.classList.contains("queue-banner--trial-countdown")).toBe(true);

--- a/projects/hutch/src/runtime/web/trial-countdown.client.test.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.client.test.ts
@@ -93,15 +93,15 @@ function getCountdownElement(doc: Document): Element {
 }
 
 describe("initTrialCountdown — tick updates the text every second using a clock-skew-corrected now", () => {
-	it("rewrites the textContent every 1000ms with the new Xd Xh Xm Xs string", () => {
+	it("rewrites the textContent every 1000ms with the new countdown string so the user sees the second-by-second tick when under a minute matters", () => {
 		const serverNow = "2026-01-01T00:00:00.000Z";
-		const endsAt = new Date(Date.parse(serverNow) + 2 * ONE_HOUR_MS).toISOString();
+		const endsAt = new Date(Date.parse(serverNow) + 5 * ONE_MINUTE_MS).toISOString();
 		const { document } = createDom(
 			buildFixture({
 				endsAtIso: endsAt,
 				serverNowIso: serverNow,
 				state: "active",
-				escalation: "urgent",
+				escalation: "critical",
 				text: "placeholder",
 			}),
 		);
@@ -111,13 +111,13 @@ describe("initTrialCountdown — tick updates the text every second using a cloc
 		initTrialCountdown(clock.deps).attach();
 
 		const el = getCountdownElement(document);
-		expect(el.textContent).toBe("0d 2h 0m 0s in your free trial");
+		expect(el.textContent).toBe("5m 0s left in your free trial");
 
 		advanceClock(clock, ONE_SECOND_MS);
-		expect(el.textContent).toBe("0d 1h 59m 59s in your free trial");
+		expect(el.textContent).toBe("4m 59s left in your free trial");
 
 		advanceClock(clock, ONE_SECOND_MS);
-		expect(el.textContent).toBe("0d 1h 59m 58s in your free trial");
+		expect(el.textContent).toBe("4m 58s left in your free trial");
 	});
 
 	it("corrects for client clock skew so a client clock that's 10 minutes ahead still produces the server-relative countdown", () => {
@@ -138,7 +138,7 @@ describe("initTrialCountdown — tick updates the text every second using a cloc
 		initTrialCountdown(clock.deps).attach();
 
 		expect(getCountdownElement(document).textContent).toBe(
-			"0d 5h 0m 0s in your free trial",
+			"5h 0m left in your free trial",
 		);
 	});
 });
@@ -254,7 +254,7 @@ describe("initTrialCountdown — htmx swaps", () => {
 
 		clock.swapListener();
 
-		expect(el.textContent).toBe("0d 1h 0m 0s in your free trial");
+		expect(el.textContent).toBe("1h 0m left in your free trial");
 	});
 });
 
@@ -308,7 +308,7 @@ describe("initTrialCountdown — clock skew fallback", () => {
 		initTrialCountdown(clock.deps).attach();
 
 		expect(getCountdownElement(document).textContent).toBe(
-			"0d 1h 0m 0s in your free trial",
+			"1h 0m left in your free trial",
 		);
 	});
 
@@ -328,7 +328,7 @@ describe("initTrialCountdown — clock skew fallback", () => {
 		initTrialCountdown(clock.deps).attach();
 
 		expect(getCountdownElement(document).textContent).toBe(
-			"0d 0h 30m 0s in your free trial",
+			"30m 0s left in your free trial",
 		);
 	});
 });

--- a/projects/hutch/src/runtime/web/trial-countdown.format.test.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.format.test.ts
@@ -83,22 +83,43 @@ describe("deriveTrialEscalation", () => {
 });
 
 describe("formatTrialDisplay", () => {
-	it("renders the active countdown as `Xd Xh Xm Xs in your free trial`", () => {
-		expect(
-			formatTrialDisplay({
-				state: "active",
-				endsAtIso: "2026-01-15T00:00:00.000Z",
-				serverNowIso: "2026-01-01T00:00:00.000Z",
-				remaining: {
-					days: 13,
-					hours: 12,
-					minutes: 33,
-					seconds: 22,
-					totalMs: 1,
-				},
-				escalation: "soft",
-			}),
-		).toBe("13d 12h 33m 22s in your free trial");
+	function active(remaining: {
+		days: number;
+		hours: number;
+		minutes: number;
+		seconds: number;
+	}) {
+		return formatTrialDisplay({
+			state: "active",
+			endsAtIso: "2026-01-15T00:00:00.000Z",
+			serverNowIso: "2026-01-01T00:00:00.000Z",
+			remaining: { ...remaining, totalMs: 1 },
+			escalation: "soft",
+		});
+	}
+
+	it("drops minutes and seconds when at least one day remains so multi-day trials show a stable `Xd Yh`", () => {
+		expect(active({ days: 13, hours: 12, minutes: 33, seconds: 22 })).toBe(
+			"13d 12h left in your free trial",
+		);
+	});
+
+	it("falls back to `Xh Ym` when less than a day remains so the user sees minute-by-minute progress", () => {
+		expect(active({ days: 0, hours: 2, minutes: 33, seconds: 22 })).toBe(
+			"2h 33m left in your free trial",
+		);
+	});
+
+	it("falls back to `Xm Ys` when less than an hour remains so the user sees the second tick", () => {
+		expect(active({ days: 0, hours: 0, minutes: 5, seconds: 22 })).toBe(
+			"5m 22s left in your free trial",
+		);
+	});
+
+	it("falls back to bare `Ys` when less than a minute remains so the final countdown isn't padded with `0d 0h 0m`", () => {
+		expect(active({ days: 0, hours: 0, minutes: 0, seconds: 53 })).toBe(
+			"53s left in your free trial",
+		);
 	});
 
 	it("renders the expired state as the standalone 'Free trial is over!' message", () => {

--- a/projects/hutch/src/runtime/web/trial-countdown.format.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.format.ts
@@ -50,8 +50,15 @@ export function deriveTrialEscalation(
 
 export function formatTrialDisplay(trial: TrialDisplay): string {
 	if (trial.state === "expired") return "Free trial is over!";
-	const { days, hours, minutes, seconds } = trial.remaining;
-	return `${days}d ${hours}h ${minutes}m ${seconds}s in your free trial`;
+	return `${formatTrialUnits(trial.remaining)} left in your free trial`;
+}
+
+function formatTrialUnits(remaining: TrialRemaining): string {
+	const { days, hours, minutes, seconds } = remaining;
+	if (days > 0) return `${days}d ${hours}h`;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
 }
 
 export function toTrialDisplay(


### PR DESCRIPTION
## Summary

The header trial countdown rendered as `0d 0h 0m 53s in your free trial` even when only seconds were left, so a trial in its last minute read as a wall of placeholder zeros. Now it scales to the largest non-zero unit and shows two units of meaningful precision:

| Remaining | Before | After |
|---|---|---|
| 13d 12h 33m 22s | `13d 12h 33m 22s in your free trial` | `13d 12h left in your free trial` |
| 2h 33m 22s | `0d 2h 33m 22s in your free trial` | `2h 33m left in your free trial` |
| 5m 22s | `0d 0h 5m 22s in your free trial` | `5m 22s left in your free trial` |
| 53s | `0d 0h 0m 53s in your free trial` | `53s left in your free trial` |

Granularity matches what the user can act on at each scale: hours tick when there's a day or more, minutes tick when there's an hour or more, seconds tick when there's a minute or less. The expired message (`Free trial is over!`) is unchanged.

## Test plan
- [x] `trial-countdown.format.test.ts` — four format tier cases (days / hours / minutes / seconds) + expired
- [x] `trial-countdown.client.test.ts` — per-second tick test updated to 5-minute window so the seconds tick is observable; clock-skew + htmx-swap + missing-data-server-now-iso cases updated to new format
- [x] `base.component.test.ts` — header countdown text assertion updated
- [x] `queue.subscription-banner.route.test.ts` — integration regex broadened to match all four tiers
- [x] Full `nx run hutch:lint` and 1558-test suite pass locally

https://claude.ai/code/session_014151oSZFmRFzKy998V9694

---
_Generated by [Claude Code](https://claude.ai/code/session_014151oSZFmRFzKy998V9694)_