### PR TITLE
fix(hutch): contain wide tables in reader iframe to stop stray scrollbars

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe-srcdoc.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe-srcdoc.test.ts
@@ -55,6 +55,21 @@ describe("buildReaderIframeSrcdoc", () => {
 		expect(css).toContain("background: transparent");
 	});
 
+	it("contains wide tables inside themselves so they do not push the iframe horizontally and trigger a stray vertical scrollbar", () => {
+		const srcdoc = buildReaderIframeSrcdoc({ content: "" });
+		const doc = new JSDOM(srcdoc).window.document;
+		const style = doc.querySelector("style");
+		assert(style, "style block must exist");
+		const css = style.textContent ?? "";
+
+		expect(css).toMatch(
+			/\.article-body__content\s+table\s*{[^}]*overflow-x:\s*auto/,
+		);
+		expect(css).toMatch(
+			/\.article-body__content\s+table\s*{[^}]*max-width:\s*100%/,
+		);
+	});
+
 	it("does not strip the article content's own tags (the sandbox is responsible for isolation)", () => {
 		const dangerous =
 			'<p>safe</p><style>html{display:none}</style><img onerror="x">';

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.styles.css
@@ -103,6 +103,20 @@ body {
   margin: 1.25rem 0;
 }
 
+/**
+ * 1. Wide tables (common in extracted PDFs) would otherwise push past the
+ *    iframe width. The horizontal scrollbar that appears on the iframe then
+ *    steals vertical space at the bottom, which forces the browser to add a
+ *    vertical scrollbar too — even though reader-iframe.client.ts sized the
+ *    iframe to its content height. Contain the overflow inside the table
+ *    itself so neither iframe scrollbar appears.
+ */
+.article-body__content table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .article-body__content code {
   font-size: 0.875em;
   padding: 0.15em 0.3em;


### PR DESCRIPTION
## Summary

On a small subset of reader-view pages (e.g. [the Mythical Man-Month PDF view](https://readplace.com/view/https%3A%2F%2Fweb.eecs.umich.edu%2F~weimerw%2F2018-481%2Freadings%2Fmythical-man-month.pdf)) the sandboxed reader iframe shows a vertical scrollbar, even though `reader-iframe.client.ts` sizes the iframe element to the content's `scrollHeight`.

## Root cause

The pages that regress contain a wide element (in the repro, a 927px wide `<table>` extracted from a PDF) that overflows the ~648px iframe width. Browsers then render the iframe's *horizontal* scrollbar — which consumes ~15px of vertical space at the bottom of the iframe. Now `iframe.height` matches `content.scrollHeight`, but the visible content area is `iframe.height − scrollbar.height`, so 15px of content fall below the fold and the browser adds a vertical scrollbar to reach them.

Reproduced in DevTools on the live page:

```
iframeBoundingWidth: 648
docElementScrollWidth: 927   ← wider than the iframe → horizontal scrollbar
docElementScrollHeight: 153228 = iframeBoundingHeight  ← already correctly sized
```

## Fix

Constrain wide tables to the iframe width and scroll inside the table itself, matching the existing pattern for `<pre>` (`overflow-x: auto`). After the fix the scrollWidth equals the iframe width (648 = 648), so neither scrollbar appears.

The existing comment in `article-body.styles.css` reserves the iframe's own scrollbar as a debug signal for genuine height-calculation regressions — that intent is preserved (real height bugs still surface a scrollbar; this fix only addresses the width-overflow path).

A regression test in `reader-iframe-srcdoc.test.ts` asserts the table CSS rule is present in the embedded stylesheet.

`/ultrareview` is recommended here — the fix is one CSS rule but the failure mode (scrollbar caused by horizontal overflow eating vertical space) is easy to regress.

## Test plan

- [x] `pnpm nx test hutch` (1518 passed)
- [x] `pnpm lint` (clean)
- [x] Manually verified in a local Playwright browser against the production page that injecting the new CSS rule drops `docElementScrollWidth` from 927 → 648 (i.e. the horizontal overflow is gone, which is what removes the vertical scrollbar)

https://claude.ai/code/session_01HeyY6yy2oFfQttGrFwNwd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeyY6yy2oFfQttGrFwNwd3)_