### PR TITLE
fix(hutch): render share URLs against the current environment's origin

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -545,6 +545,7 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	const queueRouter = initQueueRoutes({
 		validateSaveableUrl: deps.validateSaveableUrl,
+		appOrigin,
 		findArticlesByUser: deps.findArticlesByUser,
 		findArticleById: deps.findArticleById,
 		findArticleByUrl: deps.findArticleByUrl,
@@ -602,6 +603,7 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	const viewRouter = initViewRoutes({
 		validateSaveableUrl: deps.validateSaveableUrl,
+		appOrigin,
 		findArticleByUrl: deps.findArticleByUrl,
 		readArticleContent: deps.readArticleContent,
 		findGeneratedSummary: deps.findGeneratedSummary,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -108,6 +108,7 @@ function markExtensionSavedArticle(res: Response): void {
 
 interface QueueDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
+	appOrigin: string;
 	findArticlesByUser: FindArticlesByUser;
 	findArticleById: FindArticleById;
 	findArticleByUrl: FindArticleByUrl;
@@ -246,6 +247,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		sendComponent(
 			req, res,
 			Base(ReaderPage({ ...ownedArticle, content: state.content }, {
+				appOrigin: deps.appOrigin,
 				summary: state.summary,
 				summaryPollUrl: state.summaryPollUrl,
 				crawl: state.crawl,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
@@ -582,7 +582,7 @@ describe("Queue routes", () => {
 				assert(btn, "share button must be rendered on /queue/:id/view");
 				const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
 				expect(`${shareUrl.origin}${shareUrl.pathname}`).toBe(
-					`https://readplace.com/view/${encodeURIComponent(articleUrl)}`,
+					`${TEST_APP_ORIGIN}/view/${encodeURIComponent(articleUrl)}`,
 				);
 				expect(shareUrl.searchParams.get("utm_source")).toBe("share-balloon");
 				expect(shareUrl.searchParams.get("utm_medium")).toBe("share");
@@ -593,7 +593,7 @@ describe("Queue routes", () => {
 				assert(copyBtn, "copy button must be rendered on /queue/:id/view");
 				const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
 				expect(`${copyUrl.origin}${copyUrl.pathname}`).toBe(
-					`https://readplace.com/view/${encodeURIComponent(articleUrl)}`,
+					`${TEST_APP_ORIGIN}/view/${encodeURIComponent(articleUrl)}`,
 				);
 				expect(copyUrl.searchParams.get("utm_source")).toBe("share-balloon");
 				expect(copyUrl.searchParams.get("utm_medium")).toBe("copy");

--- a/projects/hutch/src/runtime/web/pages/queue/queue.share-balloon.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.share-balloon.route.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+	createFakeApplyParseResult,
+	createFakePublishLinkSaved,
+	createFakePublishRecrawlLinkInitiated,
+	createFakePublishSaveAnonymousLink,
+	createNoopLogError,
+} from "@packages/test-fixtures";
+import { initReadabilityParser } from "@packages/article-parser";
+import { useTestServer, loginAgent } from "../../../test-app";
+
+const ARTICLE_URL = "https://example.com/shareable";
+const ARTICLE_HTML = `
+<html><head><title>Shareable</title></head>
+<body><article>
+	<h1>Shareable</h1>
+	<p>Body copy that easily clears the readability threshold check.</p>
+	<p>A second paragraph adds enough words for the parser to succeed.</p>
+</article></body></html>`;
+
+const useApp = useTestServer();
+
+async function saveAndOpenReader(appOrigin: string): Promise<Document> {
+	const crawlArticle = async () => ({ status: "fetched" as const, html: ARTICLE_HTML });
+	const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+	const { parseArticle } = initReadabilityParser({
+		crawlArticle,
+		sitePreParsers: [],
+		logError: createNoopLogError(),
+	});
+	const applyParseResult = createFakeApplyParseResult({
+		articleStore: fixture.articleStore,
+		articleCrawl: fixture.articleCrawl,
+		parseArticle,
+	});
+	const harness = useApp({
+		...fixture,
+		parser: { parseArticle, crawlArticle },
+		events: {
+			publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+			publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+			publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+			publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+			publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+			publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+			publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+			publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
+		},
+		shared: { ...fixture.shared, appOrigin },
+	});
+	const agent = await loginAgent(harness.server, harness.auth);
+
+	await agent.post("/queue/save").type("form").send({ url: ARTICLE_URL });
+	const queueDoc = new JSDOM((await agent.get("/queue")).text).window.document;
+	const articleId = queueDoc
+		.querySelector("[data-test-article-list] .queue-article")
+		?.getAttribute("data-test-article");
+	assert(articleId, "saved article must surface in the queue");
+
+	const response = await agent.get(`/queue/${articleId}/view`);
+	expect(response.status).toBe(200);
+	return new JSDOM(response.text).window.document;
+}
+
+describe("GET /queue/:id/view share balloon", () => {
+	it("renders share URLs using the default test fixture's appOrigin", async () => {
+		const doc = await saveAndOpenReader(TEST_APP_ORIGIN);
+
+		const btn = doc.querySelector("[data-test-share-balloon]");
+		assert(btn, "share button must be rendered");
+		const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
+		expect(shareUrl.origin).toBe(TEST_APP_ORIGIN);
+		expect(shareUrl.pathname).toBe(`/view/${encodeURIComponent(ARTICLE_URL)}`);
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		expect(copyUrl.origin).toBe(TEST_APP_ORIGIN);
+		expect(copyUrl.pathname).toBe(`/view/${encodeURIComponent(ARTICLE_URL)}`);
+	});
+
+	it("renders share URLs against the appOrigin configured at the composition root (not a hardcoded host)", async () => {
+		const doc = await saveAndOpenReader("https://staging.readplace.com");
+
+		const btn = doc.querySelector("[data-test-share-balloon]");
+		assert(btn, "share button must be rendered");
+		const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
+		expect(shareUrl.origin).toBe("https://staging.readplace.com");
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		expect(copyUrl.origin).toBe("https://staging.readplace.com");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.test.ts
@@ -35,9 +35,11 @@ function makeArticle(overrides: Partial<SavedArticle> = {}): SavedArticle {
 	};
 }
 
+const DEFAULT_APP_ORIGIN = "http://localhost:3000";
+
 describe("ReaderPage", () => {
 	it("renders the share balloon wrap so client init can attach to it", () => {
-		const html = Base(ReaderPage(makeArticle()), {
+		const html = Base(ReaderPage(makeArticle(), { appOrigin: DEFAULT_APP_ORIGIN }), {
 			isAuthenticated: true,
 			emailVerified: undefined,
 		}).to("text/html").body;
@@ -51,7 +53,7 @@ describe("ReaderPage", () => {
 		const article = makeArticle({
 			userId: UserIdSchema.parse("abcdef0123456789abcdef0123456789"),
 		});
-		const html = Base(ReaderPage(article), {
+		const html = Base(ReaderPage(article, { appOrigin: DEFAULT_APP_ORIGIN }), {
 			isAuthenticated: true,
 			emailVerified: undefined,
 		}).to("text/html").body;
@@ -70,5 +72,23 @@ describe("ReaderPage", () => {
 		assert(copyHref, "copy button must carry a data-share-url");
 		const copyUrl = new URL(copyHref);
 		assert.equal(copyUrl.searchParams.get("utm_content"), "abcdef");
+	});
+
+	it("renders the share-balloon URLs against the supplied appOrigin, not a hardcoded host", () => {
+		const html = Base(
+			ReaderPage(makeArticle(), { appOrigin: "https://staging.readplace.com" }),
+			{ isAuthenticated: true, emailVerified: undefined },
+		).to("text/html").body;
+		const doc = new JSDOM(html).window.document;
+
+		const shareBtn = doc.querySelector("[data-test-share-balloon]");
+		assert(shareBtn, "share button must be rendered");
+		const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+		assert.equal(shareUrl.origin, "https://staging.readplace.com");
+
+		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+		assert(copyBtn, "copy button must be rendered");
+		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+		assert.equal(copyUrl.origin, "https://staging.readplace.com");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -15,8 +15,6 @@ import {
 import { shareUserIdPrefix } from "../../shared/share-balloon/share-user-id-prefix";
 import { READER_STYLES } from "./reader.styles";
 
-const CANONICAL_BASE_URL = "https://readplace.com";
-
 const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "utf-8");
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
@@ -42,7 +40,8 @@ export function markReadPostUrl(articleId: string, slot: "top" | "bottom"): stri
 
 export function ReaderPage(
 	article: SavedArticle,
-	options?: {
+	options: {
+		appOrigin: string;
 		summary?: GeneratedSummary;
 		summaryPollUrl?: string;
 		crawl?: ArticleCrawl;
@@ -59,13 +58,13 @@ export function ReaderPage(
 		estimatedReadTime: article.estimatedReadTime,
 		url: article.url,
 		content: article.content,
-		crawl: options?.crawl,
-		readerPollUrl: options?.readerPollUrl,
-		summary: options?.summary,
-		summaryPollUrl: options?.summaryPollUrl,
+		crawl: options.crawl,
+		readerPollUrl: options.readerPollUrl,
+		summary: options.summary,
+		summaryPollUrl: options.summaryPollUrl,
 		summaryOpen: true,
-		progress: options?.progress,
-		audioEnabled: options?.audioEnabled,
+		progress: options.progress,
+		audioEnabled: options.audioEnabled,
 		backLink: {
 			topHref: "/queue?utm_source=reader&utm_medium=internal&utm_content=back-top",
 			bottomHref: "/queue?utm_source=reader&utm_medium=internal&utm_content=back-bottom",
@@ -85,10 +84,10 @@ export function ReaderPage(
 				fields: [{ name: "status", value: "read" }],
 			},
 		],
-		extensionInstallUrl: options?.extensionInstallUrl,
+		extensionInstallUrl: options.extensionInstallUrl,
 	});
 	const shareBalloon = renderShareBalloon({
-		shareUrl: `${CANONICAL_BASE_URL}/view/${encodeURIComponent(article.url)}`,
+		shareUrl: `${options.appOrigin}/view/${encodeURIComponent(article.url)}`,
 		shareTitle: article.metadata.title,
 		shareHint: "Click here to share this post!",
 		shareSource: "reader-internal",
@@ -99,7 +98,7 @@ export function ReaderPage(
 	return {
 		seo: {
 			title: formatReaderDocumentTitle(article.metadata.title),
-			description: truncateForSeo(pickExcerpt(options?.summary, article.metadata.excerpt)),
+			description: truncateForSeo(pickExcerpt(options.summary, article.metadata.excerpt)),
 			canonicalUrl: `/queue/${articleId}/view`,
 			robots: "noindex, nofollow",
 		},

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -8,6 +8,7 @@ import { sharedUserIdFrom } from "./view-expiry";
 
 const baseInput: ViewPageInput = {
 	articleUrl: "https://example.com/post",
+	appOrigin: "http://localhost:3000",
 	metadata: {
 		title: "Hello World",
 		siteName: "example.com",
@@ -511,6 +512,44 @@ describe("ViewPage", () => {
 			assert(shareBtn, "share button must be rendered");
 			const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
 			assert.equal(shareUrl.searchParams.get("utm_content"), null);
+		});
+
+		it("renders the share-balloon URLs against the supplied appOrigin, not a hardcoded host", () => {
+			const doc = render({
+				...baseInput,
+				appOrigin: "https://staging.readplace.com",
+			});
+
+			const shareBtn = doc.querySelector("[data-test-share-balloon]");
+			assert(shareBtn, "share button must be rendered");
+			const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
+			assert.equal(shareUrl.origin, "https://staging.readplace.com");
+
+			const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+			assert(copyBtn, "copy button must be rendered");
+			const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+			assert.equal(copyUrl.origin, "https://staging.readplace.com");
+		});
+
+		it("keeps the SEO canonical URL on https://readplace.com regardless of appOrigin (search indexing must stay on production)", () => {
+			const doc = render({
+				...baseInput,
+				appOrigin: "https://staging.readplace.com",
+			});
+
+			const canonical = `https://readplace.com/view/${encodeURIComponent("https://example.com/post")}`;
+			assert.equal(
+				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+				canonical,
+			);
+			assert.equal(
+				doc.querySelector('meta[property="og:url"]')?.getAttribute("content"),
+				canonical,
+			);
+			const script = doc.querySelector('script[type="application/ld+json"]');
+			assert(script, "JSON-LD script must be rendered");
+			const data = JSON.parse(script.textContent ?? "{}");
+			assert.equal(data.url, canonical);
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -25,6 +25,10 @@ const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" d
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
 const EXPIRY_COUNTER_SCRIPT = `<script src="/client-dist/expiry-counter.client.js" defer></script>`;
 
+/** SEO-only constant: <link rel="canonical"> and JSON-LD url must always point
+ * at production so search engines index a single host. The share URL uses the
+ * visitor's current origin (input.appOrigin) instead — copying a link on
+ * staging should paste the staging URL, not production. */
 const CANONICAL_BASE_URL = "https://readplace.com";
 const DEFAULT_OG_IMAGE = `${STATIC_BASE_URL}/og-image-1200x630.png`;
 const DEFAULT_TWITTER_IMAGE = `${STATIC_BASE_URL}/twitter-card-1200x600.png`;
@@ -82,6 +86,7 @@ export function buildExpiryFields(
 
 export interface ViewPageInput {
 	articleUrl: string;
+	appOrigin: string;
 	metadata: ArticleMetadata;
 	estimatedReadTime: Minutes;
 	content?: string;
@@ -114,9 +119,10 @@ export function ViewPage(input: ViewPageInput): PageBody {
 	});
 
 	const canonicalViewUrl = `${CANONICAL_BASE_URL}/view/${encodeURIComponent(input.articleUrl)}`;
+	const shareableViewUrl = `${input.appOrigin}/view/${encodeURIComponent(input.articleUrl)}`;
 
 	const shareBalloon = renderShareBalloon({
-		shareUrl: canonicalViewUrl,
+		shareUrl: shareableViewUrl,
 		shareTitle: input.metadata.title,
 		shareHint: "Click here to share this view!",
 		shareSource: "reader-public",

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -49,6 +49,7 @@ import { ViewPage, formatViewDocumentTitle, type ViewAction } from "./view.compo
 
 interface ViewDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
+	appOrigin: string;
 	findArticleByUrl: FindArticleByUrl;
 	readArticleContent: ReadArticleContent;
 	findGeneratedSummary: FindGeneratedSummary;
@@ -225,6 +226,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 			Base(
 				ViewPage({
 					articleUrl,
+					appOrigin: deps.appOrigin,
 					metadata,
 					estimatedReadTime,
 					content: state.content,

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -466,7 +466,7 @@ describe("View routes", () => {
 			expect(btn.getAttribute("aria-label")).toBe("Share this article");
 			const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
 			expect(`${shareUrl.origin}${shareUrl.pathname}`).toBe(
-				`https://readplace.com/view/${ENCODED}`,
+				`${TEST_APP_ORIGIN}/view/${ENCODED}`,
 			);
 			expect(shareUrl.searchParams.get("utm_source")).toBe("share-balloon");
 			expect(shareUrl.searchParams.get("utm_medium")).toBe("share");
@@ -477,11 +477,53 @@ describe("View routes", () => {
 			assert(copyBtn, "copy button must be rendered");
 			const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
 			expect(`${copyUrl.origin}${copyUrl.pathname}`).toBe(
-				`https://readplace.com/view/${ENCODED}`,
+				`${TEST_APP_ORIGIN}/view/${ENCODED}`,
 			);
 			expect(copyUrl.searchParams.get("utm_source")).toBe("share-balloon");
 			expect(copyUrl.searchParams.get("utm_medium")).toBe("copy");
 			expect(copyUrl.searchParams.get("utm_campaign")).toBe("reader-public");
+		});
+
+		it("renders share URLs against the appOrigin configured at the composition root (not a hardcoded host)", async () => {
+			const parseArticle: ParseArticle = async () => buildParseResult();
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const harness = useApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
+				},
+				shared: { ...fixture.shared, appOrigin: "https://staging.readplace.com" },
+			});
+
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const btn = doc.querySelector("[data-test-share-balloon]");
+			assert(btn, "share button must be rendered");
+			const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
+			expect(shareUrl.origin).toBe("https://staging.readplace.com");
+
+			const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
+			assert(copyBtn, "copy button must be rendered");
+			const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
+			expect(copyUrl.origin).toBe("https://staging.readplace.com");
+
+			expect(
+				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+			).toBe(`https://readplace.com/view/${ENCODED}`);
 		});
 
 		it("renders a dismiss button with an accessible label", async () => {


### PR DESCRIPTION
## Summary

- Share/Copy buttons on `/view/<url>` and `/queue/:id/view` were hardcoded to `https://readplace.com`, so links copied on staging or in local dev pasted as production URLs.
- Wire `appOrigin` through `initViewRoutes` and `initQueueRoutes` into the page components and use it for the share URL.
- Keep `CANONICAL_BASE_URL = "https://readplace.com"` for `<link rel="canonical">` and JSON-LD `url` — SEO must index a single host regardless of which deploy the visitor is on.

## Test plan

- [x] Component-level: `view.component.test.ts` and `reader.component.test.ts` assert that swapping `appOrigin` swaps the share/copy URL origin, while the SEO canonical stays on `readplace.com`.
- [x] Route-level: existing `view.route.test.ts` share-balloon test updated to expect `TEST_APP_ORIGIN`; new test overrides `shared.appOrigin` to `https://staging.readplace.com` and asserts the rendered share URL origin tracks it.
- [x] Route-level (new): `queue.share-balloon.route.test.ts` covers `/queue/:id/view` with both the default fixture origin and a swapped staging origin. Existing `queue.reader.advanced.route.test.ts` share-balloon assertion updated from hardcoded `https://readplace.com` to `TEST_APP_ORIGIN`.
- [x] `pnpm nx test hutch` → all 1670 tests pass (144 suites).
- [x] `pnpm nx check hutch` → 100% function/line coverage maintained, all thresholds met.
- [x] `pnpm nx lint hutch` → clean.

## Regression-proof claim

Three layers protect the fix:
1. **Types**: `appOrigin` is a required field on `ViewPageInput`, `ReaderPage` options, and both router dependency types — any missed call site fails `tsc`.
2. **Component tests**: rendered share-URL origin must equal the input.
3. **Route tests**: overriding `shared.appOrigin` in the test fixture and asserting the rendered origin changes proves the dependency reaches the page. A future revert to a hardcoded constant cannot pass CI.

https://claude.ai/code/session_01CzeqRmAJexJPVGjCtsmcme

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzeqRmAJexJPVGjCtsmcme)_