### PR TITLE
feat(hutch): add /import from-URL acquisition mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@packages/domain':
         specifier: workspace:*
         version: link:../../src/packages/domain
+      '@packages/extract-links-from-page':
+        specifier: workspace:*
+        version: link:../../src/packages/extract-links-from-page
       '@packages/hutch-infra-components':
         specifier: workspace:*
         version: link:../../src/packages/hutch-infra-components
@@ -703,6 +706,34 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  src/packages/extract-links-from-page:
+    dependencies:
+      '@packages/crawl-article':
+        specifier: workspace:*
+        version: link:../crawl-article
+      '@packages/domain':
+        specifier: workspace:*
+        version: link:../domain
+      linkedom:
+        specifier: 0.18.12
+        version: 0.18.12
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      c8:
+        specifier: 10.1.3
+        version: 10.1.3
+      concurrently:
+        specifier: 9.2.1
+        version: 9.2.1
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@22.19.1)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   src/packages/hutch-infra-components:
     dependencies:
       '@aws-sdk/client-eventbridge':
@@ -843,6 +874,9 @@ importers:
       '@packages/domain':
         specifier: workspace:*
         version: link:../domain
+      '@packages/extract-links-from-page':
+        specifier: workspace:*
+        version: link:../extract-links-from-page
       '@packages/hutch-infra-components':
         specifier: workspace:*
         version: link:../hutch-infra-components

