### PR TITLE
fix(save-link): make curl-impersonate layer zip reproducible

### DIFF
--- a/projects/save-link/tools/build-curl-impersonate-layer.mjs
+++ b/projects/save-link/tools/build-curl-impersonate-layer.mjs
@@ -79,7 +79,20 @@ function createZip(layerRoot) {
 		rmSync(OUTPUT_ZIP);
 	}
 	console.log(`[build-layer] creating ${OUTPUT_ZIP}`);
-	run("zip", ["--recurse-paths", "--symlinks", OUTPUT_ZIP, "."], { cwd: layerRoot });
+	/* Deterministic build: pin mtimes to a fixed epoch (tar extraction sets
+	 * them to "now"), feed a sorted file list to zip (readdir order varies
+	 * between APFS and ext4), and strip OS-specific extra fields with -X
+	 * (high-precision timestamps, uid/gid). Without this, the zip SHA-256
+	 * changes on every rebuild, Pulumi replaces the LayerVersion, and every
+	 * Lambda that mounts the layer re-configures on every deploy. */
+	const script = [
+		"find . -exec touch -t 200001010000.00 {} +",
+		'find . \\( -type f -o -type l \\) -print | LC_ALL=C sort | zip -X --symlinks -@ "$OUTPUT_ZIP"',
+	].join(" && ");
+	run("sh", ["-c", script], {
+		cwd: layerRoot,
+		env: { ...process.env, OUTPUT_ZIP },
+	});
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- Pin file mtimes to a fixed epoch, feed a sorted file list to `zip`, and strip OS-specific extra fields when building the curl-impersonate Lambda layer.
- Two consecutive `pnpm deploy-infra` (or `check-infra`) runs against the same source code no longer report a phantom `LayerVersion` replacement plus the cascade of five Lambda config updates that mount the layer.

## Why

`tools/build-curl-impersonate-layer.mjs` rebuilds the layer zip on every deploy. The previous `zip --recurse-paths --symlinks` invocation captured extraction-time mtimes and `readdir` ordering, so every rebuild produced a different SHA-256. Pulumi hashes the `FileArchive` contents itself, so a fresh hash became a `LayerVersion` replacement, which in turn forced a config update on every Lambda that references `curlImpersonateLayer.arn`.

## How

In `createZip`, replace the single `zip` call with a small shell pipeline invoked via `sh -c`:

1. `find . -exec touch -t 200001010000.00 {} +` — normalize mtimes to a fixed epoch.
2. `find . \( -type f -o -type l \) -print | LC_ALL=C sort | zip -X --symlinks -@ "$OUTPUT_ZIP"` — feed a sorted file list to `zip` and strip OS-specific extra fields with `-X`.

The output path is passed through `env` rather than interpolated into the shell string so paths with spaces stay safe.

## Test plan

- [x] `node projects/save-link/tools/build-curl-impersonate-layer.mjs` twice in a row produces an identical SHA-256 (`8c3053ca963ac158e95d298636182f35963613d80cdb94c56ffe8886f3c8aaad` locally).
- [x] `unzip -lv` shows both entries with mtime `2000-01-01 00:00`, alphabetical order, and `zipinfo -v` reports `length of extra field: 0 bytes` for both.
- [x] `pnpm nx run save-link:check` passes (100% coverage maintained).
- [ ] After merge: one `pulumi up` to land the now-deterministic layer; subsequent `check-infra` runs from any developer should report `0 changes. 474 unchanged`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015gwMtFfvVdpiky8tRZbcjy)_