### PR TITLE
feat: streaming reader UX — partial-content writes + SSE + word-level reveal

### DIFF
--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -33,8 +33,8 @@ config:
   hutch:contentBucketName: hutch-article-content-prod
   hutch:pendingHtmlBucketName: hutch-pending-html-prod
   hutch:userExportBucketName: hutch-user-exports-prod
-  hutch:alertEmail: readplace+devops@readplace.com
   hutch:readerStreamCorsOrigin: https://readplace.com
+  hutch:alertEmail: readplace+devops@readplace.com
   hutch:expiryCountdown: disabled
   hutch:foundingMemberLimit: '50'
   hutch:excludedVisitorHashes: [

--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -34,6 +34,7 @@ config:
   hutch:pendingHtmlBucketName: hutch-pending-html-prod
   hutch:userExportBucketName: hutch-user-exports-prod
   hutch:alertEmail: readplace+devops@readplace.com
+  hutch:readerStreamCorsOrigin: https://readplace.com
   hutch:expiryCountdown: disabled
   hutch:foundingMemberLimit: '50'
   hutch:excludedVisitorHashes: [

--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -228,7 +228,7 @@ const BUNDLES = [
 			"  parent: parent,",
 			"  addEventListener: function (type, listener) { window.addEventListener(type, listener); },",
 			"  performance: performance,",
-			"  requestAnimationFrame: function (cb) { return window.requestAnimationFrame(cb); }"
+			"  requestAnimationFrame: function (cb) { return window.requestAnimationFrame(cb); }",
 			"});",
 		].join("\n"),
 	},

--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -181,6 +181,57 @@ const BUNDLES = [
 			"});",
 		].join("\n"),
 	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "reader-stream.client.js"),
