### PR TITLE
docs(save-link): correct curl-impersonate layer contents comment

### DIFF
--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -68,8 +68,9 @@ const ocrImageTags = z
 	.parse(JSON.parse(readFileSync(".lib/ocr-image-tags.json", "utf-8")));
 
 // --- curl-impersonate Lambda Layer ---
-// Contains the curl_chrome116 binary + BoringSSL shared libraries that produce
-// a Chrome TLS fingerprint, bypassing Akamai/Cloudflare JA3/JA4 blocks.
+// Contains the curl_chrome116 bash wrapper and the statically-linked
+// curl-impersonate-chrome binary (BoringSSL embedded) that produce a Chrome
+// TLS fingerprint, bypassing Akamai/Cloudflare JA3/JA4 blocks.
 // Built by tools/build-curl-impersonate-layer.mjs before `pulumi up`.
 const curlImpersonateLayer = new aws.lambda.LayerVersion("curl-impersonate", {
 	layerName: "curl-impersonate-chrome",


### PR DESCRIPTION
## Summary

- The comment above `curlImpersonateLayer` in `projects/save-link/src/infra/index.ts` claimed the layer ships "the curl_chrome116 binary + BoringSSL shared libraries", but `tools/build-curl-impersonate-layer.mjs` only stages the `curl_chrome116` bash wrapper and the statically-linked `curl-impersonate-chrome` binary (v0.8.0+ embeds BoringSSL — no `.so` files).
- Reworded the comment to match what the build script actually copies into `/opt/bin`.

## Test plan

- [ ] Comment-only change; no runtime behaviour affected. Verify CI passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm7As1x4k5hxuGqiF7XSXV)_