### PR TITLE
docs(blog): add post on auto-refreshing AI summaries

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/ai-summary-updates-with-the-article.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/ai-summary-updates-with-the-article.md
@@ -1,0 +1,49 @@
+---
+title: "Your AI Summary Updates When the Article Does"
+description: "Readplace keeps one TL;DR per link. When it later reads a cleaner copy of a page, it rebuilds the summary instead of serving the stale one, so your saved articles stay accurate without a manual refresh."
+slug: "ai-summary-updates-with-the-article"
+date: "2026-05-31"
+author: "Fayner Brack"
+keywords: "ai summary, article tl;dr, read it later, stale summary, summary refresh, save articles, deepseek summary, readplace"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Readplace keeps one TL;DR per link, shared across anyone who saves it. The first save sometimes grabs a thin copy of a page, like a paywall screen or a half-loaded article, and the summary matches that thin copy. Readplace re-reads pages it saved and often lands a cleaner, fuller version. It now rebuilds the summary against that better copy on its own. The refreshed TL;DR replaces the stale one for the next reader who opens that link. You get an accurate summary without asking for a refresh.
+
+</div>
+</details>
+
+You save a long article on Monday. The TL;DR reads oddly short, like it missed half the piece. You open the article and the full text is right there. So why did the summary come up thin?
+
+The cause sits in how the page loaded the first time. Some sites serve a stripped page to a first-time visitor. A paywall throws up a teaser. A bot guard returns a near-empty shell. A slow page hands over half its body before the connection drops. Readplace saved what it got, and the summary described that thin copy.
+
+Readplace does not stop at the first read. It re-checks saved pages, and it grades each copy it pulls. A fuller, cleaner copy outranks a thin one. When a better copy arrives, Readplace swaps it in as the version you read.
+
+The summary used to stay behind. The page upgraded to the clean copy, yet the old TL;DR sat on top of it. You read the full article and a summary built from the broken version. That gap is now closed.
+
+## How the summary catches up
+
+Readplace marks the moment a saved page changes. A new content grade or a real edit to the text both count as a change. The app raises a small internal signal that says, this link has a better copy now.
+
+A separate worker listens for that signal. It checks that the clean copy is readable, then clears the stale summary and asks for a fresh one. The same DeepSeek step that wrote the first TL;DR runs again, this time against the better copy. If you want the full picture of that step, read [how AI TL;DR actually works in Readplace](/blog/how-ai-tldr-actually-works).
+
+Readplace caches one summary per link, so the rebuilt TL;DR lands for the next reader who saves or opens that link too.
+
+There is a sharper version of this problem. A thin first copy can be short enough that Readplace skips the summary outright, tagging it too short to bother with. The page later upgrades to the full article, long enough to summarise well. The old code left it tagged as skipped. The new path notices the upgrade and builds the summary it passed on the first time.
+
+## Why this matters for your queue
+
+A summary you cannot trust is worse than no summary. You glance at the TL;DR, decide the piece is light, and skip something worth your time. Or the reverse, where a broken summary buries a quick read under a wall of words you did not need.
+
+Readplace treats the TL;DR as a triage tool. It helps you pick what to read and when. That job works only if the summary matches the article in front of you. Tying the summary to the best copy of the page keeps that promise honest.
+
+This builds on the way Readplace re-reads saved pages. It already asks a site whether a page changed before pulling it again, which keeps your list current and spares the publisher the traffic. Read more on that in [how Readplace saves a page without getting blocked](/blog/save-pages-without-getting-blocked).
+
+## See it on a stubborn save
+
+Save an article that fought you the first time, like a news page behind a soft wall or a slow longread. Give Readplace a beat to re-read it. Open the card and check the TL;DR against the full text. It should describe the article you actually get, not the shell the site served at first.
+
+[Create an account](https://readplace.com) or [view the source on GitHub](https://github.com/Readplace/readplace.com).


### PR DESCRIPTION
## What

New blog post: **"Your AI Summary Updates When the Article Does"** (`ai-summary-updates-with-the-article.md`).

It covers the `canonical-content-changed` feature shipped in `997b759`: when Readplace re-reads a saved page and lands a cleaner, fuller copy (after a degraded first crawl, a paywall shell, or a real publisher edit), it now rebuilds the cached TL;DR against that better copy instead of serving the stale one. It also covers the sharper case where a summary was skipped as "too short" on a thin first copy and now regenerates once the full article arrives.

## Why this topic

Reviewed every commit on `main` after the last published post (`import-links-from-a-page`, 2026-05-31). The genuinely un-blogged, conversion-relevant feature was the summary-regeneration seam. It demonstrates a real competitive advantage (AI summaries that stay accurate when the underlying page improves) and ties into two existing posts for internal linking:

- [how AI TL;DR actually works](/blog/how-ai-tldr-actually-works)
- [how Readplace saves a page without getting blocked](/blog/save-pages-without-getting-blocked)

A subscription-cancellation post was the other candidate but was set aside to avoid pricing/promo references that date quickly.

## Notes

- 672 words, within the 400–800 target. Active voice, short sentences, no pricing or founding-member references.
- Frontmatter matches the schema in `blog.posts.ts`; slug equals filename; no duplicate slugs. Validated all 17 posts against the discovery module's parse + assertions.
- Dependencies are not installed in this fresh container, so the full `nx` test run was not executed. Verification was done by replicating the discovery module's frontmatter/slug/uniqueness checks directly.

https://claude.ai/code/session_01Xx5RyvBPiinRMXi6gQm27N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx5RyvBPiinRMXi6gQm27N)_