--- a/projects/hutch/knip.config.ts
+++ b/projects/hutch/knip.config.ts
@@ -38,6 +38,7 @@ export default {
 		"@packages/article-state-types",
 		"@packages/crawl-article",
 		"@packages/domain",
+		"@packages/extract-links-from-page",
 		"@packages/onboarding-extension-signal",
 		"@packages/refresh-article-content",
 		"@packages/retriable",

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -51,6 +51,7 @@
     "@packages/article-state-types": "workspace:*",
     "@packages/crawl-article": "workspace:*",
     "@packages/domain": "workspace:*",
+    "@packages/extract-links-from-page": "workspace:*",
     "@packages/hutch-infra-components": "workspace:*",
     "@packages/hutch-logger": "workspace:*",
     "@packages/hutch-storage-client": "workspace:*",

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -16,6 +16,7 @@ import { requireEnv } from '../runtime/domain/require-env'
 import { initRefreshArticleIfStale } from '@packages/test-fixtures/providers/article-freshness'
 import type { ExtractPdf } from '@packages/crawl-article'
 import { CRAWL_PERSONAS, initCrawlArticle, initCrawlFetch } from '@packages/crawl-article'
+import { initExtractLinksFromPageUrl } from '@packages/extract-links-from-page'
 import { initReadabilityParser, mediumPreParser, theInformationPreParser } from '@packages/article-parser'
 import { initInMemoryRefreshArticleContent } from '@packages/test-fixtures/providers/events'
 import { initInMemoryUpdateFetchTimestamp } from '@packages/test-fixtures/providers/events'
@@ -125,6 +126,10 @@ const { app: hutchApp, auth, email } = createTestApp({
   },
   freshness: { refreshArticleIfStale },
   summary,
+  importSession: {
+    importSessionStore: fixture.importSession.importSessionStore,
+    extractLinksFromPageUrl: initExtractLinksFromPageUrl({ crawlFetch, validateUrl: e2eValidateSaveableUrl }),
+  },
   shared: {
     validateSaveableUrl: e2eValidateSaveableUrl,
     appOrigin: fixture.shared.appOrigin,

--- a/projects/hutch/src/e2e/queue-flow/action-catalog.ts
+++ b/projects/hutch/src/e2e/queue-flow/action-catalog.ts
@@ -38,6 +38,11 @@ export type ImportActionKey =
 	| 'import-deselect-all-select-some'
 	| 'import-paginated-select-all-spans-pages'
 
+export type ImportFromUrlActionKey =
+	| 'import-from-url-happy-path'
+	| 'import-from-url-page-returns-500'
+	| 'import-from-url-page-has-no-links'
+
 export const TEST_ARTICLE_COUNT = 4
 export const PAGINATION_ARTICLE_COUNT = 17
 export const SEED_ARTICLE_COUNT = 2
@@ -83,6 +88,7 @@ export type QueueFlowActionKey =
 	| SeedActionKey
 	| QueueActionKey
 	| ImportActionKey
+	| ImportFromUrlActionKey
 
 // Fails to compile if the tuple omits any union member — keeps skipFactory
 // callers in run.e2e-staging.ts from silently dropping a key the local test
@@ -125,3 +131,9 @@ export const IMPORT_ACTION_KEYS = [
 	'import-deselect-all-select-some',
 	'import-paginated-select-all-spans-pages',
 ] as const satisfies AssertExhaustive<ImportActionKey, readonly ImportActionKey[]>
+
+export const IMPORT_FROM_URL_ACTION_KEYS = [
+	'import-from-url-happy-path',
+	'import-from-url-page-returns-500',
+	'import-from-url-page-has-no-links',
+] as const satisfies AssertExhaustive<ImportFromUrlActionKey, readonly ImportFromUrlActionKey[]>

--- a/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
@@ -93,7 +93,7 @@ export function createImportFromUrlActions(
 				await openFromUrlPanel(page, config)
 				await submitUrl(page, `${config.baseUrl}/e2e/fixtures/links-page-empty`)
 				const error = page.locator('[data-test-import-error]')
-				await expect(error).toContainText("couldn't find any links")
+				await expect(error).toContainText("outbound links")
 				await page.goto(`${config.baseUrl}/queue`, { waitUntil: 'domcontentloaded' })
 				importFromUrlProgress.pageWithoutLinksSurfaced = true
 			},

--- a/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { expect, type Page } from '@playwright/test'
+import type { PageAction } from '../hateoas/navigation-handler.types'
+import type { ImportFromUrlActionKey } from './action-catalog'
+import { isOnPage, clickAndWaitForPageReload } from '../page-interactions'
+import type { AuthProgress } from './auth-actions'
+import type { QueueProgress } from './queue-actions'
+
+export type ImportFromUrlProgress = {
+	happyPathImported: boolean
+	pageError500Surfaced: boolean
+	pageWithoutLinksSurfaced: boolean
+}
+
+export type ImportFromUrlActionsConfig = { baseUrl: string }
+
+async function openFromUrlPanel(page: Page, config: ImportFromUrlActionsConfig): Promise<void> {
+	await page.goto(`${config.baseUrl}/import?mode=from-url`, { waitUntil: 'domcontentloaded' })
+}
+
+async function submitUrl(page: Page, url: string): Promise<void> {
+	await page.locator('[data-test-import-from-url-input]').fill(url)
+	await clickAndWaitForPageReload(page, page.locator('[data-test-action="import-from-url-submit"]'))
+}
+
+async function commitAndAssertOnQueue(page: Page): Promise<void> {
+	await clickAndWaitForPageReload(page, page.locator('[data-test-action="import-commit"]'))
+	const onQueue = await isOnPage(page, 'page-queue')
+	assert.ok(onQueue, 'commit must redirect to /queue')
+}
+
+async function deleteAllOnQueue(page: Page): Promise<void> {
+	let count = await page.locator('[data-test-action="delete"]').count()
+	while (count > 0) {
+		await clickAndWaitForPageReload(page, page.locator('[data-test-action="delete"]').first())
+		count = await page.locator('[data-test-action="delete"]').count()
+	}
+}
+
+export function createImportFromUrlActions(
+	config: ImportFromUrlActionsConfig,
+	queueProgress: QueueProgress,
+	importFromUrlProgress: ImportFromUrlProgress,
+): (authProgress: AuthProgress) => Record<ImportFromUrlActionKey, PageAction> {
+	return (authProgress) => ({
+		'import-from-url-happy-path': {
+			isAvailable: async (page) => {
+				if (!authProgress.loggedIn) return false
+				if (!queueProgress.cleanupDeleted) return false
+				if (importFromUrlProgress.happyPathImported) return false
+				return isOnPage(page, 'page-queue')
+			},
+			execute: async (page) => {
+				await openFromUrlPanel(page, config)
+				await submitUrl(page, `${config.baseUrl}/e2e/fixtures/links-page/happy`)
+				const summary = page.locator('[data-test-import-summary] .import__summary-count')
+				await expect(summary).toHaveText('3')
+				await commitAndAssertOnQueue(page)
+				const cards = await page.locator('[data-test-article]').count()
+				assert.equal(cards, 3, 'from-url happy path: expected 3 cards on /queue')
+				await deleteAllOnQueue(page)
+				importFromUrlProgress.happyPathImported = true
+			},
+		},
+
+		'import-from-url-page-returns-500': {
+			isAvailable: async (page) => {
+				if (!authProgress.loggedIn) return false
+				if (!queueProgress.cleanupDeleted) return false
+				if (!importFromUrlProgress.happyPathImported) return false
+				if (importFromUrlProgress.pageError500Surfaced) return false
+				return isOnPage(page, 'page-queue')
+			},
+			execute: async (page) => {
+				await openFromUrlPanel(page, config)
+				await submitUrl(page, `${config.baseUrl}/e2e/fixtures/links-page-error`)
+				const error = page.locator('[data-test-import-error]')
+				await expect(error).toContainText("couldn't fetch")
+				importFromUrlProgress.pageError500Surfaced = true
+			},
+		},
+
+		'import-from-url-page-has-no-links': {
+			isAvailable: async (page) => {
+				if (!authProgress.loggedIn) return false
+				if (!queueProgress.cleanupDeleted) return false
+				if (!importFromUrlProgress.pageError500Surfaced) return false
+				if (importFromUrlProgress.pageWithoutLinksSurfaced) return false
+				return isOnPage(page, 'page-queue')
+			},
+			execute: async (page) => {
+				await openFromUrlPanel(page, config)
+				await submitUrl(page, `${config.baseUrl}/e2e/fixtures/links-page-empty`)
+				const error = page.locator('[data-test-import-error]')
+				await expect(error).toContainText("couldn't find any links")
+				importFromUrlProgress.pageWithoutLinksSurfaced = true
+			},
+		},
+	})
+}

--- a/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
@@ -56,8 +56,8 @@ export function createImportFromUrlActions(
 				const summary = page.locator('[data-test-import-summary] .import__summary-count')
 				await expect(summary).toHaveText('3')
 				await commitAndAssertOnQueue(page)
-				const cards = await page.locator('[data-test-article]').count()
-				assert.equal(cards, 3, 'from-url happy path: expected 3 cards on /queue')
+				const flash = page.locator('[data-test-import-flash]')
+				await expect(flash).toContainText('Imported 3')
 				await deleteAllOnQueue(page)
 				importFromUrlProgress.happyPathImported = true
 			},
@@ -76,6 +76,7 @@ export function createImportFromUrlActions(
 				await submitUrl(page, `${config.baseUrl}/e2e/fixtures/links-page-error`)
 				const error = page.locator('[data-test-import-error]')
 				await expect(error).toContainText("couldn't fetch")
+				await page.goto(`${config.baseUrl}/queue`, { waitUntil: 'domcontentloaded' })
 				importFromUrlProgress.pageError500Surfaced = true
 			},
 		},
@@ -93,6 +94,7 @@ export function createImportFromUrlActions(
 				await submitUrl(page, `${config.baseUrl}/e2e/fixtures/links-page-empty`)
 				const error = page.locator('[data-test-import-error]')
 				await expect(error).toContainText("couldn't find any links")
+				await page.goto(`${config.baseUrl}/queue`, { waitUntil: 'domcontentloaded' })
 				importFromUrlProgress.pageWithoutLinksSurfaced = true
 			},
 		},

--- a/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/import-from-url-actions.ts
@@ -15,7 +15,7 @@ export type ImportFromUrlProgress = {
 export type ImportFromUrlActionsConfig = { baseUrl: string }
 
 async function openFromUrlPanel(page: Page, config: ImportFromUrlActionsConfig): Promise<void> {
-	await page.goto(`${config.baseUrl}/import?mode=from-url`, { waitUntil: 'domcontentloaded' })
+	await page.goto(`${config.baseUrl}/import?mode=from-url&feature=import-link-public`, { waitUntil: 'domcontentloaded' })
 }
 
 async function submitUrl(page: Page, url: string): Promise<void> {

--- a/projects/hutch/src/e2e/queue-flow/queue-flow.ts
+++ b/projects/hutch/src/e2e/queue-flow/queue-flow.ts
@@ -9,6 +9,7 @@ import type {
   SavePermalinkActionKey,
   BannerOnReaderActionKey,
   ImportActionKey,
+  ImportFromUrlActionKey,
   QueueFlowActionKey,
 } from './action-catalog'
 import { createAuthActions, type AuthData, type AuthProgress } from './auth-actions'
@@ -25,6 +26,7 @@ export type PreQueueActionFactories = {
   savePermalink: (authProgress: AuthProgress) => Record<SavePermalinkActionKey, PageAction>
   bannerOnReader: (authProgress: AuthProgress) => Record<BannerOnReaderActionKey, PageAction>
   importActions: (authProgress: AuthProgress) => Record<ImportActionKey, PageAction>
+  importFromUrlActions: (authProgress: AuthProgress) => Record<ImportFromUrlActionKey, PageAction>
 }
 
 export interface QueueFlowConfig {
@@ -47,7 +49,7 @@ export async function runQueueFlow(page: Page, config: QueueFlowConfig): Promise
 
   const queueProgress = config.queueProgress
 
-  const { anonymousView, onboarding, seed, cleanup, passwordReset, savePermalink, bannerOnReader, importActions } = config.preQueueActionFactories
+  const { anonymousView, onboarding, seed, cleanup, passwordReset, savePermalink, bannerOnReader, importActions, importFromUrlActions } = config.preQueueActionFactories
 
   const allActions: Record<QueueFlowActionKey, PageAction> = {
     ...anonymousView(authProgress),
@@ -60,6 +62,7 @@ export async function runQueueFlow(page: Page, config: QueueFlowConfig): Promise
     ...createAuthActions(config.authData, authProgress, config.passwordResetProgress),
     ...createQueueActions(authProgress, queueProgress, config.testArticles),
     ...importActions(authProgress),
+    ...importFromUrlActions(authProgress),
   }
 
   const allProgressObjects: Record<string, boolean>[] = [

--- a/projects/hutch/src/e2e/queue-flow/run.e2e-local.ts
+++ b/projects/hutch/src/e2e/queue-flow/run.e2e-local.ts
@@ -3,6 +3,7 @@ import { test } from '@playwright/test'
 import { createBannerOnReaderActions, type BannerOnReaderProgress } from './banner-on-reader-actions'
 import { createCleanupActions, type CleanupProgress } from './cleanup-actions'
 import { createImportActions, type ImportProgress } from './import-actions'
+import { createImportFromUrlActions, type ImportFromUrlProgress } from './import-from-url-actions'
 import { createOnboardingActions, type OnboardingProgress } from './onboarding-actions'
 import { createPasswordResetActions, type PasswordResetProgress } from './password-reset-actions'
 import { createSavePermalinkActions, type SavePermalinkProgress } from './save-permalink-actions'
@@ -89,6 +90,12 @@ test.describe('Queue management flow (local)', () => {
       paginatedSelectAllSpansPagesImported: false,
     }
 
+    const importFromUrlProgress: ImportFromUrlProgress = {
+      happyPathImported: false,
+      pageError500Surfaced: false,
+      pageWithoutLinksSurfaced: false,
+    }
+
     await runQueueFlow(page, {
       baseURL: BASE_URL,
       testArticles: createLocalTestArticles(BASE_URL),
@@ -123,8 +130,9 @@ test.describe('Queue management flow (local)', () => {
           bannerOnReaderProgress,
         ),
         importActions: createImportActions({ baseUrl: BASE_URL }, queueProgress, importProgress),
+        importFromUrlActions: createImportFromUrlActions({ baseUrl: BASE_URL }, queueProgress, importFromUrlProgress),
       },
-      preQueueProgressObjects: [viewPageProgress, seedProgress, cleanupProgress, passwordResetProgress, onboardingProgress, savePermalinkProgress, bannerOnReaderProgress, importProgress],
+      preQueueProgressObjects: [viewPageProgress, seedProgress, cleanupProgress, passwordResetProgress, onboardingProgress, savePermalinkProgress, bannerOnReaderProgress, importProgress, importFromUrlProgress],
       maxNavigations: 120,
     })
   })

--- a/projects/hutch/src/e2e/queue-flow/run.e2e-staging.ts
+++ b/projects/hutch/src/e2e/queue-flow/run.e2e-staging.ts
@@ -5,6 +5,7 @@ import { test } from '@playwright/test'
 import type { PageAction } from '../hateoas/navigation-handler.types'
 import {
   IMPORT_ACTION_KEYS,
+  IMPORT_FROM_URL_ACTION_KEYS,
   ONBOARDING_ACTION_KEYS,
   PASSWORD_RESET_ACTION_KEYS,
   SEED_ACTION_KEYS,
@@ -12,6 +13,7 @@ import {
 import { createBannerOnReaderActions, type BannerOnReaderProgress } from './banner-on-reader-actions'
 import { createCleanupActions, type CleanupProgress } from './cleanup-actions'
 import type { ImportProgress } from './import-actions'
+import type { ImportFromUrlProgress } from './import-from-url-actions'
 import { createSavePermalinkActions, type SavePermalinkProgress } from './save-permalink-actions'
 import { createAnonymousViewPageActions, type ViewPageProgress } from './view-page-actions'
 import type { OnboardingProgress } from './onboarding-actions'
@@ -109,6 +111,12 @@ test.describe('Queue management flow (staging)', () => {
       paginatedSelectAllSpansPagesImported: true,
     }
 
+    const importFromUrlProgress: ImportFromUrlProgress = {
+      happyPathImported: true,
+      pageError500Surfaced: true,
+      pageWithoutLinksSurfaced: true,
+    }
+
     const queueProgress: QueueProgress = {
       allArticlesAdded: false,
       paginationArticlesAdded: false,
@@ -175,6 +183,7 @@ test.describe('Queue management flow (staging)', () => {
           bannerOnReaderProgress,
         ),
         importActions: skipFactory(IMPORT_ACTION_KEYS),
+        importFromUrlActions: skipFactory(IMPORT_FROM_URL_ACTION_KEYS),
       },
       preQueueProgressObjects: [
         viewPageProgress,
@@ -185,6 +194,7 @@ test.describe('Queue management flow (staging)', () => {
         seedProgress,
         passwordResetProgress,
         importProgress,
+        importFromUrlProgress,
       ],
       maxNavigations: 100,
     })

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -14,6 +14,7 @@ import {
 	initCrawlFetch,
 	initFetchThumbnailImage,
 } from "@packages/crawl-article";
+import { initExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import { initFinalizeArticle } from "save-link/finalize-article";
 import { initCrawlAndFinalizeArticle } from "save-link/crawl-and-finalize-article";
 import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
@@ -173,6 +174,7 @@ function initProviders() {
 		const { putPendingHtml } = initPutPendingHtml({ client: new S3Client({}), bucketName: pendingHtmlBucketName });
 		const extractPdf = createPdfDeferralStub(publishStaleCheckRequested);
 		const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
+		const extractLinksFromPageUrl = initExtractLinksFromPageUrl({ crawlFetch });
 		const { parseHtml } = initReadabilityParser({
 			crawlArticle,
 			sitePreParsers: [theInformationPreParser, mediumPreParser],
@@ -231,6 +233,7 @@ function initProviders() {
 			articleStore,
 			readArticleContent,
 			importSessionStore,
+			extractLinksFromPageUrl,
 			subscriptionProviders,
 			trialScheduler,
 			createSubscriptionOnExistingCustomer: stripeSubscriptions.createSubscriptionOnExistingCustomer,
@@ -295,6 +298,7 @@ function initProviders() {
 	const { publishStaleCheckRequested } = initInMemoryStaleCheckRequested({ logger: consoleLogger });
 	const extractPdf = createPdfDeferralStub(publishStaleCheckRequested);
 	const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
+	const extractLinksFromPageUrl = initExtractLinksFromPageUrl({ crawlFetch });
 	const { parseHtml } = initReadabilityParser({
 		crawlArticle,
 		sitePreParsers: [theInformationPreParser, mediumPreParser],
@@ -384,6 +388,7 @@ function initProviders() {
 			logError,
 		}),
 		importSessionStore,
+		extractLinksFromPageUrl,
 		subscriptionProviders: devSubscriptionProviders,
 		trialScheduler: devTrialScheduler,
 		createSubscriptionOnExistingCustomer: devStripeSubscriptions.createSubscriptionOnExistingCustomer,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -174,7 +174,7 @@ function initProviders() {
 		const { putPendingHtml } = initPutPendingHtml({ client: new S3Client({}), bucketName: pendingHtmlBucketName });
 		const extractPdf = createPdfDeferralStub(publishStaleCheckRequested);
 		const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
-		const extractLinksFromPageUrl = initExtractLinksFromPageUrl({ crawlFetch });
+		const extractLinksFromPageUrl = initExtractLinksFromPageUrl({ crawlFetch, validateUrl: validateSaveableUrl });
 		const { parseHtml } = initReadabilityParser({
 			crawlArticle,
 			sitePreParsers: [theInformationPreParser, mediumPreParser],
@@ -298,7 +298,7 @@ function initProviders() {
 	const { publishStaleCheckRequested } = initInMemoryStaleCheckRequested({ logger: consoleLogger });
 	const extractPdf = createPdfDeferralStub(publishStaleCheckRequested);
 	const crawlArticle = initCrawlArticle({ crawlFetch, extractPdf, logError });
-	const extractLinksFromPageUrl = initExtractLinksFromPageUrl({ crawlFetch });
+	const extractLinksFromPageUrl = initExtractLinksFromPageUrl({ crawlFetch, validateUrl: validateSaveableUrl });
 	const { parseHtml } = initReadabilityParser({
 		crawlArticle,
 		sitePreParsers: [theInformationPreParser, mediumPreParser],

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -260,16 +260,16 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 			x: 6, y: 40, width: 12, height: 4,
 			view: "pie",
 		}),
-		/** Stacked counts of import_uploaded vs import_committed surface
-		 *  silent upload→commit failures (uploaded but never committed). */
+		/** Stacked counts of acquire events vs import_committed surface
+		 *  silent acquire→commit failures (acquired but never committed). */
 		logWidget({
 			region,
-			title: "Import upload → commit funnel per day",
+			title: "Import acquire → commit funnel per day",
 			logGroupNames: [hutchLogGroupName],
 			query: [
 				"fields @timestamp, event",
 				`| filter stream = "${STREAMS.analytics}"`,
-				`| filter event in ["${ANALYTICS_EVENTS.importUploaded}", "${ANALYTICS_EVENTS.importCommitted}"]`,
+				`| filter event in ["${ANALYTICS_EVENTS.importUploaded}", "${ANALYTICS_EVENTS.importFromUrlAcquired}", "${ANALYTICS_EVENTS.importCommitted}"]`,
 				"| stats count(*) as imports by bin(1d), event",
 			].join(" "),
 			x: 0, y: 44, width: 24, height: 6,

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -18,6 +18,7 @@ export const STREAMS = {
 export const ANALYTICS_EVENTS = {
 	pageview: "pageview",
 	importUploaded: "import_uploaded",
+	importFromUrlAcquired: "import_from_url_acquired",
 	importCommitted: "import_committed",
 	articleRead: "article_read",
 } as const;

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -37,7 +37,7 @@ function toSession(row: z.infer<typeof SessionRow>): ImportSession {
 		createdAt: row.createdAt,
 		expiresAt: row.expiresAt,
 		totalUrls: row.totalUrls,
-		totalFoundInFile: row.totalFoundInFile,
+		totalFound: row.totalFoundInFile,
 		truncated: row.truncated,
 		deselected: allSelected
 			? new Set(row.deselected ?? [])
@@ -65,7 +65,7 @@ export function initDynamoDbImportSession(deps: {
 	}
 
 	return {
-		createImportSession: async ({ userId, urls, truncated, totalFoundInFile }) => {
+		createImportSession: async ({ userId, urls, truncated, totalFound }) => {
 			const id = ImportSessionIdSchema.parse(randomBytes(16).toString("hex"));
 			const createdAt = deps.now().toISOString();
 			const expiresAt = Math.floor(deps.now().getTime() / 1000) + IMPORT_SESSION_TTL_SECONDS;
@@ -76,7 +76,7 @@ export function initDynamoDbImportSession(deps: {
 					createdAt,
 					expiresAt,
 					totalUrls: urls.length,
-					totalFoundInFile,
+					totalFoundInFile: totalFound,
 					truncated,
 					urls: [...urls],
 					deselected: [],
@@ -89,7 +89,7 @@ export function initDynamoDbImportSession(deps: {
 				createdAt,
 				expiresAt,
 				totalUrls: urls.length,
-				totalFoundInFile,
+				totalFound,
 				truncated,
 				deselected: new Set<number>(),
 			};

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -101,6 +101,7 @@ import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
 import { initQueueRoutes } from "./web/pages/queue/queue.page";
 import { initImportSessionRoutes } from "./web/pages/import/import.page";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
 import { initSaveRoutes } from "./web/pages/save/save.page";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
@@ -200,6 +201,7 @@ interface AppDependencies {
 	httpErrorMessageMapping: HttpErrorMessageMapping;
 	logParseError: LogParseError;
 	importSessionStore: ImportSessionStore;
+	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
 	now: () => Date;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	createCheckoutSession: CreateCheckoutSession;
@@ -457,6 +459,36 @@ export function createApp(dependencies: AppDependencies): Express {
 		app.get("/e2e/fixtures/pdf/:id.pdf", (_req: Request, res: Response) => {
 			res.type("application/pdf").send(E2E_FIXTURE_PDF);
 		});
+
+		/** Deterministic newsletter-style page for the /import?mode=from-url
+		 * e2e flow. Same gating as the article fixture: present on staging and
+		 * dev, absent on the production Lambda. The `:label` segment lets tests
+		 * inject per-run-unique links so concurrent CI runs don't collide on
+		 * the same harvested URL set. */
+		app.get("/e2e/fixtures/links-page/:label", (req: Request, res: Response) => {
+			const label = String(req.params.label).replace(/[^a-zA-Z0-9-]/g, "");
+			const anchors = [1, 2, 3]
+				.map(
+					(i) =>
+						`<a href="${appOrigin}/privacy?import-from-url-${label}-${i}">Article ${i}</a>`,
+				)
+				.join("\n");
+			res
+				.type("text/html")
+				.send(
+					`<!doctype html><html><head><title>Test newsletter ${label}</title></head><body><nav><a href="/subscribe">Subscribe</a></nav>${anchors}</body></html>`,
+				);
+		});
+
+		app.get("/e2e/fixtures/links-page-empty", (_req: Request, res: Response) => {
+			res
+				.type("text/html")
+				.send("<!doctype html><html><body><p>No outbound links here.</p></body></html>");
+		});
+
+		app.get("/e2e/fixtures/links-page-error", (_req: Request, res: Response) => {
+			res.status(500).type("text/html").send("<html><body>boom</body></html>");
+		});
 	}
 
 	app.get("/install", async (req: Request, res: Response) => {
@@ -597,6 +629,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	const importRouter = initImportSessionRoutes({
 		validateSaveableUrl: deps.validateSaveableUrl,
 		importSessionStore: deps.importSessionStore,
+		extractLinksFromPageUrl: deps.extractLinksFromPageUrl,
 		saveArticle: deps.saveArticle,
 		updateArticleStatus: deps.updateArticleStatus,
 		markCrawlPending: deps.markCrawlPending,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -114,6 +114,7 @@ import type { ExchangeGoogleCode } from "@packages/test-fixtures/providers/googl
 import type { OAuthModel } from "@packages/test-fixtures/providers/oauth";
 import type { ValidateAccessToken } from "./web/dual-auth.middleware";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import request from "supertest";
 import { createApp } from "./server";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
@@ -308,6 +309,7 @@ export interface SharedBundle {
 
 export interface ImportSessionBundle {
 	importSessionStore: ImportSessionStore;
+	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
 }
 
 export interface BotDefenseBundle {
@@ -445,6 +447,7 @@ function flattenFixtureToAppDependencies(
 		adminEmails: fixture.admin.adminEmails,
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,
 		importSessionStore: fixture.importSession.importSessionStore,
+		extractLinksFromPageUrl: fixture.importSession.extractLinksFromPageUrl,
 		now: fixture.shared.now,
 		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,
 		createCheckoutSession: fixture.stripe.createCheckoutSession,

--- a/projects/hutch/src/runtime/web/middleware/analytics.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.ts
@@ -49,6 +49,20 @@ export interface ImportCommittedEvent {
 	is_authenticated: 1;
 }
 
+export interface ImportFromUrlAcquiredEvent {
+	stream: typeof STREAMS.analytics;
+	event: typeof ANALYTICS_EVENTS.importFromUrlAcquired;
+	timestamp: string;
+	path: "/import/from-url";
+	utm_source: "import-feature";
+	utm_medium: "form";
+	utm_campaign: "from-url";
+	url_count: number;
+	truncated: 0 | 1;
+	visitor_hash: string | null;
+	is_authenticated: 1;
+}
+
 export interface ArticleReadEvent {
 	stream: typeof STREAMS.analytics;
 	event: typeof ANALYTICS_EVENTS.articleRead;
@@ -61,6 +75,7 @@ export type AnalyticsEvent =
 	| AnalyticsPageview
 	| ImportUploadedEvent
 	| ImportCommittedEvent
+	| ImportFromUrlAcquiredEvent
 	| ArticleReadEvent;
 
 const SKIP_PATHS = new Set([

--- a/projects/hutch/src/runtime/web/pages/import/import.acquire.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.acquire.template.html
@@ -9,7 +9,7 @@
       {{{panelHtml}}}
       <p class="import__fallback">
         Larger files or more than 2,000 links? Email
-        <a class="import__fallback-link" href="mailto:fayner@readplace.com">fayner@readplace.com</a>
+        <a class="import__fallback-link" href="mailto:readplace+import@readplace.com">readplace+import@readplace.com</a>
         and I&rsquo;ll lift the limit for you.
       </p>
     </main>

--- a/projects/hutch/src/runtime/web/pages/import/import.acquire.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.acquire.template.html
@@ -1,0 +1,15 @@
+    <main class="import import--upload">
+      <header class="import__header">
+        <h1 class="import__title">Import <span class="import__title-mark">links</span></h1>
+        <p class="import__intro">
+          Upload any text-shaped export &mdash; HTML, JSON, plain text &mdash; or paste a link to a page (newsletter, blogroll) and Readplace will pull every <code>http(s)://</code> URL out for you to review before saving.
+        </p>
+      </header>
+      {{{tabsHtml}}}
+      {{{panelHtml}}}
+      <p class="import__fallback">
+        Larger files or more than 2,000 links? Email
+        <a class="import__fallback-link" href="mailto:fayner@readplace.com">fayner@readplace.com</a>
+        and I&rsquo;ll lift the limit for you.
+      </p>
+    </main>

--- a/projects/hutch/src/runtime/web/pages/import/import.acquire.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.acquire.template.html
@@ -9,7 +9,7 @@
       {{{panelHtml}}}
       <p class="import__fallback">
         Larger files or more than 2,000 links? Email
-        <a class="import__fallback-link" href="mailto:readplace+import@readplace.com">readplace+import@readplace.com</a>
+        <a class="import__fallback-link" href="mailto:readplace+migrate@readplace.com">readplace+migrate@readplace.com</a>
         and I&rsquo;ll lift the limit for you.
       </p>
     </main>

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -3,10 +3,16 @@ import { join } from "node:path";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { IMPORT_STYLES } from "./import.styles";
-import type { ImportUploadViewModel, ImportViewModel } from "./import.viewmodel";
+import type { ImportAcquireViewModel, ImportViewModel } from "./import.viewmodel";
 
 const IMPORT_TEMPLATE = readFileSync(join(__dirname, "import.template.html"), "utf-8");
+const IMPORT_ACQUIRE_TEMPLATE = readFileSync(join(__dirname, "import.acquire.template.html"), "utf-8");
+const IMPORT_TABS_TEMPLATE = readFileSync(join(__dirname, "import.tabs.template.html"), "utf-8");
 const IMPORT_UPLOAD_TEMPLATE = readFileSync(join(__dirname, "import.upload.template.html"), "utf-8");
+const IMPORT_FROM_URL_PANEL_TEMPLATE = readFileSync(
+	join(__dirname, "import.from-url.panel.template.html"),
+	"utf-8",
+);
 const IMPORT_CLIENT_SCRIPT = `<script src="/client-dist/import.client.js" defer></script>`;
 
 const UPLOAD_AUTO_SUBMIT_SCRIPT = `
@@ -82,22 +88,24 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 	};
 }
 
-export function ImportUploadPage(vm: ImportUploadViewModel): PageBody {
-	const content = render(IMPORT_UPLOAD_TEMPLATE, {
-		...vm,
-		errorMessage: vm.errors?.[0]?.message,
-	});
+export function ImportAcquirePage(vm: ImportAcquireViewModel): PageBody {
+	const data = { ...vm, errorMessage: vm.errors?.[0]?.message };
+	const tabsHtml = render(IMPORT_TABS_TEMPLATE, data);
+	const panelHtml = vm.isUpload
+		? render(IMPORT_UPLOAD_TEMPLATE, data)
+		: render(IMPORT_FROM_URL_PANEL_TEMPLATE, data);
+	const content = render(IMPORT_ACQUIRE_TEMPLATE, { ...data, tabsHtml, panelHtml });
 
 	return {
 		seo: {
 			title: "Import Links — Readplace",
-			description: "Upload an export file and import the links into your queue.",
-			canonicalUrl: "/import",
+			description: "Upload an export file or paste a URL to import links into your queue.",
+			canonicalUrl: vm.isUpload ? "/import" : "/import?mode=from-url",
 			robots: "noindex, nofollow",
 		},
 		styles: IMPORT_STYLES,
 		bodyClass: "page-import",
 		content: { html: content },
-		scripts: `${IMPORT_CLIENT_SCRIPT}${UPLOAD_AUTO_SUBMIT_SCRIPT}`,
+		scripts: vm.isUpload ? `${IMPORT_CLIENT_SCRIPT}${UPLOAD_AUTO_SUBMIT_SCRIPT}` : IMPORT_CLIENT_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -3,7 +3,29 @@ import { join } from "node:path";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { IMPORT_STYLES } from "./import.styles";
-import type { ImportAcquireViewModel, ImportViewModel } from "./import.viewmodel";
+import type {
+	ImportAcquireViewModel,
+	ImportTabViewModel,
+	ImportViewModel,
+} from "./import.viewmodel";
+
+interface RenderedTab {
+	readonly key: ImportTabViewModel["key"];
+	readonly label: string;
+	readonly href: string;
+	readonly cssClass: "import__tab import__tab--active" | "import__tab";
+	readonly ariaCurrent: "page" | "false";
+}
+
+function renderTab(tab: ImportTabViewModel): RenderedTab {
+	return {
+		key: tab.key,
+		label: tab.label,
+		href: tab.href,
+		cssClass: tab.isActive ? "import__tab import__tab--active" : "import__tab",
+		ariaCurrent: tab.isActive ? "page" : "false",
+	};
+}
 
 const IMPORT_TEMPLATE = readFileSync(join(__dirname, "import.template.html"), "utf-8");
 const IMPORT_ACQUIRE_TEMPLATE = readFileSync(join(__dirname, "import.acquire.template.html"), "utf-8");
@@ -89,7 +111,8 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 }
 
 export function ImportAcquirePage(vm: ImportAcquireViewModel): PageBody {
-	const data = { ...vm, errorMessage: vm.errors?.[0]?.message };
+	const tabs = vm.tabs.map(renderTab);
+	const data = { ...vm, tabs, errorMessage: vm.errors?.[0]?.message };
 	const tabsHtml = vm.showFromUrl ? render(IMPORT_TABS_TEMPLATE, data) : "";
 	const panelHtml = vm.isUpload
 		? render(IMPORT_UPLOAD_TEMPLATE, data)

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -90,7 +90,7 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 
 export function ImportAcquirePage(vm: ImportAcquireViewModel): PageBody {
 	const data = { ...vm, errorMessage: vm.errors?.[0]?.message };
-	const tabsHtml = render(IMPORT_TABS_TEMPLATE, data);
+	const tabsHtml = vm.showFromUrl ? render(IMPORT_TABS_TEMPLATE, data) : "";
 	const panelHtml = vm.isUpload
 		? render(IMPORT_UPLOAD_TEMPLATE, data)
 		: render(IMPORT_FROM_URL_PANEL_TEMPLATE, data);

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -5,6 +5,7 @@ import { render } from "../../render";
 import { IMPORT_STYLES } from "./import.styles";
 import type {
 	ImportAcquireViewModel,
+	ImportMode,
 	ImportTabViewModel,
 	ImportViewModel,
 } from "./import.viewmodel";
@@ -36,6 +37,12 @@ const IMPORT_FROM_URL_PANEL_TEMPLATE = readFileSync(
 	"utf-8",
 );
 const IMPORT_CLIENT_SCRIPT = `<script src="/client-dist/import.client.js" defer></script>`;
+
+interface PanelConfig {
+	readonly template: string;
+	readonly canonicalUrl: string;
+	readonly scripts: string;
+}
 
 const UPLOAD_AUTO_SUBMIT_SCRIPT = `
 <script>
@@ -110,25 +117,37 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 	};
 }
 
+const PANEL_CONFIG: Record<ImportMode, PanelConfig> = {
+	upload: {
+		template: IMPORT_UPLOAD_TEMPLATE,
+		canonicalUrl: "/import",
+		scripts: `${IMPORT_CLIENT_SCRIPT}${UPLOAD_AUTO_SUBMIT_SCRIPT}`,
+	},
+	"from-url": {
+		template: IMPORT_FROM_URL_PANEL_TEMPLATE,
+		canonicalUrl: "/import?mode=from-url",
+		scripts: IMPORT_CLIENT_SCRIPT,
+	},
+};
+
 export function ImportAcquirePage(vm: ImportAcquireViewModel): PageBody {
+	const panel = PANEL_CONFIG[vm.mode];
 	const tabs = vm.tabs.map(renderTab);
 	const data = { ...vm, tabs, errorMessage: vm.errors?.[0]?.message };
 	const tabsHtml = vm.showFromUrl ? render(IMPORT_TABS_TEMPLATE, data) : "";
-	const panelHtml = vm.isUpload
-		? render(IMPORT_UPLOAD_TEMPLATE, data)
-		: render(IMPORT_FROM_URL_PANEL_TEMPLATE, data);
+	const panelHtml = render(panel.template, data);
 	const content = render(IMPORT_ACQUIRE_TEMPLATE, { ...data, tabsHtml, panelHtml });
 
 	return {
 		seo: {
 			title: "Import Links — Readplace",
 			description: "Upload an export file or paste a URL to import links into your queue.",
-			canonicalUrl: vm.isUpload ? "/import" : "/import?mode=from-url",
+			canonicalUrl: panel.canonicalUrl,
 			robots: "noindex, nofollow",
 		},
 		styles: IMPORT_STYLES,
 		bodyClass: "page-import",
 		content: { html: content },
-		scripts: vm.isUpload ? `${IMPORT_CLIENT_SCRIPT}${UPLOAD_AUTO_SUBMIT_SCRIPT}` : IMPORT_CLIENT_SCRIPT,
+		scripts: panel.scripts,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
@@ -30,4 +30,28 @@ describe("importErrorMessageMapping", () => {
 			"That import session has expired. Please upload the file again.",
 		);
 	});
+
+	it("maps import_url_invalid to the private-network message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_url_invalid" })).toBe(
+			"That URL can't be crawled — Readplace blocks private-network and non-http(s) addresses.",
+		);
+	});
+
+	it("maps import_url_fetch_failed to the can't-fetch message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_url_fetch_failed" })).toBe(
+			"We couldn't fetch that page. It might be down, blocking automated requests, or returned an error. If the page is slow, try saving its HTML and using the upload tab.",
+		);
+	});
+
+	it("maps import_url_unsupported to the non-HTML message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_url_unsupported" })).toBe(
+			"That URL doesn't point at an HTML page. Paste a link to an article index or newsletter web view.",
+		);
+	});
+
+	it("maps import_url_too_large to the too-large message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_url_too_large" })).toBe(
+			"That page is too large to scan for links.",
+		);
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
@@ -15,7 +15,7 @@ describe("importErrorMessageMapping", () => {
 
 	it("maps import_too_large to the 5 MiB / contact fallback message", () => {
 		expect(importErrorMessageMapping({ error_code: "import_too_large" })).toBe(
-			"That file is too large. The limit is 5 MiB — please get in touch at readplace+import@readplace.com to increase the limit.",
+			"That file is too large. The limit is 5 MiB — please get in touch at readplace+migrate@readplace.com to increase the limit.",
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
@@ -15,7 +15,7 @@ describe("importErrorMessageMapping", () => {
 
 	it("maps import_too_large to the 5 MiB / contact fallback message", () => {
 		expect(importErrorMessageMapping({ error_code: "import_too_large" })).toBe(
-			"That file is too large. The limit is 5 MiB — please get in touch at readplace+migrate@readplace.com to increase the limit.",
+			"That file is too large. The limit is 5 MiB — please get in touch at readplace+import@readplace.com to increase the limit.",
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.test.ts
@@ -54,4 +54,10 @@ describe("importErrorMessageMapping", () => {
 			"That page is too large to scan for links.",
 		);
 	});
+
+	it("maps import_url_no_links to the from-url no-links message", () => {
+		expect(importErrorMessageMapping({ error_code: "import_url_no_links" })).toBe(
+			"We couldn't find any outbound links on that page.",
+		);
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.error.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.ts
@@ -2,6 +2,10 @@ const IMPORT_ERROR_MESSAGES: Record<string, string> = {
 	import_too_large: "That file is too large. The limit is 5 MiB — please get in touch at readplace+migrate@readplace.com to increase the limit.",
 	import_no_urls: "We couldn't find any links in that file.",
 	import_session_not_found: "That import session has expired. Please upload the file again.",
+	import_url_invalid: "That URL can't be crawled — Readplace blocks private-network and non-http(s) addresses.",
+	import_url_fetch_failed: "We couldn't fetch that page. It might be down, blocking automated requests, or returned an error. If the page is slow, try saving its HTML and using the upload tab.",
+	import_url_unsupported: "That URL doesn't point at an HTML page. Paste a link to an article index or newsletter web view.",
+	import_url_too_large: "That page is too large to scan for links.",
 };
 
 export type ImportErrorMessageMapping = (query: Record<string, unknown>) => string | undefined;

--- a/projects/hutch/src/runtime/web/pages/import/import.error.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.ts
@@ -1,5 +1,5 @@
 const IMPORT_ERROR_MESSAGES: Record<string, string> = {
-	import_too_large: "That file is too large. The limit is 5 MiB — please get in touch at readplace+import@readplace.com to increase the limit.",
+	import_too_large: "That file is too large. The limit is 5 MiB — please get in touch at readplace+migrate@readplace.com to increase the limit.",
 	import_no_urls: "We couldn't find any links in that file.",
 	import_session_not_found: "That import session has expired. Please upload the file again.",
 	import_url_invalid: "That URL can't be crawled — Readplace blocks private-network and non-http(s) addresses.",

--- a/projects/hutch/src/runtime/web/pages/import/import.error.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.ts
@@ -1,5 +1,5 @@
 const IMPORT_ERROR_MESSAGES: Record<string, string> = {
-	import_too_large: "That file is too large. The limit is 5 MiB — please get in touch at readplace+migrate@readplace.com to increase the limit.",
+	import_too_large: "That file is too large. The limit is 5 MiB — please get in touch at readplace+import@readplace.com to increase the limit.",
 	import_no_urls: "We couldn't find any links in that file.",
 	import_session_not_found: "That import session has expired. Please upload the file again.",
 	import_url_invalid: "That URL can't be crawled — Readplace blocks private-network and non-http(s) addresses.",

--- a/projects/hutch/src/runtime/web/pages/import/import.error.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.error.ts
@@ -6,6 +6,7 @@ const IMPORT_ERROR_MESSAGES: Record<string, string> = {
 	import_url_fetch_failed: "We couldn't fetch that page. It might be down, blocking automated requests, or returned an error. If the page is slow, try saving its HTML and using the upload tab.",
 	import_url_unsupported: "That URL doesn't point at an HTML page. Paste a link to an article index or newsletter web view.",
 	import_url_too_large: "That page is too large to scan for links.",
+	import_url_no_links: "We couldn't find any outbound links on that page.",
 };
 
 export type ImportErrorMessageMapping = (query: Record<string, unknown>) => string | undefined;

--- a/projects/hutch/src/runtime/web/pages/import/import.from-url.panel.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.from-url.panel.template.html
@@ -1,0 +1,22 @@
+      {{#if errorMessage}}
+      <p class="import__upload-error" role="alert" data-test-import-error>{{errorMessage}}</p>
+      {{/if}}
+      <form class="import__from-url-form" method="POST" action="{{fromUrlAction}}"
+            data-test-form="import-from-url"
+            hx-post="{{fromUrlAction}}" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
+        <label class="import__from-url-label" for="import-from-url-input">Newsletter or index URL</label>
+        <div class="import__from-url-row">
+          <input id="import-from-url-input"
+                 class="import__from-url-input"
+                 type="url"
+                 name="url"
+                 required
+                 inputmode="url"
+                 autocomplete="off"
+                 spellcheck="false"
+                 placeholder="https://newsletter.example/issue-42"
+                 data-test-import-from-url-input>
+          <button class="import__from-url-btn" type="submit" data-test-action="import-from-url-submit">Fetch links</button>
+        </div>
+        <p class="import__from-url-meta">Readplace will load the page and list every outbound link.</p>
+      </form>

--- a/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
@@ -204,7 +204,7 @@ describe("POST /import/from-url routes", () => {
 			);
 		});
 
-		it("redirects with import_no_urls when the harvested list is empty", async () => {
+		it("redirects with import_url_no_links when the harvested list is empty", async () => {
 			const harness = useApp(
 				withExtractor({
 					status: "OK",
@@ -220,7 +220,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_no_urls",
+				"/import?mode=from-url&error_code=import_url_no_links",
 			);
 		});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
@@ -31,7 +31,7 @@ describe("POST /import/from-url routes", () => {
 			expect(fromUrlTab.getAttribute("aria-current")).toBe("page");
 			const uploadTab = doc.querySelector('[data-test-import-tab="upload"]');
 			assert(uploadTab, "upload tab anchor must be rendered");
-			expect(uploadTab.getAttribute("aria-current")).toBeNull();
+			expect(uploadTab.getAttribute("aria-current")).toBe("false");
 			const form = doc.querySelector('[data-test-form="import-from-url"]');
 			assert(form, "from-url form must be rendered");
 			expect(form.getAttribute("action")).toBe("/import/from-url");
@@ -41,26 +41,34 @@ describe("POST /import/from-url routes", () => {
 			expect(input.getAttribute("name")).toBe("url");
 		});
 
-		it("does not render the upload form when mode=from-url", async () => {
+		it("renders only the from-url form (no upload form) when mode=from-url", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?mode=from-url&feature=import-link-public");
 
 			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector('[data-test-form="import-file"]')).toBeNull();
+			const formIds = Array.from(doc.querySelectorAll("[data-test-form]")).map(
+				(el) => el.getAttribute("data-test-form"),
+			);
+			expect(formIds).toEqual(["import-from-url"]);
 		});
 
-		it("does not render the from-url tab without the feature flag", async () => {
+		it("renders only the upload form (no tabs) without the feature flag", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get("/import?mode=from-url");
 
 			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector('[data-test-import-tab="from-url"]')).toBeNull();
-			const form = doc.querySelector('[data-test-form="import-file"]');
-			assert(form, "falls back to upload form without feature flag");
+			const tabKeys = Array.from(doc.querySelectorAll("[data-test-import-tab]")).map(
+				(el) => el.getAttribute("data-test-import-tab"),
+			);
+			expect(tabKeys).toEqual([]);
+			const formIds = Array.from(doc.querySelectorAll("[data-test-form]")).map(
+				(el) => el.getAttribute("data-test-form"),
+			);
+			expect(formIds).toEqual(["import-file"]);
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { useTestServer, loginAgent } from "../../../test-app";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "@packages/test-fixtures";
+import type { ExtractLinksFromPageResult } from "@packages/extract-links-from-page";
+
+function withExtractor(result: ExtractLinksFromPageResult) {
+	const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+	fixture.importSession.extractLinksFromPageUrl = async () => result;
+	return fixture;
+}
+
+const useApp = useTestServer();
+
+describe("POST /import/from-url routes", () => {
+	describe("GET /import?mode=from-url", () => {
+		it("renders the from-url panel with the from-url tab active", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/import?mode=from-url");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const fromUrlTab = doc.querySelector('[data-test-import-tab="from-url"]');
+			assert(fromUrlTab, "from-url tab anchor must be rendered");
+			expect(fromUrlTab.getAttribute("aria-current")).toBe("page");
+			const uploadTab = doc.querySelector('[data-test-import-tab="upload"]');
+			assert(uploadTab, "upload tab anchor must be rendered");
+			expect(uploadTab.getAttribute("aria-current")).toBeNull();
+			const form = doc.querySelector('[data-test-form="import-from-url"]');
+			assert(form, "from-url form must be rendered");
+			expect(form.getAttribute("action")).toBe("/import/from-url");
+			const input = form.querySelector('[data-test-import-from-url-input]');
+			assert(input, "url input must be rendered");
+			expect(input.getAttribute("type")).toBe("url");
+			expect(input.getAttribute("name")).toBe("url");
+		});
+
+		it("does not render the upload form when mode=from-url", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/import?mode=from-url");
+
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector('[data-test-form="import-file"]')).toBeNull();
+		});
+	});
+
+	describe("POST /import/from-url (unauthenticated)", () => {
+		it("redirects to /login", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server)
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/login");
+		});
+	});
+
+	describe("POST /import/from-url (authenticated)", () => {
+		it("creates a session from the harvested URLs and redirects to the review screen", async () => {
+			const harness = useApp(
+				withExtractor({
+					status: "OK",
+					links: {
+						urls: ["https://example.com/a", "https://example.com/b"],
+						truncated: false,
+						totalFound: 2,
+					},
+				}),
+			);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			expect(response.status).toBe(303);
+			assert.match(
+				response.headers.location,
+				/^\/import\/[a-f0-9]{32}$/,
+				"redirect must point at the new session",
+			);
+
+			const review = await agent.get(response.headers.location);
+			const doc = new JSDOM(review.text).window.document;
+			const urls = Array.from(doc.querySelectorAll("[data-test-import-url]"))
+				.map((el) => el.textContent)
+				.sort();
+			expect(urls).toEqual(["https://example.com/a", "https://example.com/b"]);
+		});
+
+		it("redirects with import_url_invalid for a missing url body", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/import/from-url").type("form").send({});
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_invalid",
+			);
+		});
+
+		it("redirects with import_url_invalid when the extractor reports INVALID_URL", async () => {
+			const harness = useApp(withExtractor({ status: "INVALID_URL" }));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "http://localhost/secret" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_invalid",
+			);
+		});
+
+		it("redirects with import_url_fetch_failed when the fetch returns http 500", async () => {
+			const harness = useApp(
+				withExtractor({ status: "FETCH_FAILED", reason: "http", httpStatus: 500 }),
+			);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_fetch_failed",
+			);
+		});
+
+		it("redirects with import_url_fetch_failed on timeout", async () => {
+			const harness = useApp(withExtractor({ status: "FETCH_FAILED", reason: "timeout" }));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_fetch_failed",
+			);
+		});
+
+		it("redirects with import_url_fetch_failed on network error", async () => {
+			const harness = useApp(withExtractor({ status: "FETCH_FAILED", reason: "network" }));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_fetch_failed",
+			);
+		});
+
+		it("redirects with import_url_too_large when the page exceeds the size cap", async () => {
+			const harness = useApp(withExtractor({ status: "FETCH_FAILED", reason: "too_large" }));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_too_large",
+			);
+		});
+
+		it("redirects with import_url_unsupported for non-HTML content-types", async () => {
+			const harness = useApp(
+				withExtractor({ status: "UNSUPPORTED_CONTENT_TYPE", contentType: "application/pdf" }),
+			);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42.pdf" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_url_unsupported",
+			);
+		});
+
+		it("redirects with import_no_urls when the harvested list is empty", async () => {
+			const harness = useApp(
+				withExtractor({
+					status: "OK",
+					links: { urls: [], truncated: false, totalFound: 0 },
+				}),
+			);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe(
+				"/import?mode=from-url&error_code=import_no_urls",
+			);
+		});
+
+		it("trims surrounding whitespace before validating the url", async () => {
+			const harness = useApp(
+				withExtractor({
+					status: "OK",
+					links: { urls: ["https://example.com/a"], truncated: false, totalFound: 1 },
+				}),
+			);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "  https://news.example/  " });
+
+			expect(response.status).toBe(303);
+			assert.match(response.headers.location, /^\/import\/[a-f0-9]{32}$/);
+		});
+
+		it("renders the error message on the from-url panel after redirect", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get(
+				"/import?mode=from-url&error_code=import_url_invalid",
+			);
+
+			const doc = new JSDOM(response.text).window.document;
+			const error = doc.querySelector("[data-test-import-error]");
+			assert(error, "error banner must be rendered");
+			expect(error.textContent).toContain("private-network");
+		});
+	});
+
+	describe("Analytics events", () => {
+		it("emits import_from_url_acquired with url_count on success", async () => {
+			const harness = useApp(
+				withExtractor({
+					status: "OK",
+					links: {
+						urls: ["https://example.com/a", "https://example.com/b"],
+						truncated: false,
+						totalFound: 2,
+					},
+				}),
+			);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			const events = harness.analytics.events.filter(
+				(e) => e.event === "import_from_url_acquired",
+			);
+			assert.equal(events.length, 1, "exactly one import_from_url_acquired event");
+			const event = events[0];
+			assert(event.event === "import_from_url_acquired");
+			assert.equal(event.url_count, 2);
+			assert.equal(event.utm_source, "import-feature");
+			assert.equal(event.utm_medium, "form");
+			assert.equal(event.utm_campaign, "from-url");
+			assert.equal(event.is_authenticated, 1);
+		});
+
+		it("does not emit import_from_url_acquired on failure paths", async () => {
+			const harness = useApp(withExtractor({ status: "INVALID_URL" }));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "http://localhost/" });
+
+			await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "" });
+
+			const events = harness.analytics.events.filter(
+				(e) => e.event === "import_from_url_acquired",
+			);
+			assert.equal(events.length, 0);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
@@ -17,12 +17,12 @@ function withExtractor(result: ExtractLinksFromPageResult) {
 const useApp = useTestServer();
 
 describe("POST /import/from-url routes", () => {
-	describe("GET /import?mode=from-url", () => {
+	describe("GET /import?mode=from-url&feature=import-link-public", () => {
 		it("renders the from-url panel with the from-url tab active", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
-			const response = await agent.get("/import?mode=from-url");
+			const response = await agent.get("/import?mode=from-url&feature=import-link-public");
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -45,10 +45,22 @@ describe("POST /import/from-url routes", () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
-			const response = await agent.get("/import?mode=from-url");
+			const response = await agent.get("/import?mode=from-url&feature=import-link-public");
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector('[data-test-form="import-file"]')).toBeNull();
+		});
+
+		it("does not render the from-url tab without the feature flag", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/import?mode=from-url");
+
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector('[data-test-import-tab="from-url"]')).toBeNull();
+			const form = doc.querySelector('[data-test-form="import-file"]');
+			assert(form, "falls back to upload form without feature flag");
 		});
 	});
 
@@ -106,7 +118,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_invalid",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_invalid",
 			);
 		});
 
@@ -121,7 +133,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_invalid",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_invalid",
 			);
 		});
 
@@ -138,7 +150,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_fetch_failed",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_fetch_failed",
 			);
 		});
 
@@ -153,7 +165,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_fetch_failed",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_fetch_failed",
 			);
 		});
 
@@ -168,7 +180,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_fetch_failed",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_fetch_failed",
 			);
 		});
 
@@ -183,7 +195,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_too_large",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_too_large",
 			);
 		});
 
@@ -200,7 +212,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_unsupported",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_unsupported",
 			);
 		});
 
@@ -220,7 +232,7 @@ describe("POST /import/from-url routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe(
-				"/import?mode=from-url&error_code=import_url_no_links",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_no_links",
 			);
 		});
 
@@ -247,7 +259,7 @@ describe("POST /import/from-url routes", () => {
 			const agent = await loginAgent(harness.server, harness.auth);
 
 			const response = await agent.get(
-				"/import?mode=from-url&error_code=import_url_invalid",
+				"/import?mode=from-url&feature=import-link-public&error_code=import_url_invalid",
 			);
 
 			const doc = new JSDOM(response.text).window.document;

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -53,7 +53,7 @@ const FROM_URL_ERROR_REDIRECT = {
 	fetchFailed: "/import?mode=from-url&error_code=import_url_fetch_failed",
 	unsupported: "/import?mode=from-url&error_code=import_url_unsupported",
 	tooLarge: "/import?mode=from-url&error_code=import_url_too_large",
-	noUrls: "/import?mode=from-url&error_code=import_no_urls",
+	noUrls: "/import?mode=from-url&error_code=import_url_no_links",
 } as const;
 
 export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -49,11 +49,11 @@ const UPLOAD_ERROR_REDIRECT = {
 } as const;
 
 const FROM_URL_ERROR_REDIRECT = {
-	invalid: "/import?mode=from-url&error_code=import_url_invalid",
-	fetchFailed: "/import?mode=from-url&error_code=import_url_fetch_failed",
-	unsupported: "/import?mode=from-url&error_code=import_url_unsupported",
-	tooLarge: "/import?mode=from-url&error_code=import_url_too_large",
-	noUrls: "/import?mode=from-url&error_code=import_url_no_links",
+	invalid: "/import?mode=from-url&feature=import-link-public&error_code=import_url_invalid",
+	fetchFailed: "/import?mode=from-url&feature=import-link-public&error_code=import_url_fetch_failed",
+	unsupported: "/import?mode=from-url&feature=import-link-public&error_code=import_url_unsupported",
+	tooLarge: "/import?mode=from-url&feature=import-link-public&error_code=import_url_too_large",
+	noUrls: "/import?mode=from-url&feature=import-link-public&error_code=import_url_no_links",
 } as const;
 
 export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
@@ -72,9 +72,11 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const errorMessage = importErrorMessageMapping(req.query);
 		const mode = typeof req.query.mode === "string" ? req.query.mode : undefined;
+		const showFromUrl = req.query.feature === "import-link-public";
 		const vm = toImportAcquireViewModel({
 			mode,
 			errors: errorMessage ? [{ message: errorMessage }] : undefined,
+			showFromUrl,
 		});
 		sendComponent(req, res, Base(ImportAcquirePage(vm), await deps.buildBannerState(req)));
 	});

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -12,6 +12,7 @@ import {
 } from "@packages/domain/import-session";
 import type { ImportSessionStore } from "@packages/domain/import-session";
 import type { ValidateSaveableUrl, SaveableUrl, SaveableUrlErrorCode } from "@packages/domain/article";
+import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { Base } from "../../base.component";
 import type { BuildBannerState } from "../../banner-state";
@@ -24,15 +25,16 @@ import {
 	IMPORT_SKIPPED_COOKIE_NAME,
 	encodeImportSkippedCookie,
 } from "./import-skipped-cookie";
-import { ImportPage, ImportUploadPage } from "./import.component";
+import { ImportAcquirePage, ImportPage } from "./import.component";
 import { importErrorMessageMapping } from "./import.error";
-import { toImportUploadViewModel, toImportViewModel } from "./import.viewmodel";
+import { toImportAcquireViewModel, toImportViewModel } from "./import.viewmodel";
 import { initMultipartUpload } from "./multipart-upload";
 import { parseImportPage } from "./import.url";
 
 interface ImportRouteDependencies extends SaveArticleFromUrlDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
 	importSessionStore: ImportSessionStore;
+	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
 	logError: (message: string, error?: Error) => void;
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
 	salt: string;
@@ -44,6 +46,14 @@ const UPLOAD_ERROR_REDIRECT = {
 	tooLarge: "/import?error_code=import_too_large",
 	noUrls: "/import?error_code=import_no_urls",
 	sessionNotFound: "/import?error_code=import_session_not_found",
+} as const;
+
+const FROM_URL_ERROR_REDIRECT = {
+	invalid: "/import?mode=from-url&error_code=import_url_invalid",
+	fetchFailed: "/import?mode=from-url&error_code=import_url_fetch_failed",
+	unsupported: "/import?mode=from-url&error_code=import_url_unsupported",
+	tooLarge: "/import?mode=from-url&error_code=import_url_too_large",
+	noUrls: "/import?mode=from-url&error_code=import_no_urls",
 } as const;
 
 export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
@@ -61,10 +71,12 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 	router.get("/", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const errorMessage = importErrorMessageMapping(req.query);
-		const vm = toImportUploadViewModel({
+		const mode = typeof req.query.mode === "string" ? req.query.mode : undefined;
+		const vm = toImportAcquireViewModel({
+			mode,
 			errors: errorMessage ? [{ message: errorMessage }] : undefined,
 		});
-		sendComponent(req, res, Base(ImportUploadPage(vm), await deps.buildBannerState(req)));
+		sendComponent(req, res, Base(ImportAcquirePage(vm), await deps.buildBannerState(req)));
 	});
 
 	router.post("/", rawBodyParser, sizeLimitHandler, async (req: Request, res: Response) => {
@@ -75,7 +87,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			return;
 		}
 
-		const { urls, truncated, totalFoundInFile } = extractUrls(parsed.file.content);
+		const { urls, truncated, totalFound } = extractUrls(parsed.file.content);
 		if (urls.length === 0) {
 			res.redirect(303, UPLOAD_ERROR_REDIRECT.noUrls);
 			return;
@@ -85,7 +97,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			userId: req.userId,
 			urls,
 			truncated,
-			totalFoundInFile,
+			totalFound,
 		});
 		deps.analytics.info({
 			stream: STREAMS.analytics,
@@ -95,6 +107,60 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			utm_source: "import-feature",
 			utm_medium: "form",
 			utm_campaign: "file-upload",
+			url_count: urls.length,
+			truncated: truncated ? 1 : 0,
+			visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
+			is_authenticated: 1,
+		});
+		res.redirect(303, `/import/${session.id}`);
+	});
+
+	router.post("/from-url", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const rawUrl = typeof req.body?.url === "string" ? req.body.url.trim() : "";
+		if (rawUrl === "") {
+			res.redirect(303, FROM_URL_ERROR_REDIRECT.invalid);
+			return;
+		}
+
+		const result = await deps.extractLinksFromPageUrl(rawUrl);
+		if (result.status === "INVALID_URL") {
+			res.redirect(303, FROM_URL_ERROR_REDIRECT.invalid);
+			return;
+		}
+		if (result.status === "UNSUPPORTED_CONTENT_TYPE") {
+			res.redirect(303, FROM_URL_ERROR_REDIRECT.unsupported);
+			return;
+		}
+		if (result.status === "FETCH_FAILED") {
+			const redirect =
+				result.reason === "too_large"
+					? FROM_URL_ERROR_REDIRECT.tooLarge
+					: FROM_URL_ERROR_REDIRECT.fetchFailed;
+			res.redirect(303, redirect);
+			return;
+		}
+
+		const { urls, truncated, totalFound } = result.links;
+		if (urls.length === 0) {
+			res.redirect(303, FROM_URL_ERROR_REDIRECT.noUrls);
+			return;
+		}
+
+		const session = await deps.importSessionStore.createImportSession({
+			userId: req.userId,
+			urls,
+			truncated,
+			totalFound,
+		});
+		deps.analytics.info({
+			stream: STREAMS.analytics,
+			event: ANALYTICS_EVENTS.importFromUrlAcquired,
+			timestamp: deps.now().toISOString(),
+			path: "/import/from-url",
+			utm_source: "import-feature",
+			utm_medium: "form",
+			utm_campaign: "from-url",
 			url_count: urls.length,
 			truncated: truncated ? 1 : 0,
 			visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -43,7 +43,7 @@ describe("Import routes", () => {
 	});
 
 	describe("GET /import (authenticated)", () => {
-		it("renders the upload form", async () => {
+		it("renders the upload form with the upload tab marked active", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
@@ -57,6 +57,12 @@ describe("Import routes", () => {
 			const button = form.querySelector('[data-test-action="import-upload"]');
 			assert(button, "Upload button must remain in the DOM as the no-JS fallback");
 			expect(button.textContent).toBe("Upload");
+			const uploadTab = doc.querySelector('[data-test-import-tab="upload"]');
+			assert(uploadTab, "upload tab anchor must be rendered");
+			expect(uploadTab.getAttribute("aria-current")).toBe("page");
+			const fromUrlTab = doc.querySelector('[data-test-import-tab="from-url"]');
+			assert(fromUrlTab, "from-url tab anchor must be rendered");
+			expect(fromUrlTab.getAttribute("aria-current")).toBeNull();
 		});
 
 		it("renders the upload form in idle state with both idle and uploading regions", async () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -118,7 +118,7 @@ describe("Import routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			const error = doc.querySelector("[data-test-import-error]");
 			assert(error, "error banner must be rendered");
-			expect(error.textContent).toContain("readplace+import@readplace.com");
+			expect(error.textContent).toContain("readplace+migrate@readplace.com");
 		});
 
 		it("renders the import_session_not_found message when error_code=import_session_not_found", async () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -57,12 +57,8 @@ describe("Import routes", () => {
 			const button = form.querySelector('[data-test-action="import-upload"]');
 			assert(button, "Upload button must remain in the DOM as the no-JS fallback");
 			expect(button.textContent).toBe("Upload");
-			const uploadTab = doc.querySelector('[data-test-import-tab="upload"]');
-			assert(uploadTab, "upload tab anchor must be rendered");
-			expect(uploadTab.getAttribute("aria-current")).toBe("page");
-			const fromUrlTab = doc.querySelector('[data-test-import-tab="from-url"]');
-			assert(fromUrlTab, "from-url tab anchor must be rendered");
-			expect(fromUrlTab.getAttribute("aria-current")).toBeNull();
+			expect(doc.querySelector('[data-test-import-tabs]')).toBeNull();
+			expect(doc.querySelector('[data-test-import-tab="from-url"]')).toBeNull();
 		});
 
 		it("renders the upload form in idle state with both idle and uploading regions", async () => {
@@ -120,7 +116,7 @@ describe("Import routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			const error = doc.querySelector("[data-test-import-error]");
 			assert(error, "error banner must be rendered");
-			expect(error.textContent).toContain("readplace+migrate@readplace.com");
+			expect(error.textContent).toContain("readplace+import@readplace.com");
 		});
 
 		it("renders the import_session_not_found message when error_code=import_session_not_found", async () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -43,7 +43,7 @@ describe("Import routes", () => {
 	});
 
 	describe("GET /import (authenticated)", () => {
-		it("renders the upload form with the upload tab marked active", async () => {
+		it("renders the upload form with no tabs (feature flag off by default)", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
@@ -57,8 +57,10 @@ describe("Import routes", () => {
 			const button = form.querySelector('[data-test-action="import-upload"]');
 			assert(button, "Upload button must remain in the DOM as the no-JS fallback");
 			expect(button.textContent).toBe("Upload");
-			expect(doc.querySelector('[data-test-import-tabs]')).toBeNull();
-			expect(doc.querySelector('[data-test-import-tab="from-url"]')).toBeNull();
+			const tabKeys = Array.from(doc.querySelectorAll("[data-test-import-tab]")).map(
+				(el) => el.getAttribute("data-test-import-tab"),
+			);
+			expect(tabKeys).toEqual([]);
 		});
 
 		it("renders the upload form in idle state with both idle and uploading regions", async () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.styles.css
+++ b/projects/hutch/src/runtime/web/pages/import/import.styles.css
@@ -39,6 +39,98 @@
   border-radius: var(--radius-sm);
 }
 
+/* ---------- Acquisition tabs ---------- */
+
+.import__tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin: 0 0 24px;
+}
+
+.import__tab {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 16px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--muted-foreground);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.import__tab:hover {
+  color: var(--foreground);
+}
+
+.import__tab--active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
+
+/* ---------- From-URL panel ---------- */
+
+.import__from-url-form {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin: 0 0 24px;
+}
+
+.import__from-url-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.import__from-url-row {
+  display: flex;
+  gap: 8px;
+}
+
+.import__from-url-input {
+  flex: 1;
+  height: var(--input-height);
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.9375rem;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.import__from-url-input:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  border-color: var(--primary);
+}
+
+.import__from-url-btn {
+  height: var(--input-height);
+  padding: 0 20px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.import__from-url-btn:hover {
+  background: var(--color-brand-dark);
+}
+
+.import__from-url-meta {
+  margin: 4px 0 0;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+}
+
 /* ---------- Upload page ---------- */
 
 .import--upload .import__header {

--- a/projects/hutch/src/runtime/web/pages/import/import.tabs.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.tabs.template.html
@@ -1,10 +1,12 @@
       <nav class="import__tabs" aria-label="Import source" data-test-import-tabs>
         <a class="import__tab {{#if isUpload}}import__tab--active{{/if}}"
-           href="/import"
+           href="{{tabUploadHref}}"
            {{#if isUpload}}aria-current="page"{{/if}}
            data-test-import-tab="upload">Upload a file</a>
+        {{#if showFromUrl}}
         <a class="import__tab {{#if isFromUrl}}import__tab--active{{/if}}"
-           href="/import?mode=from-url"
+           href="{{tabFromUrlHref}}"
            {{#if isFromUrl}}aria-current="page"{{/if}}
            data-test-import-tab="from-url">Paste a link</a>
+        {{/if}}
       </nav>

--- a/projects/hutch/src/runtime/web/pages/import/import.tabs.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.tabs.template.html
@@ -1,12 +1,8 @@
       <nav class="import__tabs" aria-label="Import source" data-test-import-tabs>
-        <a class="import__tab {{#if isUpload}}import__tab--active{{/if}}"
-           href="{{tabUploadHref}}"
-           {{#if isUpload}}aria-current="page"{{/if}}
-           data-test-import-tab="upload">Upload a file</a>
-        {{#if showFromUrl}}
-        <a class="import__tab {{#if isFromUrl}}import__tab--active{{/if}}"
-           href="{{tabFromUrlHref}}"
-           {{#if isFromUrl}}aria-current="page"{{/if}}
-           data-test-import-tab="from-url">Paste a link</a>
-        {{/if}}
+        {{#each tabs}}
+        <a class="{{cssClass}}"
+           href="{{href}}"
+           aria-current="{{ariaCurrent}}"
+           data-test-import-tab="{{key}}">{{label}}</a>
+        {{/each}}
       </nav>

--- a/projects/hutch/src/runtime/web/pages/import/import.tabs.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.tabs.template.html
@@ -1,0 +1,10 @@
+      <nav class="import__tabs" aria-label="Import source" data-test-import-tabs>
+        <a class="import__tab {{#if isUpload}}import__tab--active{{/if}}"
+           href="/import"
+           {{#if isUpload}}aria-current="page"{{/if}}
+           data-test-import-tab="upload">Upload a file</a>
+        <a class="import__tab {{#if isFromUrl}}import__tab--active{{/if}}"
+           href="/import?mode=from-url"
+           {{#if isFromUrl}}aria-current="page"{{/if}}
+           data-test-import-tab="from-url">Paste a link</a>
+      </nav>

--- a/projects/hutch/src/runtime/web/pages/import/import.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.template.html
@@ -6,7 +6,7 @@
 
       {{#if truncated}}
       <p class="import__truncated-banner" role="status" data-test-import-truncated>
-        Your file contained {{totalFound}} links. The first {{totalUrls}} were imported.
+        We found {{totalFound}} links. The first {{totalUrls}} were imported.
       </p>
       {{/if}}
 

--- a/projects/hutch/src/runtime/web/pages/import/import.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.template.html
@@ -6,7 +6,7 @@
 
       {{#if truncated}}
       <p class="import__truncated-banner" role="status" data-test-import-truncated>
-        Your file contained {{totalFoundInFile}} links. The first {{totalUrls}} were imported.
+        Your file contained {{totalFound}} links. The first {{totalUrls}} were imported.
       </p>
       {{/if}}
 

--- a/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
+++ b/projects/hutch/src/runtime/web/pages/import/import.upload.template.html
@@ -1,10 +1,3 @@
-    <main class="import import--upload">
-      <header class="import__header">
-        <h1 class="import__title">Import <span class="import__title-mark">links</span></h1>
-        <p class="import__intro">
-          Upload any text-shaped export &mdash; HTML, JSON, plain text &mdash; and Readplace will pull every <code>http(s)://</code> URL out for you to review before saving.
-        </p>
-      </header>
       {{#if errorMessage}}
       <p class="import__upload-error" role="alert" data-test-import-error>{{errorMessage}}</p>
       {{/if}}
@@ -37,9 +30,3 @@
           <p class="import__progress-label" data-import-progress-label>Preparing upload&hellip;</p>
         </div>
       </form>
-      <p class="import__fallback">
-        Larger files or more than 2,000 links? Email
-        <a class="import__fallback-link" href="mailto:readplace+migrate@readplace.com">readplace+migrate@readplace.com</a>
-        and I&rsquo;ll lift the limit for you.
-      </p>
-    </main>

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -171,11 +171,18 @@ describe("toImportAcquireViewModel", () => {
 		expect(vm.fromUrlAction).toBe("/import/from-url");
 	});
 
-	it("sets isFromUrl true when mode=from-url", () => {
-		const vm = toImportAcquireViewModel({ mode: "from-url" });
+	it("sets isFromUrl true when mode=from-url and showFromUrl is true", () => {
+		const vm = toImportAcquireViewModel({ mode: "from-url", showFromUrl: true });
 		expect(vm.mode).toBe("from-url");
 		expect(vm.isUpload).toBe(false);
 		expect(vm.isFromUrl).toBe(true);
+	});
+
+	it("falls back to upload when mode=from-url but showFromUrl is false", () => {
+		const vm = toImportAcquireViewModel({ mode: "from-url", showFromUrl: false });
+		expect(vm.mode).toBe("upload");
+		expect(vm.isUpload).toBe(true);
+		expect(vm.isFromUrl).toBe(false);
 	});
 
 	it("falls back to upload for an unrecognised mode value", () => {
@@ -192,5 +199,22 @@ describe("toImportAcquireViewModel", () => {
 	it("leaves errors undefined when no message is provided", () => {
 		const vm = toImportAcquireViewModel({});
 		expect(vm.errors).toBeUndefined();
+	});
+
+	it("defaults showFromUrl to false", () => {
+		const vm = toImportAcquireViewModel({});
+		expect(vm.showFromUrl).toBe(false);
+	});
+
+	it("includes feature param in tab hrefs when showFromUrl is true", () => {
+		const vm = toImportAcquireViewModel({ showFromUrl: true });
+		expect(vm.tabUploadHref).toBe("/import?feature=import-link-public");
+		expect(vm.tabFromUrlHref).toBe("/import?mode=from-url&feature=import-link-public");
+	});
+
+	it("omits feature param from tab hrefs when showFromUrl is false", () => {
+		const vm = toImportAcquireViewModel({ showFromUrl: false });
+		expect(vm.tabUploadHref).toBe("/import");
+		expect(vm.tabFromUrlHref).toBe("/import?mode=from-url");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -1,7 +1,7 @@
 import { ImportSessionIdSchema } from "@packages/domain/import-session";
 import type { ImportSession } from "@packages/domain/import-session";
 import { UserIdSchema } from "@packages/domain/user";
-import { toImportUploadViewModel, toImportViewModel } from "./import.viewmodel";
+import { toImportAcquireViewModel, toImportViewModel } from "./import.viewmodel";
 
 function makeSession(overrides: Partial<ImportSession> = {}): ImportSession {
 	return {
@@ -10,7 +10,7 @@ function makeSession(overrides: Partial<ImportSession> = {}): ImportSession {
 		createdAt: "2026-05-01T00:00:00.000Z",
 		expiresAt: 1_780_000_000,
 		totalUrls: 0,
-		totalFoundInFile: 0,
+		totalFound: 0,
 		truncated: false,
 		deselected: new Set<number>(),
 		...overrides,
@@ -148,8 +148,8 @@ describe("toImportViewModel", () => {
 		expect(vm.toggleAllUrl).toBe(`/import/${session.id}/toggle-all?page=3`);
 	});
 
-	it("propagates the truncated flag and totalFoundInFile from the session header", () => {
-		const session = makeSession({ totalUrls: 2_000, totalFoundInFile: 2_345, truncated: true });
+	it("propagates the truncated flag and totalFound from the session header", () => {
+		const session = makeSession({ totalUrls: 2_000, totalFound: 2_345, truncated: true });
 
 		const vm = toImportViewModel(
 			{ session, pageUrls: ["https://example.com/x"], page: 1, pageSize: 50 },
@@ -157,23 +157,40 @@ describe("toImportViewModel", () => {
 		);
 
 		expect(vm.truncated).toBe(true);
-		expect(vm.totalFoundInFile).toBe(2_345);
+		expect(vm.totalFound).toBe(2_345);
 	});
 });
 
-describe("toImportUploadViewModel", () => {
-	it("returns /import as the upload action URL", () => {
-		const vm = toImportUploadViewModel({});
+describe("toImportAcquireViewModel", () => {
+	it("defaults the mode to upload when no mode is provided", () => {
+		const vm = toImportAcquireViewModel({});
+		expect(vm.mode).toBe("upload");
+		expect(vm.isUpload).toBe(true);
+		expect(vm.isFromUrl).toBe(false);
 		expect(vm.uploadAction).toBe("/import");
+		expect(vm.fromUrlAction).toBe("/import/from-url");
+	});
+
+	it("sets isFromUrl true when mode=from-url", () => {
+		const vm = toImportAcquireViewModel({ mode: "from-url" });
+		expect(vm.mode).toBe("from-url");
+		expect(vm.isUpload).toBe(false);
+		expect(vm.isFromUrl).toBe(true);
+	});
+
+	it("falls back to upload for an unrecognised mode value", () => {
+		const vm = toImportAcquireViewModel({ mode: "garbage" });
+		expect(vm.mode).toBe("upload");
+		expect(vm.isUpload).toBe(true);
 	});
 
 	it("passes through an error message when provided", () => {
-		const vm = toImportUploadViewModel({ errors: [{ message: "We couldn't find any links in that file." }] });
+		const vm = toImportAcquireViewModel({ errors: [{ message: "We couldn't find any links in that file." }] });
 		expect(vm.errors?.[0]?.message).toBe("We couldn't find any links in that file.");
 	});
 
 	it("leaves errors undefined when no message is provided", () => {
-		const vm = toImportUploadViewModel({});
+		const vm = toImportAcquireViewModel({});
 		expect(vm.errors).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -165,30 +165,23 @@ describe("toImportAcquireViewModel", () => {
 	it("defaults the mode to upload when no mode is provided", () => {
 		const vm = toImportAcquireViewModel({});
 		expect(vm.mode).toBe("upload");
-		expect(vm.isUpload).toBe(true);
-		expect(vm.isFromUrl).toBe(false);
 		expect(vm.uploadAction).toBe("/import");
 		expect(vm.fromUrlAction).toBe("/import/from-url");
 	});
 
-	it("sets isFromUrl true when mode=from-url and showFromUrl is true", () => {
+	it("sets mode to from-url when mode=from-url and showFromUrl is true", () => {
 		const vm = toImportAcquireViewModel({ mode: "from-url", showFromUrl: true });
 		expect(vm.mode).toBe("from-url");
-		expect(vm.isUpload).toBe(false);
-		expect(vm.isFromUrl).toBe(true);
 	});
 
 	it("falls back to upload when mode=from-url but showFromUrl is false", () => {
 		const vm = toImportAcquireViewModel({ mode: "from-url", showFromUrl: false });
 		expect(vm.mode).toBe("upload");
-		expect(vm.isUpload).toBe(true);
-		expect(vm.isFromUrl).toBe(false);
 	});
 
 	it("falls back to upload for an unrecognised mode value", () => {
 		const vm = toImportAcquireViewModel({ mode: "garbage" });
 		expect(vm.mode).toBe("upload");
-		expect(vm.isUpload).toBe(true);
 	});
 
 	it("passes through an error message when provided", () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.test.ts
@@ -206,15 +206,23 @@ describe("toImportAcquireViewModel", () => {
 		expect(vm.showFromUrl).toBe(false);
 	});
 
-	it("includes feature param in tab hrefs when showFromUrl is true", () => {
-		const vm = toImportAcquireViewModel({ showFromUrl: true });
-		expect(vm.tabUploadHref).toBe("/import?feature=import-link-public");
-		expect(vm.tabFromUrlHref).toBe("/import?mode=from-url&feature=import-link-public");
+	it("emits no tabs when showFromUrl is false", () => {
+		const vm = toImportAcquireViewModel({ showFromUrl: false });
+		expect(vm.tabs).toEqual([]);
 	});
 
-	it("omits feature param from tab hrefs when showFromUrl is false", () => {
-		const vm = toImportAcquireViewModel({ showFromUrl: false });
-		expect(vm.tabUploadHref).toBe("/import");
-		expect(vm.tabFromUrlHref).toBe("/import?mode=from-url");
+	it("emits both tabs with the upload tab active by default when showFromUrl is true", () => {
+		const vm = toImportAcquireViewModel({ showFromUrl: true });
+		expect(vm.tabs.map((t) => t.key)).toEqual(["upload", "from-url"]);
+		expect(vm.tabs[0].isActive).toBe(true);
+		expect(vm.tabs[0].href).toBe("/import?feature=import-link-public");
+		expect(vm.tabs[1].isActive).toBe(false);
+		expect(vm.tabs[1].href).toBe("/import?mode=from-url&feature=import-link-public");
+	});
+
+	it("marks the from-url tab active when mode=from-url and showFromUrl is true", () => {
+		const vm = toImportAcquireViewModel({ mode: "from-url", showFromUrl: true });
+		expect(vm.tabs[0].isActive).toBe(false);
+		expect(vm.tabs[1].isActive).toBe(true);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -13,8 +13,6 @@ export interface ImportTabViewModel {
 
 export interface ImportAcquireViewModel {
 	readonly mode: ImportMode;
-	readonly isUpload: boolean;
-	readonly isFromUrl: boolean;
 	readonly showFromUrl: boolean;
 	readonly errors?: readonly ComponentError[];
 	readonly uploadAction: string;
@@ -38,8 +36,6 @@ export function toImportAcquireViewModel(input: {
 		: [];
 	return {
 		mode,
-		isUpload: mode === "upload",
-		isFromUrl: mode === "from-url",
 		showFromUrl,
 		errors: input.errors,
 		uploadAction: "/import",

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -4,6 +4,13 @@ import { buildImportToggleAllUrl, buildImportToggleUrl, buildImportUrl } from ".
 
 export type ImportMode = "upload" | "from-url";
 
+export interface ImportTabViewModel {
+	readonly key: ImportMode;
+	readonly label: string;
+	readonly href: string;
+	readonly isActive: boolean;
+}
+
 export interface ImportAcquireViewModel {
 	readonly mode: ImportMode;
 	readonly isUpload: boolean;
@@ -12,8 +19,7 @@ export interface ImportAcquireViewModel {
 	readonly errors?: readonly ComponentError[];
 	readonly uploadAction: string;
 	readonly fromUrlAction: string;
-	readonly tabUploadHref: string;
-	readonly tabFromUrlHref: string;
+	readonly tabs: readonly ImportTabViewModel[];
 }
 
 export function toImportAcquireViewModel(input: {
@@ -24,6 +30,12 @@ export function toImportAcquireViewModel(input: {
 	const showFromUrl = input.showFromUrl ?? false;
 	const mode: ImportMode = input.mode === "from-url" && showFromUrl ? "from-url" : "upload";
 	const featureParam = showFromUrl ? "?feature=import-link-public" : "";
+	const tabs: readonly ImportTabViewModel[] = showFromUrl
+		? [
+				{ key: "upload", label: "Upload a file", href: `/import${featureParam}`, isActive: mode === "upload" },
+				{ key: "from-url", label: "Paste a link", href: "/import?mode=from-url&feature=import-link-public", isActive: mode === "from-url" },
+			]
+		: [];
 	return {
 		mode,
 		isUpload: mode === "upload",
@@ -32,8 +44,7 @@ export function toImportAcquireViewModel(input: {
 		errors: input.errors,
 		uploadAction: "/import",
 		fromUrlAction: "/import/from-url",
-		tabUploadHref: `/import${featureParam}`,
-		tabFromUrlHref: `/import?mode=from-url${showFromUrl ? "&feature=import-link-public" : ""}`,
+		tabs,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -2,15 +2,29 @@ import type { ImportSessionPage } from "@packages/domain/import-session";
 import type { ComponentError } from "../../shared/component-error.types";
 import { buildImportToggleAllUrl, buildImportToggleUrl, buildImportUrl } from "./import.url";
 
-export interface ImportUploadViewModel {
+export type ImportMode = "upload" | "from-url";
+
+export interface ImportAcquireViewModel {
+	readonly mode: ImportMode;
+	readonly isUpload: boolean;
+	readonly isFromUrl: boolean;
 	readonly errors?: readonly ComponentError[];
 	readonly uploadAction: string;
+	readonly fromUrlAction: string;
 }
 
-export function toImportUploadViewModel(input: { errors?: readonly ComponentError[] }): ImportUploadViewModel {
+export function toImportAcquireViewModel(input: {
+	mode?: string;
+	errors?: readonly ComponentError[];
+}): ImportAcquireViewModel {
+	const mode: ImportMode = input.mode === "from-url" ? "from-url" : "upload";
 	return {
+		mode,
+		isUpload: mode === "upload",
+		isFromUrl: mode === "from-url",
 		errors: input.errors,
 		uploadAction: "/import",
+		fromUrlAction: "/import/from-url",
 	};
 }
 
@@ -24,7 +38,7 @@ export interface ImportViewModel {
 	readonly sessionId: string;
 	readonly rows: readonly ImportRowViewModel[];
 	readonly totalUrls: number;
-	readonly totalFoundInFile: number;
+	readonly totalFound: number;
 	readonly totalSelected: number;
 	readonly truncated: boolean;
 	readonly currentPage: number;
@@ -60,7 +74,7 @@ export function toImportViewModel(
 			};
 		}),
 		totalUrls: session.totalUrls,
-		totalFoundInFile: session.totalFoundInFile,
+		totalFound: session.totalFound,
 		totalSelected,
 		truncated: session.truncated,
 		currentPage: page,

--- a/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.viewmodel.ts
@@ -8,23 +8,32 @@ export interface ImportAcquireViewModel {
 	readonly mode: ImportMode;
 	readonly isUpload: boolean;
 	readonly isFromUrl: boolean;
+	readonly showFromUrl: boolean;
 	readonly errors?: readonly ComponentError[];
 	readonly uploadAction: string;
 	readonly fromUrlAction: string;
+	readonly tabUploadHref: string;
+	readonly tabFromUrlHref: string;
 }
 
 export function toImportAcquireViewModel(input: {
 	mode?: string;
 	errors?: readonly ComponentError[];
+	showFromUrl?: boolean;
 }): ImportAcquireViewModel {
-	const mode: ImportMode = input.mode === "from-url" ? "from-url" : "upload";
+	const showFromUrl = input.showFromUrl ?? false;
+	const mode: ImportMode = input.mode === "from-url" && showFromUrl ? "from-url" : "upload";
+	const featureParam = showFromUrl ? "?feature=import-link-public" : "";
 	return {
 		mode,
 		isUpload: mode === "upload",
 		isFromUrl: mode === "from-url",
+		showFromUrl,
 		errors: input.errors,
 		uploadAction: "/import",
 		fromUrlAction: "/import/from-url",
+		tabUploadHref: `/import${featureParam}`,
+		tabFromUrlHref: `/import?mode=from-url${showFromUrl ? "&feature=import-link-public" : ""}`,
 	};
 }
 

--- a/src/packages/domain/src/import-session/collect-import-links.test.ts
+++ b/src/packages/domain/src/import-session/collect-import-links.test.ts
@@ -1,0 +1,86 @@
+import { collectImportLinks } from "./collect-import-links";
+import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
+
+describe("collectImportLinks", () => {
+	it("preserves valid http and https URLs in order", () => {
+		const result = collectImportLinks([
+			"https://example.com/post",
+			"http://example.org/article",
+		]);
+
+		expect(result.urls).toEqual([
+			"https://example.com/post",
+			"http://example.org/article",
+		]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("dedupes URLs case-insensitively on host and ignores trailing slash on path-only", () => {
+		const result = collectImportLinks([
+			"https://EXAMPLE.com/",
+			"https://example.com",
+			"https://example.com/post",
+		]);
+
+		expect(result.urls).toEqual([
+			"https://EXAMPLE.com/",
+			"https://example.com/post",
+		]);
+	});
+
+	it("preserves URLs with query strings and fragments during normalization", () => {
+		const result = collectImportLinks([
+			"https://example.com/?q=test",
+			"https://example.com/#section",
+			"https://example.com/page?a=1#top",
+		]);
+
+		expect(result.urls).toEqual([
+			"https://example.com/?q=test",
+			"https://example.com/#section",
+			"https://example.com/page?a=1#top",
+		]);
+	});
+
+	it("caps the result at MAX_URLS_PER_IMPORT and reports truncation with the total found", () => {
+		const urls = Array.from(
+			{ length: MAX_URLS_PER_IMPORT + 5 },
+			(_v, i) => `https://example.com/post-${i}`,
+		);
+
+		const result = collectImportLinks(urls);
+
+		expect(result.urls).toHaveLength(MAX_URLS_PER_IMPORT);
+		expect(result.truncated).toBe(true);
+		expect(result.totalFound).toBe(MAX_URLS_PER_IMPORT + 5);
+	});
+
+	it("returns an empty result when given no URLs", () => {
+		const result = collectImportLinks([]);
+
+		expect(result.urls).toEqual([]);
+		expect(result.truncated).toBe(false);
+		expect(result.totalFound).toBe(0);
+	});
+
+	it("rejects non-saveable schemes and bare strings", () => {
+		const result = collectImportLinks([
+			"mailto:foo@bar.com",
+			"javascript:alert(1)",
+			"chrome://settings",
+			"about:blank",
+			"data:text/html,<h1>x</h1>",
+			"file:///etc/passwd",
+			"/relative/path",
+			"https://example.com/keep",
+		]);
+
+		expect(result.urls).toEqual(["https://example.com/keep"]);
+	});
+
+	it("skips entries that fail URL parsing", () => {
+		const result = collectImportLinks(["http://", "not-a-url", "https://example.com/ok"]);
+
+		expect(result.urls).toEqual(["https://example.com/ok"]);
+	});
+});

--- a/src/packages/domain/src/import-session/collect-import-links.ts
+++ b/src/packages/domain/src/import-session/collect-import-links.ts
@@ -1,0 +1,46 @@
+import { SaveArticleInputSchema } from "../article/article.schema";
+import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
+import type { ImportLinksResult } from "./import-session.types";
+
+function hasPathOrQueryOrHash(parsed: URL): boolean {
+	if (parsed.pathname !== "/") return true;
+	if (parsed.search) return true;
+	if (parsed.hash) return true;
+	return false;
+}
+
+function normalizeUrl(url: string): string {
+	const parsed = new URL(url);
+	parsed.hostname = parsed.hostname.toLowerCase();
+	if (hasPathOrQueryOrHash(parsed)) return parsed.toString();
+	return `${parsed.protocol}//${parsed.host}`;
+}
+
+function hasHttpScheme(raw: string): boolean {
+	return /^https?:\/\//i.test(raw);
+}
+
+export function collectImportLinks(rawUrls: Iterable<string>): ImportLinksResult {
+	const seen = new Set<string>();
+	const urls: string[] = [];
+	let truncated = false;
+
+	for (const raw of rawUrls) {
+		if (!hasHttpScheme(raw)) continue;
+
+		const parsed = SaveArticleInputSchema.safeParse({ url: raw });
+		if (!parsed.success) continue;
+
+		const normalized = normalizeUrl(parsed.data.url);
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+
+		if (urls.length >= MAX_URLS_PER_IMPORT) {
+			truncated = true;
+			continue;
+		}
+		urls.push(parsed.data.url);
+	}
+
+	return { urls, truncated, totalFound: seen.size };
+}

--- a/src/packages/domain/src/import-session/extract-urls.test.ts
+++ b/src/packages/domain/src/import-session/extract-urls.test.ts
@@ -1,5 +1,4 @@
 import { extractUrls } from "./extract-urls";
-import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
 
 describe("extractUrls", () => {
 	it("extracts http and https URLs from plain text", () => {
@@ -64,76 +63,18 @@ describe("extractUrls", () => {
 		]);
 	});
 
-	it("dedupes URLs case-insensitively on host and ignores trailing slash on path-only", () => {
-		const text = [
-			"https://EXAMPLE.com/",
-			"https://example.com",
-			"https://example.com/post",
-		].join(" ");
-
-		const result = extractUrls(Buffer.from(text));
-
-		expect(result.urls).toEqual(["https://EXAMPLE.com/", "https://example.com/post"]);
-	});
-
-	it("preserves URLs with query strings and fragments during normalization", () => {
-		const text = [
-			"https://example.com/?q=test",
-			"https://example.com/#section",
-			"https://example.com/page?a=1#top",
-		].join("\n");
-
-		const result = extractUrls(Buffer.from(text));
-
-		expect(result.urls).toEqual([
-			"https://example.com/?q=test",
-			"https://example.com/#section",
-			"https://example.com/page?a=1#top",
-		]);
-	});
-
-	it("caps the result at MAX_URLS_PER_IMPORT and reports truncation with the total found", () => {
-		const urls = Array.from(
-			{ length: MAX_URLS_PER_IMPORT + 5 },
-			(_v, i) => `https://example.com/post-${i}`,
-		);
-
-		const result = extractUrls(Buffer.from(urls.join("\n")));
-
-		expect(result.urls).toHaveLength(MAX_URLS_PER_IMPORT);
-		expect(result.truncated).toBe(true);
-		expect(result.totalFoundInFile).toBe(MAX_URLS_PER_IMPORT + 5);
-	});
-
 	it("returns an empty list when the buffer contains no URLs", () => {
 		const result = extractUrls(Buffer.from("No links here. Just prose."));
 
 		expect(result.urls).toEqual([]);
 		expect(result.truncated).toBe(false);
-		expect(result.totalFoundInFile).toBe(0);
-	});
-
-	it("rejects non-saveable schemes and bare strings", () => {
-		const text = [
-			"mailto:foo@bar.com",
-			"javascript:alert(1)",
-			"chrome://settings",
-			"about:blank",
-			"data:text/html,<h1>x</h1>",
-			"file:///etc/passwd",
-			"/relative/path",
-			"https://example.com/keep",
-		].join("\n");
-
-		const result = extractUrls(Buffer.from(text));
-
-		expect(result.urls).toEqual(["https://example.com/keep"]);
+		expect(result.totalFound).toBe(0);
 	});
 
 	it("skips matches that fail URL parsing after trailing punctuation is stripped", () => {
 		// `http://.` matches the URL_REGEX (it has at least one char after `://`),
 		// but stripping the trailing `.` leaves `http://` which fails `new URL()`.
-		// This forces the !parsed.success branch in extractUrls.
+		// This forces the !parsed.success branch in collectImportLinks.
 		const text = "see http://. for details";
 
 		const result = extractUrls(Buffer.from(text));

--- a/src/packages/domain/src/import-session/extract-urls.ts
+++ b/src/packages/domain/src/import-session/extract-urls.ts
@@ -1,15 +1,8 @@
-import { SaveArticleInputSchema } from "../article/article.schema";
-import { MAX_URLS_PER_IMPORT } from "./import-session.schema";
-
-export interface ExtractUrlsResult {
-	readonly urls: readonly string[];
-	readonly truncated: boolean;
-	readonly totalFoundInFile: number;
-}
+import { collectImportLinks } from "./collect-import-links";
+import type { ImportLinksResult } from "./import-session.types";
 
 const URL_REGEX = /\bhttps?:\/\/[^\s<>"'()[\]{}|\\^`]+/gi;
 const TRAILING_PUNCTUATION = /[.,;:!?>'"\])]+$/;
-const EMPTY: ExtractUrlsResult = { urls: [], truncated: false, totalFoundInFile: 0 };
 
 function decodeBuffer(buffer: Buffer): string {
 	const utf8 = buffer.toString("utf8");
@@ -19,45 +12,11 @@ function decodeBuffer(buffer: Buffer): string {
 	return utf8;
 }
 
-function hasPathOrQueryOrHash(parsed: URL): boolean {
-	if (parsed.pathname !== "/") return true;
-	if (parsed.search) return true;
-	if (parsed.hash) return true;
-	return false;
-}
-
-function normalizeUrl(url: string): string {
-	const parsed = new URL(url);
-	parsed.hostname = parsed.hostname.toLowerCase();
-	if (hasPathOrQueryOrHash(parsed)) return parsed.toString();
-	return `${parsed.protocol}//${parsed.host}`;
-}
-
-export function extractUrls(buffer: Buffer): ExtractUrlsResult {
+export function extractUrls(buffer: Buffer): ImportLinksResult {
 	const text = decodeBuffer(buffer);
 	const matches = text.match(URL_REGEX);
-	if (!matches) return EMPTY;
+	if (!matches) return { urls: [], truncated: false, totalFound: 0 };
 
-	const seen = new Set<string>();
-	const urls: string[] = [];
-	let truncated = false;
-
-	for (const raw of matches) {
-		const stripped = raw.replace(TRAILING_PUNCTUATION, "");
-
-		const parsed = SaveArticleInputSchema.safeParse({ url: stripped });
-		if (!parsed.success) continue;
-
-		const normalized = normalizeUrl(parsed.data.url);
-		if (seen.has(normalized)) continue;
-		seen.add(normalized);
-
-		if (urls.length >= MAX_URLS_PER_IMPORT) {
-			truncated = true;
-			continue;
-		}
-		urls.push(parsed.data.url);
-	}
-
-	return { urls, truncated, totalFoundInFile: seen.size };
+	const stripped = matches.map((raw) => raw.replace(TRAILING_PUNCTUATION, ""));
+	return collectImportLinks(stripped);
 }

--- a/src/packages/domain/src/import-session/import-session.types.ts
+++ b/src/packages/domain/src/import-session/import-session.types.ts
@@ -1,13 +1,19 @@
 import type { UserId } from "../user/user.types";
 import type { ImportSessionId } from "./import-session.schema";
 
+export interface ImportLinksResult {
+	readonly urls: readonly string[];
+	readonly truncated: boolean;
+	readonly totalFound: number;
+}
+
 export interface ImportSession {
 	readonly id: ImportSessionId;
 	readonly userId: UserId;
 	readonly createdAt: string;
 	readonly expiresAt: number;
 	readonly totalUrls: number;
-	readonly totalFoundInFile: number;
+	readonly totalFound: number;
 	readonly truncated: boolean;
 	readonly deselected: ReadonlySet<number>;
 }
@@ -23,7 +29,7 @@ export type CreateImportSession = (params: {
 	userId: UserId;
 	urls: readonly string[];
 	truncated: boolean;
-	totalFoundInFile: number;
+	totalFound: number;
 }) => Promise<ImportSession>;
 
 export type FindImportSession = (params: {

--- a/src/packages/domain/src/import-session/index.ts
+++ b/src/packages/domain/src/import-session/index.ts
@@ -1,5 +1,6 @@
 export type {
 	ImportSession,
+	ImportLinksResult,
 	ImportSessionPage,
 	CreateImportSession,
 	FindImportSession,
@@ -21,4 +22,5 @@ export {
 	IMPORT_PAGE_SIZE,
 	IMPORT_COMMIT_CONCURRENCY,
 } from "./import-session.schema";
-export { extractUrls, type ExtractUrlsResult } from "./extract-urls";
+export { extractUrls } from "./extract-urls";
+export { collectImportLinks } from "./collect-import-links";

--- a/src/packages/extract-links-from-page/.c8rc.json
+++ b/src/packages/extract-links-from-page/.c8rc.json
@@ -1,0 +1,9 @@
+{
+  "all": true,
+  "src": "src",
+  "reporter": ["html", "json-summary"],
+  "reports-dir": "./coverage",
+  "resolve": ".",
+  "source-map": true,
+  "exclude-after-remap": true
+}

--- a/src/packages/extract-links-from-page/biome.json
+++ b/src/packages/extract-links-from-page/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../../../biome.config.base.json"]
+}

--- a/src/packages/extract-links-from-page/enforce-coverage.config.js
+++ b/src/packages/extract-links-from-page/enforce-coverage.config.js
@@ -1,0 +1,21 @@
+const baseConfig = require('../../../enforce-coverage.config.base');
+const path = require('path');
+
+const config = {
+  ...baseConfig,
+  thresholds: {
+    statements: 100,
+    branches: 100,
+    functions: 100,
+    lines: 100,
+  },
+};
+
+config.enforceCoverage({
+  projectRoot: path.resolve(__dirname),
+  thresholds: config.thresholds,
+  showTextTable: true,
+  extraExcludePatterns: [
+    ...(config.extraExcludePatterns || []),
+  ],
+});

--- a/src/packages/extract-links-from-page/knip.config.ts
+++ b/src/packages/extract-links-from-page/knip.config.ts
@@ -1,0 +1,15 @@
+import type { KnipConfig } from "knip";
+
+export default {
+	ignoreDependencies: [
+		"@packages/crawl-article",
+		"@packages/domain",
+	],
+	ignoreBinaries: [
+		"knip",
+		"biome",
+	],
+	jest: {
+		entry: ["src/**/*.test.ts"],
+	},
+} satisfies KnipConfig;

--- a/src/packages/extract-links-from-page/package.json
+++ b/src/packages/extract-links-from-page/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@packages/extract-links-from-page",
+  "version": "1.0.0",
+  "description": "Fetches a page via CrawlFetch and harvests its outbound links for the /import from-url acquirer",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "private": true,
+  "scripts": {
+    "compile": "tsc",
+    "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
+    "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
+    "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",
+    "check": "pnpm lint && pnpm test-with-coverage",
+    "check-infra": "echo 'No infrastructure — shared library'"
+  },
+  "dependencies": {
+    "@packages/crawl-article": "workspace:*",
+    "@packages/domain": "workspace:*",
+    "linkedom": "0.18.12"
+  },
+  "devDependencies": {
+    "@types/jest": "29.5.14",
+    "c8": "10.1.3",
+    "concurrently": "9.2.1",
+    "jest": "29.7.0",
+    "typescript": "5.9.3"
+  }
+}

--- a/src/packages/extract-links-from-page/project.json
+++ b/src/packages/extract-links-from-page/project.json
@@ -1,0 +1,10 @@
+{
+  "name": "@packages/extract-links-from-page",
+  "targets": {
+    "check": {
+      "command": "pnpm lint && pnpm test-with-coverage",
+      "options": { "cwd": "{projectRoot}" },
+      "dependsOn": ["compile"]
+    }
+  }
+}

--- a/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
@@ -281,7 +281,35 @@ describe("initExtractLinksFromPageUrl", () => {
 		expect(result).toEqual({ status: "FETCH_FAILED", reason: "http", httpStatus: 404 });
 	});
 
-	it("rejects responses larger than 5 MiB", async () => {
+	it("rejects via Content-Length header without downloading the body", async () => {
+		let bodyRead = false;
+		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
+			crawlFetch: fakeFetch(async () => {
+				const response = new Response("short", {
+					status: 200,
+					headers: {
+						"content-type": "text/html",
+						"content-length": String(6 * 1024 * 1024),
+					},
+				});
+				Object.defineProperty(response, "url", { value: "https://news.example/issues/42" });
+				const originalArrayBuffer = response.arrayBuffer.bind(response);
+				response.arrayBuffer = async () => {
+					bodyRead = true;
+					return originalArrayBuffer();
+				};
+				return response;
+			}),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "too_large" });
+		expect(bodyRead).toBe(false);
+	});
+
+	it("rejects responses larger than 5 MiB when Content-Length is absent", async () => {
 		const body = "a".repeat(5 * 1024 * 1024 + 1);
 		const extract = initExtractLinksFromPageUrl({
 			validateUrl: validateSaveableUrl,

--- a/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
@@ -1,4 +1,5 @@
 import type { CrawlFetch } from "@packages/crawl-article";
+import { validateSaveableUrl } from "@packages/domain/article";
 import { initExtractLinksFromPageUrl } from "./extract-links-from-page";
 
 function htmlResponse(html: string, opts?: { url?: string }): Response {
@@ -21,6 +22,7 @@ describe("initExtractLinksFromPageUrl", () => {
 		const html =
 			'<html><body><a href="https://other.com/post-1">A</a><a href="https://other.com/post-2">B</a></body></html>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
 		});
 
@@ -37,6 +39,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	it("resolves relative hrefs against response.url after redirects", async () => {
 		const html = '<html><body><a href="/post">A</a></body></html>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () =>
 				htmlResponse(html, { url: "https://redirect.example/issues/42" }),
 			),
@@ -52,6 +55,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	it("falls back to the requested URL when response.url is empty", async () => {
 		const html = '<html><body><a href="https://elsewhere.com/post">A</a></body></html>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => {
 				const r = new Response(html, {
 					status: 200,
@@ -76,6 +80,7 @@ describe("initExtractLinksFromPageUrl", () => {
 			<a href="https://outside.com/article">Editorial</a>
 		`;
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
 		});
 
@@ -90,6 +95,7 @@ describe("initExtractLinksFromPageUrl", () => {
 		const html =
 			'<a href="https://news.example/issues/42">Permalink</a><a href="https://news.example/">Home</a><a href="https://outside.com/a">Article</a>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
 		});
 
@@ -111,6 +117,7 @@ describe("initExtractLinksFromPageUrl", () => {
 			<a href="https://outside.com/keep">Keep</a>
 		`;
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
 		});
 
@@ -125,6 +132,7 @@ describe("initExtractLinksFromPageUrl", () => {
 		const html =
 			'<a href="https://other.com/post">A</a><a href="https://OTHER.com/post">B</a><a href="https://other.com/post">C</a>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
 		});
 
@@ -138,6 +146,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	it("skips hrefs that fail URL parsing against the base", async () => {
 		const html = '<a href="http://%ZZ"></a><a href="https://outside.com/ok"></a>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
 		});
 
@@ -150,6 +159,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("returns OK with an empty list when the page has no anchors", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () =>
 				htmlResponse("<html><body><p>just text</p></body></html>", {
 					url: "https://news.example/issues/42",
@@ -167,6 +177,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	it("returns INVALID_URL for unsaveable inputs without fetching", async () => {
 		let fetched = false;
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => {
 				fetched = true;
 				return htmlResponse("");
@@ -181,6 +192,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("returns INVALID_URL for non-string-like rubbish", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse("")),
 		});
 
@@ -191,6 +203,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("maps an AbortError from the fetch timeout to FETCH_FAILED { reason: timeout }", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async (_url, init) => {
 				return new Promise<Response>((_resolve, reject) => {
 					init?.signal?.addEventListener("abort", () => {
@@ -213,6 +226,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("maps a network error to FETCH_FAILED { reason: network }", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => {
 				throw new TypeError("dns failure");
 			}),
@@ -225,6 +239,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("maps a non-Error throw to FETCH_FAILED { reason: network }", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => {
 				throw "boom";
 			}),
@@ -237,6 +252,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("maps an AbortError that fires before the timeout to FETCH_FAILED { reason: timeout }", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => {
 				const err = new Error("aborted by caller");
 				err.name = "AbortError";
@@ -251,6 +267,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("maps !response.ok to FETCH_FAILED with the http status", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () =>
 				new Response("nope", {
 					status: 404,
@@ -267,6 +284,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	it("rejects responses larger than 5 MiB", async () => {
 		const body = "a".repeat(5 * 1024 * 1024 + 1);
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => htmlResponse(body, { url: "https://news.example/issues/42" })),
 		});
 
@@ -277,6 +295,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("returns UNSUPPORTED_CONTENT_TYPE for non-HTML responses", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () =>
 				new Response("%PDF-1.4", {
 					status: 200,
@@ -292,6 +311,7 @@ describe("initExtractLinksFromPageUrl", () => {
 
 	it("treats a missing content-type as UNSUPPORTED_CONTENT_TYPE", async () => {
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () => {
 				// Uint8Array body avoids the auto-applied text/plain content-type that
 				// Response('string', …) sets. With no header, headers.get('content-type')
@@ -308,6 +328,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	it("accepts application/xhtml+xml as HTML", async () => {
 		const html = '<a href="https://outside.com/x">X</a>';
 		const extract = initExtractLinksFromPageUrl({
+			validateUrl: validateSaveableUrl,
 			crawlFetch: fakeFetch(async () =>
 				new Response(html, {
 					status: 200,

--- a/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
@@ -1,0 +1,325 @@
+import type { CrawlFetch } from "@packages/crawl-article";
+import { initExtractLinksFromPageUrl } from "./extract-links-from-page";
+
+function htmlResponse(html: string, opts?: { url?: string }): Response {
+	const response = new Response(html, {
+		status: 200,
+		headers: { "content-type": "text/html; charset=utf-8" },
+	});
+	if (opts?.url) {
+		Object.defineProperty(response, "url", { value: opts.url });
+	}
+	return response;
+}
+
+function fakeFetch(impl: (url: string, init?: { signal?: AbortSignal }) => Promise<Response>): CrawlFetch {
+	return impl;
+}
+
+describe("initExtractLinksFromPageUrl", () => {
+	it("returns OK with absolute hrefs preserved as-is", async () => {
+		const html =
+			'<html><body><a href="https://other.com/post-1">A</a><a href="https://other.com/post-2">B</a></body></html>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual([
+			"https://other.com/post-1",
+			"https://other.com/post-2",
+		]);
+	});
+
+	it("resolves relative hrefs against response.url after redirects", async () => {
+		const html = '<html><body><a href="/post">A</a></body></html>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () =>
+				htmlResponse(html, { url: "https://redirect.example/issues/42" }),
+			),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual([]);
+	});
+
+	it("falls back to the requested URL when response.url is empty", async () => {
+		const html = '<html><body><a href="https://elsewhere.com/post">A</a></body></html>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => {
+				const r = new Response(html, {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				});
+				Object.defineProperty(r, "url", { value: "" });
+				return r;
+			}),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://elsewhere.com/post"]);
+	});
+
+	it("drops same-host hrefs (newsletter chrome links)", async () => {
+		const html = `
+			<a href="/subscribe">Subscribe</a>
+			<a href="https://news.example/footer">Footer</a>
+			<a href="https://outside.com/article">Editorial</a>
+		`;
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://outside.com/article"]);
+	});
+
+	it("drops the source URL itself if it appears in the page", async () => {
+		const html =
+			'<a href="https://news.example/issues/42">Permalink</a><a href="https://news.example/">Home</a><a href="https://outside.com/a">Article</a>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://outside.com/a"]);
+	});
+
+	it("drops mailto:, javascript:, tel:, data:, fragments, and empty hrefs", async () => {
+		const html = `
+			<a href="mailto:user@example.com">Mail</a>
+			<a href="javascript:alert(1)">JS</a>
+			<a href="tel:+15551234">Tel</a>
+			<a href="data:text/html,x">Data</a>
+			<a href="#section">Frag</a>
+			<a href="">Empty</a>
+			<a href="https://outside.com/keep">Keep</a>
+		`;
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://outside.com/keep"]);
+	});
+
+	it("dedupes harvested hrefs via collectImportLinks", async () => {
+		const html =
+			'<a href="https://other.com/post">A</a><a href="https://OTHER.com/post">B</a><a href="https://other.com/post">C</a>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://other.com/post"]);
+	});
+
+	it("skips hrefs that fail URL parsing against the base", async () => {
+		const html = '<a href="http://%ZZ"></a><a href="https://outside.com/ok"></a>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(html, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://outside.com/ok"]);
+	});
+
+	it("returns OK with an empty list when the page has no anchors", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () =>
+				htmlResponse("<html><body><p>just text</p></body></html>", {
+					url: "https://news.example/issues/42",
+				}),
+			),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual([]);
+	});
+
+	it("returns INVALID_URL for unsaveable inputs without fetching", async () => {
+		let fetched = false;
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => {
+				fetched = true;
+				return htmlResponse("");
+			}),
+		});
+
+		const result = await extract("http://localhost/internal");
+
+		expect(result.status).toBe("INVALID_URL");
+		expect(fetched).toBe(false);
+	});
+
+	it("returns INVALID_URL for non-string-like rubbish", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse("")),
+		});
+
+		const result = await extract("not a url at all");
+
+		expect(result.status).toBe("INVALID_URL");
+	});
+
+	it("maps an AbortError from the fetch timeout to FETCH_FAILED { reason: timeout }", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async (_url, init) => {
+				return new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => {
+						const err = new Error("aborted");
+						err.name = "AbortError";
+						reject(err);
+					});
+				});
+			}),
+		});
+
+		jest.useFakeTimers();
+		const promise = extract("https://news.example/issues/42");
+		jest.advanceTimersByTime(10_001);
+		const result = await promise;
+		jest.useRealTimers();
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "timeout" });
+	});
+
+	it("maps a network error to FETCH_FAILED { reason: network }", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => {
+				throw new TypeError("dns failure");
+			}),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "network" });
+	});
+
+	it("maps a non-Error throw to FETCH_FAILED { reason: network }", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => {
+				throw "boom";
+			}),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "network" });
+	});
+
+	it("maps an AbortError that fires before the timeout to FETCH_FAILED { reason: timeout }", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => {
+				const err = new Error("aborted by caller");
+				err.name = "AbortError";
+				throw err;
+			}),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "timeout" });
+	});
+
+	it("maps !response.ok to FETCH_FAILED with the http status", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () =>
+				new Response("nope", {
+					status: 404,
+					headers: { "content-type": "text/html" },
+				}),
+			),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "http", httpStatus: 404 });
+	});
+
+	it("rejects responses larger than 5 MiB", async () => {
+		const body = "a".repeat(5 * 1024 * 1024 + 1);
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => htmlResponse(body, { url: "https://news.example/issues/42" })),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "FETCH_FAILED", reason: "too_large" });
+	});
+
+	it("returns UNSUPPORTED_CONTENT_TYPE for non-HTML responses", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () =>
+				new Response("%PDF-1.4", {
+					status: 200,
+					headers: { "content-type": "application/pdf" },
+				}),
+			),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "UNSUPPORTED_CONTENT_TYPE", contentType: "application/pdf" });
+	});
+
+	it("treats a missing content-type as UNSUPPORTED_CONTENT_TYPE", async () => {
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () => {
+				// Uint8Array body avoids the auto-applied text/plain content-type that
+				// Response('string', …) sets. With no header, headers.get('content-type')
+				// returns null, exercising the missing-content-type branch.
+				return new Response(new Uint8Array([60, 104, 116, 109, 108, 62]), { status: 200 });
+			}),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result).toEqual({ status: "UNSUPPORTED_CONTENT_TYPE", contentType: "" });
+	});
+
+	it("accepts application/xhtml+xml as HTML", async () => {
+		const html = '<a href="https://outside.com/x">X</a>';
+		const extract = initExtractLinksFromPageUrl({
+			crawlFetch: fakeFetch(async () =>
+				new Response(html, {
+					status: 200,
+					headers: { "content-type": "application/xhtml+xml; charset=utf-8" },
+				}),
+			),
+		});
+
+		const result = await extract("https://news.example/issues/42");
+
+		expect(result.status).toBe("OK");
+		if (result.status !== "OK") throw new Error("expected OK");
+		expect(result.links.urls).toEqual(["https://outside.com/x"]);
+	});
+});

--- a/src/packages/extract-links-from-page/src/extract-links-from-page.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { parseHTML } from "linkedom";
 import type { CrawlFetch } from "@packages/crawl-article";
-import { validateSaveableUrl } from "@packages/domain/article";
+import type { ValidateSaveableUrl } from "@packages/domain/article";
 import {
 	collectImportLinks,
 	type ImportLinksResult,
@@ -57,9 +57,10 @@ function harvestLinks(html: string, baseUrl: string, sourceUrl: string): ImportL
 
 export function initExtractLinksFromPageUrl(deps: {
 	crawlFetch: CrawlFetch;
+	validateUrl: ValidateSaveableUrl;
 }): ExtractLinksFromPageUrl {
 	return async (pageUrl) => {
-		const validation = validateSaveableUrl(pageUrl);
+		const validation = deps.validateUrl(pageUrl);
 		if (validation.status === "ERROR") return { status: "INVALID_URL" };
 
 		const controller = new AbortController();

--- a/src/packages/extract-links-from-page/src/extract-links-from-page.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert";
+import { parseHTML } from "linkedom";
+import type { CrawlFetch } from "@packages/crawl-article";
+import { validateSaveableUrl } from "@packages/domain/article";
+import {
+	collectImportLinks,
+	type ImportLinksResult,
+} from "@packages/domain/import-session";
+
+const MAX_PAGE_BYTES = 5 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 10_000;
+const HTML_CONTENT_TYPES: readonly string[] = ["text/html", "application/xhtml+xml"];
+
+export type ExtractLinksFromPageResult =
+	| { readonly status: "OK"; readonly links: ImportLinksResult }
+	| { readonly status: "INVALID_URL" }
+	| { readonly status: "UNSUPPORTED_CONTENT_TYPE"; readonly contentType: string }
+	| {
+			readonly status: "FETCH_FAILED";
+			readonly reason: "timeout" | "network" | "http" | "too_large";
+			readonly httpStatus?: number;
+	  };
+
+export type ExtractLinksFromPageUrl = (
+	pageUrl: string,
+) => Promise<ExtractLinksFromPageResult>;
+
+function contentTypeIsHtml(contentType: string): boolean {
+	const lower = contentType.toLowerCase().split(";")[0].trim();
+	return HTML_CONTENT_TYPES.includes(lower);
+}
+
+function resolveHref(href: string | null, base: URL): string | undefined {
+	assert(href !== null, "a[href] selector must produce a non-null href");
+	const trimmed = href.trim();
+	if (trimmed === "") return undefined;
+	if (trimmed.startsWith("#")) return undefined;
+	try {
+		return new URL(trimmed, base.href).toString();
+	} catch {
+		return undefined;
+	}
+}
+
+function harvestLinks(html: string, baseUrl: string, sourceUrl: string): ImportLinksResult {
+	const { document } = parseHTML(html);
+	const base = new URL(baseUrl);
+	const sourceNormalized = new URL(sourceUrl).toString();
+	const anchors = Array.from(document.querySelectorAll("a[href]"));
+	const raw = anchors
+		.map((anchor) => resolveHref(anchor.getAttribute("href"), base))
+		.filter((url): url is string => url !== undefined)
+		.filter((url) => new URL(url).host !== base.host)
+		.filter((url) => url !== sourceNormalized);
+	return collectImportLinks(raw);
+}
+
+export function initExtractLinksFromPageUrl(deps: {
+	crawlFetch: CrawlFetch;
+}): ExtractLinksFromPageUrl {
+	return async (pageUrl) => {
+		const validation = validateSaveableUrl(pageUrl);
+		if (validation.status === "ERROR") return { status: "INVALID_URL" };
+
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+		let response: Response;
+		try {
+			response = await deps.crawlFetch(validation.url, { signal: controller.signal });
+		} catch (error) {
+			if (controller.signal.aborted) {
+				return { status: "FETCH_FAILED", reason: "timeout" };
+			}
+			const reason = error instanceof Error && error.name === "AbortError" ? "timeout" : "network";
+			return { status: "FETCH_FAILED", reason };
+		} finally {
+			clearTimeout(timer);
+		}
+
+		if (!response.ok) {
+			return { status: "FETCH_FAILED", reason: "http", httpStatus: response.status };
+		}
+
+		const contentType = response.headers.get("content-type") ?? "";
+		if (!contentTypeIsHtml(contentType)) {
+			return { status: "UNSUPPORTED_CONTENT_TYPE", contentType };
+		}
+
+		const buffer = await response.arrayBuffer();
+		if (buffer.byteLength > MAX_PAGE_BYTES) {
+			return { status: "FETCH_FAILED", reason: "too_large" };
+		}
+
+		const html = new TextDecoder("utf-8").decode(buffer);
+		const baseUrl = response.url === "" ? validation.url : response.url;
+		const links = harvestLinks(html, baseUrl, validation.url);
+		return { status: "OK", links };
+	};
+}

--- a/src/packages/extract-links-from-page/src/extract-links-from-page.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.ts
@@ -87,6 +87,11 @@ export function initExtractLinksFromPageUrl(deps: {
 			return { status: "UNSUPPORTED_CONTENT_TYPE", contentType };
 		}
 
+		const declaredLength = response.headers.get("content-length");
+		if (declaredLength !== null && Number(declaredLength) > MAX_PAGE_BYTES) {
+			return { status: "FETCH_FAILED", reason: "too_large" };
+		}
+
 		const buffer = await response.arrayBuffer();
 		if (buffer.byteLength > MAX_PAGE_BYTES) {
 			return { status: "FETCH_FAILED", reason: "too_large" };

--- a/src/packages/extract-links-from-page/src/index.ts
+++ b/src/packages/extract-links-from-page/src/index.ts
@@ -1,0 +1,5 @@
+export {
+	initExtractLinksFromPageUrl,
+	type ExtractLinksFromPageUrl,
+	type ExtractLinksFromPageResult,
+} from "./extract-links-from-page";

--- a/src/packages/extract-links-from-page/tsconfig.json
+++ b/src/packages/extract-links-from-page/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.config.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/src/packages/extract-links-from-page/tsconfig.lint.json
+++ b/src/packages/extract-links-from-page/tsconfig.lint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/src/packages/test-fixtures/knip.config.ts
+++ b/src/packages/test-fixtures/knip.config.ts
@@ -14,6 +14,7 @@ export default {
 		"@packages/article-resource-unique-id",
 		"@packages/crawl-article",
 		"@packages/domain",
+		"@packages/extract-links-from-page",
 		"@packages/hutch-infra-components",
 		"@packages/hutch-logger",
 	],

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -139,6 +139,7 @@
     "@packages/article-resource-unique-id": "workspace:*",
     "@packages/crawl-article": "workspace:*",
     "@packages/domain": "workspace:*",
+    "@packages/extract-links-from-page": "workspace:*",
     "@packages/hutch-infra-components": "workspace:*",
     "@packages/hutch-logger": "workspace:*",
     "zod": "4.1.13"

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -3,6 +3,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ArticleMetadata, Minutes, ValidateSaveableUrl } from "@packages/domain/article";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import type { BotDefenseEvent } from "./providers/auth/bot-defense.types";
 import type { ConversionEvent } from "./providers/auth/conversion.types";
 import type { ExchangeGoogleCode } from "./providers/google-auth/google-token.types";
@@ -295,6 +296,7 @@ export interface SharedBundle {
 
 export interface ImportSessionBundle {
 	importSessionStore: ImportSessionStore;
+	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
 }
 
 export interface BotDefenseBundle {

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -20,6 +20,7 @@ import { initInMemoryStripeSubscriptions } from "./providers/stripe-subscription
 import { initInMemorySubscriptionProviders } from "./providers/subscription-providers/in-memory-subscription-providers";
 import { initInMemoryTrialScheduler } from "./providers/trial-scheduler/in-memory-trial-scheduler";
 import { initInMemoryImportSession } from "./providers/import-session/in-memory-import-session";
+import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import { initInMemorySaveLinkRawHtmlCommand } from "./providers/events/in-memory-save-link-raw-html-command";
 import { initInMemoryExportUserDataCommand } from "./providers/events/in-memory-export-user-data-command";
 import { initInMemoryCancelSubscriptionCommand } from "./providers/events/in-memory-cancel-subscription-command";
@@ -198,6 +199,15 @@ export function createFakePublishRecrawlLinkInitiated(
 	};
 }
 
+export const stubExtractLinksFromPageUrl: ExtractLinksFromPageUrl = async () => ({
+	status: "OK",
+	links: {
+		urls: ["https://example.com/a", "https://example.com/b"],
+		truncated: false,
+		totalFound: 2,
+	},
+});
+
 export const TEST_APP_ORIGIN = "http://localhost:3000";
 
 export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
@@ -324,6 +334,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		},
 		importSession: {
 			importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
+			extractLinksFromPageUrl: stubExtractLinksFromPageUrl,
 		},
 		shared: {
 			validateSaveableUrl,

--- a/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.test.ts
+++ b/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.test.ts
@@ -17,7 +17,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b"],
 			truncated: false,
-			totalFoundInFile: 2,
+			totalFound: 2,
 		});
 
 		expect(session.totalUrls).toBe(2);
@@ -31,7 +31,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
-			totalFoundInFile: 1,
+			totalFound: 1,
 		});
 
 		const peek = await store.findImportSession({ id: session.id, userId: otherUser });
@@ -53,7 +53,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
-			totalFoundInFile: 1,
+			totalFound: 1,
 		});
 
 		// Advance past TTL
@@ -68,7 +68,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b"],
 			truncated: false,
-			totalFoundInFile: 2,
+			totalFound: 2,
 		});
 
 		await store.toggleImportSelection({ id: session.id, userId: owner, index: 0, checked: false });
@@ -88,7 +88,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
 			truncated: false,
-			totalFoundInFile: 3,
+			totalFound: 3,
 		});
 
 		await store.toggleAllImportSelection({ id: session.id, userId: owner, checked: false });
@@ -104,7 +104,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b"],
 			truncated: false,
-			totalFoundInFile: 2,
+			totalFound: 2,
 		});
 		await store.toggleImportSelection({ id: session.id, userId: owner, index: 0, checked: false });
 		await store.toggleImportSelection({ id: session.id, userId: owner, index: 1, checked: false });
@@ -122,7 +122,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
 			truncated: false,
-			totalFoundInFile: 3,
+			totalFound: 3,
 		});
 
 		await store.toggleAllImportSelection({ id: session.id, userId: owner, checked: false });
@@ -139,7 +139,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a", "https://example.com/b"],
 			truncated: false,
-			totalFoundInFile: 2,
+			totalFound: 2,
 		});
 
 		await store.toggleAllImportSelection({ id: session.id, userId: otherUser, checked: false });
@@ -155,7 +155,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
-			totalFoundInFile: 1,
+			totalFound: 1,
 		});
 
 		await store.toggleImportSelection({ id: session.id, userId: otherUser, index: 0, checked: false });
@@ -167,7 +167,7 @@ describe("initInMemoryImportSession", () => {
 	it("returns the page slice for the requested page", async () => {
 		const store = initInMemoryImportSession({ now: () => new Date() });
 		const urls = Array.from({ length: 12 }, (_v, i) => `https://example.com/post-${i}`);
-		const session = await store.createImportSession({ userId: owner, urls, truncated: true, totalFoundInFile: 15 });
+		const session = await store.createImportSession({ userId: owner, urls, truncated: true, totalFound: 15 });
 
 		const page2 = await store.loadImportSessionPage({ id: session.id, userId: owner, page: 2, pageSize: 5 });
 		assert(page2, "page 2 must exist");
@@ -182,7 +182,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
-			totalFoundInFile: 1,
+			totalFound: 1,
 		});
 
 		expect(
@@ -200,7 +200,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
-			totalFoundInFile: 1,
+			totalFound: 1,
 		});
 
 		await store.deleteImportSession({ id: session.id, userId: owner });
@@ -214,7 +214,7 @@ describe("initInMemoryImportSession", () => {
 			userId: owner,
 			urls: ["https://example.com/a"],
 			truncated: false,
-			totalFoundInFile: 1,
+			totalFound: 1,
 		});
 
 		await store.deleteImportSession({ id: session.id, userId: otherUser });

--- a/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.ts
+++ b/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.ts
@@ -31,7 +31,7 @@ export function initInMemoryImportSession(deps: {
 	}
 
 	return {
-		createImportSession: async ({ userId, urls, truncated, totalFoundInFile }) => {
+		createImportSession: async ({ userId, urls, truncated, totalFound }) => {
 			const id = ImportSessionIdSchema.parse(randomBytes(16).toString("hex"));
 			const createdAt = deps.now().toISOString();
 			const expiresAt = Math.floor(deps.now().getTime() / 1000) + IMPORT_SESSION_TTL_SECONDS;
@@ -42,7 +42,7 @@ export function initInMemoryImportSession(deps: {
 				createdAt,
 				expiresAt,
 				totalUrls: urls.length,
-				totalFoundInFile,
+				totalFound,
 				truncated,
 				deselected,
 			};


### PR DESCRIPTION
## Summary

- Imports become a tabbed acquisition surface. Existing file-upload tab is unchanged; new "Paste a link" tab accepts a newsletter or index URL.
- Server fetches it via the production `CrawlFetch` chain (Cloudflare/Fastly resilience), harvests external `<a href>` links via linkedom, and feeds the result into the same `ImportSessionStore` → review → commit pipeline as the upload flow.
- The acquirer is a new `@packages/extract-links-from-page` package so future acquisition modes (PDF, etc.) can plug into the same `ImportLinksResult` contract without touching the review pipeline.
- Failure modes map to dedicated error codes (`import_url_invalid` / `import_url_fetch_failed` / `import_url_unsupported` / `import_url_too_large`) and re-render the active tab via `/import?mode=from-url`. Analytics emits `import_from_url_acquired` on success so funnels keep upload vs from-url separate.

## Architecture notes

- Domain rename `ExtractUrlsResult` → `ImportLinksResult` and `totalFoundInFile` → `totalFound` makes the acquisition seam explicit. The DynamoDB column stays `totalFoundInFile` on disk, mapped via `toSession()`.
- Same-host links are filtered at acquisition time (newsletters are link aggregators, same-host links are nearly always nav/footer chrome).
- Synchronous fetch with the existing 10s `CrawlFetch` timeout. Pages > 5 MiB fall back to the upload path via clear error copy.
- Tab state lives in the URL (`/import?mode=upload|from-url`) — consistent with the project's URL-as-state convention.
- New E2E fixture routes `/e2e/fixtures/links-page/:label`, `/e2e/fixtures/links-page-empty`, `/e2e/fixtures/links-page-error` so the e2e flow doesn't depend on the public internet (same gating as the existing article fixture: present on staging and dev, absent on the production Lambda).

## Test plan

- [x] `@packages/extract-links-from-page` unit tests cover 100% statements/branches/functions/lines (20 tests).
- [x] `@packages/domain` tests cover the extracted `collectImportLinks` + slimmed-down `extractUrls` (310 tests).
- [x] `hutch` integration tests cover the new `POST /import/from-url` route, every failure variant → tab-preserving redirect, the new analytics event, and the active-tab marker in the GET render.
- [x] `pnpm check` passes across all 24 projects with 100% coverage.
- [ ] Manual smoke locally: paste a real newsletter URL, verify the review screen shows editorial links only.
- [ ] Manual smoke locally: paste `http://localhost/anything` → see `import_url_invalid` banner on the from-url tab.
- [ ] Manual smoke locally: paste a URL returning a PDF → see `import_url_unsupported` banner.

https://claude.ai/code/session_01GoLfaHkFk9V2WWHPuagucF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoLfaHkFk9V2WWHPuagucF)_