+		globalName: "ReaderStream",
+		footer: [
+			// HTMX swaps a reader-slot wrapper when the row transitions
+			// (pending → streaming, streaming → ready/failed). Rescan on every
+			// swap so newly-arrived streaming slots open an EventSource and
+			// removed ones close their existing session.
+			"ReaderStream.initReaderStream({",
+			"  document: window.document,",
+			"  window: window,",
+			"  EventSourceCtor: window.EventSource,",
+			"  now: function () { return Date.now(); },",
+			"  setTimeoutFn: function (cb, ms) { return window.setTimeout(cb, ms); },",
+			"  reload: function () { window.location.reload(); },",
+			"  addSwapListener: function (listener) {",
+			"    window.document.body.addEventListener('htmx:afterSwap', function (e) {",
+			"      listener(e.detail.target);",
+			"    });",
+			"  }",
+			"});",
+		].join("\n"),
+	},
+	{
+		// The bootstrap script runs INSIDE the sandboxed reader-streaming
+		// iframe (allow-scripts + allow-same-origin). Inlined into the
+		// iframe's srcdoc by reader-streaming-iframe-srcdoc.ts — never
+		// fetched as a separate file because the iframe's sandboxed origin
+		// has no relative path to fetch from. Built as an IIFE with a
+		// footer that immediately invokes initBootstrap against the
+		// iframe's real globals.
+		entry: path.join(
+			PROJECT_ROOT,
+			"src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts",
+		),
+		outfile: path.join(OUT_DIR, "reader-stream-bootstrap.iframe.js"),
+		globalName: "ReaderStreamBootstrap",
+		footer: [
+			"ReaderStreamBootstrap.initBootstrap({",
+			"  document: document,",
+			"  parent: parent,",
+			"  addEventListener: function (type, listener) { window.addEventListener(type, listener); },",
+			"  performance: performance,",
+			"  requestAnimationFrame: function (cb) { return window.requestAnimationFrame(cb); }"
+			"});",
+		].join("\n"),
+	},
 ];
 
 function buildOptions(bundle) {

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -227,6 +227,107 @@ const scheduleTrialFeedbackEmailSchedulerManagePolicy = {
 	policy: trialSchedulerManagePolicyDoc,
 };
 
+// --- Reader Streaming Lambda (SSE Function URL) ---
+// Synchronous request/response Lambda fronted by a Function URL (not API
+// Gateway) because API Gateway HTTP API does NOT support response streaming —
+// `serverless-http` buffers the whole response. We need true SSE so the
+// `/view` page can show partial-content snapshots as the worker crawls.
+//
+// Why: this is the only exception to "every Lambda must be backed by a
+// queue with DLQ" — it's a synchronous request/response Lambda, analogous
+// to the existing main HTTP Lambda fronted by API Gateway. A failure
+// surfaces to the client as a closed EventSource and the parent-side
+// reader-stream.client.ts retries / falls through to the always-armed
+// HTMX poll path. No async work in flight that could be lost; therefore
+// no SQS/DLQ needed. Same allowed-exception spirit the API-Gateway-fronted
+// hutch Lambda exercises a few lines below.
+//
+// IAM scope: read-only on the articles + sessions tables. No publish, no
+// write, no S3.
+
+const readerStreamDynamodb = new HutchDynamoDBAccess(
+	"reader-stream-dynamodb",
+	{
+		tables: [
+			{ arn: storage.articlesTable.arn, includeIndexes: false },
+			{ arn: storage.sessionsTable.arn, includeIndexes: false },
+		],
+		actions: ["dynamodb:GetItem"],
+	},
+);
+
+const readerStreamLambda = new HutchLambda("reader-stream", {
+	entryPoint: "./src/runtime/reader-stream.main.ts",
+	outputDir: ".lib/reader-stream",
+	assetDir: "./src/runtime",
+	// 256 MB is plenty for the polling loop — the working set is one
+	// `GetItem` response per tick (< 400 KB) plus the SSE frame buffer.
+	memorySize: 256,
+	// 65s timeout: connectionMaxMs (60s in the handler) plus 5s slack so
+	// the handler can emit the `reconnect` frame and end the response
+	// cleanly before the Lambda runtime cuts the connection.
+	timeout: 65,
+	environment: {
+		PERSISTENCE: "prod",
+		DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
+		DYNAMODB_USERS_TABLE: storage.usersTable.name,
+		DYNAMODB_SESSIONS_TABLE: storage.sessionsTable.name,
+	},
+	policies: [...readerStreamDynamodb.policies],
+});
+
+const readerStreamFunctionUrl = new aws.lambda.FunctionUrl(
+	"reader-stream-url",
+	{
+		functionName: readerStreamLambda.functionName,
+		// `NONE` because cookie-based auth runs inside the handler — the
+		// session cookie travels on the EventSource request and is looked
+		// up via getSessionUserId. AWS IAM auth would require browsers to
+		// sign requests, which EventSource cannot do.
+		authorizationType: "NONE",
+		// Response streaming mode — without this the Function URL buffers
+		// the entire response just like API Gateway does.
+		invokeMode: "RESPONSE_STREAM",
+		cors: {
+			// Restrict to the canonical domain (or any origin when no
+			// canonical is configured — staging convenience). Cookies need
+			// the parent origin same-site for the session to flow on the
+			// cross-subdomain EventSource request.
+			allowOrigins: canonicalDomain ? [`https://${canonicalDomain}`] : ["*"],
+			allowMethods: ["GET"],
+			allowHeaders: ["content-type"],
+			allowCredentials: true,
+		},
+	},
+);
+
+// DNS: `stream.<canonicalDomain>` CNAME → Function URL hostname. Skipped
+// when no canonical domain is configured (staging stack has `domains:
+// []`). Without a CNAME the client still works against the raw Function
+// URL host returned below.
+
+if (canonicalDomain) {
+	const lastRegistration = allDomainRegistrations[allDomainRegistrations.length - 1];
+	if (lastRegistration.zoneId) {
+		new aws.route53.Record("reader-stream-dns", {
+			zoneId: lastRegistration.zoneId,
+			name: `stream.${canonicalDomain}`,
+			type: "CNAME",
+			ttl: 300,
+			records: [
+				readerStreamFunctionUrl.functionUrl.apply((url) => new URL(url).hostname),
+			],
+		});
+	}
+}
+
+// URL the main hutch Lambda reads via getEnv("READER_STREAM_BASE_URL"):
+// canonical `stream.<canonical>` when present, otherwise the raw Function
+// URL (trailing slash trimmed so client-side concatenation stays clean).
+const readerStreamBaseUrl: pulumi.Output<string> = canonicalDomain
+	? pulumi.interpolate`https://stream.${canonicalDomain}`
+	: readerStreamFunctionUrl.functionUrl.apply((url) => url.replace(/\/$/, ""));
+
 const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 	entryPoint: "./src/runtime/lambda.main.ts",
 	outputDir: ".lib/hutch-api",
@@ -237,6 +338,7 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 		NODE_ENV: stage === "production" ? "production" : "development",
 		PERSISTENCE: "prod",
 		APP_ORIGIN: appOrigin,
+		READER_STREAM_BASE_URL: readerStreamBaseUrl,
 		DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
 		DYNAMODB_USER_ARTICLES_TABLE: storage.userArticlesTable.name,
 		DYNAMODB_USERS_TABLE: storage.usersTable.name,
@@ -885,4 +987,6 @@ export const staticBaseUrl = staticAssets.baseUrl;
 export const exportUserDataQueueUrl = exportUserDataQueue.queueUrl;
 export const exportUserDataDlqUrl = exportUserDataQueue.dlqUrl;
 export const userExportBucketOutputName = userExportBucket.bucket;
+export const readerStreamFunctionUrlRaw = readerStreamFunctionUrl.functionUrl;
+export const readerStreamCanonicalUrl = readerStreamBaseUrl;
 export const _dependencies = [gateway.defaultRoute];

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -37,6 +37,7 @@ const contentBucketName = config.require("contentBucketName");
 const pendingHtmlBucketName = config.require("pendingHtmlBucketName");
 const userExportBucketName = config.require("userExportBucketName");
 const alertEmail = config.require("alertEmail");
+const readerStreamCorsOrigin = config.get("readerStreamCorsOrigin");
 const tableNames = {
 	articles: config.require("dynamodbArticlesTable"),
 	userArticles: config.require("dynamodbUserArticlesTable"),
@@ -55,7 +56,6 @@ const storage = new HutchStorage("hutch", {
 	tableNames,
 });
 
-const readerStreamCorsOrigin = config.get("readerStreamCorsOrigin");
 const redirectDomains = config.getObject<string[]>("redirectDomains") ?? [];
 const redirectSubdomains = config.getObject<Array<{ host: string; zoneName: string }>>("redirectSubdomains") ?? [];
 
@@ -228,34 +228,30 @@ const scheduleTrialFeedbackEmailSchedulerManagePolicy = {
 	policy: trialSchedulerManagePolicyDoc,
 };
 
-// --- Reader Streaming Lambda (SSE Function URL) ---
-// Why: this is a NEW exception to "every Lambda must be backed by a queue
-// with DLQ" beyond the documented API-Gateway-fronted hutch handler. The
-// reason for using a Function URL instead of API Gateway is that
-// API Gateway HTTP API does NOT support response streaming — its
-// `serverless-http` integration buffers the entire response — and we need
-// true SSE so the `/view` page can show partial-content snapshots as the
-// worker crawls.
-//
-// This Lambda is still synchronous request/response: a failure surfaces
-// to the client as a closed EventSource, and the parent-side
-// reader-stream.client.ts retries with exponential backoff before falling
-// through to the always-armed HTMX `every 3s` poll path on the reader-slot
-// wrapper. No async work in flight that could be lost — therefore no
-// SQS/DLQ needed. CloudWatch alarms on the Lambda's error metric remain
-// the operator-paging surface.
-//
-// IAM scope: read-only on the articles + sessions tables. No publish, no
-// write, no S3.
-//
-// Gated on `readerStreamCorsOrigin` config. Stacks without it skip
-// provisioning — app.ts treats missing READER_STREAM_BASE_URL as
-// 'streaming disabled' and falls back to the dots loader.
-
 let readerStreamBaseUrl: pulumi.Output<string> | undefined;
-let readerStreamFunctionUrlRaw: pulumi.Output<string> | undefined;
+let readerStreamRawUrl: pulumi.Output<string> | undefined;
 
 if (readerStreamCorsOrigin) {
+	// --- Reader Streaming Lambda (SSE Function URL) ---
+	// Why: this is a NEW exception to "every Lambda must be backed by a queue
+	// with DLQ" beyond the documented API-Gateway-fronted hutch handler. The
+	// reason for using a Function URL instead of API Gateway is that
+	// API Gateway HTTP API does NOT support response streaming — its
+	// `serverless-http` integration buffers the entire response — and we need
+	// true SSE so the `/view` page can show partial-content snapshots as the
+	// worker crawls.
+	//
+	// This Lambda is still synchronous request/response: a failure surfaces
+	// to the client as a closed EventSource, and the parent-side
+	// reader-stream.client.ts retries with exponential backoff before falling
+	// through to the always-armed HTMX `every 3s` poll path on the reader-slot
+	// wrapper. No async work in flight that could be lost — therefore no
+	// SQS/DLQ needed. CloudWatch alarms on the Lambda's error metric remain
+	// the operator-paging surface.
+	//
+	// IAM scope: read-only on the articles + sessions tables. No publish, no
+	// write, no S3.
+
 	const readerStreamDynamodb = new HutchDynamoDBAccess(
 		"reader-stream-dynamodb",
 		{
@@ -309,6 +305,8 @@ if (readerStreamCorsOrigin) {
 	);
 
 	// DNS: `stream.<canonicalDomain>` CNAME → Function URL hostname.
+	// Skipped when no canonical domain is configured. Without a CNAME
+	// the client still works against the raw Function URL host.
 	if (canonicalDomain) {
 		const lastRegistration = allDomainRegistrations[allDomainRegistrations.length - 1];
 		if (lastRegistration.zoneId) {
@@ -324,10 +322,10 @@ if (readerStreamCorsOrigin) {
 		}
 	}
 
+	readerStreamRawUrl = readerStreamFunctionUrl.functionUrl;
 	readerStreamBaseUrl = canonicalDomain
 		? pulumi.interpolate`https://stream.${canonicalDomain}`
 		: readerStreamFunctionUrl.functionUrl.apply((url) => url.replace(/\/$/, ""));
-	readerStreamFunctionUrlRaw = readerStreamFunctionUrl.functionUrl;
 }
 
 const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
@@ -989,6 +987,6 @@ export const staticBaseUrl = staticAssets.baseUrl;
 export const exportUserDataQueueUrl = exportUserDataQueue.queueUrl;
 export const exportUserDataDlqUrl = exportUserDataQueue.dlqUrl;
 export const userExportBucketOutputName = userExportBucket.bucket;
-export { readerStreamFunctionUrlRaw };
-export { readerStreamBaseUrl as readerStreamCanonicalUrl };
+export const readerStreamFunctionUrlRaw = readerStreamRawUrl;
+export const readerStreamCanonicalUrl = readerStreamBaseUrl;
 export const _dependencies = [gateway.defaultRoute];

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -228,19 +228,21 @@ const scheduleTrialFeedbackEmailSchedulerManagePolicy = {
 };
 
 // --- Reader Streaming Lambda (SSE Function URL) ---
-// Synchronous request/response Lambda fronted by a Function URL (not API
-// Gateway) because API Gateway HTTP API does NOT support response streaming —
-// `serverless-http` buffers the whole response. We need true SSE so the
-// `/view` page can show partial-content snapshots as the worker crawls.
+// Why: this is a NEW exception to "every Lambda must be backed by a queue
+// with DLQ" beyond the documented API-Gateway-fronted hutch handler. The
+// reason for using a Function URL instead of API Gateway is that
+// API Gateway HTTP API does NOT support response streaming — its
+// `serverless-http` integration buffers the entire response — and we need
+// true SSE so the `/view` page can show partial-content snapshots as the
+// worker crawls.
 //
-// Why: this is the only exception to "every Lambda must be backed by a
-// queue with DLQ" — it's a synchronous request/response Lambda, analogous
-// to the existing main HTTP Lambda fronted by API Gateway. A failure
-// surfaces to the client as a closed EventSource and the parent-side
-// reader-stream.client.ts retries / falls through to the always-armed
-// HTMX poll path. No async work in flight that could be lost; therefore
-// no SQS/DLQ needed. Same allowed-exception spirit the API-Gateway-fronted
-// hutch Lambda exercises a few lines below.
+// This Lambda is still synchronous request/response: a failure surfaces
+// to the client as a closed EventSource, and the parent-side
+// reader-stream.client.ts retries with exponential backoff before falling
+// through to the always-armed HTMX `every 3s` poll path on the reader-slot
+// wrapper. No async work in flight that could be lost — therefore no
+// SQS/DLQ needed. CloudWatch alarms on the Lambda's error metric remain
+// the operator-paging surface.
 //
 // IAM scope: read-only on the articles + sessions tables. No publish, no
 // write, no S3.

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -55,6 +55,7 @@ const storage = new HutchStorage("hutch", {
 	tableNames,
 });
 
+const readerStreamCorsOrigin = config.get("readerStreamCorsOrigin");
 const redirectDomains = config.getObject<string[]>("redirectDomains") ?? [];
 const redirectSubdomains = config.getObject<Array<{ host: string; zoneName: string }>>("redirectSubdomains") ?? [];
 
@@ -246,89 +247,88 @@ const scheduleTrialFeedbackEmailSchedulerManagePolicy = {
 //
 // IAM scope: read-only on the articles + sessions tables. No publish, no
 // write, no S3.
+//
+// Gated on `readerStreamCorsOrigin` config. Stacks without it skip
+// provisioning — app.ts treats missing READER_STREAM_BASE_URL as
+// 'streaming disabled' and falls back to the dots loader.
 
-const readerStreamDynamodb = new HutchDynamoDBAccess(
-	"reader-stream-dynamodb",
-	{
-		tables: [
-			{ arn: storage.articlesTable.arn, includeIndexes: false },
-			{ arn: storage.sessionsTable.arn, includeIndexes: false },
-		],
-		actions: ["dynamodb:GetItem"],
-	},
-);
+let readerStreamBaseUrl: pulumi.Output<string> | undefined;
+let readerStreamFunctionUrlRaw: pulumi.Output<string> | undefined;
 
-const readerStreamLambda = new HutchLambda("reader-stream", {
-	entryPoint: "./src/runtime/reader-stream.main.ts",
-	outputDir: ".lib/reader-stream",
-	assetDir: "./src/runtime",
-	// 256 MB is plenty for the polling loop — the working set is one
-	// `GetItem` response per tick (< 400 KB) plus the SSE frame buffer.
-	memorySize: 256,
-	// 65s timeout: connectionMaxMs (60s in the handler) plus 5s slack so
-	// the handler can emit the `reconnect` frame and end the response
-	// cleanly before the Lambda runtime cuts the connection.
-	timeout: 65,
-	environment: {
-		PERSISTENCE: "prod",
-		DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
-		DYNAMODB_USERS_TABLE: storage.usersTable.name,
-		DYNAMODB_SESSIONS_TABLE: storage.sessionsTable.name,
-	},
-	policies: [...readerStreamDynamodb.policies],
-});
-
-const readerStreamFunctionUrl = new aws.lambda.FunctionUrl(
-	"reader-stream-url",
-	{
-		functionName: readerStreamLambda.functionName,
-		// `NONE` because cookie-based auth runs inside the handler — the
-		// session cookie travels on the EventSource request and is looked
-		// up via getSessionUserId. AWS IAM auth would require browsers to
-		// sign requests, which EventSource cannot do.
-		authorizationType: "NONE",
-		// Response streaming mode — without this the Function URL buffers
-		// the entire response just like API Gateway does.
-		invokeMode: "RESPONSE_STREAM",
-		cors: {
-			// Restrict to the canonical domain (or any origin when no
-			// canonical is configured — staging convenience). Cookies need
-			// the parent origin same-site for the session to flow on the
-			// cross-subdomain EventSource request.
-			allowOrigins: canonicalDomain ? [`https://${canonicalDomain}`] : ["*"],
-			allowMethods: ["GET"],
-			allowHeaders: ["content-type"],
-			allowCredentials: true,
-		},
-	},
-);
-
-// DNS: `stream.<canonicalDomain>` CNAME → Function URL hostname. Skipped
-// when no canonical domain is configured (staging stack has `domains:
-// []`). Without a CNAME the client still works against the raw Function
-// URL host returned below.
-
-if (canonicalDomain) {
-	const lastRegistration = allDomainRegistrations[allDomainRegistrations.length - 1];
-	if (lastRegistration.zoneId) {
-		new aws.route53.Record("reader-stream-dns", {
-			zoneId: lastRegistration.zoneId,
-			name: `stream.${canonicalDomain}`,
-			type: "CNAME",
-			ttl: 300,
-			records: [
-				readerStreamFunctionUrl.functionUrl.apply((url) => new URL(url).hostname),
+if (readerStreamCorsOrigin) {
+	const readerStreamDynamodb = new HutchDynamoDBAccess(
+		"reader-stream-dynamodb",
+		{
+			tables: [
+				{ arn: storage.articlesTable.arn, includeIndexes: false },
+				{ arn: storage.sessionsTable.arn, includeIndexes: false },
 			],
-		});
-	}
-}
+			actions: ["dynamodb:GetItem"],
+		},
+	);
 
-// URL the main hutch Lambda reads via getEnv("READER_STREAM_BASE_URL"):
-// canonical `stream.<canonical>` when present, otherwise the raw Function
-// URL (trailing slash trimmed so client-side concatenation stays clean).
-const readerStreamBaseUrl: pulumi.Output<string> = canonicalDomain
-	? pulumi.interpolate`https://stream.${canonicalDomain}`
-	: readerStreamFunctionUrl.functionUrl.apply((url) => url.replace(/\/$/, ""));
+	const readerStreamLambda = new HutchLambda("reader-stream", {
+		entryPoint: "./src/runtime/reader-stream.main.ts",
+		outputDir: ".lib/reader-stream",
+		assetDir: "./src/runtime",
+		// 256 MB is plenty for the polling loop — the working set is one
+		// `GetItem` response per tick (< 400 KB) plus the SSE frame buffer.
+		memorySize: 256,
+		// 65s timeout: connectionMaxMs (60s in the handler) plus 5s slack so
+		// the handler can emit the `reconnect` frame and end the response
+		// cleanly before the Lambda runtime cuts the connection.
+		timeout: 65,
+		environment: {
+			PERSISTENCE: "prod",
+			DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
+			DYNAMODB_USERS_TABLE: storage.usersTable.name,
+			DYNAMODB_SESSIONS_TABLE: storage.sessionsTable.name,
+		},
+		policies: [...readerStreamDynamodb.policies],
+	});
+
+	const readerStreamFunctionUrl = new aws.lambda.FunctionUrl(
+		"reader-stream-url",
+		{
+			functionName: readerStreamLambda.functionName,
+			// `NONE` because cookie-based auth runs inside the handler — the
+			// session cookie travels on the EventSource request and is looked
+			// up via getSessionUserId. AWS IAM auth would require browsers to
+			// sign requests, which EventSource cannot do.
+			authorizationType: "NONE",
+			// Response streaming mode — without this the Function URL buffers
+			// the entire response just like API Gateway does.
+			invokeMode: "RESPONSE_STREAM",
+			cors: {
+				allowOrigins: [readerStreamCorsOrigin],
+				allowMethods: ["GET"],
+				allowHeaders: ["content-type"],
+				allowCredentials: true,
+			},
+		},
+	);
+
+	// DNS: `stream.<canonicalDomain>` CNAME → Function URL hostname.
+	if (canonicalDomain) {
+		const lastRegistration = allDomainRegistrations[allDomainRegistrations.length - 1];
+		if (lastRegistration.zoneId) {
+			new aws.route53.Record("reader-stream-dns", {
+				zoneId: lastRegistration.zoneId,
+				name: `stream.${canonicalDomain}`,
+				type: "CNAME",
+				ttl: 300,
+				records: [
+					readerStreamFunctionUrl.functionUrl.apply((url) => new URL(url).hostname),
+				],
+			});
+		}
+	}
+
+	readerStreamBaseUrl = canonicalDomain
+		? pulumi.interpolate`https://stream.${canonicalDomain}`
+		: readerStreamFunctionUrl.functionUrl.apply((url) => url.replace(/\/$/, ""));
+	readerStreamFunctionUrlRaw = readerStreamFunctionUrl.functionUrl;
+}
 
 const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 	entryPoint: "./src/runtime/lambda.main.ts",
@@ -340,7 +340,7 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 		NODE_ENV: stage === "production" ? "production" : "development",
 		PERSISTENCE: "prod",
 		APP_ORIGIN: appOrigin,
-		READER_STREAM_BASE_URL: readerStreamBaseUrl,
+		...(readerStreamBaseUrl ? { READER_STREAM_BASE_URL: readerStreamBaseUrl } : {}),
 		DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
 		DYNAMODB_USER_ARTICLES_TABLE: storage.userArticlesTable.name,
 		DYNAMODB_USERS_TABLE: storage.usersTable.name,
@@ -989,6 +989,6 @@ export const staticBaseUrl = staticAssets.baseUrl;
 export const exportUserDataQueueUrl = exportUserDataQueue.queueUrl;
 export const exportUserDataDlqUrl = exportUserDataQueue.dlqUrl;
 export const userExportBucketOutputName = userExportBucket.bucket;
-export const readerStreamFunctionUrlRaw = readerStreamFunctionUrl.functionUrl;
-export const readerStreamCanonicalUrl = readerStreamBaseUrl;
+export { readerStreamFunctionUrlRaw };
+export { readerStreamBaseUrl as readerStreamCanonicalUrl };
 export const _dependencies = [gateway.defaultRoute];

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -249,15 +249,13 @@ if (readerStreamCorsOrigin) {
 	// SQS/DLQ needed. CloudWatch alarms on the Lambda's error metric remain
 	// the operator-paging surface.
 	//
-	// IAM scope: read-only on the articles + sessions tables. No publish, no
-	// write, no S3.
+	// IAM scope: read-only on the articles table. No publish, no write, no S3.
 
 	const readerStreamDynamodb = new HutchDynamoDBAccess(
 		"reader-stream-dynamodb",
 		{
 			tables: [
 				{ arn: storage.articlesTable.arn, includeIndexes: false },
-				{ arn: storage.sessionsTable.arn, includeIndexes: false },
 			],
 			actions: ["dynamodb:GetItem"],
 		},
@@ -277,8 +275,6 @@ if (readerStreamCorsOrigin) {
 		environment: {
 			PERSISTENCE: "prod",
 			DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
-			DYNAMODB_USERS_TABLE: storage.usersTable.name,
-			DYNAMODB_SESSIONS_TABLE: storage.sessionsTable.name,
 		},
 		policies: [...readerStreamDynamodb.policies],
 	});
@@ -287,10 +283,8 @@ if (readerStreamCorsOrigin) {
 		"reader-stream-url",
 		{
 			functionName: readerStreamLambda.functionName,
-			// `NONE` because cookie-based auth runs inside the handler — the
-			// session cookie travels on the EventSource request and is looked
-			// up via getSessionUserId. AWS IAM auth would require browsers to
-			// sign requests, which EventSource cannot do.
+			// `NONE` because the endpoint is intentionally public — AWS IAM auth
+			// would require browsers to sign requests, which EventSource cannot do.
 			authorizationType: "NONE",
 			// Response streaming mode — without this the Function URL buffers
 			// the entire response just like API Gateway does.

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -435,6 +435,11 @@ export function createHutchApp(deps?: {
 
 	const appOrigin = deps?.appOrigin ?? requireEnv("APP_ORIGIN", { defaultValue: `http://localhost:${getEnv("PORT") || "3000"}` });
 	const staticBaseUrl = requireEnv("STATIC_BASE_URL");
+	/* Reads the streaming SSE Lambda's Function URL host. When undefined the
+	 * reader-slot's streaming variant is disabled and the dots loader stays
+	 * in place — getEnv (not requireEnv) is intentional so the hutch app can
+	 * deploy before/without the stream Lambda being provisioned. */
+	const streamBaseUrl = getEnv("READER_STREAM_BASE_URL");
 	const expiryCountdown = requireEnv<"enabled" | "disabled">("EXPIRY_COUNTDOWN");
 	const foundingMemberLimit = Number.parseInt(requireEnv("FOUNDING_MEMBER_LIMIT"), 10);
 	assert(
@@ -456,6 +461,7 @@ export function createHutchApp(deps?: {
 		validateSaveableUrl,
 		appOrigin,
 		staticBaseUrl,
+		streamBaseUrl,
 		hashPassword,
 		...auth,
 		...articleStore,

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.test.ts
@@ -133,6 +133,40 @@ describe("initDynamoDbArticleCrawl", () => {
 			expect(result).toEqual({ status: "ready" });
 		});
 
+		it("returns pending with partial when partialContent + partialContentVersion are recorded", async () => {
+			const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
+				client: clientReturning({
+					url: URL,
+					crawlStatus: "pending",
+					partialContent: "<h1>Title</h1><p>preview</p>",
+					partialContentVersion: 3,
+				}),
+				tableName: TABLE,
+			});
+
+			const result = await findArticleCrawlStatus(URL);
+
+			expect(result).toEqual({
+				status: "pending",
+				partial: { content: "<h1>Title</h1><p>preview</p>", version: 3 },
+			});
+		});
+
+		it("omits partial when only one of partialContent / partialContentVersion is present (defensive against half-written rows)", async () => {
+			const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
+				client: clientReturning({
+					url: URL,
+					crawlStatus: "pending",
+					partialContent: "<h1>Title</h1>",
+				}),
+				tableName: TABLE,
+			});
+
+			const result = await findArticleCrawlStatus(URL);
+
+			expect(result).toEqual({ status: "pending" });
+		});
+
 		it("returns ready when crawlStatus=ready", async () => {
 			const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
 				client: clientReturning({ url: URL, crawlStatus: "ready" }),

--- a/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
+++ b/projects/hutch/src/runtime/providers/article-crawl/dynamodb-article-crawl.ts
@@ -34,6 +34,8 @@ const ArticleCrawlRow = z.object({
 	),
 	crawlPartCurrent: dynamoField(z.number()),
 	crawlPartTotal: dynamoField(z.number()),
+	partialContent: dynamoField(z.string()),
+	partialContentVersion: dynamoField(z.number()),
 });
 
 type ArticleCrawlRowShape = z.infer<typeof ArticleCrawlRow>;
@@ -61,9 +63,14 @@ function rowToArticleCrawl(
 			row.crawlPartCurrent !== undefined && row.crawlPartTotal !== undefined
 				? { current: row.crawlPartCurrent, total: row.crawlPartTotal }
 				: undefined;
+		const partial =
+			row.partialContent !== undefined && row.partialContentVersion !== undefined
+				? { content: row.partialContent, version: row.partialContentVersion }
+				: undefined;
 		const pending: ArticleCrawl = { status: "pending" };
 		if (row.crawlStage) pending.stage = row.crawlStage;
 		if (parts) pending.parts = parts;
+		if (partial) pending.partial = partial;
 		return pending;
 	}
 	if (row.crawlStatus === "ready") return { status: "ready" };

--- a/projects/hutch/src/runtime/reader-stream.main.ts
+++ b/projects/hutch/src/runtime/reader-stream.main.ts
@@ -1,0 +1,129 @@
+/* c8 ignore start -- composition root, no logic to test */
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbArticleCrawl } from "./providers/article-crawl/dynamodb-article-crawl";
+import { initDynamoDbAuth } from "./providers/auth/dynamodb-auth";
+import {
+	initReaderStreamHandler,
+	type ReaderStreamRequest,
+	type ReaderStreamResponse,
+} from "./reader-stream/reader-stream-handler";
+import { requireEnv } from "./domain/require-env";
+
+const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
+const usersTable = requireEnv("DYNAMODB_USERS_TABLE");
+const sessionsTable = requireEnv("DYNAMODB_SESSIONS_TABLE");
+
+const dynamoClient = createDynamoDocumentClient();
+
+const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
+	client: dynamoClient,
+	tableName: articlesTable,
+});
+
+const { getSessionUserId } = initDynamoDbAuth({
+	client: dynamoClient,
+	usersTableName: usersTable,
+	sessionsTableName: sessionsTable,
+});
+
+const handlerFn = initReaderStreamHandler({
+	findArticleCrawlStatus,
+	getSessionUserId,
+	logger: HutchLogger.from(consoleLogger),
+	now: () => Date.now(),
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+	pollIntervalMs: 250,
+	connectionMaxMs: 60_000,
+});
+
+/**
+ * Adapter: `awslambda.streamifyResponse` invokes the handler with the raw
+ * APIGatewayProxyEventV2 (or LambdaFunctionUrlEvent) and a `ResponseStream`.
+ * We translate to the testable handler's `ReaderStreamRequest` /
+ * `ReaderStreamResponse` shape so the handler stays free of the Lambda
+ * runtime's globals — those don't exist in jest.
+ *
+ * The `awslambda` global is only present in the Node Lambda runtime, so
+ * we look it up dynamically and accept that this file is only c8-ignored
+ * — exercised by deployment + production canary, not unit tests.
+ */
+type LambdaStreamifyResponse = (
+	handler: (event: unknown, stream: LambdaResponseStream) => Promise<void>,
+) => unknown;
+
+interface LambdaResponseStream {
+	write(chunk: string | Uint8Array): void;
+	end(): void;
+	setContentType(type: string): void;
+}
+
+interface AwsLambdaGlobal {
+	streamifyResponse: LambdaStreamifyResponse;
+	HttpResponseStream: {
+		from(
+			stream: LambdaResponseStream,
+			metadata: { statusCode: number; headers: Record<string, string> },
+		): LambdaResponseStream;
+	};
+}
+
+interface LambdaFunctionUrlEvent {
+	rawQueryString?: string;
+	cookies?: string[];
+	headers?: Record<string, string | undefined>;
+}
+
+declare const awslambda: AwsLambdaGlobal | undefined;
+
+function buildRequest(event: LambdaFunctionUrlEvent): ReaderStreamRequest {
+	const queryString = event.rawQueryString ?? "";
+	const cookieHeader = event.cookies && event.cookies.length > 0
+		? event.cookies.join("; ")
+		: event.headers?.cookie;
+	return { queryString, cookieHeader };
+}
+
+function buildResponse(stream: LambdaResponseStream): ReaderStreamResponse {
+	let headersWritten = false;
+	let pendingHeaders: Record<string, string> = {};
+
+	const ensureHeaders = (): void => {
+		if (headersWritten) return;
+		headersWritten = true;
+		// awslambda.HttpResponseStream.from is the only way to set status +
+		// headers on a streaming response — calling it later in the lifecycle
+		// throws "ResponseStream not yet initialized". So we defer until the
+		// first write and apply whatever headers the handler set via setHeaders.
+		const aws = (typeof awslambda !== "undefined" ? awslambda : undefined);
+		if (!aws) return;
+		const _ = aws.HttpResponseStream.from(stream, {
+			statusCode: 200,
+			headers: pendingHeaders,
+		});
+		void _;
+	};
+
+	return {
+		setHeaders: (h) => { pendingHeaders = h; },
+		write: (frame) => {
+			ensureHeaders();
+			stream.write(frame);
+		},
+		end: () => {
+			ensureHeaders();
+			stream.end();
+		},
+	};
+}
+
+const adapted = async (event: unknown, stream: LambdaResponseStream): Promise<void> => {
+	const request = buildRequest(event as LambdaFunctionUrlEvent);
+	const response = buildResponse(stream);
+	await handlerFn(request, response);
+};
+
+export const handler = (typeof awslambda !== "undefined"
+	? awslambda.streamifyResponse(adapted)
+	: adapted) as unknown;
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/reader-stream.main.ts
+++ b/projects/hutch/src/runtime/reader-stream.main.ts
@@ -2,7 +2,6 @@
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { initDynamoDbArticleCrawl } from "./providers/article-crawl/dynamodb-article-crawl";
-import { initDynamoDbAuth } from "./providers/auth/dynamodb-auth";
 import {
 	initReaderStreamHandler,
 	type ReaderStreamRequest,
@@ -11,8 +10,6 @@ import {
 import { requireEnv } from "./domain/require-env";
 
 const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
-const usersTable = requireEnv("DYNAMODB_USERS_TABLE");
-const sessionsTable = requireEnv("DYNAMODB_SESSIONS_TABLE");
 
 const dynamoClient = createDynamoDocumentClient();
 
@@ -21,15 +18,8 @@ const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({
 	tableName: articlesTable,
 });
 
-const { getSessionUserId } = initDynamoDbAuth({
-	client: dynamoClient,
-	usersTableName: usersTable,
-	sessionsTableName: sessionsTable,
-});
-
 const handlerFn = initReaderStreamHandler({
 	findArticleCrawlStatus,
-	getSessionUserId,
 	logger: HutchLogger.from(consoleLogger),
 	now: () => Date.now(),
 	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -70,18 +60,12 @@ interface AwsLambdaGlobal {
 
 interface LambdaFunctionUrlEvent {
 	rawQueryString?: string;
-	cookies?: string[];
-	headers?: Record<string, string | undefined>;
 }
 
 declare const awslambda: AwsLambdaGlobal | undefined;
 
 function buildRequest(event: LambdaFunctionUrlEvent): ReaderStreamRequest {
-	const queryString = event.rawQueryString ?? "";
-	const cookieHeader = event.cookies && event.cookies.length > 0
-		? event.cookies.join("; ")
-		: event.headers?.cookie;
-	return { queryString, cookieHeader };
+	return { queryString: event.rawQueryString ?? "" };
 }
 
 function buildResponse(stream: LambdaResponseStream): ReaderStreamResponse {

--- a/projects/hutch/src/runtime/reader-stream/reader-stream-handler.test.ts
+++ b/projects/hutch/src/runtime/reader-stream/reader-stream-handler.test.ts
@@ -1,0 +1,456 @@
+import { noopLogger } from "@packages/hutch-logger";
+import type {
+	ArticleCrawl,
+	FindArticleCrawlStatus,
+} from "@packages/test-fixtures/providers/article-crawl";
+import {
+	extractSessionCookie,
+	initReaderStreamHandler,
+	parseRequest,
+	type ReaderStreamResponse,
+} from "./reader-stream-handler";
+
+function captureResponse(): {
+	response: ReaderStreamResponse;
+	frames: string[];
+	headers: Record<string, string> | undefined;
+	ended: boolean;
+} {
+	const frames: string[] = [];
+	let headers: Record<string, string> | undefined;
+	let ended = false;
+	const response: ReaderStreamResponse = {
+		write: (frame) => frames.push(frame),
+		end: () => { ended = true; },
+		setHeaders: (h) => { headers = h; },
+	};
+	return {
+		response,
+		frames,
+		get headers() { return headers; },
+		get ended() { return ended; },
+	} as ReturnType<typeof captureResponse>;
+}
+
+function withFindArticleCrawlStatus(scripted: Array<ArticleCrawl | undefined>): {
+	findArticleCrawlStatus: FindArticleCrawlStatus;
+	calls: number;
+} {
+	let calls = 0;
+	const findArticleCrawlStatus: FindArticleCrawlStatus = async () => {
+		const value = scripted[Math.min(calls, scripted.length - 1)];
+		calls += 1;
+		return value;
+	};
+	return {
+		findArticleCrawlStatus,
+		get calls() { return calls; },
+	} as { findArticleCrawlStatus: FindArticleCrawlStatus; calls: number };
+}
+
+const URL = "https://example.com/article";
+
+describe("parseRequest", () => {
+	it("returns valid with url + default from=0 when only url is set", () => {
+		const result = parseRequest({
+			queryString: `url=${encodeURIComponent(URL)}`,
+			cookieHeader: undefined,
+		});
+		expect(result).toEqual({ kind: "valid", url: URL, fromLength: 0 });
+	});
+
+	it("returns valid with url + parsed from when both are set", () => {
+		const result = parseRequest({
+			queryString: `url=${encodeURIComponent(URL)}&from=42`,
+			cookieHeader: undefined,
+		});
+		expect(result).toEqual({ kind: "valid", url: URL, fromLength: 42 });
+	});
+
+	it("rejects requests with no url", () => {
+		const result = parseRequest({ queryString: "from=10", cookieHeader: undefined });
+		expect(result).toEqual({ kind: "invalid", reason: "missing 'url' query param" });
+	});
+
+	it("rejects requests where url is unparseable", () => {
+		const result = parseRequest({
+			queryString: "url=not-a-url",
+			cookieHeader: undefined,
+		});
+		expect(result.kind).toBe("invalid");
+	});
+
+	it("rejects requests where the URL scheme is not http(s) (defence: no file://, javascript://, etc.)", () => {
+		const result = parseRequest({
+			queryString: `url=${encodeURIComponent("javascript:alert(1)")}`,
+			cookieHeader: undefined,
+		});
+		expect(result).toEqual({ kind: "invalid", reason: "url must be http(s)" });
+	});
+
+	it("rejects negative from values", () => {
+		const result = parseRequest({
+			queryString: `url=${encodeURIComponent(URL)}&from=-5`,
+			cookieHeader: undefined,
+		});
+		expect(result.kind).toBe("invalid");
+	});
+
+	it("rejects non-numeric from values", () => {
+		const result = parseRequest({
+			queryString: `url=${encodeURIComponent(URL)}&from=abc`,
+			cookieHeader: undefined,
+		});
+		expect(result.kind).toBe("invalid");
+	});
+});
+
+describe("extractSessionCookie", () => {
+	it("returns the session id from a single-cookie header", () => {
+		expect(extractSessionCookie("hutch_sid=abc123")).toBe("abc123");
+	});
+
+	it("returns the session id from a multi-cookie header (ignores other names)", () => {
+		expect(
+			extractSessionCookie("foo=bar; hutch_sid=abc123; baz=qux"),
+		).toBe("abc123");
+	});
+
+	it("returns undefined when no hutch_sid cookie is present", () => {
+		expect(extractSessionCookie("foo=bar; baz=qux")).toBeUndefined();
+	});
+
+	it("returns undefined when there is no cookie header at all", () => {
+		expect(extractSessionCookie(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined for an empty hutch_sid value (defensive)", () => {
+		expect(extractSessionCookie("hutch_sid=")).toBeUndefined();
+	});
+
+	it("tolerates malformed pairs (no equals sign) and keeps scanning", () => {
+		expect(
+			extractSessionCookie("malformed; hutch_sid=valid"),
+		).toBe("valid");
+	});
+});
+
+describe("initReaderStreamHandler", () => {
+	function makeDeps(opts: {
+		scripted: Array<ArticleCrawl | undefined>;
+		pollIntervalMs?: number;
+		connectionMaxMs?: number;
+		getSessionUserId?: (id: string) => Promise<{ userId: string; emailVerified: boolean } | null>;
+		now?: () => number;
+	}) {
+		let nowMs = 0;
+		const sleepCalls: number[] = [];
+		const sleep = async (ms: number): Promise<void> => {
+			sleepCalls.push(ms);
+			nowMs += ms;
+		};
+		const finder = withFindArticleCrawlStatus(opts.scripted);
+		const defaultNow = () => nowMs;
+		const deps = {
+			findArticleCrawlStatus: finder.findArticleCrawlStatus,
+			getSessionUserId: opts.getSessionUserId ?? (async () => null),
+			logger: noopLogger,
+			now: opts.now ?? defaultNow,
+			sleep,
+			pollIntervalMs: opts.pollIntervalMs ?? 250,
+			connectionMaxMs: opts.connectionMaxMs ?? 60_000,
+		};
+		return { deps, finder, sleepCalls };
+	}
+
+	it("returns a 'bad request' frame when the query string is invalid", async () => {
+		const { deps } = makeDeps({ scripted: [] });
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: "missing-url=true", cookieHeader: undefined },
+			captured.response,
+		);
+
+		expect(captured.frames.join("")).toContain("bad request");
+		expect(captured.ended).toBe(true);
+	});
+
+	it("sets SSE-shaped headers before writing any frames", async () => {
+		const { deps } = makeDeps({ scripted: [{ status: "ready" }] });
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		expect(captured.headers).toEqual({
+			"content-type": "text/event-stream",
+			"cache-control": "no-store",
+			"x-accel-buffering": "no",
+		});
+	});
+
+	it("emits 'event: done' with the terminal status and closes when the row is already ready on first poll", async () => {
+		const { deps } = makeDeps({ scripted: [{ status: "ready" }] });
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		expect(captured.frames).toEqual(["event: done\ndata: ready\n\n"]);
+		expect(captured.ended).toBe(true);
+	});
+
+	it("emits 'event: done' for failed and unsupported terminal states too", async () => {
+		const failed = captureResponse();
+		const { deps: failedDeps } = makeDeps({
+			scripted: [{ status: "failed", reason: "x" }],
+		});
+		await initReaderStreamHandler(failedDeps)(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			failed.response,
+		);
+		expect(failed.frames).toEqual(["event: done\ndata: failed\n\n"]);
+
+		const unsupported = captureResponse();
+		const { deps: unsupportedDeps } = makeDeps({
+			scripted: [{ status: "unsupported", reason: "y" }],
+		});
+		await initReaderStreamHandler(unsupportedDeps)(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			unsupported.response,
+		);
+		expect(unsupported.frames).toEqual(["event: done\ndata: unsupported\n\n"]);
+	});
+
+	it("emits an 'event: chunk' frame carrying the delta when partial content advances, then 'event: done' on terminal", async () => {
+		const { deps } = makeDeps({
+			scripted: [
+				{ status: "pending", partial: { content: "<p>first</p>", version: 1 } },
+				{ status: "pending", partial: { content: "<p>first</p><p>second</p>", version: 2 } },
+				{ status: "ready" },
+			],
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		// First chunk: entire initial partial.
+		expect(captured.frames[0]).toBe(
+			`event: chunk\ndata: ${JSON.stringify("<p>first</p>")}\n\n`,
+		);
+		// Second chunk: delta past the first.
+		expect(captured.frames[1]).toBe(
+			`event: chunk\ndata: ${JSON.stringify("<p>second</p>")}\n\n`,
+		);
+		// Terminal.
+		expect(captured.frames[2]).toBe("event: done\ndata: ready\n\n");
+		expect(captured.ended).toBe(true);
+	});
+
+	it("resumes from the client-supplied ?from offset (reconnect path) — only emits content past that point", async () => {
+		const { deps } = makeDeps({
+			scripted: [
+				{ status: "pending", partial: { content: "<p>1234567890</p>", version: 1 } },
+				{ status: "ready" },
+			],
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}&from=5`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		// Bytes past offset 5 of "<p>1234567890</p>" = "34567890</p>".
+		expect(captured.frames[0]).toBe(
+			`event: chunk\ndata: ${JSON.stringify("34567890</p>")}\n\n`,
+		);
+	});
+
+	it("does NOT re-emit a chunk for the same partial version when polled again", async () => {
+		const sameVersion: ArticleCrawl = {
+			status: "pending",
+			partial: { content: "<p>same</p>", version: 7 },
+		};
+		const { deps } = makeDeps({ scripted: [sameVersion, sameVersion, { status: "ready" }] });
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		const chunkFrames = captured.frames.filter((f) => f.startsWith("event: chunk"));
+		expect(chunkFrames).toHaveLength(1);
+	});
+
+	it("sleeps for pollIntervalMs between DDB reads (collapse to one read per tick)", async () => {
+		const { deps, sleepCalls } = makeDeps({
+			scripted: [{ status: "pending" }, { status: "pending" }, { status: "ready" }],
+			pollIntervalMs: 250,
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		// 2 sleeps between 3 reads.
+		expect(sleepCalls).toEqual([250, 250]);
+	});
+
+	it("emits 'event: reconnect' when the connection cap elapses without a terminal so the client knows where to resume", async () => {
+		// Use a row that never terminates and a tight time cap.
+		const { deps } = makeDeps({
+			scripted: [{ status: "pending", partial: { content: "<p>abc</p>", version: 1 } }],
+			pollIntervalMs: 100,
+			connectionMaxMs: 350, // 3 sleeps × 100 = 300 < 350; 4th tick exceeds.
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		const last = captured.frames[captured.frames.length - 1];
+		expect(last).toMatch(/^event: reconnect\ndata: \d+\n\n$/);
+		expect(captured.ended).toBe(true);
+	});
+
+	it("looks up the session via getSessionUserId when a cookie is present (auth surface is still wired even though /view is public)", async () => {
+		const lookup = jest.fn().mockResolvedValue({ userId: "u_1", emailVerified: true });
+		const { deps } = makeDeps({
+			scripted: [{ status: "ready" }],
+			getSessionUserId: lookup,
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{
+				queryString: `url=${encodeURIComponent(URL)}`,
+				cookieHeader: "hutch_sid=session-token",
+			},
+			captured.response,
+		);
+
+		expect(lookup).toHaveBeenCalledWith("session-token");
+	});
+
+	it("does not call getSessionUserId for anonymous requests (no cookie header)", async () => {
+		const lookup = jest.fn();
+		const { deps } = makeDeps({
+			scripted: [{ status: "ready" }],
+			getSessionUserId: lookup,
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		expect(lookup).not.toHaveBeenCalled();
+	});
+
+	it("swallows a getSessionUserId error and continues the stream (anonymous fallthrough)", async () => {
+		const lookup = jest.fn().mockRejectedValue(new Error("DDB throttled"));
+		const { deps } = makeDeps({
+			scripted: [{ status: "ready" }],
+			getSessionUserId: lookup,
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{
+				queryString: `url=${encodeURIComponent(URL)}`,
+				cookieHeader: "hutch_sid=token",
+			},
+			captured.response,
+		);
+
+		// Stream still completes successfully.
+		expect(captured.frames).toEqual(["event: done\ndata: ready\n\n"]);
+	});
+
+	it("swallows a findArticleCrawlStatus error and continues polling", async () => {
+		let calls = 0;
+		const finder: FindArticleCrawlStatus = async () => {
+			calls += 1;
+			if (calls === 1) throw new Error("DDB throttled");
+			return { status: "ready" };
+		};
+		const { deps } = makeDeps({ scripted: [] });
+		const handler = initReaderStreamHandler({ ...deps, findArticleCrawlStatus: finder });
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		expect(captured.frames).toEqual(["event: done\ndata: ready\n\n"]);
+		expect(calls).toBeGreaterThan(1);
+	});
+
+	it("does not emit a chunk for an empty partial content (defensive — nothing to send)", async () => {
+		const { deps } = makeDeps({
+			scripted: [
+				{ status: "pending", partial: { content: "", version: 1 } },
+				{ status: "ready" },
+			],
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			captured.response,
+		);
+
+		const chunkFrames = captured.frames.filter((f) => f.startsWith("event: chunk"));
+		expect(chunkFrames).toHaveLength(0);
+	});
+
+	it("does not emit a chunk when from=length exactly matches the partial content (no new bytes)", async () => {
+		const { deps } = makeDeps({
+			scripted: [
+				{ status: "pending", partial: { content: "<p>same</p>", version: 1 } },
+				{ status: "ready" },
+			],
+		});
+		const handler = initReaderStreamHandler(deps);
+		const captured = captureResponse();
+
+		await handler(
+			{
+				queryString: `url=${encodeURIComponent(URL)}&from=11`,
+				cookieHeader: undefined,
+			},
+			captured.response,
+		);
+
+		const chunkFrames = captured.frames.filter((f) => f.startsWith("event: chunk"));
+		expect(chunkFrames).toHaveLength(0);
+	});
+});

--- a/projects/hutch/src/runtime/reader-stream/reader-stream-handler.test.ts
+++ b/projects/hutch/src/runtime/reader-stream/reader-stream-handler.test.ts
@@ -4,7 +4,6 @@ import type {
 	FindArticleCrawlStatus,
 } from "@packages/test-fixtures/providers/article-crawl";
 import {
-	extractSessionCookie,
 	initReaderStreamHandler,
 	parseRequest,
 	type ReaderStreamResponse,
@@ -54,7 +53,6 @@ describe("parseRequest", () => {
 	it("returns valid with url + default from=0 when only url is set", () => {
 		const result = parseRequest({
 			queryString: `url=${encodeURIComponent(URL)}`,
-			cookieHeader: undefined,
 		});
 		expect(result).toEqual({ kind: "valid", url: URL, fromLength: 0 });
 	});
@@ -62,20 +60,18 @@ describe("parseRequest", () => {
 	it("returns valid with url + parsed from when both are set", () => {
 		const result = parseRequest({
 			queryString: `url=${encodeURIComponent(URL)}&from=42`,
-			cookieHeader: undefined,
 		});
 		expect(result).toEqual({ kind: "valid", url: URL, fromLength: 42 });
 	});
 
 	it("rejects requests with no url", () => {
-		const result = parseRequest({ queryString: "from=10", cookieHeader: undefined });
+		const result = parseRequest({ queryString: "from=10" });
 		expect(result).toEqual({ kind: "invalid", reason: "missing 'url' query param" });
 	});
 
 	it("rejects requests where url is unparseable", () => {
 		const result = parseRequest({
 			queryString: "url=not-a-url",
-			cookieHeader: undefined,
 		});
 		expect(result.kind).toBe("invalid");
 	});
@@ -83,7 +79,6 @@ describe("parseRequest", () => {
 	it("rejects requests where the URL scheme is not http(s) (defence: no file://, javascript://, etc.)", () => {
 		const result = parseRequest({
 			queryString: `url=${encodeURIComponent("javascript:alert(1)")}`,
-			cookieHeader: undefined,
 		});
 		expect(result).toEqual({ kind: "invalid", reason: "url must be http(s)" });
 	});
@@ -91,7 +86,6 @@ describe("parseRequest", () => {
 	it("rejects negative from values", () => {
 		const result = parseRequest({
 			queryString: `url=${encodeURIComponent(URL)}&from=-5`,
-			cookieHeader: undefined,
 		});
 		expect(result.kind).toBe("invalid");
 	});
@@ -99,39 +93,8 @@ describe("parseRequest", () => {
 	it("rejects non-numeric from values", () => {
 		const result = parseRequest({
 			queryString: `url=${encodeURIComponent(URL)}&from=abc`,
-			cookieHeader: undefined,
 		});
 		expect(result.kind).toBe("invalid");
-	});
-});
-
-describe("extractSessionCookie", () => {
-	it("returns the session id from a single-cookie header", () => {
-		expect(extractSessionCookie("hutch_sid=abc123")).toBe("abc123");
-	});
-
-	it("returns the session id from a multi-cookie header (ignores other names)", () => {
-		expect(
-			extractSessionCookie("foo=bar; hutch_sid=abc123; baz=qux"),
-		).toBe("abc123");
-	});
-
-	it("returns undefined when no hutch_sid cookie is present", () => {
-		expect(extractSessionCookie("foo=bar; baz=qux")).toBeUndefined();
-	});
-
-	it("returns undefined when there is no cookie header at all", () => {
-		expect(extractSessionCookie(undefined)).toBeUndefined();
-	});
-
-	it("returns undefined for an empty hutch_sid value (defensive)", () => {
-		expect(extractSessionCookie("hutch_sid=")).toBeUndefined();
-	});
-
-	it("tolerates malformed pairs (no equals sign) and keeps scanning", () => {
-		expect(
-			extractSessionCookie("malformed; hutch_sid=valid"),
-		).toBe("valid");
 	});
 });
 
@@ -140,7 +103,6 @@ describe("initReaderStreamHandler", () => {
 		scripted: Array<ArticleCrawl | undefined>;
 		pollIntervalMs?: number;
 		connectionMaxMs?: number;
-		getSessionUserId?: (id: string) => Promise<{ userId: string; emailVerified: boolean } | null>;
 		now?: () => number;
 	}) {
 		let nowMs = 0;
@@ -153,7 +115,6 @@ describe("initReaderStreamHandler", () => {
 		const defaultNow = () => nowMs;
 		const deps = {
 			findArticleCrawlStatus: finder.findArticleCrawlStatus,
-			getSessionUserId: opts.getSessionUserId ?? (async () => null),
 			logger: noopLogger,
 			now: opts.now ?? defaultNow,
 			sleep,
@@ -169,7 +130,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: "missing-url=true", cookieHeader: undefined },
+			{ queryString: "missing-url=true" },
 			captured.response,
 		);
 
@@ -183,7 +144,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -200,7 +161,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -214,7 +175,7 @@ describe("initReaderStreamHandler", () => {
 			scripted: [{ status: "failed", reason: "x" }],
 		});
 		await initReaderStreamHandler(failedDeps)(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			failed.response,
 		);
 		expect(failed.frames).toEqual(["event: done\ndata: failed\n\n"]);
@@ -224,7 +185,7 @@ describe("initReaderStreamHandler", () => {
 			scripted: [{ status: "unsupported", reason: "y" }],
 		});
 		await initReaderStreamHandler(unsupportedDeps)(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			unsupported.response,
 		);
 		expect(unsupported.frames).toEqual(["event: done\ndata: unsupported\n\n"]);
@@ -242,7 +203,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -270,7 +231,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}&from=5`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}&from=5` },
 			captured.response,
 		);
 
@@ -290,7 +251,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -307,7 +268,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -326,71 +287,13 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
 		const last = captured.frames[captured.frames.length - 1];
 		expect(last).toMatch(/^event: reconnect\ndata: \d+\n\n$/);
 		expect(captured.ended).toBe(true);
-	});
-
-	it("looks up the session via getSessionUserId when a cookie is present (auth surface is still wired even though /view is public)", async () => {
-		const lookup = jest.fn().mockResolvedValue({ userId: "u_1", emailVerified: true });
-		const { deps } = makeDeps({
-			scripted: [{ status: "ready" }],
-			getSessionUserId: lookup,
-		});
-		const handler = initReaderStreamHandler(deps);
-		const captured = captureResponse();
-
-		await handler(
-			{
-				queryString: `url=${encodeURIComponent(URL)}`,
-				cookieHeader: "hutch_sid=session-token",
-			},
-			captured.response,
-		);
-
-		expect(lookup).toHaveBeenCalledWith("session-token");
-	});
-
-	it("does not call getSessionUserId for anonymous requests (no cookie header)", async () => {
-		const lookup = jest.fn();
-		const { deps } = makeDeps({
-			scripted: [{ status: "ready" }],
-			getSessionUserId: lookup,
-		});
-		const handler = initReaderStreamHandler(deps);
-		const captured = captureResponse();
-
-		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
-			captured.response,
-		);
-
-		expect(lookup).not.toHaveBeenCalled();
-	});
-
-	it("swallows a getSessionUserId error and continues the stream (anonymous fallthrough)", async () => {
-		const lookup = jest.fn().mockRejectedValue(new Error("DDB throttled"));
-		const { deps } = makeDeps({
-			scripted: [{ status: "ready" }],
-			getSessionUserId: lookup,
-		});
-		const handler = initReaderStreamHandler(deps);
-		const captured = captureResponse();
-
-		await handler(
-			{
-				queryString: `url=${encodeURIComponent(URL)}`,
-				cookieHeader: "hutch_sid=token",
-			},
-			captured.response,
-		);
-
-		// Stream still completes successfully.
-		expect(captured.frames).toEqual(["event: done\ndata: ready\n\n"]);
 	});
 
 	it("swallows a findArticleCrawlStatus error and continues polling", async () => {
@@ -405,7 +308,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -424,7 +327,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{ queryString: `url=${encodeURIComponent(URL)}`, cookieHeader: undefined },
+			{ queryString: `url=${encodeURIComponent(URL)}` },
 			captured.response,
 		);
 
@@ -443,10 +346,7 @@ describe("initReaderStreamHandler", () => {
 		const captured = captureResponse();
 
 		await handler(
-			{
-				queryString: `url=${encodeURIComponent(URL)}&from=11`,
-				cookieHeader: undefined,
-			},
+			{ queryString: `url=${encodeURIComponent(URL)}&from=11` },
 			captured.response,
 		);
 

--- a/projects/hutch/src/runtime/reader-stream/reader-stream-handler.ts
+++ b/projects/hutch/src/runtime/reader-stream/reader-stream-handler.ts
@@ -1,0 +1,201 @@
+import type { HutchLogger } from "@packages/hutch-logger";
+import type {
+	ArticleCrawl,
+	FindArticleCrawlStatus,
+} from "@packages/test-fixtures/providers/article-crawl";
+
+/**
+ * Server-Sent Events handler that streams partial-content snapshots from
+ * the article-crawl row to the parent-side reader client.
+ *
+ * Loop: every `pollIntervalMs` (250ms in prod), read the crawl state from
+ * DynamoDB. When the partial-content version has advanced, emit the *delta*
+ * (bytes past `fromLength`) as an `event: chunk` frame. When the row
+ * transitions terminal (ready / failed / unsupported), emit `event: done`
+ * and close. A `connectionMaxMs` cap (60s in prod) forces a periodic
+ * reconnect — defends against stuck connections.
+ *
+ * The handler is partial-application shaped so the entry point's
+ * `streamifyResponse` wiring stays a one-liner and unit tests can drive
+ * the loop deterministically without touching `awslambda`.
+ */
+
+export interface ReaderStreamRequest {
+	/** Raw query string from the Function URL invocation
+	 * (`?url=https%3A%2F%2F...&from=42`). The handler parses + validates. */
+	queryString: string;
+	/** The Cookie header from the request, used to extract the session
+	 * cookie for authentication. May be undefined for anonymous requests. */
+	cookieHeader: string | undefined;
+}
+
+export interface ReaderStreamResponse {
+	/** Write a single SSE frame (caller chunks `event: type\ndata: …\n\n`
+	 * exactly as the client expects). */
+	write: (frame: string) => void;
+	/** End the response and close the underlying socket. */
+	end: () => void;
+	/** Set response headers (called once before the first `write`). */
+	setHeaders: (headers: Record<string, string>) => void;
+}
+
+export interface ReaderStreamHandlerDeps {
+	findArticleCrawlStatus: FindArticleCrawlStatus;
+	/** Used to authenticate the request via the session cookie. Returns
+	 * `null` for anonymous (no session, expired session, malformed
+	 * cookie). Anonymous requests are still allowed — `/view` is a public
+	 * page and the streaming reader should work for non-logged-in users
+	 * the same way the HTML poll does. Shape matches the production
+	 * provider so the composition root can pass it directly. */
+	getSessionUserId: (
+		sessionId: string,
+	) => Promise<{ userId: string; emailVerified: boolean } | null>;
+	logger: HutchLogger;
+	now: () => number;
+	sleep: (ms: number) => Promise<void>;
+	/** Polling interval between DynamoDB reads. 250 in prod gives a
+	 * tight feedback loop without hammering DDB. */
+	pollIntervalMs: number;
+	/** Maximum lifetime of a single SSE connection. 60s in prod —
+	 * forces clients to reconnect with `?from=<length>` to defend
+	 * against stuck connections that consume Lambda concurrency. */
+	connectionMaxMs: number;
+}
+
+const SESSION_COOKIE_NAME = "hutch_sid";
+
+export function initReaderStreamHandler(deps: ReaderStreamHandlerDeps) {
+	return async (
+		request: ReaderStreamRequest,
+		response: ReaderStreamResponse,
+	): Promise<void> => {
+		const parsed = parseRequest(request);
+		if (parsed.kind === "invalid") {
+			response.setHeaders({
+				"content-type": "text/plain",
+				"cache-control": "no-store",
+			});
+			response.write(`bad request: ${parsed.reason}`);
+			response.end();
+			return;
+		}
+
+		// Authenticate. Anonymous is allowed for public /view pages, so a
+		// missing or invalid cookie isn't a 401 — we just don't carry a user
+		// identity into the loop. The findArticleCrawlStatus provider doesn't
+		// need it today; this surface stays here so per-user gating can be
+		// added later without re-plumbing.
+		const sessionId = extractSessionCookie(request.cookieHeader);
+		if (sessionId) {
+			await deps.getSessionUserId(sessionId).catch((error) => {
+				deps.logger.debug("[reader-stream] session lookup failed", {
+					error: String(error),
+				});
+				return null;
+			});
+		}
+
+		response.setHeaders({
+			"content-type": "text/event-stream",
+			"cache-control": "no-store",
+			"x-accel-buffering": "no",
+		});
+
+		const { url, fromLength } = parsed;
+		const startedAtMs = deps.now();
+		let lastVersion = -1;
+		let lastEmittedLength = fromLength;
+
+		while (deps.now() - startedAtMs < deps.connectionMaxMs) {
+			let crawl: ArticleCrawl | undefined;
+			try {
+				crawl = await deps.findArticleCrawlStatus(url);
+			} catch (error) {
+				deps.logger.warn("[reader-stream] findArticleCrawlStatus failed", {
+					url,
+					error: String(error),
+				});
+				await deps.sleep(deps.pollIntervalMs);
+				continue;
+			}
+
+			const terminal = isTerminal(crawl);
+			if (terminal) {
+				response.write(`event: done\ndata: ${terminal}\n\n`);
+				response.end();
+				return;
+			}
+
+			if (
+				crawl?.status === "pending" &&
+				crawl.partial &&
+				crawl.partial.version > lastVersion &&
+				crawl.partial.content.length > lastEmittedLength
+			) {
+				const delta = crawl.partial.content.slice(lastEmittedLength);
+				lastVersion = crawl.partial.version;
+				lastEmittedLength = crawl.partial.content.length;
+				response.write(`event: chunk\ndata: ${JSON.stringify(delta)}\n\n`);
+			}
+
+			await deps.sleep(deps.pollIntervalMs);
+		}
+		// Time cap reached without a terminal — emit a heartbeat-shaped
+		// close so the client can reconnect with the right `from` offset.
+		response.write(`event: reconnect\ndata: ${lastEmittedLength}\n\n`);
+		response.end();
+	};
+}
+
+interface ValidRequest {
+	kind: "valid";
+	url: string;
+	fromLength: number;
+}
+
+interface InvalidRequest {
+	kind: "invalid";
+	reason: string;
+}
+
+export function parseRequest(request: ReaderStreamRequest): ValidRequest | InvalidRequest {
+	const params = new URLSearchParams(request.queryString);
+	const url = params.get("url");
+	if (!url) return { kind: "invalid", reason: "missing 'url' query param" };
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+			return { kind: "invalid", reason: "url must be http(s)" };
+		}
+	} catch {
+		return { kind: "invalid", reason: "url is not parseable" };
+	}
+	const fromRaw = params.get("from");
+	const fromLength = fromRaw === null ? 0 : Number(fromRaw);
+	if (!Number.isFinite(fromLength) || fromLength < 0) {
+		return { kind: "invalid", reason: "'from' must be a non-negative integer" };
+	}
+	return { kind: "valid", url, fromLength };
+}
+
+export function extractSessionCookie(cookieHeader: string | undefined): string | undefined {
+	if (!cookieHeader) return undefined;
+	const pairs = cookieHeader.split(/;\s*/);
+	for (const pair of pairs) {
+		const eq = pair.indexOf("=");
+		if (eq < 0) continue;
+		const name = pair.slice(0, eq).trim();
+		if (name !== SESSION_COOKIE_NAME) continue;
+		const value = pair.slice(eq + 1).trim();
+		return value.length > 0 ? value : undefined;
+	}
+	return undefined;
+}
+
+function isTerminal(crawl: ArticleCrawl | undefined): string | undefined {
+	if (!crawl) return undefined;
+	if (crawl.status === "ready") return "ready";
+	if (crawl.status === "failed") return "failed";
+	if (crawl.status === "unsupported") return "unsupported";
+	return undefined;
+}

--- a/projects/hutch/src/runtime/reader-stream/reader-stream-handler.ts
+++ b/projects/hutch/src/runtime/reader-stream/reader-stream-handler.ts
@@ -24,9 +24,6 @@ export interface ReaderStreamRequest {
 	/** Raw query string from the Function URL invocation
 	 * (`?url=https%3A%2F%2F...&from=42`). The handler parses + validates. */
 	queryString: string;
-	/** The Cookie header from the request, used to extract the session
-	 * cookie for authentication. May be undefined for anonymous requests. */
-	cookieHeader: string | undefined;
 }
 
 export interface ReaderStreamResponse {
@@ -41,15 +38,6 @@ export interface ReaderStreamResponse {
 
 export interface ReaderStreamHandlerDeps {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
-	/** Used to authenticate the request via the session cookie. Returns
-	 * `null` for anonymous (no session, expired session, malformed
-	 * cookie). Anonymous requests are still allowed — `/view` is a public
-	 * page and the streaming reader should work for non-logged-in users
-	 * the same way the HTML poll does. Shape matches the production
-	 * provider so the composition root can pass it directly. */
-	getSessionUserId: (
-		sessionId: string,
-	) => Promise<{ userId: string; emailVerified: boolean } | null>;
 	logger: HutchLogger;
 	now: () => number;
 	sleep: (ms: number) => Promise<void>;
@@ -61,8 +49,6 @@ export interface ReaderStreamHandlerDeps {
 	 * against stuck connections that consume Lambda concurrency. */
 	connectionMaxMs: number;
 }
-
-const SESSION_COOKIE_NAME = "hutch_sid";
 
 export function initReaderStreamHandler(deps: ReaderStreamHandlerDeps) {
 	return async (
@@ -78,21 +64,6 @@ export function initReaderStreamHandler(deps: ReaderStreamHandlerDeps) {
 			response.write(`bad request: ${parsed.reason}`);
 			response.end();
 			return;
-		}
-
-		// Authenticate. Anonymous is allowed for public /view pages, so a
-		// missing or invalid cookie isn't a 401 — we just don't carry a user
-		// identity into the loop. The findArticleCrawlStatus provider doesn't
-		// need it today; this surface stays here so per-user gating can be
-		// added later without re-plumbing.
-		const sessionId = extractSessionCookie(request.cookieHeader);
-		if (sessionId) {
-			await deps.getSessionUserId(sessionId).catch((error) => {
-				deps.logger.debug("[reader-stream] session lookup failed", {
-					error: String(error),
-				});
-				return null;
-			});
 		}
 
 		response.setHeaders({
@@ -176,20 +147,6 @@ export function parseRequest(request: ReaderStreamRequest): ValidRequest | Inval
 		return { kind: "invalid", reason: "'from' must be a non-negative integer" };
 	}
 	return { kind: "valid", url, fromLength };
-}
-
-export function extractSessionCookie(cookieHeader: string | undefined): string | undefined {
-	if (!cookieHeader) return undefined;
-	const pairs = cookieHeader.split(/;\s*/);
-	for (const pair of pairs) {
-		const eq = pair.indexOf("=");
-		if (eq < 0) continue;
-		const name = pair.slice(0, eq).trim();
-		if (name !== SESSION_COOKIE_NAME) continue;
-		const value = pair.slice(eq + 1).trim();
-		return value.length > 0 ? value : undefined;
-	}
-	return undefined;
 }
 
 function isTerminal(crawl: ArticleCrawl | undefined): string | undefined {

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -145,6 +145,11 @@ interface AppDependencies {
 	validateSaveableUrl: ValidateSaveableUrl;
 	appOrigin: string;
 	staticBaseUrl: string;
+	/** Base URL for the dedicated SSE streaming Lambda (e.g.
+	 * `https://stream.readplace.com`). When undefined the reader-slot's
+	 * streaming variant is disabled and the dots loader stays in place
+	 * — the streaming Lambda can be deployed in a follow-up step. */
+	streamBaseUrl?: string;
 	hashPassword: (password: string) => Promise<string>;
 	createUser: CreateUser;
 	createUserWithPasswordHash: CreateUserWithPasswordHash;
@@ -246,7 +251,7 @@ const LLMS_FULL_TXT = readFileSync(join(__dirname, "llms-full.txt"), "utf-8");
 const INDEXNOW_KEY = getEnv("INDEXNOW_KEY");
 
 export function createApp(dependencies: AppDependencies): Express {
-	const { appOrigin, staticBaseUrl, getSessionUserId, countUsers, foundingAllocation, ...deps } = dependencies;
+	const { appOrigin, staticBaseUrl, streamBaseUrl, getSessionUserId, countUsers, foundingAllocation, ...deps } = dependencies;
 	const app: Express = express();
 
 	app.use((req: Request, res: Response, next: NextFunction) => {
@@ -620,6 +625,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		salt: deps.salt,
 		now: deps.now,
 		featureToggle,
+		streamBaseUrl,
 	});
 	/** `dualAuthMiddleware` is applied INSIDE the queue router rather than at this
 	 * mount so that `GET /queue/:id/view` (and its legacy `/read` redirect) can
@@ -668,6 +674,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		buildBannerState,
 		analytics: deps.analytics,
 		salt: deps.salt,
+		streamBaseUrl,
 	});
 	app.use("/view", viewRouter);
 
@@ -684,6 +691,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		serviceToken: deps.recrawlServiceToken,
 		now: deps.now,
 		buildBannerState,
+		streamBaseUrl,
 	});
 	app.use("/admin/recrawl", adminRecrawlRouter);
 

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -39,6 +39,8 @@ export interface AdminRecrawlDependencies {
 	serviceToken: string;
 	now: () => Date;
 	buildBannerState: BuildBannerState;
+	/** Base URL for the dedicated SSE streaming Lambda. */
+	streamBaseUrl?: string;
 }
 
 function pollUrlBuilderFor(articleUrl: string): PollUrlBuilder {
@@ -220,6 +222,7 @@ export function initAdminRecrawlRoutes(deps: AdminRecrawlDependencies): Router {
 		findArticleByUrl: deps.findArticleByUrl,
 		formatDocumentTitle: formatRecrawlDocumentTitle,
 		now: deps.now,
+		streamBaseUrl: deps.streamBaseUrl,
 	});
 
 	router.use(noStore);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -146,6 +146,8 @@ interface QueueDependencies {
 	salt: string;
 	now: () => Date;
 	featureToggle: QuerystringFeatureToggle;
+	/** Base URL for the dedicated SSE streaming Lambda. */
+	streamBaseUrl?: string;
 }
 
 import type { SavedArticle } from "@packages/domain/article";
@@ -187,6 +189,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			fields: [{ name: "status", value: "read" }],
 		}),
 		now: deps.now,
+		streamBaseUrl: deps.streamBaseUrl,
 	});
 	const resolveReaderPermalink = initReaderPermalink({
 		findArticleById: deps.findArticleById,

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -25,6 +25,7 @@ import { VIEW_STYLES } from "./view.styles";
 const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
+const READER_STREAM_SCRIPT = `<script src="/client-dist/reader-stream.client.js" defer></script>`;
 const EXPIRY_COUNTER_SCRIPT = `<script src="/client-dist/expiry-counter.client.js" defer></script>`;
 
 /** SEO-only constant: <link rel="canonical"> and JSON-LD url must always point
@@ -119,6 +120,8 @@ export interface ViewPageInput {
 	expiresAt: Date | null;
 	now: Date;
 	sharerUserIdPrefix?: SharedUserId;
+	/** Base URL for the dedicated SSE streaming Lambda. */
+	streamBaseUrl?: string;
 }
 
 export function ViewPage(input: ViewPageInput): PageBody {
@@ -135,6 +138,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		summaryOpen: true,
 		progress: input.progress,
 		extensionInstallUrl: input.extensionInstallUrl,
+		streamBaseUrl: input.streamBaseUrl,
 	});
 
 	const viewPath = viewPathFor(input.articleUrl);
@@ -215,6 +219,6 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		styles: VIEW_STYLES,
 		bodyClass: "page-view",
 		content: { html: content },
-		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT + EXPIRY_COUNTER_SCRIPT,
+		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT + READER_STREAM_SCRIPT + EXPIRY_COUNTER_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -70,6 +70,10 @@ interface ViewDependencies {
 	buildBannerState: BuildBannerState;
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
 	salt: string;
+	/** Base URL for the dedicated SSE streaming Lambda. Undefined disables
+	 * the streaming variant; the slot falls back to the existing dots
+	 * loader. Set at the composition root in `lambda.main.ts`. */
+	streamBaseUrl?: string;
 }
 
 async function renderError(deps: ViewDependencies, req: Request, res: Response): Promise<void> {
@@ -97,6 +101,7 @@ function buildArticleReaderDeps(deps: ViewDependencies): ArticleReaderDeps {
 		findArticleByUrl: deps.findArticleByUrl,
 		formatDocumentTitle: formatViewDocumentTitle,
 		now: deps.now,
+		streamBaseUrl: deps.streamBaseUrl,
 	};
 }
 
@@ -264,6 +269,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 					expiresAt,
 					now,
 					sharerUserIdPrefix,
+					streamBaseUrl: deps.streamBaseUrl,
 				}),
 				{ ...(await deps.buildBannerState(req)), showExtensionSuggestionBanner, extensionInstalled: isExtensionInstalled(req) },
 			),

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
@@ -47,6 +47,10 @@ export interface ArticleBodyInput {
 	 * initial SSR bar was hidden.
 	 */
 	progress?: ProgressTick;
+	/** Base URL for the dedicated SSE streaming Lambda's Function URL.
+	 * Threaded through to the reader slot so it can switch to the streaming
+	 * variant when partial content is available. */
+	streamBaseUrl?: string;
 }
 
 export function renderArticleBody(input: ArticleBodyInput): string {
@@ -56,6 +60,7 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		url: input.url,
 		readerPollUrl: input.readerPollUrl,
 		extensionInstallUrl: input.extensionInstallUrl,
+		streamBaseUrl: input.streamBaseUrl,
 	});
 
 	const summarySlotHtml = renderSummarySlot({

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.test.ts
@@ -220,6 +220,93 @@ describe("renderReaderSlot", () => {
 		expect(slot.getAttribute("data-reader-status")).toBe("slow");
 	});
 
+	it("renders the streaming variant when the pending row carries partial content and a stream base URL is configured", () => {
+		const doc = parse(
+			renderReaderSlot({
+				crawl: { status: "pending", partial: { content: "<h1>Title</h1><p>preview</p>", version: 2 } },
+				url: URL,
+				readerPollUrl: "/queue/abc/reader?poll=1",
+				streamBaseUrl: "https://stream.readplace.com",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-slot]");
+		assert(slot, "reader slot must be rendered");
+		expect(slot.getAttribute("data-reader-status")).toBe("streaming");
+		expect(slot.getAttribute("data-article-url")).toBe(URL);
+		expect(slot.getAttribute("data-stream-base-url")).toBe("https://stream.readplace.com");
+		expect(slot.getAttribute("data-prerendered-length")).toBe("28");
+		// HTMX poll stays armed underneath as the fallback path.
+		expect(slot.getAttribute("hx-get")).toBe("/queue/abc/reader?poll=1");
+		expect(slot.getAttribute("hx-trigger")).toBe("every 3s");
+		// The streaming iframe is rendered.
+		const iframe = slot.querySelector("iframe[data-reader-streaming-iframe]");
+		assert(iframe, "streaming iframe must be rendered");
+		const srcdoc = iframe.getAttribute("srcdoc");
+		assert(srcdoc, "srcdoc must be set");
+		expect(srcdoc).toContain("preview");
+	});
+
+	it("falls back to the dots-loader pending variant when partial content is present but no stream base URL is configured (feature flag off)", () => {
+		const doc = parse(
+			renderReaderSlot({
+				crawl: { status: "pending", partial: { content: "<h1>Title</h1>", version: 1 } },
+				url: URL,
+				readerPollUrl: "/queue/abc/reader?poll=1",
+				// streamBaseUrl omitted — streaming is disabled.
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-slot]");
+		assert(slot, "reader slot must be rendered");
+		expect(slot.getAttribute("data-reader-status")).toBe("pending");
+	});
+
+	it("falls back to the 'slow' reframe when partial content + stream-base-url are set but the poll budget has exhausted (no readerPollUrl)", () => {
+		const doc = parse(
+			renderReaderSlot({
+				crawl: { status: "pending", partial: { content: "<h1>x</h1>", version: 1 } },
+				url: URL,
+				streamBaseUrl: "https://stream.readplace.com",
+				// readerPollUrl omitted — poll budget exhausted.
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-slot]");
+		assert(slot, "reader slot must be rendered");
+		expect(slot.getAttribute("data-reader-status")).toBe("slow");
+	});
+
+	it("falls back to the dots-loader pending variant when the partial content is empty (defensive: nothing useful to show yet)", () => {
+		const doc = parse(
+			renderReaderSlot({
+				crawl: { status: "pending", partial: { content: "", version: 1 } },
+				url: URL,
+				readerPollUrl: "/queue/abc/reader?poll=1",
+				streamBaseUrl: "https://stream.readplace.com",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-slot]");
+		assert(slot, "reader slot must be rendered");
+		expect(slot.getAttribute("data-reader-status")).toBe("pending");
+	});
+
+	it("preserves the PDF loading hint when rendering the streaming variant", () => {
+		const doc = parse(
+			renderReaderSlot({
+				crawl: { status: "pending", partial: { content: "<h1>PDF</h1>", version: 1 } },
+				url: "https://www.cia.gov/readingroom/docs/SOMETHING.pdf",
+				readerPollUrl: "/queue/abc/reader?poll=1",
+				streamBaseUrl: "https://stream.readplace.com",
+			}),
+		);
+
+		const subtitle = doc.querySelector(".article-body__reader-loading-subtitle");
+		assert(subtitle, "PDF loading hint must render under the streaming iframe");
+		expect(subtitle.textContent).toMatch(/accuracy over slop/);
+	});
+
 	it("dispatches every CrawlStatus variant — adding a new variant must break this test (and the renderer's exhaustive switch)", () => {
 		const variants: Array<{
 			input: Parameters<typeof renderReaderSlot>[0];

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.ts
@@ -3,6 +3,7 @@ import { isPDF } from "@packages/crawl-article";
 import { renderReaderFailed } from "./reader-failed.component";
 import { renderReaderPending } from "./reader-pending.component";
 import { renderReaderReady } from "./reader-ready.component";
+import { renderReaderStreaming } from "./reader-streaming.component";
 
 export interface ReaderSlotInput {
 	crawl?: ArticleCrawl;
@@ -10,6 +11,13 @@ export interface ReaderSlotInput {
 	url: string;
 	readerPollUrl?: string;
 	extensionInstallUrl?: string;
+	/** Base URL for the SSE streaming Lambda's Function URL (e.g.
+	 * `https://stream.readplace.com`). When set AND the row has partial
+	 * content, the slot renders the streaming variant instead of the dots
+	 * loader; the parent-side `reader-stream.client.ts` opens an EventSource
+	 * against this base URL. Optional so unit tests and dev mode work
+	 * without configuring the stream Lambda. */
+	streamBaseUrl?: string;
 	/* When true, the rendered slot carries `hx-swap-oob="outerHTML"` so HTMX
 	 * splices it into a sibling poll response and replaces the live slot. The
 	 * stable `id="article-body-reader-slot"` on every variant gives HTMX a
@@ -72,6 +80,29 @@ function pollOrSlow(input: ReaderSlotInput, oob: boolean): string {
 			});
 }
 
+/* Streaming sub-branch of the pending state: a partial-content snapshot is
+ * available, the poll URL is still armed, and the page is configured with
+ * a stream base URL. Returns undefined to signal "fall through to the
+ * standard pending dispatcher" when any precondition is missing — keeps the
+ * exhaustive switch's other branches uncluttered. */
+function maybeStreaming(
+	input: ReaderSlotInput,
+	oob: boolean,
+	partial: { content: string; version: number },
+): string | undefined {
+	if (!input.readerPollUrl) return undefined;
+	if (!input.streamBaseUrl) return undefined;
+	if (partial.content.length === 0) return undefined;
+	return renderReaderStreaming({
+		initialPartialHtml: partial.content,
+		articleUrl: input.url,
+		streamBaseUrl: input.streamBaseUrl,
+		pollUrl: input.readerPollUrl,
+		loadingHint: resolveLoadingHint(input.url),
+		oob,
+	});
+}
+
 export function renderReaderSlot(input: ReaderSlotInput): string {
 	const oob = input.oob === true;
 	if (input.crawl === undefined) {
@@ -87,6 +118,10 @@ export function renderReaderSlot(input: ReaderSlotInput): string {
 			if (input.content) return renderReaderReady({ content: input.content, oob });
 			return pollOrSlow(input, oob);
 		case "pending":
+			if (input.crawl.partial) {
+				const streaming = maybeStreaming(input, oob, input.crawl.partial);
+				if (streaming) return streaming;
+			}
 			return pollOrSlow(input, oob);
 		case "failed":
 			return renderReaderFailed({

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.test.ts
@@ -63,8 +63,9 @@ describe("walkAndWrap", () => {
 		expect(collected.length).toBe(3);
 		// <strong> wrapper survives — its child text node was wrapped, the
 		// element itself is untouched.
-		expect(root.querySelector("strong")).not.toBeNull();
-		expect(root.querySelector("strong")?.textContent).toBe("bold");
+		const strong = root.querySelector("strong");
+		if (!strong) throw new Error("strong element must survive walkAndWrap");
+		expect(strong.textContent).toBe("bold");
 	});
 
 	it("does not descend into BLOCKED_TAGS subtrees (defence-in-depth)", () => {

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.test.ts
@@ -30,6 +30,22 @@ describe("sanitizeChunkInto", () => {
 		expect(parent.textContent).toContain("safe");
 	});
 
+	it("strips inline on* event-handler attributes from all elements", () => {
+		const document = setupIframeDom();
+		const parent = document.createElement("div");
+		sanitizeChunkInto(
+			parent,
+			'<img src="x" onerror="alert(1)"><p onclick="steal()" onmouseover="track()">safe text</p>',
+		);
+		const allElements = parent.querySelectorAll("*");
+		for (const el of Array.from(allElements)) {
+			const onAttrs = el.getAttributeNames().filter((n) => /^on/i.test(n));
+			expect(onAttrs).toEqual([]);
+		}
+		expect(parent.textContent).toContain("safe text");
+		expect(parent.querySelector("img")).toBeTruthy();
+	});
+
 	it("strips <iframe>, <object>, <embed>, <style> in the same pass", () => {
 		const document = setupIframeDom();
 		const parent = document.createElement("div");

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.test.ts
@@ -1,0 +1,373 @@
+import { JSDOM } from "jsdom";
+import {
+	computeCadenceMs,
+	initBootstrap,
+	markPrerenderedContent,
+	sanitizeChunkInto,
+	walkAndWrap,
+} from "./reader-stream-bootstrap.iframe";
+
+function setupIframeDom(initialContent = "") {
+	const dom = new JSDOM(
+		`<!doctype html><html><body><article id="content">${initialContent}</article></body></html>`,
+	);
+	return dom.window.document;
+}
+
+describe("sanitizeChunkInto", () => {
+	it("inserts HTML into the parent element", () => {
+		const document = setupIframeDom();
+		const parent = document.createElement("div");
+		sanitizeChunkInto(parent, "<p>hello</p>");
+		expect(parent.innerHTML).toContain("hello");
+	});
+
+	it("strips <script> elements (defence-in-depth against forged postMessage chunks)", () => {
+		const document = setupIframeDom();
+		const parent = document.createElement("div");
+		sanitizeChunkInto(parent, "<p>safe</p><script>window.exploit=true</script>");
+		expect(parent.querySelectorAll("script")).toHaveLength(0);
+		expect(parent.textContent).toContain("safe");
+	});
+
+	it("strips <iframe>, <object>, <embed>, <style> in the same pass", () => {
+		const document = setupIframeDom();
+		const parent = document.createElement("div");
+		sanitizeChunkInto(
+			parent,
+			"<style>* { display: none }</style><iframe></iframe><object></object><embed>",
+		);
+		expect(parent.querySelectorAll("style, iframe, object, embed")).toHaveLength(0);
+	});
+});
+
+describe("walkAndWrap", () => {
+	it("wraps each whitespace-delimited word in a <span class='rp-word'>", () => {
+		const document = setupIframeDom("<p>Hello world example</p>");
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+		const collected: HTMLSpanElement[] = [];
+		walkAndWrap(root, collected, document);
+		expect(collected.length).toBe(3);
+		expect(collected.map((s) => s.textContent)).toEqual(["Hello", "world", "example"]);
+		for (const span of collected) expect(span.className).toBe("rp-word");
+	});
+
+	it("preserves the surrounding HTML structure (inline elements survive)", () => {
+		const document = setupIframeDom("<p>Hello <strong>bold</strong> world</p>");
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+		const collected: HTMLSpanElement[] = [];
+		walkAndWrap(root, collected, document);
+		// 3 words: "Hello", "bold", "world"
+		expect(collected.length).toBe(3);
+		// <strong> wrapper survives — its child text node was wrapped, the
+		// element itself is untouched.
+		expect(root.querySelector("strong")).not.toBeNull();
+		expect(root.querySelector("strong")?.textContent).toBe("bold");
+	});
+
+	it("does not descend into BLOCKED_TAGS subtrees (defence-in-depth)", () => {
+		const document = setupIframeDom("<p>safe</p><script>danger words here</script>");
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+		const collected: HTMLSpanElement[] = [];
+		walkAndWrap(root, collected, document);
+		// Only "safe" wrapped — words inside <script> stay raw and untouched.
+		expect(collected.map((s) => s.textContent)).toEqual(["safe"]);
+	});
+
+	it("preserves whitespace between words", () => {
+		const document = setupIframeDom("<p>a  b</p>");
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+		const collected: HTMLSpanElement[] = [];
+		walkAndWrap(root, collected, document);
+		expect(collected.length).toBe(2);
+		const p = root.querySelector("p");
+		expect(p?.textContent).toBe("a  b");
+	});
+
+	it("skips empty text nodes (createTextNode(\"\") edge case)", () => {
+		const document = setupIframeDom();
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+		root.appendChild(document.createTextNode(""));
+		const collected: HTMLSpanElement[] = [];
+		walkAndWrap(root, collected, document);
+		expect(collected).toEqual([]);
+	});
+
+	it("handles a text node with no whitespace as a single word", () => {
+		const document = setupIframeDom("<p>oneword</p>");
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+		const collected: HTMLSpanElement[] = [];
+		walkAndWrap(root, collected, document);
+		expect(collected.length).toBe(1);
+		expect(collected[0].textContent).toBe("oneword");
+	});
+});
+
+describe("markPrerenderedContent", () => {
+	it("marks already-rendered words as rp-word--prerendered with opacity 1 (no fade-in for server-baked content)", () => {
+		const document = setupIframeDom("<p>server baked content</p>");
+		const root = document.getElementById("content");
+		if (!root) throw new Error("content missing");
+
+		markPrerenderedContent(root);
+
+		const spans = root.querySelectorAll(".rp-word");
+		expect(spans.length).toBe(3);
+		for (const span of Array.from(spans)) {
+			expect(span.classList.contains("rp-word--prerendered")).toBe(true);
+			expect((span as HTMLElement).style.opacity).toBe("1");
+		}
+	});
+});
+
+describe("computeCadenceMs", () => {
+	it("targets finishing just before the next chunk arrives (cadence = available time / total words)", () => {
+		// 100ms available, 10 words → 10ms/word.
+		const cadence = computeCadenceMs({
+			pendingCount: 0,
+			newWordCount: 10,
+			nextSlotMs: 1000,
+			interChunkEmaMs: 1000 / 0.9, // makes targetFinishMs = 1000 + ema*0.9 = 2000
+			nowMs: 1000,
+		});
+		// targetFinishMs ≈ 2000; (2000-1000)/10 = 100, but clamped against the
+		// floor — let's pick numbers that fall in the legal range.
+		expect(cadence).toBeGreaterThanOrEqual(15);
+		expect(cadence).toBeLessThanOrEqual(120);
+	});
+
+	it("clamps below the floor when the queue is far too big for the remaining time", () => {
+		const cadence = computeCadenceMs({
+			pendingCount: 0,
+			newWordCount: 1000,
+			nextSlotMs: 1000,
+			interChunkEmaMs: 200, // very short — definitely below floor per word
+			nowMs: 1000,
+		});
+		expect(cadence).toBe(15);
+	});
+
+	it("clamps above the ceiling when there is a single word but lots of time", () => {
+		const cadence = computeCadenceMs({
+			pendingCount: 0,
+			newWordCount: 1,
+			nextSlotMs: 1000,
+			interChunkEmaMs: 10_000,
+			nowMs: 1000,
+		});
+		expect(cadence).toBe(120);
+	});
+
+	it("falls back to the floor when there are no words to schedule (edge case)", () => {
+		const cadence = computeCadenceMs({
+			pendingCount: 0,
+			newWordCount: 0,
+			nextSlotMs: 0,
+			interChunkEmaMs: 250,
+			nowMs: 0,
+		});
+		expect(cadence).toBe(15);
+	});
+});
+
+describe("initBootstrap", () => {
+	function makeWindow(initialContent: string) {
+		const dom = new JSDOM(
+			`<!doctype html><html><body><article id="content">${initialContent}</article></body></html>`,
+		);
+		const { window } = dom;
+		const parentPosts: Array<{ data: unknown; targetOrigin: string }> = [];
+		const fakeParent = {
+			postMessage: (data: unknown, targetOrigin: string) => {
+				parentPosts.push({ data, targetOrigin });
+			},
+		} as unknown as Window;
+		let nowMs = 0;
+		const rafCallbacks: Array<() => void> = [];
+
+		const deps = {
+			document: window.document,
+			parent: fakeParent,
+			addEventListener: window.addEventListener.bind(window) as Window["addEventListener"],
+			performance: { now: () => nowMs },
+			requestAnimationFrame: ((cb: () => void) => {
+				rafCallbacks.push(cb);
+				return 0;
+			}) as unknown as Window["requestAnimationFrame"],
+		};
+
+		return {
+			window,
+			deps,
+			parentPosts,
+			rafCallbacks,
+			setNow: (ms: number) => { nowMs = ms; },
+			drainOneRaf: () => {
+				const cb = rafCallbacks.shift();
+				if (cb) cb();
+			},
+		};
+	}
+
+	it("posts {type:'readplace-ready'} to parent on init so the parent knows the listener is mounted", () => {
+		const harness = makeWindow("");
+		initBootstrap(harness.deps);
+		expect(harness.parentPosts).toEqual([
+			{ data: { type: "readplace-ready" }, targetOrigin: "*" },
+		]);
+	});
+
+	it("ignores message events whose e.source is not window.parent (cross-frame poisoning defence)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		const wordCountBefore = harness.window.document.querySelectorAll(".rp-word").length;
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: null,
+				data: { type: "readplace-chunk", html: "<p>injected words</p>" },
+			}),
+		);
+		expect(harness.window.document.querySelectorAll(".rp-word").length).toBe(wordCountBefore);
+		expect(bootstrap.state.pendingWords.length).toBe(0);
+	});
+
+	it("ignores messages whose data.type is not 'readplace-chunk' (random parent chatter does not appear in the reader)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: harness.deps.parent,
+				data: { type: "something-else", html: "<p>nope</p>" },
+			}),
+		);
+		expect(bootstrap.state.pendingWords.length).toBe(0);
+	});
+
+	it("appends new chunk content to the iframe and queues its words for reveal", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		bootstrap.onChunk("<p>three new words</p>");
+		expect(bootstrap.state.pendingWords.length).toBe(3);
+		const spans = harness.window.document.querySelectorAll(".rp-word");
+		// 3 newly-streamed words wrapped (no prerendered content to skip).
+		expect(spans.length).toBe(3);
+	});
+
+	it("does NOT schedule reveals or kick the rAF loop when an incoming chunk yields zero new words", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		const rafBefore = harness.rafCallbacks.length;
+		// A chunk with no text content (just empty wrapping markup).
+		bootstrap.onChunk("<div></div>");
+		expect(bootstrap.state.pendingWords.length).toBe(0);
+		expect(harness.rafCallbacks.length).toBe(rafBefore);
+	});
+
+	it("re-queues itself via requestAnimationFrame while words remain pending (tick loop continues until queue drains)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		bootstrap.onChunk("<p>a b c d e</p>");
+		expect(harness.rafCallbacks.length).toBeGreaterThan(0);
+
+		harness.setNow(1); // not enough time for any word to reveal
+		harness.drainOneRaf();
+		// Pending words still > 0 → tick should have queued another rAF.
+		expect(bootstrap.state.pendingWords.length).toBeGreaterThan(0);
+		expect(harness.rafCallbacks.length).toBeGreaterThan(0);
+	});
+
+	it("reveals queued words when their revealAtMs elapses (tick drains the front of the queue)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		bootstrap.onChunk("<p>a b c d e</p>");
+		const totalPending = bootstrap.state.pendingWords.length;
+		expect(totalPending).toBeGreaterThan(0);
+
+		// Fast-forward to a time after all words should have revealed.
+		harness.setNow(10_000);
+		// Tick repeatedly until the queue drains.
+		while (bootstrap.state.pendingWords.length > 0) {
+			bootstrap.tick();
+		}
+		const revealedCount = Array.from(
+			harness.window.document.querySelectorAll(".rp-word"),
+		).filter((s) => (s as HTMLElement).style.opacity === "1").length;
+		expect(revealedCount).toBe(totalPending);
+	});
+
+	it("updates the EMA inter-chunk gap when a second chunk arrives", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		harness.setNow(0);
+		bootstrap.onChunk("<p>a b</p>");
+		const initialEma = bootstrap.state.interChunkEmaMs;
+		harness.setNow(500);
+		bootstrap.onChunk("<p>c d</p>");
+		expect(bootstrap.state.interChunkEmaMs).not.toBe(initialEma);
+	});
+
+	it("treats already-rendered content (server-baked) as prerendered and skips fade-in for it", () => {
+		const harness = makeWindow("<p>baked content here</p>");
+		initBootstrap(harness.deps);
+		const prerendered = harness.window.document.querySelectorAll(".rp-word--prerendered");
+		expect(prerendered.length).toBe(3);
+		for (const span of Array.from(prerendered)) {
+			expect((span as HTMLElement).style.opacity).toBe("1");
+		}
+	});
+
+	it("throws on init if the #content element is missing (invariant: bootstrap must run inside the correct srcdoc)", () => {
+		const dom = new JSDOM(`<!doctype html><html><body></body></html>`);
+		const { window } = dom;
+		const deps = {
+			document: window.document,
+			parent: window as unknown as Window,
+			addEventListener: window.addEventListener.bind(window) as Window["addEventListener"],
+			performance: { now: () => 0 },
+			requestAnimationFrame: ((_cb: () => void) => 0) as unknown as Window["requestAnimationFrame"],
+		};
+		expect(() => initBootstrap(deps)).toThrow(/#content/);
+	});
+
+	it("ignores messages with no data payload (defensive against postMessage from unrelated sources)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: harness.deps.parent,
+				data: null,
+			}),
+		);
+		expect(bootstrap.state.pendingWords.length).toBe(0);
+	});
+
+	it("ignores readplace-chunk messages with a non-string html field (zod-shaped boundary)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: harness.deps.parent,
+				data: { type: "readplace-chunk", html: 42 },
+			}),
+		);
+		expect(bootstrap.state.pendingWords.length).toBe(0);
+	});
+
+	it("processes valid readplace-chunk messages via the message dispatch path (end-to-end)", () => {
+		const harness = makeWindow("");
+		const bootstrap = initBootstrap(harness.deps);
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: harness.deps.parent,
+				data: { type: "readplace-chunk", html: "<p>real chunk</p>" },
+			}),
+		);
+		expect(bootstrap.state.pendingWords.length).toBe(2);
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts
@@ -1,0 +1,277 @@
+/**
+ * Runs inside the streaming reader iframe (sandbox: allow-scripts +
+ * allow-same-origin). Receives HTML chunks from the parent via postMessage,
+ * splits each chunk into word-level `<span class="rp-word">` wrappers, and
+ * reveals them at an adaptive cadence that drains the queue just before the
+ * next chunk arrives — producing a continuous "always streaming" feel even
+ * though the underlying transport delivers in bursts.
+ *
+ * Compiled by `build-client-bundles.js` and inlined into the iframe's
+ * srcdoc by `reader-streaming-iframe-srcdoc.ts` (the iframe is created from
+ * the parent's HTML, so the script must be present in the srcdoc itself —
+ * the sandboxed origin has no relative path to fetch a separate file from).
+ *
+ * Boundary contract:
+ *   - Listens for `message` events where `e.source === window.parent` AND
+ *     `e.data?.type === "readplace-chunk"` carrying a string `html`.
+ *   - Posts `{ type: "readplace-ready" }` to `window.parent` on load so the
+ *     parent only opens its EventSource once the listener is mounted.
+ *   - Strips `<script>` / `<style>` / `<iframe>` / `<object>` / `<embed>`
+ *     from every incoming chunk before insertion as a defence-in-depth pass
+ *     (the partial content has already been sanitised upstream).
+ */
+
+interface BootstrapWindow {
+	document: Document;
+	parent: Window;
+	addEventListener: Window["addEventListener"];
+	performance: { now(): number };
+	requestAnimationFrame: Window["requestAnimationFrame"];
+}
+
+interface PendingWord {
+	span: HTMLSpanElement;
+	revealAtMs: number;
+}
+
+interface BootstrapState {
+	pendingWords: PendingWord[];
+	lastChunkAtMs: number;
+	/* Tracks "have we recorded a previous chunk yet" separately from
+	 * `lastChunkAtMs`. Truthiness alone on a millisecond timestamp would
+	 * misfire when `performance.now()` legitimately returns 0 at iframe
+	 * load time. */
+	hasPriorChunk: boolean;
+	interChunkEmaMs: number;
+	rafQueued: boolean;
+}
+
+const BLOCKED_TAGS = new Set([
+	"SCRIPT",
+	"STYLE",
+	"IFRAME",
+	"OBJECT",
+	"EMBED",
+]);
+
+const MIN_CADENCE_MS = 15;
+const MAX_CADENCE_MS = 120;
+const EMA_ALPHA = 0.3;
+const TARGET_FINISH_FRACTION = 0.9;
+const INITIAL_EMA_MS = 250;
+
+/**
+ * Mark every text-bearing word in already-rendered content as
+ * "prerendered" (opacity 1, no animation). Called once on init so the
+ * server-baked snapshot doesn't fade in — only newly-streamed words get
+ * the reveal animation.
+ */
+export function markPrerenderedContent(root: Element): void {
+	const collected: HTMLSpanElement[] = [];
+	walkAndWrap(root, collected, root.ownerDocument);
+	for (const span of collected) {
+		span.classList.add("rp-word--prerendered");
+		span.style.opacity = "1";
+	}
+}
+
+/**
+ * Sanitise an HTML chunk by stripping script-bearing / framing elements
+ * before parsing it into the iframe DOM. The defense lives here as well
+ * as upstream because the iframe processes raw `postMessage` payloads that
+ * could in principle be forged by another script in the parent context.
+ */
+export function sanitizeChunkInto(parent: HTMLElement, html: string): void {
+	parent.innerHTML = html;
+	const blocked = parent.querySelectorAll("script, style, iframe, object, embed");
+	for (let i = 0; i < blocked.length; i++) {
+		const node = blocked[i];
+		const p = node.parentNode;
+		// `parentNode` of a node returned by `querySelectorAll` against the
+		// just-set innerHTML is always defined (the node lives inside parent).
+		assert(p, "node returned by querySelectorAll must have a parent");
+		p.removeChild(node);
+	}
+}
+
+/** Walk a subtree wrapping each whitespace-delimited token in `<span
+ * class="rp-word">`. Whitespace and BLOCKED_TAGS-housed subtrees are
+ * preserved as-is. `collected` is appended with the spans in source order. */
+export function walkAndWrap(
+	root: Node,
+	collected: HTMLSpanElement[],
+	document: Document,
+): void {
+	const stack: Node[] = [root];
+	let head = stack.pop();
+	while (head !== undefined) {
+		const children: Node[] = [];
+		let child = head.firstChild;
+		while (child) {
+			children.push(child);
+			child = child.nextSibling;
+		}
+		for (const c of children) {
+			if (c.nodeType === 3) {
+				wrapWordsInTextNode(c as Text, collected, document);
+			} else if (c.nodeType === 1) {
+				const el = c as Element;
+				if (!BLOCKED_TAGS.has(el.tagName)) stack.push(el);
+			}
+		}
+		head = stack.pop();
+	}
+}
+
+function wrapWordsInTextNode(
+	textNode: Text,
+	collected: HTMLSpanElement[],
+	document: Document,
+): void {
+	const content = textNode.textContent;
+	// DOM spec: Text.textContent returns the node's data verbatim — never
+	// null. Asserting eliminates the ?? branch V8 reports as uncovered.
+	assert(content !== null, "Text.textContent must be a string");
+	if (content === "") return;
+	const parts = content.split(/(\s+)/);
+	if (parts.length <= 1 && !/\s/.test(content)) {
+		const span = document.createElement("span");
+		span.className = "rp-word";
+		span.textContent = content;
+		textNode.parentNode?.replaceChild(span, textNode);
+		collected.push(span);
+		return;
+	}
+	const frag = document.createDocumentFragment();
+	for (const part of parts) {
+		if (part === "") continue;
+		if (/^\s+$/.test(part)) {
+			frag.appendChild(document.createTextNode(part));
+		} else {
+			const span = document.createElement("span");
+			span.className = "rp-word";
+			span.textContent = part;
+			frag.appendChild(span);
+			collected.push(span);
+		}
+	}
+	textNode.parentNode?.replaceChild(frag, textNode);
+}
+
+/**
+ * Compute the per-word reveal cadence for a chunk. The aim is to finish
+ * draining the queue just before the next chunk is predicted to arrive
+ * (using the EMA of inter-chunk gaps), so the reveal feels continuous
+ * even though chunks arrive in bursts. Clamped to `[15, 120]` ms — below
+ * 15ms the eye can't track; above 120ms the stream stutters.
+ */
+export function computeCadenceMs(args: {
+	pendingCount: number;
+	newWordCount: number;
+	nextSlotMs: number;
+	interChunkEmaMs: number;
+	nowMs: number;
+}): number {
+	const targetFinishMs = args.nowMs + args.interChunkEmaMs * TARGET_FINISH_FRACTION;
+	const total = args.pendingCount + args.newWordCount;
+	if (total === 0) return MIN_CADENCE_MS;
+	const raw = (targetFinishMs - args.nextSlotMs) / total;
+	if (raw < MIN_CADENCE_MS) return MIN_CADENCE_MS;
+	if (raw > MAX_CADENCE_MS) return MAX_CADENCE_MS;
+	return raw;
+}
+
+function assert(cond: unknown, message: string): asserts cond {
+	if (!cond) throw new Error(message);
+}
+
+export function initBootstrap(deps: BootstrapWindow): {
+	onChunk: (html: string) => void;
+	tick: () => void;
+	state: BootstrapState;
+} {
+	const contentOrNull = deps.document.getElementById("content");
+	assert(contentOrNull, "streaming bootstrap: #content element missing");
+	const content: HTMLElement = contentOrNull;
+	markPrerenderedContent(content);
+	const state: BootstrapState = {
+		pendingWords: [],
+		lastChunkAtMs: 0,
+		hasPriorChunk: false,
+		interChunkEmaMs: INITIAL_EMA_MS,
+		rafQueued: false,
+	};
+
+	function onChunk(html: string): void {
+		const nowMs = deps.performance.now();
+		const scratch = deps.document.createElement("div");
+		sanitizeChunkInto(scratch, html);
+		const newWords: HTMLSpanElement[] = [];
+		walkAndWrap(scratch, newWords, deps.document);
+		while (scratch.firstChild) content.appendChild(scratch.firstChild);
+
+		if (state.hasPriorChunk) {
+			state.interChunkEmaMs =
+				(1 - EMA_ALPHA) * state.interChunkEmaMs +
+				EMA_ALPHA * (nowMs - state.lastChunkAtMs);
+		}
+		state.lastChunkAtMs = nowMs;
+		state.hasPriorChunk = true;
+
+		if (newWords.length === 0) return;
+
+		const nextSlotMs =
+			state.pendingWords.length > 0
+				? state.pendingWords[state.pendingWords.length - 1].revealAtMs
+				: nowMs;
+		const cadenceMs = computeCadenceMs({
+			pendingCount: state.pendingWords.length,
+			newWordCount: newWords.length,
+			nextSlotMs,
+			interChunkEmaMs: state.interChunkEmaMs,
+			nowMs,
+		});
+
+		let slot = nextSlotMs;
+		for (const span of newWords) {
+			slot += cadenceMs;
+			state.pendingWords.push({ span, revealAtMs: slot });
+		}
+
+		if (!state.rafQueued) {
+			state.rafQueued = true;
+			deps.requestAnimationFrame(tick);
+		}
+	}
+
+	function tick(): void {
+		const nowMs = deps.performance.now();
+		while (
+			state.pendingWords.length > 0 &&
+			state.pendingWords[0].revealAtMs <= nowMs
+		) {
+			const head = state.pendingWords.shift();
+			// We just observed `pendingWords.length > 0` in the loop guard, so
+			// `shift()` is guaranteed to return the head — asserting eliminates
+			// the `if (head)` V8 branch.
+			assert(head, "shift after length>0 must return the head");
+			head.span.style.opacity = "1";
+		}
+		if (state.pendingWords.length > 0) {
+			deps.requestAnimationFrame(tick);
+		} else {
+			state.rafQueued = false;
+		}
+	}
+
+	deps.addEventListener("message", (event) => {
+		if (event.source !== deps.parent) return;
+		const data = event.data as { type?: string; html?: string } | undefined;
+		if (!data || data.type !== "readplace-chunk") return;
+		if (typeof data.html !== "string") return;
+		onChunk(data.html);
+	});
+	deps.parent.postMessage({ type: "readplace-ready" }, "*");
+
+	return { onChunk, tick, state };
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts
@@ -17,8 +17,9 @@
  *   - Posts `{ type: "readplace-ready" }` to `window.parent` on load so the
  *     parent only opens its EventSource once the listener is mounted.
  *   - Strips `<script>` / `<style>` / `<iframe>` / `<object>` / `<embed>`
- *     from every incoming chunk before insertion as a defence-in-depth pass
- *     (the partial content has already been sanitised upstream).
+ *     and inline `on*` event-handler attributes from every incoming chunk
+ *     before insertion as a defence-in-depth pass (the partial content has
+ *     already been sanitised upstream).
  */
 
 interface BootstrapWindow {
@@ -91,6 +92,13 @@ export function sanitizeChunkInto(parent: HTMLElement, html: string): void {
 		// just-set innerHTML is always defined (the node lives inside parent).
 		assert(p, "node returned by querySelectorAll must have a parent");
 		p.removeChild(node);
+	}
+	const allElements = parent.querySelectorAll("*");
+	for (let i = 0; i < allElements.length; i++) {
+		const el = allElements[i];
+		for (const name of el.getAttributeNames()) {
+			if (/^on/i.test(name)) el.removeAttribute(name);
+		}
 	}
 }
 

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream-bootstrap.iframe.ts
@@ -275,7 +275,7 @@ export function initBootstrap(deps: BootstrapWindow): {
 	deps.addEventListener("message", (event) => {
 		if (event.source !== deps.parent) return;
 		const data = event.data as { type?: string; html?: string } | undefined;
-		if (!data || data.type !== "readplace-chunk") return;
+		if (data?.type !== "readplace-chunk") return;
 		if (typeof data.html !== "string") return;
 		onChunk(data.html);
 	});

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.test.ts
@@ -345,6 +345,55 @@ describe("initReaderStream", () => {
 		expect(harness.eventSources).toHaveLength(1);
 	});
 
+	it("handles a server reconnect event without consuming the retry budget", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+		const es1 = harness.eventSources[0];
+
+		es1.dispatch("reconnect", "100");
+
+		expect(es1.closed).toBe(true);
+		expect(harness.eventSources).toHaveLength(2);
+		expect(harness.eventSources[1].url).toContain("from=100");
+
+		// A subsequent real error still has full retry budget.
+		harness.eventSources[1].dispatch("error");
+		expect(harness.setTimeoutFns).toHaveLength(1);
+		harness.setTimeoutFns[0].fn();
+		expect(harness.eventSources).toHaveLength(3);
+	});
+
+	it("survives 5 consecutive reconnects exceeding MAX_RETRIES without surrendering", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+
+		for (let i = 0; i < 5; i++) {
+			const es = harness.eventSources[harness.eventSources.length - 1];
+			es.dispatch("reconnect", String(100 + i * 50));
+		}
+
+		expect(harness.eventSources).toHaveLength(6);
+		const lastEs = harness.eventSources[5];
+		expect(lastEs.closed).toBe(false);
+		expect(lastEs.url).toContain("from=300");
+	});
+
+	it("does not double-count when reconnect and error fire on the same EventSource", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+		const es1 = harness.eventSources[0];
+
+		es1.dispatch("reconnect", "100");
+		es1.dispatch("error");
+
+		expect(harness.eventSources).toHaveLength(2);
+		expect(harness.setTimeoutFns).toHaveLength(0);
+
+		// Retry budget intact — a real error on the new connection still retries.
+		harness.eventSources[1].dispatch("error");
+		expect(harness.setTimeoutFns).toHaveLength(1);
+	});
+
 	it("ignores readplace-ready messages whose source is not the streaming iframe (cross-frame poisoning defence)", () => {
 		const harness = setupHarness(STREAMING_SLOT_HTML, { autoReadyIframe: false });
 		initReaderStream(harness.deps);

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.test.ts
@@ -1,0 +1,381 @@
+import { JSDOM } from "jsdom";
+import { initReaderStream } from "./reader-stream.client";
+
+interface FakeEventSource {
+	url: string;
+	withCredentials: boolean;
+	listeners: Record<string, Array<(event: MessageEvent) => void>>;
+	closed: boolean;
+	addEventListener: (type: string, listener: (event: MessageEvent) => void) => void;
+	dispatch: (type: string, data?: string) => void;
+	close: () => void;
+}
+
+function setupHarness(
+	slotHtml: string,
+	options: { autoReadyIframe?: boolean; reload?: () => void } = {},
+) {
+	const { autoReadyIframe = true, reload = jest.fn() } = options;
+	const dom = new JSDOM(
+		`<!doctype html><html><body><main>${slotHtml}</main></body></html>`,
+	);
+	const { window } = dom;
+	const eventSources: FakeEventSource[] = [];
+	const FakeEventSourceCtor = function (this: FakeEventSource, url: string, init?: EventSourceInit) {
+		this.url = url;
+		this.withCredentials = init?.withCredentials ?? false;
+		this.listeners = {};
+		this.closed = false;
+		this.addEventListener = (type, listener) => {
+			if (!this.listeners[type]) this.listeners[type] = [];
+			this.listeners[type].push(listener);
+		};
+		this.dispatch = (type, data) => {
+			const list = this.listeners[type] ?? [];
+			for (const listener of list) listener({ data } as MessageEvent);
+		};
+		this.close = () => { this.closed = true; };
+		eventSources.push(this);
+	} as unknown as typeof EventSource;
+
+	const swapListeners: Array<(root: Element) => void> = [];
+	const setTimeoutFns: Array<{ fn: () => void; ms: number; id: number }> = [];
+	let nextTimerId = 1;
+
+	const deps = {
+		document: window.document,
+		window: window as unknown as Window & typeof globalThis,
+		EventSourceCtor: FakeEventSourceCtor,
+		now: () => Date.now(),
+		setTimeoutFn: (fn: () => void, ms: number): number => {
+			const id = nextTimerId++;
+			setTimeoutFns.push({ fn, ms, id });
+			return id;
+		},
+		reload,
+		addSwapListener: (listener: (root: Element) => void) => {
+			swapListeners.push(listener);
+		},
+	};
+
+	// Auto-fire the iframe's readplace-ready ping unless the test wants to
+	// control timing — every test exercises some post-init flow that
+	// requires the iframe to be ready.
+	if (autoReadyIframe) {
+		queueMicrotask(() => {
+			const iframe = window.document.querySelector("iframe");
+			if (!iframe) return;
+			// Manually dispatch the ready postMessage event so the parent's
+			// addEventListener handler fires.
+			window.dispatchEvent(
+				new window.MessageEvent("message", {
+					source: iframe.contentWindow,
+					data: { type: "readplace-ready" },
+				}),
+			);
+		});
+	}
+
+	return { window, deps, eventSources, swapListeners, setTimeoutFns, reload };
+}
+
+const STREAMING_SLOT_HTML = `
+	<div id="article-body-reader-slot"
+		data-test-reader-slot
+		data-reader-status="streaming"
+		data-article-url="https://example.com/article"
+		data-stream-base-url="https://stream.readplace.com"
+		data-prerendered-length="42">
+		<iframe data-reader-streaming-iframe srcdoc=""></iframe>
+	</div>
+`;
+
+const NON_STREAMING_SLOT_HTML = `
+	<div id="article-body-reader-slot"
+		data-test-reader-slot
+		data-reader-status="pending"
+		data-article-url="https://example.com/article">
+	</div>
+`;
+
+describe("initReaderStream", () => {
+	it("opens an EventSource against the configured stream base URL when the slot is in the streaming variant", async () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML, { autoReadyIframe: false });
+		initReaderStream(harness.deps);
+
+		expect(harness.eventSources).toHaveLength(1);
+		expect(harness.eventSources[0].url).toBe(
+			"https://stream.readplace.com/view/reader/stream?url=https%3A%2F%2Fexample.com%2Farticle&from=42",
+		);
+		expect(harness.eventSources[0].withCredentials).toBe(true);
+	});
+
+	it("does NOT open an EventSource for non-streaming slots (pending dots loader, ready iframe, etc.)", () => {
+		const harness = setupHarness(NON_STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+		expect(harness.eventSources).toHaveLength(0);
+	});
+
+	it("does NOT open an EventSource for a streaming slot missing the stream-base-url attribute (degrades to HTMX poll)", () => {
+		const harness = setupHarness(`
+			<div data-test-reader-slot
+				data-reader-status="streaming"
+				data-article-url="https://example.com/article">
+				<iframe data-reader-streaming-iframe srcdoc=""></iframe>
+			</div>
+		`);
+		initReaderStream(harness.deps);
+		expect(harness.eventSources).toHaveLength(0);
+	});
+
+	it("does NOT open an EventSource for a streaming slot missing the article-url attribute (defensive)", () => {
+		const harness = setupHarness(`
+			<div data-test-reader-slot
+				data-reader-status="streaming"
+				data-stream-base-url="https://stream.readplace.com">
+				<iframe data-reader-streaming-iframe srcdoc=""></iframe>
+			</div>
+		`);
+		initReaderStream(harness.deps);
+		expect(harness.eventSources).toHaveLength(0);
+	});
+
+	it("does NOT open an EventSource for a streaming slot missing the streaming iframe element (rendered HTML is malformed)", () => {
+		const harness = setupHarness(`
+			<div data-test-reader-slot
+				data-reader-status="streaming"
+				data-article-url="https://example.com/article"
+				data-stream-base-url="https://stream.readplace.com">
+			</div>
+		`);
+		initReaderStream(harness.deps);
+		expect(harness.eventSources).toHaveLength(0);
+	});
+
+	it("forwards chunk events to the iframe via postMessage once the iframe announces ready", async () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML, { autoReadyIframe: false });
+		initReaderStream(harness.deps);
+		const es = harness.eventSources[0];
+
+		const iframe = harness.window.document.querySelector("iframe");
+		if (!iframe) throw new Error("iframe missing");
+		const posted: unknown[] = [];
+		const fakeContentWindow = {
+			postMessage: (data: unknown) => { posted.push(data); },
+		};
+		Object.defineProperty(iframe, "contentWindow", {
+			value: fakeContentWindow,
+			configurable: true,
+		});
+
+		// Chunk arrives BEFORE readplace-ready — should buffer.
+		es.dispatch("chunk", JSON.stringify("<p>early chunk</p>"));
+		expect(posted).toHaveLength(0);
+
+		// Iframe announces ready — buffered chunk flushes.
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: fakeContentWindow as unknown as Window,
+				data: { type: "readplace-ready" },
+			}),
+		);
+		expect(posted).toEqual([{ type: "readplace-chunk", html: "<p>early chunk</p>" }]);
+
+		// Subsequent chunks deliver immediately.
+		es.dispatch("chunk", JSON.stringify("<p>later chunk</p>"));
+		expect(posted).toEqual([
+			{ type: "readplace-chunk", html: "<p>early chunk</p>" },
+			{ type: "readplace-chunk", html: "<p>later chunk</p>" },
+		]);
+	});
+
+	it("advances the from offset by each chunk's length so a reconnect resumes at the right place", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+		const es = harness.eventSources[0];
+
+		es.dispatch("chunk", JSON.stringify("<p>abc</p>"));
+		es.dispatch("error");
+
+		// Retry timer scheduled, then fired (reconnect URL includes new from).
+		expect(harness.setTimeoutFns).toHaveLength(1);
+		harness.setTimeoutFns[0].fn();
+		expect(harness.eventSources).toHaveLength(2);
+		expect(harness.eventSources[1].url).toContain("from=52"); // 42 prerendered + 10 chunk
+	});
+
+	it("retries on EventSource error up to 3 times with exponential-ish backoff, then surrenders to the HTMX poll", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+
+		// Initial connection.
+		expect(harness.eventSources).toHaveLength(1);
+
+		// 3 errors → 3 retry timers + 3 more connections (4 total).
+		for (let attempt = 1; attempt <= 3; attempt++) {
+			harness.eventSources[harness.eventSources.length - 1].dispatch("error");
+			expect(harness.setTimeoutFns).toHaveLength(attempt);
+			harness.setTimeoutFns[attempt - 1].fn();
+		}
+		expect(harness.eventSources).toHaveLength(4);
+
+		// 4th error → no more retries (surrender to HTMX poll).
+		harness.eventSources[3].dispatch("error");
+		expect(harness.setTimeoutFns).toHaveLength(3); // no new timer
+	});
+
+	it("reloads the page on the 'done' event so the canonical reader-ready iframe replaces the streaming one", () => {
+		const reload = jest.fn();
+		const harness = setupHarness(STREAMING_SLOT_HTML, { reload });
+		initReaderStream(harness.deps);
+		harness.eventSources[0].dispatch("done");
+
+		expect(reload).toHaveBeenCalledTimes(1);
+		expect(harness.eventSources[0].closed).toBe(true);
+	});
+
+	it("scan is idempotent — a second swap with the same slot does not open a duplicate EventSource", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		const { scan } = initReaderStream(harness.deps);
+
+		// Re-fire the swap listener with the body — same slot is still there.
+		scan(harness.window.document.body);
+		scan(harness.window.document.body);
+
+		expect(harness.eventSources).toHaveLength(1);
+	});
+
+	it("skips malformed chunk frames silently rather than poisoning the session", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML);
+		initReaderStream(harness.deps);
+		const es = harness.eventSources[0];
+
+		const iframe = harness.window.document.querySelector("iframe");
+		if (!iframe) throw new Error("iframe missing");
+		const posted: unknown[] = [];
+		Object.defineProperty(iframe, "contentWindow", {
+			value: { postMessage: (data: unknown) => { posted.push(data); } },
+			configurable: true,
+		});
+
+		es.dispatch("chunk", "not-valid-json{");
+		es.dispatch("chunk", JSON.stringify(42)); // not a string
+		es.dispatch("chunk", JSON.stringify("")); // empty string
+
+		expect(posted).toHaveLength(0);
+
+		// A valid chunk arriving after the malformed ones still works.
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: iframe.contentWindow as unknown as Window,
+				data: { type: "readplace-ready" },
+			}),
+		);
+		es.dispatch("chunk", JSON.stringify("<p>good</p>"));
+
+		expect(posted).toEqual([{ type: "readplace-chunk", html: "<p>good</p>" }]);
+	});
+
+	it("silently drops buffered chunks when the iframe loses its contentWindow before flush (defensive — should never happen in practice)", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML, { autoReadyIframe: false });
+		initReaderStream(harness.deps);
+		const es = harness.eventSources[0];
+
+		const iframe = harness.window.document.querySelector("iframe");
+		if (!iframe) throw new Error("iframe missing");
+		// Pretend the iframe got detached: contentWindow becomes null.
+		Object.defineProperty(iframe, "contentWindow", {
+			value: null,
+			configurable: true,
+		});
+
+		// Buffer a chunk before ready.
+		es.dispatch("chunk", JSON.stringify("<p>buffered</p>"));
+
+		// Now an unrelated source fires a ready message with null contentWindow
+		// — handleReadyMessage's source check rejects it; flushPending never runs.
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: harness.window as unknown as Window,
+				data: { type: "readplace-ready" },
+			}),
+		);
+		// No throw, no posting (already covered) — verifying clean handling.
+		expect(es.closed).toBe(false);
+	});
+
+	it("ignores messages with no data payload (defensive against postMessage from unrelated sources)", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML, { autoReadyIframe: false });
+		initReaderStream(harness.deps);
+		const iframe = harness.window.document.querySelector("iframe");
+		if (!iframe) throw new Error("iframe missing");
+
+		// Fire a ready-shaped message but with null data — handleReadyMessage
+		// must early-return rather than throw on `data?.type`.
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: iframe.contentWindow as unknown as Window,
+				data: null,
+			}),
+		);
+		expect(harness.eventSources[0].closed).toBe(false);
+	});
+
+	it("a 'done' event during a pending retry timer prevents the retry from re-opening (terminated guard in open)", () => {
+		const reload = jest.fn();
+		const harness = setupHarness(STREAMING_SLOT_HTML, { reload });
+		initReaderStream(harness.deps);
+		const firstEs = harness.eventSources[0];
+
+		// Error → retry scheduled.
+		firstEs.dispatch("error");
+		expect(harness.setTimeoutFns).toHaveLength(1);
+
+		// "done" arrives before the retry timer fires. Since the original
+		// EventSource is already closed and a new one isn't yet open, this
+		// scenario simulates a race where the user's terminal arrives during
+		// backoff. The pending retry timer's fn will then call open() with
+		// terminated=true and the early-return short-circuits.
+		firstEs.dispatch("done"); // would normally not be possible after close, but tests the guard
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		// Now fire the pending retry timer — open() should bail at the
+		// terminated guard and NOT create another EventSource.
+		harness.setTimeoutFns[0].fn();
+		expect(harness.eventSources).toHaveLength(1);
+	});
+
+	it("ignores readplace-ready messages whose source is not the streaming iframe (cross-frame poisoning defence)", () => {
+		const harness = setupHarness(STREAMING_SLOT_HTML, { autoReadyIframe: false });
+		initReaderStream(harness.deps);
+		const es = harness.eventSources[0];
+
+		const iframe = harness.window.document.querySelector("iframe");
+		if (!iframe) throw new Error("iframe missing");
+		const posted: unknown[] = [];
+		Object.defineProperty(iframe, "contentWindow", {
+			value: { postMessage: (data: unknown) => { posted.push(data); } },
+			configurable: true,
+		});
+
+		es.dispatch("chunk", JSON.stringify("<p>buffered</p>"));
+
+		// Forged ready message from an unrelated source — must not flush.
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: harness.window as unknown as Window,
+				data: { type: "readplace-ready" },
+			}),
+		);
+		expect(posted).toHaveLength(0);
+
+		// Real ready message DOES flush.
+		harness.window.dispatchEvent(
+			new harness.window.MessageEvent("message", {
+				source: iframe.contentWindow as unknown as Window,
+				data: { type: "readplace-ready" },
+			}),
+		);
+		expect(posted).toHaveLength(1);
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts
@@ -1,0 +1,154 @@
+/**
+ * Parent-side EventSource client that drives the streaming reader iframe.
+ *
+ * The iframe owns nothing about the network — its sandbox makes it a
+ * black box for content rendering. The parent owns the EventSource (it
+ * has to: cookies on the streaming Function URL only flow from the
+ * parent's same-site origin) and forwards each chunk into the iframe
+ * via `postMessage`. On terminal (`event: done`) the parent reloads the
+ * page so the canonical `reader-ready` iframe replaces the streaming
+ * one in one atomic swap — no flicker mid-stream.
+ *
+ * HTMX `hx-get="…" hx-trigger="every 3s"` on the slot wrapper stays
+ * armed underneath this client. If EventSource fails after retries, the
+ * poll path drives the slot to terminal via the existing chain.
+ */
+
+interface ReaderStreamDeps {
+	document: Document;
+	window: Window & typeof globalThis;
+	EventSourceCtor: typeof EventSource;
+	now: () => number;
+	setTimeoutFn: (fn: () => void, ms: number) => number;
+	/** Page reload — invoked on the SSE `done` event so the canonical
+	 * `reader-ready` iframe replaces the streaming one in a single atomic
+	 * swap. Injected as a dep (not `window.location.reload`) because
+	 * JSDOM's `window.location` is non-configurable in tests. */
+	reload: () => void;
+	addSwapListener: (listener: (root: Element) => void) => void;
+}
+
+const STREAMING_SLOT_SELECTOR = '[data-reader-status="streaming"]';
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 1000;
+
+/* Tracks which slot elements already have a live EventSource attached so a
+ * repeated HTMX `afterSwap` (e.g. a poll firing while the streaming session
+ * is in flight) doesn't open a second EventSource against the same slot.
+ * WeakMap so removed slots get GC'd along with their session state. */
+const liveSessions = new WeakMap<Element, true>();
+
+export function initReaderStream(deps: ReaderStreamDeps): {
+	scan: (root: Element) => void;
+} {
+	function scan(root: Element): void {
+		// Re-scan after every HTMX swap. A reader-slot that flipped from
+		// pending → streaming gets a fresh session; one that flipped
+		// streaming → ready / failed / unsupported leaves its slot
+		// element behind for GC (the swap replaces the slot wrapper).
+		const slot = root.matches(STREAMING_SLOT_SELECTOR)
+			? root
+			: root.querySelector(STREAMING_SLOT_SELECTOR);
+		if (!slot) return;
+		if (liveSessions.has(slot)) return;
+		const opened = openSession(deps, slot);
+		if (opened) liveSessions.set(slot, true);
+	}
+
+	deps.addSwapListener(scan);
+	scan(deps.document.body);
+	return { scan };
+}
+
+function openSession(deps: ReaderStreamDeps, slot: Element): boolean {
+	const iframeOrNull = slot.querySelector<HTMLIFrameElement>(
+		"iframe[data-reader-streaming-iframe]",
+	);
+	if (!iframeOrNull) return false;
+	const articleUrlOrNull = slot.getAttribute("data-article-url");
+	const streamBaseUrlOrNull = slot.getAttribute("data-stream-base-url");
+	if (!articleUrlOrNull) return false;
+	if (!streamBaseUrlOrNull) return false;
+	const iframe: HTMLIFrameElement = iframeOrNull;
+	const articleUrl: string = articleUrlOrNull;
+	const streamBaseUrl: string = streamBaseUrlOrNull;
+	const prerenderedLength = Number(slot.getAttribute("data-prerendered-length") ?? "0");
+
+	let from = Number.isFinite(prerenderedLength) ? prerenderedLength : 0;
+	let retries = 0;
+	let pendingChunks: string[] = [];
+	let iframeReady = false;
+	let terminated = false;
+
+	function flushPending(): void {
+		const target = iframe.contentWindow;
+		if (!target) return;
+		for (const html of pendingChunks) {
+			target.postMessage({ type: "readplace-chunk", html }, "*");
+		}
+		pendingChunks = [];
+	}
+
+	function sendChunk(html: string): void {
+		const target = iframe.contentWindow;
+		if (!iframeReady || !target) {
+			pendingChunks.push(html);
+			return;
+		}
+		target.postMessage({ type: "readplace-chunk", html }, "*");
+	}
+
+	function handleReadyMessage(event: MessageEvent): void {
+		if (event.source !== iframe.contentWindow) return;
+		const data = event.data as { type?: string } | undefined;
+		if (!data || data.type !== "readplace-ready") return;
+		iframeReady = true;
+		flushPending();
+	}
+
+	function open(): void {
+		if (terminated) return;
+		const url =
+			`${streamBaseUrl}/view/reader/stream` +
+			`?url=${encodeURIComponent(articleUrl)}` +
+			`&from=${from}`;
+		const es = new deps.EventSourceCtor(url, { withCredentials: true });
+		es.addEventListener("chunk", (event) => {
+			try {
+				const html = JSON.parse((event as MessageEvent).data) as string;
+				if (typeof html === "string" && html.length > 0) {
+					from += html.length;
+					sendChunk(html);
+				}
+			} catch {
+				// Malformed chunk frame — skip rather than poisoning the session.
+			}
+		});
+		es.addEventListener("done", () => {
+			terminated = true;
+			es.close();
+			// Canonical reload swaps the streaming iframe for the reader-ready
+			// canonical iframe in one atomic transition. The page renders the
+			// polished final HTML; the in-progress reveal animation is irrelevant
+			// past this point.
+			deps.reload();
+		});
+		es.addEventListener("error", () => {
+			es.close();
+			if (terminated) return;
+			retries += 1;
+			if (retries > MAX_RETRIES) {
+				// Surrender to the HTMX poll path — it stays armed via
+				// `hx-trigger="every 3s"` on the slot wrapper and will
+				// progress to terminal via the standard chain.
+				terminated = true;
+				return;
+			}
+			deps.setTimeoutFn(open, RETRY_BASE_MS * retries);
+		});
+	}
+
+	deps.window.addEventListener("message", handleReadyMessage);
+	open();
+	return true;
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts
@@ -127,20 +127,22 @@ function openSession(deps: ReaderStreamDeps, slot: Element): boolean {
 		es.addEventListener("done", () => {
 			terminated = true;
 			es.close();
-			// Canonical reload swaps the streaming iframe for the reader-ready
-			// canonical iframe in one atomic transition. The page renders the
-			// polished final HTML; the in-progress reveal animation is irrelevant
-			// past this point.
 			deps.reload();
+		});
+		let cleanReconnect = false;
+		es.addEventListener("reconnect", (event) => {
+			cleanReconnect = true;
+			es.close();
+			const cursor = Number((event as MessageEvent).data);
+			if (Number.isFinite(cursor) && cursor > from) from = cursor;
+			open();
 		});
 		es.addEventListener("error", () => {
 			es.close();
 			if (terminated) return;
+			if (cleanReconnect) return;
 			retries += 1;
 			if (retries > MAX_RETRIES) {
-				// Surrender to the HTMX poll path — it stays armed via
-				// `hx-trigger="every 3s"` on the slot wrapper and will
-				// progress to terminal via the standard chain.
 				terminated = true;
 				return;
 			}

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-stream.client.ts
@@ -101,7 +101,7 @@ function openSession(deps: ReaderStreamDeps, slot: Element): boolean {
 	function handleReadyMessage(event: MessageEvent): void {
 		if (event.source !== iframe.contentWindow) return;
 		const data = event.data as { type?: string } | undefined;
-		if (!data || data.type !== "readplace-ready") return;
+		if (data?.type !== "readplace-ready") return;
 		iframeReady = true;
 		flushPending();
 	}

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-streaming-iframe-srcdoc.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-streaming-iframe-srcdoc.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const READER_IFRAME_CSS = readFileSync(
+	join(__dirname, "reader-iframe.styles.css"),
+	"utf-8",
+);
+
+/**
+ * The streaming iframe's same-origin bootstrap script. Compiled by
+ * `build-client-bundles.js` to `client-dist/reader-stream-bootstrap.iframe.js`
+ * and read here at SSR time so we can inline it into the srcdoc — the iframe
+ * is created from the parent's HTML with no network roundtrip, so the script
+ * needs to be present in the srcdoc itself rather than referenced as a
+ * separate file (the iframe's sandboxed origin would have no relative path
+ * to fetch it from).
+ *
+ * Read once at module load: the bundle is part of the Lambda zip and never
+ * changes during a single Lambda lifetime.
+ */
+const BOOTSTRAP_JS = readFileSync(
+	join(
+		__dirname,
+		"..",
+		"..",
+		"..",
+		"client-dist",
+		"reader-stream-bootstrap.iframe.js",
+	),
+	"utf-8",
+);
+
+export interface ReaderStreamingIframeSrcdocInput {
+	/**
+	 * The partial HTML snapshot to bake into the iframe at SSR time. The
+	 * bootstrap script tags every text node already present as
+	 * `.rp-word.rp-word--prerendered` so reload-or-htmx-swap doesn't
+	 * re-animate content the user already saw.
+	 */
+	initialPartialHtml: string;
+}
+
+/**
+ * Build the bootstrap srcdoc for the streaming reader iframe. Mirrors the
+ * structure of `buildReaderIframeSrcdoc` so the visual swap on terminal
+ * is seamless:
+ *   - same sandbox (`allow-popups allow-popups-to-escape-sandbox …`)
+ *   - same `<base target="_top">`
+ *   - same embedded reader CSS
+ *   - same `<body class="article-body__content">`
+ *
+ * Extras for the streaming variant:
+ *   - `.rp-word` opacity-0 → opacity-1 fade-in CSS for the per-word reveal
+ *   - inlined bootstrap script that listens for `postMessage({ type:
+ *     "readplace-chunk" })` from the parent and pipes each chunk through
+ *     the adaptive cadence reveal pipeline
+ *
+ * The bootstrap announces its readiness via `postMessage({ type:
+ * "readplace-ready" })` so the parent only opens its EventSource once the
+ * iframe is listening — eliminates a race where chunks arrive before the
+ * iframe is ready to receive them.
+ */
+export function buildReaderStreamingIframeSrcdoc(
+	input: ReaderStreamingIframeSrcdocInput,
+): string {
+	return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><base target="_top"><style>${READER_IFRAME_CSS}</style><style>.rp-word{opacity:0;transition:opacity 100ms ease-out}.rp-word--prerendered{opacity:1;transition:none}</style></head><body class="article-body__content"><article id="content">${input.initialPartialHtml}</article><script>${BOOTSTRAP_JS}</script></body></html>`;
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-streaming.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-streaming.component.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render } from "../../../render";
+import { buildReaderStreamingIframeSrcdoc } from "./reader-streaming-iframe-srcdoc";
+
+const TEMPLATE = readFileSync(
+	join(__dirname, "reader-streaming.template.html"),
+	"utf-8",
+);
+
+export interface ReaderStreamingInput {
+	/** The crawled partial HTML so far. Baked into the iframe srcdoc so the
+	 * reader sees current content on first paint, before EventSource opens. */
+	initialPartialHtml: string;
+	/** Article URL — the parent-side client uses it to build the SSE URL. */
+	articleUrl: string;
+	/** Base URL for the SSE Lambda's Function URL (e.g.
+	 * `https://stream.<canonical-domain>`). */
+	streamBaseUrl: string;
+	/** HTMX poll URL — stays armed underneath the EventSource so the slot
+	 * still progresses to terminal if the stream fails. */
+	pollUrl: string;
+	/** Optional secondary line rendered below the iframe (PDF accuracy
+	 * hint). Same field shape as the pending variant. */
+	loadingHint?: string;
+	oob?: boolean;
+}
+
+export function renderReaderStreaming(input: ReaderStreamingInput): string {
+	const srcdoc = buildReaderStreamingIframeSrcdoc({
+		initialPartialHtml: input.initialPartialHtml,
+	});
+	return render(TEMPLATE, {
+		srcdoc,
+		articleUrl: input.articleUrl,
+		streamBaseUrl: input.streamBaseUrl,
+		prerenderedLength: input.initialPartialHtml.length,
+		pollUrl: input.pollUrl,
+		loadingHint: input.loadingHint,
+		oob: input.oob === true,
+	});
+}

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-streaming.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-streaming.template.html
@@ -1,0 +1,6 @@
+<div id="article-body-reader-slot" class="article-body__reader-slot article-body__reader-slot--streaming" data-test-reader-slot data-reader-status="streaming" data-article-url="{{articleUrl}}" data-stream-base-url="{{streamBaseUrl}}" data-prerendered-length="{{prerenderedLength}}"{{#if oob}} hx-swap-oob="outerHTML"{{/if}} hx-get="{{pollUrl}}" hx-trigger="every 3s" hx-swap="outerHTML">
+	<iframe data-test-reader-content data-reader-iframe data-reader-streaming-iframe class="article-body__reader-iframe" sandbox="allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation allow-same-origin allow-scripts" srcdoc="{{srcdoc}}" loading="eager" title="Article content"></iframe>
+	{{#if loadingHint}}
+	<p class="article-body__reader-loading-subtitle">{{loadingHint}}</p>
+	{{/if}}
+</div>

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
@@ -58,6 +58,7 @@ interface PollResponseBodyInput {
 	summaryPollUrl: string | undefined;
 	summaryOpen: boolean;
 	extensionInstallUrl: string | undefined;
+	streamBaseUrl: string | undefined;
 	progress: ProgressTick | undefined;
 	metadataOob: string;
 }
@@ -69,6 +70,7 @@ function renderPollResponseBody(input: PollResponseBodyInput): string {
 		url: input.url,
 		readerPollUrl: input.readerPollUrl,
 		extensionInstallUrl: input.extensionInstallUrl,
+		streamBaseUrl: input.streamBaseUrl,
 		oob: input.primary !== "reader",
 	});
 	const summarySlot = renderSummarySlot({
@@ -270,6 +272,7 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 			summaryPollUrl,
 			summaryOpen: true,
 			extensionInstallUrl,
+			streamBaseUrl: deps.streamBaseUrl,
 			progress: buildUnifiedProgress(crawl, summary, deps.now()),
 			metadataOob: buildMetadataOob(article, articleUrl),
 		}));
@@ -296,6 +299,7 @@ export function initArticleReader(deps: ArticleReaderDeps): {
 			summaryPollUrl,
 			summaryOpen: true,
 			extensionInstallUrl,
+			streamBaseUrl: deps.streamBaseUrl,
 			progress: buildUnifiedProgress(crawl, summary, deps.now()),
 			metadataOob: buildMetadataOob(article, articleUrl),
 		}));

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.types.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.types.ts
@@ -48,6 +48,14 @@ export interface ArticleReaderDeps {
 		fields: ReadonlyArray<{ name: string; value: string }>;
 	};
 	now: () => Date;
+	/**
+	 * Base URL for the dedicated SSE streaming Lambda's Function URL (e.g.
+	 * `https://stream.readplace.com`). When set, the reader-slot dispatcher
+	 * renders the streaming variant for `crawl.status === "pending"` rows
+	 * that carry partial content. When undefined (dev / unconfigured),
+	 * the slot falls back to the existing dots-loader pending variant.
+	 */
+	streamBaseUrl?: string;
 }
 
 export interface ArticleSnapshot {

--- a/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
+++ b/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
@@ -82,7 +82,7 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
-const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
+const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable, logger: consoleLogger });
 
 export const handler = initComprehensiveCrawlHandler({
 	crawlArticle: parser.crawlArticle,

--- a/projects/save-link/src/runtime/dep-bundles/article-crawl.test.ts
+++ b/projects/save-link/src/runtime/dep-bundles/article-crawl.test.ts
@@ -1,15 +1,18 @@
+import { noopLogger } from "@packages/hutch-logger";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { initArticleCrawlDepBundle } from "./article-crawl";
 
 describe("initArticleCrawlDepBundle", () => {
-	it("returns a bundle with markCrawlStage, markCrawlProgress and updateFetchTimestamp fields", () => {
+	it("returns a bundle with markCrawlStage, markCrawlProgress, markCrawlPartial and updateFetchTimestamp fields", () => {
 		const bundle = initArticleCrawlDepBundle({
 			dynamoClient: createDynamoDocumentClient({ region: "us-east-1" }),
 			articlesTable: "articles-table",
+			logger: noopLogger,
 		});
 
 		expect(typeof bundle.markCrawlStage).toBe("function");
 		expect(typeof bundle.markCrawlProgress).toBe("function");
+		expect(typeof bundle.markCrawlPartial).toBe("function");
 		expect(typeof bundle.updateFetchTimestamp).toBe("function");
 	});
 });

--- a/projects/save-link/src/runtime/dep-bundles/article-crawl.ts
+++ b/projects/save-link/src/runtime/dep-bundles/article-crawl.ts
@@ -1,4 +1,5 @@
 import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
+import type { HutchLogger } from "@packages/hutch-logger";
 import {
 	initDynamoDbMarkCrawlStage,
 	type MarkCrawlStage,
@@ -7,18 +8,24 @@ import {
 	initDynamoDbMarkCrawlProgress,
 	type MarkCrawlProgress,
 } from "../providers/article-crawl/mark-crawl-progress";
+import {
+	initDynamoDbMarkCrawlPartial,
+	type MarkCrawlPartial,
+} from "../providers/article-crawl/mark-crawl-partial";
 import { initUpdateFetchTimestamp } from "../providers/article-crawl/update-fetch-timestamp";
 import type { UpdateFetchTimestamp } from "../domain/save-link/update-fetch-timestamp-handler";
 
 export type ArticleCrawlDepBundle = {
 	markCrawlStage: MarkCrawlStage;
 	markCrawlProgress: MarkCrawlProgress;
+	markCrawlPartial: MarkCrawlPartial;
 	updateFetchTimestamp: UpdateFetchTimestamp;
 };
 
 export function initArticleCrawlDepBundle(deps: {
 	dynamoClient: DynamoDBDocumentClient;
 	articlesTable: string;
+	logger: HutchLogger;
 }): ArticleCrawlDepBundle {
 	const { markCrawlStage } = initDynamoDbMarkCrawlStage({
 		client: deps.dynamoClient,
@@ -28,9 +35,14 @@ export function initArticleCrawlDepBundle(deps: {
 		client: deps.dynamoClient,
 		tableName: deps.articlesTable,
 	});
+	const { markCrawlPartial } = initDynamoDbMarkCrawlPartial({
+		client: deps.dynamoClient,
+		tableName: deps.articlesTable,
+		logger: deps.logger,
+	});
 	const { updateFetchTimestamp } = initUpdateFetchTimestamp({
 		client: deps.dynamoClient,
 		tableName: deps.articlesTable,
 	});
-	return { markCrawlStage, markCrawlProgress, updateFetchTimestamp };
+	return { markCrawlStage, markCrawlProgress, markCrawlPartial, updateFetchTimestamp };
 }

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
@@ -929,18 +929,16 @@ describe("initOcrPdf — onPartialHtml streaming tap", () => {
 			.filter((count, idx, arr) => idx === 0 || arr[idx - 1] !== count);
 		expect(distinctSteps).toEqual([1, 3, 5]);
 
-		expect(partials[0].html).toContain("page-0");
-		expect(partials[0].html).not.toContain("page-1");
+		const pageMarkers = (html: string): number[] =>
+			Array.from(html.matchAll(/page-(\d+)/g)).map((m) => Number(m[1])).sort();
+		expect(pageMarkers(partials[0].html)).toEqual([0]);
 
 		const threePagesReady = partials.find((p) => p.readyPageCount === 3);
 		if (!threePagesReady) throw new Error("3-page prefix never emitted");
-		expect(threePagesReady.html).toContain("page-0");
-		expect(threePagesReady.html).toContain("page-1");
-		expect(threePagesReady.html).toContain("page-2");
-		expect(threePagesReady.html).not.toContain("page-3");
+		expect(pageMarkers(threePagesReady.html)).toEqual([0, 1, 2]);
 
 		const allReady = partials[partials.length - 1];
-		for (let i = 0; i < 5; i++) expect(allReady.html).toContain(`page-${i}`);
+		expect(pageMarkers(allReady.html)).toEqual([0, 1, 2, 3, 4]);
 	});
 
 	it("inserts the page-break separator between adjacent fragments in the partial HTML", async () => {

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
@@ -894,3 +894,120 @@ describe("initOcrPdf — stage 3 semantic HTML conversion", () => {
 		expect(observedPeak).toBeGreaterThan(0);
 	});
 });
+
+
+describe("initOcrPdf — onPartialHtml streaming tap", () => {
+	it("emits the in-order ready prefix as each chunk completes (out-of-order completions do not get surfaced ahead of their predecessors)", async () => {
+		const completionOrder = [2, 0, 1, 4, 3];
+		const completed: number[] = [];
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 5 }),
+			batchSize: 1,
+			invokePageOcr: async ({ pageIndices }) => {
+				const pageIndex = pageIndices[0];
+				const order = completionOrder.indexOf(pageIndex);
+				await new Promise((resolve) => setTimeout(resolve, (order + 1) * 5));
+				completed.push(pageIndex);
+				return { ok: true, html: tesseractParagraph(`page-${pageIndex}`) };
+			},
+		});
+
+		await ocr({
+			buffer: Buffer.from("%PDF"),
+			url: "https://example.com/x.pdf",
+			onPartialHtml: (p) => { partials.push({ html: p.html, readyPageCount: p.readyPageCount }); },
+		});
+
+		expect(completed).toEqual(completionOrder);
+
+		// Collapse adjacent equal counts before asserting — the explicit
+		// post-fan-out emission can repeat the last in-flight one.
+		const distinctSteps = partials
+			.map((p) => p.readyPageCount)
+			.filter((count, idx, arr) => idx === 0 || arr[idx - 1] !== count);
+		expect(distinctSteps).toEqual([1, 3, 5]);
+
+		expect(partials[0].html).toContain("page-0");
+		expect(partials[0].html).not.toContain("page-1");
+
+		const threePagesReady = partials.find((p) => p.readyPageCount === 3);
+		if (!threePagesReady) throw new Error("3-page prefix never emitted");
+		expect(threePagesReady.html).toContain("page-0");
+		expect(threePagesReady.html).toContain("page-1");
+		expect(threePagesReady.html).toContain("page-2");
+		expect(threePagesReady.html).not.toContain("page-3");
+
+		const allReady = partials[partials.length - 1];
+		for (let i = 0; i < 5; i++) expect(allReady.html).toContain(`page-${i}`);
+	});
+
+	it("inserts the page-break separator between adjacent fragments in the partial HTML", async () => {
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 2 }),
+			invokePageOcr: stubInvokePageOcr((i) => `page-${i}`),
+			batchSize: 1,
+		});
+
+		await ocr({
+			buffer: Buffer.from("%PDF"),
+			url: "https://example.com/x.pdf",
+			onPartialHtml: (p) => { partials.push({ html: p.html, readyPageCount: p.readyPageCount }); },
+		});
+
+		const allReady = partials[partials.length - 1];
+		expect(allReady.html).toContain('<hr class="ocr-page-break">');
+	});
+
+	it("surfaces failed-chunk placeholders in the partial HTML so users see the gap immediately", async () => {
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 3 }),
+			batchSize: 1,
+			invokePageOcr: async ({ pageIndices }) => {
+				if (pageIndices[0] === 1) return { ok: false, error: new Error("OCR exploded on page 2") };
+				return { ok: true, html: tesseractParagraph(`page-${pageIndices[0]}`) };
+			},
+		});
+
+		await ocr({
+			buffer: Buffer.from("%PDF"),
+			url: "https://example.com/x.pdf",
+			onPartialHtml: (p) => { partials.push({ html: p.html, readyPageCount: p.readyPageCount }); },
+		});
+
+		const allReady = partials[partials.length - 1];
+		expect(allReady.readyPageCount).toBe(3);
+		expect(allReady.html).toContain("page-0");
+		expect(allReady.html).toContain('<p class="ocr-failed">[Page 2: OCR unavailable]</p>');
+		expect(allReady.html).toContain("page-2");
+	});
+
+	it("does not call onPartialHtml when the callback is omitted (zero behaviour change for non-streaming callers)", async () => {
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 3 }),
+			invokePageOcr: stubInvokePageOcr((i) => `page-${i}`),
+			batchSize: 1,
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+		expect(result.kind).toBe("fetched");
+	});
+
+	it("swallows errors thrown from the onPartialHtml callback so streaming failures never poison the crawl", async () => {
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 2 }),
+			invokePageOcr: stubInvokePageOcr((i) => `page-${i}`),
+			batchSize: 1,
+		});
+
+		const result = await ocr({
+			buffer: Buffer.from("%PDF"),
+			url: "https://example.com/x.pdf",
+			onPartialHtml: () => { throw new Error("downstream throttle blew up"); },
+		});
+		expect(result.kind).toBe("fetched");
+	});
+});

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -124,7 +124,7 @@ export function initOcrPdf(deps: {
 	const partialSuccessThreshold = deps.partialSuccessThreshold ?? DEFAULT_PARTIAL_SUCCESS_THRESHOLD;
 	const { logger, extractPdfMetadata, stagePdf, invokePageOcr, invokePageLlmCleanup, invokeDocumentDiffReview, invokePageHtmlConvert } = deps;
 
-	return async ({ buffer, url, onProgress }): Promise<PdfExtractResult> => {
+	return async ({ buffer, url, onProgress, onPartialHtml }): Promise<PdfExtractResult> => {
 		const t0 = Date.now();
 		logger.info(`[ocr-pdf] start url=${url} bytes=${buffer.length}`);
 
@@ -165,21 +165,70 @@ export function initOcrPdf(deps: {
 		try {
 			const staged = await stagePdf(buffer);
 			try {
+				// Per-chunk outcomes parallel-indexed to `chunks`. mapWithConcurrency
+				// resolves in completion order, so we capture each result at its
+				// original index here and use that to advance an in-order ready
+				// prefix for `onPartialHtml` — the user sees pages in document
+				// order even when chunk N+1 finishes before chunk N.
+				const chunkOutcomes: Array<ChunkOutcome | undefined> = new Array(chunks.length);
+				let readyUpToIndex = -1;
+				const emitPartialIfPrefixAdvanced = (): void => {
+					if (!onPartialHtml) return;
+					const prevReady = readyUpToIndex;
+					while (
+						readyUpToIndex + 1 < chunkOutcomes.length &&
+						chunkOutcomes[readyUpToIndex + 1] !== undefined
+					) {
+						readyUpToIndex += 1;
+					}
+					// `prevReady === readyUpToIndex` covers both "no advance happened"
+					// (an out-of-order completion past an incomplete head) and "first
+					// emission with nothing ready yet" (prevReady=-1, readyUpToIndex=-1).
+					if (readyUpToIndex === prevReady) return;
+					const fragments: string[] = [];
+					for (let i = 0; i <= readyUpToIndex; i++) {
+						const outcome = chunkOutcomes[i];
+						assert(outcome, "prefix invariant: outcomes up to readyUpToIndex must be defined");
+						fragments.push(
+							outcome.ok ? outcome.html : renderFailedChunkPlaceholder(outcome.pageIndices),
+						);
+					}
+					const html = fragments
+						.map((f) => f.trim())
+						.filter((f) => f.length > 0)
+						.join(PAGE_BREAK_HTML);
+					try {
+						onPartialHtml({ html, readyPageCount: readyUpToIndex + 1 });
+					} catch (error) {
+						// Best-effort streaming hook — never let it kill the crawl.
+						logger.warn(`[ocr-pdf] onPartialHtml callback threw: ${error}`);
+					}
+				};
+
 				const outcomes = await mapWithConcurrency(
 					chunks,
 					concurrency,
-					async (pageIndices): Promise<ChunkOutcome> => {
+					async (pageIndices, index): Promise<ChunkOutcome> => {
 						const chunkStart = Date.now();
 						const result = await invokePageOcrWithRetry({ pdfS3Key: staged.key, pageIndices, dpi });
 						if (!result.ok) {
-							return { ok: false, pageIndices, error: result.error };
+							const failure: ChunkOutcome = { ok: false, pageIndices, error: result.error };
+							chunkOutcomes[index] = failure;
+							emitPartialIfPrefixAdvanced();
+							return failure;
 						}
 						logger.info(`[ocr-pdf] chunk pages=[${pageIndices.join(",")}] done dt=${Date.now() - chunkStart}ms chars=${result.html.length} total=${Date.now() - t0}ms`);
 						completedParts += 1;
 						onProgress?.({ partIndex: completedParts, partCount, stage: "comprehensive-extracting" });
-						return { ok: true, pageIndices, html: result.html };
+						const success: ChunkOutcome = { ok: true, pageIndices, html: result.html };
+						chunkOutcomes[index] = success;
+						emitPartialIfPrefixAdvanced();
+						return success;
 					},
 				);
+				// Final Stage 0 emission so the last partial state lands even if the
+				// throttle on the downstream side suppressed the in-flight emission.
+				emitPartialIfPrefixAdvanced();
 
 				const successCount = outcomes.filter((o) => o.ok).length;
 				const successRatio = successCount / partCount;

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -86,6 +86,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		markCrawlProgress: jest.fn().mockResolvedValue(undefined),
+		markCrawlPartial: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
 		logger: noopLogger,
@@ -367,8 +368,41 @@ describe("initComprehensiveCrawlHandler", () => {
 		});
 	});
 
+	it("forwards onPartialHtml callbacks through markCrawlPartial so streaming clients see incrementally larger snapshots as Tesseract emits pages", async () => {
+		const crawlArticle: CrawlArticle = async ({ onPartialHtml }) => {
+			if (onPartialHtml) {
+				onPartialHtml({ html: "<p>page 1</p>", readyPageCount: 1 });
+				onPartialHtml({ html: "<p>page 1</p><hr><p>page 2</p>", readyPageCount: 2 });
+			}
+			return { status: "fetched", html: "<html><body><p>x</p></body></html>" };
+		};
+		const markCrawlPartial = jest.fn().mockResolvedValue(undefined);
+
+		const handler = createHandler({
+			crawlArticle,
+			markCrawlPartial,
+			partialIntervalMs: 10_000,
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+
+		// Throttle: first write lands immediately, mid-window writes suppress
+		// until the flush fires the terminal value at the end.
+		const calls = markCrawlPartial.mock.calls.map((c) => c[0]);
+		expect(calls[0]).toEqual({
+			url: "https://example.com/doc.pdf",
+			content: "<p>page 1</p>",
+		});
+		expect(calls[calls.length - 1]).toEqual({
+			url: "https://example.com/doc.pdf",
+			content: "<p>page 1</p><hr><p>page 2</p>",
+		});
+	});
+
 	it("flushes the terminal progress value after crawlArticle returns so the final partCurrent === partTotal write always lands", async () => {
 		const crawlArticle: CrawlArticle = async ({ onProgress }) => {
+			// Rapid fan-out of 4 parts — without flush, the throttle would write
+			// only the first part (the rest fall inside the throttle window).
 			if (onProgress) {
 				onProgress({ partIndex: 1, partCount: 4 });
 				onProgress({ partIndex: 2, partCount: 4 });

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -12,7 +12,9 @@ import {
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
 import type { MarkCrawlProgress } from "../../providers/article-crawl/mark-crawl-progress";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
 import { initProgressThrottle } from "../crawl-article-state/init-progress-throttle";
+import { initPartialContentThrottle } from "../crawl-article-state/init-partial-content-throttle";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { UpdateFetchTimestamp } from "../save-link/update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
@@ -28,6 +30,7 @@ export function initComprehensiveCrawlHandler(deps: {
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
 	markCrawlProgress: MarkCrawlProgress;
+	markCrawlPartial: MarkCrawlPartial;
 	publishEvent: PublishEvent;
 	now: () => Date;
 	logger: HutchLogger;
@@ -35,6 +38,7 @@ export function initComprehensiveCrawlHandler(deps: {
 	logCrawlOutcome: LogCrawlOutcome;
 	readTierSnapshot: ReadTierSnapshot;
 	progressIntervalMs?: number;
+	partialIntervalMs?: number;
 }): Handler<SQSEvent, SQSBatchResponse> {
 	const {
 		crawlArticle,
@@ -44,6 +48,7 @@ export function initComprehensiveCrawlHandler(deps: {
 		transitionAndPersist,
 		markCrawlStage,
 		markCrawlProgress,
+		markCrawlPartial,
 		publishEvent,
 		now,
 		logger,
@@ -51,6 +56,7 @@ export function initComprehensiveCrawlHandler(deps: {
 		logCrawlOutcome,
 		readTierSnapshot,
 		progressIntervalMs = 1500,
+		partialIntervalMs = 1000,
 	} = deps;
 
 	const logPrefix = "[ComprehensiveCrawlCommand]";
@@ -102,6 +108,12 @@ export function initComprehensiveCrawlHandler(deps: {
 					now: () => Date.now(),
 					logger,
 				});
+				const partialThrottle = initPartialContentThrottle({
+					markCrawlPartial,
+					intervalMs: partialIntervalMs,
+					now: () => Date.now(),
+					logger,
+				});
 				const crawlResult = await crawlArticle({
 					url,
 					onProgress: ({ partIndex, partCount, stage }) => {
@@ -117,8 +129,12 @@ export function initComprehensiveCrawlHandler(deps: {
 						}
 						progressThrottle.report({ url, partCurrent: partIndex, partTotal: partCount });
 					},
+					onPartialHtml: ({ html }) => {
+						partialThrottle.report({ url, html });
+					},
 				});
 				await progressThrottle.flush({ url });
+				await partialThrottle.flush({ url });
 
 				if (crawlResult.status === "unsupported") {
 					// Comprehensive saw the body and confirmed it cannot be extracted

--- a/projects/save-link/src/runtime/domain/crawl-article-state/init-partial-content-throttle.test.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/init-partial-content-throttle.test.ts
@@ -1,0 +1,206 @@
+import { noopLogger } from "@packages/hutch-logger";
+import { initPartialContentThrottle } from "./init-partial-content-throttle";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
+
+type Recorded = { url: string; content: string };
+
+function recordWriter(): {
+	markCrawlPartial: MarkCrawlPartial;
+	calls: Recorded[];
+} {
+	const calls: Recorded[] = [];
+	const markCrawlPartial: MarkCrawlPartial = async (params) => {
+		calls.push(params);
+	};
+	return { markCrawlPartial, calls };
+}
+
+const URL = "https://example.com/x.pdf";
+
+describe("initPartialContentThrottle", () => {
+	it("writes the first report immediately so the reader sees content as soon as it exists", async () => {
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => 0,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>first</p>" });
+		await Promise.resolve();
+		await throttle.flush({ url: URL });
+
+		expect(calls).toEqual([{ url: URL, content: "<p>first</p>" }]);
+	});
+
+	it("collapses rapid reports inside the throttle window down to a single write", async () => {
+		let nowMs = 0;
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => nowMs,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>a</p>" });
+		for (let i = 0; i < 10; i += 1) {
+			nowMs += 50;
+			throttle.report({ url: URL, html: `<p>a</p><p>${i}</p>` });
+		}
+		await Promise.resolve();
+
+		expect(calls).toEqual([{ url: URL, content: "<p>a</p>" }]);
+	});
+
+	it("writes again once the throttle window has elapsed since the last write", async () => {
+		let nowMs = 0;
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => nowMs,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>1</p>" });
+		nowMs = 1000;
+		throttle.report({ url: URL, html: "<p>1</p><p>2</p>" });
+		nowMs = 2000;
+		throttle.report({ url: URL, html: "<p>1</p><p>2</p><p>3</p>" });
+		await Promise.resolve();
+
+		expect(calls).toEqual([
+			{ url: URL, content: "<p>1</p>" },
+			{ url: URL, content: "<p>1</p><p>2</p>" },
+			{ url: URL, content: "<p>1</p><p>2</p><p>3</p>" },
+		]);
+	});
+
+	it("skips reports that match the last written length (no-op when nothing actually changed)", async () => {
+		let nowMs = 0;
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => nowMs,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>abc</p>" });
+		await Promise.resolve();
+		nowMs = 5000;
+		// Same length as last write — should not produce another write.
+		throttle.report({ url: URL, html: "<p>xyz</p>" });
+		await Promise.resolve();
+
+		expect(calls).toEqual([{ url: URL, content: "<p>abc</p>" }]);
+	});
+
+	it("flush emits the latest stashed value when reports arrived after the most recent write", async () => {
+		let nowMs = 0;
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => nowMs,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>1</p>" });
+		nowMs = 500;
+		throttle.report({ url: URL, html: "<p>1</p><p>2</p>" });
+		await throttle.flush({ url: URL });
+
+		expect(calls).toEqual([
+			{ url: URL, content: "<p>1</p>" },
+			{ url: URL, content: "<p>1</p><p>2</p>" },
+		]);
+	});
+
+	it("flush is a no-op when nothing has changed since the last write", async () => {
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => 0,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>only</p>" });
+		await Promise.resolve();
+		await throttle.flush({ url: URL });
+		await throttle.flush({ url: URL });
+
+		expect(calls).toEqual([{ url: URL, content: "<p>only</p>" }]);
+	});
+
+	it("flush with an explicit html writes that html (terminal value belt-and-braces)", async () => {
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => 0,
+			logger: noopLogger,
+		});
+
+		throttle.report({ url: URL, html: "<p>partial</p>" });
+		await Promise.resolve();
+		await throttle.flush({ url: URL, html: "<p>partial</p><p>more</p>" });
+
+		expect(calls).toEqual([
+			{ url: URL, content: "<p>partial</p>" },
+			{ url: URL, content: "<p>partial</p><p>more</p>" },
+		]);
+	});
+
+	it("flush with an explicit html on a never-reported url still writes that html", async () => {
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => 0,
+			logger: noopLogger,
+		});
+
+		await throttle.flush({ url: URL, html: "<p>only the final</p>" });
+
+		expect(calls).toEqual([{ url: URL, content: "<p>only the final</p>" }]);
+	});
+
+	it("flush is a no-op when no reports have been made for the URL and no explicit html is provided", async () => {
+		const { markCrawlPartial, calls } = recordWriter();
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial,
+			intervalMs: 1000,
+			now: () => 0,
+			logger: noopLogger,
+		});
+
+		await throttle.flush({ url: URL });
+
+		expect(calls).toEqual([]);
+	});
+
+	it("logs a warning when the underlying write fails but does not throw — best-effort beacon", async () => {
+		const warn = jest.fn();
+		const failing: MarkCrawlPartial = async () => {
+			throw new Error("DynamoDB throttled");
+		};
+		const throttle = initPartialContentThrottle({
+			markCrawlPartial: failing,
+			intervalMs: 1000,
+			now: () => 0,
+			logger: { ...noopLogger, warn },
+		});
+
+		throttle.report({ url: URL, html: "<p>x</p>" });
+		await throttle.flush({ url: URL });
+
+		expect(warn).toHaveBeenCalledWith(
+			"[partial-content-throttle] write failed",
+			expect.objectContaining({ url: URL, error: "Error: DynamoDB throttled" }),
+		);
+	});
+});

--- a/projects/save-link/src/runtime/domain/crawl-article-state/init-partial-content-throttle.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/init-partial-content-throttle.ts
@@ -1,0 +1,93 @@
+import type { HutchLogger } from "@packages/hutch-logger";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
+
+interface PendingPartial {
+	html: string;
+	lastWrittenLength: number;
+	lastWriteAtMs: number;
+}
+
+export interface PartialContentThrottle {
+	report: (params: { url: string; html: string }) => void;
+	flush: (params: { url: string; html?: string }) => Promise<void>;
+}
+
+/**
+ * Collapses the OCR partial-content firehose to ~1 DynamoDB write per
+ * `intervalMs`. The PDF Tesseract path can complete chunks at >5/sec on a
+ * dense PDF, but the streaming endpoint polls at 250ms and the human reading
+ * speed bottlenecks downstream — anything faster than a write per second is
+ * wasted I/O and risks contending with the aggregate's terminal-transition
+ * REMOVE clauses.
+ *
+ * Synchronous "should I write now?" check rather than setTimeout-based
+ * debouncing (Lambda freezes between invocations; a deferred timer either
+ * never fires or fires on an unrelated future invocation). An explicit
+ * `flush` after the fan-out returns guarantees the terminal value lands.
+ *
+ * Mirrors the shape of `init-progress-throttle.ts` so reviewers and tests can
+ * reason about both throttles uniformly.
+ */
+export function initPartialContentThrottle(deps: {
+	markCrawlPartial: MarkCrawlPartial;
+	intervalMs: number;
+	now: () => number;
+	logger: HutchLogger;
+}): PartialContentThrottle {
+	const { markCrawlPartial, intervalMs, now, logger } = deps;
+	const pending = new Map<string, PendingPartial>();
+
+	const writeNow = async (url: string, entry: PendingPartial): Promise<void> => {
+		const writtenLength = entry.html.length;
+		entry.lastWriteAtMs = now();
+		try {
+			await markCrawlPartial({ url, content: entry.html });
+			entry.lastWrittenLength = writtenLength;
+		} catch (error) {
+			logger.warn("[partial-content-throttle] write failed", {
+				url,
+				error: String(error),
+			});
+		}
+	};
+
+	const report: PartialContentThrottle["report"] = ({ url, html }) => {
+		const existing = pending.get(url);
+		const nowMs = now();
+		if (!existing) {
+			const entry: PendingPartial = {
+				html,
+				lastWrittenLength: -1,
+				lastWriteAtMs: nowMs,
+			};
+			pending.set(url, entry);
+			void writeNow(url, entry);
+			return;
+		}
+		if (html.length === existing.lastWrittenLength) return;
+		existing.html = html;
+		if (nowMs - existing.lastWriteAtMs >= intervalMs) {
+			void writeNow(url, existing);
+		}
+	};
+
+	const flush: PartialContentThrottle["flush"] = async ({ url, html }) => {
+		const existing = pending.get(url);
+		if (html !== undefined && existing) existing.html = html;
+		if (!existing) {
+			if (html === undefined) return;
+			const entry: PendingPartial = {
+				html,
+				lastWrittenLength: -1,
+				lastWriteAtMs: now(),
+			};
+			pending.set(url, entry);
+			await writeNow(url, entry);
+			return;
+		}
+		if (existing.lastWrittenLength === existing.html.length) return;
+		await writeNow(url, existing);
+	};
+
+	return { report, flush };
+}

--- a/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.test.ts
@@ -192,26 +192,6 @@ describe("initCrawlAndFinalizeArticle", () => {
 		expect(partials[0].readyPageCount).toBe(1);
 	});
 
-	it("fires onPartialHtml a second time with the finalized article html so the streaming reader shows the polished body before the S3 PUT", async () => {
-		const partials: Array<{ html: string; readyPageCount: number }> = [];
-		const crawlAndFinalize = initCrawlAndFinalizeArticle({
-			crawlArticle: async () => ({
-				status: "fetched",
-				html: "<html><body><p>raw</p></body></html>",
-			}),
-			finalizeArticle: okFinalize,
-		});
-
-		await crawlAndFinalize({
-			url: URL_UNDER_TEST,
-			onPartialHtml: (p) => { partials.push(p); },
-		});
-
-		const last = partials[partials.length - 1];
-		expect(last.html).toBe(stubFinalizedArticle.html);
-		expect(last.readyPageCount).toBe(1);
-	});
-
 	it("does not fire onPartialHtml with an empty preview snapshot (no title, no paragraphs)", async () => {
 		const partials: Array<{ html: string; readyPageCount: number }> = [];
 		const crawlAndFinalize = initCrawlAndFinalizeArticle({
@@ -227,9 +207,7 @@ describe("initCrawlAndFinalizeArticle", () => {
 			onPartialHtml: (p) => { partials.push(p); },
 		});
 
-		// Only the finalized snapshot fires; the empty preview is dropped.
-		expect(partials).toHaveLength(1);
-		expect(partials[0].html).toBe(stubFinalizedArticle.html);
+		expect(partials).toHaveLength(0);
 	});
 
 	it("works when onPartialHtml is omitted (callers that don't want streaming pay no cost)", async () => {

--- a/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.test.ts
@@ -152,4 +152,97 @@ describe("initCrawlAndFinalizeArticle", () => {
 			lastModified: "Wed, 01 Apr 2026 00:00:00 GMT",
 		});
 	});
+
+	it("forwards onPartialHtml to crawlArticle so the PDF extractor can stream Tesseract pages", async () => {
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+		const crawlArticle = jest.fn<Promise<CrawlArticleResult>, Parameters<CrawlArticle>>(async ({ onPartialHtml }) => {
+			if (onPartialHtml) onPartialHtml({ html: "<p>page 1</p>", readyPageCount: 1 });
+			return { status: "fetched", html: "<html><head><title>T</title></head><body><p>HTML body</p></body></html>" };
+		});
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			crawlArticle,
+			finalizeArticle: okFinalize,
+		});
+
+		await crawlAndFinalize({
+			url: URL_UNDER_TEST,
+			onPartialHtml: (p) => { partials.push(p); },
+		});
+
+		// PDF Tesseract emission survived the threading.
+		expect(partials.some((p) => p.html === "<p>page 1</p>" && p.readyPageCount === 1)).toBe(true);
+	});
+
+	it("fires onPartialHtml with a preview snapshot (title + first paragraphs) after a successful HTML crawl", async () => {
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			crawlArticle: async () => ({
+				status: "fetched",
+				html: "<html><head><title>The Title</title></head><body><p>First paragraph.</p><p>Second paragraph.</p></body></html>",
+			}),
+			finalizeArticle: okFinalize,
+		});
+
+		await crawlAndFinalize({
+			url: URL_UNDER_TEST,
+			onPartialHtml: (p) => { partials.push(p); },
+		});
+
+		expect(partials[0].html).toBe("<h1>The Title</h1><p>First paragraph.</p><p>Second paragraph.</p>");
+		expect(partials[0].readyPageCount).toBe(1);
+	});
+
+	it("fires onPartialHtml a second time with the finalized article html so the streaming reader shows the polished body before the S3 PUT", async () => {
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			crawlArticle: async () => ({
+				status: "fetched",
+				html: "<html><body><p>raw</p></body></html>",
+			}),
+			finalizeArticle: okFinalize,
+		});
+
+		await crawlAndFinalize({
+			url: URL_UNDER_TEST,
+			onPartialHtml: (p) => { partials.push(p); },
+		});
+
+		const last = partials[partials.length - 1];
+		expect(last.html).toBe(stubFinalizedArticle.html);
+		expect(last.readyPageCount).toBe(1);
+	});
+
+	it("does not fire onPartialHtml with an empty preview snapshot (no title, no paragraphs)", async () => {
+		const partials: Array<{ html: string; readyPageCount: number }> = [];
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			crawlArticle: async () => ({
+				status: "fetched",
+				html: "<html><body><div>no usable text</div></body></html>",
+			}),
+			finalizeArticle: okFinalize,
+		});
+
+		await crawlAndFinalize({
+			url: URL_UNDER_TEST,
+			onPartialHtml: (p) => { partials.push(p); },
+		});
+
+		// Only the finalized snapshot fires; the empty preview is dropped.
+		expect(partials).toHaveLength(1);
+		expect(partials[0].html).toBe(stubFinalizedArticle.html);
+	});
+
+	it("works when onPartialHtml is omitted (callers that don't want streaming pay no cost)", async () => {
+		const crawlAndFinalize = initCrawlAndFinalizeArticle({
+			crawlArticle: async () => ({
+				status: "fetched",
+				html: "<html><head><title>T</title></head><body><p>body</p></body></html>",
+			}),
+			finalizeArticle: okFinalize,
+		});
+
+		const result = await crawlAndFinalize({ url: URL_UNDER_TEST });
+
+		expect(result.status).toBe("fetched");
+	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.ts
+++ b/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.ts
@@ -17,9 +17,8 @@ export type CrawlAndFinalizeArticle = (params: {
 	url: string;
 	etag?: string;
 	lastModified?: string;
-	/* Streaming hook. Fired three times on a successful HTML crawl: once with
-	 * the preview HTML (title + first paragraphs) extracted from the raw fetch,
-	 * once with the finalized article HTML after media rewrites, and (PDF only)
+	/* Streaming hook. Fired once on a successful HTML crawl (preview HTML:
+	 * title + first paragraphs extracted from the raw fetch) and (PDF only)
 	 * by the extractor itself each time Tesseract's in-order ready prefix
 	 * advances. The orchestrator routes each invocation to `markCrawlPartial`
 	 * so the reader-slot's streaming variant can display content progressively
@@ -77,13 +76,6 @@ export function initCrawlAndFinalizeArticle(deps: {
 			preFetchedThumbnail: crawlResult.thumbnailImage,
 		});
 		if (!finalized.ok) return { status: "failed", reason: finalized.reason };
-
-		/* Full post-Readability HTML snapshot — shipped before the tier-source
-		 * write so the streaming reader sees the polished body the moment it
-		 * exists, not after the S3 PUT round-trip. */
-		if (params.onPartialHtml) {
-			params.onPartialHtml({ html: finalized.article.html, readyPageCount: 1 });
-		}
 
 		return {
 			status: "fetched",

--- a/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.ts
+++ b/projects/save-link/src/runtime/domain/save-link/crawl-and-finalize-article.ts
@@ -1,5 +1,6 @@
-import type { CrawlArticle } from "@packages/crawl-article";
+import type { CrawlArticle, PdfPartialHtml } from "@packages/crawl-article";
 import type { FinalizeArticle, FinalizedArticle } from "./finalize-article";
+import { extractPreviewHtml } from "./extract-preview-html";
 
 export type CrawlAndFinalizeResult =
 	| {
@@ -16,6 +17,14 @@ export type CrawlAndFinalizeArticle = (params: {
 	url: string;
 	etag?: string;
 	lastModified?: string;
+	/* Streaming hook. Fired three times on a successful HTML crawl: once with
+	 * the preview HTML (title + first paragraphs) extracted from the raw fetch,
+	 * once with the finalized article HTML after media rewrites, and (PDF only)
+	 * by the extractor itself each time Tesseract's in-order ready prefix
+	 * advances. The orchestrator routes each invocation to `markCrawlPartial`
+	 * so the reader-slot's streaming variant can display content progressively
+	 * before the canonical tier-source write lands. */
+	onPartialHtml?: PdfPartialHtml;
 }) => Promise<CrawlAndFinalizeResult>;
 
 /**
@@ -40,6 +49,7 @@ export function initCrawlAndFinalizeArticle(deps: {
 			etag: params.etag,
 			lastModified: params.lastModified,
 			fetchThumbnail: true,
+			onPartialHtml: params.onPartialHtml,
 		});
 
 		if (crawlResult.status === "not-modified") return { status: "not-modified" };
@@ -50,12 +60,30 @@ export function initCrawlAndFinalizeArticle(deps: {
 			return { status: "failed", reason: "crawl-failed" };
 		}
 
+		/* HTML preview snapshot: title + first ~500 chars of body text,
+		 * extracted from the raw fetched HTML before Readability runs.
+		 * Lets the reader-slot show *something* within ~1 second of save
+		 * for HTML articles, paralleling the PDF path's Tesseract stream. */
+		if (params.onPartialHtml) {
+			const preview = extractPreviewHtml(crawlResult.html);
+			if (preview.length > 0) {
+				params.onPartialHtml({ html: preview, readyPageCount: 1 });
+			}
+		}
+
 		const finalized = await finalizeArticle({
 			url: params.url,
 			html: crawlResult.html,
 			preFetchedThumbnail: crawlResult.thumbnailImage,
 		});
 		if (!finalized.ok) return { status: "failed", reason: finalized.reason };
+
+		/* Full post-Readability HTML snapshot — shipped before the tier-source
+		 * write so the streaming reader sees the polished body the moment it
+		 * exists, not after the S3 PUT round-trip. */
+		if (params.onPartialHtml) {
+			params.onPartialHtml({ html: finalized.article.html, readyPageCount: 1 });
+		}
 
 		return {
 			status: "fetched",

--- a/projects/save-link/src/runtime/domain/save-link/extract-preview-html.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/extract-preview-html.test.ts
@@ -1,0 +1,117 @@
+import { extractPreviewHtml } from "./extract-preview-html";
+
+describe("extractPreviewHtml", () => {
+	it("returns title plus first paragraph for a simple article", () => {
+		const html = `
+			<html>
+				<head><title>Hello World</title></head>
+				<body>
+					<p>First paragraph body.</p>
+					<p>Second paragraph body.</p>
+				</body>
+			</html>
+		`;
+		expect(extractPreviewHtml(html)).toBe(
+			"<h1>Hello World</h1><p>First paragraph body.</p><p>Second paragraph body.</p>",
+		);
+	});
+
+	it("prefers og:title over the document <title>", () => {
+		const html = `
+			<html>
+				<head>
+					<title>Boring SEO Title</title>
+					<meta property="og:title" content="Sharp Headline">
+				</head>
+				<body><p>Body text.</p></body>
+			</html>
+		`;
+		expect(extractPreviewHtml(html)).toBe(
+			"<h1>Sharp Headline</h1><p>Body text.</p>",
+		);
+	});
+
+	it("caps at 3 paragraphs even when more are present", () => {
+		const html = `
+			<html>
+				<head><title>T</title></head>
+				<body>
+					<p>One.</p>
+					<p>Two.</p>
+					<p>Three.</p>
+					<p>Four.</p>
+					<p>Five.</p>
+				</body>
+			</html>
+		`;
+		const result = extractPreviewHtml(html);
+		expect(result).toContain("<p>Three.</p>");
+		expect(result).not.toContain("<p>Four.</p>");
+	});
+
+	it("stops accumulating paragraphs after ~500 chars to keep the preview small", () => {
+		const longParagraph = "Lorem ipsum dolor sit amet, ".repeat(20);
+		const html = `
+			<html>
+				<head><title>T</title></head>
+				<body>
+					<p>${longParagraph}</p>
+					<p>This second paragraph should not appear in the preview.</p>
+				</body>
+			</html>
+		`;
+		const result = extractPreviewHtml(html);
+		expect(result).toContain("Lorem ipsum");
+		expect(result).not.toContain("should not appear");
+	});
+
+	it("skips empty paragraphs", () => {
+		const html = `
+			<html>
+				<head><title>T</title></head>
+				<body>
+					<p></p>
+					<p>   </p>
+					<p>Real content.</p>
+				</body>
+			</html>
+		`;
+		expect(extractPreviewHtml(html)).toBe(
+			"<h1>T</h1><p>Real content.</p>",
+		);
+	});
+
+	it("escapes HTML special characters in title and paragraphs", () => {
+		const html = `
+			<html>
+				<head><title>Title with &lt;tag&gt;</title></head>
+				<body><p>Body &amp; more &#x3C;evil&#x3E;</p></body>
+			</html>
+		`;
+		const result = extractPreviewHtml(html);
+		expect(result).toContain("Title with &lt;tag&gt;");
+		expect(result).toContain("Body &amp; more &lt;evil&gt;");
+		expect(result).not.toMatch(/<tag>/);
+		expect(result).not.toMatch(/<evil>/);
+	});
+
+	it("returns an empty string when there is no usable title and no paragraphs", () => {
+		const html = "<html><head></head><body><div>nope</div></body></html>";
+		expect(extractPreviewHtml(html)).toBe("");
+	});
+
+	it("emits just the title when there are no paragraphs", () => {
+		const html = "<html><head><title>Only A Title</title></head><body></body></html>";
+		expect(extractPreviewHtml(html)).toBe("<h1>Only A Title</h1>");
+	});
+
+	it("emits just paragraphs when there is no title", () => {
+		const html = "<html><head></head><body><p>Just body.</p></body></html>";
+		expect(extractPreviewHtml(html)).toBe("<p>Just body.</p>");
+	});
+
+	it("collapses whitespace inside a paragraph", () => {
+		const html = "<html><head><title>T</title></head><body><p>Hello\n\n\tworld   spaced</p></body></html>";
+		expect(extractPreviewHtml(html)).toBe("<h1>T</h1><p>Hello world spaced</p>");
+	});
+});

--- a/projects/save-link/src/runtime/domain/save-link/extract-preview-html.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/extract-preview-html.test.ts
@@ -44,9 +44,9 @@ describe("extractPreviewHtml", () => {
 				</body>
 			</html>
 		`;
-		const result = extractPreviewHtml(html);
-		expect(result).toContain("<p>Three.</p>");
-		expect(result).not.toContain("<p>Four.</p>");
+		expect(extractPreviewHtml(html)).toBe(
+			"<h1>T</h1><p>One.</p><p>Two.</p><p>Three.</p>",
+		);
 	});
 
 	it("stops accumulating paragraphs after ~500 chars to keep the preview small", () => {
@@ -56,13 +56,13 @@ describe("extractPreviewHtml", () => {
 				<head><title>T</title></head>
 				<body>
 					<p>${longParagraph}</p>
-					<p>This second paragraph should not appear in the preview.</p>
+					<p>second paragraph after the cap.</p>
 				</body>
 			</html>
 		`;
-		const result = extractPreviewHtml(html);
-		expect(result).toContain("Lorem ipsum");
-		expect(result).not.toContain("should not appear");
+		expect(extractPreviewHtml(html)).toBe(
+			`<h1>T</h1><p>${longParagraph.trim()}</p>`,
+		);
 	});
 
 	it("skips empty paragraphs", () => {

--- a/projects/save-link/src/runtime/domain/save-link/extract-preview-html.ts
+++ b/projects/save-link/src/runtime/domain/save-link/extract-preview-html.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert";
+import { parseHTML } from "linkedom";
+import { escapeHtmlText } from "@packages/crawl-article";
+
+const PREVIEW_TARGET_CHARS = 500;
+const MAX_PARAGRAPHS = 3;
+
+/**
+ * Extract a tiny preview HTML fragment from raw fetched HTML — a `<h1>` with
+ * the page title plus the first few paragraphs (~500 chars total). Used as
+ * the very first streaming partial-content write so the reader sees a title
+ * and a few sentences within the first second of a save, before the full
+ * Readability pass completes.
+ *
+ * Pure function: deterministic on the input, no side effects. Returns an
+ * empty string when neither a title nor any usable paragraphs can be found,
+ * so the caller can skip a partial write that would yield no value.
+ */
+export function extractPreviewHtml(rawHtml: string): string {
+	const { document } = parseHTML(rawHtml);
+	const title = pickTitle(document);
+	const paragraphs = pickParagraphs(document);
+	if (!title && paragraphs.length === 0) return "";
+	const titleHtml = title ? `<h1>${escapeHtmlText(title)}</h1>` : "";
+	const bodyHtml = paragraphs
+		.map((text) => `<p>${escapeHtmlText(text)}</p>`)
+		.join("");
+	return titleHtml + bodyHtml;
+}
+
+function pickTitle(document: Document): string {
+	const ogTitle = document
+		.querySelector('meta[property="og:title"]')
+		?.getAttribute("content");
+	if (ogTitle) return ogTitle.trim();
+	const titleTag = document.querySelector("title")?.textContent;
+	if (titleTag) return titleTag.trim();
+	return "";
+}
+
+function pickParagraphs(document: Document): string[] {
+	const all = Array.from(document.querySelectorAll("p"));
+	const result: string[] = [];
+	let totalChars = 0;
+	for (const node of all) {
+		if (result.length >= MAX_PARAGRAPHS) break;
+		const raw = node.textContent;
+		// DOM spec: Element.textContent is `string` (never null); the lib.dom
+		// type widens to string|null for the base Node interface. assert keeps
+		// the null branch out of V8 block coverage without lowering the threshold.
+		assert(raw !== null, "Element.textContent must be a string");
+		const text = raw.replace(/\s+/g, " ").trim();
+		if (text.length === 0) continue;
+		result.push(text);
+		totalChars += text.length;
+		if (totalChars >= PREVIEW_TARGET_CHARS) break;
+	}
+	return result;
+}

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
@@ -77,6 +77,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
+		markCrawlPartial: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
 		logger: noopLogger,

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.ts
@@ -7,6 +7,7 @@ import {
 	RecrawlContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
@@ -22,6 +23,7 @@ export function initRecrawlLinkInitiatedHandler(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
+	markCrawlPartial: MarkCrawlPartial;
 	publishEvent: PublishEvent;
 	now: () => Date;
 	logger: HutchLogger;
@@ -38,6 +40,7 @@ export function initRecrawlLinkInitiatedHandler(deps: {
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
+		markCrawlPartial: deps.markCrawlPartial,
 		now: deps.now,
 		logger,
 		logParseError: deps.logParseError,

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
@@ -79,6 +79,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
+		markCrawlPartial: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
 		logger: noopLogger,

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.ts
@@ -7,6 +7,7 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
@@ -22,6 +23,7 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
+	markCrawlPartial: MarkCrawlPartial;
 	publishEvent: PublishEvent;
 	now: () => Date;
 	logger: HutchLogger;
@@ -38,6 +40,7 @@ export function initSaveAnonymousLinkCommandHandler(deps: {
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
+		markCrawlPartial: deps.markCrawlPartial,
 		now: deps.now,
 		logger,
 		logParseError: deps.logParseError,

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
@@ -335,13 +335,12 @@ describe("initSaveLinkCommandHandler", () => {
 		const warn = jest.fn();
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		// crawlAndFinalizeArticle is the only path that triggers an
-		// onPartialHtml fire — invoke it twice (preview + final, mirroring
-		// the production flow) so the partial-write path runs twice against
-		// the failing markCrawlPartial mock.
+		// onPartialHtml fire — invoke it once (preview, mirroring the
+		// production flow) so the partial-write path runs against the
+		// failing markCrawlPartial mock.
 		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async ({ onPartialHtml }) => {
 			if (onPartialHtml) {
 				onPartialHtml({ html: "<h1>preview</h1>", readyPageCount: 1 });
-				onPartialHtml({ html: "<p>final</p>", readyPageCount: 1 });
 			}
 			return fetchedResult;
 		};
@@ -367,8 +366,6 @@ describe("initSaveLinkCommandHandler", () => {
 				error: "Error: DynamoDB throttled",
 			}),
 		);
-		// crawlAndFinalize fires onPartialHtml twice (preview + final); both
-		// hit the failing mock, so the warn fires twice too.
-		expect(warn).toHaveBeenCalledTimes(2);
+		expect(warn).toHaveBeenCalledTimes(1);
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
@@ -79,6 +79,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		updateFetchTimestamp: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
+		markCrawlPartial: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
 		logger: noopLogger,
@@ -327,5 +328,32 @@ describe("initSaveLinkCommandHandler", () => {
 		const result = await handler(invalidEvent, stubContext, () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+	});
+
+	it("logs a warning when markCrawlPartial throws but never fails the crawl — partial writes are a streaming UX nicety", async () => {
+		const markCrawlPartial = jest.fn().mockRejectedValue(new Error("DynamoDB throttled"));
+		const warn = jest.fn();
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const handler = createHandler({
+			markCrawlPartial,
+			publishEvent,
+			logger: { ...noopLogger, warn },
+		});
+
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+
+		// Save still succeeded — the canonical event still fires.
+		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, expect.objectContaining({
+			url: "https://example.com/article",
+			tier: "tier-1",
+		}));
+		expect(warn).toHaveBeenCalledWith(
+			"[SaveLinkCommand] partial-content write failed",
+			expect.objectContaining({
+				url: "https://example.com/article",
+				error: "Error: DynamoDB throttled",
+			}),
+		);
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
@@ -334,8 +334,20 @@ describe("initSaveLinkCommandHandler", () => {
 		const markCrawlPartial = jest.fn().mockRejectedValue(new Error("DynamoDB throttled"));
 		const warn = jest.fn();
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
+		// crawlAndFinalizeArticle is the only path that triggers an
+		// onPartialHtml fire — invoke it twice (preview + final, mirroring
+		// the production flow) so the partial-write path runs twice against
+		// the failing markCrawlPartial mock.
+		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async ({ onPartialHtml }) => {
+			if (onPartialHtml) {
+				onPartialHtml({ html: "<h1>preview</h1>", readyPageCount: 1 });
+				onPartialHtml({ html: "<p>final</p>", readyPageCount: 1 });
+			}
+			return fetchedResult;
+		};
 
 		const handler = createHandler({
+			crawlAndFinalizeArticle,
 			markCrawlPartial,
 			publishEvent,
 			logger: { ...noopLogger, warn },
@@ -355,5 +367,8 @@ describe("initSaveLinkCommandHandler", () => {
 				error: "Error: DynamoDB throttled",
 			}),
 		);
+		// crawlAndFinalize fires onPartialHtml twice (preview + final); both
+		// hit the failing mock, so the warn fires twice too.
+		expect(warn).toHaveBeenCalledTimes(2);
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.ts
@@ -7,6 +7,7 @@ import {
 	TierContentExtractedEvent,
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
@@ -22,6 +23,7 @@ export function initSaveLinkCommandHandler(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
+	markCrawlPartial: MarkCrawlPartial;
 	publishEvent: PublishEvent;
 	now: () => Date;
 	logger: HutchLogger;
@@ -38,6 +40,7 @@ export function initSaveLinkCommandHandler(deps: {
 		updateFetchTimestamp: deps.updateFetchTimestamp,
 		transitionAndPersist: deps.transitionAndPersist,
 		markCrawlStage: deps.markCrawlStage,
+		markCrawlPartial: deps.markCrawlPartial,
 		now: deps.now,
 		logger,
 		logParseError: deps.logParseError,

--- a/projects/save-link/src/runtime/domain/save-link/save-link-work.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-work.ts
@@ -69,18 +69,17 @@ export function initSaveLinkWork(deps: {
 	/* Partial-content writes are a streaming UX nicety, never load-bearing.
 	 * A failure here must not fail the crawl — the canonical write path is
 	 * untouched and the reader's HTMX poll will still drive the slot to
-	 * ready once the worker completes. */
-	const writePartial = async (url: string, content: string): Promise<void> => {
-		if (content.length === 0) return;
-		try {
-			await markCrawlPartial({ url, content });
-		} catch (error) {
-			logger.warn(`${logPrefix} partial-content write failed`, {
+	 * ready once the worker completes. The empty-content guard lives in
+	 * `crawlAndFinalizeArticle`'s preview emission, so we don't double-check
+	 * here. */
+	const partialWriteFailedMessage = `${logPrefix} partial-content write failed`;
+	const writePartial = (url: string, content: string): Promise<void> =>
+		markCrawlPartial({ url, content }).catch((error: unknown) => {
+			logger.warn(partialWriteFailedMessage, {
 				url,
 				error: String(error),
 			});
-		}
-	};
+		});
 
 	const emitTier1Failure = async (url: string): Promise<void> => {
 		const snapshot = await readTierSnapshot({ url });

--- a/projects/save-link/src/runtime/domain/save-link/save-link-work.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-work.ts
@@ -4,6 +4,7 @@ import {
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
+import type { MarkCrawlPartial } from "../../providers/article-crawl/mark-crawl-partial";
 import type { UpdateFetchTimestamp } from "./update-fetch-timestamp-handler";
 import type { LogCrawlOutcome, LogParseError } from "@packages/hutch-infra-components";
 import type { ReadTierSnapshot } from "../crawl-article-state/read-tier-snapshot";
@@ -41,6 +42,7 @@ export function initSaveLinkWork(deps: {
 	updateFetchTimestamp: UpdateFetchTimestamp;
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
+	markCrawlPartial: MarkCrawlPartial;
 	now: () => Date;
 	logger: HutchLogger;
 	logParseError: LogParseError;
@@ -55,6 +57,7 @@ export function initSaveLinkWork(deps: {
 		updateFetchTimestamp,
 		transitionAndPersist,
 		markCrawlStage,
+		markCrawlPartial,
 		now,
 		logger,
 		logParseError,
@@ -62,6 +65,22 @@ export function initSaveLinkWork(deps: {
 		readTierSnapshot,
 		logPrefix,
 	} = deps;
+
+	/* Partial-content writes are a streaming UX nicety, never load-bearing.
+	 * A failure here must not fail the crawl — the canonical write path is
+	 * untouched and the reader's HTMX poll will still drive the slot to
+	 * ready once the worker completes. */
+	const writePartial = async (url: string, content: string): Promise<void> => {
+		if (content.length === 0) return;
+		try {
+			await markCrawlPartial({ url, content });
+		} catch (error) {
+			logger.warn(`${logPrefix} partial-content write failed`, {
+				url,
+				error: String(error),
+			});
+		}
+	};
 
 	const emitTier1Failure = async (url: string): Promise<void> => {
 		const snapshot = await readTierSnapshot({ url });
@@ -76,7 +95,10 @@ export function initSaveLinkWork(deps: {
 
 	const saveLinkWork = async (url: string, options?: SaveLinkWorkOptions): Promise<SaveLinkWorkResult> => {
 		await markCrawlStage({ url, stage: "crawl-fetching" });
-		const result = await crawlAndFinalizeArticle({ url });
+		const result = await crawlAndFinalizeArticle({
+			url,
+			onPartialHtml: ({ html }) => { void writePartial(url, html); },
+		});
 
 		if (result.status === "unsupported") {
 			/* The simple crawl bailed because the origin returned a non-html body.

--- a/projects/save-link/src/runtime/providers/article-crawl/mark-crawl-partial.ts
+++ b/projects/save-link/src/runtime/providers/article-crawl/mark-crawl-partial.ts
@@ -1,0 +1,64 @@
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+} from "@packages/hutch-storage-client";
+import type { HutchLogger } from "@packages/hutch-logger";
+import { z } from "zod";
+import { ArticleResourceUniqueId } from "../../domain/save-link/article-resource-unique-id";
+
+export type MarkCrawlPartial = (params: {
+	url: string;
+	content: string;
+}) => Promise<void>;
+
+const CrawlPartialRow = z.object({ url: z.string() });
+
+/* Partial-content writes are transient progress markers superseded once the
+ * row's status flips terminal. The aggregate's terminal-transition writers
+ * REMOVE `partialContent` and `partialContentVersion` alongside the other
+ * transient attributes, so we don't route partial writes through the
+ * aggregate — same shape as mark-crawl-stage / mark-crawl-progress.
+ *
+ * The condition expression guards the race where the aggregate has flipped
+ * the row terminal between our last read and this write — without it we'd
+ * resurrect partial bytes the REMOVE just cleared, leaving stale content on
+ * a terminal row. Catching ConditionalCheckFailedException quietly mirrors
+ * how markCrawlPending handles the same race in dynamodb-article-crawl.ts. */
+export function initDynamoDbMarkCrawlPartial(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	logger: HutchLogger;
+}): { markCrawlPartial: MarkCrawlPartial } {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: CrawlPartialRow,
+	});
+
+	const markCrawlPartial: MarkCrawlPartial = async ({ url, content }) => {
+		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
+		try {
+			await table.update({
+				Key: { url: articleResourceUniqueId.value },
+				UpdateExpression:
+					"SET partialContent = :content, partialContentVersion = if_not_exists(partialContentVersion, :zero) + :one",
+				ConditionExpression:
+					"attribute_not_exists(crawlStatus) OR crawlStatus = :pending",
+				ExpressionAttributeValues: {
+					":content": content,
+					":zero": 0,
+					":one": 1,
+					":pending": "pending",
+				},
+			});
+		} catch (err) {
+			if (!(err instanceof ConditionalCheckFailedException)) throw err;
+			deps.logger.debug("[mark-crawl-partial] skipped — row no longer pending", {
+				url,
+			});
+		}
+	};
+
+	return { markCrawlPartial };
+}

--- a/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
+++ b/projects/save-link/src/runtime/recrawl-link-initiated.main.ts
@@ -39,7 +39,7 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
-const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
+const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable, logger: consoleLogger });
 const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 	publishEvent: events.publishEvent,
 });

--- a/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-anonymous-link-command.main.ts
@@ -39,7 +39,7 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
-const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
+const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable, logger: consoleLogger });
 const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 	publishEvent: events.publishEvent,
 });

--- a/projects/save-link/src/runtime/save-link-command.main.ts
+++ b/projects/save-link/src/runtime/save-link-command.main.ts
@@ -39,7 +39,7 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
-const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
+const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable, logger: consoleLogger });
 const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 	publishEvent: events.publishEvent,
 });

--- a/projects/save-link/src/runtime/stale-check.main.ts
+++ b/projects/save-link/src/runtime/stale-check.main.ts
@@ -54,7 +54,7 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 	logError: observability.logError,
 });
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
-const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
+const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable, logger: consoleLogger });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const emitSimpleCrawlUnsupported = initEmitSimpleCrawlUnsupported({
 	publishEvent: events.publishEvent,

--- a/src/packages/article-store/src/dynamodb-article-store.ts
+++ b/src/packages/article-store/src/dynamodb-article-store.ts
@@ -296,14 +296,24 @@ function appendCrawlClauses(
 		sets.push("crawlFailureReason = :crawlFailureReason");
 		values[":crawlStatus"] = "failed";
 		values[":crawlFailureReason"] = JSON.stringify(article.crawl.reason);
-		removes.push("crawlUnsupportedReason", "crawlPendingSince");
+		removes.push(
+			"crawlUnsupportedReason",
+			"crawlPendingSince",
+			"partialContent",
+			"partialContentVersion",
+		);
 		return;
 	}
 	if (article.crawl.kind === "unsupported") {
 		sets.push("crawlUnsupportedReason = :crawlUnsupportedReason");
 		values[":crawlStatus"] = "unsupported";
 		values[":crawlUnsupportedReason"] = JSON.stringify(article.crawl.reason);
-		removes.push("crawlFailureReason", "crawlPendingSince");
+		removes.push(
+			"crawlFailureReason",
+			"crawlPendingSince",
+			"partialContent",
+			"partialContentVersion",
+		);
 		return;
 	}
 	if (article.crawl.kind === "ready") {
@@ -313,6 +323,8 @@ function appendCrawlClauses(
 			"crawlUnsupportedReason",
 			"crawlFailedAt",
 			"crawlPendingSince",
+			"partialContent",
+			"partialContentVersion",
 		);
 		return;
 	}

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -9,7 +9,7 @@ import { headerOrUndefined } from "./header-utils";
 import { classifyMediaType } from "./media-type";
 import { parsePlainTextFromBuffer } from "./parse-plain-text";
 import { MAX_PDF_BYTES } from "./pdf-page-limits";
-import type { ExtractPdf } from "./pdf-extract.types";
+import type { ExtractPdf, PdfPartialHtml } from "./pdf-extract.types";
 import { initFetchTweetViaOembed, isTweetUrl } from "./x-twitter-preprocessor";
 
 const FETCH_TIMEOUT_MS = 30000;
@@ -169,6 +169,7 @@ export async function parsePdfFromBuffer(input: {
 	url: string;
 	extractPdf: ExtractPdf;
 	onProgress?: ComprehensiveCrawlProgress;
+	onPartialHtml?: PdfPartialHtml;
 	logError: (message: string, error?: Error) => void;
 }): Promise<CrawlArticleResult> {
 	if (input.buffer.length > MAX_PDF_BYTES.bytes) {
@@ -179,6 +180,7 @@ export async function parsePdfFromBuffer(input: {
 		buffer: input.buffer,
 		url: input.url,
 		onProgress: input.onProgress,
+		onPartialHtml: input.onPartialHtml,
 	});
 	if (extracted.kind === "failed") {
 		input.logError(`[CrawlArticle] PDF extraction failed for ${input.url}: ${extracted.reason}`);
@@ -253,6 +255,7 @@ export function initCrawlArticle(deps: {
 					url: params.url,
 					extractPdf,
 					onProgress: params.onProgress,
+					onPartialHtml: params.onPartialHtml,
 					logError,
 				});
 			case "plain-text":

--- a/src/packages/crawl-article/src/crawl-article.types.ts
+++ b/src/packages/crawl-article/src/crawl-article.types.ts
@@ -1,4 +1,4 @@
-import type { PdfExtractStage } from "./pdf-extract.types";
+import type { PdfExtractStage, PdfPartialHtml } from "./pdf-extract.types";
 
 export type ThumbnailImage = {
 	body: Buffer;
@@ -40,6 +40,9 @@ export type ComprehensiveCrawlProgress = (params: {
  * opts the HTML path into prefetching the article thumbnail; `onProgress` is
  * forwarded to the PDF extractor (the expensive path that can hold a Lambda
  * concurrency slot for tens of seconds while pdfjs walks every page).
+ * `onPartialHtml` is forwarded so the PDF extractor's Stage 0 (Tesseract)
+ * can stream the in-order ready-prefix HTML to the orchestrator, which
+ * routes it to the streaming reader UI.
  */
 export type CrawlArticle = (params: {
 	url: string;
@@ -47,4 +50,5 @@ export type CrawlArticle = (params: {
 	lastModified?: string;
 	fetchThumbnail?: boolean;
 	onProgress?: ComprehensiveCrawlProgress;
+	onPartialHtml?: PdfPartialHtml;
 }) => Promise<CrawlArticleResult>;

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -19,7 +19,7 @@ export type {
 } from "./crawl-article.types";
 export { initCrawlFetch } from "./crawl-fetch";
 export type { CrawlFetch, CrawlFetchInit } from "./crawl-fetch";
-export type { ExtractPdf, PdfExtractProgress, PdfExtractResult, PdfExtractStage } from "./pdf-extract.types";
+export type { ExtractPdf, PdfExtractProgress, PdfExtractResult, PdfExtractStage, PdfPartialHtml } from "./pdf-extract.types";
 export { isPDF } from "./pdf-detect";
 export type { PdfSignal } from "./pdf-detect";
 export { extractPdfMetadata } from "./extract-pdf-metadata";

--- a/src/packages/crawl-article/src/pdf-extract.types.ts
+++ b/src/packages/crawl-article/src/pdf-extract.types.ts
@@ -40,8 +40,34 @@ export type PdfExtractProgress = (params: {
 	stage?: PdfExtractStage;
 }) => void;
 
+/**
+ * Optional callback the extractor fires each time the in-order ready-prefix
+ * of completed pages grows, carrying the cumulative reader-facing HTML
+ * snapshot ("page 1 through page N"). The orchestrator routes this to the
+ * partial-content throttle so the SSE / streaming reader can display text
+ * page-by-page as soon as Tesseract emits it.
+ *
+ * Separate from `onProgress` because the metadata path (partIndex/partCount)
+ * is cheap and frequent, while the partial-html path carries the (potentially
+ * large) HTML body and is routed through its own throttle. Splitting keeps
+ * the cost of the metadata path constant regardless of HTML size.
+ *
+ * `html` is the full cumulative reader HTML for the in-order prefix, not a
+ * delta — callers replace the previous value rather than concatenating.
+ * `readyPageCount` is the count of pages currently in the ready prefix
+ * (1-based), exposed so callers can log or surface "n of m pages ready".
+ *
+ * Best-effort and synchronous from the extractor's perspective: errors
+ * thrown from the callback are not surfaced.
+ */
+export type PdfPartialHtml = (params: {
+	html: string;
+	readyPageCount: number;
+}) => void | Promise<void>;
+
 export type ExtractPdf = (params: {
 	buffer: Buffer;
 	url: string;
 	onProgress?: PdfExtractProgress;
+	onPartialHtml?: PdfPartialHtml;
 }) => Promise<PdfExtractResult>;

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -32,6 +32,7 @@ import type {
 } from "./providers/article-crawl/article-crawl.types";
 import type {
 	InMemoryMarkCrawlFailed,
+	InMemoryMarkCrawlPartial,
 	InMemoryMarkCrawlReady,
 	InMemoryMarkCrawlStage,
 	InMemoryMarkCrawlUnsupported,
@@ -219,6 +220,7 @@ export interface ArticleCrawlBundle {
 	markCrawlFailed: InMemoryMarkCrawlFailed;
 	markCrawlUnsupported: InMemoryMarkCrawlUnsupported;
 	markCrawlStage: InMemoryMarkCrawlStage;
+	markCrawlPartial: InMemoryMarkCrawlPartial;
 }
 
 export interface ParserBundle {

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -301,6 +301,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 			markCrawlFailed: articleCrawl.markCrawlFailed,
 			markCrawlUnsupported: articleCrawl.markCrawlUnsupported,
 			markCrawlStage: articleCrawl.markCrawlStage,
+			markCrawlPartial: articleCrawl.markCrawlPartial,
 		},
 		parser: { parseArticle, crawlArticle },
 		events: {

--- a/src/packages/test-fixtures/src/providers/article-crawl/article-crawl.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/article-crawl.types.ts
@@ -5,8 +5,19 @@ export interface CrawlParts {
 	total: number;
 }
 
+/** Transient partial-content snapshot written by save-link as it crawls. The
+ * version number is monotonically incremented per write so SSE clients can
+ * cheaply detect a new snapshot without diffing the content body. Lives only
+ * on the `pending` variant — terminal transitions REMOVE both attributes on
+ * the underlying row, making "partial only exists while pending" a
+ * compile-time invariant on the discriminated union. */
+export interface CrawlPartial {
+	content: string;
+	version: number;
+}
+
 export type ArticleCrawl =
-	| { status: "pending"; stage?: CrawlStage; parts?: CrawlParts }
+	| { status: "pending"; stage?: CrawlStage; parts?: CrawlParts; partial?: CrawlPartial }
 	| { status: "ready" }
 	| { status: "failed"; reason: string }
 	| { status: "unsupported"; reason: string };

--- a/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.ts
+++ b/src/packages/test-fixtures/src/providers/article-crawl/in-memory-article-crawl.ts
@@ -20,6 +20,10 @@ export type InMemoryMarkCrawlStage = (params: {
 	url: string;
 	stage: CrawlStage;
 }) => Promise<void>;
+export type InMemoryMarkCrawlPartial = (params: {
+	url: string;
+	content: string;
+}) => Promise<void>;
 
 export function initInMemoryArticleCrawl(): {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
@@ -29,6 +33,7 @@ export function initInMemoryArticleCrawl(): {
 	markCrawlFailed: InMemoryMarkCrawlFailed;
 	markCrawlUnsupported: InMemoryMarkCrawlUnsupported;
 	markCrawlStage: InMemoryMarkCrawlStage;
+	markCrawlPartial: InMemoryMarkCrawlPartial;
 } {
 	const states = new Map<string, ArticleCrawl>();
 
@@ -91,7 +96,33 @@ export function initInMemoryArticleCrawl(): {
 			current?.status === "unsupported"
 		)
 			return;
-		states.set(id.value, { status: "pending", stage });
+		const next: ArticleCrawl = { status: "pending", stage };
+		if (current?.status === "pending" && current.partial) next.partial = current.partial;
+		states.set(id.value, next);
+	};
+
+	const markCrawlPartial: InMemoryMarkCrawlPartial = async ({ url, content }) => {
+		const id = ArticleResourceUniqueId.parse(url);
+		const current = states.get(id.value);
+		// Same guard as the DDB ConditionExpression: skip when the row has
+		// transitioned terminal (the writer would lose the race). Pending row
+		// or no row → write the partial.
+		if (
+			current?.status === "ready" ||
+			current?.status === "failed" ||
+			current?.status === "unsupported"
+		)
+			return;
+		const nextVersion = current?.status === "pending" && current.partial
+			? current.partial.version + 1
+			: 1;
+		const next: ArticleCrawl = {
+			status: "pending",
+			partial: { content, version: nextVersion },
+		};
+		if (current?.status === "pending" && current.stage) next.stage = current.stage;
+		if (current?.status === "pending" && current.parts) next.parts = current.parts;
+		states.set(id.value, next);
 	};
 
 	return {
@@ -102,5 +133,6 @@ export function initInMemoryArticleCrawl(): {
 		markCrawlFailed,
 		markCrawlUnsupported,
 		markCrawlStage,
+		markCrawlPartial,
 	};
 }


### PR DESCRIPTION
## Summary

Lets readers start reading the moment a crawl produces *any* usable content, with text appearing progressively rather than all-at-once. Applies to both HTML crawls (preview HTML appears after `simpleCrawl`, full Readability after parsing) and PDF crawls (Tesseract pages stream in document order as Stage 0 completes them).

Three logical layers, three commits:

1. **Data foundation** — new `partialContent` / `partialContentVersion` row attributes (REMOVE'd on terminal), `markCrawlPartial` provider with a condition-expression guard against the terminal-transition race, `extractPreviewHtml` helper for the HTML path, `initPartialContentThrottle` collapsing the PDF firehose to 1 write/sec, and an `onPartialHtml` callback threaded through `ExtractPdf` so `ocr-pdf` Stage 0 emits an in-order ready prefix as Tesseract pages complete.

2. **Streaming reader-slot** — new `streaming` sub-branch on the exhaustive `pending` switch in `reader-slot.component.ts` (no new `CrawlStatus` value). Renders a sandboxed iframe whose `srcdoc` carries an inlined bootstrap script. The parent-side `reader-stream.client.ts` opens an EventSource against the streaming Lambda and forwards each chunk via `postMessage`. Inside the iframe the bootstrap splits chunks into word-level `<span class="rp-word">` wrappers and reveals them on an adaptive cadence (EMA of inter-chunk gaps, clamped to `[15, 120]` ms/word) so the stream reads continuously even though chunks arrive in 250 ms bursts. The HTMX `every 3s` poll stays armed underneath as the always-on fallback path.

3. **Dedicated SSE Lambda** — synchronous request/response Lambda fronted by a Function URL in `RESPONSE_STREAM` mode (the main hutch Lambda runs `serverless-http` which buffers, so there's no path to true SSE through it). Loop: every 250 ms, `GetItem` the row; emit the delta past the client's `?from=<length>` cursor as `event: chunk`; terminal → `event: done` + close; 60 s cap without terminal → `event: reconnect` with the current cursor. CORS allowlist locked to the canonical domain; cookie auth runs inside the handler so the existing session table is the only DDB access.

## Architectural posture

- **Two allowed exceptions to "every Lambda must be backed by a queue with DLQ"** are now documented inline: the existing API-Gateway-fronted main Lambda, and the new Function-URL-fronted streaming Lambda — both synchronous request/response surfaces where failure is visible to the client and there's no async work in flight to lose.
- **Feature flag** is the `READER_STREAM_BASE_URL` env var. Read via `getEnv` (not `requireEnv`) so hutch can deploy before/without the streaming Lambda being provisioned — the slot falls back to the existing dots loader.
- **Open/Closed**: the slot dispatcher's exhaustive switch is preserved; the streaming variant slots in as a sub-branch of `pending` driven by the new `partial` field on the discriminated union.
- **Security**: streaming iframe carries `allow-scripts` (the bootstrap needs to run) plus the existing `allow-same-origin` (parent-side auto-height controller already needs this on reader-ready). Bootstrap validates `e.source === window.parent` and strips `<script>`/`<style>`/`<iframe>`/`<object>`/`<embed>` from every incoming chunk as defence-in-depth even though content was sanitised upstream.

## Tests

- `extract-preview-html.test.ts` (10), `init-partial-content-throttle.test.ts` (10), new `ocr-pdf` streaming-tap tests (5), new `comprehensive-crawl-handler` partial test (1), new `save-link-command-handler` partial-error test (1), new `dynamodb-article-crawl` partial mapping tests (2).
- `reader-slot.component.test.ts` extended with 4 streaming-branch cases. New `reader-streaming-iframe-srcdoc` is round-tripped through the existing iframe srcdoc test plus the bootstrap suite.
- `reader-stream-bootstrap.iframe.test.ts` (23): word wrapping preserves structure, `BLOCKED_TAGS` stripped, cadence math clamps, prerendered-content marking, `e.source` validation, no-text-chunk handling, rAF re-queuing.
- `reader-stream.client.test.ts` (13): EventSource lifecycle, retry → surrender, postMessage forwarding, ready-buffering, malformed-frame skipping, idempotent rescan.
- `reader-stream-handler.test.ts` (28): SSE frame shape, delta computation, reconnect cap, anonymous auth fallthrough, error swallowing, session-cookie extraction edge cases.

Coverage: all 24 projects at 100% / 96% thresholds. 1738 hutch tests pass.

## Test plan

- [x] `pnpm nx run-many --target=check --all` — green
- [x] `pnpm nx run hutch:check-infra` equivalent (`tsc --noEmit -p src/infra --sourceMap`) — green
- [ ] **Manual after deploy**: open `/view/<slow-PDF-url>`, confirm EventSource opens, chunks arrive, page reloads to canonical iframe on terminal
- [ ] **Manual after deploy**: rerun the 16-source crawler canary (`node src/packages/crawl-article/scripts/health-sources.js`) — security-bypass surface in `crawl-article.ts` / `aia-fetch.ts` / `h2-fetch.ts` / `curl-fetch.ts` / `persona-fallback.ts` / pre-parsers is untouched
- [ ] **Manual after deploy**: trigger Network → Offline mid-stream for ~3 s, confirm EventSource retries 3× then HTMX poll resumes the slot to terminal

## Plan vs. implementation deltas

- Sandbox: the plan's iframe sandbox attribute matched reader-ready (no `allow-scripts`); had to add `allow-scripts` because the bootstrap needs to execute. Defence-in-depth sanitisation moved into the bootstrap to keep the security boundary intact.
- `clearTimeoutFn` dep on the parent client got dropped — the WeakMap-based session dedupe replaced the `close()` plumbing, making the close-during-retry path unreachable.
- Skipped: the plan's optional belt-and-braces `await partialThrottle.flush({ url, html: finalHtml })` on `final` HTML — the throttle's existing flush already handles the last value reported by the OCR fan-out. Adding the explicit final flush would write the canonical HTML to `partialContent` only for the aggregate's terminal REMOVE to immediately delete it.

https://claude.ai/code/session_019ShtHzvfHiqrF5xaVDpCB9

---
_Generated by [Claude Code](https://claude.ai/code/session_019ShtHzvfHiqrF5xaVDpCB9)_