### PR TITLE
feat(article-parser): replace inline <video> with a placeholder linking to the original

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.styles.css
@@ -98,6 +98,23 @@ body {
   color: var(--color-text-secondary);
 }
 
+/**
+ * Substitute the article-parser inserts in place of a native <video>
+ * the reader cannot play (the body renders inside a sandboxed iframe
+ * with no allow-scripts, and many publishers lazy-load video via JS so
+ * the stored HTML never has a playable src). Subtle brand-tinted left
+ * border, echoing the blockquote callout.
+ */
+.article-body__content .reader-video-placeholder {
+  margin: 1.5rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-brand);
+  border-radius: 4px;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+}
+
 .article-body__content pre {
   overflow-x: auto;
   padding: 1rem;

--- a/src/packages/article-parser/src/index.ts
+++ b/src/packages/article-parser/src/index.ts
@@ -8,4 +8,5 @@ export type {
 export { initReadabilityParser } from "./readability-parser";
 export { mediumPreParser } from "./medium-pre-parser";
 export { theInformationPreParser } from "./the-information-pre-parser";
+export { replaceVideosWithPlaceholder } from "./replace-videos-with-placeholder";
 export { resolveRelativeUrls } from "./resolve-relative-urls";

--- a/src/packages/article-parser/src/readability-parser.test.ts
+++ b/src/packages/article-parser/src/readability-parser.test.ts
@@ -540,6 +540,80 @@ describe("initReadabilityParser", () => {
 			}
 		});
 
+		it("replaces a native <video> in the article body with a brand-styled placeholder linking to the original", () => {
+			const htmlWithVideo = `
+			<html><head><title>Performance Post</title></head>
+			<body><article>
+				<h1>Performance Post</h1>
+				<p>Intro paragraph long enough to satisfy readability extraction with several words to score well.</p>
+				<video src="https://cdn.example.com/clip.mp4"></video>
+				<p>Trailing paragraph long enough to keep the article scoreable for readability extraction.</p>
+			</article></body></html>`;
+			const { parseHtml } = initParser();
+
+			const result = parseHtml({
+				url: "https://performance.dev/posts/how-is-linear-so-fast",
+				html: htmlWithVideo,
+				thumbnailUrl: null,
+			});
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.article.content).not.toContain("<video");
+				expect(result.article.content).toContain('class="reader-video-placeholder"');
+				expect(result.article.content).toContain(
+					'href="https://performance.dev/posts/how-is-linear-so-fast"',
+				);
+				expect(result.article.content).toContain(">performance.dev<");
+				expect(result.article.content).toContain("Watch this video on ");
+			}
+		});
+
+		it("inserts one placeholder per <video> when the body contains several", () => {
+			const htmlWithVideos = `
+			<html><head><title>Many Videos</title></head>
+			<body><article>
+				<h1>Many Videos</h1>
+				<p>Intro paragraph long enough to satisfy readability extraction with several words to score well.</p>
+				<video src="a.mp4"></video>
+				<p>Middle paragraph long enough to satisfy readability extraction with several words to score well.</p>
+				<video src="b.mp4"></video>
+				<p>Trailing paragraph long enough to satisfy readability extraction with several words to score well.</p>
+			</article></body></html>`;
+			const { parseHtml } = initParser();
+
+			const result = parseHtml({
+				url: "https://example.com/many",
+				html: htmlWithVideos,
+				thumbnailUrl: null,
+			});
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.article.content).not.toContain("<video");
+				const matches = result.article.content.match(
+					/class="reader-video-placeholder"/g,
+				);
+				expect(matches?.length).toBe(2);
+			}
+		});
+
+		it("leaves articles without <video> unchanged", () => {
+			const { parseHtml } = initParser();
+
+			const result = parseHtml({
+				url: "https://example.com/article",
+				html: ARTICLE_HTML,
+				thumbnailUrl: null,
+			});
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.article.content).not.toContain("reader-video-placeholder");
+				expect(result.article.content).toContain("first paragraph");
+			}
+		});
+
 		it("escapes HTML-significant characters in the extracted title", () => {
 			const preParser: SitePreParser = {
 				matches: () => true,

--- a/src/packages/article-parser/src/readability-parser.ts
+++ b/src/packages/article-parser/src/readability-parser.ts
@@ -8,6 +8,7 @@ import type {
 	SiteArticleContent,
 	SitePreParser,
 } from "./article-parser.types";
+import { replaceVideosWithPlaceholder } from "./replace-videos-with-placeholder";
 import { resolveRelativeUrls } from "./resolve-relative-urls";
 
 export function initReadabilityParser(deps: {
@@ -45,7 +46,19 @@ export function initReadabilityParser(deps: {
 		let parsed: ReturnType<Readability["parse"]>;
 		try {
 			normalizeImplicitBody(document);
-			parsed = new Readability(document).parse();
+			replaceVideosWithPlaceholder({
+				document,
+				originalUrl: params.url,
+				renderPlaceholder: renderVideoPlaceholder,
+			});
+			/* `reader-video-placeholder` joins Readability's default
+			 * `CLASSES_TO_PRESERVE` (concat'd internally) so the CSS hook
+			 * survives `_cleanClasses`; the <p> tag is also exempt from
+			 * `_cleanConditionally`, keeping the link-bearing callout from
+			 * being dropped for link density. */
+			parsed = new Readability(document, {
+				classesToPreserve: ["reader-video-placeholder"],
+			}).parse();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			return { ok: false, reason: `Readability parse failed: ${message}` };
@@ -175,4 +188,23 @@ function escapeHtmlText(text: string): string {
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;")
 		.replace(/"/g, "&quot;");
+}
+
+const VIDEO_PLACEHOLDER_LEAD = "Watch this video on ";
+const VIDEO_PLACEHOLDER_TRAILING = " →";
+
+function renderVideoPlaceholder(ctx: {
+	document: Document;
+	originalUrl: string;
+	hostname: string;
+}): Element {
+	const placeholder = ctx.document.createElement("p");
+	placeholder.setAttribute("class", "reader-video-placeholder");
+	placeholder.appendChild(ctx.document.createTextNode(VIDEO_PLACEHOLDER_LEAD));
+	const link = ctx.document.createElement("a");
+	link.setAttribute("href", ctx.originalUrl);
+	link.appendChild(ctx.document.createTextNode(ctx.hostname));
+	placeholder.appendChild(link);
+	placeholder.appendChild(ctx.document.createTextNode(VIDEO_PLACEHOLDER_TRAILING));
+	return placeholder;
 }

--- a/src/packages/article-parser/src/replace-videos-with-placeholder.test.ts
+++ b/src/packages/article-parser/src/replace-videos-with-placeholder.test.ts
@@ -1,0 +1,180 @@
+import { parseHTML } from "linkedom";
+import { replaceVideosWithPlaceholder } from "./replace-videos-with-placeholder";
+
+function parse(html: string): Document {
+	return parseHTML(html).document;
+}
+
+function fakeRenderer(): {
+	render: Parameters<typeof replaceVideosWithPlaceholder>[0]["renderPlaceholder"];
+	calls: { originalUrl: string; hostname: string }[];
+} {
+	const calls: { originalUrl: string; hostname: string }[] = [];
+	const render: Parameters<typeof replaceVideosWithPlaceholder>[0]["renderPlaceholder"] = (ctx) => {
+		calls.push({ originalUrl: ctx.originalUrl, hostname: ctx.hostname });
+		const ph = ctx.document.createElement("p");
+		ph.setAttribute("data-ph", String(calls.length));
+		return ph;
+	};
+	return { render, calls };
+}
+
+describe("replaceVideosWithPlaceholder", () => {
+	it("replaces a single <video> with the rendered placeholder", () => {
+		const document = parse(
+			'<html><body><article><p>Before</p><video src="x.mp4"></video><p>After</p></article></body></html>',
+		);
+		const { render } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+
+		expect(document.querySelectorAll("video")).toHaveLength(0);
+		expect(document.querySelectorAll("p[data-ph]")).toHaveLength(1);
+		const article = document.querySelector("article");
+		expect(article?.innerHTML).toContain("Before");
+		expect(article?.innerHTML).toContain("After");
+	});
+
+	it("replaces every <video> in document order and keeps siblings stable", () => {
+		const document = parse(
+			"<html><body><article>" +
+				"<p>p1</p><video src='a.mp4'></video>" +
+				"<p>p2</p><video src='b.mp4'></video>" +
+				"<p>p3</p><video src='c.mp4'></video>" +
+				"<p>p4</p><video src='d.mp4'></video>" +
+				"<p>p5</p><video src='e.mp4'></video>" +
+				"<p>p6</p>" +
+				"</article></body></html>",
+		);
+		const { render } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+
+		expect(document.querySelectorAll("video")).toHaveLength(0);
+		const placeholders = Array.from(document.querySelectorAll("p[data-ph]"));
+		expect(placeholders).toHaveLength(5);
+		expect(placeholders.map((el) => el.getAttribute("data-ph"))).toEqual([
+			"1",
+			"2",
+			"3",
+			"4",
+			"5",
+		]);
+		const article = document.querySelector("article");
+		const texts = Array.from(article?.querySelectorAll("p") ?? [])
+			.filter((el) => !el.hasAttribute("data-ph"))
+			.map((el) => el.textContent);
+		expect(texts).toEqual(["p1", "p2", "p3", "p4", "p5", "p6"]);
+	});
+
+	it("removes <source> and <track> children with the <video>", () => {
+		const document = parse(
+			"<html><body><article>" +
+				'<video poster="cover.jpg">' +
+				'<source src="a.mp4" type="video/mp4">' +
+				'<track kind="captions" src="cap.vtt">' +
+				"</video>" +
+				"</article></body></html>",
+		);
+		const { render } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+
+		expect(document.querySelectorAll("video")).toHaveLength(0);
+		expect(document.querySelectorAll("source")).toHaveLength(0);
+		expect(document.querySelectorAll("track")).toHaveLength(0);
+		expect(document.querySelectorAll("p[data-ph]")).toHaveLength(1);
+	});
+
+	it("replaces a <video> even when it already has a real src attribute", () => {
+		const document = parse(
+			'<html><body><article><video src="https://cdn.example.com/clip.mp4"></video></article></body></html>',
+		);
+		const { render } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+
+		expect(document.querySelectorAll("video")).toHaveLength(0);
+		expect(document.querySelectorAll("p[data-ph]")).toHaveLength(1);
+	});
+
+	it("is a no-op when the document has no <video>", () => {
+		const document = parse(
+			"<html><body><article><p>Just text.</p></article></body></html>",
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+
+		expect(calls).toEqual([]);
+		expect(document.querySelector("article")?.innerHTML).toContain("Just text.");
+	});
+
+	it("is idempotent — a second pass finds no <video> to replace", () => {
+		const document = parse(
+			"<html><body><article>" +
+				"<video src='a.mp4'></video>" +
+				"<video src='b.mp4'></video>" +
+				"</article></body></html>",
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+		const callsAfterFirst = calls.length;
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://example.com/article",
+			renderPlaceholder: render,
+		});
+
+		expect(callsAfterFirst).toBe(2);
+		expect(calls.length).toBe(callsAfterFirst);
+		expect(document.querySelectorAll("video")).toHaveLength(0);
+		expect(document.querySelectorAll("p[data-ph]")).toHaveLength(2);
+	});
+
+	it("passes the article URL and hostname to the placeholder renderer", () => {
+		const document = parse(
+			"<html><body><article><video src='a.mp4'></video></article></body></html>",
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceVideosWithPlaceholder({
+			document,
+			originalUrl: "https://performance.dev/posts/how-is-linear-so-fast",
+			renderPlaceholder: render,
+		});
+
+		expect(calls).toEqual([
+			{
+				originalUrl: "https://performance.dev/posts/how-is-linear-so-fast",
+				hostname: "performance.dev",
+			},
+		]);
+	});
+});

--- a/src/packages/article-parser/src/replace-videos-with-placeholder.ts
+++ b/src/packages/article-parser/src/replace-videos-with-placeholder.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert";
+
+/* Native <video> elements never play in the reader: the body is rendered
+ * inside a sandboxed iframe with no allow-scripts, and many publishers
+ * lazy-load videos via JS (data-src/data-poster) so the stored
+ * pre-hydration HTML has no playable src either way. Substitute each
+ * <video> with a small text callout that links back to the original
+ * article. The placeholder element is built by an injected
+ * `renderPlaceholder` so the user-facing copy stays in a single pure
+ * function next to the rest of the reader-parser copy. */
+export function replaceVideosWithPlaceholder(params: {
+	document: Document;
+	originalUrl: string;
+	renderPlaceholder: (ctx: {
+		document: Document;
+		originalUrl: string;
+		hostname: string;
+	}) => Element;
+}): void {
+	const hostname = new URL(params.originalUrl).hostname;
+	const videos = Array.from(params.document.querySelectorAll("video"));
+	for (const video of videos) {
+		const placeholder = params.renderPlaceholder({
+			document: params.document,
+			originalUrl: params.originalUrl,
+			hostname,
+		});
+		const parent = video.parentNode;
+		assert(parent, "Video element selected from the document must have a parent node");
+		parent.insertBefore(placeholder, video);
+		video.remove();
+	}
+}


### PR DESCRIPTION
## Summary

- Native `<video>` elements never play in the reader (sandboxed iframe with no `allow-scripts`, and many publishers lazy-load video via JS so the stored pre-hydration HTML has no playable `src` either way). Pages like [performance.dev's "How is Linear so fast"](https://readplace.com/view/performance.dev/how-is-linear-so-fast-a-technical-breakdown) rendered 5 blank black boxes.
- New `replaceVideosWithPlaceholder` walker runs inside `parseHtml` (between `normalizeImplicitBody` and Readability) and substitutes each `<video>` with `<p class="reader-video-placeholder">Watch this video on <a href="{originalUrl}">{hostname}</a> →</p>`.
- `<p>` is exempt from Readability's `_cleanConditionally`, so the link-bearing callout isn't dropped for link density. The class joins Readability's default `CLASSES_TO_PRESERVE` via the new `classesToPreserve: ["reader-video-placeholder"]` option so the CSS hook survives `_cleanClasses`. The reader-iframe stylesheet styles it as a subtle brand-tinted callout, echoing the existing blockquote treatment.

## Test plan

- [x] `pnpm nx run @packages/article-parser:check` — 116 tests pass, 100% statements/branches/functions/lines coverage.
- [x] Walker unit tests: single video, 5 videos (count + document order), `<source>`/`<track>` children removed with parent, video with real `src`, no videos no-op, idempotency, renderer receives `{originalUrl, hostname}`.
- [x] Integration tests through `parseHtml`: placeholder appears in `result.article.content`, `<video` does not, `href` equals the passed url, link text equals hostname, ≥2 placeholders for a 2-video body, existing no-video `ARTICLE_HTML` unchanged (regression).
- [x] `pnpm nx run hutch:check` — CSS/unused-css gate passes (descendant selector `.article-body__content .reader-video-placeholder` is exempt from the bare-class regex).
- [ ] Eyeball at `/view/<encoded performance.dev URL>` once deployed — confirm the brand-bordered callout renders in light/dark and the link opens the original in the parent tab.

https://claude.ai/code/session_012wUt9Xxa8YTBhoKCBZoDnH

---
_Generated by [Claude Code](https://claude.ai/code/session_012wUt9Xxa8YTBhoKCBZoDnH)_