### PR TITLE
feat(hutch): make founding-member limit configurable per environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -42,6 +42,7 @@ export TRIAL_SCHEDULER_GROUP_NAME='hutch-trial-end-dev'
 export TRIAL_SCHEDULER_ROLE_ARN='arn:aws:iam::000000000000:role/hutch-trial-scheduler-role-dev'
 export ANALYTICS_SALT='local-dev-salt'
 export EXPIRY_COUNTDOWN='enabled'
+export FOUNDING_MEMBER_LIMIT='50'
 # Comma-separated list of emails allowed to hit /admin/recrawl.
 # Leave empty in local dev to fail-closed; set to your email before testing.
 export ADMIN_EMAILS=''

--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -32,6 +32,7 @@ config:
   hutch:userExportBucketName: hutch-user-exports-prod
   hutch:alertEmail: readplace+devops@readplace.com
   hutch:expiryCountdown: disabled
+  hutch:foundingMemberLimit: '50'
   hutch:excludedVisitorHashes: [
     b4248a499303636a,
     cae1bf1ec4181321,

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -24,5 +24,6 @@ config:
   hutch:userExportBucketName: hutch-user-exports-staging
   hutch:alertEmail: readplace+staging@readplace.com
   hutch:expiryCountdown: enabled
+  hutch:foundingMemberLimit: '5'
   hutch:excludedVisitorHashes: []
 encryptionsalt: v1:fILgDgnVVEY=:v1:sFKytKYEpZU4Qs+9:o/Q+JSj6rS/qo7p6WyjaekWrgFAk5A==

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -255,6 +255,7 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 		TRIAL_SCHEDULER_GROUP_NAME: trialSchedulerGroup.name,
 		TRIAL_SCHEDULER_ROLE_ARN: trialSchedulerRole.arn,
 		EXPIRY_COUNTDOWN: config.require("expiryCountdown"),
+		FOUNDING_MEMBER_LIMIT: config.require("foundingMemberLimit"),
 	},
 	policies: [
 		...dynamodb.policies,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -86,10 +86,7 @@ import type { BotDefenseEvent } from "./web/auth/auth.page";
 import type { ConversionEvent } from "./conversions";
 import type { AnalyticsEvent } from "./web/middleware/analytics";
 import { httpErrorMessageMapping } from "./web/pages/queue/queue.error";
-import {
-	FOUNDING_MEMBER_LIMIT,
-	initFoundingAllocation,
-} from "./web/shared/founding-progress/founding-allocation";
+import { initFoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import { getEnv, requireEnv } from "./domain/require-env";
 
 /**
@@ -434,6 +431,11 @@ export function createHutchApp(deps?: {
 	const appOrigin = deps?.appOrigin ?? requireEnv("APP_ORIGIN", { defaultValue: `http://localhost:${getEnv("PORT") || "3000"}` });
 	const staticBaseUrl = requireEnv("STATIC_BASE_URL");
 	const expiryCountdown = requireEnv<"enabled" | "disabled">("EXPIRY_COUNTDOWN");
+	const foundingMemberLimit = Number.parseInt(requireEnv("FOUNDING_MEMBER_LIMIT"), 10);
+	assert(
+		Number.isInteger(foundingMemberLimit) && foundingMemberLimit > 0,
+		"FOUNDING_MEMBER_LIMIT must be a positive integer",
+	);
 	const adminEmails = parseAdminEmails(requireEnv("ADMIN_EMAILS"));
 	const recrawlServiceToken = requireEnv("RECRAWL_SERVICE_TOKEN");
 	const salt = requireEnv("ANALYTICS_SALT");
@@ -467,9 +469,7 @@ export function createHutchApp(deps?: {
 		conversionLogger: HutchLogger.fromJSON<ConversionEvent>(),
 		analytics: analyticsLogger,
 		salt,
-		foundingAllocation: initFoundingAllocation({
-			foundingMemberLimit: FOUNDING_MEMBER_LIMIT,
-		}),
+		foundingAllocation: initFoundingAllocation({ foundingMemberLimit }),
 		expiryCountdown,
 	});
 

--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts
@@ -1,5 +1,3 @@
-export const FOUNDING_MEMBER_LIMIT = 50;
-
 export interface FoundingAllocation {
 	foundingMemberLimit: number;
 	isFoundingAllocationExhausted: (userCount: number) => boolean;


### PR DESCRIPTION
## Summary

- Lift `FOUNDING_MEMBER_LIMIT` out of a hardcoded constant and thread it through the same Pulumi config → Lambda env var → `requireEnv` pipeline that `expiryCountdown` already uses, so each environment can pick its own cap.
- Set staging to `5` (so the allocation-exhausted flow — trial signups, hidden progress bar, changed pricing copy — can be exercised without seeding 50 accounts) and keep prod at `50`.
- Local dev reads `FOUNDING_MEMBER_LIMIT=50` from `.envrc`, so behaviour is unchanged outside staging.

## Changes

- `projects/hutch/Pulumi.staging.yaml` — new `hutch:foundingMemberLimit: '5'`
- `projects/hutch/Pulumi.prod.yaml` — new `hutch:foundingMemberLimit: '50'`
- `projects/hutch/src/infra/index.ts` — wire `FOUNDING_MEMBER_LIMIT` into the `HutchLambda` environment via `config.require("foundingMemberLimit")`
- `projects/hutch/src/runtime/app.ts` — parse the env var with `requireEnv`, assert it's a positive integer, and pass it into `initFoundingAllocation` (all inside the existing `/* c8 ignore */` composition root)
- `projects/hutch/src/runtime/web/shared/founding-progress/founding-allocation.ts` — drop the now-unused `FOUNDING_MEMBER_LIMIT` constant; the `initFoundingAllocation` factory keeps its tests
- `.envrc` — `export FOUNDING_MEMBER_LIMIT='50'` for local dev / `server.main.ts`

The single source of truth still flows through `createHutchApp → initFoundingAllocation`, so every downstream surface (signup gating, progress bar, home/auth copy, blog-post `{{foundingMemberLimit}}` placeholder) picks up the staging value automatically.

## Test plan

- [x] `pnpm nx run hutch:check` — lint, type-check, unit + integration, 100% coverage, knip (all green)
- [ ] Confirm staging `/` shows `0 / 5 founding members` after deploy and the allocation-exhausted flow engages once 5 accounts exist
- [ ] Confirm prod `/` continues to show `… / 50 founding members`

---
_Generated by [Claude Code](https://claude.ai/code/session_0175qbriWL6KHnkr7jQtTSD8)_