### PR TITLE
feat(hutch): trial-feedback research email for churned trials

### DIFF
--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -6,6 +6,7 @@ import { HutchLambda, HutchAPIGateway, HutchDynamoDBAccess, HutchEventBus, Hutch
 import {
 	CancelSubscriptionCommand,
 	ExportUserDataCommand,
+	SendTrialFeedbackEmailCommand,
 	SubscriptionCancellationScheduledEvent,
 	SubscriptionCancelledEvent,
 	SubscriptionChargeFailedEvent,
@@ -218,6 +219,11 @@ const trialSchedulerManagePolicy = {
 
 const cancelSubscriptionSchedulerManagePolicy = {
 	name: "hutch-cancel-subscription-scheduler-manage",
+	policy: trialSchedulerManagePolicyDoc,
+};
+
+const scheduleTrialFeedbackEmailSchedulerManagePolicy = {
+	name: "hutch-schedule-trial-feedback-email-scheduler-manage",
 	policy: trialSchedulerManagePolicyDoc,
 };
 
@@ -686,6 +692,112 @@ const subscriptionChargeFailedWithSQS = new HutchSQSBackedLambda("subscription-c
 
 eventBus.subscribe(SubscriptionChargeFailedEvent, subscriptionChargeFailedWithSQS);
 
+// --- Schedule Trial Feedback Email ---
+// SQS-backed Lambda that subscribes to SubscriptionCancelledEvent. When the
+// cancel comes from a trial (reason='user_initiated_trial'), it creates a
+// one-shot EventBridge Scheduler firing TRIAL_FEEDBACK_EMAIL_DELAY_MS later
+// with SendTrialFeedbackEmailCommand. Paid cancels and stripe-webhook cancels
+// are ignored (paid churn is out of audience scope, and trial cancels never
+// route through the Stripe webhook). The schedule name is deterministic per
+// userId so at-least-once duplicates overwrite rather than stack.
+
+const scheduleTrialFeedbackEmailQueue = new HutchSQS("schedule-trial-feedback-email", {
+	visibilityTimeoutSeconds: 30,
+});
+
+const scheduleTrialFeedbackEmailLambda = new HutchLambda(
+	LAMBDA_NAMES.scheduleTrialFeedbackEmail,
+	{
+		entryPoint: "./src/runtime/schedule-trial-feedback-email.main.ts",
+		outputDir: ".lib/schedule-trial-feedback-email",
+		assetDir: "./src/runtime",
+		memorySize: 128,
+		timeout: 30,
+		environment: {
+			PERSISTENCE: "prod",
+			EVENT_BUS_ARN: eventBus.eventBusArn,
+			TRIAL_SCHEDULER_GROUP_NAME: trialSchedulerGroup.name,
+			TRIAL_SCHEDULER_ROLE_ARN: trialSchedulerRole.arn,
+		},
+		policies: [scheduleTrialFeedbackEmailSchedulerManagePolicy],
+	},
+);
+
+const scheduleTrialFeedbackEmailWithSQS = new HutchSQSBackedLambda(
+	"schedule-trial-feedback-email",
+	{
+		lambda: scheduleTrialFeedbackEmailLambda,
+		queue: scheduleTrialFeedbackEmailQueue,
+		alertEmailDLQEntry: alertEmail,
+		batchSize: 1,
+	},
+);
+
+eventBus.subscribe(SubscriptionCancelledEvent, scheduleTrialFeedbackEmailWithSQS);
+
+// --- Send Trial Feedback Email ---
+// SQS-backed Lambda invoked by the EventBridge Scheduler one-shot created
+// above. Re-reads the subscription row to confirm the user is still cancelled
+// (reactivation guard) and hasn't already received the email (sent-flag),
+// then sends Fayner's "what was missing?" research email with a single
+// personalised clause derived from the count of articles the user saved.
+
+const sendTrialFeedbackEmailDynamodb = new HutchDynamoDBAccess(
+	"send-trial-feedback-email-dynamodb",
+	{
+		tables: [
+			{ arn: storage.subscriptionProvidersTable.arn, includeIndexes: false },
+			{ arn: storage.usersTable.arn, includeIndexes: true },
+			{ arn: storage.articlesTable.arn, includeIndexes: false },
+			{ arn: storage.userArticlesTable.arn, includeIndexes: true },
+		],
+		actions: [
+			"dynamodb:GetItem",
+			"dynamodb:BatchGetItem",
+			"dynamodb:Query",
+			"dynamodb:UpdateItem",
+		],
+	},
+);
+
+const sendTrialFeedbackEmailQueue = new HutchSQS("send-trial-feedback-email", {
+	visibilityTimeoutSeconds: 60,
+});
+
+const sendTrialFeedbackEmailLambda = new HutchLambda(
+	LAMBDA_NAMES.sendTrialFeedbackEmail,
+	{
+		entryPoint: "./src/runtime/send-trial-feedback-email.main.ts",
+		outputDir: ".lib/send-trial-feedback-email",
+		assetDir: "./src/runtime",
+		memorySize: 256,
+		timeout: 60,
+		environment: {
+			PERSISTENCE: "prod",
+			DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE: storage.subscriptionProvidersTable.name,
+			DYNAMODB_USERS_TABLE: storage.usersTable.name,
+			DYNAMODB_SESSIONS_TABLE: storage.sessionsTable.name,
+			DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
+			DYNAMODB_USER_ARTICLES_TABLE: storage.userArticlesTable.name,
+			RESEND_API_KEY: requireEnv("RESEND_API_KEY"),
+			STATIC_BASE_URL: staticAssets.baseUrl,
+		},
+		policies: [...sendTrialFeedbackEmailDynamodb.policies],
+	},
+);
+
+const sendTrialFeedbackEmailWithSQS = new HutchSQSBackedLambda(
+	"send-trial-feedback-email",
+	{
+		lambda: sendTrialFeedbackEmailLambda,
+		queue: sendTrialFeedbackEmailQueue,
+		alertEmailDLQEntry: alertEmail,
+		batchSize: 1,
+	},
+);
+
+eventBus.subscribe(SendTrialFeedbackEmailCommand, sendTrialFeedbackEmailWithSQS);
+
 // --- Analytics Dashboard ---
 // The widget builder lives in runtime/observability/analytics-dashboard so the
 // dashboard JSON is constructable and assertable outside the Pulumi runtime —
@@ -738,6 +850,14 @@ const subscriptionLogGroups = [
 	}),
 	new aws.cloudwatch.LogGroup("handle-subscription-cancelled-log-group", {
 		name: LOG_GROUPS.handleSubscriptionCancelled,
+		retentionInDays: 30,
+	}),
+	new aws.cloudwatch.LogGroup("schedule-trial-feedback-email-log-group", {
+		name: LOG_GROUPS.scheduleTrialFeedbackEmail,
+		retentionInDays: 30,
+	}),
+	new aws.cloudwatch.LogGroup("send-trial-feedback-email-log-group", {
+		name: LOG_GROUPS.sendTrialFeedbackEmail,
 		retentionInDays: 30,
 	}),
 ];

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -335,4 +335,6 @@ export const SUBSCRIPTION_DASHBOARD_LOG_GROUPS: readonly string[] = [
 	LOG_GROUPS.subscriptionChargeFailed,
 	LOG_GROUPS.cancelSubscription,
 	LOG_GROUPS.handleSubscriptionCancelled,
+	LOG_GROUPS.scheduleTrialFeedbackEmail,
+	LOG_GROUPS.sendTrialFeedbackEmail,
 ];

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -58,6 +58,8 @@ export const LAMBDA_NAMES = {
 	subscriptionChargeFailed: "subscription-charge-failed",
 	cancelSubscription: "cancel-subscription",
 	handleSubscriptionCancelled: "handle-subscription-cancelled",
+	scheduleTrialFeedbackEmail: "schedule-trial-feedback-email",
+	sendTrialFeedbackEmail: "send-trial-feedback-email",
 } as const;
 
 type LogGroupName<T extends string> = `/aws/lambda/${T}-handler`;
@@ -69,6 +71,8 @@ export const LOG_GROUPS = {
 	subscriptionChargeFailed: `/aws/lambda/${LAMBDA_NAMES.subscriptionChargeFailed}-handler`,
 	cancelSubscription: `/aws/lambda/${LAMBDA_NAMES.cancelSubscription}-handler`,
 	handleSubscriptionCancelled: `/aws/lambda/${LAMBDA_NAMES.handleSubscriptionCancelled}-handler`,
+	scheduleTrialFeedbackEmail: `/aws/lambda/${LAMBDA_NAMES.scheduleTrialFeedbackEmail}-handler`,
+	sendTrialFeedbackEmail: `/aws/lambda/${LAMBDA_NAMES.sendTrialFeedbackEmail}-handler`,
 } as const satisfies {
 	readonly [K in keyof typeof LAMBDA_NAMES]: LogGroupName<(typeof LAMBDA_NAMES)[K]>;
 };

--- a/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.test.ts
+++ b/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.test.ts
@@ -434,4 +434,69 @@ describe("initDynamoDbSubscriptionProviders", () => {
 			expect(command.input.ExpressionAttributeValues?.[":status"]).toBe("active");
 		});
 	});
