### PR TITLE
feat(save-link): read born-digital PDFs from the text layer, OCR only scans

### DIFF
--- a/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
+++ b/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
@@ -6,7 +6,7 @@ import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
-import { extractPdfMetadata } from "@packages/crawl-article";
+import { extractPdfMetadata, extractPdfText } from "@packages/crawl-article";
 import { requireEnv } from "../require-env";
 import { initComprehensiveCrawlHandler } from "./domain/comprehensive-crawl/comprehensive-crawl-handler";
 import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
@@ -61,6 +61,7 @@ const { invokePageHtmlConvert } = initInvokePdfPageHtmlConvert({ client: lambdaC
 
 const extractPdf = initSaveLinkPdfExtract({
 	extractPdfMetadata,
+	extractPdfText,
 	stagePdf,
 	invokePageOcr,
 	invokePageLlmCleanup,

--- a/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.test.ts
@@ -40,6 +40,7 @@ describe("initSaveLinkPdfExtract", () => {
 
 		const extractPdf = initSaveLinkPdfExtract({
 			extractPdfMetadata,
+			extractPdfText: async () => "",
 			stagePdf,
 			invokePageOcr,
 			invokePageLlmCleanup: stubPageLlmCleanup,
@@ -54,5 +55,28 @@ describe("initSaveLinkPdfExtract", () => {
 		assert.equal(result.title, "Scanned Doc");
 		assert(result.html.includes("page-0"));
 		assert(result.html.includes("page-1"));
+	});
+
+	it("routes born-digital pages through the text layer instead of OCR", async () => {
+		let ocrCalled = false;
+		const extractPdf = initSaveLinkPdfExtract({
+			extractPdfMetadata: async () => ({ numPages: 1, title: "Digital" }),
+			extractPdfText: async () => "the embedded text layer",
+			stagePdf: async () => ({ key: "unused", cleanup: async () => {} }),
+			invokePageOcr: async () => {
+				ocrCalled = true;
+				return { ok: true, html: "" };
+			},
+			invokePageLlmCleanup: stubPageLlmCleanup,
+			invokeDocumentDiffReview: stubDocumentDiffReview,
+			invokePageHtmlConvert: stubPageHtmlConvert,
+			logger: noopLogger,
+		});
+
+		const result = await extractPdf({ buffer: Buffer.from("%PDF-"), url: "https://example.com/doc.pdf" });
+		assert.equal(result.kind, "fetched");
+		assert(result.kind === "fetched");
+		assert.equal(ocrCalled, false);
+		assert(result.html.includes("the embedded text layer"));
 	});
 });

--- a/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/init-save-link-pdf-extract.ts
@@ -1,4 +1,4 @@
-import type { ExtractPdf, ExtractPdfMetadata } from "@packages/crawl-article";
+import type { ExtractPdf, ExtractPdfMetadata, ExtractPdfText } from "@packages/crawl-article";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { initOcrPdf } from "./ocr-pdf";
 import type { InvokePdfPageOcr, StagePdfToS3 } from "./pdf-page-ocr-invoker.types";
@@ -7,19 +7,21 @@ import type { InvokePdfDocumentDiffReview } from "./pdf-document-diff-review-inv
 import type { InvokePdfPageHtmlConvert } from "./pdf-page-html-convert-invoker.types";
 
 /**
- * Composition helper for the comprehensive-crawl Lambda. The OCR pipeline is
- * a five-step pipeline: (1) pdfinfo for page count + title, (2) stage the
- * PDF to S3 once, (3) fan out per-page Tesseract OCR Lambdas, (4) feed
- * each page's text through the per-page LLM cleanup Lambda and then a
- * single whole-document diff-review Lambda, (5) fan out the per-page HTML
- * conversion Lambda that emits semantic HTML5 (headings, lists, tables,
- * pre/code, …) so Readability renders the reader view with structure
- * instead of a wall of paragraphs. Each step degrades gracefully — any
- * stage's failure ships the prior stage's output rather than failing the
- * whole document.
+ * Composition helper for the comprehensive-crawl Lambda. Pages that carry an
+ * embedded text layer are read directly with `pdftotext` and skip straight to
+ * semantic HTML conversion — no rasterisation, OCR, cleanup, or diff-review.
+ * Image-only pages fall through to the OCR pipeline: (1) pdfinfo for page
+ * count + title, (2) stage the PDF to S3 once, (3) fan out per-page Tesseract
+ * OCR Lambdas, (4) feed each page's text through the per-page LLM cleanup
+ * Lambda and then a single whole-document diff-review Lambda, (5) fan out the
+ * per-page HTML conversion Lambda that emits semantic HTML5 (headings, lists,
+ * tables, pre/code, …) so Readability renders the reader view with structure
+ * instead of a wall of paragraphs. Each step degrades gracefully — any stage's
+ * failure ships the prior stage's output rather than failing the whole document.
  */
 export function initSaveLinkPdfExtract(deps: {
 	extractPdfMetadata: ExtractPdfMetadata;
+	extractPdfText: ExtractPdfText;
 	stagePdf: StagePdfToS3;
 	invokePageOcr: InvokePdfPageOcr;
 	invokePageLlmCleanup: InvokePdfPageLlmCleanup;
@@ -29,6 +31,7 @@ export function initSaveLinkPdfExtract(deps: {
 }): ExtractPdf {
 	return initOcrPdf({
 		extractPdfMetadata: deps.extractPdfMetadata,
+		extractPdfText: deps.extractPdfText,
 		stagePdf: deps.stagePdf,
 		invokePageOcr: deps.invokePageOcr,
 		invokePageLlmCleanup: deps.invokePageLlmCleanup,

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.test.ts
@@ -69,6 +69,7 @@ function makeOcr(overrides: Partial<Parameters<typeof initOcrPdf>[0]> = {}) {
 	return initOcrPdf({
 		logger: noopLogger,
 		extractPdfMetadata: stubMetadata({ numPages: 1 }),
+		extractPdfText: async () => "",
 		stagePdf: stubStagePdf(),
 		invokePageOcr: stubInvokePageOcr(() => "default page text"),
 		invokePageLlmCleanup: stubCleanupPassthrough,
@@ -892,5 +893,149 @@ describe("initOcrPdf — stage 3 semantic HTML conversion", () => {
 
 		expect(observedPeak).toBeLessThanOrEqual(2);
 		expect(observedPeak).toBeGreaterThan(0);
+	});
+});
+
+describe("initOcrPdf — text-layer fast path", () => {
+	it("reads born-digital pages from the text layer, skipping staging/OCR/cleanup/diff-review", async () => {
+		let stageCalled = false;
+		let ocrCalled = false;
+		let cleanupCalled = false;
+		let diffReviewCalled = false;
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 2, title: "Born Digital" }),
+			extractPdfText: async () => "alpha text\fbeta text",
+			stagePdf: async () => {
+				stageCalled = true;
+				return { key: "unused", cleanup: async () => {} };
+			},
+			invokePageOcr: async () => {
+				ocrCalled = true;
+				return { ok: true, html: "" };
+			},
+			invokePageLlmCleanup: async ({ ocrText }) => {
+				cleanupCalled = true;
+				return { ok: true, cleanedText: ocrText, applied: false };
+			},
+			invokeDocumentDiffReview: async ({ pages }) => {
+				diffReviewCalled = true;
+				return { ok: true, applied: false, pages: pages.map((p) => ({ pageIndex: p.pageIndex, finalText: p.cleanedText })) };
+			},
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF-1.7"), url: "https://example.com/paper.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(stageCalled).toBe(false);
+		expect(ocrCalled).toBe(false);
+		expect(cleanupCalled).toBe(false);
+		expect(diffReviewCalled).toBe(false);
+		expect(result.title).toBe("Born Digital");
+		expect(result.html).toContain('<p class="ocr-tesseract">alpha text</p>');
+		expect(result.html).toContain('<p class="ocr-tesseract">beta text</p>');
+	});
+
+	it("still sends each text-layer page through the html-convert stage", async () => {
+		const converted: Array<{ pageIndex: number; pageText: string }> = [];
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 2 }),
+			extractPdfText: async () => "first page\fsecond page",
+			invokePageHtmlConvert: async ({ pageIndex, pageText }) => {
+				converted.push({ pageIndex, pageText });
+				return { ok: true, pageIndex, semanticHtml: `<h2>Page ${pageIndex}</h2>`, applied: true };
+			},
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(converted.sort((a, b) => a.pageIndex - b.pageIndex)).toEqual([
+			{ pageIndex: 0, pageText: "first page" },
+			{ pageIndex: 1, pageText: "second page" },
+		]);
+		expect(result.html).toContain("<h2>Page 0</h2>");
+		expect(result.html).toContain("<h2>Page 1</h2>");
+	});
+
+	it("OCRs only the image pages of a mixed text/scanned PDF", async () => {
+		const ocrCalls: number[][] = [];
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 3, title: "Mixed" }),
+			// page 0 has a text layer, pages 1 and 2 are image-only (empty segments)
+			extractPdfText: async () => "page zero text\f\f",
+			invokePageOcr: async ({ pageIndices }) => {
+				ocrCalls.push([...pageIndices]);
+				return { ok: true, html: tesseractParagraph(`ocr-page-${pageIndices[0]}`) };
+			},
+			batchSize: 1,
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/mixed.pdf" });
+
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(ocrCalls.sort((a, b) => a[0] - b[0])).toEqual([[1], [2]]);
+		expect(result.html).toContain('<p class="ocr-tesseract">page zero text</p>');
+		expect(result.html).toContain('<p class="ocr-tesseract">ocr-page-1</p>');
+		expect(result.html).toContain('<p class="ocr-tesseract">ocr-page-2</p>');
+	});
+
+	it("counts text-layer pages as successes so a mostly-digital PDF survives a failed image page", async () => {
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 5, title: "Mostly digital" }),
+			// 4 text pages + 1 image page (the trailing empty segment)
+			extractPdfText: async () => "p0\fp1\fp2\fp3\f",
+			invokePageOcr: async () => ({ ok: false, error: new Error("image page defeated OCR") }),
+			batchSize: 1,
+			partialSuccessThreshold: 0.8,
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		// 4/5 pages succeed via the text layer = 80%, meeting the threshold; the
+		// single failed image page renders a placeholder.
+		expect(result.kind).toBe("fetched");
+		if (result.kind !== "fetched") return;
+		expect(result.html).toContain('<p class="ocr-tesseract">p0</p>');
+		expect(result.html).toContain('<p class="ocr-failed">[Page 5: OCR unavailable]</p>');
+	});
+
+	it("reports text-layer pages as completed extraction progress without an OCR fan-out", async () => {
+		const progress: { partIndex: number; partCount: number; stage?: string }[] = [];
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 2 }),
+			extractPdfText: async () => "alpha\fbeta",
+		});
+
+		await ocr({
+			buffer: Buffer.from("%PDF"),
+			url: "https://example.com/x.pdf",
+			onProgress: (params) => { progress.push(params); },
+		});
+
+		// 2 text pages → 2 extracting fires, 1 cleaning stage-change marker, 2
+		// html-convert fires = 5 total.
+		expect(progress.filter((p) => p.stage === "comprehensive-extracting").length).toBe(2);
+		expect(progress.filter((p) => p.stage === "comprehensive-cleaning").length).toBe(3);
+		expect(progress.find((p) => p.stage === "comprehensive-cleaning" && p.partIndex === 0)).toBeDefined();
+	});
+
+	it("returns 'failed' when pdftotext throws — no silent OCR fallback", async () => {
+		let ocrCalled = false;
+		const ocr = makeOcr({
+			extractPdfMetadata: stubMetadata({ numPages: 2 }),
+			extractPdfText: async () => { throw new Error("pdftotext not found"); },
+			invokePageOcr: async ({ pageIndices }) => {
+				ocrCalled = true;
+				return { ok: true, html: tesseractParagraph(`ocr-${pageIndices[0]}`) };
+			},
+		});
+
+		const result = await ocr({ buffer: Buffer.from("%PDF"), url: "https://example.com/x.pdf" });
+
+		expect(result).toEqual({ kind: "failed", reason: "OCR pipeline failed: pdftotext not found" });
+		expect(ocrCalled).toBe(false);
 	});
 });

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -392,16 +392,13 @@ type ChunkOutcome =
 	| { ok: false; chunkIndex: number; pageIndices: readonly number[]; error: Error };
 
 /** Split `pdftotext` output into per-page text. pdftotext separates pages with
- * a form-feed (`\f`); a trailing form-feed yields an extra empty segment that
- * is ignored by indexing up to `numPages`. Pages beyond the produced segments
- * (e.g. pdftotext returned "" because it failed or the page is image-only) are
- * empty, i.e. image pages. */
+ * a form-feed (`\f`); a trailing form-feed yields an extra empty segment
+ * trimmed by `slice`. Pages beyond the produced segments default to empty
+ * strings — these are image-only pages routed to OCR. */
 function splitPageTexts(fullText: string, numPages: number): string[] {
 	const segments = fullText.split("\f");
-	const pages: string[] = [];
-	for (let i = 0; i < numPages; i++) {
-		pages.push(segments[i] ?? "");
-	}
+	const pages = segments.slice(0, numPages);
+	while (pages.length < numPages) pages.push("");
 	return pages;
 }
 

