### PR TITLE
feat(hutch): surface public expiry in red and add Never expires hint

### DIFF
--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -108,6 +108,41 @@ describe("ViewPage", () => {
 		expect(link.textContent).toBe("Read in your queue");
 	});
 
+	it("renders an action's hint as a small caption below the button when provided", () => {
+		const doc = render({
+			...baseInput,
+			actions: [
+				{
+					name: "Save to My Queue",
+					href: "/save?url=x",
+					variant: "primary",
+					hint: "Never expires",
+				},
+			],
+		});
+
+		const hint = doc.querySelector("[data-test-view-cta-hint]");
+		assert(hint, "cta hint must be rendered when hint is provided");
+		assert.equal(hint.tagName, "SMALL");
+		assert.equal(hint.textContent, "Never expires");
+	});
+
+	it("omits the hint element when an action has no hint", () => {
+		const doc = render({
+			...baseInput,
+			actions: [
+				{
+					name: "Paste another link",
+					href: "/view",
+					variant: "secondary",
+				},
+			],
+		});
+
+		const hints = doc.querySelectorAll("[data-test-view-cta-hint]");
+		assert.equal(hints.length, 0);
+	});
+
 	it("renders multiple actions when the model has more than one", () => {
 		const doc = render({
 			...baseInput,

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -139,6 +139,8 @@ describe("ViewPage", () => {
 			],
 		});
 
+		const action = doc.querySelector("[data-test-view-cta-action]");
+		assert(action, "cta action must be rendered so selector is valid");
 		const hints = doc.querySelectorAll("[data-test-view-cta-hint]");
 		assert.equal(hints.length, 0);
 	});

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -50,6 +50,7 @@ export interface ViewAction {
 	href: string;
 	variant: "primary" | "secondary";
 	expirySaveLink?: boolean;
+	hint?: string;
 }
 
 export type ExpiryState = "permanent" | "counting" | "expired";

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -204,6 +204,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				href: `/save?${saveParams.toString()}`,
 				variant: "primary",
 				expirySaveLink: counting,
+				hint: "Never expires",
 			},
 			{
 				name: "Paste another link",

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -204,7 +204,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				href: `/save?${saveParams.toString()}`,
 				variant: "primary",
 				expirySaveLink: counting,
-				hint: "Never expires",
+				...(expiresAt !== null ? { hint: "Never expires" } : {}),
 			},
 			{
 				name: "Paste another link",

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -202,6 +202,9 @@ describe("View routes", () => {
 			const parsed = new URL(href, "http://localhost");
 			expect(parsed.pathname).toBe("/save");
 			expect(parsed.searchParams.get("url")).toBe(ARTICLE_URL);
+			const hint = doc.querySelector("[data-test-view-cta-hint]");
+			assert(hint, "Save action must surface the 'Never expires' hint");
+			expect(hint.textContent).toBe("Never expires");
 		});
 
 		it("includes utm_* query params in the Save action href", async () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1335,6 +1335,8 @@ describe("View routes", () => {
 			const parsed = new URL(href, "http://localhost");
 			expect(parsed.searchParams.get("utm_content")).toBe(null);
 			expect(action.hasAttribute("data-expiry-save-link")).toBe(false);
+			const hint = doc.querySelector("[data-test-view-cta-hint]");
+			expect(hint).toBe(null);
 		});
 
 		it("re-saving an article (savedAt bump) resets the counter to the full 3-day window", async () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.styles.css
+++ b/projects/hutch/src/runtime/web/pages/view/view.styles.css
@@ -23,6 +23,13 @@
   margin: 0 auto;
 }
 
+.view__cta-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+
 .view__cta-btn {
   display: block;
   box-sizing: border-box;
@@ -35,6 +42,13 @@
   text-align: center;
   text-decoration: none;
   cursor: pointer;
+}
+
+.view__cta-hint {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--color-error);
+  text-align: center;
 }
 
 /* purgecss-ignore-start: modifier suffix is interpolated from ViewAction.variant in view.template.html */
@@ -88,7 +102,7 @@
 }
 
 .view__expiry--counting {
-  color: var(--color-text-muted);
+  color: var(--color-error);
 }
 
 .view__expiry--expired {

--- a/projects/hutch/src/runtime/web/pages/view/view.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view.template.html
@@ -9,7 +9,10 @@
     <aside class="view__cta" data-test-view-cta>
       <div class="view__cta-content">
         {{#each actions}}
-        <a class="view__cta-btn view__cta-btn--{{variant}}" href="{{href}}" data-test-view-cta-action{{#if expirySaveLink}} data-expiry-save-link{{/if}}>{{name}}</a>
+        <div class="view__cta-item">
+          <a class="view__cta-btn view__cta-btn--{{variant}}" href="{{href}}" data-test-view-cta-action{{#if expirySaveLink}} data-expiry-save-link{{/if}}>{{name}}</a>
+          {{#if hint}}<small class="view__cta-hint" data-test-view-cta-hint>{{hint}}</small>{{/if}}
+        </div>
         {{/each}}
       </div>
       <p class="view__expiry view__expiry--{{expiryState}}" data-test-view-expiry data-expiry-state="{{expiryState}}"{{#if expiresAtIso}} data-expires-at="{{expiresAtIso}}"{{/if}}>{{expiryMessage}}</p>


### PR DESCRIPTION
## Summary

- Switch the `Public access will expire in …` copy from `--color-text-muted` to `--color-error` so the deadline stops blending into the surrounding chrome.
- Add an optional `hint` to `ViewAction` and set `"Never expires"` on the Save to My Queue button, rendered as a small `<small data-test-view-cta-hint>` in the same red so the contrast with the expiring public link is immediate.
- Wrap each CTA in a `view__cta-item` flex column so the button + hint stack cleanly under one action without affecting the side-by-side layout.

## Test plan

- [x] `nx test hutch` — 1656 unit/integration tests pass, including new coverage for the hint rendering both with and without the field set, and the route-level assertion that the Save action surfaces the copy.
- [x] `nx check hutch` — 100% statements/functions/lines, branch coverage threshold met, unused-CSS check clean.
- [x] `nx lint hutch` — biome + knip + tsc + unused-css all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VR8sHVZLYwfUpnuNAGmuqk)_