### PR TITLE
feat(hutch): canonicalize /view URLs to drop https:// and url encoding

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -147,15 +147,13 @@ describe("GET /", () => {
 		expect(submit?.textContent).toBe("Open in reader view");
 	});
 
-	it("should redirect homepage paste-link submissions to /view/<encoded-url> preserving UTM on the logged pageview", async () => {
+	it("should redirect homepage paste-link submissions to /view/<canonical-url> preserving UTM on the logged pageview", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const response = await request(harness.server).get(
 			"/view?url=https%3A%2F%2Fexample.com%2Farticle&utm_source=homepage&utm_medium=internal&utm_content=homepage-link-input",
 		);
 		expect(response.status).toBe(302);
-		expect(response.headers.location).toBe(
-			`/view/${encodeURIComponent("https://example.com/article")}`,
-		);
+		expect(response.headers.location).toBe("/view/example.com/article");
 	});
 
 	it("should render the secondary CTA linking to GitHub", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
@@ -582,7 +582,7 @@ describe("Queue routes", () => {
 				assert(btn, "share button must be rendered on /queue/:id/view");
 				const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
 				expect(`${shareUrl.origin}${shareUrl.pathname}`).toBe(
-					`${TEST_APP_ORIGIN}/view/${encodeURIComponent(articleUrl)}`,
+					`${TEST_APP_ORIGIN}/view/example.com/shareable-post`,
 				);
 				expect(shareUrl.searchParams.get("utm_source")).toBe("share-balloon");
 				expect(shareUrl.searchParams.get("utm_medium")).toBe("share");
@@ -593,7 +593,7 @@ describe("Queue routes", () => {
 				assert(copyBtn, "copy button must be rendered on /queue/:id/view");
 				const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
 				expect(`${copyUrl.origin}${copyUrl.pathname}`).toBe(
-					`${TEST_APP_ORIGIN}/view/${encodeURIComponent(articleUrl)}`,
+					`${TEST_APP_ORIGIN}/view/example.com/shareable-post`,
 				);
 				expect(copyUrl.searchParams.get("utm_source")).toBe("share-balloon");
 				expect(copyUrl.searchParams.get("utm_medium")).toBe("copy");

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
@@ -327,7 +327,7 @@ describe("Queue routes", () => {
 
 			expect(response.status).toBe(302);
 			const location = new URL(response.headers.location, TEST_APP_ORIGIN);
-			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			expect(location.pathname).toBe(`/view/${new URL(articleUrl).host}${new URL(articleUrl).pathname}`);
 			expect(location.searchParams.get("utm_source")).toBe("read");
 			expect(location.searchParams.get("utm_medium")).toBe("share");
 			expect(location.searchParams.get("utm_campaign")).toBe("read-permalink");
@@ -358,7 +358,7 @@ describe("Queue routes", () => {
 
 			expect(response.status).toBe(302);
 			const location = new URL(response.headers.location, TEST_APP_ORIGIN);
-			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			expect(location.pathname).toBe(`/view/${new URL(articleUrl).host}${new URL(articleUrl).pathname}`);
 			expect(location.searchParams.get("utm_source")).toBe("read");
 			expect(location.searchParams.get("utm_medium")).toBe("share");
 			expect(location.searchParams.get("utm_campaign")).toBe("read-permalink");
@@ -384,7 +384,7 @@ describe("Queue routes", () => {
 
 			expect(response.status).toBe(302);
 			const location = new URL(response.headers.location, TEST_APP_ORIGIN);
-			expect(location.pathname).toBe(`/view/${encodeURIComponent(articleUrl)}`);
+			expect(location.pathname).toBe(`/view/${new URL(articleUrl).host}${new URL(articleUrl).pathname}`);
 			expect(location.searchParams.get("utm_source")).toBe("twitter");
 			expect(location.searchParams.get("utm_medium")).toBe("social");
 			expect([...location.searchParams.keys()].filter((k) => k.startsWith("utm_"))).toHaveLength(2);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.share-balloon.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.share-balloon.route.test.ts
@@ -73,13 +73,13 @@ describe("GET /queue/:id/view share balloon", () => {
 		assert(btn, "share button must be rendered");
 		const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
 		expect(shareUrl.origin).toBe(TEST_APP_ORIGIN);
-		expect(shareUrl.pathname).toBe(`/view/${encodeURIComponent(ARTICLE_URL)}`);
+		expect(shareUrl.pathname).toBe(`/view/example.com/shareable`);
 
 		const copyBtn = doc.querySelector("[data-test-share-balloon-copy]");
 		assert(copyBtn, "copy button must be rendered");
 		const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
 		expect(copyUrl.origin).toBe(TEST_APP_ORIGIN);
-		expect(copyUrl.pathname).toBe(`/view/${encodeURIComponent(ARTICLE_URL)}`);
+		expect(copyUrl.pathname).toBe(`/view/example.com/shareable`);
 	});
 
 	it("renders share URLs against the appOrigin configured at the composition root (not a hardcoded host)", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
@@ -70,7 +70,7 @@ describe("resolveReaderPermalink", () => {
 			kind: "redirect",
 			redirect: {
 				statusCode: 302,
-				location: `/view/${encodeURIComponent(ARTICLE_URL)}?${DEFAULT_UTM}&utm_content=${STRANGER_ID_PREFIX}`,
+				location: `/view/example.com/shared-article?${DEFAULT_UTM}&utm_content=${STRANGER_ID_PREFIX}`,
 			},
 		});
 	});
@@ -91,7 +91,7 @@ describe("resolveReaderPermalink", () => {
 			kind: "redirect",
 			redirect: {
 				statusCode: 302,
-				location: `/view/${encodeURIComponent(ARTICLE_URL)}?${DEFAULT_UTM}`,
+				location: `/view/example.com/shared-article?${DEFAULT_UTM}`,
 			},
 		});
 		expect(ownerLookupCalls).toBe(0);
@@ -112,7 +112,7 @@ describe("resolveReaderPermalink", () => {
 			kind: "redirect",
 			redirect: {
 				statusCode: 302,
-				location: `/view/${encodeURIComponent(ARTICLE_URL)}?utm_source=newsletter&utm_campaign=weekly`,
+				location: `/view/example.com/shared-article?utm_source=newsletter&utm_campaign=weekly`,
 			},
 		});
 	});
@@ -131,7 +131,7 @@ describe("resolveReaderPermalink", () => {
 		});
 	});
 
-	it("percent-encodes special characters in the article URL when building the /view redirect", async () => {
+	it("keeps slashes unencoded in the /view redirect and encodes only the article URL's ?", async () => {
 		const trickyUrl = "https://example.com/path with spaces?a=b&c=d";
 		const resolve = initReaderPermalink(createDeps({
 			findArticleUrlById: async () => trickyUrl,
@@ -143,7 +143,7 @@ describe("resolveReaderPermalink", () => {
 			kind: "redirect",
 			redirect: {
 				statusCode: 302,
-				location: `/view/${encodeURIComponent(trickyUrl)}?${DEFAULT_UTM}`,
+				location: `/view/example.com/path%20with%20spaces%3Fa=b&c=d?${DEFAULT_UTM}`,
 			},
 		});
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
@@ -9,6 +9,7 @@ import type {
 import type { Redirect } from "../../redirect.component";
 import { shareUserIdPrefix } from "../../shared/share-user-id";
 import { collectUtmParams } from "../../shared/utm";
+import { viewPathFor } from "../view/view-path";
 
 export interface ReaderPermalinkDeps {
 	findArticleById: FindArticleById;
@@ -55,7 +56,7 @@ function buildShareRedirectUrl(
 	if (requesterId !== undefined) {
 		params.set("utm_content", shareUserIdPrefix(requesterId));
 	}
-	return `/view/${encodeURIComponent(articleUrl)}?${params.toString()}`;
+	return `${viewPathFor(articleUrl)}?${params.toString()}`;
 }
 
 export function initReaderPermalink(deps: ReaderPermalinkDeps) {

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -13,6 +13,7 @@ import {
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
 import { shareUserIdPrefix } from "../../shared/share-balloon/share-user-id-prefix";
+import { viewPathFor } from "../view/view-path";
 import { READER_STYLES } from "./reader.styles";
 
 const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "utf-8");
@@ -87,7 +88,7 @@ export function ReaderPage(
 		extensionInstallUrl: options.extensionInstallUrl,
 	});
 	const shareBalloon = renderShareBalloon({
-		shareUrl: `${options.appOrigin}/view/${encodeURIComponent(article.url)}`,
+		shareUrl: `${options.appOrigin}${viewPathFor(article.url)}`,
 		shareTitle: article.metadata.title,
 		shareHint: "Click here to share this post!",
 		shareSource: "reader-internal",

--- a/projects/hutch/src/runtime/web/pages/save/save-permalink.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-permalink.test.ts
@@ -1,7 +1,7 @@
 import { buildSavePermalink, runSavePermalinkCli } from "./save-permalink";
 
 describe("buildSavePermalink", () => {
-	it("should build a save URL with utm params and percent-encoded url", () => {
+	it("should build a save URL with utm params and the scheme-less canonical view path", () => {
 		const result = buildSavePermalink({
 			baseUrl: "https://readplace.com",
 			url: "https://fagnerbrack.com/example",
@@ -10,11 +10,11 @@ describe("buildSavePermalink", () => {
 		});
 
 		expect(result).toBe(
-			"https://readplace.com/view/https%3A%2F%2Ffagnerbrack.com%2Fexample?utm_source=fagnerbrack.com&utm_content=top",
+			"https://readplace.com/view/fagnerbrack.com/example?utm_source=fagnerbrack.com&utm_content=top",
 		);
 	});
 
-	it("should encode special characters inside the target url", () => {
+	it("should encode the article URL's query separator inside the path", () => {
 		const result = buildSavePermalink({
 			baseUrl: "https://readplace.com",
 			url: "https://example.com/path?q=hello world&x=1",
@@ -23,7 +23,7 @@ describe("buildSavePermalink", () => {
 		});
 
 		expect(result).toBe(
-			"https://readplace.com/view/https%3A%2F%2Fexample.com%2Fpath%3Fq%3Dhello%20world%26x%3D1?utm_source=src&utm_content=ctx",
+			"https://readplace.com/view/example.com/path%3Fq=hello%20world&x=1?utm_source=src&utm_content=ctx",
 		);
 	});
 });
@@ -52,7 +52,7 @@ describe("runSavePermalinkCli", () => {
 		const { code, out, err } = runCli(["medium-top", "https://fagnerbrack.com/example"]);
 		expect(code).toBe(0);
 		expect(out).toBe(
-			"https://readplace.com/view/https%3A%2F%2Ffagnerbrack.com%2Fexample?utm_source=fagnerbrack.com&utm_content=top\n",
+			"https://readplace.com/view/fagnerbrack.com/example?utm_source=fagnerbrack.com&utm_content=top\n",
 		);
 		expect(err).toBe("");
 	});
@@ -61,7 +61,7 @@ describe("runSavePermalinkCli", () => {
 		const { code, out, err } = runCli(["medium-bottom", "https://fagnerbrack.com/example"]);
 		expect(code).toBe(0);
 		expect(out).toBe(
-			"https://readplace.com/view/https%3A%2F%2Ffagnerbrack.com%2Fexample?utm_source=fagnerbrack.com&utm_content=bottom\n",
+			"https://readplace.com/view/fagnerbrack.com/example?utm_source=fagnerbrack.com&utm_content=bottom\n",
 		);
 		expect(err).toBe("");
 	});

--- a/projects/hutch/src/runtime/web/pages/save/save-permalink.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-permalink.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { viewPathFor } from "../view/view-path";
 
 const DEFAULT_BASE_URL = "https://readplace.com";
 
@@ -26,7 +27,7 @@ export function buildSavePermalink(params: {
 		`utm_source=${encodeURIComponent(params.utmSource)}`,
 		`utm_content=${encodeURIComponent(params.utmContent)}`,
 	].join("&");
-	return `${params.baseUrl}/view/${encodeURIComponent(params.url)}?${query}`;
+	return `${params.baseUrl}${viewPathFor(params.url)}?${query}`;
 }
 
 type CliIO = {

--- a/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
@@ -48,9 +48,21 @@ describe("viewPathFor", () => {
 		expect(viewPathFor("https://example.com")).toBe("/view/example.com/");
 	});
 
-	it("preserves percent-encoded sequences in the pathname", () => {
+	it("double-encodes literal percent signs (%25) so they survive Express decode", () => {
 		expect(viewPathFor("https://example.com/path%25foo")).toBe(
-			"/view/example.com/path%25foo",
+			"/view/example.com/path%2525foo",
+		);
+	});
+
+	it("double-encodes %25 followed by two hex digits (previously lossy)", () => {
+		expect(viewPathFor("https://example.com/path%25C3")).toBe(
+			"/view/example.com/path%2525C3",
+		);
+	});
+
+	it("leaves regular percent-encoded bytes untouched (only %25 is double-encoded)", () => {
+		expect(viewPathFor("https://example.com/path%C3%A9")).toBe(
+			"/view/example.com/path%C3%A9",
 		);
 	});
 });
@@ -147,10 +159,10 @@ describe("parseViewPath", () => {
 		});
 	});
 
-	it("redirects https:// paths with bare % and re-encodes them in the redirect target", () => {
+	it("redirects https:// paths with bare % and double-encodes the re-encoded %25 in the redirect target", () => {
 		expect(parse("https://example.com/path%foo")).toEqual({
 			kind: "redirect",
-			canonicalPath: "/view/example.com/path%25foo",
+			canonicalPath: "/view/example.com/path%2525foo",
 		});
 	});
 
@@ -170,6 +182,13 @@ describe("parseViewPath", () => {
 
 	it("is round-trip stable for percent-encoded article URLs through Express decode", () => {
 		const url = "https://example.com/path%25foo";
+		const path = viewPathFor(url);
+		const rawWildcard = decodeURIComponent(path.slice("/view/".length));
+		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });
+	});
+
+	it("is round-trip stable for %25 followed by two hex digits through Express decode", () => {
+		const url = "https://example.com/path%25C3";
 		const path = viewPathFor(url);
 		const rawWildcard = decodeURIComponent(path.slice("/view/".length));
 		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });

--- a/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
@@ -1,0 +1,150 @@
+import { parseViewPath, viewPathFor } from "./view-path";
+
+function parse(decodedAndEncoded: string): ReturnType<typeof parseViewPath>;
+function parse(args: { rawPath: string; encodedPath: string }): ReturnType<typeof parseViewPath>;
+function parse(args: string | { rawPath: string; encodedPath: string }): ReturnType<typeof parseViewPath> {
+	if (typeof args === "string") return parseViewPath({ rawPath: args, encodedPath: args });
+	return parseViewPath(args);
+}
+
+describe("viewPathFor", () => {
+	it("strips the https:// scheme and keeps slashes unencoded", () => {
+		expect(viewPathFor("https://example.com/post")).toBe("/view/example.com/post");
+	});
+
+	it("preserves tildes and other unreserved path characters", () => {
+		expect(
+			viewPathFor(
+				"https://web.eecs.umich.edu/~weimerw/2018-481/readings/mythical-man-month.pdf",
+			),
+		).toBe(
+			"/view/web.eecs.umich.edu/~weimerw/2018-481/readings/mythical-man-month.pdf",
+		);
+	});
+
+	it("retains the explicit http:// scheme so http articles are unambiguous", () => {
+		expect(viewPathFor("http://example.com/post")).toBe("/view/http://example.com/post");
+	});
+
+	it("keeps non-default ports on the host segment", () => {
+		expect(viewPathFor("https://example.com:8080/post")).toBe(
+			"/view/example.com:8080/post",
+		);
+	});
+
+	it("percent-encodes the article URL's query separator so Express keeps it in the path", () => {
+		expect(viewPathFor("https://example.com/post?foo=bar")).toBe(
+			"/view/example.com/post%3Ffoo=bar",
+		);
+	});
+
+	it("percent-encodes the article URL's fragment separator", () => {
+		expect(viewPathFor("https://example.com/post#section")).toBe(
+			"/view/example.com/post%23section",
+		);
+	});
+
+	it("renders an empty pathname as a single trailing slash from the URL constructor", () => {
+		expect(viewPathFor("https://example.com")).toBe("/view/example.com/");
+	});
+});
+
+describe("parseViewPath", () => {
+	it("treats a plain host/path as an https article", () => {
+		expect(parse("example.com/post")).toEqual({
+			kind: "render",
+			articleUrl: "https://example.com/post",
+		});
+	});
+
+	it("renders the literal http:// canonical without redirecting", () => {
+		expect(parse("http://example.com/post")).toEqual({
+			kind: "render",
+			articleUrl: "http://example.com/post",
+		});
+	});
+
+	it("redirects an old https:// path to the scheme-less canonical", () => {
+		expect(parse("https://example.com/post")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/example.com/post",
+		});
+	});
+
+	it("redirects a collapsed https:/ path to the canonical", () => {
+		expect(parse("https:/example.com/post")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/example.com/post",
+		});
+	});
+
+	it("redirects a collapsed http:/ path to the http:// canonical", () => {
+		expect(parse("http:/example.com/post")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/http://example.com/post",
+		});
+	});
+
+	it("preserves the article URL's query when re-encoded into the path", () => {
+		expect(parse("example.com/post?foo=bar")).toEqual({
+			kind: "render",
+			articleUrl: "https://example.com/post?foo=bar",
+		});
+	});
+
+	it("redirects old https://...?foo=bar format to canonical, re-encoding the ? into the path", () => {
+		expect(parse("https://example.com/post?foo=bar")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/example.com/post%3Ffoo=bar",
+		});
+	});
+
+	it("redirects old https://...#frag format to canonical, re-encoding the # into the path", () => {
+		expect(parse("https://example.com/post#frag")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/example.com/post%23frag",
+		});
+	});
+
+	it("redirects old http:/...?foo=bar to a canonical that keeps http:// and encodes the article ?", () => {
+		expect(parse("http:/example.com/post?foo=bar")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/http://example.com/post%3Ffoo=bar",
+		});
+	});
+
+	it("redirects encoded http%3A%2F%2F (legacy) to the http:// canonical", () => {
+		expect(
+			parseViewPath({
+				rawPath: "http://example.com/post",
+				encodedPath: "http%3A%2F%2Fexample.com%2Fpost",
+			}),
+		).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/http://example.com/post",
+		});
+	});
+
+	it("renders the canonical http:// when the original URL has the literal `://`", () => {
+		expect(
+			parseViewPath({
+				rawPath: "http://example.com/post",
+				encodedPath: "http://example.com/post",
+			}),
+		).toEqual({ kind: "render", articleUrl: "http://example.com/post" });
+	});
+
+	it("is round-trip stable: parseViewPath(viewPathFor(url).slice('/view/'.length)) renders the same url", () => {
+		const url = "https://web.eecs.umich.edu/~weimerw/path";
+		const path = viewPathFor(url);
+		const rawWildcard = path.slice("/view/".length);
+		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });
+	});
+
+	it("is round-trip stable for http URLs when the original URL kept the literal ://", () => {
+		const url = "http://example.com/post";
+		const path = viewPathFor(url);
+		const rawWildcard = path.slice("/view/".length);
+		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
@@ -47,6 +47,12 @@ describe("viewPathFor", () => {
 	it("renders an empty pathname as a single trailing slash from the URL constructor", () => {
 		expect(viewPathFor("https://example.com")).toBe("/view/example.com/");
 	});
+
+	it("preserves percent-encoded sequences in the pathname", () => {
+		expect(viewPathFor("https://example.com/path%25foo")).toBe(
+			"/view/example.com/path%25foo",
+		);
+	});
 });
 
 describe("parseViewPath", () => {
@@ -134,6 +140,20 @@ describe("parseViewPath", () => {
 		).toEqual({ kind: "render", articleUrl: "http://example.com/post" });
 	});
 
+	it("re-encodes bare % from Express-decoded paths so the article URL stays valid", () => {
+		expect(parse("example.com/path%foo")).toEqual({
+			kind: "render",
+			articleUrl: "https://example.com/path%25foo",
+		});
+	});
+
+	it("redirects https:// paths with bare % and re-encodes them in the redirect target", () => {
+		expect(parse("https://example.com/path%foo")).toEqual({
+			kind: "redirect",
+			canonicalPath: "/view/example.com/path%25foo",
+		});
+	});
+
 	it("is round-trip stable: parseViewPath(viewPathFor(url).slice('/view/'.length)) renders the same url", () => {
 		const url = "https://web.eecs.umich.edu/~weimerw/path";
 		const path = viewPathFor(url);
@@ -145,6 +165,13 @@ describe("parseViewPath", () => {
 		const url = "http://example.com/post";
 		const path = viewPathFor(url);
 		const rawWildcard = path.slice("/view/".length);
+		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });
+	});
+
+	it("is round-trip stable for percent-encoded article URLs through Express decode", () => {
+		const url = "https://example.com/path%25foo";
+		const path = viewPathFor(url);
+		const rawWildcard = decodeURIComponent(path.slice("/view/".length));
 		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-path.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.ts
@@ -47,10 +47,14 @@ export function parseViewPath(input: ParseViewPathInput): ParseViewPathResult {
 	return { kind: "render", articleUrl: `https://${rawPath}` };
 }
 
-/** Re-encode `?` and `#` from the decoded article URL so the canonical keeps
- * them inside the path rather than letting Express split them into req.query. */
+/** Re-encode `%25` (literal `%`), `?`, and `#` so the canonical survives
+ * Express's `decodeURIComponent` on the wildcard param. `%25` is the URL
+ * constructor's encoding of a literal percent sign; double-encoding it to
+ * `%2525` ensures Express decode yields `%25` back, preserving round-trip
+ * fidelity. Regular percent-encoded bytes (e.g. `%C3%A9` for é) are left
+ * alone — Express decodes them to the actual character, which is equivalent. */
 function encodeArticlePathInfo(decodedTail: string): string {
-	return decodedTail.replace(/\?/g, "%3F").replace(/#/g, "%23");
+	return decodedTail.replace(/%25/g, "%2525").replace(/\?/g, "%3F").replace(/#/g, "%23");
 }
 
 /** Express decodes percent-encoding in the wildcard param, so `%25` (literal %)

--- a/projects/hutch/src/runtime/web/pages/view/view-path.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.ts
@@ -29,25 +29,34 @@ export function viewPathFor(articleUrl: string): string {
 /** Parses the wildcard segment of `/view/*` into either the article URL to
  * render or the canonical path to 301-redirect to. */
 export function parseViewPath(input: ParseViewPathInput): ParseViewPathResult {
-	const normalized = input.rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
+	const rawPath = reEncodePartialPercents(input.rawPath);
+	const normalized = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
 	const httpsMatch = /^https:\/\/(.+)$/i.exec(normalized);
 	if (httpsMatch) {
 		return { kind: "redirect", canonicalPath: `/view/${encodeArticlePathInfo(httpsMatch[1])}` };
 	}
 	const httpMatch = /^http:\/\/(.+)$/i.exec(normalized);
 	if (httpMatch) {
-		const wasCollapsed = input.rawPath !== normalized;
+		const wasCollapsed = rawPath !== normalized;
 		const wasSchemeEncoded = /^http%3a/i.test(input.encodedPath);
 		if (wasCollapsed || wasSchemeEncoded) {
 			return { kind: "redirect", canonicalPath: `/view/http://${encodeArticlePathInfo(httpMatch[1])}` };
 		}
 		return { kind: "render", articleUrl: normalized };
 	}
-	return { kind: "render", articleUrl: `https://${input.rawPath}` };
+	return { kind: "render", articleUrl: `https://${rawPath}` };
 }
 
 /** Re-encode `?` and `#` from the decoded article URL so the canonical keeps
  * them inside the path rather than letting Express split them into req.query. */
 function encodeArticlePathInfo(decodedTail: string): string {
 	return decodedTail.replace(/\?/g, "%3F").replace(/#/g, "%23");
+}
+
+/** Express decodes percent-encoding in the wildcard param, so `%25` (literal %)
+ * arrives as bare `%`. When the next two characters aren't hex digits, prepending
+ * `https://` would create an invalid URL. Re-encoding these orphaned `%`
+ * restores round-trip fidelity. */
+function reEncodePartialPercents(s: string): string {
+	return s.replace(/%(?![0-9a-fA-F]{2})/g, "%25");
 }

--- a/projects/hutch/src/runtime/web/pages/view/view-path.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.ts
@@ -1,0 +1,53 @@
+/** Canonical `/view/...` paths drop the implicit `https://` scheme and keep
+ * slashes unencoded so the article URL reads naturally in the browser bar.
+ * `http://` is preserved literally because http is the minority case and the
+ * scheme would otherwise be ambiguous. `?` and `#` inside the article URL
+ * are percent-encoded so Express's query parser only sees Readplace tracking
+ * params. */
+
+export type ParseViewPathResult =
+	| { kind: "render"; articleUrl: string }
+	| { kind: "redirect"; canonicalPath: string };
+
+export type ParseViewPathInput = {
+	/** Express-decoded wildcard from `req.params[0]`. */
+	rawPath: string;
+	/** Original URL-encoded wildcard from `req.originalUrl` (path-only, no
+	 * query). Used to detect the legacy `http%3A%2F%2F` form whose decoded
+	 * value collides with the new canonical `http://` form. */
+	encodedPath: string;
+};
+
+/** Builds the canonical `/view/...` path for an article URL. */
+export function viewPathFor(articleUrl: string): string {
+	const u = new URL(articleUrl);
+	const tail = encodeArticlePathInfo(`${u.host}${u.pathname}${u.search}${u.hash}`);
+	const scheme = u.protocol === "http:" ? "http://" : "";
+	return `/view/${scheme}${tail}`;
+}
+
+/** Parses the wildcard segment of `/view/*` into either the article URL to
+ * render or the canonical path to 301-redirect to. */
+export function parseViewPath(input: ParseViewPathInput): ParseViewPathResult {
+	const normalized = input.rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
+	const httpsMatch = /^https:\/\/(.+)$/i.exec(normalized);
+	if (httpsMatch) {
+		return { kind: "redirect", canonicalPath: `/view/${encodeArticlePathInfo(httpsMatch[1])}` };
+	}
+	const httpMatch = /^http:\/\/(.+)$/i.exec(normalized);
+	if (httpMatch) {
+		const wasCollapsed = input.rawPath !== normalized;
+		const wasSchemeEncoded = /^http%3a/i.test(input.encodedPath);
+		if (wasCollapsed || wasSchemeEncoded) {
+			return { kind: "redirect", canonicalPath: `/view/http://${encodeArticlePathInfo(httpMatch[1])}` };
+		}
+		return { kind: "render", articleUrl: normalized };
+	}
+	return { kind: "render", articleUrl: `https://${input.rawPath}` };
+}
+
+/** Re-encode `?` and `#` from the decoded article URL so the canonical keeps
+ * them inside the path rather than letting Express split them into req.query. */
+function encodeArticlePathInfo(decodedTail: string): string {
+	return decodedTail.replace(/\?/g, "%3F").replace(/#/g, "%23");
+}

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -135,7 +135,7 @@ describe("ViewPage", () => {
 	it("emits OG metadata using the article title and excerpt", () => {
 		const doc = render();
 
-		const canonical = `https://readplace.com/view/${encodeURIComponent("https://example.com/post")}`;
+		const canonical = `https://readplace.com/view/example.com/post`;
 		expect(
 			doc.querySelector('meta[property="og:title"]')?.getAttribute("content"),
 		).toBe("Hello World | Reader View");
@@ -500,7 +500,7 @@ describe("ViewPage", () => {
 				appOrigin: "https://staging.readplace.com",
 			});
 
-			const canonical = `https://readplace.com/view/${encodeURIComponent("https://example.com/post")}`;
+			const canonical = `https://readplace.com/view/example.com/post`;
 			assert.equal(
 				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
 				canonical,

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -18,6 +18,7 @@ import {
 	renderShareBalloon,
 } from "../../shared/share-balloon/share-balloon.component";
 import type { SharedUserId } from "./view-expiry";
+import { viewPathFor } from "./view-path";
 import { VIEW_STYLES } from "./view.styles";
 
 const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
@@ -117,8 +118,9 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		extensionInstallUrl: input.extensionInstallUrl,
 	});
 
-	const canonicalViewUrl = `${CANONICAL_BASE_URL}/view/${encodeURIComponent(input.articleUrl)}`;
-	const shareableViewUrl = `${input.appOrigin}/view/${encodeURIComponent(input.articleUrl)}`;
+	const viewPath = viewPathFor(input.articleUrl);
+	const canonicalViewUrl = `${CANONICAL_BASE_URL}${viewPath}`;
+	const shareableViewUrl = `${input.appOrigin}${viewPath}`;
 
 	const shareBalloon = renderShareBalloon({
 		shareUrl: shareableViewUrl,
@@ -165,7 +167,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		seo: {
 			title: formatViewDocumentTitle(input.metadata.title),
 			description,
-			canonicalUrl: `/view/${encodeURIComponent(input.articleUrl)}`,
+			canonicalUrl: viewPath,
 			ogType: "article",
 			ogImage,
 			ogImageAlt,

--- a/projects/hutch/src/runtime/web/pages/view/view.extension-suggestion-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.extension-suggestion-banner.route.test.ts
@@ -17,8 +17,7 @@ import {
 	createFakePublishSaveAnonymousLink,
 } from "@packages/test-fixtures";
 
-const ARTICLE_URL = "https://example.com/post";
-const ENCODED = encodeURIComponent(ARTICLE_URL);
+const CANONICAL_PATH = "example.com/post";
 
 type OkParseResult = Extract<ParseArticleResult, { ok: true }>;
 type ParsedArticle = OkParseResult["article"];
@@ -62,7 +61,7 @@ describe("GET /view/{url} — extension suggestion banner", () => {
 			summary: { ...fixture.summary, findGeneratedSummary },
 		});
 
-		const response = await request(harness.server).get(`/view/${ENCODED}`);
+		const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 		expect(response.status).toBe(200);
 		expect(bannerAttr(response.text)).toBe("true");
@@ -94,7 +93,7 @@ describe("GET /view/{url} — extension suggestion banner", () => {
 			summary: { ...fixture.summary, findGeneratedSummary },
 		});
 
-		const response = await request(harness.server).get(`/view/${ENCODED}`);
+		const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 		expect(bannerAttr(response.text)).toBe("false");
 	});
@@ -124,7 +123,7 @@ describe("GET /view/{url} — extension suggestion banner", () => {
 			summary: { ...fixture.summary, findGeneratedSummary },
 		});
 
-		const response = await request(harness.server).get(`/view/${ENCODED}`);
+		const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 		expect(bannerAttr(response.text)).toBe("true");
 	});

--- a/projects/hutch/src/runtime/web/pages/view/view.metadata.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.metadata.route.test.ts
@@ -19,7 +19,7 @@ import {
 } from "@packages/test-fixtures";
 
 const ARTICLE_URL = "https://example.com/post";
-const ENCODED = encodeURIComponent(ARTICLE_URL);
+const CANONICAL_PATH = "example.com/post";
 
 type OkParseResult = Extract<ParseArticleResult, { ok: true }>;
 type ParsedArticle = OkParseResult["article"];
@@ -77,7 +77,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -96,7 +96,7 @@ describe("View routes", () => {
 			).toBe("article");
 			expect(
 				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
-			).toBe(`https://readplace.com/view/${ENCODED}`);
+			).toBe(`https://readplace.com/view/${CANONICAL_PATH}`);
 			expect(
 				doc
 					.querySelector('meta[name="twitter:description"]')
@@ -142,7 +142,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -181,7 +181,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const scripts = doc.querySelectorAll('script[type="application/ld+json"]');
@@ -222,7 +222,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -312,7 +312,7 @@ describe("View routes", () => {
 			).toBe("Open in reader view");
 		});
 
-		it("redirects GET /view?url=<valid> to /view/<encoded-url>", async () => {
+		it("redirects GET /view?url=<valid> to /view/<canonical-url>", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const response = await request(harness.server).get(
@@ -320,7 +320,7 @@ describe("View routes", () => {
 			);
 
 			expect(response.status).toBe(302);
-			expect(response.headers.location).toBe(`/view/${ENCODED}`);
+			expect(response.headers.location).toBe(`/view/${CANONICAL_PATH}`);
 		});
 
 		it("renders the save-error page when GET /view?url=<invalid>", async () => {
@@ -356,7 +356,7 @@ describe("View routes", () => {
 			const { articleStore } = harness;
 
 			const response = await request(harness.server).get(
-				`/view/${encodeURIComponent("http://localhost:3000/queue")}`,
+				"/view/http://localhost:3000/queue",
 			);
 
 			expect(response.status).toBe(200);
@@ -397,7 +397,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -458,7 +458,7 @@ describe("View routes", () => {
 			});
 			await articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			expect(parseSpy).not.toHaveBeenCalled();
@@ -524,7 +524,7 @@ describe("View routes", () => {
 			});
 			await articleCrawl.markCrawlFailed({ url: ARTICLE_URL, reason: "blocked" });
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			// /view never re-parses inline; recovery happens in the stale-check Lambda.
@@ -569,7 +569,7 @@ describe("View routes", () => {
 			});
 			const { articleStore } = harness;
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
@@ -616,7 +616,7 @@ describe("View routes", () => {
 				.type("form")
 				.send({ email: "test@example.com", password: "password123" });
 
-			const response = await agent.get(`/view/${ENCODED}`);
+			const response = await agent.get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
@@ -674,7 +674,7 @@ describe("View routes", () => {
 			});
 			await articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 
-			await request(harness.server).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 			expect(publishStaleCheckRequested).toHaveBeenCalledWith({ url: ARTICLE_URL });
@@ -724,7 +724,7 @@ describe("View routes", () => {
 				savedAt: new Date(),
 			});
 
-			await request(harness.server).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 			expect(publishStaleCheckRequested).toHaveBeenCalledWith({ url: ARTICLE_URL });
@@ -775,8 +775,8 @@ describe("View routes", () => {
 			// visit would have re-published SaveAnonymousLinkCommand. Now it must
 			// stay quiet for both — the stale-check Lambda observes a failed row
 			// and short-circuits to action=skip.
-			await request(harness.server).get(`/view/${ENCODED}`);
-			await request(harness.server).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${CANONICAL_PATH}`);
+			await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 			expect(publishStaleCheckRequested).toHaveBeenCalledWith({ url: ARTICLE_URL });
@@ -808,7 +808,7 @@ describe("View routes", () => {
 				reason: "non-html content type: application/pdf",
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -845,13 +845,13 @@ describe("View routes", () => {
 				},
 			});
 
-			await request(harness.server).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: ARTICLE_URL });
 		});
 	});
 
-	describe("GET /view/<encoded-url> with Accept: text/markdown", () => {
+	describe("GET /view/<canonical-url> with Accept: text/markdown", () => {
 		it("returns the article body as markdown without the share/save UI", async () => {
 			const parseArticle: ParseArticle = async () =>
 				buildParseResult({
@@ -884,7 +884,7 @@ describe("View routes", () => {
 			});
 
 			const response = await request(harness.server)
-				.get(`/view/${ENCODED}`)
+				.get(`/view/${CANONICAL_PATH}`)
 				.set("Accept", "text/markdown");
 
 			expect(response.status).toBe(200);
@@ -909,7 +909,7 @@ describe("View routes", () => {
 			});
 
 			const response = await request(harness.server)
-				.get(`/view/${ENCODED}`)
+				.get(`/view/${CANONICAL_PATH}`)
 				.set("Accept", "text/markdown");
 
 			expect(response.status).toBe(200);

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -45,6 +45,7 @@ import { SaveErrorPage } from "../save/save-error.component";
 import { ViewLandingPage } from "./view-landing.component";
 import type { ExistsUserByIdPrefix } from "@packages/test-fixtures/providers/auth";
 import { PERMANENT_ARTICLE_DOMAINS, computePublicViewExpiry, formatSaveUtmContent, sharedUserIdFrom, sharedUserIdFromQueryParams, type ExpiryCountdown } from "./view-expiry";
+import { parseViewPath, viewPathFor } from "./view-path";
 import { ViewPage, formatViewDocumentTitle, type ViewAction } from "./view.component";
 
 interface ViewDependencies {
@@ -106,7 +107,7 @@ function handleViewLanding(deps: ViewDependencies) {
 			await renderError(deps, req, res);
 			return;
 		}
-		res.redirect(302, `/view/${encodeURIComponent(validation.url)}`);
+		res.redirect(302, viewPathFor(validation.url));
 	};
 }
 
@@ -115,12 +116,16 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		req: Request<Record<string, string>>,
 		res: Response,
 	): Promise<void> => {
-		const rawPath = req.params[0];
-		// API Gateway v2 HTTP API decodes %2F to / before invoking Lambda, so
-		// /view/https%3A%2F%2Fexample.com arrives here as /view/https://example.com.
-		// Restore the scheme's second slash if any proxy collapsed it (https:/ → https://).
-		const normalizedUrl = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
-		const validation = deps.validateSaveableUrl(normalizedUrl);
+		const queryIndex = req.originalUrl.indexOf("?");
+		const originalPath = queryIndex === -1 ? req.originalUrl : req.originalUrl.slice(0, queryIndex);
+		const encodedPath = originalPath.slice("/view/".length);
+		const parsed = parseViewPath({ rawPath: req.params[0], encodedPath });
+		if (parsed.kind === "redirect") {
+			const queryString = queryIndex === -1 ? "" : req.originalUrl.slice(queryIndex);
+			res.redirect(301, `${parsed.canonicalPath}${queryString}`);
+			return;
+		}
+		const validation = deps.validateSaveableUrl(parsed.articleUrl);
 		if (validation.status === "ERROR") {
 			await renderError(deps, req, res);
 			return;

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -21,6 +21,8 @@ import { MAX_POLLS } from "../../shared/article-reader/article-reader";
 
 const ARTICLE_URL = "https://example.com/post";
 const ENCODED = encodeURIComponent(ARTICLE_URL);
+const CANONICAL_PATH = "example.com/post";
+const PERMANENT_CANONICAL_PATH = "fagnerbrack.com/some-article";
 
 type OkParseResult = Extract<ParseArticleResult, { ok: true }>;
 type ParsedArticle = OkParseResult["article"];
@@ -51,7 +53,7 @@ function ctaAction(doc: Document): Element {
 const useApp = useTestServer();
 
 describe("View routes", () => {
-	describe("GET /view/<encoded-url>", () => {
+	describe("GET /view/<canonical-url>", () => {
 		it("renders the article body for an anonymous visitor (200)", async () => {
 			const parseArticle: ParseArticle = async () => buildParseResult();
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
@@ -78,7 +80,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -94,7 +96,49 @@ describe("View routes", () => {
 			expect(iframeDoc.body.innerHTML.trim()).toBe("<p>Body copy.</p>");
 		});
 
-		it("renders the article when the path arrives with decoded slashes (API Gateway shape)", async () => {
+		it("301-redirects the legacy percent-encoded format to the scheme-less canonical", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(`/view/${ENCODED}`);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(`/view/${CANONICAL_PATH}`);
+		});
+
+		it("301-redirects the legacy decoded https:// path (API Gateway shape) to the canonical", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(`/view/${ARTICLE_URL}`);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(`/view/${CANONICAL_PATH}`);
+		});
+
+		it("301-redirects when the scheme's second slash has been collapsed (https:/)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(
+				`/view/${ARTICLE_URL.replace("://", ":/")}`,
+			);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(`/view/${CANONICAL_PATH}`);
+		});
+
+		it("preserves the Readplace tracking query string when redirecting from the legacy format", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(
+				`/view/${ENCODED}?utm_source=medium&utm_campaign=x`,
+			);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(
+				`/view/${CANONICAL_PATH}?utm_source=medium&utm_campaign=x`,
+			);
+		});
+
+		it("renders the article at the http:// canonical without redirecting", async () => {
 			const parseArticle: ParseArticle = async () => buildParseResult();
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const applyParseResult = createFakeApplyParseResult({
@@ -104,10 +148,7 @@ describe("View routes", () => {
 			});
 			const harness = useApp({
 				...fixture,
-				parser: {
-					parseArticle,
-					crawlArticle: fixture.parser.crawlArticle,
-				},
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
 				events: {
 					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
 					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
@@ -120,7 +161,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ARTICLE_URL}`);
+			const response = await request(harness.server).get(`/view/http://example.com/post`);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
@@ -129,7 +170,43 @@ describe("View routes", () => {
 			);
 		});
 
-		it("renders the article when the scheme's second slash has been collapsed", async () => {
+		it("301-redirects http:/ (collapsed scheme) to the http:// canonical", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(`/view/http:/example.com/post`);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(`/view/http://example.com/post`);
+		});
+
+		it("301-redirects the percent-encoded http format to the http:// canonical", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get(
+				`/view/${encodeURIComponent("http://example.com/post")}`,
+			);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(`/view/http://example.com/post`);
+		});
+
+		it("301-redirects the legacy encoded PDF URL to the human-readable canonical (drops https + URL encoding)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const articleUrl =
+				"https://web.eecs.umich.edu/~weimerw/2018-481/readings/mythical-man-month.pdf";
+
+			const response = await request(harness.server).get(
+				`/view/${encodeURIComponent(articleUrl)}`,
+			);
+
+			expect(response.status).toBe(301);
+			expect(response.headers.location).toBe(
+				"/view/web.eecs.umich.edu/~weimerw/2018-481/readings/mythical-man-month.pdf",
+			);
+		});
+
+		it("renders the article URL with the user-friendly canonical path containing slashes", async () => {
+			const articleUrl = "https://web.eecs.umich.edu/~weimerw/2018-481/readings/mythical-man-month.pdf";
 			const parseArticle: ParseArticle = async () => buildParseResult();
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const applyParseResult = createFakeApplyParseResult({
@@ -139,10 +216,7 @@ describe("View routes", () => {
 			});
 			const harness = useApp({
 				...fixture,
-				parser: {
-					parseArticle,
-					crawlArticle: fixture.parser.crawlArticle,
-				},
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
 				events: {
 					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
 					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
@@ -156,14 +230,16 @@ describe("View routes", () => {
 			});
 
 			const response = await request(harness.server).get(
-				`/view/${ARTICLE_URL.replace("://", ":/")}`,
+				"/view/web.eecs.umich.edu/~weimerw/2018-481/readings/mythical-man-month.pdf",
 			);
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe(
-				"Hello World",
-			);
+			const action = ctaAction(doc);
+			const href = action.getAttribute("href");
+			assert(href, "save action must have an href");
+			const parsed = new URL(href, "http://localhost");
+			expect(parsed.searchParams.get("url")).toBe(articleUrl);
 		});
 
 		it("renders a Save action pointing to /save with the article URL in the href", async () => {
@@ -192,7 +268,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -231,7 +307,7 @@ describe("View routes", () => {
 			});
 
 			const response = await request(harness.server).get(
-				`/view/${ENCODED}?utm_source=medium&utm_campaign=x&foo=bar`,
+				`/view/${CANONICAL_PATH}?utm_source=medium&utm_campaign=x&foo=bar`,
 			);
 
 			const doc = new JSDOM(response.text).window.document;
@@ -280,7 +356,7 @@ describe("View routes", () => {
 				.type("form")
 				.send({ email: "reader@example.com", password: "password123" });
 
-			const response = await agent.get(`/view/${ENCODED}`);
+			const response = await agent.get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -325,7 +401,7 @@ describe("View routes", () => {
 				.send({ email: "reader@example.com", password: "password123" });
 			await agent.post("/queue/save").type("form").send({ url: ARTICLE_URL });
 
-			const response = await agent.get(`/view/${ENCODED}`);
+			const response = await agent.get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -373,7 +449,7 @@ describe("View routes", () => {
 				.type("form")
 				.send({ url: ARTICLE_URL });
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -407,7 +483,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const actions = doc.querySelectorAll("[data-test-view-cta-action]");
@@ -452,7 +528,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const wrap = doc.querySelector("[data-test-share-balloon-wrap]");
@@ -463,7 +539,7 @@ describe("View routes", () => {
 			expect(btn.getAttribute("aria-label")).toBe("Share this article");
 			const shareUrl = new URL(btn.getAttribute("data-share-url") ?? "");
 			expect(`${shareUrl.origin}${shareUrl.pathname}`).toBe(
-				`${TEST_APP_ORIGIN}/view/${ENCODED}`,
+				`${TEST_APP_ORIGIN}/view/${CANONICAL_PATH}`,
 			);
 			expect(shareUrl.searchParams.get("utm_source")).toBe("share-balloon");
 			expect(shareUrl.searchParams.get("utm_medium")).toBe("share");
@@ -474,7 +550,7 @@ describe("View routes", () => {
 			assert(copyBtn, "copy button must be rendered");
 			const copyUrl = new URL(copyBtn.getAttribute("data-share-url") ?? "");
 			expect(`${copyUrl.origin}${copyUrl.pathname}`).toBe(
-				`${TEST_APP_ORIGIN}/view/${ENCODED}`,
+				`${TEST_APP_ORIGIN}/view/${CANONICAL_PATH}`,
 			);
 			expect(copyUrl.searchParams.get("utm_source")).toBe("share-balloon");
 			expect(copyUrl.searchParams.get("utm_medium")).toBe("copy");
@@ -505,7 +581,7 @@ describe("View routes", () => {
 				shared: { ...fixture.shared, appOrigin: "https://staging.readplace.com" },
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const btn = doc.querySelector("[data-test-share-balloon]");
@@ -520,7 +596,7 @@ describe("View routes", () => {
 
 			expect(
 				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
-			).toBe(`https://readplace.com/view/${ENCODED}`);
+			).toBe(`https://readplace.com/view/${CANONICAL_PATH}`);
 		});
 
 		it("renders a dismiss button with an accessible label", async () => {
@@ -549,7 +625,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const closeBtn = doc.querySelector("[data-test-share-balloon-close]");
@@ -583,7 +659,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const script = doc.querySelector(
@@ -619,7 +695,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const status = doc.querySelector("[data-share-balloon-status]");
@@ -654,7 +730,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const label = doc.querySelector("[data-test-share-balloon-copied]");
@@ -689,7 +765,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const btn = doc.querySelector("[data-test-share-balloon]");
@@ -732,7 +808,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const avatar = doc.querySelector("[data-test-share-balloon-avatar]");
@@ -766,7 +842,7 @@ describe("View routes", () => {
 				},
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			expect(
@@ -817,7 +893,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -864,7 +940,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -911,7 +987,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -962,7 +1038,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -1013,7 +1089,7 @@ describe("View routes", () => {
  },
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const slot = doc.querySelector("[data-test-reader-summary]");
@@ -1191,7 +1267,7 @@ describe("View routes", () => {
 
 			// Land on /view first so the row exists; then the reader poll has
 			// something to read back.
-			await request(harness.server).get(`/view/${ENCODED}`);
+			await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const first = await request(harness.server).get(
 				`/view/reader?url=${encodeURIComponent(ARTICLE_URL)}&poll=1`,
@@ -1258,7 +1334,7 @@ describe("View routes", () => {
 				savedAt: new Date("2026-05-03T13:54:27.000Z"),
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const counter = doc.querySelector("[data-test-view-expiry]");
@@ -1270,10 +1346,8 @@ describe("View routes", () => {
 		it("renders state=permanent when the article domain is in PERMANENT_ARTICLE_DOMAINS", async () => {
 			const now = new Date("2026-05-04T00:00:00.000Z");
 			const { harness } = makeHarness(now);
-			const permanentUrl = "https://fagnerbrack.com/some-article";
-			const encoded = encodeURIComponent(permanentUrl);
 
-			const response = await request(harness.server).get(`/view/${encoded}`);
+			const response = await request(harness.server).get(`/view/${PERMANENT_CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const counter = doc.querySelector("[data-test-view-expiry]");
@@ -1290,7 +1364,7 @@ describe("View routes", () => {
 			const prefix = result.userId.slice(0, 6).toLowerCase();
 
 			const response = await request(harness.server).get(
-				`/view/${ENCODED}?utm_content=${prefix}`,
+				`/view/${CANONICAL_PATH}?utm_content=${prefix}`,
 			);
 
 			const doc = new JSDOM(response.text).window.document;
@@ -1310,7 +1384,7 @@ describe("View routes", () => {
 			});
 
 			const response = await request(harness.server).get(
-				`/view/${ENCODED}?utm_content=ffffff`,
+				`/view/${CANONICAL_PATH}?utm_content=ffffff`,
 			);
 
 			const doc = new JSDOM(response.text).window.document;
@@ -1329,7 +1403,7 @@ describe("View routes", () => {
 				savedAt: new Date("2026-05-01T00:00:00.000Z"),
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const counter = doc.querySelector("[data-test-view-expiry]");
@@ -1348,7 +1422,7 @@ describe("View routes", () => {
 				savedAt: new Date("2026-05-03T13:00:00.000Z"),
 			});
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -1362,10 +1436,8 @@ describe("View routes", () => {
 		it("does not stamp time-left utm_content on a permanent-domain article", async () => {
 			const now = new Date("2026-05-04T00:00:00.000Z");
 			const { harness } = makeHarness(now);
-			const permanentUrl = "https://fagnerbrack.com/some-article";
-			const encoded = encodeURIComponent(permanentUrl);
 
-			const response = await request(harness.server).get(`/view/${encoded}`);
+			const response = await request(harness.server).get(`/view/${PERMANENT_CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const action = ctaAction(doc);
@@ -1386,7 +1458,7 @@ describe("View routes", () => {
 				savedAt: new Date("2026-05-01T00:00:00.000Z"),
 			});
 
-			const expiredResponse = await request(harness.server).get(`/view/${ENCODED}`);
+			const expiredResponse = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 			const expiredCounter = new JSDOM(expiredResponse.text).window.document.querySelector(
 				"[data-test-view-expiry]",
 			);
@@ -1398,7 +1470,7 @@ describe("View routes", () => {
 				savedAt: now,
 			});
 
-			const freshResponse = await request(harness.server).get(`/view/${ENCODED}`);
+			const freshResponse = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 			const freshCounter = new JSDOM(freshResponse.text).window.document.querySelector(
 				"[data-test-view-expiry]",
 			);
@@ -1418,7 +1490,7 @@ describe("View routes", () => {
 				.type("form")
 				.send({ email: "sharer@example.com", password: "password123" });
 
-			const response = await agent.get(`/view/${ENCODED}`);
+			const response = await agent.get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const shareBtn = doc.querySelector("[data-test-share-balloon]");
@@ -1433,7 +1505,7 @@ describe("View routes", () => {
 			const now = new Date("2026-05-04T00:00:00.000Z");
 			const { harness } = makeHarness(now);
 
-			const response = await request(harness.server).get(`/view/${ENCODED}`);
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
 
 			const doc = new JSDOM(response.text).window.document;
 			const shareBtn = doc.querySelector("[data-test-share-balloon]");


### PR DESCRIPTION
## Summary

- `/view` URLs are now human-readable: `/view/web.eecs.umich.edu/~weimerw/path.pdf` instead of `/view/https%3A%2F%2Fweb.eecs.umich.edu%2F~weimerw%2Fpath.pdf`. Slashes pass through, the implicit `https://` scheme is dropped, and only `?`/`#` inside the article URL stay percent-encoded so Express keeps them in the path.
- Old paths still resolve via **301 permanent redirect** to the canonical, so existing shared links keep working: encoded `https%3A%2F%2F…`, decoded `https://…` (the API Gateway shape), and collapsed `https:/…` all redirect.
- `http://` URLs keep the literal scheme (`/view/http://example.com/post`) because stripping it would be ambiguous against the https default. Encoded (`http%3A%2F%2F…`) and collapsed (`http:/…`) variants 301-redirect to the literal canonical.
- No conflict with `/blog`, `/queue`, etc. — each lives on its own Express mount, so `/view/<host>/<arbitrary>/<slashed>/<path>` only matches the view router.

The new canonical is wired through every `/view/<url>` producer: SEO canonical/og:url, share-balloon URLs, the queue → /view share redirect, and the save-permalink CLI. Existing producers used `encodeURIComponent` directly; they now call a single `viewPathFor(articleUrl)` helper that builds the canonical.

Implementation sits in a new `view-path.ts` module with `viewPathFor` (build canonical) and `parseViewPath` (decide render vs redirect). The route handler stays thin — it asks the helper, redirects with the original Readplace tracking query string preserved, or renders.

## Test plan

- [x] Unit tests for `view-path.ts` cover https stripping, http retention, collapsed-scheme normalization, query/fragment encoding, and round-trip stability (20 tests)
- [x] Route tests assert 301 from each legacy shape (`encoded`, decoded `https://`, collapsed `https:/`, encoded `http%3A%2F%2F`, collapsed `http:/`) with Readplace tracking query preserved across the redirect
- [x] Route test covers the user-provided PDF example end-to-end (encoded → 301 → canonical, and canonical → 200 with the right Save action)
- [x] `pnpm nx run hutch:check` passes: 1713 tests green, lint/knip/biome/unused-css clean, **100% function coverage**, `view-path.ts` at 100% across the board
- [x] All consumers updated so freshly-generated /view URLs are canonical from the start (no self-redirects)
- [ ] Manual: load a legacy encoded URL from somewhere indexed (Google cache, old tweet) and confirm the 301 redirects to the new canonical in a real browser
- [ ] Manual: confirm the share balloon copies the new canonical URL on a fresh article

https://claude.ai/code/session_015Mqerdiuh6gbe8ghTXR89M

---
_Generated by [Claude Code](https://claude.ai/code/session_015Mqerdiuh6gbe8ghTXR89M)_