### PR TITLE
Route every save/recrawl/stale-check path through one finalize pipeline

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -8,7 +8,16 @@ import { initDynamoDbAuth } from "./providers/auth/dynamodb-auth";
 import { initInMemoryArticleStore } from "@packages/test-fixtures/providers/article-store";
 import { initDynamoDbArticleStore } from "./providers/article-store/dynamodb-article-store";
 import type { ExtractPdf } from "@packages/crawl-article";
-import { CRAWL_PERSONAS, initComprehensiveCrawl, initCrawlArticle, initCrawlFetch, initSimpleCrawl } from "@packages/crawl-article";
+import {
+	CRAWL_PERSONAS,
+	initComprehensiveCrawl,
+	initCrawlArticle,
+	initCrawlFetch,
+	initFetchThumbnailImage,
+	initSimpleCrawl,
+} from "@packages/crawl-article";
+import { initFinalizeArticle } from "save-link/finalize-article";
+import { initCrawlAndFinalizeArticle } from "save-link/crawl-and-finalize-article";
 import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
 import { initReadabilityParser, mediumPreParser, theInformationPreParser } from "@packages/article-parser";
 import { initRefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
@@ -292,6 +301,23 @@ function initProviders() {
 		sitePreParsers: [theInformationPreParser, mediumPreParser],
 		logError,
 	});
+	const fetchThumbnailImage = initFetchThumbnailImage({ crawlFetch, logError });
+	/* Dev composition: no S3, no CDN. Stub the media + image-upload deps so the
+	 * in-memory app still routes through the same `finalizeArticle` pipeline
+	 * every prod Lambda uses — identical algorithm, identical metadata shape,
+	 * just with no-op upload sinks. */
+	const finalizeArticle = initFinalizeArticle({
+		parseHtml,
+		downloadMedia: async () => [],
+		processContent: async ({ html }) => html,
+		fetchThumbnailImage,
+		putImageObject: async () => {},
+		imagesCdnBaseUrl: "https://dev-images.invalid",
+	});
+	const crawlAndFinalizeArticle = initCrawlAndFinalizeArticle({
+		simpleCrawl: crawlArticle,
+		finalizeArticle,
+	});
 	const finaliseSummaryFromContent = async (params: { url: string; textContent: string }) => {
 		await summaryStore.markSummaryPending({ url: params.url });
 		const summary = devSummariseInline({ textContent: params.textContent });
@@ -302,27 +328,19 @@ function initProviders() {
 		await summaryStore.markSummarySkipped({ url: params.url, reason: summary.reason });
 	};
 	const runCrawlAndSummariseInline = async (url: string) => {
-		const crawlResult = await crawlArticle({ url });
-		if (crawlResult.status === "unsupported") {
-			await crawlStore.markCrawlUnsupported({ url, reason: crawlResult.reason });
+		const result = await crawlAndFinalizeArticle({ url });
+		if (result.status === "unsupported") {
+			await crawlStore.markCrawlUnsupported({ url, reason: result.reason });
 			return;
 		}
-		if (crawlResult.status !== "fetched") {
-			await crawlStore.markCrawlFailed({ url, reason: `crawl-${crawlResult.status}` });
-			return;
-		}
-		const result = parseHtml({
-			url,
-			html: crawlResult.html,
-			thumbnailUrl: crawlResult.thumbnailUrl ?? null,
-		});
-		if (!result.ok) {
+		if (result.status === "failed") {
 			await crawlStore.markCrawlFailed({ url, reason: result.reason });
 			return;
 		}
-		await articleStore.writeContent({ url, content: result.article.content });
+		if (result.status === "not-modified") return;
+		await articleStore.writeContent({ url, content: result.article.html });
 		await crawlStore.markCrawlReady({ url });
-		await finaliseSummaryFromContent({ url, textContent: result.article.content });
+		await finaliseSummaryFromContent({ url, textContent: result.article.html });
 	};
 	const { publishLinkSaved: logOnlyPublishLinkSaved } = initInMemoryLinkSaved({ logger: consoleLogger });
 	const publishLinkSaved: typeof logOnlyPublishLinkSaved = async (params) => {

--- a/projects/save-link/package.json
+++ b/projects/save-link/package.json
@@ -12,6 +12,14 @@
     "./generate-summary": {
       "types": "./dist/runtime/domain/generate-summary/index.d.ts",
       "default": "./dist/runtime/domain/generate-summary/index.js"
+    },
+    "./finalize-article": {
+      "types": "./dist/runtime/domain/save-link/finalize-article.d.ts",
+      "default": "./dist/runtime/domain/save-link/finalize-article.js"
+    },
+    "./crawl-and-finalize-article": {
+      "types": "./dist/runtime/domain/save-link/crawl-and-finalize-article.d.ts",
+      "default": "./dist/runtime/domain/save-link/crawl-and-finalize-article.js"
     }
   },
   "typesVersions": {
@@ -21,6 +29,12 @@
       ],
       "generate-summary": [
         "./dist/runtime/domain/generate-summary/index.d.ts"
+      ],
+      "finalize-article": [
+        "./dist/runtime/domain/save-link/finalize-article.d.ts"
+      ],
+      "crawl-and-finalize-article": [
+        "./dist/runtime/domain/save-link/crawl-and-finalize-article.d.ts"
       ]
     }
   },

--- a/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
+++ b/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
@@ -19,6 +19,7 @@ import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initComprehensiveParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
 import { initMediaDepBundle } from "./dep-bundles/media";
+import { initCrawlAndFinalizeDepBundle } from "./dep-bundles/crawl-and-finalize";
 import { initEventsDepBundle } from "./dep-bundles/events";
 import { initArticleAggregateDepBundle } from "./dep-bundles/article-aggregate";
 import { initArticleCrawlDepBundle } from "./dep-bundles/article-crawl";
@@ -72,19 +73,24 @@ const observability = initObservabilityDepBundle({ logger: consoleLogger, source
 const parser = initComprehensiveParserDepBundle({ logError: observability.logError, extractPdf });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
+const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
+	parser,
+	media,
+	articleStore,
+	imagesCdnBaseUrl,
+	logError: observability.logError,
+});
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
 
 export const handler = initComprehensiveCrawlHandler({
 	comprehensiveCrawl: parser.comprehensiveCrawl,
-	parseHtml: parser.parseHtml,
-	...media,
+	finalizeArticle: crawlAndFinalize.finalizeArticle,
 	...articleStore,
 	...events,
 	...articleAggregate,
 	...articleCrawl,
 	...observability,
-	imagesCdnBaseUrl,
 	now,
 });

--- a/projects/save-link/src/runtime/dep-bundles/crawl-and-finalize.test.ts
+++ b/projects/save-link/src/runtime/dep-bundles/crawl-and-finalize.test.ts
@@ -1,0 +1,36 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { noopLogger } from "@packages/hutch-logger";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initArticleStoreDepBundle } from "./article-store";
+import { initCrawlAndFinalizeDepBundle } from "./crawl-and-finalize";
+import { initMediaDepBundle } from "./media";
+import { initParserDepBundle } from "./parser";
+
+describe("initCrawlAndFinalizeDepBundle", () => {
+	it("returns a bundle with finalizeArticle and crawlAndFinalizeArticle fields", () => {
+		const parser = initParserDepBundle({ logError: () => {} });
+		const articleStore = initArticleStoreDepBundle({
+			s3Client: new S3Client({ region: "us-east-1" }),
+			dynamoClient: createDynamoDocumentClient({ region: "us-east-1" }),
+			contentBucketName: "content-bucket",
+			articlesTable: "articles-table",
+		});
+		const media = initMediaDepBundle({
+			parser,
+			articleStore,
+			logger: noopLogger,
+			imagesCdnBaseUrl: "https://cdn.example",
+		});
+
+		const bundle = initCrawlAndFinalizeDepBundle({
+			parser,
+			media,
+			articleStore,
+			imagesCdnBaseUrl: "https://cdn.example",
+			logError: () => {},
+		});
+
+		expect(typeof bundle.finalizeArticle).toBe("function");
+		expect(typeof bundle.crawlAndFinalizeArticle).toBe("function");
+	});
+});

--- a/projects/save-link/src/runtime/dep-bundles/crawl-and-finalize.ts
+++ b/projects/save-link/src/runtime/dep-bundles/crawl-and-finalize.ts
@@ -1,0 +1,50 @@
+import { initFetchThumbnailImage } from "@packages/crawl-article";
+import {
+	initFinalizeArticle,
+	type FinalizeArticle,
+} from "../domain/save-link/finalize-article";
+import {
+	initCrawlAndFinalizeArticle,
+	type CrawlAndFinalizeArticle,
+} from "../domain/save-link/crawl-and-finalize-article";
+import type { LogError } from "./observability";
+import type { ArticleStoreDepBundle } from "./article-store";
+import type { MediaDepBundle } from "./media";
+import type { ParserDepBundle } from "./parser";
+
+export type CrawlAndFinalizeDepBundle = {
+	finalizeArticle: FinalizeArticle;
+	crawlAndFinalizeArticle: CrawlAndFinalizeArticle;
+};
+
+/* Wires the unified parse → media → thumbnail-upload pipeline. Every
+ * caller that produces a tier source — SaveLink, RecrawlLinkInitiated,
+ * SaveAnonymousLink, StaleCheckRequested, ComprehensiveCrawlCommand,
+ * SaveLinkRawHtmlCommand, and the in-memory dev wrappers — composes its
+ * Lambda by including this bundle, so the algorithm cannot drift between
+ * triggers. */
+export function initCrawlAndFinalizeDepBundle(deps: {
+	parser: ParserDepBundle;
+	media: MediaDepBundle;
+	articleStore: ArticleStoreDepBundle;
+	imagesCdnBaseUrl: string;
+	logError: LogError;
+}): CrawlAndFinalizeDepBundle {
+	const fetchThumbnailImage = initFetchThumbnailImage({
+		crawlFetch: deps.parser.crawlFetch,
+		logError: deps.logError,
+	});
+	const finalizeArticle = initFinalizeArticle({
+		parseHtml: deps.parser.parseHtml,
+		downloadMedia: deps.media.downloadMedia,
+		processContent: deps.media.processContent,
+		fetchThumbnailImage,
+		putImageObject: deps.articleStore.putImageObject,
+		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,
+	});
+	const crawlAndFinalizeArticle = initCrawlAndFinalizeArticle({
+		simpleCrawl: deps.parser.simpleCrawl,
+		finalizeArticle,
+	});
+	return { finalizeArticle, crawlAndFinalizeArticle };
+}

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -1,5 +1,3 @@
-import posthtml from "posthtml";
-import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import type { ComprehensiveCrawl } from "@packages/crawl-article";
 import { markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
@@ -9,10 +7,7 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import { initComprehensiveCrawlHandler } from "./comprehensive-crawl-handler";
-import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "../save-link/download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
+import type { FinalizeArticle, FinalizedArticle } from "../save-link/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -59,26 +54,24 @@ function createSqsEvent(detail: {
 	};
 }
 
-const noopDownloadMedia: DownloadMedia = async () => [];
-
-const processContent = initProcessContentWithLocalMedia({
-	rewriteHtmlUrls: (html, rewriteUrl) => {
-		const plugin = urls({ eachURL: rewriteUrl });
-		return posthtml().use(plugin).process(html).then(result => result.html);
-	},
-});
-
 const successfulComprehensiveCrawl: ComprehensiveCrawl = async () => ({
 	status: "fetched",
 	html: "<html><body><p>Extracted PDF content</p></body></html>",
 });
 
-const successfulParse: ParseHtml = () => ({
-	ok: true,
-	article: { title: "Test", siteName: "example.com", excerpt: "test", wordCount: 10, content: "<p>Extracted PDF content</p>" },
-});
+const stubFinalizedArticle: FinalizedArticle = {
+	html: "<p>Extracted PDF content</p>",
+	metadata: {
+		title: "Test",
+		siteName: "example.com",
+		excerpt: "test",
+		wordCount: 10,
+		estimatedReadTime: 1,
+		imageUrl: undefined,
+	},
+};
 
-const imagesCdnBaseUrl = "https://cdn.example.com";
+const okFinalize: FinalizeArticle = async () => ({ ok: true, article: stubFinalizedArticle });
 
 type HandlerDeps = Parameters<typeof initComprehensiveCrawlHandler>[0];
 