+
+	describe("markTrialFeedbackEmailSent", () => {
+		it("issues a guarded Update that records trialFeedbackEmailSentAt and bumps updatedAt", async () => {
+			let received: unknown;
+			const client = createFakeClient((input) => {
+				received = input;
+				return {};
+			});
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			await subs.markTrialFeedbackEmailSent({
+				userId: USER_ID,
+				sentAt: "2026-06-04T00:00:00.000Z",
+			});
+
+			const command = received as {
+				input: {
+					Key?: Record<string, unknown>;
+					UpdateExpression?: string;
+					ConditionExpression?: string;
+					ExpressionAttributeValues?: Record<string, unknown>;
+				};
+			};
+			expect(command.input.Key).toEqual({ userId: USER_ID });
+			expect(command.input.UpdateExpression).toContain(
+				"trialFeedbackEmailSentAt = :sentAt",
+			);
+			expect(command.input.UpdateExpression).toContain("updatedAt = :now");
+			expect(command.input.ConditionExpression).toContain("attribute_exists(userId)");
+			expect(command.input.ExpressionAttributeValues?.[":sentAt"]).toBe(
+				"2026-06-04T00:00:00.000Z",
+			);
+			expect(command.input.ExpressionAttributeValues?.[":now"]).toBe(
+				"2026-05-22T10:00:00.000Z",
+			);
+		});
+	});
+
+	describe("findByUserId with trialFeedbackEmailSentAt", () => {
+		it("parses a cancelled trial row that carries trialFeedbackEmailSentAt", async () => {
+			const client = createFakeClient(() => ({
+				Item: {
+					userId: USER_ID,
+					provider: "stripe",
+					status: "cancelled",
+					trialFeedbackEmailSentAt: "2026-06-04T00:00:00.000Z",
+					createdAt: "2026-05-20T10:00:00.000Z",
+					updatedAt: "2026-06-04T00:00:00.000Z",
+				},
+			}));
+			const subs = initDynamoDbSubscriptionProviders({
+				client: client as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: NOW,
+			});
+
+			const row = await subs.findByUserId(USER_ID);
+			assert(row, "row must be returned");
+			expect(row.trialFeedbackEmailSentAt).toBe("2026-06-04T00:00:00.000Z");
+		});
+	});
 });

--- a/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.ts
+++ b/projects/hutch/src/runtime/providers/subscription-providers/dynamodb-subscription-providers.ts
@@ -12,6 +12,7 @@ import type {
 	MarkSubscriptionCancelled,
 	MarkSubscriptionCancelledByUserId,
 	MarkSubscriptionPendingCancellation,
+	MarkTrialFeedbackEmailSent,
 	SubscriptionRecord,
 	UpsertActiveSubscription,
 	UpsertTrialingSubscription,
@@ -25,6 +26,7 @@ const SubscriptionProviderRow = z.object({
 	status: z.enum(["trialing", "active", "pending_cancellation", "cancelled"]),
 	trialEndsAt: dynamoField(z.string()),
 	cancellationEffectiveAt: dynamoField(z.string()),
+	trialFeedbackEmailSentAt: dynamoField(z.string()),
 	createdAt: z.string(),
 	updatedAt: z.string(),
 });
@@ -38,6 +40,9 @@ function toRecord(row: z.infer<typeof SubscriptionProviderRow>): SubscriptionRec
 		status: row.status,
 		...(row.trialEndsAt !== undefined ? { trialEndsAt: row.trialEndsAt } : {}),
 		...(row.cancellationEffectiveAt !== undefined ? { cancellationEffectiveAt: row.cancellationEffectiveAt } : {}),
+		...(row.trialFeedbackEmailSentAt !== undefined
+			? { trialFeedbackEmailSentAt: row.trialFeedbackEmailSentAt }
+			: {}),
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt,
 	};
@@ -56,6 +61,7 @@ export function initDynamoDbSubscriptionProviders(deps: {
 	markCancelled: MarkSubscriptionCancelled;
 	markCancelledByUserId: MarkSubscriptionCancelledByUserId;
 	markActive: MarkSubscriptionActive;
+	markTrialFeedbackEmailSent: MarkTrialFeedbackEmailSent;
 } {
 	const table = defineDynamoTable({
 		client: deps.client,
@@ -181,6 +187,22 @@ export function initDynamoDbSubscriptionProviders(deps: {
 		});
 	};
 
+	const markTrialFeedbackEmailSent: MarkTrialFeedbackEmailSent = async ({
+		userId,
+		sentAt,
+	}) => {
+		await table.update({
+			Key: { userId },
+			UpdateExpression:
+				"SET trialFeedbackEmailSentAt = :sentAt, updatedAt = :now",
+			ConditionExpression: "attribute_exists(userId)",
+			ExpressionAttributeValues: {
+				":sentAt": sentAt,
+				":now": deps.now().toISOString(),
+			},
+		});
+	};
+
 	return {
 		findByUserId,
 		findBySubscriptionId,
@@ -190,5 +212,6 @@ export function initDynamoDbSubscriptionProviders(deps: {
 		markCancelled,
 		markCancelledByUserId,
 		markActive,
+		markTrialFeedbackEmailSent,
 	};
 }

--- a/projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.test.ts
+++ b/projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.test.ts
@@ -233,4 +233,107 @@ describe("initAwsTrialScheduler", () => {
 			);
 		});
 	});
+
+	describe("createTrialFeedbackEmailSchedule", () => {
+		it("issues a CreateScheduleCommand with name=trial-feedback-<userId>, group, at(...) expression, and SendTrialFeedbackEmailCommand target", async () => {
+			const { client, captured } = buildFakeClient();
+			const scheduler = initAwsTrialScheduler({
+				client,
+				scheduleGroupName: GROUP_NAME,
+				schedulerRoleArn: ROLE_ARN,
+				eventBusArn: EVENT_BUS_ARN,
+			});
+
+			await scheduler.createTrialFeedbackEmailSchedule({
+				userId: USER_ID,
+				firesAt: "2026-06-08T10:00:00.000Z",
+			});
+
+			assert.equal(captured.commands.length, 1);
+			const cmd = captured.commands[0];
+			assert.ok(cmd instanceof CreateScheduleCommand);
+			const input = cmd.input;
+			assert.equal(input.Name, `trial-feedback-${USER_ID}`);
+			assert.equal(input.GroupName, GROUP_NAME);
+			assert.equal(input.ScheduleExpression, "at(2026-06-08T10:00:00)");
+			assert.equal(input.FlexibleTimeWindow?.Mode, "OFF");
+			assert.equal(input.ActionAfterCompletion, "DELETE");
+			assert.equal(input.State, "ENABLED");
+			assert.equal(input.Target?.Arn, EVENT_BUS_ARN);
+			assert.equal(input.Target?.RoleArn, ROLE_ARN);
+			assert.equal(input.Target?.EventBridgeParameters?.Source, "hutch.subscriptions");
+			assert.equal(
+				input.Target?.EventBridgeParameters?.DetailType,
+				"SendTrialFeedbackEmailCommand",
+			);
+			const payload = JSON.parse(input.Target?.Input ?? "{}");
+			assert.equal(payload.userId, USER_ID);
+		});
+
+		it("strips fractional seconds and the trailing Z from firesAt", async () => {
+			const { client, captured } = buildFakeClient();
+			const scheduler = initAwsTrialScheduler({
+				client,
+				scheduleGroupName: GROUP_NAME,
+				schedulerRoleArn: ROLE_ARN,
+				eventBusArn: EVENT_BUS_ARN,
+			});
+
+			await scheduler.createTrialFeedbackEmailSchedule({
+				userId: USER_ID,
+				firesAt: "2026-06-08T10:00:00Z",
+			});
+
+			const cmd = captured.commands[0];
+			assert.ok(cmd instanceof CreateScheduleCommand);
+			assert.equal(cmd.input.ScheduleExpression, "at(2026-06-08T10:00:00)");
+		});
+	});
+
+	describe("deleteTrialFeedbackEmailSchedule", () => {
+		it("issues a DeleteScheduleCommand with name=trial-feedback-<userId> + group", async () => {
+			const { client, captured } = buildFakeClient();
+			const scheduler = initAwsTrialScheduler({
+				client,
+				scheduleGroupName: GROUP_NAME,
+			});
+
+			await scheduler.deleteTrialFeedbackEmailSchedule({ userId: USER_ID });
+
+			assert.equal(captured.commands.length, 1);
+			const cmd = captured.commands[0];
+			assert.ok(cmd instanceof DeleteScheduleCommand);
+			assert.equal(cmd.input.Name, `trial-feedback-${USER_ID}`);
+			assert.equal(cmd.input.GroupName, GROUP_NAME);
+		});
+
+		it("swallows ResourceNotFoundException — delete is idempotent", async () => {
+			const notFound = new Error("Schedule not found");
+			notFound.name = "ResourceNotFoundException";
+			const { client } = buildFakeClient({ deleteThrows: notFound });
+			const scheduler = initAwsTrialScheduler({
+				client,
+				scheduleGroupName: GROUP_NAME,
+			});
+
+			await assert.doesNotReject(
+				scheduler.deleteTrialFeedbackEmailSchedule({ userId: USER_ID }),
+			);
+		});
+
+		it("re-throws any other error", async () => {
+			const wrenchInGears = new Error("Internal failure");
+			wrenchInGears.name = "InternalServerException";
+			const { client } = buildFakeClient({ deleteThrows: wrenchInGears });
+			const scheduler = initAwsTrialScheduler({
+				client,
+				scheduleGroupName: GROUP_NAME,
+			});
+
+			await assert.rejects(
+				scheduler.deleteTrialFeedbackEmailSchedule({ userId: USER_ID }),
+				/Internal failure/,
+			);
+		});
+	});
 });

