### PR TITLE
fix(infra): namespace HutchLambda RolePolicy Pulumi names to prevent URN collisions

### DIFF
--- a/src/packages/hutch-infra-components/src/infra/hutch-lambda.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-lambda.ts
@@ -229,11 +229,17 @@ export class HutchLambda extends pulumi.ComponentResource {
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
 
 		for (const p of args.policies) {
-			new aws.iam.RolePolicy(p.name, {
+			new aws.iam.RolePolicy(`${name}-${p.name}-rp`, {
 				name: p.name,
 				role: this.role.name,
 				policy: p.policy,
-			}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+			}, {
+				parent: this,
+				aliases: [
+					{ name: p.name, parent: this },
+					{ name: p.name, parent: pulumi.rootStackResource },
+				],
+			});
 		}
 
 		const hasEnvironment = Object.keys(args.environment).length > 0;


### PR DESCRIPTION
## Summary

A Pulumi child resource's URN encodes the parent's type but not its name, so two `HutchLambda`s given an inline policy with the same `p.name` resolved to the identical URN (`…hutch:infra:HutchLambda$aws:iam/rolePolicy:RolePolicy::<p.name>`) and `pulumi up` failed at plan time with *Duplicate resource URN*. This already bit us twice — PR #453 (`hutch-trial-scheduler-manage`, fixed surgically in 83d94075) and earlier in save-link (924dab58, worked around with a `renamePolicies` helper).

This eliminates the whole class of bug inside `HutchLambda` itself.

- Fold the Lambda name into the Pulumi logical name: `new aws.iam.RolePolicy(`${name}-${p.name}-rp`, …)`. `name` is the `HutchLambda` constructor's first arg and already unique per Lambda, so cross-Lambda collisions become unrepresentable.
- Keep the AWS inline-policy `name: p.name` unchanged — no AWS resource is touched, no 128-char `RolePolicyName` limit is approached.
- Add two aliases so existing state is recognised in place:
  - `{ name: p.name, parent: this }` — matches the current state URN, so Pulumi performs an in-place URN update instead of a replace.
  - `{ name: p.name, parent: pulumi.rootStackResource }` — makes the previously-implicit pre-ComponentResource alias explicit (the original alias relied on the implicit logical name `p.name`, which now changes).

Other `RolePolicy` creators (`hutch-sqs-backed-lambda.ts`, `hutch-dlq-event-handler.ts`, `event-bus.ts`, `projects/hutch/src/infra/index.ts` trial-scheduler) already derive their logical name from a per-instance-unique component name and cannot collide — left alone.

Expected deploy diff for all four stacks (hutch staging+prod, save-link staging+prod): **0 changes**.

## Rebased onto main (`8dd5dc1`)

Clean rebase — main never touched `hutch-lambda.ts`, so there were no conflicts. The rebase did pull in a new `HutchLambda("canonical-content-changed")` (save-link) that still uses the manual `renamePolicies(...)` workaround; its renamed policy names are already per-Lambda-unique, and the `{ name: p.name, parent: this }` alias matches its existing on-main URN, so it is recognised in place with **zero churn** like every other Lambda — no code change required. The newly-added `renamePolicies` call reinforces that the optional follow-up (removing those manual calls now that `HutchLambda` namespaces policies itself) is still worth a separate, deliberate pass.

## Test plan

- [x] `pnpm nx run @packages/hutch-infra-components:check` — green (tsc, biome, knip).
- [x] `pnpm nx run hutch:compile` / `pnpm nx run save-link:compile` — both green.
- [x] Full `pnpm check` (pre-commit hook) — all projects green (26 after rebase).
- [ ] CI: `hutch / deploy-staging` and `save-link / deploy-staging` — confirm `pulumi up` shows no `RolePolicy` replacements.
- [ ] CI: `hutch / deploy-prod` and `save-link / deploy-prod` — same.


---
_Generated by [Claude Code](https://claude.ai/code/session_012zDqVzEoU6XDZoQL9xudTd)_