### PR TITLE
refactor: type publishEvent generically over HutchEvent constants

### DIFF
--- a/projects/hutch/src/runtime/export-user-data/export-user-data-handler.test.ts
+++ b/projects/hutch/src/runtime/export-user-data/export-user-data-handler.test.ts
@@ -3,6 +3,7 @@ import type { SQSBatchResponse, SQSEvent, SQSRecord, SQSRecordAttributes } from 
 import { initInMemoryArticleStore } from "@packages/test-fixtures/providers/article-store";
 import type { Minutes } from "@packages/domain/article";
 import type { UserId } from "@packages/domain/user";
+import { UserDataExportedEvent } from "@packages/hutch-infra-components";
 import type { UploadUserDataExport } from "../providers/user-data-export/user-data-export.types";
 import { initExportUserDataHandler } from "./export-user-data-handler";
 
@@ -64,11 +65,11 @@ function createHarness(): HandlerHarness {
 		sendEmail: async (msg) => {
 			emailCalls.push({ to: msg.to, subject: msg.subject, html: msg.html });
 		},
-		publishEvent: async (params: { source: string; detailType: string; detail: string }) => {
+		publishEvent: async (event, detail) => {
 			publishedEvents.push({
-				source: params.source,
-				detailType: params.detailType,
-				detail: JSON.parse(params.detail),
+				source: event.source,
+				detailType: event.detailType,
+				detail,
 			});
 		},
 		logger: HutchLogger.from(noopLogger),
@@ -130,7 +131,8 @@ describe("initExportUserDataHandler", () => {
 		expect(email.html).toContain("7 days");
 
 		expect(harness.publishedEvents).toHaveLength(1);
-		expect(harness.publishedEvents[0].detailType).toBe("UserDataExported");
+		expect(harness.publishedEvents[0].source).toBe(UserDataExportedEvent.source);
+		expect(harness.publishedEvents[0].detailType).toBe(UserDataExportedEvent.detailType);
 		expect(harness.publishedEvents[0].detail).toEqual({
 			userId,
 			articleCount: 1,
@@ -248,8 +250,8 @@ describe("initExportUserDataHandler", () => {
 			sendEmail: async (msg) => {
 				emailCalls.push({ to: msg.to });
 			},
-			publishEvent: async (params) => {
-				publishedEvents.push({ detail: JSON.parse(params.detail) });
+			publishEvent: async (_event, detail) => {
+				publishedEvents.push({ detail });
 			},
 			logger: HutchLogger.from(noopLogger),
 			now: fixedNow,

--- a/projects/hutch/src/runtime/export-user-data/export-user-data-handler.ts
+++ b/projects/hutch/src/runtime/export-user-data/export-user-data-handler.ts
@@ -121,15 +121,11 @@ async function processCommand(
 		to: detail.email,
 	});
 
-	await deps.publishEvent({
-		source: UserDataExportedEvent.source,
-		detailType: UserDataExportedEvent.detailType,
-		detail: JSON.stringify({
-			userId: detail.userId,
-			articleCount: articles.length,
-			s3Key,
-			exportedAt,
-		}),
+	await deps.publishEvent(UserDataExportedEvent, {
+		userId: detail.userId,
+		articleCount: articles.length,
+		s3Key,
+		exportedAt,
 	});
 
 	deps.logger.info("[ExportUserData] export completed", {

--- a/projects/hutch/src/runtime/providers/events/eventbridge-cancel-subscription-command.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-cancel-subscription-command.ts
@@ -6,20 +6,9 @@ import type { PublishCancelSubscriptionCommand } from "@packages/test-fixtures/p
 export function initEventBridgeCancelSubscriptionCommand(deps: {
 	publishEvent: PublishEvent;
 }): { publishCancelSubscriptionCommand: PublishCancelSubscriptionCommand } {
-	const { publishEvent } = deps;
-
-	const publishCancelSubscriptionCommand: PublishCancelSubscriptionCommand = async (params) => {
-		await publishEvent({
-			source: CancelSubscriptionCommand.source,
-			detailType: CancelSubscriptionCommand.detailType,
-			detail: JSON.stringify(
-				CancelSubscriptionCommand.detailSchema.parse({
-					userId: params.userId,
-				}),
-			),
-		});
+	return {
+		publishCancelSubscriptionCommand: (params) =>
+			deps.publishEvent(CancelSubscriptionCommand, params),
 	};
-
-	return { publishCancelSubscriptionCommand };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-export-user-data-command.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-export-user-data-command.ts
@@ -6,20 +6,9 @@ import type { PublishExportUserDataCommand } from "@packages/test-fixtures/provi
 export function initEventBridgeExportUserDataCommand(deps: {
 	publishEvent: PublishEvent;
 }): { publishExportUserDataCommand: PublishExportUserDataCommand } {
-	const { publishEvent } = deps;
-
-	const publishExportUserDataCommand: PublishExportUserDataCommand = async (params) => {
-		await publishEvent({
-			source: ExportUserDataCommand.source,
-			detailType: ExportUserDataCommand.detailType,
-			detail: JSON.stringify({
-				userId: params.userId,
-				email: params.email,
-				requestedAt: params.requestedAt,
-			}),
-		});
+	return {
+		publishExportUserDataCommand: (params) =>
+			deps.publishEvent(ExportUserDataCommand, params),
 	};
-
-	return { publishExportUserDataCommand };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-link-saved.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-link-saved.ts
@@ -6,19 +6,8 @@ import type { PublishLinkSaved } from "@packages/test-fixtures/providers/events"
 export function initEventBridgeLinkSaved(deps: {
 	publishEvent: PublishEvent;
 }): { publishLinkSaved: PublishLinkSaved } {
-	const { publishEvent } = deps;
-
-	const publishLinkSaved: PublishLinkSaved = async (params) => {
-		await publishEvent({
-			source: SaveLinkCommand.source,
-			detailType: SaveLinkCommand.detailType,
-			detail: JSON.stringify({
-				url: params.url,
-				userId: params.userId,
-			}),
-		});
+	return {
+		publishLinkSaved: (params) => deps.publishEvent(SaveLinkCommand, params),
 	};
-
-	return { publishLinkSaved };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-recrawl-link-initiated.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-recrawl-link-initiated.ts
@@ -6,16 +6,9 @@ import type { PublishRecrawlLinkInitiated } from "@packages/test-fixtures/provid
 export function initEventBridgeRecrawlLinkInitiated(deps: {
 	publishEvent: PublishEvent;
 }): { publishRecrawlLinkInitiated: PublishRecrawlLinkInitiated } {
-	const { publishEvent } = deps;
-
-	const publishRecrawlLinkInitiated: PublishRecrawlLinkInitiated = async (params) => {
-		await publishEvent({
-			source: RecrawlLinkInitiatedEvent.source,
-			detailType: RecrawlLinkInitiatedEvent.detailType,
-			detail: JSON.stringify({ url: params.url }),
-		});
+	return {
+		publishRecrawlLinkInitiated: (params) =>
+			deps.publishEvent(RecrawlLinkInitiatedEvent, params),
 	};
-
-	return { publishRecrawlLinkInitiated };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-save-anonymous-link.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-save-anonymous-link.ts
@@ -6,16 +6,9 @@ import type { PublishSaveAnonymousLink } from "@packages/test-fixtures/providers
 export function initEventBridgeSaveAnonymousLink(deps: {
 	publishEvent: PublishEvent;
 }): { publishSaveAnonymousLink: PublishSaveAnonymousLink } {
-	const { publishEvent } = deps;
-
-	const publishSaveAnonymousLink: PublishSaveAnonymousLink = async (params) => {
-		await publishEvent({
-			source: SaveAnonymousLinkCommand.source,
-			detailType: SaveAnonymousLinkCommand.detailType,
-			detail: JSON.stringify({ url: params.url }),
-		});
+	return {
+		publishSaveAnonymousLink: (params) =>
+			deps.publishEvent(SaveAnonymousLinkCommand, params),
 	};
-
-	return { publishSaveAnonymousLink };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-save-link-raw-html-command.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-save-link-raw-html-command.ts
@@ -6,20 +6,9 @@ import type { PublishSaveLinkRawHtmlCommand } from "@packages/test-fixtures/prov
 export function initEventBridgeSaveLinkRawHtmlCommand(deps: {
 	publishEvent: PublishEvent;
 }): { publishSaveLinkRawHtmlCommand: PublishSaveLinkRawHtmlCommand } {
-	const { publishEvent } = deps;
-
-	const publishSaveLinkRawHtmlCommand: PublishSaveLinkRawHtmlCommand = async (params) => {
-		await publishEvent({
-			source: SaveLinkRawHtmlCommand.source,
-			detailType: SaveLinkRawHtmlCommand.detailType,
-			detail: JSON.stringify({
-				url: params.url,
-				userId: params.userId,
-				title: params.title,
-			}),
-		});
+	return {
+		publishSaveLinkRawHtmlCommand: (params) =>
+			deps.publishEvent(SaveLinkRawHtmlCommand, params),
 	};
-
-	return { publishSaveLinkRawHtmlCommand };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-stale-check-requested.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-stale-check-requested.ts
@@ -6,16 +6,9 @@ import type { PublishStaleCheckRequested } from "@packages/test-fixtures/provide
 export function initEventBridgeStaleCheckRequested(deps: {
 	publishEvent: PublishEvent;
 }): { publishStaleCheckRequested: PublishStaleCheckRequested } {
-	const { publishEvent } = deps;
-
-	const publishStaleCheckRequested: PublishStaleCheckRequested = async (params) => {
-		await publishEvent({
-			source: StaleCheckRequestedEvent.source,
-			detailType: StaleCheckRequestedEvent.detailType,
-			detail: JSON.stringify({ url: params.url }),
-		});
+	return {
+		publishStaleCheckRequested: (params) =>
+			deps.publishEvent(StaleCheckRequestedEvent, params),
 	};
-
-	return { publishStaleCheckRequested };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-subscription-cancelled.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-subscription-cancelled.ts
@@ -6,22 +6,9 @@ import type { PublishSubscriptionCancelled } from "@packages/test-fixtures/provi
 export function initEventBridgeSubscriptionCancelled(deps: {
 	publishEvent: PublishEvent;
 }): { publishSubscriptionCancelled: PublishSubscriptionCancelled } {
-	const { publishEvent } = deps;
-
-	const publishSubscriptionCancelled: PublishSubscriptionCancelled = async (params) => {
-		await publishEvent({
-			source: SubscriptionCancelledEvent.source,
-			detailType: SubscriptionCancelledEvent.detailType,
-			detail: JSON.stringify(
-				SubscriptionCancelledEvent.detailSchema.parse({
-					userId: params.userId,
-					subscriptionId: params.subscriptionId,
-					reason: params.reason,
-				}),
-			),
-		});
+	return {
+		publishSubscriptionCancelled: (params) =>
+			deps.publishEvent(SubscriptionCancelledEvent, params),
 	};
-
-	return { publishSubscriptionCancelled };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-subscription-charge-failed.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-subscription-charge-failed.ts
@@ -6,21 +6,9 @@ import type { PublishSubscriptionChargeFailed } from "@packages/test-fixtures/pr
 export function initEventBridgeSubscriptionChargeFailed(deps: {
 	publishEvent: PublishEvent;
 }): { publishSubscriptionChargeFailed: PublishSubscriptionChargeFailed } {
-	const { publishEvent } = deps;
-
-	const publishSubscriptionChargeFailed: PublishSubscriptionChargeFailed = async (params) => {
-		await publishEvent({
-			source: SubscriptionChargeFailedEvent.source,
-			detailType: SubscriptionChargeFailedEvent.detailType,
-			detail: JSON.stringify(
-				SubscriptionChargeFailedEvent.detailSchema.parse({
-					userId: params.userId,
-					reason: params.reason,
-				}),
-			),
-		});
+	return {
+		publishSubscriptionChargeFailed: (params) =>
+			deps.publishEvent(SubscriptionChargeFailedEvent, params),
 	};
-
-	return { publishSubscriptionChargeFailed };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-subscription-charge-succeeded.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-subscription-charge-succeeded.ts
@@ -6,22 +6,9 @@ import type { PublishSubscriptionChargeSucceeded } from "@packages/test-fixtures
 export function initEventBridgeSubscriptionChargeSucceeded(deps: {
 	publishEvent: PublishEvent;
 }): { publishSubscriptionChargeSucceeded: PublishSubscriptionChargeSucceeded } {
-	const { publishEvent } = deps;
-
-	const publishSubscriptionChargeSucceeded: PublishSubscriptionChargeSucceeded = async (params) => {
-		await publishEvent({
-			source: SubscriptionChargeSucceededEvent.source,
-			detailType: SubscriptionChargeSucceededEvent.detailType,
-			detail: JSON.stringify(
-				SubscriptionChargeSucceededEvent.detailSchema.parse({
-					userId: params.userId,
-					subscriptionId: params.subscriptionId,
-					customerId: params.customerId,
-				}),
-			),
-		});
+	return {
+		publishSubscriptionChargeSucceeded: (params) =>
+			deps.publishEvent(SubscriptionChargeSucceededEvent, params),
 	};
-
-	return { publishSubscriptionChargeSucceeded };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/events/eventbridge-update-fetch-timestamp.ts
+++ b/projects/hutch/src/runtime/providers/events/eventbridge-update-fetch-timestamp.ts
@@ -6,19 +6,9 @@ import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/provid
 export function initEventBridgeUpdateFetchTimestamp(deps: {
 	publishEvent: PublishEvent;
 }): { publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp } {
-	const { publishEvent } = deps;
-
-	const publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp = async (params) => {
-		await publishEvent({
-			source: UpdateFetchTimestampCommand.source,
-			detailType: UpdateFetchTimestampCommand.detailType,
-			detail: JSON.stringify({
-				url: params.url,
-				contentFetchedAt: params.contentFetchedAt,
-			}),
-		});
+	return {
+		publishUpdateFetchTimestamp: (params) =>
+			deps.publishEvent(UpdateFetchTimestampCommand, params),
 	};
-
-	return { publishUpdateFetchTimestamp };
 }
 /* c8 ignore stop */

--- a/projects/hutch/src/runtime/stripe-webhook-receiver/handlers/customer-subscription-deleted.test.ts
+++ b/projects/hutch/src/runtime/stripe-webhook-receiver/handlers/customer-subscription-deleted.test.ts
@@ -30,10 +30,10 @@ describe("initHandleCustomerSubscriptionDeleted", () => {
 		const findSubscriptionBySubscriptionId = await buildSubscriptionLookup([
 			{ userId: "user-cancel-me", subscriptionId: "sub_cancel_me" },
 		]);
-		const published: Array<{ source: string; detailType: string; detail: string }> = [];
+		const published: Array<{ event: { source: string; detailType: string }; detail: unknown }> = [];
 		const handle = initHandleCustomerSubscriptionDeleted({
 			findSubscriptionBySubscriptionId,
-			publishEvent: async (e) => { published.push(e); },
+			publishEvent: async (event, detail) => { published.push({ event, detail }); },
 		});
 
 		await handle({
@@ -42,9 +42,9 @@ describe("initHandleCustomerSubscriptionDeleted", () => {
 		});
 
 		assert.equal(published.length, 1);
-		assert.equal(published[0].source, SubscriptionCancelledEvent.source);
-		assert.equal(published[0].detailType, SubscriptionCancelledEvent.detailType);
-		assert.deepStrictEqual(JSON.parse(published[0].detail), {
+		assert.equal(published[0].event.source, SubscriptionCancelledEvent.source);
+		assert.equal(published[0].event.detailType, SubscriptionCancelledEvent.detailType);
+		assert.deepStrictEqual(published[0].detail, {
 			userId: "user-cancel-me",
 			subscriptionId: "sub_cancel_me",
 			reason: "stripe_webhook",
@@ -55,7 +55,7 @@ describe("initHandleCustomerSubscriptionDeleted", () => {
 		const published: unknown[] = [];
 		const handle = initHandleCustomerSubscriptionDeleted({
 			findSubscriptionBySubscriptionId: async () => undefined,
-			publishEvent: async (e) => { published.push(e); },
+			publishEvent: async (event, detail) => { published.push({ event, detail }); },
 		});
 
 		await handle({

--- a/projects/hutch/src/runtime/stripe-webhook-receiver/handlers/customer-subscription-deleted.ts
+++ b/projects/hutch/src/runtime/stripe-webhook-receiver/handlers/customer-subscription-deleted.ts
@@ -20,16 +20,10 @@ export function initHandleCustomerSubscriptionDeleted(
 			});
 			return;
 		}
-		await deps.publishEvent({
-			source: SubscriptionCancelledEvent.source,
-			detailType: SubscriptionCancelledEvent.detailType,
-			detail: JSON.stringify(
-				SubscriptionCancelledEvent.detailSchema.parse({
-					userId: row.userId,
-					subscriptionId,
-					reason: "stripe_webhook",
-				}),
-			),
+		await deps.publishEvent(SubscriptionCancelledEvent, {
+			userId: row.userId,
+			subscriptionId,
+			reason: "stripe_webhook",
 		});
 		logger.info("[stripe-webhook] emitted SubscriptionCancelled", {
 			userId: row.userId,

--- a/projects/save-link/src/runtime/dep-bundles/events.test.ts
+++ b/projects/save-link/src/runtime/dep-bundles/events.test.ts
@@ -3,6 +3,7 @@ import {
 	EventBridgeClient,
 	type PublishEvent,
 } from "@packages/hutch-infra-components/runtime";
+import { SimpleCrawlUnsupportedEvent } from "@packages/hutch-infra-components";
 import {
 	initEmitSimpleCrawlUnsupported,
 	initEventsDepBundle,
@@ -29,10 +30,11 @@ describe("initEmitSimpleCrawlUnsupported", () => {
 		const emit = initEmitSimpleCrawlUnsupported({ publishEvent });
 		await emit({ url: "https://example.com/doc.pdf", userId: "user-1" });
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "SimpleCrawlUnsupported",
-			detail: JSON.stringify({ url: "https://example.com/doc.pdf", userId: "user-1" }),
+		expect(publishEvent).toHaveBeenCalledWith(SimpleCrawlUnsupportedEvent, {
+			url: "https://example.com/doc.pdf",
+			userId: "user-1",
+			recrawl: undefined,
+			refresh: undefined,
 		});
 	});
 
@@ -42,10 +44,11 @@ describe("initEmitSimpleCrawlUnsupported", () => {
 		const emit = initEmitSimpleCrawlUnsupported({ publishEvent });
 		await emit({ url: "https://example.com/doc.pdf", recrawl: true });
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "SimpleCrawlUnsupported",
-			detail: JSON.stringify({ url: "https://example.com/doc.pdf", recrawl: true }),
+		expect(publishEvent).toHaveBeenCalledWith(SimpleCrawlUnsupportedEvent, {
+			url: "https://example.com/doc.pdf",
+			userId: undefined,
+			recrawl: true,
+			refresh: undefined,
 		});
 	});
 
@@ -55,10 +58,11 @@ describe("initEmitSimpleCrawlUnsupported", () => {
 		const emit = initEmitSimpleCrawlUnsupported({ publishEvent });
 		await emit({ url: "https://example.com/doc.pdf", refresh: true });
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "SimpleCrawlUnsupported",
-			detail: JSON.stringify({ url: "https://example.com/doc.pdf", refresh: true }),
+		expect(publishEvent).toHaveBeenCalledWith(SimpleCrawlUnsupportedEvent, {
+			url: "https://example.com/doc.pdf",
+			userId: undefined,
+			recrawl: undefined,
+			refresh: true,
 		});
 	});
 });

--- a/projects/save-link/src/runtime/dep-bundles/events.ts
+++ b/projects/save-link/src/runtime/dep-bundles/events.ts
@@ -59,11 +59,6 @@ export function initEventsDepBundle(deps: {
 export function initEmitSimpleCrawlUnsupported(deps: {
 	publishEvent: PublishEvent;
 }): EmitSimpleCrawlUnsupported {
-	return async ({ url, userId, recrawl, refresh }) => {
-		await deps.publishEvent({
-			source: SimpleCrawlUnsupportedEvent.source,
-			detailType: SimpleCrawlUnsupportedEvent.detailType,
-			detail: JSON.stringify({ url, userId, recrawl, refresh }),
-		});
-	};
+	return ({ url, userId, recrawl, refresh }) =>
+		deps.publishEvent(SimpleCrawlUnsupportedEvent, { url, userId, recrawl, refresh });
 }

--- a/projects/save-link/src/runtime/domain/article-aggregate/lambda-effect-dispatcher.test.ts
+++ b/projects/save-link/src/runtime/domain/article-aggregate/lambda-effect-dispatcher.test.ts
@@ -1,4 +1,14 @@
 import type { Effect } from "@packages/domain/article-aggregate";
+import {
+	AnonymousLinkSavedEvent,
+	CrawlArticleCompletedEvent,
+	CrawlArticleFailedEvent,
+	LinkSavedEvent,
+	RecrawlCompletedEvent,
+	SubmitLinkCommand,
+	SummaryGeneratedEvent,
+	SummaryGenerationFailedEvent,
+} from "@packages/hutch-infra-components";
 import { initLambdaEffectDispatcher } from "./lambda-effect-dispatcher";
 
 describe("initLambdaEffectDispatcher", () => {
@@ -61,14 +71,10 @@ describe("initLambdaEffectDispatcher", () => {
 			receiveCount: 4,
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				reason: "exceeded SQS maxReceiveCount",
-				receiveCount: 4,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(CrawlArticleFailedEvent, {
+			url: "https://example.com/article",
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -87,10 +93,8 @@ describe("initLambdaEffectDispatcher", () => {
 			url: "https://example.com/article",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "RecrawlCompleted",
-			detail: JSON.stringify({ url: "https://example.com/article" }),
+		expect(publishEvent).toHaveBeenCalledWith(RecrawlCompletedEvent, {
+			url: "https://example.com/article",
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -147,10 +151,8 @@ describe("initLambdaEffectDispatcher", () => {
 			url: "https://example.com/article",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "CrawlArticleCompleted",
-			detail: JSON.stringify({ url: "https://example.com/article" }),
+		expect(publishEvent).toHaveBeenCalledWith(CrawlArticleCompletedEvent, {
+			url: "https://example.com/article",
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -170,13 +172,9 @@ describe("initLambdaEffectDispatcher", () => {
 			userId: "user-123",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "LinkSaved",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				userId: "user-123",
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(LinkSavedEvent, {
+			url: "https://example.com/article",
+			userId: "user-123",
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -195,10 +193,8 @@ describe("initLambdaEffectDispatcher", () => {
 			url: "https://example.com/article",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "AnonymousLinkSaved",
-			detail: JSON.stringify({ url: "https://example.com/article" }),
+		expect(publishEvent).toHaveBeenCalledWith(AnonymousLinkSavedEvent, {
+			url: "https://example.com/article",
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -219,14 +215,10 @@ describe("initLambdaEffectDispatcher", () => {
 			outputTokens: 567,
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "GlobalSummaryGenerated",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				inputTokens: 1234,
-				outputTokens: 567,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(SummaryGeneratedEvent, {
+			url: "https://example.com/article",
+			inputTokens: 1234,
+			outputTokens: 567,
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -245,10 +237,8 @@ describe("initLambdaEffectDispatcher", () => {
 			url: "https://example.com/article",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.api",
-			detailType: "SubmitLinkCommand",
-			detail: JSON.stringify({ url: "https://example.com/article" }),
+		expect(publishEvent).toHaveBeenCalledWith(SubmitLinkCommand, {
+			url: "https://example.com/article",
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});
@@ -268,13 +258,9 @@ describe("initLambdaEffectDispatcher", () => {
 			userId: "user-123",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.api",
-			detailType: "SubmitLinkCommand",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				userId: "user-123",
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(SubmitLinkCommand, {
+			url: "https://example.com/article",
+			userId: "user-123",
 		});
 	});
 
@@ -294,14 +280,10 @@ describe("initLambdaEffectDispatcher", () => {
 			rawHtml: "<html>captured DOM</html>",
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.api",
-			detailType: "SubmitLinkCommand",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				userId: "user-123",
-				rawHtml: "<html>captured DOM</html>",
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(SubmitLinkCommand, {
+			url: "https://example.com/article",
+			userId: "user-123",
+			rawHtml: "<html>captured DOM</html>",
 		});
 	});
 
@@ -321,14 +303,10 @@ describe("initLambdaEffectDispatcher", () => {
 			receiveCount: 4,
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "SummaryGenerationFailed",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				reason: "exceeded SQS maxReceiveCount",
-				receiveCount: 4,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(SummaryGenerationFailedEvent, {
+			url: "https://example.com/article",
+			reason: "exceeded SQS maxReceiveCount",
+			receiveCount: 4,
 		});
 		expect(dispatchGenerateSummary).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/runtime/domain/article-aggregate/lambda-effect-dispatcher.ts
+++ b/projects/save-link/src/runtime/domain/article-aggregate/lambda-effect-dispatcher.ts
@@ -37,75 +37,46 @@ export function initLambdaEffectDispatcher(deps: {
 				 * is wired on every Lambda, so no new queue / env var / IAM grant
 				 * is required at the publisher. The future subscriber Lambda
 				 * lands via eventBus.subscribe(SubmitLinkCommand, …) in infra. */
-				await publishEvent({
-					source: SubmitLinkCommand.source,
-					detailType: SubmitLinkCommand.detailType,
-					detail: JSON.stringify({
-						url: effect.url,
-						...(effect.userId !== undefined ? { userId: effect.userId } : {}),
-						...(effect.rawHtml !== undefined ? { rawHtml: effect.rawHtml } : {}),
-					}),
+				await publishEvent(SubmitLinkCommand, {
+					url: effect.url,
+					...(effect.userId !== undefined ? { userId: effect.userId } : {}),
+					...(effect.rawHtml !== undefined ? { rawHtml: effect.rawHtml } : {}),
 				});
 				return;
 			case "publish-crawl-article-failed":
-				await publishEvent({
-					source: CrawlArticleFailedEvent.source,
-					detailType: CrawlArticleFailedEvent.detailType,
-					detail: JSON.stringify({
-						url: effect.url,
-						reason: effect.reason,
-						receiveCount: effect.receiveCount,
-					}),
+				await publishEvent(CrawlArticleFailedEvent, {
+					url: effect.url,
+					reason: effect.reason,
+					receiveCount: effect.receiveCount,
 				});
 				return;
 			case "publish-recrawl-completed":
-				await publishEvent({
-					source: RecrawlCompletedEvent.source,
-					detailType: RecrawlCompletedEvent.detailType,
-					detail: JSON.stringify({ url: effect.url }),
-				});
+				await publishEvent(RecrawlCompletedEvent, { url: effect.url });
 				return;
 			case "publish-crawl-article-completed":
-				await publishEvent({
-					source: CrawlArticleCompletedEvent.source,
-					detailType: CrawlArticleCompletedEvent.detailType,
-					detail: JSON.stringify({ url: effect.url }),
-				});
+				await publishEvent(CrawlArticleCompletedEvent, { url: effect.url });
 				return;
 			case "publish-link-saved":
-				await publishEvent({
-					source: LinkSavedEvent.source,
-					detailType: LinkSavedEvent.detailType,
-					detail: JSON.stringify({ url: effect.url, userId: effect.userId }),
+				await publishEvent(LinkSavedEvent, {
+					url: effect.url,
+					userId: effect.userId,
 				});
 				return;
 			case "publish-anonymous-link-saved":
-				await publishEvent({
-					source: AnonymousLinkSavedEvent.source,
-					detailType: AnonymousLinkSavedEvent.detailType,
-					detail: JSON.stringify({ url: effect.url }),
-				});
+				await publishEvent(AnonymousLinkSavedEvent, { url: effect.url });
 				return;
 			case "publish-summary-generated":
-				await publishEvent({
-					source: SummaryGeneratedEvent.source,
-					detailType: SummaryGeneratedEvent.detailType,
-					detail: JSON.stringify({
-						url: effect.url,
-						inputTokens: effect.inputTokens,
-						outputTokens: effect.outputTokens,
-					}),
+				await publishEvent(SummaryGeneratedEvent, {
+					url: effect.url,
+					inputTokens: effect.inputTokens,
+					outputTokens: effect.outputTokens,
 				});
 				return;
 			case "publish-summary-generation-failed":
-				await publishEvent({
-					source: SummaryGenerationFailedEvent.source,
-					detailType: SummaryGenerationFailedEvent.detailType,
-					detail: JSON.stringify({
-						url: effect.url,
-						reason: effect.reason,
-						receiveCount: effect.receiveCount,
-					}),
+				await publishEvent(SummaryGenerationFailedEvent, {
+					url: effect.url,
+					reason: effect.reason,
+					receiveCount: effect.receiveCount,
 				});
 				return;
 			default: {

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -3,6 +3,11 @@ import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { ComprehensiveCrawl } from "@packages/crawl-article";
 import { markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
+import {
+	RecrawlContentExtractedEvent,
+	RefreshContentExtractedEvent,
+	TierContentExtractedEvent,
+} from "@packages/hutch-infra-components";
 import { initComprehensiveCrawlHandler } from "./comprehensive-crawl-handler";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import type { ParseHtml } from "@packages/article-parser";
@@ -123,10 +128,10 @@ describe("initComprehensiveCrawlHandler", () => {
 			}),
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "TierContentExtracted",
-			detail: JSON.stringify({ url: "https://example.com/doc.pdf", tier: "tier-1", userId: "user-1" }),
+		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+			url: "https://example.com/doc.pdf",
+			tier: "tier-1",
+			userId: "user-1",
 		});
 	});
 
@@ -137,10 +142,10 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "TierContentExtracted",
-			detail: JSON.stringify({ url: "https://example.com/doc.pdf", tier: "tier-1" }),
+		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+			url: "https://example.com/doc.pdf",
+			tier: "tier-1",
+			userId: undefined,
 		});
 	});
 
@@ -152,10 +157,8 @@ describe("initComprehensiveCrawlHandler", () => {
 		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", recrawl: true }), stubContext, () => {});
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "RecrawlContentExtracted",
-			detail: JSON.stringify({ url: "https://example.com/doc.pdf" }),
+		expect(publishEvent).toHaveBeenCalledWith(RecrawlContentExtractedEvent, {
+			url: "https://example.com/doc.pdf",
 		});
 	});
 
@@ -175,15 +178,11 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		expect(updateFetchTimestamp).not.toHaveBeenCalled();
 		expect(publishEvent).toHaveBeenCalledTimes(1);
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "RefreshContentExtracted",
-			detail: JSON.stringify({
-				url: "https://example.com/doc.pdf",
-				etag: '"refreshed-pdf"',
-				lastModified: "Sat, 17 May 2026 00:00:00 GMT",
-				contentFetchedAt: "2026-04-18T12:00:00.000Z",
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(RefreshContentExtractedEvent, {
+			url: "https://example.com/doc.pdf",
+			etag: '"refreshed-pdf"',
+			lastModified: "Sat, 17 May 2026 00:00:00 GMT",
+			contentFetchedAt: "2026-04-18T12:00:00.000Z",
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -232,33 +232,21 @@ export function initComprehensiveCrawlHandler(deps: {
 					// runs the selector across all tier sources, picks a winner, and
 					// drives the refreshContent transition (which sets freshness +
 					// canonical) — mirrors the in-place refresh flow shape.
-					await publishEvent({
-						source: RefreshContentExtractedEvent.source,
-						detailType: RefreshContentExtractedEvent.detailType,
-						detail: JSON.stringify({
-							url,
-							etag: crawlResult.etag,
-							lastModified: crawlResult.lastModified,
-							contentFetchedAt,
-						}),
+					await publishEvent(RefreshContentExtractedEvent, {
+						url,
+						etag: crawlResult.etag,
+						lastModified: crawlResult.lastModified,
+						contentFetchedAt,
 					});
 					logger.info(`${logPrefix} emitted RefreshContentExtractedEvent`, { url });
 				} else if (recrawl) {
 					// Recrawl chain runs a clone of the selector that ALWAYS dispatches
 					// generate-summary regardless of canonical change. Emit the recrawl-
 					// specific event so admin recrawls of PDFs preserve that semantics.
-					await publishEvent({
-						source: RecrawlContentExtractedEvent.source,
-						detailType: RecrawlContentExtractedEvent.detailType,
-						detail: JSON.stringify({ url }),
-					});
+					await publishEvent(RecrawlContentExtractedEvent, { url });
 					logger.info(`${logPrefix} emitted RecrawlContentExtractedEvent`, { url });
 				} else {
-					await publishEvent({
-						source: TierContentExtractedEvent.source,
-						detailType: TierContentExtractedEvent.detailType,
-						detail: JSON.stringify({ url, tier: "tier-1", userId }),
-					});
+					await publishEvent(TierContentExtractedEvent, { url, tier: "tier-1", userId });
 					logger.info(`${logPrefix} emitted TierContentExtractedEvent`, { url, tier: "tier-1" });
 				}
 			} catch (error) {

--- a/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.test.ts
@@ -2,6 +2,7 @@ import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import { markCrawlFailed } from "@packages/domain/article-aggregate";
+import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveLinkRawHtmlCommandHandler } from "./save-link-raw-html-command-handler";
 import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
 import type { ParseHtml } from "@packages/article-parser";
@@ -115,14 +116,10 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 				imageUrl: undefined,
 			},
 		});
-		expect(deps.publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "TierContentExtracted",
-			detail: JSON.stringify({
-				url: "https://example.com/article",
-				tier: "tier-0",
-				userId: "user-1",
-			}),
+		expect(deps.publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+			url: "https://example.com/article",
+			tier: "tier-0",
+			userId: "user-1",
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.ts
@@ -125,14 +125,10 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 					pickedTier: snapshot.pickedTier,
 				});
 
-				await publishEvent({
-					source: TierContentExtractedEvent.source,
-					detailType: TierContentExtractedEvent.detailType,
-					detail: JSON.stringify({
-						url: detail.url,
-						tier: TIER,
-						userId: detail.userId,
-					}),
+				await publishEvent(TierContentExtractedEvent, {
+					url: detail.url,
+					tier: TIER,
+					userId: detail.userId,
 				});
 			} catch (error) {
 				logger.error("[SaveLinkRawHtmlCommand] record failed", {

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
@@ -2,6 +2,7 @@ import posthtml from "posthtml";
 import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { SimpleCrawl } from "@packages/crawl-article";
+import { RecrawlContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initRecrawlLinkInitiatedHandler } from "./recrawl-link-initiated-handler";
 import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
 import type { ParseHtml } from "@packages/article-parser";
@@ -107,10 +108,8 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "RecrawlContentExtracted",
-			detail: JSON.stringify({ url: "https://example.com/article" }),
+		expect(publishEvent).toHaveBeenCalledWith(RecrawlContentExtractedEvent, {
+			url: "https://example.com/article",
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.ts
@@ -77,11 +77,7 @@ export function initRecrawlLinkInitiatedHandler(deps: {
 					continue;
 				}
 
-				await publishEvent({
-					source: RecrawlContentExtractedEvent.source,
-					detailType: RecrawlContentExtractedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url }),
-				});
+				await publishEvent(RecrawlContentExtractedEvent, { url: detail.url });
 				logger.info("[RecrawlLinkInitiated] emitted RecrawlContentExtractedEvent", {
 					url: detail.url,
 				});

--- a/projects/save-link/src/runtime/domain/save-link/refresh-article-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/refresh-article-content-handler.test.ts
@@ -1,4 +1,5 @@
 import { noopLogger } from "@packages/hutch-logger";
+import { RefreshContentExtractedEvent } from "@packages/hutch-infra-components";
 import type { ReadRefreshHtml } from "@packages/test-fixtures/providers/refresh-html";
 import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
@@ -120,10 +121,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 		await handler(createSqsEvent(DETAIL), stubContext, () => {});
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
-		const call = publishEvent.mock.calls[0][0];
-		expect(call.source).toBe("hutch.save-link");
-		expect(call.detailType).toBe("RefreshContentExtracted");
-		expect(JSON.parse(call.detail)).toEqual({
+		expect(publishEvent).toHaveBeenCalledWith(RefreshContentExtractedEvent, {
 			url: URL,
 			etag: '"new-etag"',
 			lastModified: "Sun, 10 May 2026 12:00:00 GMT",

--- a/projects/save-link/src/runtime/domain/save-link/refresh-article-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/refresh-article-content-handler.ts
@@ -55,15 +55,11 @@ export function initRefreshArticleContentHandler(deps: {
 					},
 				});
 
-				await publishEvent({
-					source: RefreshContentExtractedEvent.source,
-					detailType: RefreshContentExtractedEvent.detailType,
-					detail: JSON.stringify({
-						url: detail.url,
-						etag: detail.etag,
-						lastModified: detail.lastModified,
-						contentFetchedAt: detail.contentFetchedAt,
-					}),
+				await publishEvent(RefreshContentExtractedEvent, {
+					url: detail.url,
+					etag: detail.etag,
+					lastModified: detail.lastModified,
+					contentFetchedAt: detail.contentFetchedAt,
 				});
 
 				logger.info("[RefreshArticleContent] tier-1 source written + event published", {

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
@@ -3,6 +3,7 @@ import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { SimpleCrawl } from "@packages/crawl-article";
 import { markCrawlFailed } from "@packages/domain/article-aggregate";
+import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveAnonymousLinkCommandHandler } from "./save-anonymous-link-command-handler";
 import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
 import type { ParseHtml } from "@packages/article-parser";
@@ -113,10 +114,9 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 		expect(putTierSource).toHaveBeenCalledWith(
 			expect.objectContaining({ url: "https://example.com/article", tier: "tier-1" }),
 		);
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "TierContentExtracted",
-			detail: JSON.stringify({ url: "https://example.com/article", tier: "tier-1" }),
+		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+			url: "https://example.com/article",
+			tier: "tier-1",
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.ts
@@ -77,10 +77,9 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 					continue;
 				}
 
-				await publishEvent({
-					source: TierContentExtractedEvent.source,
-					detailType: TierContentExtractedEvent.detailType,
-					detail: JSON.stringify({ url: detail.url, tier: "tier-1" }),
+				await publishEvent(TierContentExtractedEvent, {
+					url: detail.url,
+					tier: "tier-1",
 				});
 				logger.info("[SaveAnonymousLinkCommand] emitted TierContentExtractedEvent", {
 					url: detail.url,

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
@@ -3,6 +3,7 @@ import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { SimpleCrawl } from "@packages/crawl-article";
 import { markCrawlFailed } from "@packages/domain/article-aggregate";
+import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveLinkCommandHandler } from "./save-link-command-handler";
 import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
 import type { ParseHtml } from "@packages/article-parser";
@@ -125,10 +126,10 @@ describe("initSaveLinkCommandHandler", () => {
 			},
 		});
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "TierContentExtracted",
-			detail: JSON.stringify({ url: "https://example.com/article", tier: "tier-1", userId: "user-1" }),
+		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+			url: "https://example.com/article",
+			tier: "tier-1",
+			userId: "user-1",
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.ts
@@ -75,14 +75,10 @@ export function initSaveLinkCommandHandler(deps: {
 					continue;
 				}
 
-				await publishEvent({
-					source: TierContentExtractedEvent.source,
-					detailType: TierContentExtractedEvent.detailType,
-					detail: JSON.stringify({
-						url: detail.url,
-						tier: "tier-1",
-						userId: detail.userId,
-					}),
+				await publishEvent(TierContentExtractedEvent, {
+					url: detail.url,
+					tier: "tier-1",
+					userId: detail.userId,
 				});
 				logger.info("[SaveLinkCommand] emitted TierContentExtractedEvent", {
 					url: detail.url,

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -106,11 +106,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 							 * CrawlArticleCompleted directly to settle the pipeline
 							 * and skip; no aggregate transition because crawl/summary
 							 * state is unchanged. */
-							await publishEvent({
-								source: CrawlArticleCompletedEvent.source,
-								detailType: CrawlArticleCompletedEvent.detailType,
-								detail: JSON.stringify({ url: detail.url }),
-							});
+							await publishEvent(CrawlArticleCompletedEvent, { url: detail.url });
 							continue;
 						}
 						/* Either first save (no canonical yet) OR canonical exists

--- a/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-handler.test.ts
@@ -1,4 +1,5 @@
 import { noopLogger } from "@packages/hutch-logger";
+import { ComprehensiveCrawlCommand } from "@packages/hutch-infra-components";
 import { initSimpleCrawlUnsupportedPolicyHandler } from "./simple-crawl-unsupported-policy-handler";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -61,15 +62,11 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 		);
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "ComprehensiveCrawlCommand",
-			detail: JSON.stringify({
-				url: "https://example.com/doc.pdf",
-				userId: "user-1",
-				recrawl: undefined,
-				refresh: undefined,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(ComprehensiveCrawlCommand, {
+			url: "https://example.com/doc.pdf",
+			userId: "user-1",
+			recrawl: undefined,
+			refresh: undefined,
 		});
 	});
 
@@ -87,15 +84,11 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 			() => {},
 		);
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "ComprehensiveCrawlCommand",
-			detail: JSON.stringify({
-				url: "https://example.com/doc.pdf",
-				userId: undefined,
-				recrawl: true,
-				refresh: undefined,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(ComprehensiveCrawlCommand, {
+			url: "https://example.com/doc.pdf",
+			userId: undefined,
+			recrawl: true,
+			refresh: undefined,
 		});
 	});
 
@@ -113,15 +106,11 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 			() => {},
 		);
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "ComprehensiveCrawlCommand",
-			detail: JSON.stringify({
-				url: "https://example.com/doc.pdf",
-				userId: undefined,
-				recrawl: undefined,
-				refresh: true,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(ComprehensiveCrawlCommand, {
+			url: "https://example.com/doc.pdf",
+			userId: undefined,
+			recrawl: undefined,
+			refresh: true,
 		});
 	});
 
@@ -139,15 +128,11 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 			() => {},
 		);
 
-		expect(publishEvent).toHaveBeenCalledWith({
-			source: "hutch.save-link",
-			detailType: "ComprehensiveCrawlCommand",
-			detail: JSON.stringify({
-				url: "https://example.com/blob",
-				userId: undefined,
-				recrawl: undefined,
-				refresh: undefined,
-			}),
+		expect(publishEvent).toHaveBeenCalledWith(ComprehensiveCrawlCommand, {
+			url: "https://example.com/blob",
+			userId: undefined,
+			recrawl: undefined,
+			refresh: undefined,
 		});
 	});
 

--- a/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-handler.ts
+++ b/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-handler.ts
@@ -27,15 +27,11 @@ export function initSimpleCrawlUnsupportedPolicyHandler(deps: {
 				const envelope = JSON.parse(record.body);
 				const detail = SimpleCrawlUnsupportedEvent.detailSchema.parse(envelope.detail);
 
-				await publishEvent({
-					source: ComprehensiveCrawlCommand.source,
-					detailType: ComprehensiveCrawlCommand.detailType,
-					detail: JSON.stringify({
-						url: detail.url,
-						userId: detail.userId,
-						recrawl: detail.recrawl,
-						refresh: detail.refresh,
-					}),
+				await publishEvent(ComprehensiveCrawlCommand, {
+					url: detail.url,
+					userId: detail.userId,
+					recrawl: detail.recrawl,
+					refresh: detail.refresh,
 				});
 
 				logger.info(`${logPrefix} dispatched ComprehensiveCrawlCommand`, {

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -52,24 +52,11 @@ const { publishRefreshArticleContent } = initEventBridgeRefreshArticleContent({
 	putRefreshHtml,
 });
 
-const publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp = async (params) => {
-	await events.publishEvent({
-		source: UpdateFetchTimestampCommand.source,
-		detailType: UpdateFetchTimestampCommand.detailType,
-		detail: JSON.stringify({
-			url: params.url,
-			contentFetchedAt: params.contentFetchedAt,
-		}),
-	});
-};
+const publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp = (params) =>
+	events.publishEvent(UpdateFetchTimestampCommand, params);
 
-const publishSaveAnonymousLink: PublishSaveAnonymousLink = async (params) => {
-	await events.publishEvent({
-		source: SaveAnonymousLinkCommand.source,
-		detailType: SaveAnonymousLinkCommand.detailType,
-		detail: JSON.stringify({ url: params.url }),
-	});
-};
+const publishSaveAnonymousLink: PublishSaveAnonymousLink = (params) =>
+	events.publishEvent(SaveAnonymousLinkCommand, params);
 
 const { findArticleFreshness } = initFindArticleFreshness({
 	client: dynamoClient,

--- a/src/packages/hutch-infra-components/src/runtime/index.test.ts
+++ b/src/packages/hutch-infra-components/src/runtime/index.test.ts
@@ -3,6 +3,11 @@ import type {
 	EventBridgeClient,
 	PutEventsCommand,
 } from "@aws-sdk/client-eventbridge";
+import { z } from "zod";
+import {
+	SimpleCrawlUnsupportedEvent,
+	StaleCheckRequestedEvent,
+} from "../events";
 import { initEventBridgePublisher, PayloadTooLargeError } from "./index";
 
 function createFakeClient(sendImpl?: (cmd: PutEventsCommand) => Promise<unknown>): {
@@ -25,17 +30,15 @@ describe("initEventBridgePublisher", () => {
 			eventBusName: "test-bus",
 		});
 
-		await publishEvent({
-			source: "hutch.api",
-			detailType: "SomeCommand",
-			detail: JSON.stringify({ url: "https://example.com/article" }),
+		await publishEvent(StaleCheckRequestedEvent, {
+			url: "https://example.com/article",
 		});
 
 		expect(commands).toHaveLength(1);
 		expect(commands[0].input.Entries).toEqual([
 			{
-				Source: "hutch.api",
-				DetailType: "SomeCommand",
+				Source: StaleCheckRequestedEvent.source,
+				DetailType: StaleCheckRequestedEvent.detailType,
 				Detail: JSON.stringify({ url: "https://example.com/article" }),
 				EventBusName: "test-bus",
 			},
@@ -53,10 +56,8 @@ describe("initEventBridgePublisher", () => {
 		});
 
 		await expect(
-			publishEvent({
-				source: "hutch.api",
-				detailType: "SomeCommand",
-				detail: JSON.stringify({ url: "https://example.com/article" }),
+			publishEvent(StaleCheckRequestedEvent, {
+				url: "https://example.com/article",
 			}),
 		).rejects.toThrow(/EventBridge PutEvents failed/);
 	});
@@ -68,14 +69,12 @@ describe("initEventBridgePublisher", () => {
 			eventBusName: "test-bus",
 		});
 
-		// 241 KB string — pushes the request over the 240 KB cap.
+		// 241 KB URL — pushes the request over the 240 KB cap.
 		const oversize = "x".repeat(241_000);
 
 		await expect(
-			publishEvent({
-				source: "hutch.api",
-				detailType: "BloatedCommand",
-				detail: JSON.stringify({ url: "https://example.com/a", padding: oversize }),
+			publishEvent(StaleCheckRequestedEvent, {
+				url: `https://example.com/${oversize}`,
 			}),
 		).rejects.toBeInstanceOf(PayloadTooLargeError);
 
@@ -91,16 +90,14 @@ describe("initEventBridgePublisher", () => {
 		const oversize = "x".repeat(241_000);
 
 		try {
-			await publishEvent({
-				source: "hutch.api",
-				detailType: "BloatedCommand",
-				detail: JSON.stringify({ url: "https://example.com/a", padding: oversize }),
+			await publishEvent(StaleCheckRequestedEvent, {
+				url: `https://example.com/${oversize}`,
 			});
 			fail("expected publishEvent to throw");
 		} catch (error) {
 			assert(error instanceof PayloadTooLargeError);
-			expect(error.source).toBe("hutch.api");
-			expect(error.detailType).toBe("BloatedCommand");
+			expect(error.source).toBe(StaleCheckRequestedEvent.source);
+			expect(error.detailType).toBe(StaleCheckRequestedEvent.detailType);
 			expect(error.byteLength).toBeGreaterThan(240_000);
 			expect(error.name).toBe("PayloadTooLargeError");
 		}
@@ -113,10 +110,29 @@ describe("initEventBridgePublisher", () => {
 			eventBusName: "test-bus",
 		});
 
-		// 200 KB payload — well under the 240 KB cap once AWS-side envelope fields are accounted for.
-		const detail = JSON.stringify({ url: "https://example.com/a", padding: "x".repeat(200_000) });
-		await publishEvent({ source: "hutch.api", detailType: "ReasonablyLargeCommand", detail });
+		// 200 KB URL — well under the 240 KB cap once AWS-side envelope fields are accounted for.
+		await publishEvent(StaleCheckRequestedEvent, {
+			url: `https://example.com/${"x".repeat(200_000)}`,
+		});
 
 		expect(commands).toHaveLength(1);
+	});
+
+	it("rejects when the detail fails schema validation so refinements (e.g. mutex flags) cannot reach subscribers as malformed payloads", async () => {
+		const { client } = createFakeClient();
+		const { publishEvent } = initEventBridgePublisher({
+			client,
+			eventBusName: "test-bus",
+		});
+
+		await expect(
+			publishEvent(SimpleCrawlUnsupportedEvent, {
+				url: "https://example.com/doc.pdf",
+				recrawl: true,
+				refresh: true,
+			}),
+		).rejects.toBeInstanceOf(z.ZodError);
+
+		expect(client.send).not.toHaveBeenCalled();
 	});
 });

--- a/src/packages/hutch-infra-components/src/runtime/index.ts
+++ b/src/packages/hutch-infra-components/src/runtime/index.ts
@@ -1,19 +1,20 @@
 import assert from "node:assert";
+import type { z } from "zod";
 import {
 	EventBridgeClient,
 	PutEventsCommand,
 } from "@aws-sdk/client-eventbridge";
+import type { HutchEvent } from "../events";
 
 export {
 	initSqsCommandDispatcher,
 	type DispatchCommand,
 } from "./sqs-command-dispatcher";
 
-export type PublishEvent = (params: {
-	source: string;
-	detailType: string;
-	detail: string;
-}) => Promise<void>;
+export type PublishEvent = <E extends HutchEvent<z.ZodTypeAny>>(
+	event: E,
+	detail: z.infer<E["detailSchema"]>,
+) => Promise<void>;
 
 /** Defensive cap to keep `PutEventsCommand` requests inside EventBridge's
  * 256 KB per-request limit. 16 KB of headroom covers AWS-side envelope fields
@@ -49,20 +50,21 @@ export function initEventBridgePublisher(deps: {
 }): { publishEvent: PublishEvent } {
 	const { client, eventBusName } = deps;
 
-	const publishEvent: PublishEvent = async (params) => {
+	const publishEvent: PublishEvent = async (event, detail) => {
+		const validated = event.detailSchema.parse(detail);
 		const Entries = [
 			{
-				Source: params.source,
-				DetailType: params.detailType,
-				Detail: params.detail,
+				Source: event.source,
+				DetailType: event.detailType,
+				Detail: JSON.stringify(validated),
 				EventBusName: eventBusName,
 			},
 		];
 		const byteLength = Buffer.byteLength(JSON.stringify(Entries), "utf8");
 		if (byteLength > MAX_PUT_EVENTS_REQUEST_BYTES) {
 			throw new PayloadTooLargeError({
-				source: params.source,
-				detailType: params.detailType,
+				source: event.source,
+				detailType: event.detailType,
 				byteLength,
 			});
 		}

--- a/src/packages/refresh-article-content/src/eventbridge-refresh-article-content.test.ts
+++ b/src/packages/refresh-article-content/src/eventbridge-refresh-article-content.test.ts
@@ -1,3 +1,4 @@
+import { RefreshArticleContentCommand } from "@packages/hutch-infra-components";
 import { initEventBridgeRefreshArticleContent } from "./eventbridge-refresh-article-content";
 
 const PARAMS = {
@@ -48,11 +49,7 @@ describe("initEventBridgeRefreshArticleContent (put HTML to S3 then publish even
 		await publishRefreshArticleContent(PARAMS);
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
-		const call = publishEvent.mock.calls[0][0];
-		expect(call.source).toBe("hutch.api");
-		expect(call.detailType).toBe("RefreshArticleContentCommand");
-		const detail = JSON.parse(call.detail);
-		expect(detail).toEqual({
+		expect(publishEvent).toHaveBeenCalledWith(RefreshArticleContentCommand, {
 			url: PARAMS.url,
 			metadata: PARAMS.metadata,
 			estimatedReadTime: PARAMS.estimatedReadTime,
@@ -60,7 +57,8 @@ describe("initEventBridgeRefreshArticleContent (put HTML to S3 then publish even
 			lastModified: PARAMS.lastModified,
 			contentFetchedAt: PARAMS.contentFetchedAt,
 		});
-		expect(detail.html).toBeUndefined();
+		const [, detail] = publishEvent.mock.calls[0];
+		expect(detail).not.toHaveProperty("html");
 	});
 
 	it("does not publish when putRefreshHtml rejects so the consumer never reads a missing S3 object", async () => {

--- a/src/packages/refresh-article-content/src/eventbridge-refresh-article-content.ts
+++ b/src/packages/refresh-article-content/src/eventbridge-refresh-article-content.ts
@@ -11,17 +11,13 @@ export function initEventBridgeRefreshArticleContent(deps: {
 
 	const publishRefreshArticleContent: PublishRefreshArticleContent = async (params) => {
 		await putRefreshHtml({ url: params.url, html: params.html });
-		await publishEvent({
-			source: RefreshArticleContentCommand.source,
-			detailType: RefreshArticleContentCommand.detailType,
-			detail: JSON.stringify({
-				url: params.url,
-				metadata: params.metadata,
-				estimatedReadTime: params.estimatedReadTime,
-				etag: params.etag,
-				lastModified: params.lastModified,
-				contentFetchedAt: params.contentFetchedAt,
-			}),
+		await publishEvent(RefreshArticleContentCommand, {
+			url: params.url,
+			metadata: params.metadata,
+			estimatedReadTime: params.estimatedReadTime,
+			etag: params.etag,
+			lastModified: params.lastModified,
+			contentFetchedAt: params.contentFetchedAt,
 		});
 	};
 


### PR DESCRIPTION
## Summary

- Replace the string-based `PublishEvent({ source, detailType, detail })` shape with a generic `publishEvent(event, detail)` that infers the detail shape from the `HutchEvent` constant. `source`/`detailType` mix-ups become unrepresentable at compile time, and `detailSchema.parse()` is now centralised at the publisher so every publish runs Zod refinements (e.g. `SimpleCrawlUnsupportedEvent`'s `recrawl` XOR `refresh` mutex) — closes the gap where 9 of the 14 prior call sites skipped validation.
- Collapse the 12 thin `eventbridge-*` wrapper bodies to one-line forwarders that hand the event constant + params to `publishEvent`. The two `eventbridge-refresh-article-content.ts` wrappers keep their `putRefreshHtml` side-effect ordering; only the publish call shrinks.
- Update inline call sites (lambda-effect-dispatcher's 8 switch branches, stripe-webhook-receiver, export-user-data, comprehensive-crawl, save-link/save-link-raw-html/save-anonymous-link/recrawl-link-initiated/refresh-article-content/select-most-complete-content/simple-crawl-unsupported-policy handlers, the stale-check entry-point, and `initEmitSimpleCrawlUnsupported`) to the new two-arg form, removing the now-redundant `.detailSchema.parse(...)` calls that the publisher handles.
- Rework `initEventBridgePublisher`'s tests around real event constants and add one new test (`SimpleCrawlUnsupportedEvent` with both `recrawl: true` and `refresh: true`) that covers the always-on validation branch as a Zod refinement failure. Migrate every handler test to assert `publishEvent(EventConstant, detail)` instead of the wire-format object.

Wire format (`Source`, `DetailType`, `Detail` bytes) is byte-identical — no `.architecture/` snapshot required and no `defineEvent` / `defineCommand` added, renamed, or re-subscribed.

## Test plan

- [x] `pnpm nx run @packages/hutch-infra-components:test` — 6 tests pass, including the new always-on-validation test
- [x] `pnpm nx run save-link:test` — 362 tests pass (handler tests assert the new two-arg shape; the 8-branch lambda-effect-dispatcher test was the highest-risk migration and passes)
- [x] `pnpm nx run hutch:test` — 1664 tests pass
- [x] `pnpm nx run-many --target=check` — all 23 projects pass with 100% coverage thresholds met (publisher's new `detailSchema.parse(detail)` line is covered by the new Zod-refinement test)
- [x] `pnpm nx run-many --target=lint` — biome / tsc / knip clean across all projects

https://claude.ai/code/session_01PJBtUFuAYgofiR7zjppz5T

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJBtUFuAYgofiR7zjppz5T)_