--- a/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
+++ b/projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import type { ExtractPdf, ExtractPdfMetadata, PdfExtractResult } from "@packages/crawl-article";
+import type { ExtractPdf, ExtractPdfMetadata, ExtractPdfText, PdfExtractResult } from "@packages/crawl-article";
 import { deriveTitleFromUrl, escapeHtmlText, MAX_PDF_BYTES, MAX_PDF_PAGES } from "@packages/crawl-article";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { retriable } from "@packages/retriable";
@@ -95,10 +95,13 @@ const PAGE_BREAK_HTML = '<hr class="ocr-page-break">';
 // link. Failed chunks render as `<p class="ocr-failed">` placeholders so the
 // document still reads as a whole and CSS can style the gaps. Below the
 // threshold the result is rejected the same way a total fan-out failure is.
+// Text-layer chunks (read straight from `pdftotext`) always count as
+// successes — only image chunks that fail OCR count against the ratio.
 const DEFAULT_PARTIAL_SUCCESS_THRESHOLD = 0.8;
 
 export function initOcrPdf(deps: {
 	extractPdfMetadata: ExtractPdfMetadata;
+	extractPdfText: ExtractPdfText;
 	stagePdf: StagePdfToS3;
 	invokePageOcr: InvokePdfPageOcr;
 	invokePageLlmCleanup: InvokePdfPageLlmCleanup;
@@ -122,7 +125,7 @@ export function initOcrPdf(deps: {
 	const maxPages = deps.maxPages ?? MAX_PDF_PAGES;
 	const maxPdfBytes = deps.maxPdfBytes ?? MAX_PDF_BYTES.bytes;
 	const partialSuccessThreshold = deps.partialSuccessThreshold ?? DEFAULT_PARTIAL_SUCCESS_THRESHOLD;
-	const { logger, extractPdfMetadata, stagePdf, invokePageOcr, invokePageLlmCleanup, invokeDocumentDiffReview, invokePageHtmlConvert } = deps;
+	const { logger, extractPdfMetadata, extractPdfText, stagePdf, invokePageOcr, invokePageLlmCleanup, invokeDocumentDiffReview, invokePageHtmlConvert } = deps;
 
 	return async ({ buffer, url, onProgress }): Promise<PdfExtractResult> => {
 		const t0 = Date.now();
@@ -154,7 +157,35 @@ export function initOcrPdf(deps: {
 		if (partCount === 0) {
 			return { kind: "failed", reason: "OCR returned no text across all batches" };
 		}
-		let completedParts = 0;
+
+		// Text-layer routing. `pdftotext` separates pages with a form-feed; a
+		// chunk whose every page carries non-empty text is read straight from
+		// the embedded text layer — skipping rasterise/OCR and the cleanup +
+		// diff-review passes that exist only to repair OCR error. A chunk with
+		// any empty page is OCR'd. A `pdftotext` failure fails the crawl the
+		// same way a pdfinfo failure does (surfacing on the DLQ) rather than
+		// silently masking a broken binary by falling back to OCR.
+		let fullText: string;
+		try {
+			fullText = await extractPdfText(buffer);
+		} catch (error) {
+			const message = normalizeUnknownError(error).message;
+			logger.error(`[ocr-pdf] pdftotext failed t=${Date.now() - t0}ms reason=${message}`);
+			return { kind: "failed", reason: `OCR pipeline failed: ${message}` };
+		}
+		const pageTexts = splitPageTexts(fullText, metadata.numPages);
+		const textChunkIndices = new Set<number>();
+		for (let i = 0; i < chunks.length; i++) {
+			if (chunks[i].every((pageIndex) => pageTexts[pageIndex].trim().length > 0)) {
+				textChunkIndices.add(i);
+			}
+		}
+		const imageChunks = chunks
+			.map((pageIndices, chunkIndex) => ({ pageIndices, chunkIndex }))
+			.filter(({ chunkIndex }) => !textChunkIndices.has(chunkIndex));
+		logger.info(`[ocr-pdf] routing pages=${metadata.numPages} textChunks=${textChunkIndices.size} imageChunks=${imageChunks.length} t=${Date.now() - t0}ms`);
+
+		const title = metadata.title ?? deriveTitleFromUrl(url);
 
 		const invokePageOcrWithRetry = retriable(invokePageOcr, {
 			maxAttempts: PAGE_OCR_MAX_ATTEMPTS,
@@ -162,167 +193,184 @@ export function initOcrPdf(deps: {
 			shouldRetry: (result) => !result.ok,
 		});
 
+		// Pre-HTML final text per chunk index. Text chunks resolve immediately;
+		// image chunks resolve after OCR + cleanup + diff-review. Chunks absent
+		// from this map are failed OCR chunks and render as placeholders.
+		const finalTextByChunkIndex = new Map<number, string>();
+		let completedParts = 0;
+
+		// Text chunks resolve with zero network work; report them as completed
+		// extraction parts so the progress bar advances for born-digital PDFs.
+		for (const chunkIndex of [...textChunkIndices].sort((a, b) => a - b)) {
+			finalTextByChunkIndex.set(
+				chunkIndex,
+				chunks[chunkIndex].map((pageIndex) => pageTexts[pageIndex]).join("\n\n"),
+			);
+			completedParts += 1;
+			onProgress?.({ partIndex: completedParts, partCount, stage: "comprehensive-extracting" });
+		}
+
 		try {
-			const staged = await stagePdf(buffer);
-			try {
-				const outcomes = await mapWithConcurrency(
-					chunks,
-					concurrency,
-					async (pageIndices): Promise<ChunkOutcome> => {
-						const chunkStart = Date.now();
-						const result = await invokePageOcrWithRetry({ pdfS3Key: staged.key, pageIndices, dpi });
-						if (!result.ok) {
-							return { ok: false, pageIndices, error: result.error };
+			if (imageChunks.length > 0) {
+				const staged = await stagePdf(buffer);
+				try {
+					const outcomes = await mapWithConcurrency(
+						imageChunks,
+						concurrency,
+						async ({ pageIndices, chunkIndex }): Promise<ChunkOutcome> => {
+							const chunkStart = Date.now();
+							const result = await invokePageOcrWithRetry({ pdfS3Key: staged.key, pageIndices, dpi });
+							if (!result.ok) {
+								return { ok: false, chunkIndex, pageIndices, error: result.error };
+							}
+							logger.info(`[ocr-pdf] chunk pages=[${pageIndices.join(",")}] done dt=${Date.now() - chunkStart}ms chars=${result.html.length} total=${Date.now() - t0}ms`);
+							completedParts += 1;
+							onProgress?.({ partIndex: completedParts, partCount, stage: "comprehensive-extracting" });
+							return { ok: true, chunkIndex, pageIndices, html: result.html };
+						},
+					);
+
+					const okOutcomes = outcomes.filter((o): o is OkChunkOutcome => o.ok);
+					const successCount = textChunkIndices.size + okOutcomes.length;
+					const successRatio = successCount / partCount;
+					if (successRatio < partialSuccessThreshold) {
+						const failedPages = collectFailedPages(outcomes);
+						logger.error(`[ocr-pdf] succeeded ${successCount}/${partCount} chunks ratio=${successRatio.toFixed(2)} threshold=${partialSuccessThreshold} — below threshold; failed pages=[${failedPages.join(",")}]`);
+						return { kind: "failed", reason: `OCR succeeded for ${successCount} of ${partCount} chunks — below ${Math.round(partialSuccessThreshold * 100)}% threshold` };
+					}
+
+					if (successCount < partCount) {
+						const failedPages = collectFailedPages(outcomes);
+						logger.warn(`[ocr-pdf] accepting partial result ${successCount}/${partCount} chunks ratio=${successRatio.toFixed(2)} threshold=${partialSuccessThreshold}; failed pages=[${failedPages.join(",")}]`);
+					}
+
+					// Stage 1 — per-page LLM cleanup for image chunks only. Extract
+					// plain text from each Tesseract HTML chunk, fan out cleanup
+					// invocations at the lower DeepSeek concurrency, and collect
+					// cleaned text per chunk. A cleanup failure on a chunk Tesseract
+					// succeeded on falls back to the original Tesseract text — never
+					// counts against the partial-success threshold above.
+					const originalTextByChunkIndex = new Map<number, string>();
+					const cleanedTextByChunkIndex = new Map<number, string>();
+					let cleanupCompletedParts = 0;
+					// Signal the stage transition before the cleanup fan-out so the
+					// orchestrator's `markCrawlStage` advances past "extracting" the
+					// moment Tesseract finishes, even if cleanup itself takes minutes.
+					onProgress?.({ partIndex: 0, partCount, stage: "comprehensive-cleaning" });
+					await mapWithConcurrency(okOutcomes, cleanupConcurrency, async (outcome) => {
+						const originalText = joinParagraphsAsText(extractTesseractParagraphs(outcome.html));
+						originalTextByChunkIndex.set(outcome.chunkIndex, originalText);
+						const cleanupResult = await invokePageLlmCleanup({
+							pageIndex: outcome.pageIndices[0],
+							ocrText: originalText,
+						});
+						if (cleanupResult.ok) {
+							cleanedTextByChunkIndex.set(outcome.chunkIndex, cleanupResult.cleanedText);
+						} else {
+							logger.warn(`[ocr-pdf] cleanup invoke failed for pages=[${outcome.pageIndices.join(",")}] reason=${cleanupResult.error.message} — using original Tesseract text`);
+							cleanedTextByChunkIndex.set(outcome.chunkIndex, originalText);
 						}
-						logger.info(`[ocr-pdf] chunk pages=[${pageIndices.join(",")}] done dt=${Date.now() - chunkStart}ms chars=${result.html.length} total=${Date.now() - t0}ms`);
-						completedParts += 1;
-						onProgress?.({ partIndex: completedParts, partCount, stage: "comprehensive-extracting" });
-						return { ok: true, pageIndices, html: result.html };
-					},
-				);
+						cleanupCompletedParts += 1;
+						onProgress?.({ partIndex: cleanupCompletedParts, partCount, stage: "comprehensive-cleaning" });
+					});
 
-				const successCount = outcomes.filter((o) => o.ok).length;
-				const successRatio = successCount / partCount;
-				if (successRatio < partialSuccessThreshold) {
-					const failedPages = collectFailedPages(outcomes);
-					logger.error(`[ocr-pdf] succeeded ${successCount}/${partCount} chunks ratio=${successRatio.toFixed(2)} threshold=${partialSuccessThreshold} — below threshold; failed pages=[${failedPages.join(",")}]`);
-					return { kind: "failed", reason: `OCR succeeded for ${successCount} of ${partCount} chunks — below ${Math.round(partialSuccessThreshold * 100)}% threshold` };
+					// Stage 2 — document diff review. Single sync invoke with every
+					// successful image page's original + cleaned text. The Lambda
+					// computes diffs internally and returns one final text per page.
+					// On any failure the page-level cleanedText is shipped as the
+					// final text — same fall-back as if Stage 2 had been disabled.
+					const reviewInputPages = okOutcomes.map((outcome) => {
+						const originalText = originalTextByChunkIndex.get(outcome.chunkIndex);
+						const cleanedText = cleanedTextByChunkIndex.get(outcome.chunkIndex);
+						assert(originalText !== undefined, "ok outcome must have populated originalText");
+						assert(cleanedText !== undefined, "ok outcome must have populated cleanedText");
+						return { chunkIndex: outcome.chunkIndex, pageIndex: outcome.pageIndices[0], originalText, cleanedText };
+					});
+					if (reviewInputPages.length > 0) {
+						const reviewResult = await invokeDocumentDiffReview({
+							pages: reviewInputPages.map(({ pageIndex, originalText, cleanedText }) => ({ pageIndex, originalText, cleanedText })),
+						});
+						if (reviewResult.ok) {
+							const finalByPageIndex = new Map(reviewResult.pages.map((page) => [page.pageIndex, page.finalText]));
+							for (const page of reviewInputPages) {
+								const finalText = finalByPageIndex.get(page.pageIndex);
+								assert(finalText !== undefined, "diff-review must return a final text for every reviewed page");
+								finalTextByChunkIndex.set(page.chunkIndex, finalText);
+							}
+						} else {
+							logger.warn(`[ocr-pdf] diff-review invoke failed reason=${reviewResult.error.message} — using stage 1 cleaned text per page`);
+							for (const page of reviewInputPages) {
+								finalTextByChunkIndex.set(page.chunkIndex, page.cleanedText);
+							}
+						}
+					}
+				} finally {
+					await staged.cleanup();
 				}
-
-				if (successCount < partCount) {
-					const failedPages = collectFailedPages(outcomes);
-					logger.warn(`[ocr-pdf] accepting partial result ${successCount}/${partCount} chunks ratio=${successRatio.toFixed(2)} threshold=${partialSuccessThreshold}; failed pages=[${failedPages.join(",")}]`);
-				}
-
-				// Stage 1 — per-page LLM cleanup. Extract plain text from each
-				// Tesseract HTML chunk, fan out cleanup invocations at the lower
-				// DeepSeek concurrency, and collect cleaned text per chunk. A
-				// cleanup failure on a chunk Tesseract succeeded on falls back
-				// to the original Tesseract text — never counts against the
-				// partial-success threshold above (Tesseract already produced
-				// usable text for this chunk).
-				const originalTexts: Array<string | null> = outcomes.map((outcome) =>
-					outcome.ok ? joinParagraphsAsText(extractTesseractParagraphs(outcome.html)) : null,
-				);
-				const cleanedTexts: Array<string | null> = new Array(outcomes.length).fill(null);
-				let cleanupCompletedParts = 0;
-				// Signal the stage transition before the cleanup fan-out so the
-				// orchestrator's `markCrawlStage` advances past "extracting" the
-				// moment Tesseract finishes, even if cleanup itself takes minutes.
+			} else {
+				// No OCR phase ran, so the stage marker above never fired. Advance
+				// the progress bar past "extracting" before the html-convert wave.
 				onProgress?.({ partIndex: 0, partCount, stage: "comprehensive-cleaning" });
-				await mapWithConcurrency(outcomes, cleanupConcurrency, async (outcome, index) => {
-					if (!outcome.ok) return;
-					const originalText = originalTexts[index];
-					assert(originalText !== null, "ok outcome must produce non-null originalText");
-					const cleanupResult = await invokePageLlmCleanup({
-						pageIndex: outcome.pageIndices[0],
-						ocrText: originalText,
-					});
-					if (cleanupResult.ok) {
-						cleanedTexts[index] = cleanupResult.cleanedText;
-					} else {
-						logger.warn(`[ocr-pdf] cleanup invoke failed for pages=[${outcome.pageIndices.join(",")}] reason=${cleanupResult.error.message} — using original Tesseract text`);
-						cleanedTexts[index] = originalText;
-					}
-					cleanupCompletedParts += 1;
-					onProgress?.({ partIndex: cleanupCompletedParts, partCount, stage: "comprehensive-cleaning" });
-				});
-
-				// Stage 2 — document diff review. Single sync invoke with every
-				// successful page's original + cleaned text. The Lambda computes
-				// diffs internally and returns one final text per page. On any
-				// failure (invoke error, schema mismatch, document-level
-				// guardrail rejection) the page-level cleanedText is shipped as
-				// the final text — same fall-back as if Stage 2 had been disabled.
-				const reviewInputPages = outcomes
-					.map((outcome, index) => ({ outcome, index }))
-					.filter(({ outcome }) => outcome.ok)
-					.map(({ outcome, index }) => {
-						const originalText = originalTexts[index];
-						const cleanedText = cleanedTexts[index];
-						assert(originalText !== null, "ok outcome must have populated originalText");
-						assert(cleanedText !== null, "ok outcome must have populated cleanedText");
-						return { pageIndex: outcome.pageIndices[0], originalText, cleanedText };
-					});
-				const finalByPageIndex = new Map<number, string>();
-				if (reviewInputPages.length > 0) {
-					const reviewResult = await invokeDocumentDiffReview({ pages: reviewInputPages });
-					if (reviewResult.ok) {
-						for (const page of reviewResult.pages) {
-							finalByPageIndex.set(page.pageIndex, page.finalText);
-						}
-					} else {
-						logger.warn(`[ocr-pdf] diff-review invoke failed reason=${reviewResult.error.message} — using stage 1 cleaned text per page`);
-						for (const page of reviewInputPages) {
-							finalByPageIndex.set(page.pageIndex, page.cleanedText);
-						}
-					}
-				}
-
-				// Stage 3 — per-page semantic HTML conversion. Fan out one Lambda
-				// per ok page with the post-diff-review final text; each Lambda
-				// emits a sanitised HTML5 fragment with semantic structure
-				// (h2/h3, ul/ol, table, pre/code, …) so Readability renders the
-				// reader view with the article's original structure rather than
-				// a wall of paragraphs. Per-Lambda fallback wraps the text in
-				// `<p class="ocr-tesseract">` if the LLM call or guardrails
-				// reject, and the orchestrator falls back to the same wrap if
-				// the invoke itself fails.
-				const htmlByPageIndex = new Map<number, string>();
-				let htmlConvertCompletedParts = 0;
-				await mapWithConcurrency(reviewInputPages, htmlConvertConcurrency, async (page) => {
-					const finalText = finalByPageIndex.get(page.pageIndex);
-					assert(finalText !== undefined, "ok page must have a final text after stage 2");
-					const convertResult = await invokePageHtmlConvert({
-						pageIndex: page.pageIndex,
-						pageText: finalText,
-					});
-					if (convertResult.ok) {
-						htmlByPageIndex.set(page.pageIndex, convertResult.semanticHtml);
-					} else {
-						logger.warn(`[ocr-pdf] html-convert invoke failed for page=${page.pageIndex} reason=${convertResult.error.message} — wrapping final text as <p class="ocr-tesseract"> paragraphs`);
-						htmlByPageIndex.set(page.pageIndex, rewrapAsTesseractHtml(finalText));
-					}
-					htmlConvertCompletedParts += 1;
-					onProgress?.({ partIndex: htmlConvertCompletedParts, partCount, stage: "comprehensive-cleaning" });
-				});
-
-				const fragments = outcomes.map((outcome) => {
-					if (!outcome.ok) return renderFailedChunkPlaceholder(outcome.pageIndices);
-					const html = htmlByPageIndex.get(outcome.pageIndices[0]);
-					assert(html !== undefined, "ok outcome must have html after stage 3");
-					return html;
-				});
-
-				// Insert a class-tagged <hr> between adjacent chunk fragments so
-				// the reader-iframe stylesheet can render a subtle dotted
-				// page-break in book-section style. Joining with the marker
-				// (rather than appending after each fragment) keeps the break
-				// strictly *between* pages — no leading/trailing rule. The
-				// document-level sanitiser allows `class` on <hr>, so the
-				// marker survives the final defensive pass.
-				const combined = fragments.map((t) => t.trim()).filter((t) => t.length > 0).join(PAGE_BREAK_HTML);
-				if (combined.length === 0) {
-					return { kind: "failed", reason: "OCR returned no text across all batches" };
-				}
-
-				const title = metadata.title ?? deriveTitleFromUrl(url);
-				logger.info(`[ocr-pdf] done t=${Date.now() - t0}ms pages=${metadata.numPages} chars=${combined.length}`);
-				// Final sanitisation pass across the stitched body. Each per-page
-				// fragment was sanitised inside its Stage 3 Lambda, but stitching
-				// can leave dangling tags spanning page boundaries (e.g. an
-				// unclosed <ul> from page N rejoining an <li> from page N+1) —
-				// this pass closes them via linkedom's parse-then-serialise
-				// round-trip and re-enforces the element / attribute allowlist
-				// on the whole document.
-				return {
-					kind: "fetched",
-					html: buildSyntheticHtml({ title, body: sanitizeFragment(combined) }),
-					title,
-				};
-			} finally {
-				await staged.cleanup();
 			}
+
+			// Stage 3 — per-page semantic HTML conversion for every resolved
+			// chunk, text-layer and OCR'd alike. Each Lambda emits a sanitised
+			// HTML5 fragment with semantic structure (h2/h3, ul/ol, table,
+			// pre/code, …) so Readability renders the reader view with the
+			// article's original structure rather than a wall of paragraphs.
+			// Per-Lambda fallback wraps the text in `<p class="ocr-tesseract">`
+			// if the LLM call or guardrails reject.
+			const resolvedChunkIndices = [...finalTextByChunkIndex.keys()].sort((a, b) => a - b);
+			const htmlByChunkIndex = new Map<number, string>();
+			let htmlConvertCompletedParts = 0;
+			await mapWithConcurrency(resolvedChunkIndices, htmlConvertConcurrency, async (chunkIndex) => {
+				const finalText = finalTextByChunkIndex.get(chunkIndex);
+				assert(finalText !== undefined, "resolved chunk must have a final text before stage 3");
+				const convertResult = await invokePageHtmlConvert({
+					pageIndex: chunks[chunkIndex][0],
+					pageText: finalText,
+				});
+				if (convertResult.ok) {
+					htmlByChunkIndex.set(chunkIndex, convertResult.semanticHtml);
+				} else {
+					logger.warn(`[ocr-pdf] html-convert invoke failed for page=${chunks[chunkIndex][0]} reason=${convertResult.error.message} — wrapping final text as <p class="ocr-tesseract"> paragraphs`);
+					htmlByChunkIndex.set(chunkIndex, rewrapAsTesseractHtml(finalText));
+				}
+				htmlConvertCompletedParts += 1;
+				onProgress?.({ partIndex: htmlConvertCompletedParts, partCount, stage: "comprehensive-cleaning" });
+			});
+
+			const fragments = chunks.map((pageIndices, chunkIndex) => {
+				const html = htmlByChunkIndex.get(chunkIndex);
+				if (html === undefined) return renderFailedChunkPlaceholder(pageIndices);
+				return html;
+			});
+
+			// Insert a class-tagged <hr> between adjacent chunk fragments so
+			// the reader-iframe stylesheet can render a subtle dotted
+			// page-break in book-section style. Joining with the marker
+			// (rather than appending after each fragment) keeps the break
+			// strictly *between* pages — no leading/trailing rule. The
+			// document-level sanitiser allows `class` on <hr>, so the
+			// marker survives the final defensive pass.
+			const combined = fragments.map((t) => t.trim()).filter((t) => t.length > 0).join(PAGE_BREAK_HTML);
+			if (combined.length === 0) {
+				return { kind: "failed", reason: "OCR returned no text across all batches" };
+			}
+
+			logger.info(`[ocr-pdf] done t=${Date.now() - t0}ms pages=${metadata.numPages} chars=${combined.length}`);
+			// Final sanitisation pass across the stitched body. Each per-page
+			// fragment was sanitised inside its Stage 3 Lambda, but stitching
+			// can leave dangling tags spanning page boundaries (e.g. an
+			// unclosed <ul> from page N rejoining an <li> from page N+1) —
+			// this pass closes them via linkedom's parse-then-serialise
+			// round-trip and re-enforces the element / attribute allowlist
+			// on the whole document.
+			return {
+				kind: "fetched",
+				html: buildSyntheticHtml({ title, body: sanitizeFragment(combined) }),
+				title,
+			};
 		} catch (error) {
 			// Chunk failures are captured into ChunkOutcome and surface via the
 			// partial-success threshold above, not via throw. This catch covers
@@ -338,9 +386,24 @@ export function initOcrPdf(deps: {
 	};
 }
 
+type OkChunkOutcome = { ok: true; chunkIndex: number; pageIndices: readonly number[]; html: string };
 type ChunkOutcome =
-	| { ok: true; pageIndices: readonly number[]; html: string }
-	| { ok: false; pageIndices: readonly number[]; error: Error };
+	| OkChunkOutcome
+	| { ok: false; chunkIndex: number; pageIndices: readonly number[]; error: Error };
+
+/** Split `pdftotext` output into per-page text. pdftotext separates pages with
+ * a form-feed (`\f`); a trailing form-feed yields an extra empty segment that
+ * is ignored by indexing up to `numPages`. Pages beyond the produced segments
+ * (e.g. pdftotext returned "" because it failed or the page is image-only) are
+ * empty, i.e. image pages. */
+function splitPageTexts(fullText: string, numPages: number): string[] {
+	const segments = fullText.split("\f");
+	const pages: string[] = [];
+	for (let i = 0; i < numPages; i++) {
+		pages.push(segments[i] ?? "");
+	}
+	return pages;
+}
 
 function collectFailedPages(outcomes: readonly ChunkOutcome[]): number[] {
 	const failed: number[] = [];

--- a/src/packages/crawl-article/scripts/health-sources.ts
+++ b/src/packages/crawl-article/scripts/health-sources.ts
@@ -1,34 +1,13 @@
-/**
- * Labelled source list exercised by tier-1-plus-pipeline-health.ts.
- *
- * Keep the list diverse — one entry per edge-sniffing vendor we care about.
- * Failures surface the `label` in the GitHub Actions UI, not a URL.
- *
- * A canary failure is a real failure: the crawler must handle TLS-fingerprint
- * blocks (e.g. Stack Overflow via Cloudflare) so production traffic still
- * reaches the origin. Fix the crawler before touching this list.
- *
- * `expectsThumbnail` asserts the thumbnail download path: `true` means the
- * source has an og:image/twitter:image that must fetch successfully under
- * the same H2-fallback path as the article HTML, `false` means the source
- * legitimately has no thumbnail (e.g. X/Twitter via oembed returns synthetic
- * HTML with no meta tags).
- */
 export interface HealthSource {
 	label: string;
 	url: string;
 	expectedContent: string;
-	/** Substrings that MUST NOT appear in the parsed HTML — surfaces parser regressions where site chrome leaks into the article body (e.g. Medium byline, read-time, publish-date, "Press enter…" tooltip). */
 	forbiddenContent?: readonly string[];
 	expectsThumbnail: boolean;
 }
 
 export const HEALTH_SOURCES: readonly HealthSource[] = [
 	{
-		// Medium publications (e.g. itnext.io) serve an incomplete TLS chain —
-		// leaf cert without the Sectigo intermediate. Node's fetch fails with
-		// UNABLE_TO_VERIFY_LEAF_SIGNATURE. AIA chasing (aia-fetch.ts) recovers
-		// by fetching the intermediate from the leaf cert's AIA URL.
 		label: "Medium (itnext publication)",
 		url: "https://itnext.io/youre-not-praised-for-the-bugs-you-didn-t-create-ef3df6894d5c",
 		expectedContent: "developers were creating more and more bugs, only to fix them and get the prize",
@@ -47,10 +26,6 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		expectsThumbnail: true,
 	},
 	{
-		// expectedContent is picked from Readability's parsed output (not the
-		// raw HTML) so the tier-1+ canary's substring check survives the parser.
-		// The "funnel / twisting gorge" passage exists in the raw HTML but does
-		// not land in what Readability extracts for this interactive page.
 		label: "NYTimes",
 		url: "https://www.nytimes.com/projects/2012/snow-fall/index.html",
 		expectedContent: "When you’re up on top of a peak like that",
@@ -69,10 +44,6 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		expectsThumbnail: true,
 	},
 	{
-		// The Ars Technica "linux features" URL is an index of multiple short
-		// articles. Readability deterministically extracts one of them
-		// ("Monitoring network traffic with Ruby and Pcap"); expectedContent
-		// targets a distinctive substring inside that extraction.
 		label: "Ars Technica",
 		url: "https://arstechnica.com/features/2005/10/linux/",
 		expectedContent: "take a gander at The GIMP’s procedure database",
@@ -103,9 +74,6 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		expectsThumbnail: false,
 	},
 	{
-		// Tweet URLs with a `/video/<n>` or `/photo/<n>` sub-path 404 against
-		// Twitter's oembed endpoint. The crawler canonicalises to the bare
-		// `<handle>/status/<id>` form so this longhand URL still resolves.
 		label: "X (Twitter — /video/<n> longhand)",
 		url: "https://x.com/AnatoliKopadze/status/2057105488165163198/video/1?s=46",
 		expectedContent: "Stanford lecture",
@@ -118,84 +86,36 @@ export const HEALTH_SOURCES: readonly HealthSource[] = [
 		expectsThumbnail: false,
 	},
 	{
-		// The Information serves a plain Cloudflare "Attention Required!" 403 to
-		// HTTP/1.1 clients, with no `cf-mitigated: challenge` header (unlike
-		// Medium's managed challenge). The H2 fallback triggers on any Cloudflare
-		// 403 (`server: cloudflare`), not just managed challenges — this source
-		// exercises that broader gate.
-		//
-		// Article body is paywalled server-side (`fullText: null` for non-
-		// subscribers; no UA/referer trick unlocks it). The public page exposes
-		// the opening paragraphs via the React-on-Rails `freeBlurb` JSON island,
-		// so the canary anchors on a phrase from that lead paragraph — specific
-		// article content, not site chrome.
 		label: "The Information",
 		url: "https://www.theinformation.com/articles/musk-bought-1-4-billion-spacex-shares-helping-boost-control",
 		expectedContent: "his stake in SpaceX last year by purchasing $1.4 billion of stock",
 		expectsThumbnail: true,
 	},
 	{
-		// Exercises the PDF path end-to-end: detection + per-page OCR Lambda
-		// fan-out (rasterisation + DeepInfra vision) + sanitizer + Readability
-		// over the synthetic HTML. fai.org serves the file with Content-Type
-		// `application/pdf`.
-		//
-		// PDFs do not expose og:image/twitter:image metadata, so the thumbnail
-		// path is intentionally skipped — same precedent as the X/Twitter
-		// oembed entry below.
 		label: "PDF (FAI airmanship)",
 		url: "https://www.fai.org/sites/default/files/documents/airmanship_good.pdf",
 		expectedContent: "considerable confusion as to what airmanship actually comprises",
 		expectsThumbnail: false,
 	},
 	{
-		// Second PDF entry — a technical paper with equations, multi-column
-		// layout, tables, and figure captions. Exercises the vision model's
-		// structural inference on dense academic typography (Attention Is All
-		// You Need by Vaswani et al., 2017). Catches regressions where the
-		// vision pipeline degrades on structured content.
 		label: "PDF (arXiv Transformer paper)",
 		url: "https://arxiv.org/pdf/1706.03762v7",
 		expectedContent: "Attention Is All You Need",
 		expectsThumbnail: false,
 	},
 	{
-		// Akamai BotManager blocks standard curl's TLS fingerprint with HTTP/2
-		// RST_STREAM (exit 92). curl-impersonate's Chrome ClientHello bypasses
-		// this without a proxy — the discriminator is the TLS handshake, not the
-		// source IP.
 		label: "PDF (USDA sample)",
 		url: "https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf",
 		expectedContent: "Dummy PDF file",
 		expectsThumbnail: false,
 	},
 	{
-		// CIA reading-room 302-loops AWS IPs to /readingroom when the TLS
-		// fingerprint looks non-browser (curl exit 47). curl-impersonate with
-		// Chrome fingerprint returns 200 directly. Exercises --globoff +
-		// WHATWG URL re-encoding via the bracketed path segment `[16505689]`.
-		// Pages 22–25 of this 31-page scan are image-heavy and individually
-		// defeat DeepInfra's 360s SDK budget; the OCR pipeline's partial-
-		// success threshold (see ocr-pdf.ts) accepts the remaining 27/31
-		// pages (0.871) and renders placeholders for the rest.
-		// `expectedContent` appears on pages 1, 2, 3, 5, 6, 18, 21, 28, 30,
-		// 31, all outside the known-flaky range — confirmed via
-		// `pdftotext -f N -l N` against the staged source PDF.
 		label: "PDF (CIA reading room)",
 		url: "https://www.cia.gov/readingroom/docs/COMPUTERS%20AND%20AUTOMATION%20[16505689].pdf",
 		expectedContent: "Warren Commission",
 		expectsThumbnail: false,
 	},
 	{
-		// Adobe-class fingerprint-strict origin. Sent today's partial Chrome
-		// headers and Adobe's edge RSTs the h2 stream (curl exit 92,
-		// INTERNAL_ERROR). Either a coherent full-Chrome persona or the
-		// `honest-bot` persona pass. If this entry fails, the persona-fallback
-		// chain has lost both — investigate the chain before touching this URL.
-		//
-		// expectedContent anchors on page-1 prose ("four distinct fields")
-		// rather than the bullet-point text ("bookmarks in a PDF file") that
-		// the HTML-conversion LLM can restructure non-deterministically.
 		label: "PDF (Adobe sample)",
 		url: "https://www.adobe.com/support/products/enterprise/knowledgecenter/media/c4611_sample_explain.pdf",
 		expectedContent: "simple form containing four distinct fields",

--- a/src/packages/crawl-article/scripts/health-sources.ts
+++ b/src/packages/crawl-article/scripts/health-sources.ts
@@ -7,115 +7,115 @@ export interface HealthSource {
 }
 
 export const HEALTH_SOURCES: readonly HealthSource[] = [
-	{
+	{ // AIA chain — incomplete TLS cert (f9b2f36c)
 		label: "Medium (itnext publication)",
 		url: "https://itnext.io/youre-not-praised-for-the-bugs-you-didn-t-create-ef3df6894d5c",
 		expectedContent: "developers were creating more and more bugs, only to fix them and get the prize",
 		expectsThumbnail: true,
 	},
-	{
+	{ // baseline crawl sanity (f9b2f36c)
 		label: "Wikipedia (baseline)",
 		url: "https://en.wikipedia.org/wiki/Reading",
 		expectedContent: "children and adults read because it is enjoyable",
 		expectsThumbnail: true,
 	},
-	{
+	{ // newsletter extraction (f9b2f36c)
 		label: "Substack",
 		url: "https://newsletter.pragmaticengineer.com/p/wrapped-the-pragmatic-engineer-in",
 		expectedContent: "Some fundamentals will not change",
 		expectsThumbnail: true,
 	},
-	{
+	{ // interactive page Readability (f9b2f36c)
 		label: "NYTimes",
 		url: "https://www.nytimes.com/projects/2012/snow-fall/index.html",
 		expectedContent: "When you’re up on top of a peak like that",
 		expectsThumbnail: true,
 	},
-	{
+	{ // repo README extraction (f9b2f36c)
 		label: "GitHub",
 		url: "https://github.com/js-cookie/js-cookie",
 		expectedContent: "All special characters that are not allowed in the cookie-name or cookie-value",
 		expectsThumbnail: true,
 	},
-	{
+	{ // abstract page extraction (f9b2f36c)
 		label: "arXiv",
 		url: "https://arxiv.org/abs/1706.03762",
 		expectedContent: "Experiments on two machine translation tasks show these models",
 		expectsThumbnail: true,
 	},
-	{
+	{ // multi-article index Readability (f9b2f36c)
 		label: "Ars Technica",
 		url: "https://arstechnica.com/features/2005/10/linux/",
 		expectedContent: "take a gander at The GIMP’s procedure database",
 		expectsThumbnail: true,
 	},
-	{
+	{ // Cloudflare TLS fingerprint (f9b2f36c)
 		label: "Stack Overflow",
 		url: "https://stackoverflow.com/questions/11227809/why-is-processing-a-sorted-array-faster-than-processing-an-unsorted-array",
 		expectedContent: "You are a blind operator of a junction and you hear a train coming",
 		expectsThumbnail: true,
 	},
-	{
+	{ // paywall-gated longform (f9b2f36c)
 		label: "The New Yorker",
 		url: "https://www.newyorker.com/magazine/1946/08/31/hiroshima",
 		expectedContent: "Mr. Matsuo dashed up the front steps into the house and dived among the bedrolls and buried himself there",
 		expectsThumbnail: true,
 	},
-	{
+	{ // social post extraction (f9b2f36c)
 		label: "LinkedIn",
 		url: "https://www.linkedin.com/posts/fagnerbrack_ai-webdev-softwareengineering-activity-7429345910167453696-2MJD?utm_source=share&utm_medium=member_desktop&rcm=ACoAAA5sDgUBEQM_1ZyxJFG0-Bvfm4gOYd-wqo4",
 		expectedContent: "The issue now is that people realised coding was never the bottleneck",
 		expectsThumbnail: true,
 	},
-	{
+	{ // oembed tweet extraction (f9b2f36c)
 		label: "X (Twitter)",
 		url: "https://x.com/elonmusk/status/1519480761749016577",
 		expectedContent: "buying Coca-Cola to put the cocaine back in",
 		expectsThumbnail: false,
 	},
-	{
+	{ // /video/<n> URL canonicalisation (c245df93)
 		label: "X (Twitter — /video/<n> longhand)",
 		url: "https://x.com/AnatoliKopadze/status/2057105488165163198/video/1?s=46",
 		expectedContent: "Stanford lecture",
 		expectsThumbnail: false,
 	},
-	{
+	{ // plain static HTML baseline (f9b2f36c)
 		label: "Static HTML (hex.ooo)",
 		url: "https://hex.ooo/library/last_question.html",
 		expectedContent: "he had had to carry the ice and glassware",
 		expectsThumbnail: false,
 	},
-	{
+	{ // Cloudflare H2 403 fallback (f9b2f36c)
 		label: "The Information",
 		url: "https://www.theinformation.com/articles/musk-bought-1-4-billion-spacex-shares-helping-boost-control",
 		expectedContent: "his stake in SpaceX last year by purchasing $1.4 billion of stock",
 		expectsThumbnail: true,
 	},
-	{
+	{ // PDF detection + OCR pipeline (b06f2ff1)
 		label: "PDF (FAI airmanship)",
 		url: "https://www.fai.org/sites/default/files/documents/airmanship_good.pdf",
 		expectedContent: "considerable confusion as to what airmanship actually comprises",
 		expectsThumbnail: false,
 	},
-	{
+	{ // dense academic PDF with equations/tables (b415c004)
 		label: "PDF (arXiv Transformer paper)",
 		url: "https://arxiv.org/pdf/1706.03762v7",
 		expectedContent: "Attention Is All You Need",
 		expectsThumbnail: false,
 	},
-	{
+	{ // Akamai BotManager TLS fingerprint (aa3f96d7)
 		label: "PDF (USDA sample)",
 		url: "https://www.rd.usda.gov/sites/default/files/pdf-sample_0.pdf",
 		expectedContent: "Dummy PDF file",
 		expectsThumbnail: false,
 	},
-	{
+	{ // CIA 302-loop TLS + partial OCR threshold (aa3f96d7)
 		label: "PDF (CIA reading room)",
 		url: "https://www.cia.gov/readingroom/docs/COMPUTERS%20AND%20AUTOMATION%20[16505689].pdf",
 		expectedContent: "Warren Commission",
 		expectsThumbnail: false,
 	},
-	{
+	{ // Adobe edge RST_STREAM persona-fallback (3501fb72)
 		label: "PDF (Adobe sample)",
 		url: "https://www.adobe.com/support/products/enterprise/knowledgecenter/media/c4611_sample_explain.pdf",
 		expectedContent: "simple form containing four distinct fields",

--- a/src/packages/crawl-article/src/extract-pdf-text.ts
+++ b/src/packages/crawl-article/src/extract-pdf-text.ts
@@ -1,0 +1,29 @@
+/* c8 ignore start -- thin poppler-utils boundary wrapper, exercised in production at Lambda cold start and in CI via the PDF health canary (scripts/health-sources.ts → arXiv Transformer paper). The child_process call to pdftotext can't be unit-tested without re-implementing it, so consumers stub this function at the orchestrator. */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runCommand } from "./run-command";
+
+export type ExtractPdfText = (buffer: Buffer) => Promise<string>;
+
+/**
+ * Extracts the embedded text layer with `pdftotext -layout`, preserving column
+ * structure. Output separates pages with a form-feed (`\f`); the orchestrator
+ * splits on it to route each page — a non-empty segment is read straight from
+ * the text layer, an empty segment marks an image-only page that still needs
+ * OCR. Born-digital PDFs return their exact text here, skipping rasterisation +
+ * OCR + the LLM cleanup/diff-review passes that exist only to repair OCR error.
+ * Costs ~50–300 ms for the whole document regardless of page count.
+ */
+export const extractPdfText: ExtractPdfText = async (buffer) => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pdftotext-"));
+	const pdfPath = join(tempDir, "input.pdf");
+	try {
+		await writeFile(pdfPath, buffer);
+		const { stdout } = await runCommand("pdftotext", ["-layout", "-enc", "UTF-8", pdfPath, "-"]);
+		return stdout;
+	} finally {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+};
+/* c8 ignore stop */

--- a/src/packages/crawl-article/src/index.ts
+++ b/src/packages/crawl-article/src/index.ts
@@ -28,6 +28,8 @@ export { isPDF } from "./pdf-detect";
 export type { PdfSignal } from "./pdf-detect";
 export { extractPdfMetadata } from "./extract-pdf-metadata";
 export type { ExtractPdfMetadata, PdfMetadata } from "./extract-pdf-metadata";
+export { extractPdfText } from "./extract-pdf-text";
+export type { ExtractPdfText } from "./extract-pdf-text";
 export { MAX_PDF_BYTES, MAX_PDF_PAGES } from "./pdf-page-limits";
 export { renderPdfPageToPng } from "./render-pdf-page";
 export type { RenderPdfPageToPng } from "./render-pdf-page";


### PR DESCRIPTION
## What

PDFs in the comprehensive-crawl pipeline were always treated as scans: every page was rasterised at 300 DPI, Tesseract-OCR'd, then patched with three DeepSeek passes (cleanup → diff-review → HTML-convert). Four of the five PDF health canaries are born-digital with a clean text layer, so that path was slower, costlier, and less accurate than needed.

This routes **per page**:
- page has an embedded text layer → read it via `pdftotext` (skip rasterise/OCR/cleanup/diff-review)
- page is image-only → existing OCR sub-pipeline, unchanged

Both kinds converge on the existing per-page DeepSeek HTML-convert stage, then stitch + sanitise as before. Text-layer pages count as successes in the partial-success threshold, so a mostly-digital PDF survives a stray unreadable image page.

## Why it's safe / minimal
- **No infra change** — `poppler-utils` (which ships `pdftotext`) is already installed in the comprehensive-crawl container image.
- **No `defineCommand`/`defineEvent` or Lambda subscription change** → no architecture snapshot needed.
- `ExtractPdf` contract and everything downstream (finalize → tier-1 → selector → `/view`) unchanged.

## Decisions worth a look
1. **No silent fallback.** A `pdftotext` failure now fails the crawl (→ DLQ alert), the same way a `pdfinfo` failure already does — rather than silently degrading to OCR.
2. **Canary comments removed.** All comments were stripped from `health-sources.ts` per request. Those were the "why this entry exists / what edge it guards" notes; that rationale now lives only in git history. After this change, only the CIA entry still exercises the OCR path.

## Verification
- Full `pnpm check` (all 24 projects) passed locally via the pre-commit hook: lint, type-check, knip, **100% coverage**.
- `ocr-pdf.ts`: 100% lines / branches / functions / statements.
- New unit tests: all-text, mixed text+scanned, text-pages-count-as-success, progress reporting, and `pdftotext` throws → failed.
- The live `tier-1-plus-crawl-pipeline-health` PDF canaries remain the end-to-end gate.

## Test in staging
```
PULUMI_STACK=staging pnpm nx run save-link:deploy-infra
```
Then save a born-digital PDF (e.g. https://arxiv.org/pdf/1706.03762) and check the `comprehensive-crawl-command` logs for:
```
[ocr-pdf] routing pages=… textChunks=… imageChunks=0
```
(`imageChunks=0` + no `[ocr-pdf] chunk …` OCR lines = fast path). A scanned PDF (CIA reading-room) should show `imageChunks>0` and OCR chunk logs.