--- a/projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.ts
+++ b/projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.ts
@@ -8,8 +8,10 @@ import type { UserId } from "@packages/domain/user";
 import type {
 	CreateDeferredCancellationSchedule,
 	CreateTrialEndSchedule,
+	CreateTrialFeedbackEmailSchedule,
 	DeleteDeferredCancellationSchedule,
 	DeleteTrialEndSchedule,
+	DeleteTrialFeedbackEmailSchedule,
 } from "@packages/test-fixtures/providers/trial-scheduler";
 
 /** EventBridge Scheduler's `at(<iso>)` does not accept fractional seconds or a
@@ -31,6 +33,13 @@ function deferredCancellationScheduleName(userId: UserId): string {
 	return `cancel-${userId}`;
 }
 
+/** Deterministic name keyed by userId. Duplicate SubscriptionCancelledEvent
+ * deliveries (at-least-once + dual-publisher: cancel-subscription and
+ * stripe-webhook-receiver) overwrite the same schedule instead of stacking. */
+function trialFeedbackEmailScheduleName(userId: UserId): string {
+	return `trial-feedback-${userId}`;
+}
+
 export function initAwsTrialScheduler(deps: {
 	client: Pick<SchedulerClient, "send">;
 	scheduleGroupName: string;
@@ -41,6 +50,8 @@ export function initAwsTrialScheduler(deps: {
 	deleteTrialEndSchedule: DeleteTrialEndSchedule;
 	createDeferredCancellationSchedule: CreateDeferredCancellationSchedule;
 	deleteDeferredCancellationSchedule: DeleteDeferredCancellationSchedule;
+	createTrialFeedbackEmailSchedule: CreateTrialFeedbackEmailSchedule;
+	deleteTrialFeedbackEmailSchedule: DeleteTrialFeedbackEmailSchedule;
 } {
 	const createTrialEndSchedule: CreateTrialEndSchedule = async ({ userId, firesAt }) => {
 		assert(deps.eventBusArn, "eventBusArn is required for createTrialEndSchedule");
@@ -130,10 +141,63 @@ export function initAwsTrialScheduler(deps: {
 		}
 	};
 
+	const createTrialFeedbackEmailSchedule: CreateTrialFeedbackEmailSchedule = async ({
+		userId,
+		firesAt,
+	}) => {
+		assert(
+			deps.eventBusArn,
+			"eventBusArn is required for createTrialFeedbackEmailSchedule",
+		);
+		assert(
+			deps.schedulerRoleArn,
+			"schedulerRoleArn is required for createTrialFeedbackEmailSchedule",
+		);
+		await deps.client.send(
+			new CreateScheduleCommand({
+				Name: trialFeedbackEmailScheduleName(userId),
+				GroupName: deps.scheduleGroupName,
+				ScheduleExpression: `at(${toNaiveSeconds(firesAt)})`,
+				FlexibleTimeWindow: { Mode: "OFF" },
+				ActionAfterCompletion: "DELETE",
+				State: "ENABLED",
+				Target: {
+					Arn: deps.eventBusArn,
+					RoleArn: deps.schedulerRoleArn,
+					EventBridgeParameters: {
+						Source: "hutch.subscriptions",
+						DetailType: "SendTrialFeedbackEmailCommand",
+					},
+					Input: JSON.stringify({ userId }),
+				},
+			}),
+		);
+	};
+
+	const deleteTrialFeedbackEmailSchedule: DeleteTrialFeedbackEmailSchedule = async ({
+		userId,
+	}) => {
+		try {
+			await deps.client.send(
+				new DeleteScheduleCommand({
+					Name: trialFeedbackEmailScheduleName(userId),
+					GroupName: deps.scheduleGroupName,
+				}),
+			);
+		} catch (err) {
+			if (err instanceof Error && err.name === "ResourceNotFoundException") {
+				return;
+			}
+			throw err;
+		}
+	};
+
 	return {
 		createTrialEndSchedule,
 		deleteTrialEndSchedule,
 		createDeferredCancellationSchedule,
 		deleteDeferredCancellationSchedule,
+		createTrialFeedbackEmailSchedule,
+		deleteTrialFeedbackEmailSchedule,
 	};
 }

--- a/projects/hutch/src/runtime/schedule-trial-feedback-email.main.ts
+++ b/projects/hutch/src/runtime/schedule-trial-feedback-email.main.ts
@@ -1,0 +1,24 @@
+/* c8 ignore start -- composition root, no logic to test */
+import { SchedulerClient } from "@aws-sdk/client-scheduler";
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+import { initAwsTrialScheduler } from "./providers/trial-scheduler/aws-trial-scheduler";
+import { initScheduleTrialFeedbackEmailHandler } from "./schedule-trial-feedback-email/schedule-trial-feedback-email-handler";
+import { requireEnv } from "./domain/require-env";
+
+const eventBusArn = requireEnv("EVENT_BUS_ARN");
+const trialSchedulerGroupName = requireEnv("TRIAL_SCHEDULER_GROUP_NAME");
+const trialSchedulerRoleArn = requireEnv("TRIAL_SCHEDULER_ROLE_ARN");
+
+const trialScheduler = initAwsTrialScheduler({
+	client: new SchedulerClient({}),
+	scheduleGroupName: trialSchedulerGroupName,
+	schedulerRoleArn: trialSchedulerRoleArn,
+	eventBusArn,
+});
+
+export const handler = initScheduleTrialFeedbackEmailHandler({
+	createTrialFeedbackEmailSchedule: trialScheduler.createTrialFeedbackEmailSchedule,
+	now: () => new Date(),
+	logger: HutchLogger.from(consoleLogger),
+});
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/schedule-trial-feedback-email/schedule-trial-feedback-email-handler.test.ts
+++ b/projects/hutch/src/runtime/schedule-trial-feedback-email/schedule-trial-feedback-email-handler.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
+import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import { initInMemoryTrialScheduler } from "@packages/test-fixtures/providers/trial-scheduler";
+import { buildSqsEvent } from "@packages/test-fixtures/sqs";
+import {
+	initScheduleTrialFeedbackEmailHandler,
+	TRIAL_FEEDBACK_EMAIL_DELAY_MS,
+} from "./schedule-trial-feedback-email-handler";
+
+const USER_ID = UserIdSchema.parse("5".repeat(32));
+const NOW = new Date("2026-06-01T00:00:00.000Z");
+const EXPECTED_FIRES_AT = new Date(
+	NOW.getTime() + TRIAL_FEEDBACK_EMAIL_DELAY_MS,
+).toISOString();
+
+function buildEventBridgeBody(detail: {
+	userId: string;
+	subscriptionId?: string;
+	reason?:
+		| "stripe_webhook"
+		| "user_initiated_trial"
+		| "user_initiated_paid_confirmed";
+}): string {
+	return JSON.stringify({
+		detail: {
+			userId: detail.userId,
+			...(detail.subscriptionId !== undefined
+				? { subscriptionId: detail.subscriptionId }
+				: {}),
+			reason: detail.reason ?? "user_initiated_trial",
+		},
+	});
+}
+
+function buildSubject() {
+	const trialScheduler = initInMemoryTrialScheduler();
+	const handler = initScheduleTrialFeedbackEmailHandler({
+		createTrialFeedbackEmailSchedule: trialScheduler.createTrialFeedbackEmailSchedule,
+		now: () => NOW,
+		logger: HutchLogger.from(noopLogger),
+	});
+	return { handler, trialScheduler };
+}
+
+describe("schedule-trial-feedback-email handler", () => {
+	it("schedules the feedback email exactly 3 days after now when reason='user_initiated_trial'", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-trial",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						reason: "user_initiated_trial",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.deepEqual(subject.trialScheduler.allTrialFeedbackEmailSchedules(), [
+			{ userId: USER_ID, firesAt: EXPECTED_FIRES_AT },
+		]);
+	});
+
+	it("ignores cancels with reason='user_initiated_paid_confirmed' — paid churn is out of scope", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-paid",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						subscriptionId: "sub_paid",
+						reason: "user_initiated_paid_confirmed",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.deepEqual(
+			subject.trialScheduler.allTrialFeedbackEmailSchedules(),
+			[],
+		);
+	});
+
+	it("ignores Stripe-side cancels (reason='stripe_webhook') because trial users never produce one", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-stripe",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						subscriptionId: "sub_stripe",
+						reason: "stripe_webhook",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.deepEqual(
+			subject.trialScheduler.allTrialFeedbackEmailSchedules(),
+			[],
+		);
+	});
+
+	it("is idempotent for duplicate SubscriptionCancelledEvent deliveries — same deterministic schedule overwritten, not stacked", async () => {
+		const subject = buildSubject();
+
+		await subject.handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-dup-1",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						reason: "user_initiated_trial",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+		await subject.handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-dup-2",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						reason: "user_initiated_trial",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		const schedules = subject.trialScheduler.allTrialFeedbackEmailSchedules();
+		assert.equal(schedules.length, 1);
+		assert.equal(schedules[0].firesAt, EXPECTED_FIRES_AT);
+	});
+
+	it("reports a batch item failure when the scheduler throws", async () => {
+		const trialScheduler = initInMemoryTrialScheduler({
+			createTrialFeedbackEmailFails: true,
+		});
+		const handler = initScheduleTrialFeedbackEmailHandler({
+			createTrialFeedbackEmailSchedule:
+				trialScheduler.createTrialFeedbackEmailSchedule,
+			now: () => NOW,
+			logger: HutchLogger.from(noopLogger),
+		});
+
+		const result = await handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-fail",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						reason: "user_initiated_trial",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 1);
+		assert.equal(result.batchItemFailures[0].itemIdentifier, "msg-fail");
+	});
+
+	it("reports a batch item failure for malformed JSON without dropping other records in the batch", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{ messageId: "msg-bad", body: "not-json" },
+				{
+					messageId: "msg-ok",
+					body: buildEventBridgeBody({
+						userId: USER_ID,
+						reason: "user_initiated_trial",
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 1);
+		assert.equal(result.batchItemFailures[0].itemIdentifier, "msg-bad");
+		assert.deepEqual(subject.trialScheduler.allTrialFeedbackEmailSchedules(), [
+			{ userId: USER_ID, firesAt: EXPECTED_FIRES_AT },
+		]);
+	});
+
+	it("reports a batch item failure when the envelope is missing userId — the trial-cancel filter pins the schema", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{
+					messageId: "msg-schema",
+					body: JSON.stringify({
+						detail: { reason: "user_initiated_trial" },
+					}),
+				},
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 1);
+		assert.equal(result.batchItemFailures[0].itemIdentifier, "msg-schema");
+	});
+});

