### PR TITLE
fix(check-failed-articles): exclude typo domain fagnerbracj.com (NXDOMAIN)

### DIFF
--- a/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
@@ -219,6 +219,16 @@ describe("EXCLUDE_PATTERNS — operator-curated exact-URL entries", () => {
 			excluded: false,
 			label: "PwC same job ID different role slug — should NOT match",
 		},
+		{
+			url: "https://fagnerbracj.com/learn-python-the-hard-way-was-right-about-one-thing-9b6ab0b67526",
+			excluded: true,
+			label: "fagnerbracj typo domain exact (NXDOMAIN)",
+		},
+		{
+			url: "https://fagnerbrack.com/learn-python-the-hard-way-was-right-about-one-thing-9b6ab0b67526",
+			excluded: false,
+			label: "fagnerbrack correct domain — should NOT match",
+		},
 	];
 	for (const { url, excluded, label } of cases) {
 		it(`${excluded ? "excludes" : "keeps"}: ${label} — ${url}`, () => {

--- a/src/packages/check-failed-articles/scripts/exclude-patterns.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.ts
@@ -75,6 +75,10 @@ export const EXCLUDE_PATTERNS: readonly RegExp[] = [
 	// PwC HR system returns HTTP 410 Gone on every attempt — job posting was
 	// delisted at origin, so recrawl can never succeed.
 	/^https:\/\/jobs-au\.pwc\.com\/experiencedhires\/au\/en\/job\/597385WD\/Senior-Manager-Finance-Transformation-Global-Business-Services$/i,
+	// Typo domain: `fagnerbracj.com` (should be `fagnerbrack.com`, note
+	// `j` vs `k`). DNS returns NXDOMAIN — the domain does not exist and
+	// recrawl can never succeed.
+	/^https:\/\/fagnerbracj\.com\/learn-python-the-hard-way-was-right-about-one-thing-9b6ab0b67526$/i,
 ];
 
 export function isExcluded(url: string, patterns: readonly RegExp[]): boolean {


### PR DESCRIPTION
The domain `fagnerbracj.com` does not exist (DNS NXDOMAIN) — it is a typo of `fagnerbrack.com` (note `j` vs `k`). Recrawl can never succeed. Add the exact URL to the operator-curated exclude list so the failed-articles canary stops surfacing it.

Closes #447

Generated with [Claude Code](https://claude.ai/code)