@@ -87,17 +80,13 @@ const fixedNow = () => new Date("2026-04-18T12:00:00.000Z");
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	return initComprehensiveCrawlHandler({
 		comprehensiveCrawl: successfulComprehensiveCrawl,
-		parseHtml: successfulParse,
+		finalizeArticle: okFinalize,
 		putTierSource: jest.fn().mockResolvedValue(undefined),
-		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		markCrawlProgress: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
-		downloadMedia: noopDownloadMedia,
-		processContent,
-		imagesCdnBaseUrl,
 		now: fixedNow,
 		logger: noopLogger,
 		logParseError: jest.fn(),
@@ -108,7 +97,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 }
 
 describe("initComprehensiveCrawlHandler", () => {
-	it("writes a tier-1 source with the extracted PDF content and emits TierContentExtractedEvent carrying userId", async () => {
+	it("writes a tier-1 source with the finalizer's metadata and emits TierContentExtractedEvent carrying userId", async () => {
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
@@ -119,19 +108,38 @@ describe("initComprehensiveCrawlHandler", () => {
 		expect(putTierSource).toHaveBeenCalledWith({
 			url: "https://example.com/doc.pdf",
 			tier: "tier-1",
-			html: "<p>Extracted PDF content</p>",
-			metadata: expect.objectContaining({
-				title: "Test",
-				siteName: "example.com",
-				excerpt: "test",
-				wordCount: 10,
-			}),
+			html: stubFinalizedArticle.html,
+			metadata: stubFinalizedArticle.metadata,
 		});
-
 		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
 			url: "https://example.com/doc.pdf",
 			tier: "tier-1",
 			userId: "user-1",
+		});
+	});
+
+	it("threads the crawler's html + pre-fetched thumbnail into finalizeArticle (same algorithm every path uses)", async () => {
+		const preFetchedThumbnail = {
+			body: Buffer.from([0xff]),
+			contentType: "image/jpeg",
+			url: "https://example.com/og.jpg",
+			extension: ".jpg",
+		};
+		const comprehensiveCrawl: ComprehensiveCrawl = async () => ({
+			status: "fetched",
+			html: "<html><body>X</body></html>",
+			thumbnailImage: preFetchedThumbnail,
+		});
+		const finalizeArticle = jest.fn(okFinalize);
+
+		const handler = createHandler({ comprehensiveCrawl, finalizeArticle });
+
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+
+		expect(finalizeArticle).toHaveBeenCalledWith({
+			url: "https://example.com/doc.pdf",
+			html: "<html><body>X</body></html>",
+			preFetchedThumbnail,
 		});
 	});
 
@@ -270,9 +278,9 @@ describe("initComprehensiveCrawlHandler", () => {
 
 	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist (same behavior as save-link-work)", async () => {
 		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability crashed on this DOM" });
+		const finalizeArticle: FinalizeArticle = async () => ({ ok: false, reason: "Readability crashed on this DOM" });
 
-		const handler = createHandler({ parseHtml: failedParse, transitionAndPersist });
+		const handler = createHandler({ finalizeArticle, transitionAndPersist });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad.pdf" }),
@@ -304,8 +312,6 @@ describe("initComprehensiveCrawlHandler", () => {
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
-		// Fire-and-forget catch handler queues a microtask. Drain it before
-		// counting stage writes so the assertion sees the stable state.
 		await new Promise((resolve) => setImmediate(resolve));
 
 		const extractingWrites = markCrawlStage.mock.calls.filter(
@@ -363,8 +369,6 @@ describe("initComprehensiveCrawlHandler", () => {
 
 	it("flushes the terminal progress value after comprehensiveCrawl returns so the final partCurrent === partTotal write always lands", async () => {
 		const comprehensiveCrawl: ComprehensiveCrawl = async ({ onProgress }) => {
-			// Rapid fan-out of 4 parts — without flush, the throttle would write
-			// only the first part (the rest fall inside the throttle window).
 			if (onProgress) {
 				onProgress({ partIndex: 1, partCount: 4 });
 				onProgress({ partIndex: 2, partCount: 4 });
@@ -389,71 +393,6 @@ describe("initComprehensiveCrawlHandler", () => {
 			partCurrent: 4,
 			partTotal: 4,
 		});
-	});
-
-	it("uploads the crawled thumbnail to S3 and threads the resolved CDN URL into the tier-source metadata", async () => {
-		const imageBody = Buffer.from([0xff, 0xd8, 0xff]);
-		const comprehensiveCrawl: ComprehensiveCrawl = async () => ({
-			status: "fetched",
-			html: "<html></html>",
-			thumbnailImage: {
-				body: imageBody,
-				contentType: "image/jpeg",
-				url: "https://cdn.example.com/thumb.jpg",
-				extension: ".jpg",
-			},
-		});
-		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-
-		const handler = createHandler({ comprehensiveCrawl, putImageObject, putTierSource });
-
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
-
-		expect(putImageObject).toHaveBeenCalledWith(expect.objectContaining({
-			contentType: "image/jpeg",
-		}));
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({
-					imageUrl: expect.stringContaining("https://cdn.example.com/"),
-				}),
-			}),
-		);
-	});
-
-	it("threads comprehensiveCrawl.thumbnailUrl into parseHtml so the raw URL survives when the image download is skipped (parity with simple-crawl path)", async () => {
-		const comprehensiveCrawl: ComprehensiveCrawl = async () => ({
-			status: "fetched",
-			html: "<html></html>",
-			thumbnailUrl: "https://example.com/og.png",
-		});
-		const parseHtml = jest.fn(((_params) => ({
-			ok: true as const,
-			article: {
-				title: "T", siteName: "s", excerpt: "e", wordCount: 1,
-				content: "<p>x</p>",
-				imageUrl: "https://example.com/og.png",
-			},
-		})) satisfies ParseHtml);
-		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-
-		const handler = createHandler({ comprehensiveCrawl, parseHtml, putImageObject, putTierSource });
-
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
-
-		expect(parseHtml).toHaveBeenCalledWith({
-			url: "https://example.com/article",
-			html: "<html></html>",
-			thumbnailUrl: "https://example.com/og.png",
-		});
-		expect(putImageObject).not.toHaveBeenCalled();
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({ imageUrl: "https://example.com/og.png" }),
-			}),
-		);
 	});
 
 	it("records contentFetchedAt + etag + lastModified after a successful PDF extraction so future saves can short-circuit on TTL", async () => {

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -13,31 +13,22 @@ import {
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
 import type { MarkCrawlProgress } from "../../providers/article-crawl/mark-crawl-progress";
 import { initProgressThrottle } from "../crawl-article-state/init-progress-throttle";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "../save-link/download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { UpdateFetchTimestamp } from "../save-link/update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
-import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id";
-import { estimatedReadTimeFromWordCount } from "../save-link/estimated-read-time";
-import { uploadThumbnail, type ProcessContent } from "../save-link/save-link-work";
+import type { FinalizeArticle } from "../save-link/finalize-article";
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initComprehensiveCrawlHandler(deps: {
 	comprehensiveCrawl: ComprehensiveCrawl;
-	parseHtml: ParseHtml;
+	finalizeArticle: FinalizeArticle;
 	putTierSource: PutTierSource;
-	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
 	markCrawlProgress: MarkCrawlProgress;
 	publishEvent: PublishEvent;
-	downloadMedia: DownloadMedia;
-	processContent: ProcessContent;
-	imagesCdnBaseUrl: string;
 	now: () => Date;
 	logger: HutchLogger;
 	logParseError: LogParseError;
@@ -47,17 +38,13 @@ export function initComprehensiveCrawlHandler(deps: {
 }): Handler<SQSEvent, SQSBatchResponse> {
 	const {
 		comprehensiveCrawl,
-		parseHtml,
+		finalizeArticle,
 		putTierSource,
-		putImageObject,
 		updateFetchTimestamp,
 		transitionAndPersist,
 		markCrawlStage,
 		markCrawlProgress,
 		publishEvent,
-		downloadMedia,
-		processContent,
-		imagesCdnBaseUrl,
 		now,
 		logger,
 		logParseError,
@@ -156,57 +143,28 @@ export function initComprehensiveCrawlHandler(deps: {
 					throw new Error(`crawl failed for ${url}: ${reason}`);
 				}
 
-				const parseResult = parseHtml({
+				const finalized = await finalizeArticle({
 					url,
 					html: crawlResult.html,
-					thumbnailUrl: crawlResult.thumbnailUrl ?? null,
+					preFetchedThumbnail: crawlResult.thumbnailImage,
 				});
-				if (!parseResult.ok) {
-					logParseError({ url, reason: parseResult.reason });
+				if (!finalized.ok) {
+					logParseError({ url, reason: finalized.reason });
 					await transitionAndPersist(markCrawlFailed, {
 						url,
 						input: {
-							reason: { kind: "parse-error", detail: parseResult.reason },
+							reason: { kind: "parse-error", detail: finalized.reason },
 						},
 					});
 					await emitTier1Failure(url);
-					throw new Error(`crawl failed for ${url}: ${parseResult.reason}`);
+					throw new Error(`crawl failed for ${url}: ${finalized.reason}`);
 				}
-
-				const { article } = parseResult;
-				await markCrawlStage({ url, stage: "crawl-parsed" });
-				const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
-
-				const media = await downloadMedia({
-					html: article.content,
-					articleUrl: url,
-					articleResourceUniqueId,
-				});
-
-				const html = await processContent({ html: article.content, media });
-
-				const resolvedImageUrl = crawlResult.thumbnailImage
-					? await uploadThumbnail({
-							thumbnailImage: crawlResult.thumbnailImage,
-							articleResourceUniqueId,
-							putImageObject,
-							imagesCdnBaseUrl,
-						})
-					: article.imageUrl;
-				await markCrawlStage({ url, stage: "crawl-metadata-written" });
 
 				await putTierSource({
 					url,
 					tier: "tier-1",
-					html,
-					metadata: {
-						title: article.title,
-						siteName: article.siteName,
-						excerpt: article.excerpt,
-						wordCount: article.wordCount,
-						estimatedReadTime: estimatedReadTimeFromWordCount(article.wordCount),
-						imageUrl: resolvedImageUrl,
-					},
+					html: finalized.article.html,
+					metadata: finalized.article.metadata,
 				});
 				await markCrawlStage({ url, stage: "crawl-content-uploaded" });
 

--- a/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.test.ts
@@ -1,12 +1,8 @@
-import posthtml from "posthtml";
-import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
 import { markCrawlFailed } from "@packages/domain/article-aggregate";
 import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveLinkRawHtmlCommandHandler } from "./save-link-raw-html-command-handler";
-import { initProcessContentWithLocalMedia } from "../save-link/process-content-with-local-media";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "../save-link/download-media";
+import type { FinalizeArticle, FinalizedArticle } from "../save-link/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -48,34 +44,26 @@ function createSqsEvent(detail: { url: string; userId: string; title?: string })
 	};
 }
 
-const noopDownloadMedia: DownloadMedia = async () => [];
-
-const processContent = initProcessContentWithLocalMedia({
-	rewriteHtmlUrls: (html, rewriteUrl) => {
-		const plugin = urls({ eachURL: rewriteUrl });
-		return posthtml().use(plugin).process(html).then((result) => result.html);
-	},
-});
-
-const successfulParse: ParseHtml = () => ({
-	ok: true,
-	article: {
+const stubFinalizedArticle: FinalizedArticle = {
+	html: "<p>Article content</p>",
+	metadata: {
 		title: "Test",
 		siteName: "example.com",
 		excerpt: "test",
 		wordCount: 10,
-		content: "<p>Article content</p>",
+		estimatedReadTime: 1,
+		imageUrl: undefined,
 	},
-});
+};
+
+const okFinalize: FinalizeArticle = async () => ({ ok: true, article: stubFinalizedArticle });
 
 type HandlerDeps = Parameters<typeof initSaveLinkRawHtmlCommandHandler>[0];
 
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	const deps: HandlerDeps = {
 		readPendingHtml: jest.fn().mockResolvedValue("<html><body><p>Article content</p></body></html>"),
-		parseHtml: successfulParse,
-		downloadMedia: noopDownloadMedia,
-		processContent,
+		finalizeArticle: okFinalize,
 		putTierSource: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
@@ -93,7 +81,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 }
 
 describe("initSaveLinkRawHtmlCommandHandler", () => {
-	it("reads pending HTML, writes a tier-0 source with metadata, and emits TierContentExtractedEvent carrying userId", async () => {
+	it("reads pending HTML, writes a tier-0 source with the finalizer's metadata, and emits TierContentExtractedEvent carrying userId", async () => {
 		const { handler, deps } = createHandler();
 
 		await handler(
@@ -106,20 +94,34 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		expect(deps.putTierSource).toHaveBeenCalledWith({
 			url: "https://example.com/article",
 			tier: "tier-0",
-			html: "<p>Article content</p>",
-			metadata: {
-				title: "Test",
-				siteName: "example.com",
-				excerpt: "test",
-				wordCount: 10,
-				estimatedReadTime: 1,
-				imageUrl: undefined,
-			},
+			html: stubFinalizedArticle.html,
+			metadata: stubFinalizedArticle.metadata,
 		});
 		expect(deps.publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
 			url: "https://example.com/article",
 			tier: "tier-0",
 			userId: "user-1",
+		});
+	});
+
+	it("threads the captured rawHtml through finalizeArticle without preFetchedThumbnail (the raw-html path has no inline crawler image)", async () => {
+		const rawHtml = "<html><body><article><p>Body</p></article></body></html>";
+		const finalizeArticle = jest.fn(okFinalize);
+
+		const { handler } = createHandler({
+			readPendingHtml: jest.fn().mockResolvedValue(rawHtml),
+			finalizeArticle,
+		});
+
+		await handler(
+			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
+			stubContext,
+			() => {},
+		);
+
+		expect(finalizeArticle).toHaveBeenCalledWith({
+			url: "https://example.com/article",
+			html: rawHtml,
 		});
 	});
 
@@ -136,7 +138,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 	});
 
 	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist and reports the record as a batch failure so SQS redelivers it", async () => {
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability returned null" });
+		const finalizeArticle: FinalizeArticle = async () => ({ ok: false, reason: "Readability returned null" });
 		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
@@ -144,7 +146,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		const logger = { ...noopLogger, error };
 
 		const { handler } = createHandler({
-			parseHtml: failedParse,
+			finalizeArticle,
 			transitionAndPersist,
 			putTierSource,
 			publishEvent,
@@ -160,14 +162,10 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/bad",
-			input: {
-				reason: { kind: "parse-error", detail: "Readability returned null" },
-			},
+			input: { reason: { kind: "parse-error", detail: "Readability returned null" } },
 		});
 		expect(putTierSource).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
-		// Confirms the throw inside the worker propagated to the per-record catch
-		// with the expected diagnostic, even though it no longer escapes the handler.
 		expect(error).toHaveBeenCalledWith(
 			"[SaveLinkRawHtmlCommand] record failed",
 			expect.objectContaining({
@@ -179,36 +177,9 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		);
 	});
 
-	it("threads downloaded media into processContent so HTML references the CDN URLs", async () => {
-		const parseWithImage: ParseHtml = () => ({
-			ok: true,
-			article: {
-				title: "T",
-				siteName: "s",
-				excerpt: "e",
-				wordCount: 1,
-				content: '<img src="https://example.com/img.png">',
-			},
-		});
-		const downloadMedia: DownloadMedia = jest.fn().mockResolvedValue([
-			{ originalUrl: "https://example.com/img.png", cdnUrl: "https://cdn/images/abc.png" },
-		]);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-
-		const { handler } = createHandler({ parseHtml: parseWithImage, downloadMedia, putTierSource });
-
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
-
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				html: expect.stringContaining("https://cdn/images/abc.png"),
-			}),
-		);
-	});
-
 	it("emits logParseError before reporting the record as a batch failure, so the failure reaches the parse-errors dashboard", async () => {
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "no-readable-content" });
-		const { handler, deps } = createHandler({ parseHtml: failedParse });
+		const finalizeArticle: FinalizeArticle = async () => ({ ok: false, reason: "no-readable-content" });
+		const { handler, deps } = createHandler({ finalizeArticle });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
@@ -224,13 +195,13 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 	});
 
 	it("emits a tier-0 failure crawl-outcome before reporting the batch failure, reflecting tier-1's snapshot at emission time", async () => {
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "no-readable-content" });
+		const finalizeArticle: FinalizeArticle = async () => ({ ok: false, reason: "no-readable-content" });
 		const readTierSnapshot = jest.fn().mockResolvedValue({
 			tier0Status: "not_attempted",
 			tier1Status: "success",
 			pickedTier: "tier-1",
 		});
-		const { handler, deps } = createHandler({ parseHtml: failedParse, readTierSnapshot });
+		const { handler, deps } = createHandler({ finalizeArticle, readTierSnapshot });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
@@ -249,13 +220,13 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 	});
 
 	it("emits a tier-0 failure crawl-outcome with otherTierStatus=failed when tier-1 has already failed, distinguishing it from a never-attempted tier-1", async () => {
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "no-readable-content" });
+		const finalizeArticle: FinalizeArticle = async () => ({ ok: false, reason: "no-readable-content" });
 		const readTierSnapshot = jest.fn().mockResolvedValue({
 			tier0Status: "not_attempted",
 			tier1Status: "failed",
 			pickedTier: "none",
 		});
-		const { handler, deps } = createHandler({ parseHtml: failedParse, readTierSnapshot });
+		const { handler, deps } = createHandler({ finalizeArticle, readTierSnapshot });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
@@ -328,76 +299,6 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		);
 	});
 
-	it("extracts og:image from the captured rawHtml and threads it as thumbnailUrl into parseHtml so the tier-0 metadata carries imageUrl", async () => {
-		const rawHtml = `<html><head>
-			<meta property="og:image" content="https://example.com/og.png">
-		</head><body><article><p>Body</p></article></body></html>`;
-		const parseHtml = jest.fn(((_params) => ({
-			ok: true as const,
-			article: {
-				title: "T",
-				siteName: "example.com",
-				excerpt: "e",
-				wordCount: 1,
-				content: "<p>x</p>",
-				imageUrl: "https://example.com/og.png",
-			},
-		})) satisfies ParseHtml);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-		const { handler } = createHandler({
-			readPendingHtml: jest.fn().mockResolvedValue(rawHtml),
-			parseHtml,
-			putTierSource,
-		});
-
-		await handler(
-			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
-
-		expect(parseHtml).toHaveBeenCalledWith({
-			url: "https://example.com/article",
-			html: rawHtml,
-			thumbnailUrl: "https://example.com/og.png",
-		});
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({ imageUrl: "https://example.com/og.png" }),
-			}),
-		);
-	});
-
-	it("passes thumbnailUrl=null when the captured rawHtml exposes no image candidates", async () => {
-		const rawHtml = `<html><head><title>No images</title></head><body><article><p>Body</p></article></body></html>`;
-		const parseHtml = jest.fn(((_params) => ({
-			ok: true as const,
-			article: {
-				title: "T",
-				siteName: "example.com",
-				excerpt: "e",
-				wordCount: 1,
-				content: "<p>x</p>",
-			},
-		})) satisfies ParseHtml);
-		const { handler } = createHandler({
-			readPendingHtml: jest.fn().mockResolvedValue(rawHtml),
-			parseHtml,
-		});
-
-		await handler(
-			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
-
-		expect(parseHtml).toHaveBeenCalledWith({
-			url: "https://example.com/article",
-			html: rawHtml,
-			thumbnailUrl: null,
-		});
-	});
-
 	it("reports the record as a batch failure on invalid event detail (Zod failure)", async () => {
 		const { handler } = createHandler();
 
@@ -418,5 +319,4 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		const result = await handler(invalidEvent, stubContext, () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
-
 });

--- a/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.ts
@@ -11,12 +11,7 @@ import {
 	type LogCrawlOutcome,
 	type LogParseError,
 } from "@packages/hutch-infra-components";
-import { ArticleResourceUniqueId } from "../save-link/article-resource-unique-id";
-import type { ParseHtml } from "@packages/article-parser";
-import { extractFirstThumbnailUrl } from "@packages/crawl-article";
-import type { DownloadMedia } from "../save-link/download-media";
-import type { ProcessContent } from "../save-link/save-link-work";
-import { estimatedReadTimeFromWordCount } from "../save-link/estimated-read-time";
+import type { FinalizeArticle } from "../save-link/finalize-article";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
 import type { ReadPendingHtml } from "../../providers/article-store/read-pending-html";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
@@ -26,9 +21,7 @@ const TIER = "tier-0";
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initSaveLinkRawHtmlCommandHandler(deps: {
 	readPendingHtml: ReadPendingHtml;
-	parseHtml: ParseHtml;
-	downloadMedia: DownloadMedia;
-	processContent: ProcessContent;
+	finalizeArticle: FinalizeArticle;
 	putTierSource: PutTierSource;
 	publishEvent: PublishEvent;
 	transitionAndPersist: TransitionAndPersist;
@@ -39,9 +32,7 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 }): Handler<SQSEvent, SQSBatchResponse> {
 	const {
 		readPendingHtml,
-		parseHtml,
-		downloadMedia,
-		processContent,
+		finalizeArticle,
 		putTierSource,
 		publishEvent,
 		transitionAndPersist,
@@ -60,13 +51,12 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 				const detail = SaveLinkRawHtmlCommand.detailSchema.parse(envelope.detail);
 
 				const rawHtml = await readPendingHtml(detail.url);
-				const parseResult = parseHtml({
+				const finalized = await finalizeArticle({
 					url: detail.url,
 					html: rawHtml,
-					thumbnailUrl: extractFirstThumbnailUrl({ html: rawHtml, baseUrl: detail.url }),
 				});
-				if (!parseResult.ok) {
-					logParseError({ url: detail.url, reason: parseResult.reason });
+				if (!finalized.ok) {
+					logParseError({ url: detail.url, reason: finalized.reason });
 					const snapshot = await readTierSnapshot({ url: detail.url });
 					logCrawlOutcome({
 						url: detail.url,
@@ -86,32 +76,17 @@ export function initSaveLinkRawHtmlCommandHandler(deps: {
 					await transitionAndPersist(markCrawlFailed, {
 						url: detail.url,
 						input: {
-							reason: { kind: "parse-error", detail: parseResult.reason },
+							reason: { kind: "parse-error", detail: finalized.reason },
 						},
 					});
-					throw new Error(`save-link-raw-html parse failed for ${detail.url}: ${parseResult.reason}`);
+					throw new Error(`save-link-raw-html parse failed for ${detail.url}: ${finalized.reason}`);
 				}
-
-				const articleResourceUniqueId = ArticleResourceUniqueId.parse(detail.url);
-				const media = await downloadMedia({
-					html: parseResult.article.content,
-					articleUrl: detail.url,
-					articleResourceUniqueId,
-				});
-				const processedHtml = await processContent({ html: parseResult.article.content, media });
 
 				await putTierSource({
 					url: detail.url,
 					tier: TIER,
-					html: processedHtml,
-					metadata: {
-						title: parseResult.article.title,
-						siteName: parseResult.article.siteName,
-						excerpt: parseResult.article.excerpt,
-						wordCount: parseResult.article.wordCount,
-						estimatedReadTime: estimatedReadTimeFromWordCount(parseResult.article.wordCount),
-						imageUrl: parseResult.article.imageUrl,
-					},
+					html: finalized.article.html,
+					metadata: finalized.article.metadata,
 				});
 				logger.info("[SaveLinkRawHtmlCommand] tier-0 source written", {
 					url: detail.url,

--- a/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.test.ts
@@ -1,0 +1,155 @@
+import type { CrawlArticleResult, SimpleCrawl, ThumbnailImage } from "@packages/crawl-article";
+import { initCrawlAndFinalizeArticle } from "./crawl-and-finalize-article";
+import type { FinalizeArticle, FinalizedArticle } from "./finalize-article";
+
+const URL_UNDER_TEST = "https://example.com/article";
+
+const stubFinalizedArticle: FinalizedArticle = {
+	html: "<p>processed</p>",
+	metadata: {
+		title: "T",
+		siteName: "example.com",
+		excerpt: "e",
+		wordCount: 100,
+		estimatedReadTime: 1,
+		imageUrl: "https://cdn.example.com/content/x/images/abc.jpg",
+	},
+};
+
+const okFinalize: FinalizeArticle = async () => ({ ok: true, article: stubFinalizedArticle });
+
+describe("initCrawlAndFinalizeArticle", () => {
+	it("calls simpleCrawl with fetchThumbnail:true on every invocation (no opt-in flag per caller)", async () => {
+		const simpleCrawl = jest.fn<Promise<CrawlArticleResult>, Parameters<SimpleCrawl>>(async () => ({
+			status: "fetched",
+			html: "<html></html>",
+		}));
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl,
+			finalizeArticle: okFinalize,
+		});
+
+		await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(simpleCrawl).toHaveBeenCalledWith(expect.objectContaining({
+			url: URL_UNDER_TEST,
+			fetchThumbnail: true,
+		}));
+	});
+
+	it("forwards etag and lastModified so the crawler can short-circuit to not-modified (stale-check path)", async () => {
+		const simpleCrawl = jest.fn<Promise<CrawlArticleResult>, Parameters<SimpleCrawl>>(async () => ({
+			status: "not-modified",
+		}));
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl,
+			finalizeArticle: okFinalize,
+		});
+
+		await crawlAndFinalize({
+			url: URL_UNDER_TEST,
+			etag: '"abc"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
+		});
+
+		expect(simpleCrawl).toHaveBeenCalledWith(expect.objectContaining({
+			etag: '"abc"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
+		}));
+	});
+
+	it("maps the crawler's not-modified status through to the caller (stale-check uses this to publish UpdateFetchTimestamp)", async () => {
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl: async () => ({ status: "not-modified" }),
+			finalizeArticle: okFinalize,
+		});
+
+		const result = await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(result).toEqual({ status: "not-modified" });
+	});
+
+	it("maps the crawler's unsupported status through with the reason (save-link-work defers to comprehensive crawl)", async () => {
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl: async () => ({ status: "unsupported", reason: "non-html content type: application/pdf" }),
+			finalizeArticle: okFinalize,
+		});
+
+		const result = await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(result).toEqual({
+			status: "unsupported",
+			reason: "non-html content type: application/pdf",
+		});
+	});
+
+	it("maps the crawler's failed status to status:failed with a stable reason", async () => {
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl: async () => ({ status: "failed" }),
+			finalizeArticle: okFinalize,
+		});
+
+		const result = await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(result).toEqual({ status: "failed", reason: "crawl-failed" });
+	});
+
+	it("threads the crawler's pre-fetched thumbnailImage into finalizeArticle so no second image fetch fires for the SimpleCrawl path", async () => {
+		const preFetched: ThumbnailImage = {
+			body: Buffer.from([0xff, 0xd8, 0xff]),
+			contentType: "image/jpeg",
+			url: "https://example.com/og.jpg",
+			extension: ".jpg",
+		};
+		const finalizeArticle = jest.fn(okFinalize);
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl: async () => ({
+				status: "fetched",
+				html: "<html></html>",
+				thumbnailUrl: "https://example.com/og.jpg",
+				thumbnailImage: preFetched,
+			}),
+			finalizeArticle,
+		});
+
+		await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(finalizeArticle).toHaveBeenCalledWith({
+			url: URL_UNDER_TEST,
+			html: "<html></html>",
+			preFetchedThumbnail: preFetched,
+		});
+	});
+
+	it("returns the finalizer's parse failure verbatim so callers can drive the markCrawlFailed transition", async () => {
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl: async () => ({ status: "fetched", html: "<html></html>" }),
+			finalizeArticle: async () => ({ ok: false, reason: "readability crashed" }),
+		});
+
+		const result = await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(result).toEqual({ status: "failed", reason: "readability crashed" });
+	});
+
+	it("returns the finalized article + freshness headers on success so callers persist etag/lastModified", async () => {
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			simpleCrawl: async () => ({
+				status: "fetched",
+				html: "<html></html>",
+				etag: '"v1"',
+				lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
+			}),
+			finalizeArticle: okFinalize,
+		});
+
+		const result = await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(result).toEqual({
+			status: "fetched",
+			article: stubFinalizedArticle,
+			etag: '"v1"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
+		});
+	});
+});

--- a/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.ts
+++ b/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.ts
@@ -1,0 +1,67 @@
+import type { SimpleCrawl } from "@packages/crawl-article";
+import type { FinalizeArticle, FinalizedArticle } from "./finalize-article";
+
+export type CrawlAndFinalizeResult =
+	| {
+			status: "fetched";
+			article: FinalizedArticle;
+			etag?: string;
+			lastModified?: string;
+		}
+	| { status: "not-modified" }
+	| { status: "failed"; reason: string }
+	| { status: "unsupported"; reason: string };
+
+export type CrawlAndFinalizeArticle = (params: {
+	url: string;
+	etag?: string;
+	lastModified?: string;
+}) => Promise<CrawlAndFinalizeResult>;
+
+/**
+ * The ONE entry point for every URL-based article path: initial save, recrawl,
+ * stale-check, dev wrappers. Composes SimpleCrawl (always with
+ * `fetchThumbnail: true`) with `finalizeArticle`, so no caller has to remember
+ * to thread the thumbnail through — the upload happens for every fetch.
+ *
+ * Conditional etag/lastModified are forwarded to the crawler so stale-check
+ * can still short-circuit on `not-modified`; other statuses (failed,
+ * unsupported) are mapped through to the caller for handler-specific
+ * post-processing (publish event, write tier source, etc.).
+ */
+export function initCrawlAndFinalizeArticle(deps: {
+	simpleCrawl: SimpleCrawl;
+	finalizeArticle: FinalizeArticle;
+}): CrawlAndFinalizeArticle {
+	const { simpleCrawl, finalizeArticle } = deps;
+	return async (params) => {
+		const crawlResult = await simpleCrawl({
+			url: params.url,
+			etag: params.etag,
+			lastModified: params.lastModified,
+			fetchThumbnail: true,
+		});
+
+		if (crawlResult.status === "not-modified") return { status: "not-modified" };
+		if (crawlResult.status === "unsupported") {
+			return { status: "unsupported", reason: crawlResult.reason };
+		}
+		if (crawlResult.status === "failed") {
+			return { status: "failed", reason: "crawl-failed" };
+		}
+
+		const finalized = await finalizeArticle({
+			url: params.url,
+			html: crawlResult.html,
+			preFetchedThumbnail: crawlResult.thumbnailImage,
+		});
+		if (!finalized.ok) return { status: "failed", reason: finalized.reason };
+
+		return {
+			status: "fetched",
+			article: finalized.article,
+			etag: crawlResult.etag,
+			lastModified: crawlResult.lastModified,
+		};
+	};
+}

--- a/projects/save-link/src/runtime/domain/save-link/finalize-article.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/finalize-article.test.ts
@@ -1,0 +1,221 @@
+import type { ParseHtml } from "@packages/article-parser";
+import type { FetchThumbnailImage, ThumbnailImage } from "@packages/crawl-article";
+import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
+import type { DownloadMedia } from "./download-media";
+import {
+	initFinalizeArticle,
+	type ProcessContent,
+} from "./finalize-article";
+
+const URL_UNDER_TEST = "https://example.com/article";
+
+const stubParseHtml: ParseHtml = (params) => ({
+	ok: true,
+	article: {
+		title: "T",
+		siteName: "example.com",
+		excerpt: "e",
+		wordCount: 100,
+		content: `<p>${params.html.length} chars</p>`,
+		imageUrl: params.thumbnailUrl ?? undefined,
+	},
+});
+
+const noopDownloadMedia: DownloadMedia = async () => [];
+const noopProcessContent: ProcessContent = async ({ html }) => html;
+const noopFetchThumbnailImage: FetchThumbnailImage = async () => undefined;
+const noopPutImageObject: PutImageObject = async () => {};
+
+function createFinalize(overrides: {
+	parseHtml?: ParseHtml;
+	downloadMedia?: DownloadMedia;
+	processContent?: ProcessContent;
+	fetchThumbnailImage?: FetchThumbnailImage;
+	putImageObject?: PutImageObject;
+	imagesCdnBaseUrl?: string;
+} = {}) {
+	return initFinalizeArticle({
+		parseHtml: overrides.parseHtml ?? stubParseHtml,
+		downloadMedia: overrides.downloadMedia ?? noopDownloadMedia,
+		processContent: overrides.processContent ?? noopProcessContent,
+		fetchThumbnailImage: overrides.fetchThumbnailImage ?? noopFetchThumbnailImage,
+		putImageObject: overrides.putImageObject ?? noopPutImageObject,
+		imagesCdnBaseUrl: overrides.imagesCdnBaseUrl ?? "https://cdn.example.com",
+	});
+}
+
+describe("initFinalizeArticle", () => {
+	it("returns ok:false with the parser's reason when parseHtml fails", async () => {
+		const finalize = createFinalize({
+			parseHtml: () => ({ ok: false, reason: "readability crashed" }),
+		});
+
+		const result = await finalize({ url: URL_UNDER_TEST, html: "<html></html>" });
+
+		expect(result).toEqual({ ok: false, reason: "readability crashed" });
+	});
+
+	it("extracts og:image from the html and passes it to parseHtml as thumbnailUrl", async () => {
+		const parseHtml = jest.fn(stubParseHtml);
+		const finalize = createFinalize({ parseHtml });
+		const html = `<html><head>
+			<meta property="og:image" content="https://example.com/og.png">
+		</head><body><p>Body</p></body></html>`;
+
+		await finalize({ url: URL_UNDER_TEST, html });
+
+		expect(parseHtml).toHaveBeenCalledWith({
+			url: URL_UNDER_TEST,
+			html,
+			thumbnailUrl: "https://example.com/og.png",
+		});
+	});
+
+	it("passes thumbnailUrl=null to parseHtml when the html exposes no image candidates", async () => {
+		const parseHtml = jest.fn(stubParseHtml);
+		const finalize = createFinalize({ parseHtml });
+		const html = `<html><head><title>No images</title></head><body><p>Body</p></body></html>`;
+
+		await finalize({ url: URL_UNDER_TEST, html });
+
+		expect(parseHtml).toHaveBeenCalledWith({
+			url: URL_UNDER_TEST,
+			html,
+			thumbnailUrl: null,
+		});
+	});
+
+	it("skips the standalone fetchThumbnailImage call when the caller supplied a preFetchedThumbnail (avoids a redundant network fetch on the SimpleCrawl path)", async () => {
+		const preFetchedThumbnail: ThumbnailImage = {
+			body: Buffer.from([0xff, 0xd8, 0xff]),
+			contentType: "image/jpeg",
+			url: "https://example.com/og.jpg",
+			extension: ".jpg",
+		};
+		const fetchThumbnailImage = jest.fn(noopFetchThumbnailImage);
+		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
+		const finalize = createFinalize({ fetchThumbnailImage, putImageObject });
+		const html = `<html><head>
+			<meta property="og:image" content="https://example.com/og.jpg">
+		</head><body><p>Body</p></body></html>`;
+
+		const result = await finalize({ url: URL_UNDER_TEST, html, preFetchedThumbnail });
+
+		expect(fetchThumbnailImage).not.toHaveBeenCalled();
+		expect(putImageObject).toHaveBeenCalledWith(expect.objectContaining({
+			body: preFetchedThumbnail.body,
+			contentType: "image/jpeg",
+		}));
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.metadata.imageUrl).toMatch(/^https:\/\/cdn\.example\.com\/content\/.+\.jpg$/);
+		}
+	});
+
+	it("fetches the og:image cascade itself when no preFetchedThumbnail is supplied (raw-HTML and comprehensive paths)", async () => {
+		const fetchedThumbnail: ThumbnailImage = {
+			body: Buffer.from([0xff, 0xd8, 0xff]),
+			contentType: "image/jpeg",
+			url: "https://example.com/og.jpg",
+			extension: ".jpg",
+		};
+		const fetchThumbnailImage = jest.fn().mockResolvedValue(fetchedThumbnail);
+		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
+		const finalize = createFinalize({ fetchThumbnailImage, putImageObject });
+		const html = `<html><head>
+			<meta property="og:image" content="https://example.com/og.jpg">
+		</head><body><p>Body</p></body></html>`;
+
+		const result = await finalize({ url: URL_UNDER_TEST, html });
+
+		expect(fetchThumbnailImage).toHaveBeenCalledWith({
+			candidates: ["https://example.com/og.jpg"],
+			referer: URL_UNDER_TEST,
+		});
+		expect(putImageObject).toHaveBeenCalled();
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.metadata.imageUrl).toMatch(/^https:\/\/cdn\.example\.com\/content\/.+\.jpg$/);
+		}
+	});
+
+	it("falls back to the parser's raw imageUrl when fetchThumbnailImage returns undefined (origin blocked the hotlinked image)", async () => {
+		const finalize = createFinalize({
+			fetchThumbnailImage: async () => undefined,
+		});
+		const html = `<html><head>
+			<meta property="og:image" content="https://example.com/og.jpg">
+		</head><body><p>Body</p></body></html>`;
+
+		const result = await finalize({ url: URL_UNDER_TEST, html });
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.metadata.imageUrl).toBe("https://example.com/og.jpg");
+		}
+	});
+
+	it("uploads the thumbnail under a stable sha256-derived key so re-saves of the same image hit the CDN's existing entry", async () => {
+		const thumbnail: ThumbnailImage = {
+			body: Buffer.from([0xff, 0xd8, 0xff]),
+			contentType: "image/jpeg",
+			url: "https://cdn.example/identical.jpg",
+			extension: ".jpg",
+		};
+		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
+		const finalize = createFinalize({ putImageObject });
+
+		const result = await finalize({
+			url: URL_UNDER_TEST,
+			html: "<html><body></body></html>",
+			preFetchedThumbnail: thumbnail,
+		});
+
+		expect(putImageObject).toHaveBeenCalledWith(expect.objectContaining({
+			key: expect.stringMatching(/^content\/.+\/images\/[0-9a-f]{16}\.jpg$/),
+		}));
+		expect(result.ok).toBe(true);
+	});
+
+	it("threads downloaded media through processContent so the persisted html references the CDN URLs", async () => {
+		const downloadMedia: DownloadMedia = async () => [
+			{ originalUrl: "https://example.com/inline.png", cdnUrl: "https://cdn.example/inline.png" },
+		];
+		const processContent: ProcessContent = jest.fn(async ({ media }) => {
+			return media.map((m) => `<img src="${m.cdnUrl}">`).join("");
+		});
+		const finalize = createFinalize({ downloadMedia, processContent });
+
+		const result = await finalize({ url: URL_UNDER_TEST, html: "<html><body><p>Body</p></body></html>" });
+
+		expect(processContent).toHaveBeenCalled();
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.html).toContain("https://cdn.example/inline.png");
+		}
+	});
+
+	it("computes estimatedReadTime from wordCount so the metadata sidecar carries it consistently across triggers", async () => {
+		const finalize = createFinalize({
+			parseHtml: () => ({
+				ok: true,
+				article: {
+					title: "T",
+					siteName: "s",
+					excerpt: "e",
+					wordCount: 500,
+					content: "<p>x</p>",
+					imageUrl: undefined,
+				},
+			}),
+		});
+
+		const result = await finalize({ url: URL_UNDER_TEST, html: "<html></html>" });
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.metadata.wordCount).toBe(500);
+			expect(result.article.metadata.estimatedReadTime).toBeGreaterThan(0);
+		}
+	});
+});