--- a/projects/hutch/src/runtime/schedule-trial-feedback-email/schedule-trial-feedback-email-handler.ts
+++ b/projects/hutch/src/runtime/schedule-trial-feedback-email/schedule-trial-feedback-email-handler.ts
@@ -1,0 +1,61 @@
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
+import { z } from "zod";
+import { UserIdSchema } from "@packages/domain/user";
+import { SubscriptionCancelledEvent } from "@packages/hutch-infra-components";
+import type { HutchLogger } from "@packages/hutch-logger";
+import type { CreateTrialFeedbackEmailSchedule } from "@packages/test-fixtures/providers/trial-scheduler";
+
+/** Three days after the trial-cancel arrives. Long enough that the email
+ * doesn't read as automated reaction to the cancel click, short enough that
+ * the reason is still fresh in the recipient's mind. */
+export const TRIAL_FEEDBACK_EMAIL_DELAY_MS = 3 * 24 * 60 * 60 * 1000;
+
+export function initScheduleTrialFeedbackEmailHandler(deps: {
+	createTrialFeedbackEmailSchedule: CreateTrialFeedbackEmailSchedule;
+	now: () => Date;
+	logger: HutchLogger;
+}): Handler<SQSEvent, SQSBatchResponse> {
+	return async (event) => {
+		const batchItemFailures: SQSBatchItemFailure[] = [];
+
+		for (const record of event.Records) {
+			try {
+				const envelope = z
+					.object({ detail: z.unknown() })
+					.parse(JSON.parse(record.body));
+				const detail = SubscriptionCancelledEvent.detailSchema.parse(
+					envelope.detail,
+				);
+				if (detail.reason !== "user_initiated_trial") {
+					deps.logger.info(
+						"[schedule-trial-feedback-email] non-trial cancel — noop",
+						{ userId: detail.userId, reason: detail.reason },
+					);
+					continue;
+				}
+				const userId = UserIdSchema.parse(detail.userId);
+				const firesAt = new Date(
+					deps.now().getTime() + TRIAL_FEEDBACK_EMAIL_DELAY_MS,
+				).toISOString();
+				await deps.createTrialFeedbackEmailSchedule({ userId, firesAt });
+				deps.logger.info(
+					"[schedule-trial-feedback-email] schedule created",
+					{ userId, firesAt },
+				);
+			} catch (error) {
+				deps.logger.error("[schedule-trial-feedback-email] record failed", {
+					messageId: record.messageId,
+					error,
+				});
+				batchItemFailures.push({ itemIdentifier: record.messageId });
+			}
+		}
+
+		return { batchItemFailures };
+	};
+}

--- a/projects/hutch/src/runtime/send-trial-feedback-email.main.ts
+++ b/projects/hutch/src/runtime/send-trial-feedback-email.main.ts
@@ -1,0 +1,53 @@
+/* c8 ignore start -- composition root, no logic to test */
+import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+import { initDynamoDbArticleStore } from "./providers/article-store/dynamodb-article-store";
+import { initDynamoDbAuth } from "./providers/auth/dynamodb-auth";
+import { initDynamoDbSubscriptionProviders } from "./providers/subscription-providers/dynamodb-subscription-providers";
+import { initResendEmail } from "./providers/email/resend-email";
+import { initSendTrialFeedbackEmailHandler } from "./send-trial-feedback-email/send-trial-feedback-email-handler";
+import { requireEnv } from "./domain/require-env";
+
+const articlesTable = requireEnv("DYNAMODB_ARTICLES_TABLE");
+const userArticlesTable = requireEnv("DYNAMODB_USER_ARTICLES_TABLE");
+const usersTable = requireEnv("DYNAMODB_USERS_TABLE");
+const sessionsTable = requireEnv("DYNAMODB_SESSIONS_TABLE");
+const subscriptionProvidersTable = requireEnv(
+	"DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE",
+);
+const resendApiKey = requireEnv("RESEND_API_KEY");
+const staticBaseUrl = requireEnv("STATIC_BASE_URL");
+
+const dynamoClient = createDynamoDocumentClient();
+
+const subscriptionProviders = initDynamoDbSubscriptionProviders({
+	client: dynamoClient,
+	tableName: subscriptionProvidersTable,
+	now: () => new Date(),
+});
+
+const auth = initDynamoDbAuth({
+	client: dynamoClient,
+	usersTableName: usersTable,
+	sessionsTableName: sessionsTable,
+});
+
+const articleStore = initDynamoDbArticleStore({
+	client: dynamoClient,
+	tableName: articlesTable,
+	userArticlesTableName: userArticlesTable,
+});
+
+const { sendEmail } = initResendEmail(resendApiKey);
+
+export const handler = initSendTrialFeedbackEmailHandler({
+	findSubscriptionByUserId: subscriptionProviders.findByUserId,
+	findEmailByUserId: auth.findEmailByUserId,
+	findArticlesByUser: articleStore.findArticlesByUser,
+	markTrialFeedbackEmailSent: subscriptionProviders.markTrialFeedbackEmailSent,
+	sendEmail,
+	founderAvatarUrl: `${staticBaseUrl}/fayner-brack.jpg`,
+	now: () => new Date(),
+	logger: HutchLogger.from(consoleLogger),
+});
+/* c8 ignore stop */

