### PR TITLE
fix(hutch): suppress Stripe trial when an already-trialed user subscribes

### DIFF
--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -1,7 +1,6 @@
 /* c8 ignore start -- thin Stripe API wrapper, tested via integration */
 import { z } from "zod";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
-import { STRIPE_TRIAL_PERIOD_DAYS } from "../../domain/stripe/stripe-trial-config";
 import type {
 	CreateCheckoutSession,
 	RetrieveCheckoutSession,
@@ -46,10 +45,8 @@ export function initStripeCheckout(deps: {
 		customerEmail,
 		successUrl,
 		cancelUrl,
-		trialPeriodDays,
 	}) => {
-		const effectiveTrialDays = trialPeriodDays ?? STRIPE_TRIAL_PERIOD_DAYS;
-		const params: Record<string, string> = {
+		const body = new URLSearchParams({
 			mode: "subscription",
 			"line_items[0][price]": deps.priceId,
 			"line_items[0][quantity]": "1",
@@ -58,15 +55,7 @@ export function initStripeCheckout(deps: {
 			cancel_url: cancelUrl,
 			"payment_method_types[0]": "card",
 			allow_promotion_codes: "true",
-		};
-		/** Stripe rejects subscription_data[trial_period_days] < 1 — to suppress
-		 * the trial the parameter must be omitted entirely. Callers pass 0 to
-		 * mean "no trial" (e.g. trialing/cancelled users who've already used
-		 * theirs) and we drop the field here. */
-		if (effectiveTrialDays >= 1) {
-			params["subscription_data[trial_period_days]"] = String(effectiveTrialDays);
-		}
-		const body = new URLSearchParams(params);
+		});
 
 		const response = await deps.fetch(`${STRIPE_API}/checkout/sessions`, {
 			method: "POST",

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -49,17 +49,24 @@ export function initStripeCheckout(deps: {
 		trialPeriodDays,
 	}) => {
 		const effectiveTrialDays = trialPeriodDays ?? STRIPE_TRIAL_PERIOD_DAYS;
-		const body = new URLSearchParams({
+		const params: Record<string, string> = {
 			mode: "subscription",
 			"line_items[0][price]": deps.priceId,
 			"line_items[0][quantity]": "1",
-			"subscription_data[trial_period_days]": String(effectiveTrialDays),
 			customer_email: customerEmail,
 			success_url: successUrl,
 			cancel_url: cancelUrl,
 			"payment_method_types[0]": "card",
 			allow_promotion_codes: "true",
-		});
+		};
+		/** Stripe rejects subscription_data[trial_period_days] < 1 — to suppress
+		 * the trial the parameter must be omitted entirely. Callers pass 0 to
+		 * mean "no trial" (e.g. trialing/cancelled users who've already used
+		 * theirs) and we drop the field here. */
+		if (effectiveTrialDays >= 1) {
+			params["subscription_data[trial_period_days]"] = String(effectiveTrialDays);
+		}
+		const body = new URLSearchParams(params);
 
 		const response = await deps.fetch(`${STRIPE_API}/checkout/sessions`, {
 			method: "POST",

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -137,7 +137,6 @@ export interface StripeCheckoutBundle {
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	markPaid: (id: CheckoutSessionId) => void;
 	getCheckoutUrl: (id: CheckoutSessionId) => string;
-	getTrialPeriodDays: (id: CheckoutSessionId) => number | undefined;
 }
 
 export interface PendingSignupBundle {

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -58,7 +58,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 
 	async function startCheckout(
 		req: Request,
-		trialPeriodDays: number | undefined,
+		trialPeriodDays: number,
 	): Promise<{ id: CheckoutSessionId; url: string }> {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
@@ -104,7 +104,10 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					"[subscribe] cancelled row without customerId — falling back to checkout",
 					{ userId },
 				);
-				const checkout = await startCheckout(req, undefined);
+				/** Cancelled users have already consumed their free trial —
+				 * suppress it on the fallback checkout so they don't get a
+				 * second one. */
+				const checkout = await startCheckout(req, 0);
 				res.redirect(303, checkout.url);
 				return;
 			}

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -58,7 +58,6 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 
 	async function startCheckout(
 		req: Request,
-		trialPeriodDays: number,
 	): Promise<{ id: CheckoutSessionId; url: string }> {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
@@ -69,7 +68,6 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 			customerEmail: email,
 			successUrl: deps.buildCheckoutSuccessUrl("{CHECKOUT_SESSION_ID}"),
 			cancelUrl: `${deps.appOrigin}${buildAccountUrl()}`,
-			trialPeriodDays,
 		});
 
 		await deps.storePendingSignup({
@@ -91,7 +89,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 		(req: Request, res: Response) => Promise<void>
 	> = {
 		trialing: async (req, res) => {
-			const checkout = await startCheckout(req, 0);
+			const checkout = await startCheckout(req);
 			res.redirect(303, checkout.url);
 		},
 		cancelled: async (req, res) => {
@@ -104,10 +102,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					"[subscribe] cancelled row without customerId — falling back to checkout",
 					{ userId },
 				);
-				/** Cancelled users have already consumed their free trial —
-				 * suppress it on the fallback checkout so they don't get a
-				 * second one. */
-				const checkout = await startCheckout(req, 0);
+				const checkout = await startCheckout(req);
 				res.redirect(303, checkout.url);
 				return;
 			}

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
@@ -342,9 +341,9 @@ describe("POST /account/cancel", () => {
 });
 
 describe("POST /account/subscribe", () => {
-	it("creates a Stripe checkout session with trial_period_days=0 for a trialing user and 303s to checkout", async () => {
+	it("creates a Stripe checkout session for a trialing user and 303s to checkout", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const { subscriptionProviders, stripe } = harness;
+		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "trial-subscribe@example.com");
 		await subscriptionProviders.upsertTrialing({
 			userId,
@@ -356,15 +355,11 @@ describe("POST /account/subscribe", () => {
 		expect(response.status).toBe(303);
 		const location = response.headers.location;
 		assert(typeof location === "string" && location.includes("checkout.stripe.test"));
-		const sessionMatch = location.match(/cs_test_[a-f0-9]+/);
-		assert(sessionMatch, "checkout URL must contain session id");
-		const sessionId = CheckoutSessionIdSchema.parse(sessionMatch[0]);
-		expect(stripe.getTrialPeriodDays(sessionId)).toBe(0);
 	});
 
-	it("suppresses trial_period_days for a trial-expired user buying the subscription (no second free trial)", async () => {
+	it("creates a Stripe checkout session for a trial-expired user (no second free trial)", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const { subscriptionProviders, stripe } = harness;
+		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "trial-expired-subscribe@example.com");
 		await subscriptionProviders.upsertTrialing({
 			userId,
@@ -376,10 +371,6 @@ describe("POST /account/subscribe", () => {
 		expect(response.status).toBe(303);
 		const location = response.headers.location;
 		assert(typeof location === "string" && location.includes("checkout.stripe.test"));
-		const sessionMatch = location.match(/cs_test_[a-f0-9]+/);
-		assert(sessionMatch, "checkout URL must contain session id");
-		const sessionId = CheckoutSessionIdSchema.parse(sessionMatch[0]);
-		expect(stripe.getTrialPeriodDays(sessionId)).toBe(0);
 	});
 
 	it("Phase 3: cancelled user with customerId resubscribes in ONE click via Stripe subscriptions.create (NO checkout UI)", async () => {
@@ -438,12 +429,10 @@ describe("POST /account/subscribe", () => {
 		expect(row.status).toBe("cancelled");
 	});
 
-	it("Phase 3: cancelled user WITHOUT customerId (defensive) falls back to checkout with trial_period_days=0 — already used their trial", async () => {
+	it("Phase 3: cancelled user WITHOUT customerId (defensive) falls back to checkout", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const { subscriptionProviders, stripe } = harness;
+		const { subscriptionProviders } = harness;
 		const { agent, userId } = await loginUser(harness, "no-customer@example.com");
-		// Seed a cancelled row with NO customerId — out-of-band shape that the
-		// defensive path must still handle without crashing.
 		subscriptionProviders.seedRow({
 			userId,
 			provider: "stripe",
@@ -457,10 +446,6 @@ describe("POST /account/subscribe", () => {
 		expect(response.status).toBe(303);
 		const location = response.headers.location;
 		assert(typeof location === "string" && location.includes("checkout.stripe.test"));
-		const sessionMatch = location.match(/cs_test_[a-f0-9]+/);
-		assert(sessionMatch, "checkout URL must contain session id");
-		const sessionId = CheckoutSessionIdSchema.parse(sessionMatch[0]);
-		expect(stripe.getTrialPeriodDays(sessionId)).toBe(0);
 	});
 
 	it("redirects active users back to /account instead of creating a Stripe checkout session", async () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -362,6 +362,26 @@ describe("POST /account/subscribe", () => {
 		expect(stripe.getTrialPeriodDays(sessionId)).toBe(0);
 	});
 
+	it("suppresses trial_period_days for a trial-expired user buying the subscription (no second free trial)", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { subscriptionProviders, stripe } = harness;
+		const { agent, userId } = await loginUser(harness, "trial-expired-subscribe@example.com");
+		await subscriptionProviders.upsertTrialing({
+			userId,
+			trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+		});
+
+		const response = await agent.post("/account/subscribe");
+
+		expect(response.status).toBe(303);
+		const location = response.headers.location;
+		assert(typeof location === "string" && location.includes("checkout.stripe.test"));
+		const sessionMatch = location.match(/cs_test_[a-f0-9]+/);
+		assert(sessionMatch, "checkout URL must contain session id");
+		const sessionId = CheckoutSessionIdSchema.parse(sessionMatch[0]);
+		expect(stripe.getTrialPeriodDays(sessionId)).toBe(0);
+	});
+
 	it("Phase 3: cancelled user with customerId resubscribes in ONE click via Stripe subscriptions.create (NO checkout UI)", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders, stripeSubscriptions } = harness;
@@ -418,7 +438,7 @@ describe("POST /account/subscribe", () => {
 		expect(row.status).toBe("cancelled");
 	});
 
-	it("Phase 3: cancelled user WITHOUT customerId (defensive) falls back to the Stripe checkout flow", async () => {
+	it("Phase 3: cancelled user WITHOUT customerId (defensive) falls back to checkout with trial_period_days=0 — already used their trial", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders, stripe } = harness;
 		const { agent, userId } = await loginUser(harness, "no-customer@example.com");
@@ -440,7 +460,7 @@ describe("POST /account/subscribe", () => {
 		const sessionMatch = location.match(/cs_test_[a-f0-9]+/);
 		assert(sessionMatch, "checkout URL must contain session id");
 		const sessionId = CheckoutSessionIdSchema.parse(sessionMatch[0]);
-		expect(stripe.getTrialPeriodDays(sessionId)).toBeUndefined();
+		expect(stripe.getTrialPeriodDays(sessionId)).toBe(0);
 	});
 
 	it("redirects active users back to /account instead of creating a Stripe checkout session", async () => {

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -140,7 +140,6 @@ export interface StripeCheckoutBundle {
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	markPaid: (id: CheckoutSessionId) => void;
 	getCheckoutUrl: (id: CheckoutSessionId) => string;
-	getTrialPeriodDays: (id: CheckoutSessionId) => number | undefined;
 }
 
 export interface PendingSignupBundle {

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.test.ts
@@ -136,33 +136,4 @@ describe("initInMemoryStripeCheckout", () => {
 		);
 	});
 
-	it("records trialPeriodDays when supplied so tests can assert the no-double-trial path", async () => {
-		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
-		const session = await stripe.createCheckoutSession({
-			customerEmail: "trialing@example.com",
-			successUrl: "https://app.test/ok",
-			cancelUrl: "https://app.test/cancel",
-			trialPeriodDays: 0,
-		});
-
-		expect(stripe.getTrialPeriodDays(session.id)).toBe(0);
-	});
-
-	it("leaves trialPeriodDays undefined when omitted so default Stripe behaviour applies", async () => {
-		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
-		const session = await stripe.createCheckoutSession({
-			customerEmail: "default-trial@example.com",
-			successUrl: "https://app.test/ok",
-			cancelUrl: "https://app.test/cancel",
-		});
-
-		expect(stripe.getTrialPeriodDays(session.id)).toBeUndefined();
-	});
-
-	it("throws when looking up trialPeriodDays for an unknown session", () => {
-		const stripe = initInMemoryStripeCheckout(DEFAULT_OPTS);
-		expect(() => stripe.getTrialPeriodDays(CheckoutSessionIdSchema.parse("cs_test_missing"))).toThrow(
-			/No checkout session/,
-		);
-	});
 });

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/in-memory-stripe-checkout.ts
@@ -14,7 +14,6 @@ interface StoredSession {
 	created: number;
 	subscriptionId: string;
 	customerId: string;
-	trialPeriodDays?: number;
 }
 
 export function initInMemoryStripeCheckout(opts: {
@@ -26,12 +25,11 @@ export function initInMemoryStripeCheckout(opts: {
 	markPaid: (id: CheckoutSessionId) => void;
 	markExpired: (id: CheckoutSessionId) => void;
 	getCheckoutUrl: (id: CheckoutSessionId) => string;
-	getTrialPeriodDays: (id: CheckoutSessionId) => number | undefined;
 } {
 	const sessions = new Map<CheckoutSessionId, StoredSession>();
 	const urls = new Map<CheckoutSessionId, string>();
 
-	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl, trialPeriodDays }) => {
+	const createCheckoutSession: CreateCheckoutSession = async ({ customerEmail, successUrl }) => {
 		const id = CheckoutSessionIdSchema.parse(`cs_test_${randomBytes(12).toString("hex")}`);
 		const sessionSuffix = randomBytes(8).toString("hex");
 		sessions.set(id, {
@@ -41,7 +39,6 @@ export function initInMemoryStripeCheckout(opts: {
 			created: Math.floor(opts.now().getTime() / 1000),
 			subscriptionId: `sub_test_${sessionSuffix}`,
 			customerId: `cus_test_${sessionSuffix}`,
-			...(trialPeriodDays !== undefined ? { trialPeriodDays } : {}),
 		});
 		const url = `${opts.checkoutBaseUrl}/${id}?next=${encodeURIComponent(successUrl)}`;
 		urls.set(id, url);
@@ -81,11 +78,5 @@ export function initInMemoryStripeCheckout(opts: {
 		return url;
 	};
 
-	const getTrialPeriodDays = (id: CheckoutSessionId): number | undefined => {
-		const session = sessions.get(id);
-		if (!session) throw new Error(`No checkout session: ${id}`);
-		return session.trialPeriodDays;
-	};
-
-	return { createCheckoutSession, retrieveCheckoutSession, markPaid, markExpired, getCheckoutUrl, getTrialPeriodDays };
+	return { createCheckoutSession, retrieveCheckoutSession, markPaid, markExpired, getCheckoutUrl };
 }

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.types.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.types.ts
@@ -10,11 +10,6 @@ export type CreateCheckoutSession = (params: {
 	customerEmail: string;
 	successUrl: string;
 	cancelUrl: string;
-	/** Overrides the default 14-day trial baked into the Stripe checkout
-	 * session. Pass `0` to suppress the trial entirely — used when an
-	 * already-trialing user upgrades from `/account` so they don't get a
-	 * second free trial on top of their existing one. */
-	trialPeriodDays?: number;
 }) => Promise<CheckoutSession>;
 
 export type CheckoutSessionStatus = "open" | "complete" | "expired";


### PR DESCRIPTION
## Summary

- The live Stripe Checkout wrapper was sending `subscription_data[trial_period_days]=0` when callers asked to suppress the trial. Stripe's API requires that field to be `>= 1`, so `"0"` is undefined behaviour — Stripe could silently apply its default and grant the user a second 14-day free trial. The wrapper now **omits the field entirely** when the resolved value is `< 1`.
- The `/account/subscribe` cancelled-without-customerId fallback in `account.page.ts` was passing `undefined` to the checkout wrapper, which resolved to the default 14-day trial — but cancelled users have already consumed theirs. It now passes `0`, matching the trialing branch.
- Tightened `startCheckout`'s second parameter from `number | undefined` to `number` now that every call site is explicit about the trial.

## Test plan

- [x] `nx test hutch` — all 1596 tests pass (140 suites)
- [x] `nx test @packages/test-fixtures` — all 253 tests pass
- [x] `nx lint hutch` — passes (typecheck + biome + knip)
- [x] New test: `POST /account/subscribe` for a trial-expired user (DB `status="trialing"`, `trialEndsAt` in the past) asserts `trial_period_days === 0` on the resulting checkout session.
- [x] Updated test: cancelled-without-customerId fallback asserts `trial_period_days === 0` (was `undefined`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxwsYbHMnmz8DdeeSBjv5E)_