### PR TITLE
fix(hutch): create subscription Lambda log groups so dashboard widgets render

### DIFF
--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -12,7 +12,7 @@ import {
 	SubscriptionStartRequestCommand,
 } from "@packages/hutch-infra-components";
 import { EXPORT_DOWNLOAD_TTL_DAYS, EXPORT_S3_KEY_PREFIX } from "../runtime/web/pages/export/export-ttl";
-import { ANALYTICS_EVENTS, METRICS, STREAMS } from "../runtime/observability/events";
+import { ANALYTICS_EVENTS, LAMBDA_NAMES, LOG_GROUPS, METRICS, STREAMS } from "../runtime/observability/events";
 import {
 	buildAnalyticsDashboardBody,
 	SUBSCRIPTION_DASHBOARD_LOG_GROUPS,
@@ -128,9 +128,9 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 });
 
 const logGroup = new aws.cloudwatch.LogGroup("hutch-log-analytics", {
-	name: "/aws/lambda/hutch-handler",
+	name: LOG_GROUPS.hutchHandler,
 	retentionInDays: 30,
-}, { import: "/aws/lambda/hutch-handler" });
+}, { import: LOG_GROUPS.hutchHandler });
 
 const api = new aws.apigatewayv2.Api("hutch-api-gateway", {
 	name: "hutch-api-gateway",
@@ -233,7 +233,7 @@ const trialSchedulerDeletePolicy = {
 	policy: trialSchedulerDeletePolicyDoc,
 };
 
-const lambda = new HutchLambda("hutch", {
+const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 	entryPoint: "./src/runtime/lambda.main.ts",
 	outputDir: ".lib/hutch-api",
 	assetDir: "./src/runtime",
@@ -448,7 +448,7 @@ const handleSubscriptionCancelledQueue = new HutchSQS("handle-subscription-cance
 	visibilityTimeoutSeconds: 30,
 });
 
-const handleSubscriptionCancelledLambda = new HutchLambda("handle-subscription-cancelled", {
+const handleSubscriptionCancelledLambda = new HutchLambda(LAMBDA_NAMES.handleSubscriptionCancelled, {
 	entryPoint: "./src/runtime/handle-subscription-cancelled.main.ts",
 	outputDir: ".lib/handle-subscription-cancelled",
 	assetDir: "./src/runtime",
@@ -492,7 +492,7 @@ const cancelSubscriptionQueue = new HutchSQS("cancel-subscription", {
 	visibilityTimeoutSeconds: 30,
 });
 
-const cancelSubscriptionLambda = new HutchLambda("cancel-subscription", {
+const cancelSubscriptionLambda = new HutchLambda(LAMBDA_NAMES.cancelSubscription, {
 	entryPoint: "./src/runtime/cancel-subscription.main.ts",
 	outputDir: ".lib/cancel-subscription",
 	assetDir: "./src/runtime",
@@ -539,7 +539,7 @@ const subscriptionStartRequestQueue = new HutchSQS("subscription-start-request",
 	visibilityTimeoutSeconds: 30,
 });
 
-const subscriptionStartRequestLambda = new HutchLambda("subscription-start-request", {
+const subscriptionStartRequestLambda = new HutchLambda(LAMBDA_NAMES.subscriptionStartRequest, {
 	entryPoint: "./src/runtime/subscription-start-request.main.ts",
 	outputDir: ".lib/subscription-start-request",
 	assetDir: "./src/runtime",
@@ -579,7 +579,7 @@ const subscriptionChargeSucceededQueue = new HutchSQS("subscription-charge-succe
 	visibilityTimeoutSeconds: 30,
 });
 
-const subscriptionChargeSucceededLambda = new HutchLambda("subscription-charge-succeeded", {
+const subscriptionChargeSucceededLambda = new HutchLambda(LAMBDA_NAMES.subscriptionChargeSucceeded, {
 	entryPoint: "./src/runtime/subscription-charge-succeeded.main.ts",
 	outputDir: ".lib/subscription-charge-succeeded",
 	assetDir: "./src/runtime",
@@ -610,7 +610,7 @@ const subscriptionChargeFailedQueue = new HutchSQS("subscription-charge-failed",
 	visibilityTimeoutSeconds: 30,
 });
 
-const subscriptionChargeFailedLambda = new HutchLambda("subscription-charge-failed", {
+const subscriptionChargeFailedLambda = new HutchLambda(LAMBDA_NAMES.subscriptionChargeFailed, {
 	entryPoint: "./src/runtime/subscription-charge-failed.main.ts",
 	outputDir: ".lib/subscription-charge-failed",
 	assetDir: "./src/runtime",
@@ -660,6 +660,36 @@ new aws.cloudwatch.LogMetricFilter("imports-completed-filter", {
 	},
 });
 
+// AWS auto-creates Lambda log groups on first invocation, but the subscription
+// Lambdas only run after a trial ends — so until the first trial-end charge
+// fires in a stack, none of these log groups exist and the analytics dashboard's
+// Logs Insights queries against them fail with `ResourceNotFoundException`.
+// Create them explicitly so the dashboard renders an empty result set instead
+// of erroring. Names are sourced from LOG_GROUPS so a rename in events.ts
+// propagates here without manual edits.
+const subscriptionLogGroups = [
+	new aws.cloudwatch.LogGroup("subscription-start-request-log-group", {
+		name: LOG_GROUPS.subscriptionStartRequest,
+		retentionInDays: 30,
+	}),
+	new aws.cloudwatch.LogGroup("subscription-charge-succeeded-log-group", {
+		name: LOG_GROUPS.subscriptionChargeSucceeded,
+		retentionInDays: 30,
+	}),
+	new aws.cloudwatch.LogGroup("subscription-charge-failed-log-group", {
+		name: LOG_GROUPS.subscriptionChargeFailed,
+		retentionInDays: 30,
+	}),
+	new aws.cloudwatch.LogGroup("cancel-subscription-log-group", {
+		name: LOG_GROUPS.cancelSubscription,
+		retentionInDays: 30,
+	}),
+	new aws.cloudwatch.LogGroup("handle-subscription-cancelled-log-group", {
+		name: LOG_GROUPS.handleSubscriptionCancelled,
+		retentionInDays: 30,
+	}),
+];
+
 new aws.cloudwatch.Dashboard("readplace-analytics", {
 	dashboardName: "readplace-analytics",
 	dashboardBody: pulumi.output(logGroup.name).apply((hutchLogGroupName) =>
@@ -670,7 +700,7 @@ new aws.cloudwatch.Dashboard("readplace-analytics", {
 			excludedVisitorHashes,
 		})),
 	),
-});
+}, { dependsOn: subscriptionLogGroups });
 
 
 // --- Exports ---

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -1,6 +1,7 @@
 import {
 	ANALYTICS_EVENTS,
 	CONVERSION_EVENTS,
+	LAMBDA_NAMES,
 	LOG_GROUPS,
 	METRICS,
 	STREAMS,
@@ -163,6 +164,13 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 		const declared = Object.values(LOG_GROUPS);
 		const unwired = declared.filter((name) => !wired.has(name));
 		expect(unwired).toEqual([]);
+	});
+
+	it("LOG_GROUPS is mechanically derived from LAMBDA_NAMES — hand-editing a LOG_GROUPS value out of sync with its LAMBDA_NAMES entry fails CI", () => {
+		for (const key of Object.keys(LAMBDA_NAMES) as Array<keyof typeof LAMBDA_NAMES>) {
+			expect(LOG_GROUPS[key]).toBe(`/aws/lambda/${LAMBDA_NAMES[key]}-handler`);
+		}
+		expect(Object.keys(LOG_GROUPS).sort()).toEqual(Object.keys(LAMBDA_NAMES).sort());
 	});
 
 	it("omits the visitor_hash exclusion clause from every widget query when no hashes are configured", () => {

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -38,11 +38,35 @@ export const METRICS = {
 	},
 } as const;
 
-export const LOG_GROUPS = {
-	hutchHandler: "/aws/lambda/hutch-handler",
-	subscriptionStartRequest: "/aws/lambda/subscription-start-request-handler",
-	subscriptionChargeSucceeded: "/aws/lambda/subscription-charge-succeeded-handler",
-	subscriptionChargeFailed: "/aws/lambda/subscription-charge-failed-handler",
-	cancelSubscription: "/aws/lambda/cancel-subscription-handler",
-	handleSubscriptionCancelled: "/aws/lambda/handle-subscription-cancelled-handler",
+/**
+ * Names passed to `new HutchLambda(...)` for the Lambdas whose log groups
+ * the analytics dashboard queries. `HutchLambda` appends `-handler` to this
+ * name when it creates the `aws.lambda.Function`, so the matching log group
+ * AWS creates on first invocation is `/aws/lambda/<name>-handler`. Each
+ * entry here is the *single* place that name is written; `LOG_GROUPS` and
+ * the Pulumi explicit `aws.cloudwatch.LogGroup` resources both derive from
+ * it, so a rename here propagates atomically to the dashboard's log-group
+ * references and to the explicit log-group resource. The analytics-dashboard
+ * test then guarantees every entry is wired into a widget.
+ */
+export const LAMBDA_NAMES = {
+	hutchHandler: "hutch",
+	subscriptionStartRequest: "subscription-start-request",
+	subscriptionChargeSucceeded: "subscription-charge-succeeded",
+	subscriptionChargeFailed: "subscription-charge-failed",
+	cancelSubscription: "cancel-subscription",
+	handleSubscriptionCancelled: "handle-subscription-cancelled",
 } as const;
+
+type LogGroupName<T extends string> = `/aws/lambda/${T}-handler`;
+
+export const LOG_GROUPS = {
+	hutchHandler: `/aws/lambda/${LAMBDA_NAMES.hutchHandler}-handler`,
+	subscriptionStartRequest: `/aws/lambda/${LAMBDA_NAMES.subscriptionStartRequest}-handler`,
+	subscriptionChargeSucceeded: `/aws/lambda/${LAMBDA_NAMES.subscriptionChargeSucceeded}-handler`,
+	subscriptionChargeFailed: `/aws/lambda/${LAMBDA_NAMES.subscriptionChargeFailed}-handler`,
+	cancelSubscription: `/aws/lambda/${LAMBDA_NAMES.cancelSubscription}-handler`,
+	handleSubscriptionCancelled: `/aws/lambda/${LAMBDA_NAMES.handleSubscriptionCancelled}-handler`,
+} as const satisfies {
+	readonly [K in keyof typeof LAMBDA_NAMES]: LogGroupName<(typeof LAMBDA_NAMES)[K]>;
+};


### PR DESCRIPTION
## Summary

Three widgets on the analytics CloudWatch dashboard — "Trial-end charge outcomes per day", "Cancellations by reason", "Recent subscription state-changes" — render `ResourceNotFoundException` because their target log groups don't exist. AWS only auto-creates a Lambda log group on first invocation, and the five subscription Lambdas have never been invoked in any stack (no trial has ended yet).

This change:

- Creates the five subscription log groups as explicit `aws.cloudwatch.LogGroup` resources in `projects/hutch/src/infra/index.ts` so they exist from `pulumi up` onwards, with `retentionInDays: 30` matching the hutch handler.
- Adds a `LAMBDA_NAMES` registry to `projects/hutch/src/runtime/observability/events.ts` as the single source of truth for the names passed to `new HutchLambda(...)` for the six dashboard-watched Lambdas.
- Derives `LOG_GROUPS` from `LAMBDA_NAMES` via a template-literal type (`/aws/lambda/${T}-handler`) so a rename in the registry propagates atomically to the dashboard's log-group references and the Pulumi resources.
- Updates the six dashboard-watched `new HutchLambda(...)` call sites and the existing hutch log group to source their names from `LAMBDA_NAMES` / `LOG_GROUPS` instead of repeating string literals.
- Adds a `dependsOn: subscriptionLogGroups` to the dashboard resource so Pulumi creates the log groups before the dashboard within a single `pulumi up`.
- Adds an analytics-dashboard test that asserts `LOG_GROUPS[k] === ` `/aws/lambda/${LAMBDA_NAMES[k]}-handler` ` for every key — catches a hand-edited `LOG_GROUPS` entry drifting from its `LAMBDA_NAMES` source.

The existing test at `analytics-dashboard.test.ts:159-167` ("every LOG_GROUPS value is wired into the dashboard builder…") already enforces drift between `LOG_GROUPS` and dashboard widgets; the new test closes the gap between `LOG_GROUPS` and `LAMBDA_NAMES`. Save-link's 21 Lambdas are intentionally left out of the registry — they're not dashboard-watched, so they don't need the indirection.

## Test plan

- [x] `pnpm check` passes locally (24 projects, 100% coverage maintained)
- [x] New derivation test passes: `analytics-dashboard.test.ts` "LOG_GROUPS is mechanically derived from LAMBDA_NAMES"
- [ ] `pulumi preview` on each stack shows: `import` for `/aws/lambda/hutch-handler` (existing), `create` for the five subscription log groups, **no destroy / recreate of any Lambda or log group**
- [ ] After `pulumi up`, open AWS Console → CloudWatch → Dashboards → `readplace-analytics`. The three previously-erroring subscription widgets render an empty result set instead of `ResourceNotFoundException`; the other widgets continue to render data as before.
- [ ] Drift smoke test (optional): rename `LAMBDA_NAMES.subscriptionStartRequest` from `"subscription-start-request"` to `"subscription-start"` on a scratch branch. Confirm `pulumi preview` shows the matching log group and Lambda both get replaced in lockstep, and that no widget breaks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMbZSTj35L6Ptv6bcRMw8L)_