### PR TITLE
perf(queue): move re-save content refresh off the save request

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/queue-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/queue-actions.ts
@@ -281,9 +281,10 @@ export function createQueueActions(
       execute: async (page) => {
         const cardsBefore = await page.locator('.queue-article').count()
 
-        // Re-save an already-saved URL so refreshArticleIfStale takes the
-        // handleFullFetch branch and publishes publishRefreshArticleContent.
-        // Pagination URLs point to the local server, so the fetch is deterministic.
+        // Re-save an already-saved URL: it routes through the existing-article
+        // branch, which delegates any content refresh to the stale-check Lambda
+        // rather than blocking the request. The assertion verifies the re-save
+        // does not duplicate the card.
         const input = page.locator('[data-test-form="save-article"] input[name="url"]')
         await input.fill(testData.paginationUrls[0])
         await clickAndWaitForPageReload(

--- a/projects/hutch/src/e2e/queue-flow/queue-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/queue-actions.ts
@@ -282,9 +282,7 @@ export function createQueueActions(
         const cardsBefore = await page.locator('.queue-article').count()
 
         // Re-save an already-saved URL: it routes through the existing-article
-        // branch, which delegates any content refresh to the stale-check Lambda
-        // rather than blocking the request. The assertion verifies the re-save
-        // does not duplicate the card.
+        // branch, which delegates any content refresh to the stale-check Lambda.
         const input = page.locator('[data-test-form="save-article"] input[name="url"]')
         await input.fill(testData.paginationUrls[0])
         await clickAndWaitForPageReload(

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -63,7 +63,6 @@ import type {
 } from "@packages/test-fixtures/providers/article-store";
 import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/providers/events";
 import type { ReadArticleContent } from "@packages/test-fixtures/providers/article-store";
-import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
 import type {
 	FindArticleCrawlStatus,
 	ForceMarkCrawlPending,
@@ -199,7 +198,6 @@ interface AppDependencies {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;
-	refreshArticleIfStale: RefreshArticleIfStale;
 	adminEmails: readonly string[];
 	recrawlServiceToken: string;
 	publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp;
@@ -612,7 +610,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		markSummaryPending: deps.markSummaryPending,
 		findArticleCrawlStatus: deps.findArticleCrawlStatus,
 		markCrawlPending: deps.markCrawlPending,
-		refreshArticleIfStale: deps.refreshArticleIfStale,
+		publishStaleCheckRequested: deps.publishStaleCheckRequested,
 		publishUpdateFetchTimestamp: deps.publishUpdateFetchTimestamp,
 		readArticleContent: deps.readArticleContent,
 		httpErrorMessageMapping: deps.httpErrorMessageMapping,
@@ -644,7 +642,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		markSummaryPending: deps.markSummaryPending,
 		publishUpdateFetchTimestamp: deps.publishUpdateFetchTimestamp,
 		publishLinkSaved: deps.publishLinkSaved,
-		refreshArticleIfStale: deps.refreshArticleIfStale,
+		findArticleByUrl: deps.findArticleByUrl,
+		publishStaleCheckRequested: deps.publishStaleCheckRequested,
 		logError: deps.logError,
 		analytics: deps.analytics,
 		salt: deps.salt,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -447,7 +447,6 @@ function flattenFixtureToAppDependencies(
 		putPendingPdf: fixture.pendingPdf.putPendingPdf,
 		findGeneratedSummary: fixture.summary.findGeneratedSummary,
 		markSummaryPending: fixture.summary.markSummaryPending,
-		refreshArticleIfStale: fixture.freshness.refreshArticleIfStale,
 		oauthModel: fixture.oauth.oauthModel,
 		validateAccessToken: fixture.oauth.validateAccessToken,
 		sendEmail: fixture.email.sendEmail,

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -275,15 +275,12 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			const batch = saveable.slice(i, i + IMPORT_COMMIT_CONCURRENCY);
 			await Promise.all(
 				batch.map((url) =>
-					deps
-						.refreshArticleIfStale({ url })
-						.then((freshness) => saveArticleFromUrl(deps, { userId, url, freshness }))
-						.catch((error: unknown) => {
-							deps.logError(
-								`Failed to import url=${url}`,
-								error instanceof Error ? error : undefined,
-							);
-						}),
+					saveArticleFromUrl(deps, { userId, url }).catch((error: unknown) => {
+						deps.logError(
+							`Failed to import url=${url}`,
+							error instanceof Error ? error : undefined,
+						);
+					}),
 				),
 			);
 		}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.freshness.route.test.ts
@@ -1,5 +1,4 @@
-import { initRefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
-import type { PublishRefreshArticleContent } from "@packages/test-fixtures/providers/events";
+import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
 import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/providers/events";
 import { useTestServer, loginAgent } from "../../../test-app";
 import {
@@ -10,55 +9,26 @@ import {
 const useApp = useTestServer();
 
 describe("Queue freshness integration", () => {
-	it("publishes UpdateFetchTimestampCommand on first save, then RefreshArticleContentCommand on re-save", async () => {
+	it("publishes UpdateFetchTimestamp on first save, then delegates a re-save to the stale-check Lambda with no inline crawl", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		const refreshPublished: Parameters<PublishRefreshArticleContent>[0][] = [];
 		const timestampPublished: Parameters<PublishUpdateFetchTimestamp>[0][] = [];
-
-		const { refreshArticleIfStale } = initRefreshArticleIfStale({
-			findArticleFreshness: fixture.articleStore.findArticleFreshness,
-			findArticleCrawlStatus: fixture.articleCrawl.findArticleCrawlStatus,
-			crawlArticle: async (params) => {
-				if (!params.etag && !params.lastModified) {
-					return {
-						status: "fetched",
-						html: "<html><head><title>Updated</title></head><body><article><p>New content</p></article></body></html>",
-						etag: '"fresh-etag"',
-					};
-				}
-				return { status: "not-modified" };
-			},
-			parseHtml: () => ({
-				ok: true as const,
-				article: {
-					title: "Updated Article",
-					siteName: "example.com",
-					excerpt: "New content",
-					wordCount: 100,
-					content: "<p>New content</p>",
-				},
-			}),
-			publishRefreshArticleContent: async (p) => { refreshPublished.push(p); },
-			publishUpdateFetchTimestamp: async (p) => { timestampPublished.push(p); },
-			now: () => new Date(),
-			staleTtlMs: 0,
-		});
+		const staleChecksRequested: Parameters<PublishStaleCheckRequested>[0][] = [];
+		let inlineCrawls = 0;
 
 		const harness = useApp({
 			...fixture,
-			events: {
-				publishLinkSaved: fixture.events.publishLinkSaved,
-				publishRecrawlLinkInitiated: fixture.events.publishRecrawlLinkInitiated,
-				publishSaveAnonymousLink: fixture.events.publishSaveAnonymousLink,
-				publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
-				publishSaveLinkRawPdfCommand: fixture.events.publishSaveLinkRawPdfCommand,
-				publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
-				publishUpdateFetchTimestamp: async (p) => { timestampPublished.push(p); },
-				publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
-					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
-					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
+			parser: {
+				parseArticle: fixture.parser.parseArticle,
+				crawlArticle: async (params) => {
+					inlineCrawls += 1;
+					return fixture.parser.crawlArticle(params);
+				},
 			},
-			freshness: { refreshArticleIfStale },
+			events: {
+				...fixture.events,
+				publishUpdateFetchTimestamp: async (p) => { timestampPublished.push(p); },
+				publishStaleCheckRequested: async (p) => { staleChecksRequested.push(p); },
+			},
 		});
 		const { auth } = harness;
 		const agent = await loginAgent(harness.server, auth);
@@ -73,26 +43,15 @@ describe("Queue freshness integration", () => {
 			url: "https://example.com/article",
 			contentFetchedAt: expect.any(String),
 		});
-		expect(refreshPublished).toHaveLength(0);
+		expect(staleChecksRequested).toHaveLength(0);
 
 		await agent
 			.post("/queue/save")
 			.type("form")
 			.send({ url: "https://example.com/article" });
 
-		expect(refreshPublished).toHaveLength(1);
-		expect(refreshPublished[0]).toEqual({
-			url: "https://example.com/article",
-			html: expect.any(String),
-			metadata: expect.objectContaining({
-				title: "Updated Article",
-				siteName: "example.com",
-				wordCount: 100,
-			}),
-			estimatedReadTime: expect.any(Number),
-			etag: '"fresh-etag"',
-			lastModified: undefined,
-			contentFetchedAt: expect.any(String),
-		});
+		expect(staleChecksRequested).toEqual([{ url: "https://example.com/article" }]);
+		expect(timestampPublished).toHaveLength(1);
+		expect(inlineCrawls).toBe(0);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.filters.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.filters.route.test.ts
@@ -1,26 +1,33 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
+import { MinutesSchema } from "@packages/domain/article";
 import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
 
-import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
+import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
 
 const useApp = useTestServer();
 
+const cachedRow = {
+	metadata: { title: "Cached", siteName: "example.com", excerpt: "Cached", wordCount: 100 },
+	estimatedReadTime: MinutesSchema.parse(1),
+};
+
 describe("Queue routes", () => {
-	describe("POST /queue/save with existing article (skip freshness)", () => {
-		it("should save user-article relationship without re-fetching", async () => {
-			const skipFreshness: RefreshArticleIfStale = async () => ({ action: "skip" });
-			const harness = useApp({
-				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
-				freshness: { refreshArticleIfStale: skipFreshness },
-			});
-			const { auth } = harness;
+	describe("POST /queue/save with an already-cached article", () => {
+		it("saves the user-article relationship and redirects without re-fetching", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
 			const agent = await loginAgent(harness.server, auth);
+			await articleStore.saveArticleGlobally({
+				url: "https://example.com/existing",
+				...cachedRow,
+				savedAt: new Date(),
+			});
 
 			const response = await agent
 				.post("/queue/save")
@@ -31,57 +38,25 @@ describe("Queue routes", () => {
 			expect(response.headers.location).toBe("/queue#latest-saved");
 		});
 
-		it("should save for unchanged content (304)", async () => {
-			const unchangedFreshness: RefreshArticleIfStale = async () => ({ action: "unchanged" });
-			const harness = useApp({
-				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
-				freshness: { refreshArticleIfStale: unchangedFreshness },
-			});
-			const { auth } = harness;
-			const agent = await loginAgent(harness.server, auth);
-
-			const response = await agent
-				.post("/queue/save")
-				.type("form")
-				.send({ url: "https://example.com/existing" });
-
-			expect(response.status).toBe(303);
-		});
-
-		it("should publish LinkSaved event for refreshed content", async () => {
+		it("delegates the content refresh to the stale-check Lambda instead of publishing LinkSaved", async () => {
+			const staleChecksRequested: Parameters<PublishStaleCheckRequested>[0][] = [];
 			let linkSavedPublished = false;
-			const refreshedFreshness: RefreshArticleIfStale = async () => ({
-				action: "refreshed",
-				article: {
-					ok: true as const,
-					article: {
-						title: "Refreshed",
-						siteName: "example.com",
-						excerpt: "Refreshed excerpt",
-						wordCount: 100,
-						content: "<p>New content</p>",
-					},
-				},
-			});
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const harness = useApp({
 				...fixture,
 				events: {
+					...fixture.events,
 					publishLinkSaved: async () => { linkSavedPublished = true; },
-					publishRecrawlLinkInitiated: fixture.events.publishRecrawlLinkInitiated,
-					publishSaveAnonymousLink: fixture.events.publishSaveAnonymousLink,
-					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
-					publishSaveLinkRawPdfCommand: fixture.events.publishSaveLinkRawPdfCommand,
-					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
-					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
-					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
-					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
-					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
+					publishStaleCheckRequested: async (p) => { staleChecksRequested.push(p); },
 				},
-				freshness: { refreshArticleIfStale: refreshedFreshness },
 			});
-			const { auth } = harness;
+			const { auth, articleStore } = harness;
 			const agent = await loginAgent(harness.server, auth);
+			await articleStore.saveArticleGlobally({
+				url: "https://example.com/existing",
+				...cachedRow,
+				savedAt: new Date(),
+			});
 
 			const response = await agent
 				.post("/queue/save")
@@ -89,7 +64,8 @@ describe("Queue routes", () => {
 				.send({ url: "https://example.com/existing" });
 
 			expect(response.status).toBe(303);
-			expect(linkSavedPublished).toBe(true);
+			expect(staleChecksRequested).toEqual([{ url: "https://example.com/existing" }]);
+			expect(linkSavedPublished).toBe(false);
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -12,8 +12,7 @@ import {
 	createNoopLogError,
 } from "@packages/test-fixtures";
 import { initReadabilityParser } from "@packages/article-parser";
-
-import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
+import { MinutesSchema } from "@packages/domain/article";
 
 const useApp = useTestServer();
 
@@ -185,13 +184,15 @@ describe("Queue routes", () => {
 		});
 
 		it("should not render URL link when siteName is empty", async () => {
-			const skipFreshness: RefreshArticleIfStale = async () => ({ action: "skip" });
-			const harness = useApp({
-				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
-				freshness: { refreshArticleIfStale: skipFreshness },
-			});
-			const { auth } = harness;
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
 			const agent = await loginAgent(harness.server, auth);
+			await articleStore.saveArticleGlobally({
+				url: "https://example.com/existing",
+				metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+				estimatedReadTime: MinutesSchema.parse(0),
+				savedAt: new Date(),
+			});
 
 			await agent
 				.post("/queue/save")

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -3,6 +3,7 @@ import { JSDOM } from "jsdom";
 import { MinutesSchema } from "@packages/domain/article";
 import { useTestServer, loginAgent } from "../../../test-app";
 import type { ArticleReadEvent } from "../../middleware/analytics";
+import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -139,9 +140,13 @@ describe("Queue routes", () => {
 		});
 
 		it("should redirect with error code when save throws", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const harness = useApp({
-				...createDefaultTestAppFixture(TEST_APP_ORIGIN),
-				freshness: { refreshArticleIfStale: async () => { throw new Error("boom"); } },
+				...fixture,
+				articleStore: {
+					...fixture.articleStore,
+					findArticleByUrl: async () => { throw new Error("boom"); },
+				},
 			});
 			const { auth } = harness;
 			const agent = await loginAgent(harness.server, auth);
@@ -167,34 +172,26 @@ describe("Queue routes", () => {
 			expect(doc.querySelector("[data-test-save-error]")?.textContent).toBe("Could not save article. Please try again.");
 		});
 
-		it("does NOT re-prime via /queue/save when refreshArticleIfStale returns 'skip' for a previously-failed crawl (auto-heal removed; operator owns recovery)", async () => {
+		it("re-saving an already-cached article publishes StaleCheckRequested and not LinkSaved (the crawl is delegated to the stale-check Lambda)", async () => {
 			const publishedLinkSaved: { url: string; userId: string }[] = [];
+			const staleChecksRequested: Parameters<PublishStaleCheckRequested>[0][] = [];
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const harness = useApp({
 				...fixture,
 				events: {
+					...fixture.events,
 					publishLinkSaved: async (params) => { publishedLinkSaved.push(params); },
-					publishRecrawlLinkInitiated: fixture.events.publishRecrawlLinkInitiated,
-					publishSaveAnonymousLink: fixture.events.publishSaveAnonymousLink,
-					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
-					publishSaveLinkRawPdfCommand: fixture.events.publishSaveLinkRawPdfCommand,
-					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
-					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
-					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
-					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
-					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
+					publishStaleCheckRequested: async (p) => { staleChecksRequested.push(p); },
 				},
-				freshness: { refreshArticleIfStale: async () => ({ action: "skip" }) },
 			});
-			const { auth, articleStore, articleCrawl } = harness;
+			const { auth, articleStore } = harness;
 			const agent = await loginAgent(harness.server, auth);
 			await articleStore.saveArticleGlobally({
 				url: "https://example.com/article",
-				metadata: { title: "Failed", siteName: "example.com", excerpt: "", wordCount: 0 },
+				metadata: { title: "Cached", siteName: "example.com", excerpt: "", wordCount: 0 },
 				estimatedReadTime: MinutesSchema.parse(0),
 				savedAt: new Date(),
 			});
-			await articleCrawl.markCrawlFailed({ url: "https://example.com/article", reason: "blocked" });
 
 			const response = await agent
 				.post("/queue/save")
@@ -202,6 +199,7 @@ describe("Queue routes", () => {
 				.send({ url: "https://example.com/article" });
 
 			expect(response.status).toBe(303);
+			expect(staleChecksRequested).toEqual([{ url: "https://example.com/article" }]);
 			expect(publishedLinkSaved).toHaveLength(0);
 		});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -19,7 +19,6 @@ import {
 } from "../import/import-skipped-cookie";
 import type { ImportSkippedViewModel } from "./queue.viewmodel";
 import { ReaderArticleHashIdSchema } from "@packages/domain/article";
-import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
 import type {
 	DeleteArticle,
 	FindArticleById,
@@ -49,6 +48,7 @@ import type {
 import { initArticleReader } from "../../shared/article-reader/article-reader";
 import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.types";
 import type { PublishLinkSaved } from "@packages/test-fixtures/providers/events";
+import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
 import type { PublishSaveLinkRawHtmlCommand } from "@packages/test-fixtures/providers/events";
 import type { PutPendingHtml } from "@packages/test-fixtures/providers/pending-html";
 import { saveArticleFromUrl } from "../../shared/save-article/save-article-from-url";
@@ -150,7 +150,7 @@ interface QueueDependencies {
 	markSummaryPending: MarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
 	markCrawlPending: MarkCrawlPending;
-	refreshArticleIfStale: RefreshArticleIfStale;
+	publishStaleCheckRequested: PublishStaleCheckRequested;
 	publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp;
 	readArticleContent: ReadArticleContent;
 	httpErrorMessageMapping: HttpErrorMessageMapping;
@@ -412,8 +412,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		}
 
 		try {
-			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
-			const result = await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
+			const result = await saveArticleFromUrl(deps, { userId, url: validation.url });
 			markExtensionSavedArticle(res);
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
@@ -492,8 +491,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					deps.logError(
 						`[SaveHtmlOversize] falling back to URL-only url=${urlOnlyValidation.url} userId=${userId} sizeBytes=${sizeBytes}`,
 					);
-					const freshness = await deps.refreshArticleIfStale({ url: urlOnlyValidation.url });
-					const result = await saveArticleFromUrl(deps, { userId, url: urlOnlyValidation.url, freshness });
+					const result = await saveArticleFromUrl(deps, { userId, url: urlOnlyValidation.url });
 					markExtensionSavedArticle(res);
 					res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 					return;
@@ -513,8 +511,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			}
 			const articleUrl = urlValidation.url;
 
-			const freshness = await deps.refreshArticleIfStale({ url: articleUrl });
-
 			await deps.putPendingHtml({ url: articleUrl, html: parsed.data.rawHtml });
 			await deps.publishSaveLinkRawHtmlCommand({
 				url: articleUrl,
@@ -522,7 +518,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				title: parsed.data.title,
 			});
 
-			const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
+			const result = await saveArticleFromUrl(deps, { userId, url: articleUrl });
 			markExtensionSavedArticle(res);
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
@@ -639,7 +635,6 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 			try {
 				const articleUrl = validation.url;
-				const freshness = await deps.refreshArticleIfStale({ url: articleUrl });
 				const normalized = normalizeMediaType(mediaType);
 				const handler = saveContentHandlers[normalized];
 
@@ -666,7 +661,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					return;
 				}
 
-				const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
+				const result = await saveArticleFromUrl(deps, { userId, url: articleUrl });
 				markExtensionSavedArticle(res);
 				res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 			} catch (error) {
@@ -704,8 +699,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		}
 
 		try {
-			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
-			await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
+			await saveArticleFromUrl(deps, { userId, url: validation.url });
 			res.redirect(303, "/queue#latest-saved");
 		} catch (error) {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-content.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-content.route.test.ts
@@ -314,7 +314,10 @@ describe("POST /queue/save-content validation", () => {
 
 		const testApp = useApp({
 			...fixture,
-			freshness: { refreshArticleIfStale: async () => { throw new Error("boom"); } },
+			pendingHtml: {
+				putPendingHtml: async () => { throw new Error("boom"); },
+				readPendingHtml: fixture.pendingHtml.readPendingHtml,
+			},
 			shared: {
 				...fixture.shared,
 				logError: (_msg, err) => { if (err) errors.push(err); },
@@ -341,8 +344,11 @@ describe("POST /queue/save-content validation", () => {
 
 		const testApp = useApp({
 			...fixture,
-			// biome-ignore lint/suspicious/noExplicitAny: deliberately throws a non-Error to exercise the instanceof Error ? ... : undefined branch
-			freshness: { refreshArticleIfStale: async () => { throw "raw string" as any; } },
+			pendingHtml: {
+				// biome-ignore lint/suspicious/noExplicitAny: deliberately throws a non-Error to exercise the instanceof Error ? ... : undefined branch
+				putPendingHtml: async () => { throw "raw string" as any; },
+				readPendingHtml: fixture.pendingHtml.readPendingHtml,
+			},
 			shared: {
 				...fixture.shared,
 				logError: (msg, err) => { errorArgs.push([msg, err]); },

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
@@ -137,7 +137,7 @@ describe("POST /queue/save-html", () => {
 		expect(pendingHtml.readPendingHtml("https://example.com/article")).toBe("<html>captured</html>");
 	});
 
-	it("returns 500 when the underlying article save throws", async () => {
+	it("returns 500 when a downstream save dependency throws", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const errors: Error[] = [];
 
@@ -155,7 +155,10 @@ describe("POST /queue/save-html", () => {
 					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
 					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
 			},
-			freshness: { refreshArticleIfStale: async () => { throw new Error("boom"); } },
+			pendingHtml: {
+				putPendingHtml: async () => { throw new Error("boom"); },
+				readPendingHtml: fixture.pendingHtml.readPendingHtml,
+			},
 			shared: {
 				validateSaveableUrl: fixture.shared.validateSaveableUrl,
 				appOrigin: fixture.shared.appOrigin,

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
@@ -1,6 +1,7 @@
 import { ReaderArticleHashIdSchema, SaveableUrlSchema } from "@packages/domain/article";
 import { MinutesSchema } from "@packages/domain/article";
 import type { SavedArticle } from "@packages/domain/article";
+import type { GlobalArticleData } from "@packages/test-fixtures/providers/article-store";
 import { UserIdSchema } from "@packages/domain/user";
 import {
 	saveArticleFromUrl,
@@ -24,6 +25,16 @@ function makeSaved(overrides: Partial<SavedArticle> = {}): SavedArticle {
 	};
 }
 
+function makeExistingRow(): GlobalArticleData {
+	return {
+		id: articleId,
+		url: exampleUrl,
+		metadata: { title: "Cached", siteName: "example.com", excerpt: "Cached", wordCount: 100 },
+		estimatedReadTime: MinutesSchema.parse(1),
+		savedAt: new Date(),
+	};
+}
+
 interface CallTracker {
 	saved: SavedArticle;
 	calls: {
@@ -31,22 +42,28 @@ interface CallTracker {
 		markSummaryPending: number;
 		publishUpdateFetchTimestamp: number;
 		publishLinkSaved: number;
+		publishStaleCheckRequested: number;
 		updateArticleStatusUnread: number;
 	};
 	deps: SaveArticleFromUrlDependencies;
 }
 
-function makeTracker(savedOverride?: SavedArticle): CallTracker {
-	const saved = savedOverride ?? makeSaved();
+function makeTracker(params: {
+	existing: GlobalArticleData | null;
+	savedOverride?: SavedArticle;
+}): CallTracker {
+	const saved = params.savedOverride ?? makeSaved();
 	const calls = {
 		markCrawlPending: 0,
 		markSummaryPending: 0,
 		publishUpdateFetchTimestamp: 0,
 		publishLinkSaved: 0,
+		publishStaleCheckRequested: 0,
 		updateArticleStatusUnread: 0,
 	};
 	const deps: SaveArticleFromUrlDependencies = {
 		saveArticle: async () => saved,
+		findArticleByUrl: async () => params.existing,
 		updateArticleStatus: async (_id, _u, status) => {
 			if (status === "unread") calls.updateArticleStatusUnread += 1;
 			return true;
@@ -63,104 +80,65 @@ function makeTracker(savedOverride?: SavedArticle): CallTracker {
 		publishLinkSaved: async () => {
 			calls.publishLinkSaved += 1;
 		},
-		refreshArticleIfStale: async () => ({ action: "new" }),
+		publishStaleCheckRequested: async () => {
+			calls.publishStaleCheckRequested += 1;
+		},
 	};
 	return { saved, calls, deps };
 }
 
 describe("saveArticleFromUrl", () => {
-	it("primes the crawl + summary pipeline on a 'new' freshness verdict", async () => {
-		const tracker = makeTracker();
+	it("primes the crawl + summary pipeline for a brand-new URL and does not request a stale check", async () => {
+		const tracker = makeTracker({ existing: null });
 
-		await saveArticleFromUrl(tracker.deps, {
-			userId,
-			url: exampleUrl,
-			freshness: { action: "new" },
-		});
+		await saveArticleFromUrl(tracker.deps, { userId, url: exampleUrl });
 
 		expect(tracker.calls).toEqual({
 			markCrawlPending: 1,
 			markSummaryPending: 1,
 			publishUpdateFetchTimestamp: 1,
 			publishLinkSaved: 1,
+			publishStaleCheckRequested: 0,
 			updateArticleStatusUnread: 0,
 		});
 	});
 
-	it("publishes a link saved event when 'refreshed' has fresh content", async () => {
-		const tracker = makeTracker();
+	it("requests a stale check for an already-cached URL without re-priming the crawl pipeline", async () => {
+		const tracker = makeTracker({ existing: makeExistingRow() });
 
-		await saveArticleFromUrl(tracker.deps, {
-			userId,
-			url: exampleUrl,
-			freshness: {
-				action: "refreshed",
-				article: {
-					ok: true,
-					article: {
-						title: "t",
-						siteName: "s",
-						excerpt: "e",
-						wordCount: 100,
-						content: "<p>hi</p>",
-					},
-				},
-			},
+		await saveArticleFromUrl(tracker.deps, { userId, url: exampleUrl });
+
+		expect(tracker.calls).toEqual({
+			markCrawlPending: 0,
+			markSummaryPending: 0,
+			publishUpdateFetchTimestamp: 0,
+			publishLinkSaved: 0,
+			publishStaleCheckRequested: 1,
+			updateArticleStatusUnread: 0,
 		});
-
-		expect(tracker.calls.markSummaryPending).toBe(1);
-		expect(tracker.calls.publishLinkSaved).toBe(1);
-		expect(tracker.calls.markCrawlPending).toBe(0);
 	});
 
-	it("does not publish on 'refreshed' verdicts whose article has no content", async () => {
-		const tracker = makeTracker();
-
-		await saveArticleFromUrl(tracker.deps, {
-			userId,
-			url: exampleUrl,
-			freshness: {
-				action: "refreshed",
-				article: {
-					ok: true,
-					article: {
-						title: "t",
-						siteName: "s",
-						excerpt: "e",
-						wordCount: 0,
-						content: "",
-					},
-				},
-			},
-		});
-
-		expect(tracker.calls.publishLinkSaved).toBe(0);
-		expect(tracker.calls.markSummaryPending).toBe(0);
-	});
-
-	it("does not publish or re-prime on 'skip' or 'unchanged' verdicts", async () => {
-		const tracker = makeTracker();
-
-		await saveArticleFromUrl(tracker.deps, {
-			userId,
-			url: exampleUrl,
-			freshness: { action: "skip" },
-		});
-
-		expect(tracker.calls.publishLinkSaved).toBe(0);
-		expect(tracker.calls.markCrawlPending).toBe(0);
-	});
-
-	it("flips a previously-read article back to unread after a re-save", async () => {
+	it("flips a previously-read article back to unread when saving a brand-new URL", async () => {
 		const previouslyRead = makeSaved({ status: "read", readAt: new Date() });
-		const tracker = makeTracker(previouslyRead);
+		const tracker = makeTracker({ existing: null, savedOverride: previouslyRead });
 
-		const result = await saveArticleFromUrl(tracker.deps, {
-			userId,
-			url: exampleUrl,
-			freshness: { action: "new" },
+		const result = await saveArticleFromUrl(tracker.deps, { userId, url: exampleUrl });
+
+		expect(tracker.calls.updateArticleStatusUnread).toBe(1);
+		expect(result.saved.status).toBe("unread");
+		expect(result.saved.readAt).toBeUndefined();
+	});
+
+	it("flips a previously-read article back to unread when re-saving an already-cached URL", async () => {
+		const previouslyRead = makeSaved({ status: "read", readAt: new Date() });
+		const tracker = makeTracker({
+			existing: makeExistingRow(),
+			savedOverride: previouslyRead,
 		});
 
+		const result = await saveArticleFromUrl(tracker.deps, { userId, url: exampleUrl });
+
+		expect(tracker.calls.publishStaleCheckRequested).toBe(1);
 		expect(tracker.calls.updateArticleStatusUnread).toBe(1);
 		expect(result.saved.status).toBe("unread");
 		expect(result.saved.readAt).toBeUndefined();

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
@@ -1,21 +1,22 @@
 import { calculateReadTime } from "@packages/domain/article";
-import type { ContentFreshnessResult, RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
 import type { MarkCrawlPending } from "@packages/test-fixtures/providers/article-crawl";
 import type { MarkSummaryPending } from "@packages/test-fixtures/providers/article-summary";
-import type { SaveArticle, UpdateArticleStatus } from "@packages/test-fixtures/providers/article-store";
+import type { FindArticleByUrl, SaveArticle, UpdateArticleStatus } from "@packages/test-fixtures/providers/article-store";
 import type { PublishLinkSaved } from "@packages/test-fixtures/providers/events";
+import type { PublishStaleCheckRequested } from "@packages/test-fixtures/providers/events";
 import type { PublishUpdateFetchTimestamp } from "@packages/test-fixtures/providers/events";
 import type { UserId } from "@packages/domain/user";
 import type { SaveableUrl, SavedArticle } from "@packages/domain/article";
 
 export interface SaveArticleFromUrlDependencies {
 	saveArticle: SaveArticle;
+	findArticleByUrl: FindArticleByUrl;
 	updateArticleStatus: UpdateArticleStatus;
 	markCrawlPending: MarkCrawlPending;
 	markSummaryPending: MarkSummaryPending;
 	publishUpdateFetchTimestamp: PublishUpdateFetchTimestamp;
 	publishLinkSaved: PublishLinkSaved;
-	refreshArticleIfStale: RefreshArticleIfStale;
+	publishStaleCheckRequested: PublishStaleCheckRequested;
 }
 
 async function markUnreadIfRead(
@@ -29,13 +30,14 @@ async function markUnreadIfRead(
 	return saved;
 }
 
-async function saveByFreshness(
+export async function saveArticleFromUrl(
 	deps: SaveArticleFromUrlDependencies,
-	params: { userId: UserId; url: string; freshness: ContentFreshnessResult },
+	params: { userId: UserId; url: SaveableUrl },
 ): Promise<{ saved: SavedArticle }> {
-	const { userId, url, freshness } = params;
+	const { userId, url } = params;
+	const existing = await deps.findArticleByUrl(url);
 
-	if (freshness.action === "new") {
+	if (!existing) {
 		const hostname = new URL(url).hostname;
 		const saved = await deps.saveArticle({
 			userId,
@@ -65,17 +67,9 @@ async function saveByFreshness(
 		estimatedReadTime: calculateReadTime(0),
 	});
 
-	if (freshness.action === "refreshed" && freshness.article.article.content) {
-		await deps.markSummaryPending({ url });
-		await deps.publishLinkSaved({ url, userId });
-	}
+	// Re-crawl of an already-cached article is delegated to the stale-check
+	// Lambda so the save request never blocks on a remote fetch (mirrors /view).
+	await deps.publishStaleCheckRequested({ url });
 
 	return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
-}
-
-export function saveArticleFromUrl(
-	deps: SaveArticleFromUrlDependencies,
-	params: { userId: UserId; url: SaveableUrl; freshness: ContentFreshnessResult },
-): Promise<{ saved: SavedArticle }> {
-	return saveByFreshness(deps, params);
 }


### PR DESCRIPTION
## Problem

Saving a link via the `/save?url=` permalink (the "Save to Readplace" bookmarklet that auto-submits) sometimes left the save button stuck on **"Saving…"** for ~10s+ before completing.

### Root cause

- "Saving…" is purely htmx's `.htmx-request` CSS class (`queue.styles.css`, `queue.template.html`) — it clears only when the htmx request resolves. A slow button = a slow server round-trip.
- `/save?url=` → 303 → `/queue?url=` → auto-POST `/queue/save`.
- Every save handler (`POST /queue/save`, `POST /queue`, `POST /queue/save-html`) **awaited `refreshArticleIfStale({url})` inline before responding**.
- When the URL had a row older than `staleTtlMs` (24h) and the crawl status wasn't terminal-skip, that helper awaited `crawlArticle` inline — a 10s `FETCH_TIMEOUT_MS` plus HTTP/2 + curl fallbacks that can exceed 10s. This is the "sometimes ~10s" hang (it only fires when re-saving a previously-saved, now-stale URL — matching "sometimes").

## Fix

Move the content-refresh crawl off the user-facing save request, mirroring the existing `/view` pattern (`view.page.ts`). The decision now lives in the shared `saveArticleFromUrl`, branching on a single cheap `findArticleByUrl(url)` GET (no crawl):

- **Brand-new URL** — unchanged: stub hostname metadata + `markCrawlPending` + `markSummaryPending` + `publishUpdateFetchTimestamp` + `publishLinkSaved`. Cards appear immediately and the async `LinkSaved → SaveLinkCommand` pipeline populates content.
- **Already-cached URL** — `saveArticle` with empty metadata (preserves the bump-to-top / `#latest-saved` ordering), then `publishStaleCheckRequested({url})` for the off-request refresh, then `markUnreadIfRead`.

All four queue save handlers and the bulk-import commit loop drop their inline `refreshArticleIfStale` call (import becomes non-blocking too). The fix re-points existing callers to the **already-published** `StaleCheckRequestedEvent` — no new event/command/Lambda subscription, no `.architecture` snapshot change. `initRefreshArticleIfStale` stays exported and wired in both composition roots (still used by the stale-check Lambda + e2e); only the two web routers stop consuming it.

## Behaviour trade-offs

- Re-saving a stale, already-cached article no longer refreshes within the same request — the stale-check Lambda refreshes a few seconds later (the same UX `/view` already has; card/summary/reader pollers surface the update when it lands).
- First-ever save of a new URL is unchanged.
- The sync save no longer distinguishes skip/unchanged/refreshed — it branches only on existence. TTL/304/terminal-action decisioning isn't lost; it's relocated into the stale-check Lambda.
- Dev/test/e2e: `publishStaleCheckRequested` is an in-memory no-op, so a re-saved stale article won't visibly refresh locally (production unaffected — real Lambda deployed). The e2e "re-save → no duplicate" assertion still holds.

## Tests

- `save-article-from-url.test.ts` — reworked around `findArticleByUrl` (null vs a row) + a `publishStaleCheckRequested` spy. Covers: new primes crawl/summary/timestamp/LinkSaved and does **not** request a stale check; existing publishes StaleCheckRequested once with `{url}` and skips LinkSaved/crawl priming; read→unread flip on **both** branches.
- `queue.freshness.route.test.ts` — rewritten: first save publishes UpdateFetchTimestamp (not StaleCheckRequested); re-save publishes StaleCheckRequested exactly once with `{url}` and performs no inline crawl (asserted via a `crawlArticle` spy that stays at 0).
- `queue.listing.filters.route.test.ts`, `queue.listing.route.test.ts`, `queue.mutations.route.test.ts`, `queue.save-html.route.test.ts` — dropped the now-inert freshness overrides; seed already-cached rows via `saveArticleGlobally`; converted "LinkSaved for refreshed content" into "publishes StaleCheckRequested on re-save"; repointed the save-throws injection; bump-to-top test unchanged.

## Verification

- `pnpm nx run hutch:check` ✅ (typecheck + lint + jest + c8) — `save-article-from-url.ts` at 100%.
- `pnpm check` ✅ — 25 projects, all coverage thresholds met.
- Static guards: `git grep refreshArticleIfStale projects/hutch/src/runtime/web` → zero hits; `initRefreshArticleIfStale` still wired in `app.ts` (prod + dev).

## ⚠️ Needs reviewer approval

Per `CLAUDE.md`, discretionary code comments require explicit approval. I added one why-comment in `save-article-from-url.ts` mirroring the existing accepted pattern at `view.page.ts:135-138`:

```ts
// Re-crawl of an already-cached article is delegated to the stale-check
// Lambda so the save request never blocks on a remote fetch (mirrors /view).
```

Happy to drop it if you'd prefer — flagging it here as the plan directed.

## Out of scope (optional follow-up)

`/save?url=` still renders the queue twice (the throwaway `/queue?url=` auto-submit render, then the post-redirect `/queue#latest-saved` render). That's a smaller constant overhead than the variable ~10s crawl spike removed here; could be addressed later with a minimal auto-submit interstitial.

https://claude.ai/code/session_01BsedWh2sFHsTR9v6a3NPSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsedWh2sFHsTR9v6a3NPSw)_