### PR TITLE
docs(blog): add post on importing links from a single page

### DIFF
--- a/projects/browser-extension-core/src/e2e-actions/save-link-actions.ts
+++ b/projects/browser-extension-core/src/e2e-actions/save-link-actions.ts
@@ -101,7 +101,7 @@ export function createSaveLinkActions(config: {
 			const hrefs = await Promise.all(items.map(el => el.getAttribute("href")));
 			const readUrlPattern = /\/queue\/[a-f0-9]+\/view$/;
 			assert.ok(
-				hrefs.some(href => href === config.testUrl || readUrlPattern.test(href)),
+				hrefs.some(href => href !== null && (href === config.testUrl || readUrlPattern.test(href))),
 				`Expected "${config.testUrl}" or a reader URL in list hrefs, but found: ${hrefs.join(", ")}`,
 			);
 			config.progress.listVerified = true;

--- a/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.ts
+++ b/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.ts
@@ -33,7 +33,7 @@ export function initSubscriptionStartRequestHandler(
 		const userId = UserIdSchema.parse(detail.userId);
 		const row = await deps.findSubscriptionByUserId(userId);
 
-		if (!row || row.status !== "trialing") {
+		if (row?.status !== "trialing") {
 			deps.logger.info("[start-request] no trial row — noop", {
 				userId,
 				status: row?.status,

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -82,7 +82,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 		const userId = req.userId;
 		try {
 			const row = await deps.findSubscriptionByUserId(userId);
-			if (!row || row.status !== "pending_cancellation") {
+			if (row?.status !== "pending_cancellation") {
 				// Defensive noop: covers double-click + race with the deferred
 				// scheduler. The user lands back on /account and sees whatever
 				// state they're actually in.

--- a/projects/hutch/src/runtime/web/pages/blog/posts/import-links-from-a-page.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/import-links-from-a-page.md
@@ -1,0 +1,45 @@
+---
+title: "Paste One Link, Save Every Article on the Page"
+description: "Readplace can now import links from a single page. Paste a newsletter issue or a links page, and Readplace lists every outbound link for you to pick from. Save the whole batch in one click."
+slug: "import-links-from-a-page"
+date: "2026-05-30"
+author: "Fayner Brack"
+keywords: "import newsletter links, save all links from a page, bulk save articles, read it later, save newsletter to read later, extract links from web page, blogroll, readplace"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Readplace now imports links from one page. Open your queue, hit Import, and switch to the "Paste a link" tab. Drop in a newsletter issue or any page that lists articles. Readplace loads the page and lists every outbound link, each one checked by default. Untick what you skip, then click Import. The articles appear as cards right away and fill in their titles and excerpts within seconds. One page can hold up to 2,000 links. The same screen still takes a file upload too.
+
+</div>
+</details>
+
+A good newsletter drops ten or twenty links in your inbox. You mean to read half of them later. So you open the first link, wait for it to load, save it, then go back for the next one. Twenty links turn into twenty round trips.
+
+Readplace now does that in one step.
+
+## Paste the page, pick the links
+
+Open your queue and find the Import button next to the save bar. Switch to the "Paste a link" tab. Drop in the address of a newsletter issue, a blogroll, or any page that lists articles. Readplace loads the page and reads out every link that points to another site.
+
+You get a plain, checkable list. Every link starts ticked. Untick the ones you want to skip, then click Import. Readplace keeps only the outbound links, drops repeats, and ignores the page's own address, so the list stays short and clean.
+
+## Your cards show up at once
+
+Saved links appear as cards the moment you import. Each card starts with just the site name. The title, the excerpt, and the full reading copy then fill in over the next few seconds as Readplace reads each page. You watch your reading list build itself instead of staring at a spinner.
+
+The same import screen still takes a file. Got an HTML or JSON export from an old app? Upload it and pick from the same checkable list. Both paths end the same way, with the articles you chose sitting in your queue.
+
+## Built for newsletter readers
+
+Readplace pulls up to 2,000 links from one page. It caps the page download at 5 MiB and stops after 10 seconds if the site stalls, so a slow page won't hang your import. Past those limits, email <a href="mailto:readplace+migrate@readplace.com">readplace+migrate@readplace.com</a> and I'll lift the cap by hand.
+
+Newsletter subscribers get the biggest lift here. A weekly roundup of twenty links becomes one paste and a couple of unticks. People who follow link blogs and "further reading" lists save the same way, straight from the page they already trust.
+
+## Try it on this week's newsletter
+
+Open the newsletter sitting in your inbox right now. Copy the link to the web version, open your Readplace queue, and paste it into the Import box. Pick the pieces you actually mean to read, and let the rest go.
+
+[Create an account](https://readplace.com) or [view the source on GitHub](https://github.com/Readplace/readplace.com).

--- a/projects/hutch/src/runtime/web/pages/blog/posts/import-links-from-a-page.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/import-links-from-a-page.md
@@ -2,7 +2,7 @@
 title: "Paste One Link, Save Every Article on the Page"
 description: "Readplace can now import links from a single page. Paste a newsletter issue or a links page, and Readplace lists every outbound link for you to pick from. Save the whole batch in one click."
 slug: "import-links-from-a-page"
-date: "2026-05-30"
+date: "2026-05-31"
 author: "Fayner Brack"
 keywords: "import newsletter links, save all links from a page, bulk save articles, read it later, save newsletter to read later, extract links from web page, blogroll, readplace"
 ---
@@ -34,7 +34,7 @@ The same import screen still takes a file. Got an HTML or JSON export from an ol
 
 ## Built for newsletter readers
 
-Readplace pulls up to 2,000 links from one page. It caps the page download at 5 MiB and stops after 10 seconds if the site stalls, so a slow page won't hang your import. Past those limits, email <a href="mailto:readplace+migrate@readplace.com">readplace+migrate@readplace.com</a> and I'll lift the cap by hand.
+Readplace pulls up to 2,000 links from one page. It caps the page download at 5 MiB and stops after 10 seconds if the site stalls, so a slow page won't hang your import. Past those limits, email [readplace+migrate@readplace.com](mailto:readplace+migrate@readplace.com) and I'll lift the cap by hand.
 
 Newsletter subscribers get the biggest lift here. A weekly roundup of twenty links becomes one paste and a couple of unticks. People who follow link blogs and "further reading" lists save the same way, straight from the page they already trust.
 

--- a/projects/save-link/src/runtime/domain/generate-summary/link-summariser.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/link-summariser.ts
@@ -103,7 +103,7 @@ export function initLinkSummariser(deps: {
 		const textBlock = response.content.find(
 			(block) => block.type === "text",
 		);
-		if (!textBlock || textBlock.type !== "text" || !textBlock.text) {
+		if (textBlock?.type !== "text" || !textBlock.text) {
 			deps.logger.info("[summarize] no text block in response", { url: params.url });
 			return { kind: "no-text-block" };
 		}


### PR DESCRIPTION
## What

Adds a new blog post: **"Paste One Link, Save Every Article on the Page"** (`import-links-from-a-page.md`).

The post covers the `/import` from-URL acquisition mode shipped in #426. Readers can paste a newsletter issue or an index/blogroll page, and Readplace fetches it and lists every outbound link for review, checked by default, then saves the selected batch as cards that populate progressively.

## Why this topic

I reviewed every commit on `main` after the last published post (`5348b8e`, the single-fetch crawler reliability post dated 2026-05-30). Candidates since then:

- `673d84e` — `/import` from-URL acquisition mode (#426) ← **chosen**
- `b32358f` — Stripe deferred-cancellation fix (internal billing reliability)
- `5d150c6` — reader funnel opens vs reads analytics (internal observability)
- `40502bd` / `dd1e929` — founding-member limit config + promo cleanup (pricing, excluded by request)
- `e8795a1` — macOS reader-view browser POC (not customer-ready)

The from-URL import is the most conversion-relevant, customer-facing change. It targets a high-intent audience (newsletter readers and people who follow link roundups) and maps to strong search terms like "import newsletter links" and "save all links from a page".

## Post details

- 400–800 word target, customer-benefit-led, active voice, plain language.
- Accurate to the implementation: outbound-only links, dedupe, drops the source URL, 2,000-link cap, 5 MiB / 10 s fetch limits, concierge email fallback, file-upload path still present.
- No pricing or founding-member references (those are point-in-time and excluded per the brief).
- Clear CTA: paste this week's newsletter into the queue Import box.

## Verification

- `pnpm check` (full pre-commit run) passed across all 26 projects, including 100% coverage.
- Blog discovery tests pass (42 tests); the new post is parsed and served at `/blog/import-links-from-a-page`.
- Slug matches filename per the discovery invariant.

https://claude.ai/code/session_01RD4mYLizs6uFchYRD9idGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RD4mYLizs6uFchYRD9idGD)_