--- a/projects/save-link/src/runtime/domain/save-link/finalize-article.ts
+++ b/projects/save-link/src/runtime/domain/save-link/finalize-article.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import type { ParseHtml } from "@packages/article-parser";
+import {
+	extractThumbnailCandidates,
+	type FetchThumbnailImage,
+	type ThumbnailImage,
+} from "@packages/crawl-article";
+import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
+import { ArticleResourceUniqueId } from "./article-resource-unique-id";
+import type { DownloadMedia, DownloadedMedia } from "./download-media";
+import { estimatedReadTimeFromWordCount } from "./estimated-read-time";
+
+export type ProcessContent = (params: { html: string; media: DownloadedMedia[] }) => Promise<string>;
+
+export type FinalizedArticle = {
+	/** Processed body HTML with media URLs rewritten to the CDN. */
+	html: string;
+	metadata: {
+		title: string;
+		siteName: string;
+		excerpt: string;
+		wordCount: number;
+		estimatedReadTime: number;
+		imageUrl?: string;
+	};
+};
+
+export type FinalizeArticleResult =
+	| { ok: true; article: FinalizedArticle }
+	| { ok: false; reason: string };
+
+export type FinalizeArticle = (input: {
+	url: string;
+	html: string;
+	/** Image bytes that the crawler already fetched inline (SimpleCrawl with
+	 * `fetchThumbnail: true`). When present, skip the re-fetch and just upload.
+	 * When absent (raw-HTML save, comprehensive crawl), the finalizer fetches
+	 * the cascade of og:image / twitter:image / first-<img> candidates itself. */
+	preFetchedThumbnail?: ThumbnailImage;
+}) => Promise<FinalizeArticleResult>;
+
+/**
+ * The single source of truth for turning a raw HTML body into the canonical
+ * `{ html, metadata }` pair that gets persisted as a tier source. Every path
+ * that produces an article representation routes through here: SimpleCrawl
+ * save / recrawl, ComprehensiveCrawl PDF, stale-check refresh, browser-extension
+ * raw-HTML save, dev in-memory wrappers. Steps run in the same order for every
+ * caller — parseHtml → downloadMedia → processContent → fetch og:image (if not
+ * pre-fetched) → uploadThumbnail — so the resulting metadata.imageUrl always
+ * either points to the Readplace CDN (image fetch succeeded) or falls back to
+ * the raw og:image URL (image fetch failed), never silently goes missing.
+ */
+export function initFinalizeArticle(deps: {
+	parseHtml: ParseHtml;
+	downloadMedia: DownloadMedia;
+	processContent: ProcessContent;
+	fetchThumbnailImage: FetchThumbnailImage;
+	putImageObject: PutImageObject;
+	imagesCdnBaseUrl: string;
+}): FinalizeArticle {
+	const {
+		parseHtml,
+		downloadMedia,
+		processContent,
+		fetchThumbnailImage,
+		putImageObject,
+		imagesCdnBaseUrl,
+	} = deps;
+
+	return async (input) => {
+		const candidates = extractThumbnailCandidates({ html: input.html, baseUrl: input.url });
+		const thumbnailUrl = candidates[0] ?? null;
+
+		const parseResult = parseHtml({
+			url: input.url,
+			html: input.html,
+			thumbnailUrl,
+		});
+		if (!parseResult.ok) return { ok: false, reason: parseResult.reason };
+
+		const { article } = parseResult;
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(input.url);
+
+		const media = await downloadMedia({
+			html: article.content,
+			articleUrl: input.url,
+			articleResourceUniqueId,
+		});
+		const html = await processContent({ html: article.content, media });
+
+		const thumbnailImage =
+			input.preFetchedThumbnail
+			?? (await fetchThumbnailImage({ candidates, referer: input.url }));
+
+		const imageUrl = thumbnailImage
+			? await uploadThumbnail({
+					thumbnailImage,
+					articleResourceUniqueId,
+					putImageObject,
+					imagesCdnBaseUrl,
+				})
+			: article.imageUrl;
+
+		return {
+			ok: true,
+			article: {
+				html,
+				metadata: {
+					title: article.title,
+					siteName: article.siteName,
+					excerpt: article.excerpt,
+					wordCount: article.wordCount,
+					estimatedReadTime: estimatedReadTimeFromWordCount(article.wordCount),
+					imageUrl,
+				},
+			},
+		};
+	};
+}
+
+async function uploadThumbnail(args: {
+	thumbnailImage: ThumbnailImage;
+	articleResourceUniqueId: ArticleResourceUniqueId;
+	putImageObject: PutImageObject;
+	imagesCdnBaseUrl: string;
+}): Promise<string> {
+	const { thumbnailImage, articleResourceUniqueId, putImageObject, imagesCdnBaseUrl } = args;
+	const hash = createHash("sha256").update(thumbnailImage.url).digest("hex").slice(0, 16);
+	const filename = `${hash}${thumbnailImage.extension}`;
+	const key = articleResourceUniqueId.toS3ImageKey(filename);
+	await putImageObject({ key, body: thumbnailImage.body, contentType: thumbnailImage.contentType });
+	return articleResourceUniqueId.toImageCdnUrl({ baseUrl: imagesCdnBaseUrl, filename });
+}

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
@@ -1,12 +1,8 @@
-import posthtml from "posthtml";
-import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
 import { RecrawlContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initRecrawlLinkInitiatedHandler } from "./recrawl-link-initiated-handler";
-import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "./download-media";
+import type { CrawlAndFinalizeArticle, CrawlAndFinalizeResult } from "./crawl-and-finalize-article";
+import type { FinalizedArticle } from "./finalize-article";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
 
@@ -48,30 +44,26 @@ function createSqsEvent(detail: { url: string }): SQSEvent {
 	};
 }
 
-const noopDownloadMedia: DownloadMedia = async () => [];
-
-const processContent = initProcessContentWithLocalMedia({
-	rewriteHtmlUrls: (html, rewriteUrl) => {
-		const plugin = urls({ eachURL: rewriteUrl });
-		return posthtml().use(plugin).process(html).then(result => result.html);
+const stubFinalizedArticle: FinalizedArticle = {
+	html: "<p>Article content</p>",
+	metadata: {
+		title: "Test",
+		siteName: "example.com",
+		excerpt: "test",
+		wordCount: 10,
+		estimatedReadTime: 1,
+		imageUrl: undefined,
 	},
-});
+};
 
-const successfulSimpleCrawl: SimpleCrawl = async () => ({
+const fetchedResult: CrawlAndFinalizeResult = {
 	status: "fetched",
-	html: "<html><body><p>Article content</p></body></html>",
-});
+	article: stubFinalizedArticle,
+};
 
 const rejectingEmitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported = async () => {
 	throw new Error("emitSimpleCrawlUnsupported invoked unexpectedly");
 };
-
-const successfulParse: ParseHtml = () => ({
-	ok: true,
-	article: { title: "Test", siteName: "example.com", excerpt: "test", wordCount: 10, content: "<p>Article content</p>" },
-});
-
-const imagesCdnBaseUrl = "https://cdn.example.com";
 
 type HandlerDeps = Parameters<typeof initRecrawlLinkInitiatedHandler>[0];
 
@@ -79,18 +71,13 @@ const fixedNow = () => new Date("2026-04-30T12:00:00.000Z");
 
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	return initRecrawlLinkInitiatedHandler({
-		simpleCrawl: successfulSimpleCrawl,
+		crawlAndFinalizeArticle: (async () => fetchedResult) as CrawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported: rejectingEmitSimpleCrawlUnsupported,
-		parseHtml: successfulParse,
 		putTierSource: jest.fn().mockResolvedValue(undefined),
-		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
-		downloadMedia: noopDownloadMedia,
-		processContent,
-		imagesCdnBaseUrl,
 		now: fixedNow,
 		logger: noopLogger,
 		logParseError: jest.fn(),
@@ -113,14 +100,11 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 		});
 	});
 
