### PR TITLE
feat(hutch): redirect hutch-app.com → readplace.com (path + query preserved)

### DIFF
--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -11,6 +11,9 @@ config:
     - savearticles.app
     - savearticle.app
     - read.place
+  hutch:redirectSubdomains:
+    - host: www.hutch-app.com
+      zoneName: hutch-app.com
   hutch:deletionProtection: true
   hutch:staticDomains:
     - static.hutch-app.com

--- a/projects/hutch/src/infra/domain-redirect.ts
+++ b/projects/hutch/src/infra/domain-redirect.ts
@@ -2,19 +2,27 @@ import * as aws from "@pulumi/aws";
 import { HutchCertificate } from "@packages/hutch-infra-components/infra";
 
 export class DomainRedirect {
-	constructor(name: string, args: { redirectDomains: string[]; targetDomain: string }) {
-		if (args.redirectDomains.length === 0) return;
+	constructor(
+		name: string,
+		args: {
+			redirectDomains: string[];
+			redirectSubdomains?: Array<{ host: string; zoneName: string }>;
+			targetDomain: string;
+		},
+	) {
+		const redirectSubdomains = args.redirectSubdomains ?? [];
+		if (args.redirectDomains.length === 0 && redirectSubdomains.length === 0) return;
 
 		const usEast1 = new aws.Provider(`${name}-us-east-1`, {
 			region: "us-east-1",
 		});
 
-		for (const domain of args.redirectDomains) {
+		const createRedirect = ({
+			domain,
+			zoneId,
+		}: { domain: string; zoneId: Promise<string> }): void => {
 			const safeName = domain.replace(/\./g, "-");
 			const resourcePrefix = `${name}-${safeName}`;
-
-			const zone = aws.route53.getZone({ name: domain });
-			const zoneId = zone.then((z) => z.zoneId);
 
 			const cert = new HutchCertificate(resourcePrefix, {
 				primaryDomain: domain,
@@ -89,6 +97,16 @@ export class DomainRedirect {
 					},
 				],
 			});
+		};
+
+		for (const domain of args.redirectDomains) {
+			const zoneId = aws.route53.getZone({ name: domain }).then((z) => z.zoneId);
+			createRedirect({ domain, zoneId });
+		}
+
+		for (const { host, zoneName } of redirectSubdomains) {
+			const zoneId = aws.route53.getZone({ name: zoneName }).then((z) => z.zoneId);
+			createRedirect({ domain: host, zoneId });
 		}
 	}
 }

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -55,6 +55,7 @@ const storage = new HutchStorage("hutch", {
 });
 
 const redirectDomains = config.getObject<string[]>("redirectDomains") ?? [];
+const redirectSubdomains = config.getObject<Array<{ host: string; zoneName: string }>>("redirectSubdomains") ?? [];
 
 /**
  * Ordering convention:
@@ -79,10 +80,11 @@ const additionalDomainRegistrations = additionalDomains.map((domain) =>
 
 const allDomainRegistrations = [legacyDomainRegistration, ...additionalDomainRegistrations];
 
-if (redirectDomains.length > 0) {
+if (redirectDomains.length > 0 || redirectSubdomains.length > 0) {
 	assert(canonicalDomain, "redirectDomains requires domains to be configured");
 	new DomainRedirect("hutch-redirect", {
 		redirectDomains,
+		redirectSubdomains,
 		targetDomain: canonicalDomain,
 	});
 }

--- a/projects/hutch/src/runtime/host-redirect.route.test.ts
+++ b/projects/hutch/src/runtime/host-redirect.route.test.ts
@@ -1,0 +1,44 @@
+import request from "supertest";
+import { createDefaultTestAppFixture } from "@packages/test-fixtures";
+import { useTestServer } from "./test-app";
+
+const useApp = useTestServer();
+
+describe("hutch-app.com → readplace.com host redirect", () => {
+	it("301s the root path, preserving the query string", async () => {
+		const harness = useApp(createDefaultTestAppFixture("https://readplace.com"));
+		const response = await request(harness.server)
+			.get("/?ref=newsletter")
+			.set("Host", "hutch-app.com");
+		expect(response.status).toBe(301);
+		expect(response.headers.location).toBe("https://readplace.com/?ref=newsletter");
+	});
+
+	it("301s a deep app path, preserving path and multi-param query", async () => {
+		const harness = useApp(createDefaultTestAppFixture("https://readplace.com"));
+		const response = await request(harness.server)
+			.get("/queue?tag=x&page=2")
+			.set("Host", "hutch-app.com");
+		expect(response.status).toBe(301);
+		expect(response.headers.location).toBe(
+			"https://readplace.com/queue?tag=x&page=2",
+		);
+	});
+
+	it("301s blog paths via the global redirect, not a blog-specific handler", async () => {
+		const harness = useApp(createDefaultTestAppFixture("https://readplace.com"));
+		const response = await request(harness.server)
+			.get("/blog/some-post")
+			.set("Host", "hutch-app.com");
+		expect(response.status).toBe(301);
+		expect(response.headers.location).toBe(
+			"https://readplace.com/blog/some-post",
+		);
+	});
+
+	it("does not redirect requests whose Host is not hutch-app.com", async () => {
+		const harness = useApp(createDefaultTestAppFixture("https://readplace.com"));
+		const response = await request(harness.server).get("/blog");
+		expect(response.status).toBe(200);
+	});
+});

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -247,6 +247,14 @@ export function createApp(dependencies: AppDependencies): Express {
 	const { appOrigin, staticBaseUrl, getSessionUserId, countUsers, foundingAllocation, ...deps } = dependencies;
 	const app: Express = express();
 
+	app.use((req: Request, res: Response, next: NextFunction) => {
+		if (req.headers.host === "hutch-app.com") {
+			res.redirect(301, `${appOrigin}${req.originalUrl}`);
+			return;
+		}
+		next();
+	});
+
 	const blogPosts = initBlogPosts();
 
 	app.use(express.urlencoded({ extended: true }));
@@ -499,13 +507,6 @@ export function createApp(dependencies: AppDependencies): Express {
 	});
 
 	const blogRouter = initBlogRoutes({ blogPosts, buildBannerState });
-	app.use("/blog", (req: Request, res: Response, next: NextFunction) => {
-		if (req.headers.host === "hutch-app.com") {
-			res.redirect(301, `${appOrigin}${req.originalUrl}`);
-			return;
-		}
-		next();
-	});
 	app.use("/blog", blogRouter);
 	app.use("/embed", initEmbedRoutes({ appOrigin }));
 

--- a/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/blog/blog.route.test.ts
@@ -283,32 +283,6 @@ describe("old hutch-vs-* slug redirects", () => {
 	});
 });
 
-describe("hutch-app.com blog redirect", () => {
-	it("should 301 redirect /blog to readplace.com", async () => {
-		const harness = useApp(
-			createDefaultTestAppFixture("https://readplace.com"),
-		);
-		const response = await request(harness.server)
-			.get("/blog")
-			.set("Host", "hutch-app.com");
-		expect(response.status).toBe(301);
-		expect(response.headers.location).toBe("https://readplace.com/blog");
-	});
-
-	it("should 301 redirect /blog/:slug to readplace.com", async () => {
-		const harness = useApp(
-			createDefaultTestAppFixture("https://readplace.com"),
-		);
-		const response = await request(harness.server)
-			.get(`/blog/${firstPost.slug}`)
-			.set("Host", "hutch-app.com");
-		expect(response.status).toBe(301);
-		expect(response.headers.location).toBe(
-			`https://readplace.com/blog/${firstPost.slug}`,
-		);
-	});
-});
-
 describe("GET /sitemap.xml", () => {
 	it("should include /blog in the sitemap", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));


### PR DESCRIPTION
## What & why

`hutch-app.com` is the legacy brand domain; the app is now Readplace at `readplace.com`. Today `hutch-app.com` is a co-primary serving domain, so the full app is reachable there. This makes every request to `hutch-app.com` (and `www.hutch-app.com`) `301` to the same path + query on `readplace.com`, so readers converge on the canonical domain.

Example: `hutch-app.com/queue?tag=x` → `readplace.com/queue?tag=x`.

## How

Two mechanisms, one deploy:

- **Apex `hutch-app.com` → app-level middleware (runtime).** A global Express middleware registered as the first `app.use` 301s any `Host: hutch-app.com` request to `${appOrigin}${req.originalUrl}` (path + query preserved). This generalizes the previous `/blog`-only host check, which is now removed. App-level keeps `hutch-app.com` as `domains[0]` (the "legacy primary" owning the original API-Gateway/cert resource names), avoiding a churny reindex of `readplace.com` onto those names plus the two-deploy ACM dance that moving the apex into `redirectDomains` would require.
- **`www.hutch-app.com` → isolated edge redirect (infra, additive).** `DomainRedirect` is generalized to also provision a redirect for subdomain entries whose hosted zone is looked up by a parent zone name. The per-domain creation (us-east-1 ACM cert + S3 website-redirect bucket + CloudFront + Route53 A-alias) is extracted into a shared helper driven by two loops (apexes by domain, subdomains by parent zone). The three existing apex redirects (`savearticles.app`, `savearticle.app`, `read.place`) keep **byte-identical resource names**, so the `www` addition is a pure create.

`static.hutch-app.com` is intentionally left as-is (it mirrors `static.readplace.com` from the same S3 bucket and is invisible to users) — deferred to its own change. The legacy `hutch-app.com` CORS allowlist entry is also left untouched; it keys off the `Origin` header and is independent of the `Host`-based redirect.

## Tests

- New `projects/hutch/src/runtime/host-redirect.route.test.ts` asserts `301` + `Location` preserves path/query for `/?…`, a deep app path (`/queue?tag=x&page=2`), and `/blog/:slug` (proving the old blog-specific case is covered globally), plus a control that non-`hutch-app.com` hosts are not redirected.
- The subsumed `hutch-app.com blog redirect` block in `blog.route.test.ts` is removed (coverage moves to the new file).
- `pnpm nx run hutch:check` passes (type-check, lint, unit + integration tests, 100% coverage thresholds, knip, unused-css); the full monorepo pre-commit `check` also passed.

## Deploy-time verification (needs AWS creds, not run here)

1. `PULUMI_STACK=prod pnpm nx run hutch:check-infra` — confirm the plan shows only **creates** for `hutch-redirect-www-hutch-app-com-*` (cert, cert-validation, bucket, website, cdn, record) and no changes/replaces on the `hutch-app.com` apex, `readplace.com`, or `static.*` resources.
2. After deploy: `curl -sI "https://hutch-app.com/queue?tag=x"` → `301` to `https://readplace.com/queue?tag=x`; `curl -sI "https://www.hutch-app.com/blog?x=1"` → `301` to `https://readplace.com/blog?x=1` (allow a few minutes for CloudFront/DNS on first provision); `https://readplace.com/queue` → `200`; `https://static.hutch-app.com/<asset>` → unchanged.

https://claude.ai/code/session_01LRKpFwm5H1cPHRWGfhkkV9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRKpFwm5H1cPHRWGfhkkV9)_