### PR TITLE
docs: gate adding comments on human approval, encourage removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,12 @@ logger.info("[recovery] Starting…");
 
 ### Comments Document Why, Not What
 
-Do not add comments that explain what code does. Only add comments to explain **why** when the reasoning isn't obvious.
+Prefer code that explains its own why — a clearer name, an assert, a type, or a test (see the assert example at the end of this section) — over any comment. An approved comment explains **why**, never what.
+
+| Action                      | Approval                | Stance                                                            |
+|-----------------------------|-------------------------|-------------------------------------------------------------------|
+| Remove a comment            | None                    | Encouraged — remove freely, and more often than you add           |
+| Add a discretionary comment | Explicit human approval | Last resort — restructure the code to carry the why first         |
 
 ```typescript
 // BAD - Explains what (obvious from code)


### PR DESCRIPTION
## Summary

- Rewrites the opener of CLAUDE.md's "Comments Document Why, Not What" to make the add/remove asymmetry explicit.
- Removing a comment needs no approval and is encouraged ("more often than you add"); adding a *discretionary* comment requires explicit human approval and is a last resort after restructuring the code to carry the why itself (name / assert / type / test).
- "discretionary" deliberately scopes the gate so it does not contradict comments other rules already mandate — e.g. the reason / `bcoe/c8#319` reference required alongside an approved `c8 ignore` in the Coverage section.
- All existing material in the section (BAD/GOOD what-vs-why example, inline-comment convention, indexed-reference convention, time-bound / plan-bound subsection, terminal `assert` example) is untouched.

## Test plan

- [ ] Re-read the edited section in `CLAUDE.md` and confirm the table makes the asymmetry obvious at a glance.
- [ ] Confirm "see the assert example at the end of this section" still resolves to the `assert.equal(req.method, "GET")` block further down.
- [ ] Skim the Coverage section to confirm the required reason/reference comments on `c8 ignore` still read as mandatory (not "discretionary"), so the new rule does not conflict.
- [ ] Run `pnpm check` if CLAUDE.md is covered by repo markdown linting; otherwise verification is the diff review.

https://claude.ai/code/session_01PSTg6k467RZY2Vr1MZot4i

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSTg6k467RZY2Vr1MZot4i)_