-	it("reports the record as a batch failure when saveLinkWork throws on a failed crawl (so SQS redelivers just that record)", async () => {
-		const failingSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+	it("reports the record as a batch failure when crawl-and-finalize fails (so SQS redelivers just that record)", async () => {
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
-		const handler = createHandler({
-			simpleCrawl: failingSimpleCrawl,
-			publishEvent,
-		});
+		const handler = createHandler({ crawlAndFinalizeArticle, publishEvent });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/unreachable" }),
@@ -132,20 +116,20 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 
-	it("emits SimpleCrawlUnsupportedEvent with recrawl=true when simpleCrawl returns unsupported and does NOT publish RecrawlContentExtractedEvent itself (the policy → comprehensive chain will)", async () => {
+	it("emits SimpleCrawlUnsupportedEvent with recrawl=true when the crawl returns unsupported and does NOT publish RecrawlContentExtractedEvent itself (the policy → comprehensive chain will)", async () => {
 		const emitSimpleCrawlUnsupported = jest.fn<
 			ReturnType<EmitSimpleCrawlUnsupported>,
 			Parameters<EmitSimpleCrawlUnsupported>
 		>().mockResolvedValue(undefined);
 		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
-		const unsupportedSimpleCrawl: SimpleCrawl = async () => ({
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({
 			status: "unsupported",
 			reason: "non-html content type: application/pdf",
 		});
 
 		const handler = createHandler({
-			simpleCrawl: unsupportedSimpleCrawl,
+			crawlAndFinalizeArticle,
 			emitSimpleCrawlUnsupported,
 			transitionAndPersist,
 			publishEvent,

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.ts
@@ -1,6 +1,5 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import {
@@ -8,29 +7,22 @@ import {
 	RecrawlContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "./download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
-import { initSaveLinkWork, type ProcessContent } from "./save-link-work";
+import { initSaveLinkWork } from "./save-link-work";
+import type { CrawlAndFinalizeArticle } from "./crawl-and-finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 
 export function initRecrawlLinkInitiatedHandler(deps: {
-	simpleCrawl: SimpleCrawl;
+	crawlAndFinalizeArticle: CrawlAndFinalizeArticle;
 	emitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported;
-	parseHtml: ParseHtml;
 	putTierSource: PutTierSource;
-	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
 	publishEvent: PublishEvent;
-	downloadMedia: DownloadMedia;
-	processContent: ProcessContent;
-	imagesCdnBaseUrl: string;
 	now: () => Date;
 	logger: HutchLogger;
 	logParseError: LogParseError;
@@ -40,17 +32,12 @@ export function initRecrawlLinkInitiatedHandler(deps: {
 	const { publishEvent, logger } = deps;
 
 	const { saveLinkWork } = initSaveLinkWork({
-		simpleCrawl: deps.simpleCrawl,
+		crawlAndFinalizeArticle: deps.crawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported: deps.emitSimpleCrawlUnsupported,
-		parseHtml: deps.parseHtml,
 		putTierSource: deps.putTierSource,
-		putImageObject: deps.putImageObject,
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
-		downloadMedia: deps.downloadMedia,
-		processContent: deps.processContent,
-		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,
 		now: deps.now,
 		logger,
 		logParseError: deps.logParseError,

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
@@ -1,13 +1,9 @@
-import posthtml from "posthtml";
-import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
 import { markCrawlFailed } from "@packages/domain/article-aggregate";
 import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveAnonymousLinkCommandHandler } from "./save-anonymous-link-command-handler";
-import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "./download-media";
+import type { CrawlAndFinalizeArticle, CrawlAndFinalizeResult } from "./crawl-and-finalize-article";
+import type { FinalizedArticle } from "./finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
@@ -50,49 +46,40 @@ function createSqsEvent(detail: { url: string }): SQSEvent {
 	};
 }
 
-const noopDownloadMedia: DownloadMedia = async () => [];
-
-const processContent = initProcessContentWithLocalMedia({
-	rewriteHtmlUrls: (html, rewriteUrl) => {
-		const plugin = urls({ eachURL: rewriteUrl });
-		return posthtml().use(plugin).process(html).then(result => result.html);
+const stubFinalizedArticle: FinalizedArticle = {
+	html: "<p>Article content</p>",
+	metadata: {
+		title: "Test",
+		siteName: "example.com",
+		excerpt: "test",
+		wordCount: 10,
+		estimatedReadTime: 1,
+		imageUrl: undefined,
 	},
-});
+};
 
-const successfulSimpleCrawl: SimpleCrawl = async () => ({
+const fetchedResult: CrawlAndFinalizeResult = {
 	status: "fetched",
-	html: "<html><body><p>Article content</p></body></html>",
-});
+	article: stubFinalizedArticle,
+};
 
 const rejectingEmitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported = async () => {
 	throw new Error("emitSimpleCrawlUnsupported invoked unexpectedly");
 };
 
-const successfulParse: ParseHtml = () => ({
-	ok: true,
-	article: { title: "Test", siteName: "example.com", excerpt: "test", wordCount: 10, content: "<p>Article content</p>" },
-});
-
-const imagesCdnBaseUrl = "https://cdn.example.com";
-
 type HandlerDeps = Parameters<typeof initSaveAnonymousLinkCommandHandler>[0];
 
-const fixedNow = () => new Date("2026-04-18T12:00:00.000Z");
+const fixedNow = () => new Date("2026-04-30T12:00:00.000Z");
 
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	return initSaveAnonymousLinkCommandHandler({
-		simpleCrawl: successfulSimpleCrawl,
+		crawlAndFinalizeArticle: (async () => fetchedResult) as CrawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported: rejectingEmitSimpleCrawlUnsupported,
-		parseHtml: successfulParse,
 		putTierSource: jest.fn().mockResolvedValue(undefined),
-		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
-		downloadMedia: noopDownloadMedia,
-		processContent,
-		imagesCdnBaseUrl,
 		now: fixedNow,
 		logger: noopLogger,
 		logParseError: jest.fn(),
@@ -121,11 +108,11 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 	});
 
 	it("does not write a tier source or publish anything when the crawl fails (record reported as batch failure)", async () => {
-		const failedSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
-		const handler = createHandler({ simpleCrawl: failedSimpleCrawl, putTierSource, publishEvent });
+		const handler = createHandler({ crawlAndFinalizeArticle, putTierSource, publishEvent });
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/unreachable" }),
@@ -138,64 +125,35 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 
-	it("reports crawl failures via logParseError with the crawl status as reason (record routed to batchItemFailures for SQS retry)", async () => {
+	it("reports crawl failures via logParseError so the parse-errors dashboard reflects them", async () => {
 		const logParseError = jest.fn();
-		const failedSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 
-		const handler = createHandler({ simpleCrawl: failedSimpleCrawl, logParseError });
+		const handler = createHandler({ crawlAndFinalizeArticle, logParseError });
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/unreachable" }),
-			stubContext,
-			() => {},
-		);
+		await handler(createSqsEvent({ url: "https://example.com/unreachable" }), stubContext, () => {});
 
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(logParseError).toHaveBeenCalledWith({
 			url: "https://example.com/unreachable",
 			reason: "crawl-failed",
 		});
 	});
 
-	it("reports parse failures via logParseError with the parser's reason (record routed to batchItemFailures for SQS retry)", async () => {
-		const logParseError = jest.fn();
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Invalid URL" });
-
-		const handler = createHandler({ parseHtml: failedParse, logParseError });
-
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/bad" }),
-			stubContext,
-			() => {},
-		);
-
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(logParseError).toHaveBeenCalledWith({
-			url: "https://example.com/bad",
-			reason: "Invalid URL",
-		});
-	});
-
-	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist so /view + /admin/recrawl polling see failure at t+0", async () => {
+	it("routes terminal parse-error failures through markCrawlFailed via transitionAndPersist so /view + /admin/recrawl polling see failure at t+0", async () => {
 		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability crashed on this DOM" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "Readability crashed on this DOM" });
 
-		const handler = createHandler({ parseHtml: failedParse, transitionAndPersist });
+		const handler = createHandler({ crawlAndFinalizeArticle, transitionAndPersist });
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/bad" }),
-			stubContext,
-			() => {},
-		);
+		await handler(createSqsEvent({ url: "https://example.com/bad" }), stubContext, () => {});
 
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/bad",
 			input: { reason: { kind: "parse-error", detail: "Readability crashed on this DOM" } },
 		});
 	});
 
-	it("emits SimpleCrawlUnsupportedEvent without userId when simpleCrawl returns unsupported (anonymous path)", async () => {
+	it("emits SimpleCrawlUnsupportedEvent without userId when the crawl returns unsupported (anonymous path)", async () => {
 		const emitSimpleCrawlUnsupported = jest.fn<
 			ReturnType<EmitSimpleCrawlUnsupported>,
 			Parameters<EmitSimpleCrawlUnsupported>
@@ -203,13 +161,13 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-		const unsupportedSimpleCrawl: SimpleCrawl = async () => ({
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({
 			status: "unsupported",
 			reason: "non-html content type: application/pdf",
 		});
 
 		const handler = createHandler({
-			simpleCrawl: unsupportedSimpleCrawl,
+			crawlAndFinalizeArticle,
 			emitSimpleCrawlUnsupported,
 			transitionAndPersist,
 			publishEvent,

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.ts
@@ -1,6 +1,5 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import {
@@ -8,29 +7,22 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "./download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
-import { initSaveLinkWork, type ProcessContent } from "./save-link-work";
+import { initSaveLinkWork } from "./save-link-work";
+import type { CrawlAndFinalizeArticle } from "./crawl-and-finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 
 export function initSaveAnonymousLinkCommandHandler(deps: {
-	simpleCrawl: SimpleCrawl;
+	crawlAndFinalizeArticle: CrawlAndFinalizeArticle;
 	emitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported;
-	parseHtml: ParseHtml;
 	putTierSource: PutTierSource;
-	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
 	publishEvent: PublishEvent;
-	downloadMedia: DownloadMedia;
-	processContent: ProcessContent;
-	imagesCdnBaseUrl: string;
 	now: () => Date;
 	logger: HutchLogger;
 	logParseError: LogParseError;
@@ -40,17 +32,12 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 	const { publishEvent, logger } = deps;
 
 	const { saveLinkWork } = initSaveLinkWork({
-		simpleCrawl: deps.simpleCrawl,
+		crawlAndFinalizeArticle: deps.crawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported: deps.emitSimpleCrawlUnsupported,
-		parseHtml: deps.parseHtml,
 		putTierSource: deps.putTierSource,
-		putImageObject: deps.putImageObject,
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
-		downloadMedia: deps.downloadMedia,
-		processContent: deps.processContent,
-		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,
 		now: deps.now,
 		logger,
 		logParseError: deps.logParseError,

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
@@ -1,14 +1,9 @@
-import posthtml from "posthtml";
-import urls from "@11ty/posthtml-urls";
 import { noopLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
 import { markCrawlFailed } from "@packages/domain/article-aggregate";
 import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveLinkCommandHandler } from "./save-link-command-handler";
-import { initProcessContentWithLocalMedia } from "./process-content-with-local-media";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "./download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
+import type { CrawlAndFinalizeArticle, CrawlAndFinalizeResult } from "./crawl-and-finalize-article";
+import type { FinalizedArticle } from "./finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
@@ -51,30 +46,26 @@ function createSqsEvent(detail: { url: string; userId: string }): SQSEvent {
 	};
 }
 
-const noopDownloadMedia: DownloadMedia = async () => [];
-
-const processContent = initProcessContentWithLocalMedia({
-	rewriteHtmlUrls: (html, rewriteUrl) => {
-		const plugin = urls({ eachURL: rewriteUrl });
-		return posthtml().use(plugin).process(html).then(result => result.html);
+const stubFinalizedArticle: FinalizedArticle = {
+	html: "<p>Article content</p>",
+	metadata: {
+		title: "Test",
+		siteName: "example.com",
+		excerpt: "test",
+		wordCount: 10,
+		estimatedReadTime: 1,
+		imageUrl: undefined,
 	},
-});
+};
 
-const successfulSimpleCrawl: SimpleCrawl = async () => ({
+const fetchedResult: CrawlAndFinalizeResult = {
 	status: "fetched",
-	html: "<html><body><p>Article content</p></body></html>",
-});
+	article: stubFinalizedArticle,
+};
 
 const rejectingEmitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported = async () => {
 	throw new Error("emitSimpleCrawlUnsupported invoked unexpectedly");
 };
-
-const successfulParse: ParseHtml = () => ({
-	ok: true,
-	article: { title: "Test", siteName: "example.com", excerpt: "test", wordCount: 10, content: "<p>Article content</p>" },
-});
-
-const imagesCdnBaseUrl = "https://cdn.example.com";
 
 type HandlerDeps = Parameters<typeof initSaveLinkCommandHandler>[0];
 
@@ -82,18 +73,13 @@ const fixedNow = () => new Date("2026-04-18T12:00:00.000Z");
 
 function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	return initSaveLinkCommandHandler({
-		simpleCrawl: successfulSimpleCrawl,
+		crawlAndFinalizeArticle: (async () => fetchedResult) as CrawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported: rejectingEmitSimpleCrawlUnsupported,
-		parseHtml: successfulParse,
 		putTierSource: jest.fn().mockResolvedValue(undefined),
-		putImageObject: jest.fn().mockResolvedValue(undefined),
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
-		downloadMedia: noopDownloadMedia,
-		processContent,
-		imagesCdnBaseUrl,
 		now: fixedNow,
 		logger: noopLogger,
 		logParseError: jest.fn(),
@@ -104,7 +90,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 }
 
 describe("initSaveLinkCommandHandler", () => {
-	it("writes a tier-1 source with metadata and emits TierContentExtractedEvent carrying userId", async () => {
+	it("writes a tier-1 source with the finalizer's metadata and emits TierContentExtractedEvent carrying userId", async () => {
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 
@@ -115,17 +101,9 @@ describe("initSaveLinkCommandHandler", () => {
 		expect(putTierSource).toHaveBeenCalledWith({
 			url: "https://example.com/article",
 			tier: "tier-1",
-			html: "<p>Article content</p>",
-			metadata: {
-				title: "Test",
-				siteName: "example.com",
-				excerpt: "test",
-				wordCount: 10,
-				estimatedReadTime: 1,
-				imageUrl: undefined,
-			},
+			html: stubFinalizedArticle.html,
+			metadata: stubFinalizedArticle.metadata,
 		});
-
 		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
 			url: "https://example.com/article",
 			tier: "tier-1",
@@ -147,34 +125,33 @@ describe("initSaveLinkCommandHandler", () => {
 
 	it("records contentFetchedAt + etag + lastModified after a successful fetch so future saves can short-circuit on TTL", async () => {
 		const updateFetchTimestamp = jest.fn().mockResolvedValue(undefined);
-		const simpleCrawl: SimpleCrawl = async () => ({
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({
 			status: "fetched",
-			html: "<html><body><p>Article content</p></body></html>",
-			etag: '"abc123"',
-			lastModified: "Wed, 15 Apr 2026 10:00:00 GMT",
+			article: stubFinalizedArticle,
+			etag: '"v1"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
 		});
-
-		const handler = createHandler({ simpleCrawl, updateFetchTimestamp });
+		const handler = createHandler({ crawlAndFinalizeArticle, updateFetchTimestamp });
 
 		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
 		expect(updateFetchTimestamp).toHaveBeenCalledWith({
 			url: "https://example.com/article",
-			contentFetchedAt: "2026-04-18T12:00:00.000Z",
-			etag: '"abc123"',
-			lastModified: "Wed, 15 Apr 2026 10:00:00 GMT",
+			contentFetchedAt: fixedNow().toISOString(),
+			etag: '"v1"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
 		});
 	});
 
 	it("does not write a tier source or publish anything when the crawl fails (record reported as batch failure for SQS redelivery)", async () => {
-		const failedSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
 		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 
-		const handler = createHandler({ simpleCrawl: failedSimpleCrawl, putTierSource, publishEvent });
+		const handler = createHandler({ crawlAndFinalizeArticle, putTierSource, publishEvent });
 
 		const result = await handler(
-			createSqsEvent({ url: "https://example.com/unreachable", userId: "user-1" }),
+			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
 			stubContext,
 			() => {},
 		);
@@ -184,41 +161,17 @@ describe("initSaveLinkCommandHandler", () => {
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 
-	it("reports crawl failures via logParseError with the crawl status as reason (record routed to batchItemFailures for SQS retry)", async () => {
+	it("reports failures via logParseError so the parse-errors dashboard reflects them", async () => {
 		const logParseError = jest.fn();
-		const failedSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "readability crashed" });
 
-		const handler = createHandler({ simpleCrawl: failedSimpleCrawl, logParseError });
+		const handler = createHandler({ crawlAndFinalizeArticle, logParseError });
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/unreachable", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(logParseError).toHaveBeenCalledWith({
-			url: "https://example.com/unreachable",
-			reason: "crawl-failed",
-		});
-	});
-
-	it("reports parse failures via logParseError with the parser's reason (record routed to batchItemFailures for SQS retry)", async () => {
-		const logParseError = jest.fn();
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Invalid URL" });
-
-		const handler = createHandler({ parseHtml: failedParse, logParseError });
-
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
-
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(logParseError).toHaveBeenCalledWith({
-			url: "https://example.com/bad",
-			reason: "Invalid URL",
+			url: "https://example.com/article",
+			reason: "readability crashed",
 		});
 	});
 
@@ -250,19 +203,14 @@ describe("initSaveLinkCommandHandler", () => {
 			tier1Status: "not_attempted",
 			pickedTier: "tier-0",
 		});
-		const failedSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 
-		const handler = createHandler({ simpleCrawl: failedSimpleCrawl, logCrawlOutcome, readTierSnapshot });
+		const handler = createHandler({ crawlAndFinalizeArticle, logCrawlOutcome, readTierSnapshot });
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/unreachable", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(logCrawlOutcome).toHaveBeenCalledWith({
-			url: "https://example.com/unreachable",
+			url: "https://example.com/article",
 			thisTier: "tier-1",
 			thisTierStatus: "failed",
 			otherTierStatus: "success",
@@ -270,315 +218,93 @@ describe("initSaveLinkCommandHandler", () => {
 		});
 	});
 
-	it("emits a tier-1 failure crawl-outcome when the parse fails and marks the other tier as not-attempted when tier-0 never captured", async () => {
-		const logCrawlOutcome = jest.fn();
-		const readTierSnapshot = jest.fn().mockResolvedValue({
-			tier0Status: "not_attempted",
-			tier1Status: "failed",
-			pickedTier: "none",
-		});
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability crashed" });
+	it("routes terminal parse-error failures through markCrawlFailed via transitionAndPersist so readers see failure at t+0 instead of waiting ~90s for the DLQ", async () => {
+		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "Readability returned null" });
 
-		const handler = createHandler({ parseHtml: failedParse, logCrawlOutcome, readTierSnapshot });
-
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
-
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
-		expect(logCrawlOutcome).toHaveBeenCalledWith({
-			url: "https://example.com/bad",
-			thisTier: "tier-1",
-			thisTierStatus: "failed",
-			otherTierStatus: "not_attempted",
-			pickedTier: "none",
-		});
-	});
-
-	it("opts into thumbnail fetching when calling simpleCrawl", async () => {
-		const simpleCrawl = jest.fn<ReturnType<SimpleCrawl>, Parameters<SimpleCrawl>>().mockResolvedValue({
-			status: "fetched",
-			html: "<html><body><p>Article content</p></body></html>",
-		});
-
-		const handler = createHandler({ simpleCrawl });
+		const handler = createHandler({ crawlAndFinalizeArticle, transitionAndPersist });
 
 		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
-		expect(simpleCrawl).toHaveBeenCalledWith({
-			url: "https://example.com/article",
-			fetchThumbnail: true,
-		});
-	});
-
-	it("routes terminal parse errors through markCrawlFailed via transitionAndPersist so readers see failure at t+0 instead of waiting ~90s for the DLQ", async () => {
-		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
-		const failedParse: ParseHtml = () => ({ ok: false, reason: "Readability crashed on this DOM" });
-		const error = jest.fn();
-		const logger = { ...noopLogger, error };
-
-		const handler = createHandler({ parseHtml: failedParse, transitionAndPersist, logger });
-
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
-
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
-			url: "https://example.com/bad",
-			input: { reason: { kind: "parse-error", detail: "Readability crashed on this DOM" } },
+			url: "https://example.com/article",
+			input: { reason: { kind: "parse-error", detail: "Readability returned null" } },
 		});
-		// Confirms the throw inside the worker propagated to the per-record catch
-		// with the expected diagnostic, even though it no longer escapes the handler.
-		expect(error).toHaveBeenCalledWith(
-			"[SaveLinkCommand] record failed",
-			expect.objectContaining({
-				messageId: "msg-1",
-				error: expect.objectContaining({
-					message: "crawl failed for https://example.com/bad: Readability crashed on this DOM",
-				}),
-			}),
-		);
 	});
 
-	it("does NOT dispatch a terminal transition on a transient fetch failure (those stay on the SQS retry / DLQ path)", async () => {
+	it("does NOT dispatch a terminal transition on a transient crawl-failed (those stay on the SQS retry / DLQ path)", async () => {
 		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
-		const failedSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 
-		const handler = createHandler({ simpleCrawl: failedSimpleCrawl, transitionAndPersist });
+		const handler = createHandler({ crawlAndFinalizeArticle, transitionAndPersist });
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/unreachable", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
-		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
 
-	it("emits SimpleCrawlUnsupportedEvent carrying the userId when simpleCrawl reports unsupported (the policy Lambda dispatches ComprehensiveCrawlCommand)", async () => {
-		const emitSimpleCrawlUnsupported = jest.fn<
-			ReturnType<EmitSimpleCrawlUnsupported>,
-			Parameters<EmitSimpleCrawlUnsupported>
-		>().mockResolvedValue(undefined);
-		const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+	it("emits SimpleCrawlUnsupportedEvent carrying the userId when the crawl reports unsupported (the policy Lambda dispatches ComprehensiveCrawlCommand)", async () => {
+		const emitSimpleCrawlUnsupported = jest.fn().mockResolvedValue(undefined);
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-		const unsupportedSimpleCrawl: SimpleCrawl = async () => ({
-			status: "unsupported",
-			reason: "non-html content type: application/pdf",
-		});
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "unsupported", reason: "non-html content type: application/pdf" });
 
-		const handler = createHandler({
-			simpleCrawl: unsupportedSimpleCrawl,
-			emitSimpleCrawlUnsupported,
-			transitionAndPersist,
-			publishEvent,
-			putTierSource,
-		});
+		const handler = createHandler({ crawlAndFinalizeArticle, emitSimpleCrawlUnsupported, publishEvent });
 
-		const result = await handler(
-			createSqsEvent({ url: "https://example.com/doc.pdf", userId: "user-1" }),
-			stubContext,
-			() => {},
-		);
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
-		expect(result).toEqual({ batchItemFailures: [] });
-		expect(emitSimpleCrawlUnsupported).toHaveBeenCalledTimes(1);
 		expect(emitSimpleCrawlUnsupported).toHaveBeenCalledWith({
-			url: "https://example.com/doc.pdf",
+			url: "https://example.com/article",
 			userId: "user-1",
 			recrawl: undefined,
 		});
-		// The save-link Lambda emits an event, not a command: no sync tier-1
-		// write, no terminal transition (the comprehensive Lambda owns those),
-		// and no TierContentExtractedEvent — the comprehensive Lambda emits
-		// that itself after the policy dispatches the command.
-		expect(transitionAndPersist).not.toHaveBeenCalled();
-		expect(putTierSource).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
 	});
 
 	it("marks comprehensive-fetching between the simple bail-out and the event emission so the reader's progress bar advances during the policy + comprehensive Lambda's cold-start", async () => {
-		const unsupportedSimpleCrawl: SimpleCrawl = async () => ({
-			status: "unsupported",
-			reason: "non-html content type: application/pdf",
-		});
-		const markCrawlStage = jest.fn().mockResolvedValue(undefined);
-		const emitSimpleCrawlUnsupported = jest.fn().mockResolvedValue(undefined);
+		const calls: string[] = [];
+		const markCrawlStage = jest.fn(async ({ stage }: { stage: string }) => { calls.push(`stage:${stage}`); });
+		const emitSimpleCrawlUnsupported = jest.fn(async () => { calls.push("emit"); });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "unsupported", reason: "non-html" });
 
-		const handler = createHandler({
-			simpleCrawl: unsupportedSimpleCrawl,
-			markCrawlStage,
-			emitSimpleCrawlUnsupported,
-		});
+		const handler = createHandler({ crawlAndFinalizeArticle, markCrawlStage, emitSimpleCrawlUnsupported });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
 
-		const stages = markCrawlStage.mock.calls.map((call) => call[0].stage);
-		expect(stages).toContain("crawl-fetching");
-		expect(stages).toContain("comprehensive-fetching");
-		expect(stages.indexOf("comprehensive-fetching")).toBeGreaterThan(stages.indexOf("crawl-fetching"));
-		expect(stages).not.toContain("crawl-fetched");
+		expect(calls).toEqual([
+			"stage:crawl-fetching",
+			"stage:comprehensive-fetching",
+			"emit",
+		]);
 	});
 
-	it("reports the record as a batch failure when the event emission fails so SQS retries (the simple crawl is idempotent)", async () => {
-		const unsupportedSimpleCrawl: SimpleCrawl = async () => ({
-			status: "unsupported",
-			reason: "non-html content type: application/pdf",
-		});
-		const emitSimpleCrawlUnsupported = jest.fn().mockRejectedValue(new Error("EventBridge throttled"));
+	it("treats a not-modified result as an unreachable bug (save-link-work never passes conditional headers, so the crawler should never short-circuit here)", async () => {
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "not-modified" });
+		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
 
-		const handler = createHandler({
-			simpleCrawl: unsupportedSimpleCrawl,
-			emitSimpleCrawlUnsupported,
-		});
+		const handler = createHandler({ crawlAndFinalizeArticle, putTierSource });
 
 		const result = await handler(
-			createSqsEvent({ url: "https://example.com/doc.pdf", userId: "user-1" }),
+			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
 			stubContext,
 			() => {},
 		);
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+		expect(putTierSource).not.toHaveBeenCalled();
 	});
 
-	it("uploads the crawled thumbnail to S3 and threads the resolved CDN URL into the tier-source metadata", async () => {
-		const imageBody = Buffer.from([0xff, 0xd8, 0xff]);
-		const simpleCrawl: SimpleCrawl = async () => ({
-			status: "fetched",
-			html: "<html></html>",
-			thumbnailImage: {
-				body: imageBody,
-				contentType: "image/jpeg",
-				url: "https://cdn.example.com/thumb.jpg",
-				extension: ".jpg",
-			},
-		});
-		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
+	it("reports the record as a batch failure when publishEvent throws so SQS retries the whole record (the inner work is idempotent)", async () => {
+		const publishEvent = jest.fn().mockRejectedValue(new Error("eventbridge down"));
 
-		const handler = createHandler({ simpleCrawl, putImageObject, putTierSource });
+		const handler = createHandler({ publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
-
-		expect(putImageObject).toHaveBeenCalledWith({
-			key: expect.stringMatching(/^content\/example\.com%2Farticle\/images\/[0-9a-f]{16}\.jpg$/),
-			body: imageBody,
-			contentType: "image/jpeg",
-		});
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({
-					imageUrl: expect.stringMatching(/^https:\/\/cdn\.example\.com\/content\/example\.com%252Farticle\/images\/[0-9a-f]{16}\.jpg$/),
-				}),
-			}),
+		const result = await handler(
+			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
+			stubContext,
+			() => {},
 		);
-	});
 
-	it("falls back to the parsed og:image URL when the crawler did not fetch a thumbnail", async () => {
-		const parseHtml: ParseHtml = () => ({
-			ok: true,
-			article: {
-				title: "T", siteName: "s", excerpt: "e", wordCount: 1,
-				content: "<p>x</p>",
-				imageUrl: "https://example.com/og.png",
-			},
-		});
-		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-
-		const handler = createHandler({ parseHtml, putImageObject, putTierSource });
-
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
-
-		expect(putImageObject).not.toHaveBeenCalled();
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({ imageUrl: "https://example.com/og.png" }),
-			}),
-		);
-	});
-
-	it("threads crawlResult.thumbnailUrl into parseHtml so the raw og:image URL persists when the thumbnail image download was skipped", async () => {
-		const simpleCrawl: SimpleCrawl = async () => ({
-			status: "fetched",
-			html: "<html></html>",
-			thumbnailUrl: "https://example.com/og.png",
-		});
-		const parseHtml = jest.fn(((_params) => ({
-			ok: true as const,
-			article: {
-				title: "T", siteName: "s", excerpt: "e", wordCount: 1,
-				content: "<p>x</p>",
-				imageUrl: "https://example.com/og.png",
-			},
-		})) satisfies ParseHtml);
-		const putImageObject: PutImageObject = jest.fn().mockResolvedValue(undefined);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-
-		const handler = createHandler({ simpleCrawl, parseHtml, putImageObject, putTierSource });
-
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
-
-		expect(parseHtml).toHaveBeenCalledWith({
-			url: "https://example.com/article",
-			html: "<html></html>",
-			thumbnailUrl: "https://example.com/og.png",
-		});
-		expect(putImageObject).not.toHaveBeenCalled();
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				metadata: expect.objectContaining({ imageUrl: "https://example.com/og.png" }),
-			}),
-		);
-	});
-
-	it("passes thumbnailUrl=null when the crawler returned no thumbnail candidate", async () => {
-		const simpleCrawl: SimpleCrawl = async () => ({
-			status: "fetched",
-			html: "<html></html>",
-		});
-		const parseHtml = jest.fn(((_params) => ({
-			ok: true as const,
-			article: { title: "T", siteName: "s", excerpt: "e", wordCount: 1, content: "<p>x</p>" },
-		})) satisfies ParseHtml);
-
-		const handler = createHandler({ simpleCrawl, parseHtml });
-
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
-
-		expect(parseHtml).toHaveBeenCalledWith({
-			url: "https://example.com/article",
-			html: "<html></html>",
-			thumbnailUrl: null,
-		});
-	});
-
-	it("threads downloaded media through processContent so HTML references the CDN URLs", async () => {
-		const parseWithImage: ParseHtml = () => ({
-			ok: true,
-			article: { title: "T", siteName: "s", excerpt: "e", wordCount: 1, content: '<img src="https://example.com/img.png">' },
-		});
-		const downloadMedia: DownloadMedia = jest.fn().mockResolvedValue([
-			{ originalUrl: "https://example.com/img.png", cdnUrl: "https://cdn/images/abc.png" },
-		]);
-		const putTierSource: PutTierSource = jest.fn().mockResolvedValue(undefined);
-
-		const handler = createHandler({ parseHtml: parseWithImage, downloadMedia, putTierSource });
-
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
-
-		expect(putTierSource).toHaveBeenCalledWith(
-			expect.objectContaining({
-				html: expect.stringContaining("https://cdn/images/abc.png"),
-			}),
-		);
+		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
 	it("reports the record as a batch failure on invalid event detail (Zod failure surfaces before the worker runs)", async () => {
@@ -588,7 +314,7 @@ describe("initSaveLinkCommandHandler", () => {
 			Records: [{
 				messageId: "msg-1",
 				receiptHandle: "receipt-1",
-				body: JSON.stringify({ detail: { invalid: true } }),
+				body: JSON.stringify({ detail: { wrong: "shape" } }),
 				attributes: stubAttributes,
 				messageAttributes: {},
 				md5OfBody: "",
@@ -599,6 +325,7 @@ describe("initSaveLinkCommandHandler", () => {
 		};
 
 		const result = await handler(invalidEvent, stubContext, () => {});
+
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.ts
@@ -1,6 +1,5 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import {
@@ -8,29 +7,22 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia } from "./download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
-import { initSaveLinkWork, type ProcessContent } from "./save-link-work";
+import { initSaveLinkWork } from "./save-link-work";
+import type { CrawlAndFinalizeArticle } from "./crawl-and-finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 
 export function initSaveLinkCommandHandler(deps: {
-	simpleCrawl: SimpleCrawl;
+	crawlAndFinalizeArticle: CrawlAndFinalizeArticle;
 	emitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported;
-	parseHtml: ParseHtml;
 	putTierSource: PutTierSource;
-	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
 	publishEvent: PublishEvent;
-	downloadMedia: DownloadMedia;
-	processContent: ProcessContent;
-	imagesCdnBaseUrl: string;
 	now: () => Date;
 	logger: HutchLogger;
 	logParseError: LogParseError;
@@ -40,17 +32,12 @@ export function initSaveLinkCommandHandler(deps: {
 	const { publishEvent, logger } = deps;
 
 	const { saveLinkWork } = initSaveLinkWork({
-		simpleCrawl: deps.simpleCrawl,
+		crawlAndFinalizeArticle: deps.crawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported: deps.emitSimpleCrawlUnsupported,
-		parseHtml: deps.parseHtml,
 		putTierSource: deps.putTierSource,
-		putImageObject: deps.putImageObject,
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
-		downloadMedia: deps.downloadMedia,
-		processContent: deps.processContent,
-		imagesCdnBaseUrl: deps.imagesCdnBaseUrl,
 		now: deps.now,
 		logger,
 		logParseError: deps.logParseError,

--- a/projects/save-link/src/runtime/domain/save-link/save-link-work.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-work.ts
@@ -1,27 +1,17 @@
-import { createHash } from "node:crypto";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type {
-	CrawlArticleResult,
-	SimpleCrawl,
-	ThumbnailImage,
-} from "@packages/crawl-article";
 import {
 	markCrawlFailed,
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
-import { ArticleResourceUniqueId } from "./article-resource-unique-id";
-import type { ParseHtml } from "@packages/article-parser";
-import type { DownloadMedia, DownloadedMedia } from "./download-media";
-import type { PutImageObject } from "../../providers/article-store/s3-put-image-object";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
-import { estimatedReadTimeFromWordCount } from "./estimated-read-time";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
+import type { CrawlAndFinalizeArticle } from "./crawl-and-finalize-article";
 
-export type ProcessContent = (params: { html: string; media: DownloadedMedia[] }) => Promise<string>;
+export type { ProcessContent } from "./finalize-article";
 
 /**
  * `"tier-1-written"` — the worker fetched, parsed, and wrote a tier-1 source.
@@ -35,12 +25,6 @@ export type ProcessContent = (params: { html: string; media: DownloadedMedia[] }
  * must NOT publish a follow-up event itself; the comprehensive Lambda emits
  * the appropriate event after it finishes (TierContentExtractedEvent or
  * RecrawlContentExtractedEvent).
- *
- * Note: terminal `"unsupported"` is owned by the comprehensive-crawl Lambda's
- * own handler — save-link-work never decides "permanently unsupported"
- * directly anymore, since the simple crawl cannot distinguish a PDF (which
- * the comprehensive Lambda extracts) from a video/archive (which it does
- * not). All unsupported simple results flow through the event.
  */
 export type SaveLinkWorkResult = "tier-1-written" | "tier-1-deferred";
 
@@ -51,17 +35,12 @@ export type SaveLinkWorkOptions = {
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
 export function initSaveLinkWork(deps: {
-	simpleCrawl: SimpleCrawl;
+	crawlAndFinalizeArticle: CrawlAndFinalizeArticle;
 	emitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported;
-	parseHtml: ParseHtml;
 	putTierSource: PutTierSource;
-	putImageObject: PutImageObject;
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
-	downloadMedia: DownloadMedia;
-	processContent: ProcessContent;
-	imagesCdnBaseUrl: string;
 	now: () => Date;
 	logger: HutchLogger;
 	logParseError: LogParseError;
@@ -70,17 +49,12 @@ export function initSaveLinkWork(deps: {
 	logPrefix: string;
 }): { saveLinkWork: (url: string, options?: SaveLinkWorkOptions) => Promise<SaveLinkWorkResult> } {
 	const {
-		simpleCrawl,
+		crawlAndFinalizeArticle,
 		emitSimpleCrawlUnsupported,
-		parseHtml,
 		putTierSource,
-		putImageObject,
 		updateFetchTimestamp,
 		transitionAndPersist,
 		markCrawlStage,
-		downloadMedia,
-		processContent,
-		imagesCdnBaseUrl,
 		now,
 		logger,
 		logParseError,
@@ -102,108 +76,61 @@ export function initSaveLinkWork(deps: {
 
 	const saveLinkWork = async (url: string, options?: SaveLinkWorkOptions): Promise<SaveLinkWorkResult> => {
 		await markCrawlStage({ url, stage: "crawl-fetching" });
-		const crawlResult: CrawlArticleResult = await simpleCrawl({ url, fetchThumbnail: true });
+		const result = await crawlAndFinalizeArticle({ url });
 
-		if (crawlResult.status === "unsupported") {
-			/*
-			 * The simple crawl bailed because the origin returned a non-html body.
-			 * We do not know yet whether it is a PDF (the comprehensive Lambda
-			 * extracts and decides) or something the comprehensive path cannot
-			 * handle either (image, archive, …). Emit unconditionally and
-			 * let the policy → comprehensive Lambda chain's own `unsupported`
-			 * branch flip the row terminal — that keeps the "two Lambdas can
-			 * each return unsupported" matrix from being duplicated here.
-			 *
-			 * `comprehensive-fetching` is written before the emit so the
-			 * reader's progress bar moves forward immediately; the comprehensive
-			 * Lambda writes `comprehensive-extracting` once it starts pdfjs.
-			 */
+		if (result.status === "unsupported") {
+			/* The simple crawl bailed because the origin returned a non-html body.
+			 * Defer to the comprehensive Lambda — it extracts and decides whether
+			 * the content is a PDF (handle) or something else (mark unsupported).
+			 * `comprehensive-fetching` is written before the emit so the reader's
+			 * progress bar moves forward immediately. */
 			await markCrawlStage({ url, stage: "comprehensive-fetching" });
 			await emitSimpleCrawlUnsupported({ url, userId: options?.userId, recrawl: options?.recrawl });
 			logger.info(`${logPrefix} tier-1 deferred to comprehensive crawl`, {
 				url,
-				reason: crawlResult.reason,
+				reason: result.reason,
 			});
 			return "tier-1-deferred";
 		}
 
-		if (crawlResult.status !== "fetched") {
-			const reason = `crawl-${crawlResult.status}`;
-			logParseError({ url, reason });
+		if (result.status === "failed") {
+			logParseError({ url, reason: result.reason });
+			/* Parse-error reasons are terminal — re-running yields the same failure.
+			 * Flip the crawl state to `failed` immediately so readers and the canary
+			 * see it on the next poll, not after the SQS retry → DLQ delay.
+			 * Network "crawl-failed" reasons let SQS retry and only land at DLQ
+			 * after maxReceiveCount. */
+			if (result.reason !== "crawl-failed") {
+				await transitionAndPersist(markCrawlFailed, {
+					url,
+					input: { reason: { kind: "parse-error", detail: result.reason } },
+				});
+			}
 			await emitTier1Failure(url);
-			throw new Error(`crawl failed for ${url}: ${reason}`);
+			throw new Error(`crawl failed for ${url}: ${result.reason}`);
 		}
 
-		await markCrawlStage({ url, stage: "crawl-fetched" });
-
-		const parseResult = parseHtml({
-			url,
-			html: crawlResult.html,
-			thumbnailUrl: crawlResult.thumbnailUrl ?? null,
-		});
-		if (!parseResult.ok) {
-			logParseError({ url, reason: parseResult.reason });
-			// Parse failures are terminal: re-running the worker against the
-			// same HTML will re-fail the same way. Flip the crawl state to
-			// `failed` immediately so readers and the Tier 1+ canary see the
-			// terminal state on the next poll, instead of waiting for SQS
-			// retries → DLQ (~90s+) before the DLQ handler updates it.
-			await transitionAndPersist(markCrawlFailed, {
-				url,
-				input: {
-					reason: { kind: "parse-error", detail: parseResult.reason },
-				},
-			});
-			await emitTier1Failure(url);
-			throw new Error(`crawl failed for ${url}: ${parseResult.reason}`);
+		if (result.status === "not-modified") {
+			/* `not-modified` is only possible when the caller passed etag/lastModified
+			 * — save-link-work always does a fresh fetch (no conditional headers),
+			 * so the crawler can never short-circuit here. Stale-check is the path
+			 * that handles `not-modified`. */
+			throw new Error(`save-link-work received unexpected not-modified for ${url}`);
 		}
-
-		const { article } = parseResult;
-		await markCrawlStage({ url, stage: "crawl-parsed" });
-		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
-
-		const media = await downloadMedia({
-			html: article.content,
-			articleUrl: url,
-			articleResourceUniqueId,
-		});
-
-		const html = await processContent({ html: article.content, media });
-
-		// Resolve the final imageUrl that lands in the metadata sidecar — the
-		// CDN-cached thumbnail wins when the crawler fetched one, otherwise the
-		// raw og:image / twitter:image URL Readability extracted. The selector
-		// reads this when it promotes the winning tier to canonical.
-		const resolvedImageUrl = crawlResult.thumbnailImage
-			? await uploadThumbnail({
-					thumbnailImage: crawlResult.thumbnailImage,
-					articleResourceUniqueId,
-					putImageObject,
-					imagesCdnBaseUrl,
-				})
-			: article.imageUrl;
-		await markCrawlStage({ url, stage: "crawl-metadata-written" });
 
 		await putTierSource({
 			url,
 			tier: "tier-1",
-			html,
-			metadata: {
-				title: article.title,
-				siteName: article.siteName,
-				excerpt: article.excerpt,
-				wordCount: article.wordCount,
-				estimatedReadTime: estimatedReadTimeFromWordCount(article.wordCount),
-				imageUrl: resolvedImageUrl,
-			},
+			html: result.article.html,
+			metadata: result.article.metadata,
 		});
 		await markCrawlStage({ url, stage: "crawl-content-uploaded" });
 
 		await updateFetchTimestamp({
 			url,
 			contentFetchedAt: now().toISOString(),
-			etag: crawlResult.etag,
-			lastModified: crawlResult.lastModified,
+			etag: result.etag,
+			lastModified: result.lastModified,
 		});
 
 		const successSnapshot = await readTierSnapshot({ url });
@@ -217,28 +144,10 @@ export function initSaveLinkWork(deps: {
 
 		logger.info(`${logPrefix} tier-1 source written`, {
 			url,
-			hasThumbnail: crawlResult.thumbnailImage ? 1 : 0,
+			imageUrl: result.article.metadata.imageUrl ?? null,
 		});
 		return "tier-1-written";
 	};
 
 	return { saveLinkWork };
-}
-
-/** Shared with `comprehensive-crawl-handler` so both code paths upload
- * thumbnails to the same key shape. Keeping it here avoids a circular
- * import — the comprehensive handler depends on this module, not the other
- * way around. */
-export async function uploadThumbnail(args: {
-	thumbnailImage: ThumbnailImage;
-	articleResourceUniqueId: ArticleResourceUniqueId;
-	putImageObject: PutImageObject;
-	imagesCdnBaseUrl: string;
-}): Promise<string> {
-	const { thumbnailImage, articleResourceUniqueId, putImageObject, imagesCdnBaseUrl } = args;
-	const hash = createHash("sha256").update(thumbnailImage.url).digest("hex").slice(0, 16);
-	const filename = `${hash}${thumbnailImage.extension}`;
-	const key = articleResourceUniqueId.toS3ImageKey(filename);
-	await putImageObject({ key, body: thumbnailImage.body, contentType: thumbnailImage.contentType });
-	return articleResourceUniqueId.toImageCdnUrl({ baseUrl: imagesCdnBaseUrl, filename });
 }

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
@@ -443,4 +443,26 @@ describe("initRecrawlContentExtractedHandler", () => {
 			},
 		});
 	});
+
+	it("promotes another tier's imageUrl when the winner has none (recovers og:image for articles whose pre-fix tier-0 was selected over a tier-1 carrying a thumbnail)", async () => {
+		const tier0 = tierSource("tier-0", { metadata: stubMetadata({ imageUrl: undefined }) });
+		const tier1 = tierSource("tier-1", { metadata: stubMetadata({ imageUrl: "https://cdn.example/recovered.png" }) });
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-0", reason: "tier-0 body wins" }),
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			recrawlPromoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({
+					winnerTier: "tier-0",
+					metadata: expect.objectContaining({ imageUrl: "https://cdn.example/recovered.png" }),
+				}),
+			}),
+		);
+	});
 });

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -18,6 +18,7 @@ import type { SelectMostCompleteContent } from "./select-content";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
+import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
 import type { TierSource } from "./tier-source.types";
 
 export function initRecrawlContentExtractedHandler(deps: {
@@ -145,7 +146,10 @@ export function initRecrawlContentExtractedHandler(deps: {
 						url: detail.url,
 						input: {
 							winnerTier,
-							metadata: winnerSource.metadata,
+							metadata: {
+								...winnerSource.metadata,
+								imageUrl: resolveCanonicalImageUrl({ winner: winnerSource, candidates: sources }),
+							},
 							estimatedReadTime: winnerSource.metadata.estimatedReadTime,
 							contentFetchedAt: now().toISOString(),
 							now: now().toISOString(),

--- a/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.test.ts
@@ -229,6 +229,28 @@ describe("initRefreshContentExtractedHandler", () => {
 		});
 	});
 
+	it("promotes another tier's imageUrl when the winning refresh has none, so the stale-check refresh path also recovers og:image across tiers", async () => {
+		const tier0 = tierSource("tier-0", { metadata: stubMetadata({ imageUrl: undefined }) });
+		const tier1 = tierSource("tier-1", { metadata: stubMetadata({ imageUrl: "https://cdn.example/recovered.png" }) });
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-0", reason: "tier-0 body wins" }),
+			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			refreshContent,
+			expect.objectContaining({
+				input: expect.objectContaining({
+					metadata: expect.objectContaining({ imageUrl: "https://cdn.example/recovered.png" }),
+				}),
+			}),
+		);
+	});
+
 	it("reports the record as a batch failure when transitionAndPersist throws so SQS replays the whole transition once DDB is healthy again", async () => {
 		const tier1 = tierSource("tier-1");
 		const transitionAndPersist: TransitionAndPersist = jest

--- a/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.ts
@@ -10,6 +10,7 @@ import type { FindContentSourceTier } from "../../providers/article-store/find-c
 import type { ListAvailableTierSources } from "./list-available-tier-sources";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
+import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
 import type { SelectMostCompleteContent } from "./select-content";
 
 /**
@@ -109,7 +110,7 @@ export function initRefreshContentExtractedHandler(deps: {
 							siteName: winnerSource.metadata.siteName,
 							excerpt: winnerSource.metadata.excerpt,
 							wordCount: winnerSource.metadata.wordCount,
-							imageUrl: winnerSource.metadata.imageUrl,
+							imageUrl: resolveCanonicalImageUrl({ winner: winnerSource, candidates: sources }),
 						},
 						freshness: {
 							etag: detail.etag,

--- a/projects/save-link/src/runtime/domain/select-content/resolve-canonical-image-url.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/resolve-canonical-image-url.test.ts
@@ -1,0 +1,48 @@
+import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
+import type { TierSource } from "./tier-source.types";
+
+function source(overrides: { tier: TierSource["tier"]; imageUrl?: string }): TierSource {
+	return {
+		tier: overrides.tier,
+		html: "<p>x</p>",
+		metadata: {
+			title: "t",
+			siteName: "s",
+			excerpt: "e",
+			wordCount: 1,
+			estimatedReadTime: 1,
+			imageUrl: overrides.imageUrl,
+		},
+	};
+}
+
+describe("resolveCanonicalImageUrl", () => {
+	it("returns the winner's imageUrl when the winner has one", () => {
+		const winner = source({ tier: "tier-1", imageUrl: "https://example.com/winner.png" });
+		const loser = source({ tier: "tier-0", imageUrl: "https://example.com/loser.png" });
+		expect(resolveCanonicalImageUrl({ winner, candidates: [loser, winner] }))
+			.toBe("https://example.com/winner.png");
+	});
+
+	it("falls back to another candidate's imageUrl when the winner has none", () => {
+		const winner = source({ tier: "tier-0" });
+		const loser = source({ tier: "tier-1", imageUrl: "https://example.com/loser.png" });
+		expect(resolveCanonicalImageUrl({ winner, candidates: [winner, loser] }))
+			.toBe("https://example.com/loser.png");
+	});
+
+	it("returns undefined when no candidate has an imageUrl", () => {
+		const winner = source({ tier: "tier-0" });
+		const loser = source({ tier: "tier-1" });
+		expect(resolveCanonicalImageUrl({ winner, candidates: [winner, loser] }))
+			.toBeUndefined();
+	});
+
+	it("returns the first non-null imageUrl in the candidate list when the winner has none and multiple candidates do", () => {
+		const winner = source({ tier: "tier-0" });
+		const first = source({ tier: "tier-1", imageUrl: "https://example.com/first.png" });
+		const second = source({ tier: "tier-1", imageUrl: "https://example.com/second.png" });
+		expect(resolveCanonicalImageUrl({ winner, candidates: [winner, first, second] }))
+			.toBe("https://example.com/first.png");
+	});
+});

--- a/projects/save-link/src/runtime/domain/select-content/resolve-canonical-image-url.ts
+++ b/projects/save-link/src/runtime/domain/select-content/resolve-canonical-image-url.ts
@@ -1,0 +1,29 @@
+import { type CanonicalImageUrl, CanonicalImageUrlSchema } from "@packages/domain/article-aggregate";
+import type { TierSource } from "./tier-source.types";
+
+/**
+ * The selector chooses a winning tier based on body completeness, but
+ * `metadata.imageUrl` is set per tier and the tiers can disagree — tier-1
+ * may have uploaded a thumbnail to the CDN while tier-0 (or a tier-1 saved
+ * before og:image extraction landed) carries `undefined`. The queue card
+ * and social preview just need ANY image, so promote the winner's URL when
+ * present and fall back to the first non-null across the remaining
+ * candidates. Decouples "which body wins" (LLM) from "which image wins"
+ * (deterministic) so a tier whose body was rejected can still contribute
+ * its og:image when the winner has none.
+ *
+ * Returns the branded `CanonicalImageUrl` so the type checker rejects any
+ * promote/refresh transition that tries to short-circuit this resolver and
+ * pass `winnerSource.metadata.imageUrl` directly — that's the bug shape
+ * this helper exists to prevent.
+ */
+export function resolveCanonicalImageUrl(params: {
+	winner: TierSource;
+	candidates: readonly TierSource[];
+}): CanonicalImageUrl {
+	if (params.winner.metadata.imageUrl) {
+		return CanonicalImageUrlSchema.parse(params.winner.metadata.imageUrl);
+	}
+	const fallback = params.candidates.find((candidate) => candidate.metadata.imageUrl);
+	return CanonicalImageUrlSchema.parse(fallback?.metadata.imageUrl);
+}

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
@@ -236,6 +236,29 @@ describe("initSelectMostCompleteContentHandler", () => {
 		});
 	});
 
+	it("promotes the loser's imageUrl when the winner's body wins but the winner has no thumbnail (rescues og:image from a stale tier whose body the LLM rejected)", async () => {
+		const tier0 = tierSource("tier-0", { metadata: stubMetadata({ imageUrl: undefined }) });
+		const tier1 = tierSource("tier-1", { metadata: stubMetadata({ imageUrl: "https://example.com/og.png" }) });
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-0", reason: "tier-0 body wins" }),
+			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			promoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({
+					tier: "tier-0",
+					metadata: expect.objectContaining({ imageUrl: "https://example.com/og.png" }),
+				}),
+			}),
+		);
+	});
+
 	it("computes and passes a canonical content hash derived from the winning source HTML so the aggregate's hash gate can detect content equality", async () => {
 		const tier1 = tierSource("tier-1", { html: "<article><p>Distinctive winner body.</p></article>" });
 

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -16,6 +16,7 @@ import type { SelectMostCompleteContent } from "./select-content";
 import type { WriteCanonicalContent } from "../../providers/article-store/promote-tier-to-canonical";
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
+import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
 import type { TierSource } from "./tier-source.types";
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
@@ -148,7 +149,10 @@ export function initSelectMostCompleteContentHandler(deps: {
 					url: detail.url,
 					input: {
 						tier: winnerTier,
-						metadata: winnerSource.metadata,
+						metadata: {
+							...winnerSource.metadata,
+							imageUrl: resolveCanonicalImageUrl({ winner: winnerSource, candidates: sources }),
+						},
 						estimatedReadTime: winnerSource.metadata.estimatedReadTime,
 						contentFetchedAt: now().toISOString(),
 						now: now().toISOString(),

--- a/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.test.ts
@@ -1,4 +1,3 @@
-import type { SimpleCrawl } from "@packages/crawl-article";
 import type { LoadArticle, TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { noopLogger } from "@packages/hutch-logger";
 import type {
@@ -13,7 +12,11 @@ import type {
 	PublishUpdateFetchTimestamp,
 } from "@packages/test-fixtures/providers/events";
 import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
-import type { ParseHtml } from "@packages/article-parser";
+import type {
+	CrawlAndFinalizeArticle,
+	CrawlAndFinalizeResult,
+} from "../save-link/crawl-and-finalize-article";
+import type { FinalizedArticle } from "../save-link/finalize-article";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
 import { initStaleCheckHandler } from "./stale-check-handler";
@@ -65,18 +68,7 @@ function createSqsEvent(detail: { url: string }): SQSEvent {
 
 type HandlerDeps = Parameters<typeof initStaleCheckHandler>[0];
 
-const noopParseHtml: ParseHtml = () => ({
-	ok: true,
-	article: {
-		title: "t",
-		siteName: "s",
-		excerpt: "e",
-		wordCount: 200,
-		content: "<p>x</p>",
-	},
-});
-
-const noopSimpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+const failingCrawlAndFinalize: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 
 const noopFindArticleFreshness: FindArticleFreshness = async () => null;
 const noopFindArticleCrawlStatus: FindArticleCrawlStatus = async () => undefined;
@@ -85,8 +77,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 	return initStaleCheckHandler({
 		findArticleFreshness: noopFindArticleFreshness,
 		findArticleCrawlStatus: noopFindArticleCrawlStatus,
-		simpleCrawl: noopSimpleCrawl,
-		parseHtml: noopParseHtml,
+		crawlAndFinalizeArticle: failingCrawlAndFinalize,
 		publishRefreshArticleContent: jest.fn().mockResolvedValue(undefined),
 		publishUpdateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		publishSaveAnonymousLink: jest.fn().mockResolvedValue(undefined),
@@ -124,38 +115,38 @@ describe("initStaleCheckHandler", () => {
 			status: "failed",
 			reason: "parse-error",
 		});
-		const simpleCrawl = jest.fn(noopSimpleCrawl);
+		const crawlAndFinalizeArticle = jest.fn(failingCrawlAndFinalize);
 		const publishSaveAnonymousLink: PublishSaveAnonymousLink = jest.fn().mockResolvedValue(undefined);
 
 		const handler = createHandler({
 			findArticleFreshness,
 			findArticleCrawlStatus,
-			simpleCrawl,
+			crawlAndFinalizeArticle,
 			publishSaveAnonymousLink,
 		});
 
 		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
 
-		expect(simpleCrawl).not.toHaveBeenCalled();
+		expect(crawlAndFinalizeArticle).not.toHaveBeenCalled();
 		expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
 	});
 
-	it("does nothing when the row is within the TTL window (no simpleCrawl fired)", async () => {
+	it("does nothing when the row is within the TTL window (no crawl fired)", async () => {
 		const findArticleFreshness: FindArticleFreshness = async () => ({
 			etag: undefined,
 			lastModified: undefined,
 			contentFetchedAt: "2026-05-18T11:30:00.000Z",
 		});
-		const simpleCrawl = jest.fn(noopSimpleCrawl);
+		const crawlAndFinalizeArticle = jest.fn(failingCrawlAndFinalize);
 
 		const handler = createHandler({
 			findArticleFreshness,
-			simpleCrawl,
+			crawlAndFinalizeArticle,
 		});
 
 		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
 
-		expect(simpleCrawl).not.toHaveBeenCalled();
+		expect(crawlAndFinalizeArticle).not.toHaveBeenCalled();
 	});
 
 	it("publishes UpdateFetchTimestamp on 304 Not Modified", async () => {
@@ -164,14 +155,14 @@ describe("initStaleCheckHandler", () => {
 			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
 			contentFetchedAt: "2026-04-01T00:00:00.000Z",
 		});
-		const simpleCrawl: SimpleCrawl = async () => ({ status: "not-modified" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "not-modified" });
 		const publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp = jest
 			.fn()
 			.mockResolvedValue(undefined);
 
 		const handler = createHandler({
 			findArticleFreshness,
-			simpleCrawl,
+			crawlAndFinalizeArticle,
 			publishUpdateFetchTimestamp,
 		});
 
@@ -184,13 +175,38 @@ describe("initStaleCheckHandler", () => {
 		});
 	});
 
-	it("emits SimpleCrawlUnsupportedEvent with refresh=true and marks comprehensive-fetching stage when simpleCrawl returns unsupported (e.g. PDF body)", async () => {
+	it("forwards the stored etag/lastModified into crawlAndFinalize so the crawler can short-circuit on 304", async () => {
+		const findArticleFreshness: FindArticleFreshness = async () => ({
+			etag: '"abc"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
+			contentFetchedAt: "2026-04-01T00:00:00.000Z",
+		});
+		const crawlAndFinalizeArticle = jest.fn<
+			Promise<CrawlAndFinalizeResult>,
+			Parameters<CrawlAndFinalizeArticle>
+		>().mockResolvedValue({ status: "not-modified" });
+
+		const handler = createHandler({
+			findArticleFreshness,
+			crawlAndFinalizeArticle,
+		});
+
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+
+		expect(crawlAndFinalizeArticle).toHaveBeenCalledWith({
+			url: URL_UNDER_TEST,
+			etag: '"abc"',
+			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
+		});
+	});
+
+	it("emits SimpleCrawlUnsupportedEvent with refresh=true and marks comprehensive-fetching stage when crawl returns unsupported (e.g. PDF body)", async () => {
 		const findArticleFreshness: FindArticleFreshness = async () => ({
 			etag: undefined,
 			lastModified: undefined,
 			contentFetchedAt: "2026-04-01T00:00:00.000Z",
 		});
-		const simpleCrawl: SimpleCrawl = async () => ({
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({
 			status: "unsupported",
 			reason: "non-html content type: application/pdf",
 		});
@@ -204,7 +220,7 @@ describe("initStaleCheckHandler", () => {
 
 		const handler = createHandler({
 			findArticleFreshness,
-			simpleCrawl,
+			crawlAndFinalizeArticle,
 			emitSimpleCrawlUnsupported,
 			markCrawlStage,
 			publishRefreshArticleContent,
@@ -223,13 +239,13 @@ describe("initStaleCheckHandler", () => {
 		expect(publishRefreshArticleContent).not.toHaveBeenCalled();
 	});
 
-	it("skips when simpleCrawl returns failed (no further effect)", async () => {
+	it("skips when crawl returns failed (no further effect)", async () => {
 		const findArticleFreshness: FindArticleFreshness = async () => ({
 			etag: undefined,
 			lastModified: undefined,
 			contentFetchedAt: "2026-04-01T00:00:00.000Z",
 		});
-		const simpleCrawl: SimpleCrawl = async () => ({ status: "failed" });
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 		const publishRefreshArticleContent: PublishRefreshArticleContent = jest
 			.fn()
 			.mockResolvedValue(undefined);
@@ -242,7 +258,7 @@ describe("initStaleCheckHandler", () => {
 
 		const handler = createHandler({
 			findArticleFreshness,
-			simpleCrawl,
+			crawlAndFinalizeArticle,
 			publishRefreshArticleContent,
 			publishUpdateFetchTimestamp,
 			emitSimpleCrawlUnsupported,
@@ -255,55 +271,28 @@ describe("initStaleCheckHandler", () => {
 		expect(emitSimpleCrawlUnsupported).not.toHaveBeenCalled();
 	});
 
-	it("skips when parseHtml fails (terminal parse error on refreshed HTML)", async () => {
-		const findArticleFreshness: FindArticleFreshness = async () => ({
-			etag: undefined,
-			lastModified: undefined,
-			contentFetchedAt: "2026-04-01T00:00:00.000Z",
-		});
-		const simpleCrawl: SimpleCrawl = async () => ({
-			status: "fetched",
-			html: "<bad/>",
-		});
-		const parseHtml: ParseHtml = () => ({ ok: false, reason: "readability crashed" });
-		const publishRefreshArticleContent: PublishRefreshArticleContent = jest
-			.fn()
-			.mockResolvedValue(undefined);
-
-		const handler = createHandler({
-			findArticleFreshness,
-			simpleCrawl,
-			parseHtml,
-			publishRefreshArticleContent,
-		});
-
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
-
-		expect(publishRefreshArticleContent).not.toHaveBeenCalled();
-	});
-
-	it("publishes RefreshArticleContent with parsed metadata when simpleCrawl returns fetched HTML", async () => {
+	it("publishes RefreshArticleContent with the finalizer's metadata + freshness when the crawl returns fetched", async () => {
 		const findArticleFreshness: FindArticleFreshness = async () => ({
 			etag: '"prev"',
 			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
 			contentFetchedAt: "2026-04-01T00:00:00.000Z",
 		});
-		const simpleCrawl: SimpleCrawl = async () => ({
-			status: "fetched",
-			html: "<html><body><p>hi</p></body></html>",
-			etag: '"new"',
-			lastModified: "Sat, 17 May 2026 00:00:00 GMT",
-		});
-		const parseHtml: ParseHtml = () => ({
-			ok: true,
-			article: {
+		const finalizedArticle: FinalizedArticle = {
+			html: "<p>hi</p>",
+			metadata: {
 				title: "Hi",
 				siteName: "example.com",
 				excerpt: "Hi excerpt",
 				wordCount: 200,
-				content: "<p>hi</p>",
-				imageUrl: "https://example.com/img.png",
+				estimatedReadTime: 1,
+				imageUrl: "https://cdn.example.com/content/x/images/abc.png",
 			},
+		};
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({
+			status: "fetched",
+			article: finalizedArticle,
+			etag: '"new"',
+			lastModified: "Sat, 17 May 2026 00:00:00 GMT",
 		});
 		const publishRefreshArticleContent: PublishRefreshArticleContent = jest
 			.fn()
@@ -311,8 +300,7 @@ describe("initStaleCheckHandler", () => {
 
 		const handler = createHandler({
 			findArticleFreshness,
-			simpleCrawl,
-			parseHtml,
+			crawlAndFinalizeArticle,
 			publishRefreshArticleContent,
 		});
 
@@ -320,15 +308,15 @@ describe("initStaleCheckHandler", () => {
 
 		expect(publishRefreshArticleContent).toHaveBeenCalledWith({
 			url: URL_UNDER_TEST,
-			html: "<html><body><p>hi</p></body></html>",
+			html: "<p>hi</p>",
 			metadata: {
 				title: "Hi",
 				siteName: "example.com",
 				excerpt: "Hi excerpt",
 				wordCount: 200,
-				imageUrl: "https://example.com/img.png",
+				imageUrl: "https://cdn.example.com/content/x/images/abc.png",
 			},
-			estimatedReadTime: expect.any(Number),
+			estimatedReadTime: 1,
 			etag: '"new"',
 			lastModified: "Sat, 17 May 2026 00:00:00 GMT",
 			contentFetchedAt: fixedNow().toISOString(),

--- a/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.ts
+++ b/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.ts
@@ -1,7 +1,5 @@
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { SimpleCrawl } from "@packages/crawl-article";
-import { calculateReadTime } from "@packages/domain/article";
 import {
 	decideSummaryAutoHeal,
 	incrementSummaryAutoHealAttempt,
@@ -21,9 +19,9 @@ import type {
 	PublishSaveAnonymousLink,
 	PublishUpdateFetchTimestamp,
 } from "@packages/test-fixtures/providers/events";
-import type { ParseHtml } from "@packages/article-parser";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
+import type { CrawlAndFinalizeArticle } from "../save-link/crawl-and-finalize-article";
 
 /**
  * Stale-check is now a simple-only worker: PDFs flow through the same
@@ -59,8 +57,7 @@ const logPrefix = "[StaleCheckRequested]";
 export function initStaleCheckHandler(deps: {
 	findArticleFreshness: FindArticleFreshness;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
-	simpleCrawl: SimpleCrawl;
-	parseHtml: ParseHtml;
+	crawlAndFinalizeArticle: CrawlAndFinalizeArticle;
 	publishRefreshArticleContent: PublishRefreshArticleContent;
 	publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp;
 	publishSaveAnonymousLink: PublishSaveAnonymousLink;
@@ -75,8 +72,7 @@ export function initStaleCheckHandler(deps: {
 	const {
 		findArticleFreshness,
 		findArticleCrawlStatus,
-		simpleCrawl,
-		parseHtml,
+		crawlAndFinalizeArticle,
 		publishRefreshArticleContent,
 		publishUpdateFetchTimestamp,
 		publishSaveAnonymousLink,
@@ -101,7 +97,7 @@ export function initStaleCheckHandler(deps: {
 			if (now().getTime() - fetchedAt < staleTtlMs) return "skip";
 		}
 
-		const result = await simpleCrawl({
+		const result = await crawlAndFinalizeArticle({
 			url,
 			etag: freshness.etag,
 			lastModified: freshness.lastModified,
@@ -127,24 +123,17 @@ export function initStaleCheckHandler(deps: {
 			return "tier-1-deferred";
 		}
 
-		const parsed = parseHtml({
-			url,
-			html: result.html,
-			thumbnailUrl: result.thumbnailUrl ?? null,
-		});
-		if (!parsed.ok) return "skip";
-
 		await publishRefreshArticleContent({
 			url,
-			html: result.html,
+			html: result.article.html,
 			metadata: {
-				title: parsed.article.title,
-				siteName: parsed.article.siteName,
-				excerpt: parsed.article.excerpt,
-				wordCount: parsed.article.wordCount,
-				imageUrl: parsed.article.imageUrl,
+				title: result.article.metadata.title,
+				siteName: result.article.metadata.siteName,
+				excerpt: result.article.metadata.excerpt,
+				wordCount: result.article.metadata.wordCount,
+				imageUrl: result.article.metadata.imageUrl,
 			},
-			estimatedReadTime: calculateReadTime(parsed.article.wordCount),
+			estimatedReadTime: result.article.metadata.estimatedReadTime,
 			etag: result.etag,
 			lastModified: result.lastModified,
 			contentFetchedAt: now().toISOString(),

--- a/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
@@ -9,6 +9,7 @@ import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
 import { initMediaDepBundle } from "./dep-bundles/media";
+import { initCrawlAndFinalizeDepBundle } from "./dep-bundles/crawl-and-finalize";
 import { initEmitSimpleCrawlUnsupported, initEventsDepBundle } from "./dep-bundles/events";
 import { initArticleAggregateDepBundle } from "./dep-bundles/article-aggregate";
 import { initArticleCrawlDepBundle } from "./dep-bundles/article-crawl";
@@ -29,6 +30,13 @@ const observability = initObservabilityDepBundle({ logger: consoleLogger, source
 const parser = initParserDepBundle({ logError: observability.logError });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
+const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
+	parser,
+	media,
+	articleStore,
+	imagesCdnBaseUrl,
+	logError: observability.logError,
+});
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
@@ -37,14 +45,12 @@ const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 });
 
 export const handler = initRecrawlLinkInitiatedHandler({
-	...parser,
-	...media,
 	...articleStore,
 	...events,
 	...articleAggregate,
 	...articleCrawl,
 	...observability,
+	crawlAndFinalizeArticle: crawlAndFinalize.crawlAndFinalizeArticle,
 	emitSimpleCrawlUnsupported,
-	imagesCdnBaseUrl,
 	now,
 });

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -9,6 +9,7 @@ import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
 import { initMediaDepBundle } from "./dep-bundles/media";
+import { initCrawlAndFinalizeDepBundle } from "./dep-bundles/crawl-and-finalize";
 import { initEmitSimpleCrawlUnsupported, initEventsDepBundle } from "./dep-bundles/events";
 import { initArticleAggregateDepBundle } from "./dep-bundles/article-aggregate";
 import { initArticleCrawlDepBundle } from "./dep-bundles/article-crawl";
@@ -29,6 +30,13 @@ const observability = initObservabilityDepBundle({ logger: consoleLogger, source
 const parser = initParserDepBundle({ logError: observability.logError });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
+const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
+	parser,
+	media,
+	articleStore,
+	imagesCdnBaseUrl,
+	logError: observability.logError,
+});
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
@@ -37,14 +45,12 @@ const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 });
 
 export const handler = initSaveAnonymousLinkCommandHandler({
-	...parser,
-	...media,
 	...articleStore,
 	...events,
 	...articleAggregate,
 	...articleCrawl,
 	...observability,
+	crawlAndFinalizeArticle: crawlAndFinalize.crawlAndFinalizeArticle,
 	emitSimpleCrawlUnsupported,
-	imagesCdnBaseUrl,
 	now,
 });

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -9,6 +9,7 @@ import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
 import { initMediaDepBundle } from "./dep-bundles/media";
+import { initCrawlAndFinalizeDepBundle } from "./dep-bundles/crawl-and-finalize";
 import { initEmitSimpleCrawlUnsupported, initEventsDepBundle } from "./dep-bundles/events";
 import { initArticleAggregateDepBundle } from "./dep-bundles/article-aggregate";
 import { initArticleCrawlDepBundle } from "./dep-bundles/article-crawl";
@@ -29,6 +30,13 @@ const observability = initObservabilityDepBundle({ logger: consoleLogger, source
 const parser = initParserDepBundle({ logError: observability.logError });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
+const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
+	parser,
+	media,
+	articleStore,
+	imagesCdnBaseUrl,
+	logError: observability.logError,
+});
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
@@ -37,14 +45,12 @@ const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 });
 
 export const handler = initSaveLinkCommandHandler({
-	...parser,
-	...media,
 	...articleStore,
 	...events,
 	...articleAggregate,
 	...articleCrawl,
 	...observability,
+	crawlAndFinalizeArticle: crawlAndFinalize.crawlAndFinalizeArticle,
 	emitSimpleCrawlUnsupported,
-	imagesCdnBaseUrl,
 	now,
 });

--- a/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-raw-html-command.main.ts
@@ -10,6 +10,7 @@ import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
 import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
 import { initMediaDepBundle } from "./dep-bundles/media";
+import { initCrawlAndFinalizeDepBundle } from "./dep-bundles/crawl-and-finalize";
 import { initEventsDepBundle } from "./dep-bundles/events";
 import { initArticleAggregateDepBundle } from "./dep-bundles/article-aggregate";
 
@@ -27,24 +28,31 @@ const eventBridgeClient = new EventBridgeClient({});
 const now = () => new Date();
 
 // This Lambda consumes already-fetched HTML from S3 (pendingHtml bucket) and
-// never re-crawls a URL through crawlArticle — the handler uses parseHtml on
-// the raw body directly. The simple-only parser bundle suffices; no PDF path
-// is exercised here.
+// never re-crawls a URL through crawlArticle. It still goes through the
+// unified `finalizeArticle` pipeline so the og:image is fetched + uploaded to
+// the CDN with the same algorithm every other path uses — no per-trigger
+// drift on what lands in the metadata.
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link-raw-html", now });
 const parser = initParserDepBundle({ logError: observability.logError });
 const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
 const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
+const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
+	parser,
+	media,
+	articleStore,
+	imagesCdnBaseUrl,
+	logError: observability.logError,
+});
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 
 const { readPendingHtml } = initReadPendingHtml({ client: s3Client, bucketName: pendingHtmlBucketName });
 
 export const handler = initSaveLinkRawHtmlCommandHandler({
-	...parser,
-	...media,
 	...articleStore,
 	...events,
 	...articleAggregate,
 	...observability,
+	finalizeArticle: crawlAndFinalize.finalizeArticle,
 	readPendingHtml,
 });

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -14,6 +14,9 @@ import type {
 import { initStaleCheckHandler } from "./domain/stale-check/stale-check-handler";
 import { initObservabilityDepBundle } from "./dep-bundles/observability";
 import { initParserDepBundle } from "./dep-bundles/parser";
+import { initArticleStoreDepBundle } from "./dep-bundles/article-store";
+import { initMediaDepBundle } from "./dep-bundles/media";
+import { initCrawlAndFinalizeDepBundle } from "./dep-bundles/crawl-and-finalize";
 import { initArticleCrawlDepBundle } from "./dep-bundles/article-crawl";
 import { initArticleAggregateDepBundle } from "./dep-bundles/article-aggregate";
 import { initEmitSimpleCrawlUnsupported, initEventsDepBundle } from "./dep-bundles/events";
@@ -27,7 +30,9 @@ import { requireEnv } from "../require-env";
 const STALE_TTL_MS = 86_400_000;
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
+const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
+const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
 const pendingHtmlBucketName = requireEnv("PENDING_HTML_BUCKET_NAME");
 
@@ -39,6 +44,15 @@ const now = () => new Date();
 
 const observability = initObservabilityDepBundle({ logger: consoleLogger, source: "save-link", now });
 const parser = initParserDepBundle({ logError: observability.logError });
+const articleStore = initArticleStoreDepBundle({ s3Client, dynamoClient, contentBucketName, articlesTable });
+const media = initMediaDepBundle({ parser, articleStore, logger: consoleLogger, imagesCdnBaseUrl });
+const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
+	parser,
+	media,
+	articleStore,
+	imagesCdnBaseUrl,
+	logError: observability.logError,
+});
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
@@ -71,8 +85,7 @@ const { findArticleCrawlStatus } = initFindArticleCrawlStatus({
 export const handler = initStaleCheckHandler({
 	findArticleFreshness,
 	findArticleCrawlStatus,
-	simpleCrawl: parser.simpleCrawl,
-	parseHtml: parser.parseHtml,
+	crawlAndFinalizeArticle: crawlAndFinalize.crawlAndFinalizeArticle,
 	publishRefreshArticleContent,
 	publishUpdateFetchTimestamp,
 	publishSaveAnonymousLink,

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -4,11 +4,9 @@ import type {
 	CrawlArticle,
 	CrawlArticleResult,
 	SimpleCrawl,
-	ThumbnailImage,
 } from "./crawl-article.types";
 import type { CrawlFetch } from "./crawl-fetch";
-import { extensionFromContentType } from "./extension-from-content-type";
-import { extractThumbnailCandidates } from "./extract-thumbnail";
+import { extractThumbnailCandidates, initFetchThumbnailImage } from "./extract-thumbnail";
 import { headerOrUndefined } from "./header-utils";
 import { isPDF } from "./pdf-detect";
 import { MAX_PDF_BYTES } from "./pdf-page-limits";
@@ -16,8 +14,6 @@ import type { ExtractPdf } from "./pdf-extract.types";
 import { initFetchTweetViaOembed, isTweetUrl } from "./x-twitter-preprocessor";
 
 const FETCH_TIMEOUT_MS = 10000;
-const THUMBNAIL_FETCH_TIMEOUT_MS = 5000;
-const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
 
 /**
  * Browser-like headers required by Fastly/Cloudflare edge sniffers.
@@ -127,6 +123,7 @@ export function initSimpleCrawl(deps: {
 	const { crawlFetch, logError } = deps;
 	const conditionalFetch = initConditionalFetch({ crawlFetch, logError });
 	const fetchTweetViaOembed = initFetchTweetViaOembed({ crawlFetch, logError });
+	const fetchThumbnailImage = initFetchThumbnailImage({ crawlFetch, logError });
 	return async (params) => {
 		if (isTweetUrl(params.url)) {
 			return fetchTweetViaOembed(params);
@@ -145,7 +142,7 @@ export function initSimpleCrawl(deps: {
 			const candidates = extractThumbnailCandidates({ html, baseUrl: params.url });
 			const thumbnailUrl = candidates[0];
 			const thumbnailImage = params.fetchThumbnail
-				? await fetchThumbnailImage({ crawlFetch, logError, candidates, referer: params.url })
+				? await fetchThumbnailImage({ candidates, referer: params.url })
 				: undefined;
 			const result: CrawlArticleResult & { status: "fetched" } = {
 				status: "fetched",
@@ -255,62 +252,6 @@ async function handlePdfBuffer(args: {
 		lastModified: headerOrUndefined(args.response.headers, "last-modified"),
 	};
 	return result;
-}
-
-async function fetchThumbnailImage(args: {
-	crawlFetch: CrawlFetch;
-	logError: (message: string, error?: Error) => void;
-	candidates: string[];
-	referer: string;
-}): Promise<ThumbnailImage | undefined> {
-	const { crawlFetch, logError, candidates, referer } = args;
-
-	for (const candidateUrl of candidates) {
-		const result = await tryFetchImage({ crawlFetch, logError, url: candidateUrl, referer });
-		if (result) return result;
-	}
-
-	return undefined;
-}
-
-async function tryFetchImage(args: {
-	crawlFetch: CrawlFetch;
-	logError: (message: string, error?: Error) => void;
-	url: string;
-	referer: string;
-}): Promise<ThumbnailImage | undefined> {
-	const { crawlFetch, logError, url, referer } = args;
-	try {
-		const response = await crawlFetch(url, {
-			signal: AbortSignal.timeout(THUMBNAIL_FETCH_TIMEOUT_MS),
-			headers: { accept: "image/*,*/*;q=0.8" },
-			referer,
-		});
-		if (!response.ok) {
-			logError(`[CrawlArticle] Thumbnail HTTP ${response.status} for ${url}`);
-			return undefined;
-		}
-		const contentType = response.headers.get("content-type") ?? "";
-		if (!contentType.startsWith("image/")) {
-			logError(`[CrawlArticle] Thumbnail unexpected Content-Type "${contentType}" for ${url}`);
-			return undefined;
-		}
-		const contentLength = response.headers.get("content-length");
-		if (contentLength && Number.parseInt(contentLength, 10) > MAX_THUMBNAIL_BYTES) {
-			logError(`[CrawlArticle] Thumbnail too large (${contentLength} bytes) for ${url}`);
-			return undefined;
-		}
-		const arrayBuffer = await response.arrayBuffer();
-		const body = Buffer.from(arrayBuffer);
-		if (body.length > MAX_THUMBNAIL_BYTES) {
-			logError(`[CrawlArticle] Thumbnail too large (${body.length} bytes) for ${url}`);
-			return undefined;
-		}
-		return { body, contentType, url, extension: extensionFromContentType({ contentType, url }) };
-	} catch (error) {
-		logError(`[CrawlArticle] Thumbnail network error for ${url}`, error instanceof Error ? error : undefined);
-		return undefined;
-	}
 }
 
 

--- a/src/packages/crawl-article/src/extract-thumbnail.ts
+++ b/src/packages/crawl-article/src/extract-thumbnail.ts
@@ -1,4 +1,10 @@
 import { parseHTML } from "linkedom";
+import type { CrawlFetch } from "./crawl-fetch";
+import { extensionFromContentType } from "./extension-from-content-type";
+import type { ThumbnailImage } from "./crawl-article.types";
+
+const THUMBNAIL_FETCH_TIMEOUT_MS = 5000;
+const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
 
 /**
  * Single source of truth for picking the article's thumbnail URL out of
@@ -67,5 +73,71 @@ function isValidHttpUrl(url: string): boolean {
 		return parsed.protocol === "http:" || parsed.protocol === "https:";
 	} catch {
 		return false;
+	}
+}
+
+export type FetchThumbnailImage = (params: {
+	candidates: readonly string[];
+	referer: string;
+}) => Promise<ThumbnailImage | undefined>;
+
+/**
+ * Walks the candidate list and returns the first image that downloads cleanly
+ * within the timeout / size / content-type bounds. Shared between SimpleCrawl
+ * (which prefetches inline) and any caller that already has HTML in hand
+ * (raw-html save, comprehensive crawl post-extract) — same algorithm, same
+ * bounds, no per-path drift.
+ */
+export function initFetchThumbnailImage(deps: {
+	crawlFetch: CrawlFetch;
+	logError: (message: string, error?: Error) => void;
+}): FetchThumbnailImage {
+	const { crawlFetch, logError } = deps;
+	return async ({ candidates, referer }) => {
+		for (const candidateUrl of candidates) {
+			const result = await tryFetchImage({ crawlFetch, logError, url: candidateUrl, referer });
+			if (result) return result;
+		}
+		return undefined;
+	};
+}
+
+async function tryFetchImage(args: {
+	crawlFetch: CrawlFetch;
+	logError: (message: string, error?: Error) => void;
+	url: string;
+	referer: string;
+}): Promise<ThumbnailImage | undefined> {
+	const { crawlFetch, logError, url, referer } = args;
+	try {
+		const response = await crawlFetch(url, {
+			signal: AbortSignal.timeout(THUMBNAIL_FETCH_TIMEOUT_MS),
+			headers: { accept: "image/*,*/*;q=0.8" },
+			referer,
+		});
+		if (!response.ok) {
+			logError(`[CrawlArticle] Thumbnail HTTP ${response.status} for ${url}`);
+			return undefined;
+		}
+		const contentType = response.headers.get("content-type") ?? "";
+		if (!contentType.startsWith("image/")) {
+			logError(`[CrawlArticle] Thumbnail unexpected Content-Type "${contentType}" for ${url}`);
+			return undefined;
+		}
+		const contentLength = response.headers.get("content-length");
+		if (contentLength && Number.parseInt(contentLength, 10) > MAX_THUMBNAIL_BYTES) {
+			logError(`[CrawlArticle] Thumbnail too large (${contentLength} bytes) for ${url}`);
+			return undefined;
+		}
+		const arrayBuffer = await response.arrayBuffer();
+		const body = Buffer.from(arrayBuffer);
+		if (body.length > MAX_THUMBNAIL_BYTES) {
+			logError(`[CrawlArticle] Thumbnail too large (${body.length} bytes) for ${url}`);
+			return undefined;
+		}
+		return { body, contentType, url, extension: extensionFromContentType({ contentType, url }) };
+	} catch (error) {
+		logError(`[CrawlArticle] Thumbnail network error for ${url}`, error instanceof Error ? error : undefined);
+		return undefined;
 	}
 }

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -8,7 +8,12 @@ export {
 } from "./crawl-article";
 export type { Persona } from "./persona-fallback";
 export { extensionFromContentType } from "./extension-from-content-type";
-export { extractFirstThumbnailUrl, extractThumbnailCandidates } from "./extract-thumbnail";
+export {
+	extractFirstThumbnailUrl,
+	extractThumbnailCandidates,
+	initFetchThumbnailImage,
+	type FetchThumbnailImage,
+} from "./extract-thumbnail";
 export type {
 	CrawlArticle,
 	CrawlArticleResult,

--- a/src/packages/domain/src/article-aggregate/canonical-image-url.ts
+++ b/src/packages/domain/src/article-aggregate/canonical-image-url.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+/* Branded type for the imageUrl that lands in canonical Article metadata
+ * after the tier selector picks a winner. The brand exists so a handler
+ * cannot pass `winnerSource.metadata.imageUrl` (plain `string | undefined`)
+ * straight into a promotion transition — TypeScript rejects the assignment.
+ * The only sanctioned producer is `resolveCanonicalImageUrl` in save-link's
+ * select-content, which routes the value through `CanonicalImageUrlSchema`
+ * (the lone factory) after rescuing an og:image from a losing tier when the
+ * winner has none.
+ *
+ * Without the brand, a future contributor could regress the cross-tier
+ * imageUrl rescue by writing `metadata: winnerSource.metadata` directly and
+ * silently dropping the fallback — the way the code worked before
+ * resolveCanonicalImageUrl existed. The brand makes that regression a
+ * compile error. */
+export const CanonicalImageUrlSchema = z.string().brand<"CanonicalImageUrl">().optional();
+export type CanonicalImageUrl = z.infer<typeof CanonicalImageUrlSchema>;

--- a/src/packages/domain/src/article-aggregate/index.ts
+++ b/src/packages/domain/src/article-aggregate/index.ts
@@ -7,6 +7,10 @@ export type {
 	SummaryState,
 } from "./article.types";
 export {
+	CanonicalImageUrlSchema,
+	type CanonicalImageUrl,
+} from "./canonical-image-url";
+export {
 	SUMMARY_AUTO_HEAL_MAX_ATTEMPTS,
 	SUMMARY_AUTO_HEAL_TTL_MS,
 } from "./auto-heal-constants";

--- a/src/packages/domain/src/article-aggregate/transitions/promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/promote-tier.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
-import type { Article } from "../article.types";
+import type { Article, ArticleMetadata } from "../article.types";
+import { CanonicalImageUrlSchema } from "../canonical-image-url";
 import { promoteTier, type PromoteTierInput } from "./promote-tier";
+
+/* Helper that brands the imageUrl on test fixtures so they satisfy the
+ * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
+ * CanonicalImageUrl }` shape. Production code goes through
+ * `resolveCanonicalImageUrl` for the same brand. */
+function canonicalMetadata(metadata: ArticleMetadata) {
+	return { ...metadata, imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl) };
+}
 
 const FIXED_PENDING = "2026-01-01T00:00:00.000Z";
 const NOW = "2026-05-13T12:00:00.000Z";
@@ -36,7 +45,7 @@ function buildInput(overrides: Partial<PromoteTierInput> = {}): PromoteTierInput
 			siteName: "New site",
 			excerpt: "New excerpt",
 			wordCount: 250,
-			imageUrl: "https://example.com/image.jpg",
+			imageUrl: CanonicalImageUrlSchema.parse("https://example.com/image.jpg"),
 		},
 		estimatedReadTime: 2,
 		contentFetchedAt: "2026-05-10T12:00:00.000Z",
@@ -67,7 +76,7 @@ describe("promoteTier", () => {
 
 		const { article } = promoteTier(
 			before,
-			buildInput({ metadata: before.metadata, estimatedReadTime: 2 }),
+			buildInput({ metadata: canonicalMetadata(before.metadata), estimatedReadTime: 2 }),
 		);
 
 		assert.equal(article.freshness.contentFetchedAt, "2026-05-10T12:00:00.000Z");
@@ -87,7 +96,7 @@ describe("promoteTier", () => {
 	it("overwrites estimatedReadTime with the supplied value", () => {
 		const { article } = promoteTier(
 			buildArticle(),
-			buildInput({ estimatedReadTime: 7, metadata: buildArticle().metadata }),
+			buildInput({ estimatedReadTime: 7, metadata: canonicalMetadata(buildArticle().metadata) }),
 		);
 
 		assert.equal(article.estimatedReadTime, 7);
@@ -96,7 +105,7 @@ describe("promoteTier", () => {
 	it("flips crawl to ready", () => {
 		const { article } = promoteTier(
 			buildArticle(),
-			buildInput({ metadata: buildArticle().metadata, estimatedReadTime: 1 }),
+			buildInput({ metadata: canonicalMetadata(buildArticle().metadata), estimatedReadTime: 1 }),
 		);
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
@@ -119,7 +128,7 @@ describe("promoteTier", () => {
 		const { article } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalContentHash: HASH_B,
 			}),
@@ -146,7 +155,7 @@ describe("promoteTier", () => {
 		const { article } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalContentHash: HASH_A,
 			}),
@@ -167,7 +176,7 @@ describe("promoteTier", () => {
 		const { article, writes } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalContentHash: HASH_A,
 			}),
@@ -189,7 +198,7 @@ describe("promoteTier", () => {
 		const { article } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalContentHash: HASH_B,
 			}),
@@ -205,7 +214,7 @@ describe("promoteTier", () => {
 		const { effects } = promoteTier(
 			buildArticle({ url: "https://example.com/post" }),
 			buildInput({
-				metadata: buildArticle().metadata,
+				metadata: canonicalMetadata(buildArticle().metadata),
 				estimatedReadTime: 1,
 				canonicalChanged: true,
 				userId: "user-123",
@@ -230,7 +239,7 @@ describe("promoteTier", () => {
 		const { effects } = promoteTier(
 			buildArticle({ url: "https://example.com/post" }),
 			buildInput({
-				metadata: buildArticle().metadata,
+				metadata: canonicalMetadata(buildArticle().metadata),
 				estimatedReadTime: 1,
 				canonicalChanged: true,
 			}),
@@ -253,7 +262,7 @@ describe("promoteTier", () => {
 		const { effects } = promoteTier(
 			buildArticle({ url: "https://example.com/post" }),
 			buildInput({
-				metadata: buildArticle().metadata,
+				metadata: canonicalMetadata(buildArticle().metadata),
 				estimatedReadTime: 1,
 				canonicalChanged: false,
 				userId: "user-123",
@@ -283,7 +292,7 @@ describe("promoteTier", () => {
 		const { effects } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalChanged: false,
 				canonicalContentHash: HASH_A,
@@ -311,7 +320,7 @@ describe("promoteTier", () => {
 		const { writes } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalContentHash: HASH_B,
 			}),
@@ -338,7 +347,7 @@ describe("promoteTier", () => {
 		const { writes } = promoteTier(
 			before,
 			buildInput({
-				metadata: before.metadata,
+				metadata: canonicalMetadata(before.metadata),
 				estimatedReadTime: 1,
 				canonicalContentHash: HASH_A,
 			}),
@@ -355,12 +364,12 @@ describe("promoteTier", () => {
 			before,
 			buildInput({
 				tier: "tier-1",
-				metadata: {
+				metadata: canonicalMetadata({
 					title: "Different",
 					siteName: "Example",
 					excerpt: "Different",
 					wordCount: 200,
-				},
+				}),
 				estimatedReadTime: 3,
 			}),
 		);

--- a/src/packages/domain/src/article-aggregate/transitions/promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/promote-tier.ts
@@ -1,10 +1,15 @@
 import type { Article, ArticleMetadata } from "../article.types";
+import type { CanonicalImageUrl } from "../canonical-image-url";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
 export interface PromoteTierInput {
 	tier: "tier-0" | "tier-1";
-	metadata: ArticleMetadata;
+	/** `imageUrl` is branded `CanonicalImageUrl` so the only way to populate it
+	 * is `resolveCanonicalImageUrl` (save-link/select-content), which rescues
+	 * an og:image from a losing tier when the winner has none. Passing
+	 * `winnerSource.metadata.imageUrl` directly is a compile error. */
+	metadata: Omit<ArticleMetadata, "imageUrl"> & { imageUrl: CanonicalImageUrl };
 	estimatedReadTime: number;
 	contentFetchedAt: string;
 	now: string;

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import type { Article } from "../article.types";
+import { CanonicalImageUrlSchema } from "../canonical-image-url";
 import {
 	recrawlPromoteTier,
 	type RecrawlPromoteTierInput,
@@ -40,7 +41,7 @@ function buildInput(overrides: Partial<RecrawlPromoteTierInput> = {}): RecrawlPr
 			siteName: "New site",
 			excerpt: "New excerpt",
 			wordCount: 250,
-			imageUrl: "https://example.com/image.jpg",
+			imageUrl: CanonicalImageUrlSchema.parse("https://example.com/image.jpg"),
 		},
 		estimatedReadTime: 3,
 		contentFetchedAt: "2026-05-10T12:00:00.000Z",
@@ -66,7 +67,7 @@ describe("recrawlPromoteTier", () => {
 					siteName: "Refreshed site",
 					excerpt: "Refreshed excerpt",
 					wordCount: 999,
-					imageUrl: "https://example.com/refreshed.jpg",
+					imageUrl: CanonicalImageUrlSchema.parse("https://example.com/refreshed.jpg"),
 				},
 			}),
 		);

--- a/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/recrawl-promote-tier.ts
@@ -1,10 +1,15 @@
 import type { Article, ArticleMetadata } from "../article.types";
+import type { CanonicalImageUrl } from "../canonical-image-url";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
 export interface RecrawlPromoteTierInput {
 	winnerTier: "tier-0" | "tier-1";
-	metadata: ArticleMetadata;
+	/** `imageUrl` is branded `CanonicalImageUrl` so the only way to populate it
+	 * is `resolveCanonicalImageUrl` (save-link/select-content), which rescues
+	 * an og:image from a losing tier when the winner has none. Passing
+	 * `winnerSource.metadata.imageUrl` directly is a compile error. */
+	metadata: Omit<ArticleMetadata, "imageUrl"> & { imageUrl: CanonicalImageUrl };
 	estimatedReadTime: number;
 	contentFetchedAt: string;
 	now: string;

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -1,15 +1,22 @@
 import assert from "node:assert/strict";
 import type { Article, ArticleMetadata } from "../article.types";
 import { CanonicalImageUrlSchema } from "../canonical-image-url";
-import { refreshContent } from "./refresh-content";
+import { refreshContent, type RefreshContentInput } from "./refresh-content";
 
 /* Helper that brands the imageUrl on test fixtures so they satisfy the
  * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
  * CanonicalImageUrl }` shape. Production code goes through
- * `resolveCanonicalImageUrl` for the same brand. */
-function canonicalMetadata(metadata: ArticleMetadata) {
-	const { imageUrl, ...rest } = metadata;
-	return { ...rest, imageUrl: CanonicalImageUrlSchema.parse(imageUrl) };
+ * `resolveCanonicalImageUrl` for the same brand. Explicit property
+ * assignment (no spread) avoids TypeScript incremental-build inference
+ * ambiguity for the branded override. */
+function canonicalMetadata(metadata: ArticleMetadata): RefreshContentInput["metadata"] {
+	return {
+		title: metadata.title,
+		siteName: metadata.siteName,
+		excerpt: metadata.excerpt,
+		wordCount: metadata.wordCount,
+		imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl),
+	};
 }
 
 const NOW = "2026-05-13T12:00:00.000Z";

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -6,17 +6,9 @@ import { refreshContent, type RefreshContentInput } from "./refresh-content";
 /* Helper that brands the imageUrl on test fixtures so they satisfy the
  * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
  * CanonicalImageUrl }` shape. Production code goes through
- * `resolveCanonicalImageUrl` for the same brand. Explicit property
- * assignment (no spread) avoids TypeScript incremental-build inference
- * ambiguity for the branded override. */
-function canonicalMetadata(metadata: ArticleMetadata): RefreshContentInput["metadata"] {
-	return {
-		title: metadata.title,
-		siteName: metadata.siteName,
-		excerpt: metadata.excerpt,
-		wordCount: metadata.wordCount,
-		imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl),
-	};
+ * `resolveCanonicalImageUrl` for the same brand. */
+function canonicalMetadata(metadata: ArticleMetadata) {
+	return { ...metadata, imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl) };
 }
 
 const NOW = "2026-05-13T12:00:00.000Z";
@@ -49,11 +41,31 @@ function buildArticle(overrides: Partial<Article> = {}): Article {
 	};
 }
 
+function buildInput(overrides: Partial<RefreshContentInput> = {}): RefreshContentInput {
+	return {
+		metadata: {
+			title: "New title",
+			siteName: "Example",
+			excerpt: "New excerpt",
+			wordCount: 250,
+			imageUrl: CanonicalImageUrlSchema.parse("https://example.com/image.jpg"),
+		},
+		freshness: {
+			etag: '"new-etag"',
+			contentFetchedAt: "2026-05-10T12:00:00.000Z",
+		},
+		estimatedReadTime: 2,
+		now: NOW,
+		canonicalContentHash: HASH_A,
+		...overrides,
+	};
+}
+
 describe("refreshContent", () => {
 	it("overwrites metadata, freshness, and estimated read time with the fetched values", () => {
 		const before = buildArticle();
 
-		const { article } = refreshContent(before, {
+		const { article } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata({
 				title: "New title",
 				siteName: "Example",
@@ -67,9 +79,7 @@ describe("refreshContent", () => {
 				contentFetchedAt: "2026-05-10T12:00:00.000Z",
 			},
 			estimatedReadTime: 2,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.equal(article.metadata.title, "New title");
 		assert.equal(article.metadata.wordCount, 250);
@@ -82,13 +92,11 @@ describe("refreshContent", () => {
 	it("writes the new canonicalContentHash onto freshness so subsequent runs can compare against it", () => {
 		const before = buildArticle();
 
-		const { article } = refreshContent(before, {
+		const { article } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.equal(article.freshness.canonicalContentHash, HASH_A);
 	});
@@ -110,13 +118,12 @@ describe("refreshContent", () => {
 			},
 		});
 
-		const { article } = refreshContent(before, {
+		const { article } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
 			canonicalContentHash: HASH_B,
-		});
+		}));
 
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 	});
@@ -137,13 +144,11 @@ describe("refreshContent", () => {
 			summary: existingSummary,
 		});
 
-		const { article } = refreshContent(before, {
+		const { article } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.deepEqual(article.summary, existingSummary);
 	});
@@ -153,13 +158,11 @@ describe("refreshContent", () => {
 			summary: { kind: "ready", summary: "stale" },
 		});
 
-		const { article, writes } = refreshContent(before, {
+		const { article, writes } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 		assert.ok(writes.includes("summary"));
@@ -175,13 +178,12 @@ describe("refreshContent", () => {
 			},
 		});
 
-		const { article } = refreshContent(before, {
+		const { article } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
 			canonicalContentHash: HASH_B,
-		});
+		}));
 
 		assert.equal(
 			article.summary.kind === "pending" ? article.summary.pendingSince : "",
@@ -192,13 +194,11 @@ describe("refreshContent", () => {
 	it("preserves crawl state so a successful refresh does not regress the crawl row", () => {
 		const before = buildArticle({ crawl: { kind: "ready" } });
 
-		const { article } = refreshContent(before, {
+		const { article } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
 	});
@@ -214,13 +214,12 @@ describe("refreshContent", () => {
 			},
 		});
 
-		const { effects } = refreshContent(before, {
+		const { effects } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
 			canonicalContentHash: HASH_B,
-		});
+		}));
 
 		assert.deepEqual(effects, [
 			{ kind: "generate-summary", url: "https://example.com/post" },
@@ -239,13 +238,11 @@ describe("refreshContent", () => {
 			summary: { kind: "ready", summary: "kept" },
 		});
 
-		const { effects } = refreshContent(before, {
+		const { effects } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.deepEqual(effects, []);
 	});
@@ -260,13 +257,12 @@ describe("refreshContent", () => {
 			},
 		});
 
-		const { writes } = refreshContent(before, {
+		const { writes } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
 			canonicalContentHash: HASH_B,
-		});
+		}));
 
 		assert.deepEqual([...writes].sort(), ["freshness", "metadata", "summary"]);
 		assert.ok(!writes.includes("crawl"), "refresh must not clobber an in-flight or already-ready crawl");
@@ -283,13 +279,11 @@ describe("refreshContent", () => {
 			summary: { kind: "ready", summary: "kept" },
 		});
 
-		const { writes } = refreshContent(before, {
+		const { writes } = refreshContent(before, buildInput({
 			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.deepEqual([...writes].sort(), ["freshness", "metadata"]);
 		assert.ok(!writes.includes("summary"));
@@ -351,7 +345,7 @@ describe("refreshContent", () => {
 		const before = buildArticle();
 		const beforeSnapshot = JSON.parse(JSON.stringify(before));
 
-		refreshContent(before, {
+		refreshContent(before, buildInput({
 			metadata: canonicalMetadata({
 				title: "Different",
 				siteName: "Example",
@@ -363,9 +357,7 @@ describe("refreshContent", () => {
 				contentFetchedAt: "2026-05-10T12:00:00.000Z",
 			},
 			estimatedReadTime: 3,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		}));
 
 		assert.deepEqual(before, beforeSnapshot);
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import type { Article, ArticleMetadata } from "../article.types";
+import type { CanonicalImageUrl } from "../canonical-image-url";
 import { CanonicalImageUrlSchema } from "../canonical-image-url";
 import { refreshContent } from "./refresh-content";
 
@@ -7,7 +8,9 @@ import { refreshContent } from "./refresh-content";
  * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
  * CanonicalImageUrl }` shape. Production code goes through
  * `resolveCanonicalImageUrl` for the same brand. */
-function canonicalMetadata(metadata: ArticleMetadata) {
+function canonicalMetadata(
+	metadata: ArticleMetadata,
+): Omit<ArticleMetadata, "imageUrl"> & { imageUrl: CanonicalImageUrl } {
 	return { ...metadata, imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl) };
 }
 

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -253,13 +253,7 @@ describe("refreshContent", () => {
 			crawl: { kind: "failed", reason: { kind: "fetch-failed", httpStatus: 503 } },
 		});
 
-		const { article, writes } = refreshContent(before, {
-			metadata: before.metadata,
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		const { article, writes } = refreshContent(before, buildInput());
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
 		assert.ok(writes.includes("crawl"), "recovery-from-failed must declare a crawl write");
@@ -270,13 +264,7 @@ describe("refreshContent", () => {
 			crawl: { kind: "pending", pendingSince: "2026-01-01T00:00:00.000Z" },
 		});
 
-		const { article, writes } = refreshContent(before, {
-			metadata: before.metadata,
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		const { article, writes } = refreshContent(before, buildInput());
 
 		assert.deepEqual(article.crawl, before.crawl);
 		assert.ok(!writes.includes("crawl"), "refresh must not write crawl when an inline crawl is in flight");
@@ -287,13 +275,7 @@ describe("refreshContent", () => {
 			crawl: { kind: "unsupported", reason: { kind: "paywall" } },
 		});
 
-		const { article, writes } = refreshContent(before, {
-			metadata: before.metadata,
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-			now: NOW,
-			canonicalContentHash: HASH_A,
-		});
+		const { article, writes } = refreshContent(before, buildInput());
 
 		assert.deepEqual(article.crawl, before.crawl);
 		assert.ok(!writes.includes("crawl"));

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import type { Article, ArticleMetadata } from "../article.types";
-import type { CanonicalImageUrl } from "../canonical-image-url";
 import { CanonicalImageUrlSchema } from "../canonical-image-url";
 import { refreshContent } from "./refresh-content";
 
@@ -8,10 +7,9 @@ import { refreshContent } from "./refresh-content";
  * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
  * CanonicalImageUrl }` shape. Production code goes through
  * `resolveCanonicalImageUrl` for the same brand. */
-function canonicalMetadata(
-	metadata: ArticleMetadata,
-): Omit<ArticleMetadata, "imageUrl"> & { imageUrl: CanonicalImageUrl } {
-	return { ...metadata, imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl) };
+function canonicalMetadata(metadata: ArticleMetadata) {
+	const { imageUrl, ...rest } = metadata;
+	return { ...rest, imageUrl: CanonicalImageUrlSchema.parse(imageUrl) };
 }
 
 const NOW = "2026-05-13T12:00:00.000Z";

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
-import type { Article } from "../article.types";
+import type { Article, ArticleMetadata } from "../article.types";
+import { CanonicalImageUrlSchema } from "../canonical-image-url";
 import { refreshContent } from "./refresh-content";
+
+/* Helper that brands the imageUrl on test fixtures so they satisfy the
+ * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
+ * CanonicalImageUrl }` shape. Production code goes through
+ * `resolveCanonicalImageUrl` for the same brand. */
+function canonicalMetadata(metadata: ArticleMetadata) {
+	return { ...metadata, imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl) };
+}
 
 const NOW = "2026-05-13T12:00:00.000Z";
 const HASH_A = "a".repeat(64);
@@ -37,13 +46,13 @@ describe("refreshContent", () => {
 		const before = buildArticle();
 
 		const { article } = refreshContent(before, {
-			metadata: {
+			metadata: canonicalMetadata({
 				title: "New title",
 				siteName: "Example",
 				excerpt: "New excerpt",
 				wordCount: 250,
 				imageUrl: "https://example.com/image.jpg",
-			},
+			}),
 			freshness: {
 				etag: '"new-etag"',
 				lastModified: "Sun, 10 May 2026 12:00:00 GMT",
@@ -66,7 +75,7 @@ describe("refreshContent", () => {
 		const before = buildArticle();
 
 		const { article } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -94,7 +103,7 @@ describe("refreshContent", () => {
 		});
 
 		const { article } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -121,7 +130,7 @@ describe("refreshContent", () => {
 		});
 
 		const { article } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -137,7 +146,7 @@ describe("refreshContent", () => {
 		});
 
 		const { article, writes } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -159,7 +168,7 @@ describe("refreshContent", () => {
 		});
 
 		const { article } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -176,7 +185,7 @@ describe("refreshContent", () => {
 		const before = buildArticle({ crawl: { kind: "ready" } });
 
 		const { article } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -198,7 +207,7 @@ describe("refreshContent", () => {
 		});
 
 		const { effects } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -223,7 +232,7 @@ describe("refreshContent", () => {
 		});
 
 		const { effects } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -244,7 +253,7 @@ describe("refreshContent", () => {
 		});
 
 		const { writes } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -267,7 +276,7 @@ describe("refreshContent", () => {
 		});
 
 		const { writes } = refreshContent(before, {
-			metadata: before.metadata,
+			metadata: canonicalMetadata(before.metadata),
 			freshness: before.freshness,
 			estimatedReadTime: before.estimatedReadTime,
 			now: NOW,
@@ -335,12 +344,12 @@ describe("refreshContent", () => {
 		const beforeSnapshot = JSON.parse(JSON.stringify(before));
 
 		refreshContent(before, {
-			metadata: {
+			metadata: canonicalMetadata({
 				title: "Different",
 				siteName: "Example",
 				excerpt: "Different",
 				wordCount: 200,
-			},
+			}),
 			freshness: {
 				etag: '"different"',
 				contentFetchedAt: "2026-05-10T12:00:00.000Z",

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.test.ts
@@ -1,15 +1,7 @@
 import assert from "node:assert/strict";
-import type { Article, ArticleMetadata } from "../article.types";
+import type { Article } from "../article.types";
 import { CanonicalImageUrlSchema } from "../canonical-image-url";
 import { refreshContent, type RefreshContentInput } from "./refresh-content";
-
-/* Helper that brands the imageUrl on test fixtures so they satisfy the
- * transition input's `Omit<ArticleMetadata, "imageUrl"> & { imageUrl:
- * CanonicalImageUrl }` shape. Production code goes through
- * `resolveCanonicalImageUrl` for the same brand. */
-function canonicalMetadata(metadata: ArticleMetadata) {
-	return { ...metadata, imageUrl: CanonicalImageUrlSchema.parse(metadata.imageUrl) };
-}
 
 const NOW = "2026-05-13T12:00:00.000Z";
 const HASH_A = "a".repeat(64);
@@ -41,7 +33,7 @@ function buildArticle(overrides: Partial<Article> = {}): Article {
 	};
 }
 
-function buildInput(overrides: Partial<RefreshContentInput> = {}): RefreshContentInput {
+function buildInput(overrides: Omit<Partial<RefreshContentInput>, "metadata"> = {}): RefreshContentInput {
 	return {
 		metadata: {
 			title: "New title",
@@ -65,21 +57,23 @@ describe("refreshContent", () => {
 	it("overwrites metadata, freshness, and estimated read time with the fetched values", () => {
 		const before = buildArticle();
 
-		const { article } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata({
+		const { article } = refreshContent(before, {
+			metadata: {
 				title: "New title",
 				siteName: "Example",
 				excerpt: "New excerpt",
 				wordCount: 250,
-				imageUrl: "https://example.com/image.jpg",
-			}),
+				imageUrl: CanonicalImageUrlSchema.parse("https://example.com/image.jpg"),
+			},
 			freshness: {
 				etag: '"new-etag"',
 				lastModified: "Sun, 10 May 2026 12:00:00 GMT",
 				contentFetchedAt: "2026-05-10T12:00:00.000Z",
 			},
 			estimatedReadTime: 2,
-		}));
+			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
 
 		assert.equal(article.metadata.title, "New title");
 		assert.equal(article.metadata.wordCount, 250);
@@ -92,11 +86,7 @@ describe("refreshContent", () => {
 	it("writes the new canonicalContentHash onto freshness so subsequent runs can compare against it", () => {
 		const before = buildArticle();
 
-		const { article } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-		}));
+		const { article } = refreshContent(before, buildInput());
 
 		assert.equal(article.freshness.canonicalContentHash, HASH_A);
 	});
@@ -119,9 +109,6 @@ describe("refreshContent", () => {
 		});
 
 		const { article } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
 			canonicalContentHash: HASH_B,
 		}));
 
@@ -144,11 +131,7 @@ describe("refreshContent", () => {
 			summary: existingSummary,
 		});
 
-		const { article } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-		}));
+		const { article } = refreshContent(before, buildInput());
 
 		assert.deepEqual(article.summary, existingSummary);
 	});
@@ -158,11 +141,7 @@ describe("refreshContent", () => {
 			summary: { kind: "ready", summary: "stale" },
 		});
 
-		const { article, writes } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-		}));
+		const { article, writes } = refreshContent(before, buildInput());
 
 		assert.deepEqual(article.summary, { kind: "pending", pendingSince: NOW });
 		assert.ok(writes.includes("summary"));
@@ -179,9 +158,6 @@ describe("refreshContent", () => {
 		});
 
 		const { article } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
 			canonicalContentHash: HASH_B,
 		}));
 
@@ -194,11 +170,7 @@ describe("refreshContent", () => {
 	it("preserves crawl state so a successful refresh does not regress the crawl row", () => {
 		const before = buildArticle({ crawl: { kind: "ready" } });
 
-		const { article } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-		}));
+		const { article } = refreshContent(before, buildInput());
 
 		assert.deepEqual(article.crawl, { kind: "ready" });
 	});
@@ -215,9 +187,6 @@ describe("refreshContent", () => {
 		});
 
 		const { effects } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
 			canonicalContentHash: HASH_B,
 		}));
 
@@ -238,11 +207,7 @@ describe("refreshContent", () => {
 			summary: { kind: "ready", summary: "kept" },
 		});
 
-		const { effects } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-		}));
+		const { effects } = refreshContent(before, buildInput());
 
 		assert.deepEqual(effects, []);
 	});
@@ -258,9 +223,6 @@ describe("refreshContent", () => {
 		});
 
 		const { writes } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
 			canonicalContentHash: HASH_B,
 		}));
 
@@ -279,11 +241,7 @@ describe("refreshContent", () => {
 			summary: { kind: "ready", summary: "kept" },
 		});
 
-		const { writes } = refreshContent(before, buildInput({
-			metadata: canonicalMetadata(before.metadata),
-			freshness: before.freshness,
-			estimatedReadTime: before.estimatedReadTime,
-		}));
+		const { writes } = refreshContent(before, buildInput());
 
 		assert.deepEqual([...writes].sort(), ["freshness", "metadata"]);
 		assert.ok(!writes.includes("summary"));
@@ -345,19 +303,22 @@ describe("refreshContent", () => {
 		const before = buildArticle();
 		const beforeSnapshot = JSON.parse(JSON.stringify(before));
 
-		refreshContent(before, buildInput({
-			metadata: canonicalMetadata({
+		refreshContent(before, {
+			metadata: {
 				title: "Different",
 				siteName: "Example",
 				excerpt: "Different",
 				wordCount: 200,
-			}),
+				imageUrl: CanonicalImageUrlSchema.parse(undefined),
+			},
 			freshness: {
 				etag: '"different"',
 				contentFetchedAt: "2026-05-10T12:00:00.000Z",
 			},
 			estimatedReadTime: 3,
-		}));
+			now: NOW,
+			canonicalContentHash: HASH_A,
+		});
 
 		assert.deepEqual(before, beforeSnapshot);
 	});

--- a/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/refresh-content.ts
@@ -3,11 +3,16 @@ import type {
 	ArticleFreshness,
 	ArticleMetadata,
 } from "../article.types";
+import type { CanonicalImageUrl } from "../canonical-image-url";
 import type { Effect } from "../effects.types";
 import type { AggregateField } from "../storage.types";
 
 export interface RefreshContentInput {
-	metadata: ArticleMetadata;
+	/** `imageUrl` is branded `CanonicalImageUrl` so the only way to populate it
+	 * is `resolveCanonicalImageUrl` (save-link/select-content), which rescues
+	 * an og:image from a losing tier when the winner has none. Passing
+	 * `winnerSource.metadata.imageUrl` directly is a compile error. */
+	metadata: Omit<ArticleMetadata, "imageUrl"> & { imageUrl: CanonicalImageUrl };
 	freshness: ArticleFreshness;
 	estimatedReadTime: number;
 	now: string;


### PR DESCRIPTION
## Summary
- Introduce `finalizeArticle` (parse → media → fetch og:image → upload to CDN) as the single pipeline every article-producing path now flows through: SimpleCrawl save / anonymous save / recrawl, ComprehensiveCrawl PDF, stale-check refresh, browser-extension raw-HTML save, in-memory dev wrappers. Same algorithm, same fetch bounds, same metadata shape — no per-trigger drift.
- For URL-based callers, `crawlAndFinalizeArticle` wraps `simpleCrawl({ fetchThumbnail: true })` + `finalizeArticle` as the single entry point. Stale-check now also downloads + uploads the thumbnail (previously stored the raw URL).
- Gate the selector's canonical `imageUrl` behind `CanonicalImageUrl` (branded type, only `resolveCanonicalImageUrl` produces it). Passing `winnerSource.metadata.imageUrl` straight into a promote/refresh transition is a compile error, so the cross-tier rescue (`use a losing tier's imageUrl when the winner lacks one`) is forced on every promotion.

## Why
Saved fagnerbrack.com Medium articles displayed the default Readplace thumbnail even though `og:image` was present in the source HTML. Three independent causes converged: stale-check didn't pass `thumbnailUrl` to `parseHtml`; save-link-work fell back to `article.imageUrl` (undefined) when the image fetch failed; the selector promoted a tier whose `imageUrl` was undefined even when another tier had one. Unifying the pipeline + branding the canonical type makes those classes of bug a compile error rather than a silent regression.

## Notable behaviour changes
- Stale-check refresh re-downloads and re-uploads the article image; the canonical URL stays on Readplace's CDN instead of pointing back at the origin.
- Browser-extension raw-HTML save now extracts the rawHtml's `og:image` and uploads it (previously stored as `undefined`).
- Comprehensive PDF crawl uses the same finalize step; PDFs without an `og:image` continue to have no thumbnail.

## Test plan
- [x] `pnpm check` (all 24 projects, 100% coverage)
- [x] New unit tests for `finalizeArticle`, `crawlAndFinalizeArticle`, `resolveCanonicalImageUrl`, `crawl-and-finalize` dep bundle, `extractFirstThumbnailUrl`
- [x] Handler-level tests (save-link, recrawl, anonymous, raw-html, comprehensive, stale-check) rewritten against the new dep shape
- [x] Domain transition tests (`promoteTier`, `recrawlPromoteTier`, `refreshContent`) updated to construct branded fixtures via `CanonicalImageUrlSchema.parse`
- [ ] Manual verification after deploy: trigger a recrawl on one of the broken fagnerbrack.com articles and confirm the og:image switches from the default fallback to a Readplace-CDN URL