### PR TITLE
fix(hutch): default https:// for schemeless /admin/recrawl paths

### DIFF
--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -96,7 +96,13 @@ function handleRecrawlArticle(
 		const rawPath = req.params[0];
 		// API Gateway v2 HTTP API decodes %2F to /, restore https:/ → https://
 		// (same normalisation as /view).
-		const normalizedUrl = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
+		const restoredScheme = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
+		// Admin pastes the bare article URL (`fagnerbrack.com/post`) without a
+		// scheme. Default to https:// so the path resolves to the same DB row
+		// as the canonical save.
+		const normalizedUrl = /^https?:\/\//i.test(restoredScheme)
+			? restoredScheme
+			: `https://${restoredScheme}`;
 		const parsed = RecrawlUrlSchema.safeParse(normalizedUrl);
 		if (!parsed.success) {
 			await renderNotFound(deps, req, res);

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
@@ -285,6 +285,26 @@ describe("Admin recrawl routes", () => {
 			);
 		});
 
+		it("treats a schemeless path segment as https:// so admins can paste `host/path` without typing the scheme", async () => {
+			const harness = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			await harness.auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+			await harness.articleStore.saveArticleGlobally({
+				url: ARTICLE_URL,
+				metadata: { title: "T", siteName: "example.com", excerpt: "", wordCount: 0 },
+				estimatedReadTime: MinutesSchema.parse(1),
+				savedAt: new Date(),
+			});
+			await harness.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
+
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
+			// Mirrors the real bug report: /admin/recrawl/example.com/post (no scheme)
+			// previously rendered the "No article URL provided" error page.
+			const response = await agent.get("/admin/recrawl/example.com/post");
+
+			expect(response.status).toBe(200);
+			expect(harness.recrawlPublishedCalls).toEqual([{ url: ARTICLE_URL }]);
+		});
+
 		it("preserves the existing ready summary on the admin recrawl trigger — summary regeneration is decided downstream by the canonicalContentHash gate, not by wiping state up front", async () => {
 			const harness = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await harness.auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });


### PR DESCRIPTION
## Summary
- Pasting `/admin/recrawl/host/path` (no scheme) into the admin recrawl path rendered the `SaveErrorPage` ("No article URL provided") and redirected back to the landing page. Root cause: `req.params[0]` arrives without a scheme, `z.url()` rejects it, and the existing `https:/` → `https://` regex only fires for collapsed-scheme paths from API Gateway.
- `handleRecrawlArticle` now prepends `https://` when the wildcard segment is missing a scheme, so admins can paste the bare article URL. The downstream `findArticleByUrl` check still 404s for URLs that aren't in the DB — no risk of stub-row creation.
- Added a regression test that hits `/admin/recrawl/example.com/post` (mirrors the bug report) and asserts the page renders and `publishRecrawlLinkInitiated` is called with the canonical `https://example.com/post`.

## Test plan
- [x] `pnpm nx run hutch:check` — lint, type-check, unit + integration tests, 100% coverage gate
- [x] New test covers the schemeless path case
- [x] Existing tests for encoded-scheme path (`/admin/recrawl/https%3A%2F%2F…`) still pass
- [ ] Manual smoke after deploy: visit `/admin/recrawl/<host>/<path>` (no scheme) on prod and confirm the recrawl page renders instead of the error