### PR TITLE
feat(hutch): gate /queue subscription banner aside behind ?feature=subscription

### DIFF
--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -28,16 +28,20 @@ describe("bannerStateFromRequest", () => {
 		expect(bannerStateFromRequest({}).emailVerified).toBeUndefined();
 	});
 
-	it("sets showAccountMenu=true when query.feature is 'account'", () => {
-		expect(bannerStateFromRequest({ query: { feature: "account" } }).showAccountMenu).toBe(true);
+	it("sets showSubscription=true when query.feature is 'subscription'", () => {
+		expect(bannerStateFromRequest({ query: { feature: "subscription" } }).showSubscription).toBe(true);
 	});
 
-	it("sets showAccountMenu=false when query.feature is absent", () => {
-		expect(bannerStateFromRequest({}).showAccountMenu).toBe(false);
+	it("sets showSubscription=false when query.feature is absent", () => {
+		expect(bannerStateFromRequest({}).showSubscription).toBe(false);
 	});
 
-	it("sets showAccountMenu=false when query.feature is a different value", () => {
-		expect(bannerStateFromRequest({ query: { feature: "other" } }).showAccountMenu).toBe(false);
+	it("sets showSubscription=false when query.feature is a different value", () => {
+		expect(bannerStateFromRequest({ query: { feature: "other" } }).showSubscription).toBe(false);
+	});
+
+	it("sets showSubscription=false when query.feature is the legacy 'account' value (renamed to 'subscription')", () => {
+		expect(bannerStateFromRequest({ query: { feature: "account" } }).showSubscription).toBe(false);
 	});
 });
 
@@ -51,7 +55,7 @@ describe("initBuildBannerState", () => {
 
 		const result = await buildBannerState({});
 
-		expect(result).toEqual({ isAuthenticated: false, emailVerified: undefined, showAccountMenu: false });
+		expect(result).toEqual({ isAuthenticated: false, emailVerified: undefined, showSubscription: false });
 		expect(getEffectiveAccess).not.toHaveBeenCalled();
 	});
 

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -28,14 +28,18 @@ export interface BannerState {
 	 * pending cancellation; "active" for trialing users; "expired" for users
 	 * whose trial has lapsed or whose subscription was cancelled. */
 	trial?: TrialDisplay;
-	showAccountMenu?: boolean;
+	/** Single feature toggle (?feature=subscription) gating subscription-aware UI:
+	 * the /account menu entry in the header, and the queue-page banner aside
+	 * that surfaces either the trial countdown or the "subscription not active"
+	 * message. */
+	showSubscription?: boolean;
 }
 
 export function bannerStateFromRequest(source: BannerStateSource): BannerState {
 	return {
 		isAuthenticated: Boolean(source.userId),
 		emailVerified: source.emailVerified,
-		showAccountMenu: source.query?.feature === "account",
+		showSubscription: source.query?.feature === "subscription",
 	};
 }
 

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -111,20 +111,20 @@ describe("Base component", () => {
 		expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
 	});
 
-	it("renders the Account nav item when showAccountMenu is true", () => {
+	it("renders the Account nav item when showSubscription is true", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: true, emailVerified: true, showAccountMenu: true }).to("text/html");
+		const result = Base(page, { isAuthenticated: true, emailVerified: true, showSubscription: true }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		const link = doc.querySelector('[data-test-nav-item="account"]');
 		assert(link, "Account nav item must be rendered when feature flag is set");
 		expect(link.textContent).toBe("Account");
-		expect(link.getAttribute("href")).toBe("/account?feature=account");
+		expect(link.getAttribute("href")).toBe("/account?feature=subscription");
 	});
 
-	it("hides the Account nav item when showAccountMenu is false", () => {
+	it("hides the Account nav item when showSubscription is false", () => {
 		const page = createTestPageBody();
-		const result = Base(page, { isAuthenticated: true, emailVerified: true, showAccountMenu: false }).to("text/html");
+		const result = Base(page, { isAuthenticated: true, emailVerified: true, showSubscription: false }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
 		expect(doc.querySelector('[data-test-nav-item="account"]')).toBeNull();

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -36,7 +36,7 @@ const BASE_TEMPLATE = readFileSync(join(__dirname, "base.template.html"), "utf-8
 
 function renderHeader(
 	variant: "default" | "transparent",
-	options: { isAuthenticated: boolean; trial: TrialDisplay | undefined; showAccountMenu: boolean },
+	options: { isAuthenticated: boolean; trial: TrialDisplay | undefined; showSubscription: boolean },
 ): string {
 	const trial = options.trial;
 	return render(HEADER_TEMPLATE, {
@@ -49,7 +49,7 @@ function renderHeader(
 			trial?.state === "active" ? trial.escalation : "expired",
 		trialEndsAtIso: trial?.state === "active" ? trial.endsAtIso : "",
 		serverNowIso: trial?.state === "active" ? trial.serverNowIso : "",
-		showAccountMenu: options.showAccountMenu,
+		showSubscription: options.showSubscription,
 	});
 }
 
@@ -224,7 +224,7 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		header: renderHeader(headerVariant, {
 			isAuthenticated: state.isAuthenticated,
 			trial: state.trial,
-			showAccountMenu: state.showAccountMenu ?? false,
+			showSubscription: state.showSubscription ?? false,
 		}),
 		content: injectPageStylesIntoMain(body.content.html, body.styles),
 		footer: renderFooter(),

--- a/projects/hutch/src/runtime/web/header.template.html
+++ b/projects/hutch/src/runtime/web/header.template.html
@@ -23,7 +23,7 @@
             <li><a href="/queue" class="nav__link" data-test-nav-item="queue">Queue</a></li>
             <li><a href="/import?utm_source=header-nav&amp;utm_medium=internal&amp;utm_content=import-link" class="nav__link" data-test-nav-item="import">Import Links</a></li>
             <li><a href="/export" class="nav__link" data-test-nav-item="export">Export</a></li>
-            {{#if showAccountMenu}}<li><a href="/account?feature=account" class="nav__link" data-test-nav-item="account">Account</a></li>{{/if}}
+            {{#if showSubscription}}<li><a href="/account?feature=subscription" class="nav__link" data-test-nav-item="account">Account</a></li>{{/if}}
             <li>
               <form method="POST" action="/logout">
                 <button type="submit" class="nav__link" data-test-nav-item="logout">Sign out</button>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -6,7 +6,7 @@ import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { QUEUE_STYLES } from "./queue.styles";
 import { renderQueueCard, toQueueCardDisplayModel } from "./queue-card/queue-card.component";
-import type { QueueViewModel } from "./queue.viewmodel";
+import type { QueueViewModel, SubscriptionBannerState } from "./queue.viewmodel";
 import { buildQueueUrl } from "./queue.url";
 import { tabQuery } from "./queue.tabs";
 
@@ -54,7 +54,7 @@ export function formatUnreadLabel(count: number): string {
 	return count > 99 ? "To read (99+)" : `To read (${count})`;
 }
 
-function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; extensionSavedArticle: boolean; browser: BrowserName; onboardingDismissed: boolean }): QueueDisplayModel {
+function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: boolean; extensionSavedArticle: boolean; browser: BrowserName; onboardingDismissed: boolean; showSubscriptionBanner: boolean }): QueueDisplayModel {
 	const activeTab = vm.filters.tab;
 	const effectiveOrder = vm.filters.order ?? tabQuery(activeTab).defaultOrder;
 	const nextOrder = effectiveOrder === "desc" ? "asc" : "desc";
@@ -69,7 +69,13 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 			browser: options.browser,
 		});
 
-	const banner = vm.subscriptionBanner;
+	/** The queue-banner aside is gated by the ?feature=subscription toggle.
+	 * When the toggle is off we collapse the banner to state="none" so the
+	 * existing `.queue-banner--none { display: none }` CSS rule hides both
+	 * the trial countdown and the "Subscription not active" message. */
+	const banner: SubscriptionBannerState = options.showSubscriptionBanner
+		? vm.subscriptionBanner
+		: { state: "none" };
 	return {
 		saveError: vm.errors?.[0]?.message,
 		saveErrorCode: vm.saveErrorCode,
@@ -123,9 +129,9 @@ const AUTO_SUBMIT_SCRIPT = `
 </script>
 `;
 
-export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; extensionSavedArticle?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; statusCode?: number }): PageBody {
+export function QueuePage(vm: QueueViewModel, options?: { saveUrl?: string; extensionInstalled?: boolean; extensionSavedArticle?: boolean; browser?: BrowserName; onboardingDismissed?: boolean; showSubscriptionBanner?: boolean; statusCode?: number }): PageBody {
 	const saveUrl = options?.saveUrl;
-	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, extensionSavedArticle: options?.extensionSavedArticle ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false });
+	const displayModel = toQueueDisplayModel(vm, { extensionInstalled: options?.extensionInstalled ?? false, extensionSavedArticle: options?.extensionSavedArticle ?? false, browser: options?.browser ?? "other", onboardingDismissed: options?.onboardingDismissed ?? false, showSubscriptionBanner: options?.showSubscriptionBanner ?? false });
 	const content = render(QUEUE_TEMPLATE, { ...displayModel, saveUrl });
 
 	const scriptParts: string[] = [];

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -329,10 +329,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		 * again so they can install the extension here. */
 		const onboardingDismissed = extensionInstalled && req.cookies?.[DISMISS_COOKIE_NAME] === ONBOARDING_VERSION;
 		const browser = detectBrowser(req);
+		const showSubscriptionBanner = deps.featureToggle.isEnabled(req, "subscription");
 		sendComponent(
 			req, res,
 			Base(
-				QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed }),
+				QueuePage(vm, { saveUrl: filterUrl, extensionInstalled, extensionSavedArticle, browser, onboardingDismissed, showSubscriptionBanner }),
 				await deps.buildBannerState(req, { preFetchedAccess: effectiveAccess }),
 			),
 		);
@@ -521,7 +522,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				summaryByUrl,
 				crawlByUrl,
 			});
-			sendComponent(req, res, Base(QueuePage(vm, { statusCode: 422 }), await deps.buildBannerState(req)));
+			const showSubscriptionBanner = deps.featureToggle.isEnabled(req, "subscription");
+			sendComponent(req, res, Base(QueuePage(vm, { statusCode: 422, showSubscriptionBanner }), await deps.buildBannerState(req)));
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
@@ -23,7 +23,7 @@ describe("Queue page banner state", () => {
 		const { auth } = harness;
 		const agent = await loginAgent(harness.server, auth);
 
-		const response = await agent.get("/queue");
+		const response = await agent.get("/queue?feature=subscription");
 		const doc = new JSDOM(response.text).window.document;
 		const banner = doc.querySelector("[data-test-subscription-banner]");
 		assert(banner, "queue banner aside must always be rendered");
@@ -31,7 +31,7 @@ describe("Queue page banner state", () => {
 		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
 	});
 
-	it("renders the header trial countdown and the queue aside trial-countdown banner for a trialing user", async () => {
+	it("renders the header trial countdown and the queue aside trial-countdown banner for a trialing user (?feature=subscription enabled)", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "trialing@example.com");
@@ -40,7 +40,7 @@ describe("Queue page banner state", () => {
 			trialEndsAt: new Date(Date.now() + 7 * ONE_DAY_MS).toISOString(),
 		});
 
-		const response = await agent.get("/queue");
+		const response = await agent.get("/queue?feature=subscription");
 		const doc = new JSDOM(response.text).window.document;
 		const countdown = doc.querySelector("[data-test-trial-countdown]");
 		assert(countdown, "global trial countdown must be rendered for a trialing user");
@@ -53,6 +53,23 @@ describe("Queue page banner state", () => {
 		expect(banner.classList.contains("queue-banner--trial-countdown")).toBe(true);
 	});
 
+	it("hides the queue aside trial-countdown banner for a trialing user when ?feature=subscription is not set (toggle off)", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { subscriptionProviders } = harness;
+		const { agent, userId } = await loginUser(harness, "trialing-no-toggle@example.com");
+		await subscriptionProviders.upsertTrialing({
+			userId,
+			trialEndsAt: new Date(Date.now() + 7 * ONE_DAY_MS).toISOString(),
+		});
+
+		const response = await agent.get("/queue");
+		const doc = new JSDOM(response.text).window.document;
+		const banner = doc.querySelector("[data-test-subscription-banner]");
+		assert(banner, "queue banner aside must always be rendered");
+		expect(banner.classList.contains("queue-banner--none")).toBe(true);
+		expect(banner.textContent?.trim()).toBe("");
+	});
+
 	it("flips the header countdown to 'Free trial is over!' and disables the save form after the trial window ends", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;
@@ -62,7 +79,7 @@ describe("Queue page banner state", () => {
 			trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
 		});
 
-		const response = await agent.get("/queue");
+		const response = await agent.get("/queue?feature=subscription");
 		const doc = new JSDOM(response.text).window.document;
 		const countdown = doc.querySelector("[data-test-trial-countdown]");
 		assert(countdown, "global trial countdown must be rendered for an expired-trial user");
@@ -77,6 +94,28 @@ describe("Queue page banner state", () => {
 		const banner = doc.querySelector("[data-test-subscription-banner]");
 		assert(banner, "queue banner aside must be rendered");
 		expect(banner.classList.contains("queue-banner--inactive")).toBe(true);
+	});
+
+	it("hides the queue aside inactive banner for an expired-trial user when ?feature=subscription is not set (save form still disabled)", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { subscriptionProviders } = harness;
+		const { agent, userId } = await loginUser(harness, "expired-no-toggle@example.com");
+		await subscriptionProviders.upsertTrialing({
+			userId,
+			trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+		});
+
+		const response = await agent.get("/queue");
+		const doc = new JSDOM(response.text).window.document;
+		const banner = doc.querySelector("[data-test-subscription-banner]");
+		assert(banner, "queue banner aside must always be rendered");
+		expect(banner.classList.contains("queue-banner--none")).toBe(true);
+		expect(banner.textContent?.trim()).toBe("");
+		/** Save-form gating is independent of the banner toggle: the queue
+		 * still goes read-only when the user's access is read-only. */
+		const saveForm = doc.querySelector('[data-test-form="save-article"]');
+		assert(saveForm, "save form must still be rendered");
+		expect(saveForm.classList.contains("queue__save-form--disabled")).toBe(true);
 	});
 
 	it("treats a legacy pending_cancellation row as inactive (no flow in the redesigned chain produces this state)", async () => {
@@ -94,7 +133,7 @@ describe("Queue page banner state", () => {
 			cancellationEffectiveAt: effectiveAt,
 		});
 
-		const response = await agent.get("/queue");
+		const response = await agent.get("/queue?feature=subscription");
 		const doc = new JSDOM(response.text).window.document;
 		const banner = doc.querySelector("[data-test-subscription-banner]");
 		assert(banner, "queue banner must always be rendered");


### PR DESCRIPTION
## Summary

Rename the `?feature=account` toggle to `?feature=subscription` so a single flag now controls **all** subscription-aware UI on the `/queue` page:

- the `/account` menu entry in the header (existing behaviour)
- the "**14 days left** in your free trial" trial-countdown CTA in the queue-banner aside (newly gated)
- the "**Subscription not active**" CTA in the queue-banner aside (newly gated)

When the toggle is off, the queue-banner aside collapses to `state="none"` so the existing `.queue-banner--none { display: none }` CSS rule hides both messages. Save-form gating stays independent: a read-only user still gets the disabled save form regardless of the banner toggle.

### Files changed

| File | Change |
|------|--------|
| `banner-state.ts` / `.test.ts` | `showAccountMenu` → `showSubscription`; reads `?feature=subscription` |
| `header.template.html` | Account nav link points to `/account?feature=subscription` |
| `base.component.ts` / `.test.ts` | Pass `showSubscription` through to the header template |
| `queue.component.ts` | New `showSubscriptionBanner` option; collapses banner to `state="none"` when off |
| `queue.page.ts` | Reads the toggle via `QuerystringFeatureToggle` on `GET /` and the `POST /save` validation-error rerender |
| `queue.subscription-banner.route.test.ts` | Adds `?feature=subscription` to all banner-asserting requests; two new tests cover the toggle-off path |

## Test plan

- [x] `pnpm test` — 1598 tests pass (140 suites)
- [x] `pnpm test-with-coverage` — all coverage thresholds met (99.64% statements, 96.01% branches, 100% functions)
- [x] `pnpm lint` — biome + knip + tsc + unused-CSS all clean
- [x] `pnpm check` (pre-commit hook) — full check ran on commit and passed

https://claude.ai/code/session_01LULDCqw3AcgJzVT8bEQooU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LULDCqw3AcgJzVT8bEQooU)_