--- a/projects/hutch/src/runtime/send-trial-feedback-email/send-trial-feedback-email-handler.test.ts
+++ b/projects/hutch/src/runtime/send-trial-feedback-email/send-trial-feedback-email-handler.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
+import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import { initInMemoryEmail } from "@packages/test-fixtures/providers/email";
+import { initInMemorySubscriptionProviders } from "@packages/test-fixtures/providers/subscription-providers";
+import type { FindArticlesByUser } from "@packages/test-fixtures/providers/article-store";
+import { buildSqsEvent } from "@packages/test-fixtures/sqs";
+import {
+	initSendTrialFeedbackEmailHandler,
+	type SendTrialFeedbackEmailDeps,
+} from "./send-trial-feedback-email-handler";
+
+const USER_ID = UserIdSchema.parse("6".repeat(32));
+const FOUNDER_AVATAR_URL = "https://static.readplace.com/fayner-brack.jpg";
+const SENT_AT = new Date("2026-06-04T10:00:00.000Z");
+
+function buildEventBridgeBody(userId: string): string {
+	return JSON.stringify({ detail: { userId } });
+}
+
+function fakeFindArticlesByUser(total: number): FindArticlesByUser {
+	return async () => ({
+		articles: [],
+		total,
+		page: 1,
+		pageSize: 20,
+	});
+}
+
+interface SubjectOverrides {
+	findEmail?: (userId: string) => Promise<string | null>;
+	articlesTotal?: number;
+}
+
+function buildSubject(overrides: SubjectOverrides = {}) {
+	const providers = initInMemorySubscriptionProviders({
+		now: () => new Date("2026-06-01T00:00:00.000Z"),
+	});
+	const email = initInMemoryEmail();
+	const findEmailByUserId = overrides.findEmail ?? (async () => "user@example.com");
+	const deps: SendTrialFeedbackEmailDeps = {
+		findSubscriptionByUserId: providers.findByUserId,
+		findEmailByUserId,
+		findArticlesByUser: fakeFindArticlesByUser(overrides.articlesTotal ?? 0),
+		markTrialFeedbackEmailSent: providers.markTrialFeedbackEmailSent,
+		sendEmail: email.sendEmail,
+		founderAvatarUrl: FOUNDER_AVATAR_URL,
+		now: () => SENT_AT,
+		logger: HutchLogger.from(noopLogger),
+	};
+	const handler = initSendTrialFeedbackEmailHandler(deps);
+	return { handler, providers, email };
+}
+
+async function seedCancelledTrial(
+	providers: ReturnType<typeof initInMemorySubscriptionProviders>,
+): Promise<void> {
+	await providers.upsertTrialing({
+		userId: USER_ID,
+		trialEndsAt: "2026-06-05T00:00:00.000Z",
+	});
+	await providers.markCancelledByUserId({ userId: USER_ID });
+}
+
+describe("send-trial-feedback-email handler", () => {
+	it("sends the email and marks the row as sent on the happy path", async () => {
+		const subject = buildSubject({ articlesTotal: 9 });
+		await seedCancelledTrial(subject.providers);
+
+		const result = await subject.handler(
+			buildSqsEvent([{ messageId: "msg-ok", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.equal(subject.email.getSentEmails().length, 1);
+		const sent = subject.email.getSentEmails()[0];
+		assert.equal(sent.to, "user@example.com");
+		assert.equal(sent.from, "Fayner from Readplace <fayner@readplace.com>");
+		assert.equal(sent.replyTo, "fayner@readplace.com");
+		assert.equal(sent.bcc, "readplace+trial_feedback@readplace.com");
+		assert.equal(sent.subject, "you tried Readplace — what was missing?");
+		assert.ok(sent.text);
+		assert.ok(sent.text.includes("saved 9 articles"));
+		assert.ok(sent.html.includes("saved 9 articles"));
+		assert.ok(sent.html.includes("fayner-brack.jpg"));
+
+		const row = await subject.providers.findByUserId(USER_ID);
+		assert(row, "row must still exist");
+		assert.equal(row.trialFeedbackEmailSentAt, SENT_AT.toISOString());
+	});
+
+	it("omits the saved-articles clause when the user saved zero — never fabricates usage", async () => {
+		const subject = buildSubject({ articlesTotal: 0 });
+		await seedCancelledTrial(subject.providers);
+
+		await subject.handler(
+			buildSqsEvent([{ messageId: "msg-zero", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		const sent = subject.email.getSentEmails()[0];
+		assert.ok(sent.text);
+		assert.ok(!sent.text.includes("saved"));
+		assert.ok(!sent.text.includes("article"));
+	});
+
+	it("noops when the user reactivated during the delay window (status='trialing')", async () => {
+		const subject = buildSubject({ articlesTotal: 5 });
+		await subject.providers.upsertTrialing({
+			userId: USER_ID,
+			trialEndsAt: "2026-06-05T00:00:00.000Z",
+		});
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{ messageId: "msg-reactivated", body: buildEventBridgeBody(USER_ID) },
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.equal(subject.email.getSentEmails().length, 0);
+		const row = await subject.providers.findByUserId(USER_ID);
+		assert(row);
+		assert.equal(row.trialFeedbackEmailSentAt, undefined);
+	});
+
+	it("noops when the user reactivated and is now status='active' (paid)", async () => {
+		const subject = buildSubject({ articlesTotal: 5 });
+		await subject.providers.upsertActive({
+			userId: USER_ID,
+			subscriptionId: "sub_active",
+			customerId: "cus_active",
+		});
+
+		await subject.handler(
+			buildSqsEvent([{ messageId: "msg-active", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		assert.equal(subject.email.getSentEmails().length, 0);
+	});
+
+	it("noops when the email was already sent — deterministic schedule + sent flag => at most one email", async () => {
+		const subject = buildSubject({ articlesTotal: 5 });
+		await seedCancelledTrial(subject.providers);
+		await subject.providers.markTrialFeedbackEmailSent({
+			userId: USER_ID,
+			sentAt: "2026-06-04T00:00:00.000Z",
+		});
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{ messageId: "msg-dup", body: buildEventBridgeBody(USER_ID) },
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.equal(subject.email.getSentEmails().length, 0);
+	});
+
+	it("noops when there is no subscription row at all", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([{ messageId: "msg-missing", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.equal(subject.email.getSentEmails().length, 0);
+	});
+
+	it("noops when there is no email on file for the user", async () => {
+		const subject = buildSubject({
+			articlesTotal: 5,
+			findEmail: async () => null,
+		});
+		await seedCancelledTrial(subject.providers);
+
+		const result = await subject.handler(
+			buildSqsEvent([{ messageId: "msg-no-email", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 0);
+		assert.equal(subject.email.getSentEmails().length, 0);
+		const row = await subject.providers.findByUserId(USER_ID);
+		assert(row);
+		assert.equal(row.trialFeedbackEmailSentAt, undefined);
+	});
+
+	it("singularises the saved-articles clause when the user saved exactly one article", async () => {
+		const subject = buildSubject({ articlesTotal: 1 });
+		await seedCancelledTrial(subject.providers);
+
+		await subject.handler(
+			buildSqsEvent([{ messageId: "msg-one", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		const sent = subject.email.getSentEmails()[0];
+		assert.ok(sent.text);
+		assert.ok(sent.text.includes("saved 1 article"));
+		assert.ok(!sent.text.includes("saved 1 articles"));
+	});
+
+	it("reports a batch item failure when sendEmail throws", async () => {
+		const providers = initInMemorySubscriptionProviders({
+			now: () => new Date("2026-06-01T00:00:00.000Z"),
+		});
+		await providers.upsertTrialing({
+			userId: USER_ID,
+			trialEndsAt: "2026-06-05T00:00:00.000Z",
+		});
+		await providers.markCancelledByUserId({ userId: USER_ID });
+
+		const handler = initSendTrialFeedbackEmailHandler({
+			findSubscriptionByUserId: providers.findByUserId,
+			findEmailByUserId: async () => "user@example.com",
+			findArticlesByUser: fakeFindArticlesByUser(2),
+			markTrialFeedbackEmailSent: providers.markTrialFeedbackEmailSent,
+			sendEmail: async () => {
+				throw new Error("Resend rejected");
+			},
+			founderAvatarUrl: FOUNDER_AVATAR_URL,
+			now: () => SENT_AT,
+			logger: HutchLogger.from(noopLogger),
+		});
+
+		const result = await handler(
+			buildSqsEvent([{ messageId: "msg-fail", body: buildEventBridgeBody(USER_ID) }]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 1);
+		assert.equal(result.batchItemFailures[0].itemIdentifier, "msg-fail");
+		const row = await providers.findByUserId(USER_ID);
+		assert(row);
+		assert.equal(row.trialFeedbackEmailSentAt, undefined);
+	});
+
+	it("reports a batch item failure for malformed JSON", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([{ messageId: "msg-bad", body: "not-json" }]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 1);
+		assert.equal(result.batchItemFailures[0].itemIdentifier, "msg-bad");
+	});
+
+	it("reports a batch item failure when the envelope is missing userId", async () => {
+		const subject = buildSubject();
+
+		const result = await subject.handler(
+			buildSqsEvent([
+				{ messageId: "msg-schema", body: JSON.stringify({ detail: {} }) },
+			]),
+			{} as never,
+			() => {},
+		);
+
+		assert(result);
+		assert.equal(result.batchItemFailures.length, 1);
+	});
+});

--- a/projects/hutch/src/runtime/send-trial-feedback-email/send-trial-feedback-email-handler.ts
+++ b/projects/hutch/src/runtime/send-trial-feedback-email/send-trial-feedback-email-handler.ts
@@ -1,0 +1,130 @@
+import type {
+	Handler,
+	SQSBatchItemFailure,
+	SQSBatchResponse,
+	SQSEvent,
+} from "aws-lambda";
+import { z } from "zod";
+import { UserIdSchema } from "@packages/domain/user";
+import { SendTrialFeedbackEmailCommand } from "@packages/hutch-infra-components";
+import type { HutchLogger } from "@packages/hutch-logger";
+import type { FindEmailByUserId } from "@packages/test-fixtures/providers/auth";
+import type { FindArticlesByUser } from "@packages/test-fixtures/providers/article-store";
+import type { SendEmail } from "@packages/test-fixtures/providers/email";
+import type {
+	FindSubscriptionByUserId,
+	MarkTrialFeedbackEmailSent,
+} from "@packages/test-fixtures/providers/subscription-providers";
+import {
+	TrialFeedbackEmail,
+	TRIAL_FEEDBACK_EMAIL_SUBJECT,
+} from "../web/auth/trial-feedback-email";
+
+const EMAIL_FROM = "Fayner from Readplace <fayner@readplace.com>";
+const EMAIL_REPLY_TO = "fayner@readplace.com";
+const EMAIL_BCC = "readplace+trial_feedback@readplace.com";
+
+export interface SendTrialFeedbackEmailDeps {
+	findSubscriptionByUserId: FindSubscriptionByUserId;
+	findEmailByUserId: FindEmailByUserId;
+	findArticlesByUser: FindArticlesByUser;
+	markTrialFeedbackEmailSent: MarkTrialFeedbackEmailSent;
+	sendEmail: SendEmail;
+	founderAvatarUrl: string;
+	now: () => Date;
+	logger: HutchLogger;
+}
+
+export function initSendTrialFeedbackEmailHandler(
+	deps: SendTrialFeedbackEmailDeps,
+): Handler<SQSEvent, SQSBatchResponse> {
+	return async (event) => {
+		const batchItemFailures: SQSBatchItemFailure[] = [];
+
+		for (const record of event.Records) {
+			try {
+				const envelope = z
+					.object({ detail: z.unknown() })
+					.parse(JSON.parse(record.body));
+				const detail = SendTrialFeedbackEmailCommand.detailSchema.parse(
+					envelope.detail,
+				);
+				const userId = UserIdSchema.parse(detail.userId);
+				await processCommand(userId, deps);
+			} catch (error) {
+				deps.logger.error("[send-trial-feedback-email] record failed", {
+					messageId: record.messageId,
+					error,
+				});
+				batchItemFailures.push({ itemIdentifier: record.messageId });
+			}
+		}
+
+		return { batchItemFailures };
+	};
+}
+
+async function processCommand(
+	userId: ReturnType<typeof UserIdSchema.parse>,
+	deps: SendTrialFeedbackEmailDeps,
+): Promise<void> {
+	const row = await deps.findSubscriptionByUserId(userId);
+	if (!row) {
+		deps.logger.info(
+			"[send-trial-feedback-email] no subscription row — noop",
+			{ userId },
+		);
+		return;
+	}
+	if (row.status !== "cancelled") {
+		deps.logger.info(
+			"[send-trial-feedback-email] user reactivated during delay window — noop",
+			{ userId, status: row.status },
+		);
+		return;
+	}
+	if (row.trialFeedbackEmailSentAt) {
+		deps.logger.info(
+			"[send-trial-feedback-email] already sent — noop",
+			{ userId, sentAt: row.trialFeedbackEmailSentAt },
+		);
+		return;
+	}
+
+	const email = await deps.findEmailByUserId(userId);
+	if (!email) {
+		deps.logger.info(
+			"[send-trial-feedback-email] no email on file — noop",
+			{ userId },
+		);
+		return;
+	}
+
+	const { total } = await deps.findArticlesByUser({
+		userId,
+		excludeContent: true,
+	});
+
+	const component = TrialFeedbackEmail({
+		founderAvatarUrl: deps.founderAvatarUrl,
+		savedArticlesCount: total,
+	});
+
+	await deps.sendEmail({
+		from: EMAIL_FROM,
+		to: email,
+		bcc: EMAIL_BCC,
+		replyTo: EMAIL_REPLY_TO,
+		subject: TRIAL_FEEDBACK_EMAIL_SUBJECT,
+		html: component.to("text/html"),
+		text: component.to("text/plain"),
+	});
+
+	const sentAt = deps.now().toISOString();
+	await deps.markTrialFeedbackEmailSent({ userId, sentAt });
+	deps.logger.info("[send-trial-feedback-email] sent", {
+		userId,
+		savedArticlesCount: total,
+		sentAt,
+	});
+}

--- a/projects/hutch/src/runtime/web/auth/trial-feedback-email.template.html
+++ b/projects/hutch/src/runtime/web/auth/trial-feedback-email.template.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>you tried Readplace — what was missing?</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:{{colors.background}};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:{{colors.background}};padding:40px 20px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:{{colors.surface}};border-radius:8px;padding:40px;">
+            <tr>
+              <td align="center" style="padding-bottom:16px;">
+                <img src="{{founderAvatarUrl}}" width="64" height="64" alt="Fayner Brack" style="border-radius:50%;display:block;">
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">You started a trial of Readplace{{usageClause}} and decided not to continue. That decision is one of the most useful things I can learn from right now, so I'm asking directly: what was missing?</p>
+                <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:{{colors.body}};">I'm not trying to change your mind or sell you anything. I'd rather know the real reason it didn't earn a place in how you read — a missing feature, the price, something that didn't work, or just that it didn't fit.</p>
+                <p style="margin:0 0 24px;font-size:16px;line-height:1.6;color:{{colors.body}};">The honest answer helps more than a polite one. A sentence is plenty, and there's nothing to click.</p>
+                <p style="margin:0;font-size:16px;line-height:1.6;color:{{colors.body}};">— Fayner</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/projects/hutch/src/runtime/web/auth/trial-feedback-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-feedback-email.test.ts
@@ -1,0 +1,156 @@
+import {
+	TrialFeedbackEmail,
+	TRIAL_FEEDBACK_EMAIL_SUBJECT,
+} from "./trial-feedback-email";
+
+const baseParams = {
+	founderAvatarUrl: "https://readplace.com/fayner-brack.jpg",
+	savedArticlesCount: 9,
+};
+
+describe("TrialFeedbackEmail", () => {
+	describe("subject", () => {
+		it("has no exclamation marks and contains exactly one question mark", () => {
+			expect(TRIAL_FEEDBACK_EMAIL_SUBJECT).not.toContain("!");
+			const questionMarks = TRIAL_FEEDBACK_EMAIL_SUBJECT.match(/\?/g) ?? [];
+			expect(questionMarks.length).toBe(1);
+		});
+
+		it("opens with 'you tried Readplace' so the recipient sees the research framing in the inbox", () => {
+			expect(TRIAL_FEEDBACK_EMAIL_SUBJECT).toContain("you tried Readplace");
+			expect(TRIAL_FEEDBACK_EMAIL_SUBJECT).toContain("what was missing?");
+		});
+	});
+
+	describe("text/plain body — voice and constraints", () => {
+		it("contains no exclamation marks", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text).not.toContain("!");
+		});
+
+		it("contains exactly one question mark — the single 'what was missing?'", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			const questionMarks = text.match(/\?/g) ?? [];
+			expect(questionMarks.length).toBe(1);
+			expect(text).toContain("what was missing?");
+		});
+
+		it("is shorter than 120 words", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			const words = text.trim().split(/\s+/);
+			expect(words.length).toBeLessThan(120);
+		});
+
+		it("signs off with '— Fayner' and nothing after it", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text.trimEnd().endsWith("— Fayner")).toBe(true);
+		});
+
+		it("is first-person ('I'/'I'm') and never speaks for the company in plural", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text).toMatch(/\bI'?m\b/);
+			expect(text).not.toMatch(/\bwe\b/i);
+			expect(text).not.toMatch(/\bour\b/i);
+		});
+
+		it("uses the brand name 'Readplace' with the correct casing", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text).toContain("Readplace");
+			expect(text).not.toContain("readplace ");
+			expect(text).not.toContain("ReadPlace");
+		});
+
+		it("contains no links — there's nothing to click", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text).not.toMatch(/https?:\/\//i);
+		});
+
+		it("contains no opt-out footer — strict to the research-email spec", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text.toLowerCase()).not.toContain("unsubscribe");
+			expect(text.toUpperCase()).not.toContain("REPLY STOP");
+		});
+	});
+
+	describe("text/plain body — saved-articles personalization", () => {
+		it("includes 'saved 9 articles' when the user saved nine", () => {
+			const text = TrialFeedbackEmail({ ...baseParams, savedArticlesCount: 9 }).to(
+				"text/plain",
+			);
+			expect(text).toContain("saved 9 articles");
+		});
+
+		it("singularises to '1 article' when the user saved one", () => {
+			const text = TrialFeedbackEmail({
+				...baseParams,
+				savedArticlesCount: 1,
+			}).to("text/plain");
+			expect(text).toContain("saved 1 article");
+			expect(text).not.toContain("saved 1 articles");
+		});
+
+		it("omits the saved-articles clause entirely when the count is zero", () => {
+			const text = TrialFeedbackEmail({
+				...baseParams,
+				savedArticlesCount: 0,
+			}).to("text/plain");
+			expect(text).not.toContain("saved");
+			expect(text).not.toContain("article");
+			expect(text).toContain("You started a trial of Readplace and decided not to continue");
+		});
+	});
+
+	describe("text/html body", () => {
+		it("renders the founder avatar with the absolute URL", () => {
+			const html = TrialFeedbackEmail(baseParams).to("text/html");
+
+			expect(html).toContain('src="https://readplace.com/fayner-brack.jpg"');
+			expect(html).toContain('alt="Fayner Brack"');
+			expect(html).toContain("border-radius:50%");
+		});
+
+		it("escapes HTML entities in the avatar URL so a hostile value cannot inject markup", () => {
+			const html = TrialFeedbackEmail({
+				...baseParams,
+				founderAvatarUrl: "https://readplace.com/avatar.jpg?\"'<>&",
+			}).to("text/html");
+
+			expect(html).toContain(
+				'src="https://readplace.com/avatar.jpg?&quot;&#x27;&lt;&gt;&amp;"',
+			);
+		});
+
+		it("produces a complete HTML document with the subject in the <title>", () => {
+			const html = TrialFeedbackEmail(baseParams).to("text/html");
+
+			expect(html).toContain("<!DOCTYPE html>");
+			expect(html).toContain("</html>");
+			expect(html).toContain("you tried Readplace");
+			expect(html).toContain("what was missing?");
+		});
+
+		it("renders the saved-articles clause when count > 0", () => {
+			const html = TrialFeedbackEmail({ ...baseParams, savedArticlesCount: 9 }).to(
+				"text/html",
+			);
+			expect(html).toContain("saved 9 articles");
+		});
+
+		it("omits the saved-articles clause entirely when count is zero", () => {
+			const html = TrialFeedbackEmail({
+				...baseParams,
+				savedArticlesCount: 0,
+			}).to("text/html");
+			expect(html).not.toContain("saved");
+			expect(html).toContain("You started a trial of Readplace and decided not to continue");
+		});
+
+		it("contains the verified copy paragraphs", () => {
+			const html = TrialFeedbackEmail(baseParams).to("text/html");
+			expect(html).toContain("what was missing?");
+			expect(html).toContain("I'm not trying to change your mind");
+			expect(html).toContain("The honest answer helps more than a polite one");
+			expect(html).toContain("— Fayner");
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/auth/trial-feedback-email.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-feedback-email.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { EMAIL_COLORS } from "../email-colors";
+import { render } from "../render";
+
+const TEMPLATE = readFileSync(
+	join(__dirname, "trial-feedback-email.template.html"),
+	"utf-8",
+);
+
+export const TRIAL_FEEDBACK_EMAIL_SUBJECT =
+	"you tried Readplace — what was missing?";
+
+interface TrialFeedbackEmailParams {
+	founderAvatarUrl: string;
+	savedArticlesCount: number;
+}
+
+interface TrialFeedbackEmailComponent {
+	to: (mediaType: "text/html" | "text/plain") => string;
+}
+
+/** Returns the saved-articles clause that follows "You started a trial of
+ * Readplace" in both the plain-text and HTML bodies. Returns an empty string
+ * when the user saved zero articles so the sentence reads naturally without
+ * any fabricated usage. */
+function usageClause(count: number): string {
+	if (count === 0) return "";
+	const noun = count === 1 ? "article" : "articles";
+	return `, saved ${count} ${noun},`;
+}
+
+export function TrialFeedbackEmail(
+	params: TrialFeedbackEmailParams,
+): TrialFeedbackEmailComponent {
+	const clause = usageClause(params.savedArticlesCount);
+	return {
+		to(mediaType) {
+			if (mediaType === "text/html") {
+				return render(TEMPLATE, {
+					founderAvatarUrl: params.founderAvatarUrl,
+					usageClause: clause,
+					colors: EMAIL_COLORS,
+				});
+			}
+
+			return [
+				`You started a trial of Readplace${clause} and decided not to continue. That decision is one of the most useful things I can learn from right now, so I'm asking directly: what was missing?`,
+				"",
+				"I'm not trying to change your mind or sell you anything. I'd rather know the real reason it didn't earn a place in how you read — a missing feature, the price, something that didn't work, or just that it didn't fit.",
+				"",
+				"The honest answer helps more than a polite one. A sentence is plenty, and there's nothing to click.",
+				"",
+				"— Fayner",
+			].join("\n");
+		},
+	};
+}

--- a/src/packages/hutch-infra-components/src/events.ts
+++ b/src/packages/hutch-infra-components/src/events.ts
@@ -557,4 +557,22 @@ export type SubscriptionChargeFailedDetail = z.infer<
 	typeof SubscriptionChargeFailedEvent.detailSchema
 >;
 
+/** Delayed trial-feedback research email request. Published by the EventBridge
+ * Scheduler one-shot created by `schedule-trial-feedback-email` when a
+ * `SubscriptionCancelledEvent` with `reason='user_initiated_trial'` arrives.
+ * Consumed by `send-trial-feedback-email` which re-reads the row to confirm
+ * the user is still cancelled (reactivation guard) before sending Fayner's
+ * "what was missing?" research email. */
+export const SendTrialFeedbackEmailCommand = defineEvent({
+	name: "send-trial-feedback-email-command",
+	source: "hutch.subscriptions",
+	detailType: "SendTrialFeedbackEmailCommand",
+	detailSchema: z.object({
+		userId: z.string(),
+	}),
+});
+export type SendTrialFeedbackEmailDetail = z.infer<
+	typeof SendTrialFeedbackEmailCommand.detailSchema
+>;
+
 export type { HutchEvent, HutchCommand };

--- a/src/packages/hutch-infra-components/src/index.ts
+++ b/src/packages/hutch-infra-components/src/index.ts
@@ -63,6 +63,8 @@ export {
 	type SubscriptionChargeSucceededDetail,
 	SubscriptionChargeFailedEvent,
 	type SubscriptionChargeFailedDetail,
+	SendTrialFeedbackEmailCommand,
+	type SendTrialFeedbackEmailDetail,
 	type HutchEvent,
 	type HutchCommand,
 } from "./events";

--- a/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.test.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.test.ts
@@ -172,6 +172,29 @@ describe("initInMemorySubscriptionProviders", () => {
 		await expect(subs.markActive({ userId })).rejects.toThrow(/No subscription row/);
 	});
 
+	it("markTrialFeedbackEmailSent records the sentAt timestamp on the row", async () => {
+		const clock = { iso: "2026-05-22T00:00:00.000Z" };
+		const subs = initInMemorySubscriptionProviders({ now: () => new Date(clock.iso) });
+		await subs.upsertTrialing({ userId, trialEndsAt: "2026-06-05T00:00:00.000Z" });
+		await subs.markCancelledByUserId({ userId });
+
+		clock.iso = "2026-06-04T00:00:00.000Z";
+		await subs.markTrialFeedbackEmailSent({ userId, sentAt: "2026-06-04T00:00:00.000Z" });
+
+		const row = await subs.findByUserId(userId);
+		assert(row, "row must exist");
+		expect(row.trialFeedbackEmailSentAt).toBe("2026-06-04T00:00:00.000Z");
+		expect(row.status).toBe("cancelled");
+		expect(row.updatedAt).toBe("2026-06-04T00:00:00.000Z");
+	});
+
+	it("throws when markTrialFeedbackEmailSent is called for an unknown user", async () => {
+		const subs = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
+		await expect(
+			subs.markTrialFeedbackEmailSent({ userId, sentAt: "2026-06-04T00:00:00.000Z" }),
+		).rejects.toThrow(/No subscription row/);
+	});
+
 	it("seedRow lets tests inject hypothetical row shapes (e.g. trialing with customerId)", async () => {
 		const subs = initInMemorySubscriptionProviders({ now: fixedNow("2026-05-22T00:00:00.000Z") });
 

--- a/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/in-memory-subscription-providers.ts
@@ -7,6 +7,7 @@ import type {
 	MarkSubscriptionCancelled,
 	MarkSubscriptionCancelledByUserId,
 	MarkSubscriptionPendingCancellation,
+	MarkTrialFeedbackEmailSent,
 	SubscriptionRecord,
 	UpsertActiveSubscription,
 	UpsertTrialingSubscription,
@@ -23,6 +24,7 @@ export function initInMemorySubscriptionProviders(opts: {
 	markCancelled: MarkSubscriptionCancelled;
 	markCancelledByUserId: MarkSubscriptionCancelledByUserId;
 	markActive: MarkSubscriptionActive;
+	markTrialFeedbackEmailSent: MarkTrialFeedbackEmailSent;
 	seedRow: (row: SubscriptionRecord) => void;
 } {
 	const rows = new Map<UserId, SubscriptionRecord>();
@@ -110,6 +112,19 @@ export function initInMemorySubscriptionProviders(opts: {
 		});
 	};
 
+	const markTrialFeedbackEmailSent: MarkTrialFeedbackEmailSent = async ({
+		userId,
+		sentAt,
+	}) => {
+		const existing = rows.get(userId);
+		assert(existing, `No subscription row for user ${userId}`);
+		rows.set(userId, {
+			...existing,
+			trialFeedbackEmailSentAt: sentAt,
+			updatedAt: opts.now().toISOString(),
+		});
+	};
+
 	/** Test-only escape hatch for seeding hypothetical row shapes (e.g. a
 	 * trialing row that also has a customerId — production paths never write
 	 * this combination, but the trial-end charge handler must still cover the
@@ -127,6 +142,7 @@ export function initInMemorySubscriptionProviders(opts: {
 		markCancelled,
 		markCancelledByUserId,
 		markActive,
+		markTrialFeedbackEmailSent,
 		seedRow,
 	};
 }

--- a/src/packages/test-fixtures/src/providers/subscription-providers/subscription-providers.types.ts
+++ b/src/packages/test-fixtures/src/providers/subscription-providers/subscription-providers.types.ts
@@ -15,6 +15,7 @@ export interface SubscriptionRecord {
 	status: SubscriptionStatus;
 	trialEndsAt?: string;
 	cancellationEffectiveAt?: string;
+	trialFeedbackEmailSentAt?: string;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -52,4 +53,9 @@ export type MarkSubscriptionCancelledByUserId = (input: {
 }) => Promise<void>;
 
 export type MarkSubscriptionActive = (input: { userId: UserId }) => Promise<void>;
+
+export type MarkTrialFeedbackEmailSent = (input: {
+	userId: UserId;
+	sentAt: string;
+}) => Promise<void>;
 /* c8 ignore stop */

--- a/src/packages/test-fixtures/src/providers/trial-scheduler/in-memory-trial-scheduler.test.ts
+++ b/src/packages/test-fixtures/src/providers/trial-scheduler/in-memory-trial-scheduler.test.ts
@@ -102,4 +102,81 @@ describe("initInMemoryTrialScheduler", () => {
 		);
 		assert.equal(scheduler.getDeferredCancellationSchedule(userId), undefined);
 	});
+
+	it("records create + delete trial-feedback-email calls independently of the other schedule kinds", async () => {
+		const userIdA = UserIdSchema.parse("1".repeat(32));
+		const userIdB = UserIdSchema.parse("2".repeat(32));
+		const scheduler = initInMemoryTrialScheduler();
+
+		await scheduler.createTrialFeedbackEmailSchedule({
+			userId: userIdA,
+			firesAt: "2026-06-08T00:00:00.000Z",
+		});
+		await scheduler.createTrialFeedbackEmailSchedule({
+			userId: userIdB,
+			firesAt: "2026-06-09T00:00:00.000Z",
+		});
+
+		assert.equal(
+			scheduler.getTrialFeedbackEmailSchedule(userIdA),
+			"2026-06-08T00:00:00.000Z",
+		);
+		assert.deepEqual(scheduler.allTrialFeedbackEmailSchedules(), [
+			{ userId: userIdA, firesAt: "2026-06-08T00:00:00.000Z" },
+			{ userId: userIdB, firesAt: "2026-06-09T00:00:00.000Z" },
+		]);
+		// The other two schedule kinds remain untouched.
+		assert.deepEqual(scheduler.allSchedules(), []);
+		assert.deepEqual(scheduler.allDeferredCancellationSchedules(), []);
+
+		await scheduler.deleteTrialFeedbackEmailSchedule({ userId: userIdA });
+
+		assert.equal(scheduler.getTrialFeedbackEmailSchedule(userIdA), undefined);
+		assert.deepEqual(scheduler.trialFeedbackEmailDeleteCalls(), [userIdA]);
+	});
+
+	it("createTrialFeedbackEmailSchedule overwrites an existing schedule for the same user (idempotent on duplicate events)", async () => {
+		const userId = UserIdSchema.parse("3".repeat(32));
+		const scheduler = initInMemoryTrialScheduler();
+
+		await scheduler.createTrialFeedbackEmailSchedule({
+			userId,
+			firesAt: "2026-06-08T00:00:00.000Z",
+		});
+		await scheduler.createTrialFeedbackEmailSchedule({
+			userId,
+			firesAt: "2026-06-10T00:00:00.000Z",
+		});
+
+		assert.equal(
+			scheduler.getTrialFeedbackEmailSchedule(userId),
+			"2026-06-10T00:00:00.000Z",
+		);
+		assert.equal(scheduler.allTrialFeedbackEmailSchedules().length, 1);
+	});
+
+	it("deleteTrialFeedbackEmailSchedule is idempotent on a missing schedule", async () => {
+		const userId = UserIdSchema.parse("4".repeat(32));
+		const scheduler = initInMemoryTrialScheduler();
+
+		await assert.doesNotReject(scheduler.deleteTrialFeedbackEmailSchedule({ userId }));
+		assert.deepEqual(scheduler.trialFeedbackEmailDeleteCalls(), [userId]);
+	});
+
+	it("createTrialFeedbackEmailSchedule throws when configured to fail", async () => {
+		const userId = UserIdSchema.parse("5".repeat(32));
+		const scheduler = initInMemoryTrialScheduler({
+			createTrialFeedbackEmailFails: true,
+		});
+
+		await assert.rejects(
+			() =>
+				scheduler.createTrialFeedbackEmailSchedule({
+					userId,
+					firesAt: "2026-06-08T00:00:00.000Z",
+				}),
+			/In-memory trial-feedback-email create failure/,
+		);
+		assert.equal(scheduler.getTrialFeedbackEmailSchedule(userId), undefined);
+	});
 });

--- a/src/packages/test-fixtures/src/providers/trial-scheduler/in-memory-trial-scheduler.ts
+++ b/src/packages/test-fixtures/src/providers/trial-scheduler/in-memory-trial-scheduler.ts
@@ -2,29 +2,39 @@ import type { UserId } from "@packages/domain/user";
 import type {
 	CreateDeferredCancellationSchedule,
 	CreateTrialEndSchedule,
+	CreateTrialFeedbackEmailSchedule,
 	DeleteDeferredCancellationSchedule,
 	DeleteTrialEndSchedule,
+	DeleteTrialFeedbackEmailSchedule,
 } from "./trial-scheduler.types";
 
 export function initInMemoryTrialScheduler(opts?: {
 	createFails?: boolean;
 	createDeferredCancellationFails?: boolean;
+	createTrialFeedbackEmailFails?: boolean;
 }): {
 	createTrialEndSchedule: CreateTrialEndSchedule;
 	deleteTrialEndSchedule: DeleteTrialEndSchedule;
 	createDeferredCancellationSchedule: CreateDeferredCancellationSchedule;
 	deleteDeferredCancellationSchedule: DeleteDeferredCancellationSchedule;
+	createTrialFeedbackEmailSchedule: CreateTrialFeedbackEmailSchedule;
+	deleteTrialFeedbackEmailSchedule: DeleteTrialFeedbackEmailSchedule;
 	getSchedule: (userId: UserId) => string | undefined;
 	allSchedules: () => readonly { userId: UserId; firesAt: string }[];
 	deleteCalls: () => readonly UserId[];
 	getDeferredCancellationSchedule: (userId: UserId) => string | undefined;
 	allDeferredCancellationSchedules: () => readonly { userId: UserId; firesAt: string }[];
 	deferredCancellationDeleteCalls: () => readonly UserId[];
+	getTrialFeedbackEmailSchedule: (userId: UserId) => string | undefined;
+	allTrialFeedbackEmailSchedules: () => readonly { userId: UserId; firesAt: string }[];
+	trialFeedbackEmailDeleteCalls: () => readonly UserId[];
 } {
 	const trialEndSchedules = new Map<UserId, string>();
 	const trialEndDeletes: UserId[] = [];
 	const deferredCancellationSchedules = new Map<UserId, string>();
 	const deferredCancellationDeletes: UserId[] = [];
+	const trialFeedbackEmailSchedules = new Map<UserId, string>();
+	const trialFeedbackEmailDeletes: UserId[] = [];
 
 	const createTrialEndSchedule: CreateTrialEndSchedule = async ({ userId, firesAt }) => {
 		if (opts?.createFails) {
@@ -55,11 +65,30 @@ export function initInMemoryTrialScheduler(opts?: {
 		deferredCancellationSchedules.delete(userId);
 	};
 
+	const createTrialFeedbackEmailSchedule: CreateTrialFeedbackEmailSchedule = async ({
+		userId,
+		firesAt,
+	}) => {
+		if (opts?.createTrialFeedbackEmailFails) {
+			throw new Error("In-memory trial-feedback-email create failure");
+		}
+		trialFeedbackEmailSchedules.set(userId, firesAt);
+	};
+
+	const deleteTrialFeedbackEmailSchedule: DeleteTrialFeedbackEmailSchedule = async ({
+		userId,
+	}) => {
+		trialFeedbackEmailDeletes.push(userId);
+		trialFeedbackEmailSchedules.delete(userId);
+	};
+
 	return {
 		createTrialEndSchedule,
 		deleteTrialEndSchedule,
 		createDeferredCancellationSchedule,
 		deleteDeferredCancellationSchedule,
+		createTrialFeedbackEmailSchedule,
+		deleteTrialFeedbackEmailSchedule,
 		getSchedule: (userId) => trialEndSchedules.get(userId),
 		allSchedules: () => Array.from(trialEndSchedules.entries()).map(([userId, firesAt]) => ({ userId, firesAt })),
 		deleteCalls: () => [...trialEndDeletes],
@@ -67,5 +96,9 @@ export function initInMemoryTrialScheduler(opts?: {
 		allDeferredCancellationSchedules: () =>
 			Array.from(deferredCancellationSchedules.entries()).map(([userId, firesAt]) => ({ userId, firesAt })),
 		deferredCancellationDeleteCalls: () => [...deferredCancellationDeletes],
+		getTrialFeedbackEmailSchedule: (userId) => trialFeedbackEmailSchedules.get(userId),
+		allTrialFeedbackEmailSchedules: () =>
+			Array.from(trialFeedbackEmailSchedules.entries()).map(([userId, firesAt]) => ({ userId, firesAt })),
+		trialFeedbackEmailDeleteCalls: () => [...trialFeedbackEmailDeletes],
 	};
 }

--- a/src/packages/test-fixtures/src/providers/trial-scheduler/trial-scheduler.types.ts
+++ b/src/packages/test-fixtures/src/providers/trial-scheduler/trial-scheduler.types.ts
@@ -18,4 +18,13 @@ export type CreateDeferredCancellationSchedule = (input: {
 export type DeleteDeferredCancellationSchedule = (input: {
 	userId: UserId;
 }) => Promise<void>;
+
+export type CreateTrialFeedbackEmailSchedule = (input: {
+	userId: UserId;
+	firesAt: string;
+}) => Promise<void>;
+
+export type DeleteTrialFeedbackEmailSchedule = (input: {
+	userId: UserId;
+}) => Promise<void>;
 /* c8 ignore stop */


### PR DESCRIPTION
## Summary

- Send Fayner's "what was missing?" research email 3 days after a trial cancels without converting. Subscribes to `SubscriptionCancelledEvent` filtered on `reason='user_initiated_trial'` — paid churn (`user_initiated_paid_confirmed`) and Stripe-side cancels (`stripe_webhook`) are out of scope.
- Two SQS-backed Lambdas. **schedule-trial-feedback-email** creates a deterministic-name EventBridge Scheduler one-shot (`trial-feedback-<userId>`) so at-least-once duplicate `SubscriptionCancelledEvent` deliveries overwrite the same schedule instead of stacking. **send-trial-feedback-email** re-reads the row at fire time, noops on any non-`cancelled` status (reactivation guard) or on a row that already has `trialFeedbackEmailSentAt` set (sent-flag dedupe), counts the user's saved articles, sends the email, and stamps the row.
- The only personalisation is a single factual clause: "saved 9 articles" / "saved 1 article" / nothing at all when the count is zero. Usage is never fabricated.
- The verified copy is encoded into 19 constraint tests (no `!`, exactly one `?`, < 120 words, first-person, signs off `— Fayner`, no links, no opt-out footer, brand casing) so the voice can't silently rot. The HTML rendition embeds the same `/fayner-brack.jpg` avatar the welcome and checkout-recovery emails use.

Routing reuses `initAwsTrialScheduler` with two new methods, the existing `subscription_providers` table (one new `trialFeedbackEmailSentAt` attribute), and the existing Resend wrapper. The IAM policy follows the `cancelSubscriptionSchedulerManagePolicy` precedent with a uniquely-named manage policy. Both Lambdas get the standard DLQ alarm via `HutchSQSBackedLambda` and their log groups are wired into the analytics dashboard.

## Test plan

- [x] `pnpm nx run hutch:check` passes — 100 % coverage on the three new modules; full coverage thresholds met (99/96/100/99).
- [x] `pnpm nx run @packages/test-fixtures:check` passes.
- [x] `pnpm nx run @packages/hutch-infra-components:check` passes.
- [x] Pre-commit hook (which runs `pnpm check` across the affected projects) ran green.
- [x] Manual content review: text/plain and text/html previewed for N=0, N=1, N=9. Saved-articles clause behaves as specified; HTML embeds avatar; no exclamation marks; signs off `— Fayner`.
- [ ] `pulumi preview` against staging to confirm the two Lambdas, SQS queues, DLQs, uniquely-named scheduler-manage policy, and EventBridge rules resolve cleanly.
- [ ] Stage smoke test: emit a `SubscriptionCancelledEvent{reason:"user_initiated_trial"}`, confirm the scheduler one-shot is created with `trial-feedback-<userId>`, fast-forward / fire the schedule, confirm one email lands in the test inbox with the expected copy and Bcc to `readplace+trial_feedback@readplace.com`.

https://claude.ai/code/session_01UywN7XKKU5vmfWYfUmfd4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01UywN7XKKU5vmfWYfUmfd4k)_