### PR TITLE
fix(save-link): promote the freshly-written tier on a media-only tie

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/view-page-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/view-page-actions.ts
@@ -113,12 +113,14 @@ export function createAnonymousViewPageActions(
 				const shareWrap = page.locator('[data-test-share-balloon-wrap]')
 				await expect(shareWrap).toHaveCount(1)
 				await expect(shareWrap).not.toHaveClass(/share-balloon__wrap--open/)
-				await page.evaluate(() => {
-					const article = document.querySelector<HTMLElement>('[data-article-body]')
-					const height = article ? article.offsetHeight : 0
-					window.scrollTo(0, Math.ceil(height * 0.5) + 1)
-				})
-				await expect(shareWrap).toHaveClass(/share-balloon__wrap--open/, { timeout: 3000 })
+				await expect(async () => {
+					await page.evaluate(() => {
+						const article = document.querySelector<HTMLElement>('[data-article-body]')
+						const height = article ? article.offsetHeight : 0
+						window.scrollTo(0, Math.ceil(height * 0.5) + 1)
+					})
+					await expect(shareWrap).toHaveClass(/share-balloon__wrap--open/, { timeout: 2000 })
+				}).toPass({ timeout: 10000 })
 				await page.locator('[data-test-share-balloon-close]').click()
 				await expect(shareWrap).not.toHaveClass(/share-balloon__wrap--open/)
 				const dismissed = await page.evaluate(() =>

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
@@ -95,7 +95,6 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
 		loadArticle: jest.fn().mockResolvedValue(undefined),
 		transitionAndPersist,
-		imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
 		now: () => FIXED_NOW,
 		logger: noopLogger,
 		...overrides,
@@ -331,13 +330,14 @@ describe("initRecrawlContentExtractedHandler", () => {
 		});
 	});
 
-	it("on a tie, breaks in favour of the candidate with more CDN-host URLs even when canonical exists", async () => {
-		// Regression: pre-Referer-fix canonical (tier-0, raw origin URLs) tied
-		// with post-fix tier-1 (CDN URLs) — LLM said "only image URLs differ",
-		// which left readers stuck on the broken hotlink-protected origin.
+	it("on a prose tie whose candidates differ only in media, promotes the freshly recrawled tier-1 without consulting the existing canonical", async () => {
+		// A prose tie can hide a media change — an image-pipeline fix (or upstream
+		// image edit) rewrites <img> URLs while the text is identical. The fresh
+		// tier-1 must win so the corrected media reaches the canonical instead of
+		// leaving the reader on a stale render.
 		const tier0 = tierSource("tier-0", { html: '<p>same body</p><img src="https://origin.example/a.png">' });
 		const tier1 = tierSource("tier-1", {
-			html: '<p>same body</p><img src="https://cdn.example.cloudfront.net/a.png"><img src="https://cdn.example.cloudfront.net/b.png">',
+			html: '<p>same body</p><img src="https://cdn.example.cloudfront.net/a.png">',
 		});
 		const writeCanonicalContent = jest.fn().mockResolvedValue(undefined);
 		const findContentSourceTier = jest.fn().mockResolvedValue("tier-0");
@@ -347,7 +347,6 @@ describe("initRecrawlContentExtractedHandler", () => {
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "only image URLs differ" }),
 			findContentSourceTier,
 			writeCanonicalContent,
-			imagesCdnBaseUrl: "https://cdn.example.cloudfront.net",
 		});
 
 		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -19,6 +19,7 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
+import { tiersDifferInMedia } from "./tiers-differ-in-media";
 import type { TierSource } from "./tier-source.types";
 
 export function initRecrawlContentExtractedHandler(deps: {
@@ -28,7 +29,6 @@ export function initRecrawlContentExtractedHandler(deps: {
 	findContentSourceTier: FindContentSourceTier;
 	loadArticle: LoadArticle;
 	transitionAndPersist: TransitionAndPersist;
-	imagesCdnBaseUrl: string;
 	now: () => Date;
 	logger: HutchLogger;
 }): Handler<SQSEvent, SQSBatchResponse> {
@@ -39,11 +39,9 @@ export function initRecrawlContentExtractedHandler(deps: {
 		findContentSourceTier,
 		loadArticle,
 		transitionAndPersist,
-		imagesCdnBaseUrl,
 		now,
 		logger,
 	} = deps;
-	const cdnHost = new URL(imagesCdnBaseUrl).host;
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -90,16 +88,16 @@ export function initRecrawlContentExtractedHandler(deps: {
 						reason: decision.reason,
 					});
 					if (decision.winner === "tie") {
-						/* The LLM treats "only image URLs differ" as a tie, but a
-						 * recrawl after the Referer fix migrates <img src> from the
-						 * origin to our CDN — never a wash. Hotlink-protected
-						 * origins 403 the reader's browser
-						 * without our server-side Referer trick, so any net-positive
-						 * shift toward the CDN host is unambiguously an improvement.
-						 * Override the tie when one candidate has more occurrences
-						 * of the CDN host than the others. */
-						const cdnTie = breakTieByCdnRewriteCount(sources, cdnHost);
-						const existingTier = cdnTie ? undefined : await findContentSourceTier(detail.url);
+						/* The LLM scores a prose tie, but a recrawl after an
+						 * image-pipeline fix (or an upstream image edit) rewrites
+						 * <img>/<source> URLs while the text is unchanged — never a
+						 * wash for the reader. When the candidates' media differs,
+						 * promote the freshly recrawled tier (tier-1) so the new
+						 * media reaches the canonical instead of keeping a stale
+						 * render. A genuine wash (identical media) keeps the existing
+						 * canonical to avoid a redundant summary regeneration. */
+						const mediaChanged = tiersDifferInMedia(sources);
+						const existingTier = mediaChanged ? undefined : await findContentSourceTier(detail.url);
 						const existingArticle = existingTier
 							? await loadArticle(detail.url)
 							: undefined;
@@ -107,27 +105,26 @@ export function initRecrawlContentExtractedHandler(deps: {
 							existingArticle?.summary.kind === "skipped" &&
 							existingArticle.summary.reason === "content-too-short";
 						const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
-						if (cdnTie) {
-							winnerTier = cdnTie.tier;
-							reason = cdnTie.reason;
-						} else if (canonicalIsHealthy) {
+						if (canonicalIsHealthy) {
 							winnerTier = undefined;
 							reason = decision.reason;
 						} else {
-							/* Either tie with no canonical yet (recovering a stuck
-							 * row), OR canonical exists but its summary is
-							 * skipped("content-too-short") — the previous canonical's
-							 * content was inadequate. By definition of "tie" both
-							 * tiers carry equivalent content; prefer tier-1
-							 * (Readability) when present, else tier-0. */
-							const fallback =
+							/* Media changed, OR a tie with no canonical yet
+							 * (recovering a stuck row), OR canonical exists but its
+							 * summary is skipped("content-too-short"). By definition of
+							 * "tie" both tiers carry equivalent prose; prefer tier-1
+							 * (Readability / the freshly recrawled tier) when present,
+							 * else tier-0. */
+							const fresh =
 								sources.find((source) => source.tier === "tier-1") ??
 								sources.find((source) => source.tier === "tier-0");
-							assert(fallback, "tie with no candidate tiers should be unreachable");
-							winnerTier = fallback.tier;
-							reason = summaryStuckOnTooShort
-								? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
-								: `tie on recrawl recovery; defaulted to ${fallback.tier}`;
+							assert(fresh, "tie with no candidate tiers should be unreachable");
+							winnerTier = fresh.tier;
+							reason = mediaChanged
+								? `media changed on prose tie; promoted ${fresh.tier}`
+								: summaryStuckOnTooShort
+									? `tie + canonical summary skipped on too-short content; promoted ${fresh.tier} to retry`
+									: `tie on recrawl recovery; defaulted to ${fresh.tier}`;
 						}
 					} else {
 						winnerTier = decision.winner;
@@ -183,23 +180,4 @@ export function initRecrawlContentExtractedHandler(deps: {
 
 		return { batchItemFailures };
 	};
-}
-
-function breakTieByCdnRewriteCount(
-	sources: readonly TierSource[],
-	cdnHost: string,
-): { tier: TierSource["tier"]; reason: string } | undefined {
-	const counts = sources
-		.map((source) => ({ tier: source.tier, count: countOccurrences(source.html, cdnHost) }))
-		.sort((a, b) => b.count - a.count);
-	const [top, second] = counts;
-	if (!top || !second || top.count <= second.count) return undefined;
-	return {
-		tier: top.tier,
-		reason: `tie broken: ${top.tier} has ${top.count} CDN-rewritten URLs vs ${second.count} in next candidate`,
-	};
-}
-
-function countOccurrences(haystack: string, needle: string): number {
-	return haystack.split(needle).length - 1;
 }

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -19,7 +19,7 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
-import { tiersDifferInMedia } from "./tiers-differ-in-media";
+import { resolveTie } from "./resolve-tie";
 import type { TierSource } from "./tier-source.types";
 
 export function initRecrawlContentExtractedHandler(deps: {
@@ -88,43 +88,19 @@ export function initRecrawlContentExtractedHandler(deps: {
 						reason: decision.reason,
 					});
 					if (decision.winner === "tie") {
-						/* The LLM scores a prose tie, but a recrawl after an
-						 * image-pipeline fix (or an upstream image edit) rewrites
-						 * <img>/<source> URLs while the text is unchanged — never a
-						 * wash for the reader. When the candidates' media differs,
-						 * promote the freshly recrawled tier (tier-1) so the new
-						 * media reaches the canonical instead of keeping a stale
-						 * render. A genuine wash (identical media) keeps the existing
-						 * canonical to avoid a redundant summary regeneration. */
-						const mediaChanged = tiersDifferInMedia(sources);
-						const existingTier = mediaChanged ? undefined : await findContentSourceTier(detail.url);
-						const existingArticle = existingTier
-							? await loadArticle(detail.url)
-							: undefined;
-						const summaryStuckOnTooShort =
-							existingArticle?.summary.kind === "skipped" &&
-							existingArticle.summary.reason === "content-too-short";
-						const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
-						if (canonicalIsHealthy) {
+						const resolution = await resolveTie({
+							sources,
+							freshTier: "tier-1",
+							url: detail.url,
+							findContentSourceTier,
+							loadArticle,
+						});
+						if (resolution.kind === "keep-canonical") {
 							winnerTier = undefined;
 							reason = decision.reason;
 						} else {
-							/* Media changed, OR a tie with no canonical yet
-							 * (recovering a stuck row), OR canonical exists but its
-							 * summary is skipped("content-too-short"). By definition of
-							 * "tie" both tiers carry equivalent prose; prefer tier-1
-							 * (Readability / the freshly recrawled tier) when present,
-							 * else tier-0. */
-							const fresh =
-								sources.find((source) => source.tier === "tier-1") ??
-								sources.find((source) => source.tier === "tier-0");
-							assert(fresh, "tie with no candidate tiers should be unreachable");
-							winnerTier = fresh.tier;
-							reason = mediaChanged
-								? `media changed on prose tie; promoted ${fresh.tier}`
-								: summaryStuckOnTooShort
-									? `tie + canonical summary skipped on too-short content; promoted ${fresh.tier} to retry`
-									: `tie on recrawl recovery; defaulted to ${fresh.tier}`;
+							winnerTier = resolution.tier;
+							reason = resolution.reason;
 						}
 					} else {
 						winnerTier = decision.winner;

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.ts
@@ -19,7 +19,7 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
-import { resolveTie } from "./resolve-tie";
+import { initResolveTie } from "./resolve-tie";
 import type { TierSource } from "./tier-source.types";
 
 export function initRecrawlContentExtractedHandler(deps: {
@@ -42,6 +42,8 @@ export function initRecrawlContentExtractedHandler(deps: {
 		now,
 		logger,
 	} = deps;
+
+	const resolveTie = initResolveTie({ findContentSourceTier, loadArticle });
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -92,8 +94,6 @@ export function initRecrawlContentExtractedHandler(deps: {
 							sources,
 							freshTier: "tier-1",
 							url: detail.url,
-							findContentSourceTier,
-							loadArticle,
 						});
 						if (resolution.kind === "keep-canonical") {
 							winnerTier = undefined;

--- a/projects/save-link/src/runtime/domain/select-content/resolve-tie.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/resolve-tie.test.ts
@@ -1,0 +1,168 @@
+import type { Article } from "@packages/domain/article-aggregate";
+import { initResolveTie } from "./resolve-tie";
+import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
+import type { TierSource, TierSourceMetadata } from "./tier-source.types";
+
+const stubMetadata: TierSourceMetadata = {
+	title: "Title",
+	siteName: "example.com",
+	excerpt: "excerpt",
+	wordCount: 100,
+	estimatedReadTime: 1,
+};
+
+function source(tier: TierSource["tier"], html = `<p>${tier} html</p>`): TierSource {
+	return { tier, html, metadata: stubMetadata };
+}
+
+function articleWithSummary(summary: Article["summary"]): Article {
+	return {
+		url: "https://example.com/a",
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0 },
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "ready" },
+		summary,
+		summaryAutoHeal: { attempts: 0 },
+	};
+}
+
+describe("initResolveTie", () => {
+	it("promotes the fresh tier when media differs, without consulting the existing canonical", async () => {
+		const findContentSourceTier: jest.MockedFunction<FindContentSourceTier> = jest.fn();
+		const loadArticle = jest.fn();
+		const resolveTie = initResolveTie({ findContentSourceTier, loadArticle });
+
+		const result = await resolveTie({
+			sources: [
+				source("tier-0", '<p>body</p><img src="https://cdn/old.png">'),
+				source("tier-1", '<p>body</p><img src="https://cdn/new.png">'),
+			],
+			freshTier: "tier-1",
+			url: "https://example.com/a",
+		});
+
+		expect(result).toEqual({
+			kind: "promote",
+			tier: "tier-1",
+			reason: "media changed on prose tie; promoted tier-1",
+			existingTier: undefined,
+		});
+		expect(findContentSourceTier).not.toHaveBeenCalled();
+		expect(loadArticle).not.toHaveBeenCalled();
+	});
+
+	it("keeps the canonical when it exists and the summary is healthy", async () => {
+		const resolveTie = initResolveTie({
+			findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue("tier-1"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary({ kind: "ready", summary: "ok" }),
+			),
+		});
+
+		const result = await resolveTie({
+			sources: [source("tier-0"), source("tier-1")],
+			freshTier: "tier-1",
+			url: "https://example.com/a",
+		});
+
+		expect(result).toEqual({ kind: "keep-canonical" });
+	});
+
+	it("promotes the fallback when the canonical summary is stuck on content-too-short and returns the existing tier", async () => {
+		const resolveTie = initResolveTie({
+			findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue("tier-0"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary({ kind: "skipped", reason: "content-too-short" }),
+			),
+		});
+
+		const result = await resolveTie({
+			sources: [source("tier-0"), source("tier-1")],
+			freshTier: "tier-1",
+			url: "https://example.com/a",
+		});
+
+		expect(result).toEqual({
+			kind: "promote",
+			tier: "tier-1",
+			reason: "tie + canonical summary skipped on too-short content; promoted tier-1 to retry",
+			existingTier: "tier-0",
+		});
+	});
+
+	it("promotes the fallback when no canonical exists", async () => {
+		const loadArticle = jest.fn();
+		const resolveTie = initResolveTie({
+			findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
+			loadArticle,
+		});
+
+		const result = await resolveTie({
+			sources: [source("tier-0"), source("tier-1")],
+			freshTier: "tier-1",
+			url: "https://example.com/a",
+		});
+
+		expect(result).toEqual({
+			kind: "promote",
+			tier: "tier-1",
+			reason: "tie with no canonical; defaulted to tier-1",
+			existingTier: undefined,
+		});
+		expect(loadArticle).not.toHaveBeenCalled();
+	});
+
+	it("falls back to tier-0 when tier-1 is not among the candidates", async () => {
+		const resolveTie = initResolveTie({
+			findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue(undefined),
+			loadArticle: jest.fn(),
+		});
+
+		const result = await resolveTie({
+			sources: [source("tier-0")],
+			freshTier: "tier-0",
+			url: "https://example.com/a",
+		});
+
+		expect(result).toEqual({
+			kind: "promote",
+			tier: "tier-0",
+			reason: "tie with no canonical; defaulted to tier-0",
+			existingTier: undefined,
+		});
+	});
+
+	it("keeps the canonical when the summary is skipped for a non-too-short reason", async () => {
+		const resolveTie = initResolveTie({
+			findContentSourceTier: jest.fn<ReturnType<FindContentSourceTier>, Parameters<FindContentSourceTier>>().mockResolvedValue("tier-1"),
+			loadArticle: jest.fn().mockResolvedValue(
+				articleWithSummary({ kind: "skipped", reason: "ai-unavailable" }),
+			),
+		});
+
+		const result = await resolveTie({
+			sources: [source("tier-0"), source("tier-1")],
+			freshTier: "tier-1",
+			url: "https://example.com/a",
+		});
+
+		expect(result).toEqual({ kind: "keep-canonical" });
+	});
+
+	it("throws when the freshly-written tier is not in the candidate set on a media-different tie", async () => {
+		const resolveTie = initResolveTie({
+			findContentSourceTier: jest.fn(),
+			loadArticle: jest.fn(),
+		});
+
+		await expect(resolveTie({
+			sources: [
+				source("tier-0", '<p>body</p><img src="https://cdn/old.png">'),
+				source("tier-0", '<p>body</p><img src="https://cdn/new.png">'),
+			],
+			freshTier: "tier-1",
+			url: "https://example.com/a",
+		})).rejects.toThrow("freshly-written tier tier-1 missing from candidate set");
+	});
+});

--- a/projects/save-link/src/runtime/domain/select-content/resolve-tie.ts
+++ b/projects/save-link/src/runtime/domain/select-content/resolve-tie.ts
@@ -6,46 +6,51 @@ import type { TierSource } from "./tier-source.types";
 
 export type TieResolution =
 	| { kind: "keep-canonical" }
-	| { kind: "promote"; tier: TierSource["tier"]; reason: string };
+	| { kind: "promote"; tier: TierSource["tier"]; reason: string; existingTier: TierSource["tier"] | undefined };
 
-export async function resolveTie(params: {
+export type ResolveTie = (params: {
 	sources: readonly TierSource[];
 	freshTier: TierSource["tier"];
 	url: string;
+}) => Promise<TieResolution>;
+
+export function initResolveTie(deps: {
 	findContentSourceTier: FindContentSourceTier;
 	loadArticle: LoadArticle;
-}): Promise<TieResolution> {
-	const { sources, freshTier, url, findContentSourceTier, loadArticle } = params;
+}): ResolveTie {
+	const { findContentSourceTier, loadArticle } = deps;
 
-	const mediaChanged = tiersDifferInMedia(sources);
+	return async ({ sources, freshTier, url }) => {
+		const mediaChanged = tiersDifferInMedia(sources);
 
-	if (mediaChanged) {
-		assert(
-			sources.some((s) => s.tier === freshTier),
-			`freshly-written tier ${freshTier} missing from candidate set`,
-		);
-		return { kind: "promote", tier: freshTier, reason: `media changed on prose tie; promoted ${freshTier}` };
-	}
+		if (mediaChanged) {
+			assert(
+				sources.some((s) => s.tier === freshTier),
+				`freshly-written tier ${freshTier} missing from candidate set`,
+			);
+			return { kind: "promote", tier: freshTier, reason: `media changed on prose tie; promoted ${freshTier}`, existingTier: undefined };
+		}
 
-	const existingTier = await findContentSourceTier(url);
-	const existingArticle = existingTier
-		? await loadArticle(url)
-		: undefined;
-	const summaryStuckOnTooShort =
-		existingArticle?.summary.kind === "skipped" &&
-		existingArticle.summary.reason === "content-too-short";
-	const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
+		const existingTier = await findContentSourceTier(url);
+		const existingArticle = existingTier
+			? await loadArticle(url)
+			: undefined;
+		const summaryStuckOnTooShort =
+			existingArticle?.summary.kind === "skipped" &&
+			existingArticle.summary.reason === "content-too-short";
+		const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
 
-	if (canonicalIsHealthy) {
-		return { kind: "keep-canonical" };
-	}
+		if (canonicalIsHealthy) {
+			return { kind: "keep-canonical" };
+		}
 
-	const fallback =
-		sources.find((s) => s.tier === "tier-1") ??
-		sources.find((s) => s.tier === "tier-0");
-	assert(fallback, "tie with no candidate tiers should be unreachable");
-	const reason = summaryStuckOnTooShort
-		? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
-		: `tie with no canonical; defaulted to ${fallback.tier}`;
-	return { kind: "promote", tier: fallback.tier, reason };
+		const fallback =
+			sources.find((s) => s.tier === "tier-1") ??
+			sources.find((s) => s.tier === "tier-0");
+		assert(fallback, "tie with no candidate tiers should be unreachable");
+		const reason = summaryStuckOnTooShort
+			? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
+			: `tie with no canonical; defaulted to ${fallback.tier}`;
+		return { kind: "promote", tier: fallback.tier, reason, existingTier };
+	};
 }

--- a/projects/save-link/src/runtime/domain/select-content/resolve-tie.ts
+++ b/projects/save-link/src/runtime/domain/select-content/resolve-tie.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert";
+import type { LoadArticle } from "@packages/domain/article-aggregate";
+import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
+import { tiersDifferInMedia } from "./tiers-differ-in-media";
+import type { TierSource } from "./tier-source.types";
+
+export type TieResolution =
+	| { kind: "keep-canonical" }
+	| { kind: "promote"; tier: TierSource["tier"]; reason: string };
+
+export async function resolveTie(params: {
+	sources: readonly TierSource[];
+	freshTier: TierSource["tier"];
+	url: string;
+	findContentSourceTier: FindContentSourceTier;
+	loadArticle: LoadArticle;
+}): Promise<TieResolution> {
+	const { sources, freshTier, url, findContentSourceTier, loadArticle } = params;
+
+	const mediaChanged = tiersDifferInMedia(sources);
+
+	if (mediaChanged) {
+		assert(
+			sources.some((s) => s.tier === freshTier),
+			`freshly-written tier ${freshTier} missing from candidate set`,
+		);
+		return { kind: "promote", tier: freshTier, reason: `media changed on prose tie; promoted ${freshTier}` };
+	}
+
+	const existingTier = await findContentSourceTier(url);
+	const existingArticle = existingTier
+		? await loadArticle(url)
+		: undefined;
+	const summaryStuckOnTooShort =
+		existingArticle?.summary.kind === "skipped" &&
+		existingArticle.summary.reason === "content-too-short";
+	const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
+
+	if (canonicalIsHealthy) {
+		return { kind: "keep-canonical" };
+	}
+
+	const fallback =
+		sources.find((s) => s.tier === "tier-1") ??
+		sources.find((s) => s.tier === "tier-0");
+	assert(fallback, "tie with no candidate tiers should be unreachable");
+	const reason = summaryStuckOnTooShort
+		? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
+		: `tie with no canonical; defaulted to ${fallback.tier}`;
+	return { kind: "promote", tier: fallback.tier, reason };
+}

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
@@ -305,6 +305,34 @@ describe("initSelectMostCompleteContentHandler", () => {
 		expect(events).toEqual(["CrawlArticleCompleted"]);
 	});
 
+	it("on a prose tie whose candidates differ in media, promotes the freshly-written tier (detail.tier) instead of keeping the healthy canonical", async () => {
+		const tier0 = tierSource("tier-0", { html: '<p>same body</p><img src="https://cdn.example/new.png">' });
+		const tier1 = tierSource("tier-1", { html: '<p>same body</p><img src="https://cdn.example/old.png">' });
+		const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+		const { handler, deps } = createHandler({
+			listAvailableTierSources: jest.fn().mockResolvedValue([tier0, tier1]),
+			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tie", reason: "identical prose, different image" }),
+			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
+			publishEvent,
+		});
+
+		// Event raised for the freshly re-saved tier-0 (extension re-save after editing an image upstream).
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+
+		expect(publishEvent).not.toHaveBeenCalled();
+		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
+			url: "https://example.com/a",
+			tier: "tier-0",
+		});
+		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
+			promoteTier,
+			expect.objectContaining({
+				input: expect.objectContaining({ tier: "tier-0" }),
+			}),
+		);
+	});
+
 	it("tie with an existing canonical whose summary is skipped(content-too-short) falls through to the deterministic tiebreaker and promotes so the row exits the stuck skipped state", async () => {
 		const tier0 = tierSource("tier-0");
 		const tier1 = tierSource("tier-1");

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -17,6 +17,7 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
+import { tiersDifferInMedia } from "./tiers-differ-in-media";
 import type { TierSource } from "./tier-source.types";
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
@@ -92,7 +93,15 @@ export function initSelectMostCompleteContentHandler(deps: {
 						reason: decision.reason,
 					});
 					if (decision.winner === "tie") {
-						const existingTier = await findContentSourceTier(detail.url);
+						/* A prose tie can still hide a media change — the user
+						 * re-saved after editing media upstream, so the freshly
+						 * written tier carries new <img>/<source> URLs the canonical
+						 * lacks. Treat that as a real change so the new media lands;
+						 * only a genuine wash (identical media) keeps the canonical. */
+						const mediaChanged = tiersDifferInMedia(sources);
+						const existingTier = mediaChanged
+							? undefined
+							: await findContentSourceTier(detail.url);
 						const existingArticle = existingTier
 							? await loadArticle(detail.url)
 							: undefined;
@@ -101,31 +110,41 @@ export function initSelectMostCompleteContentHandler(deps: {
 							existingArticle.summary.reason === "content-too-short";
 						const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
 						if (canonicalIsHealthy) {
-							/* Recrawl tie: a canonical already exists. Promoting the
-							 * same content again would be a no-op write but a real
-							 * summary regeneration — wasted Deepseek tokens. Emit
-							 * CrawlArticleCompleted directly to settle the pipeline
-							 * and skip; no aggregate transition because crawl/summary
-							 * state is unchanged. */
+							/* Recrawl tie with identical media: a canonical already
+							 * exists. Promoting the same content again would be a no-op
+							 * write but a real summary regeneration — wasted Deepseek
+							 * tokens. Emit CrawlArticleCompleted directly to settle the
+							 * pipeline and skip; no aggregate transition because
+							 * crawl/summary state is unchanged. */
 							await publishEvent(CrawlArticleCompletedEvent, { url: detail.url });
 							continue;
 						}
-						/* Either first save (no canonical yet) OR canonical exists
-						 * but its summary is skipped("content-too-short") — i.e.
-						 * the previous canonical's content was inadequate. In both
-						 * cases, by definition of "tie" both tiers carry equivalent
-						 * content; prefer tier-1 (Readability-parsed) when present,
-						 * else tier-0. promoteTier announces CanonicalContentChanged,
-						 * and the subscriber re-primes the summary so it regenerates
-						 * against the new canonical. */
-						const fallback =
-							sources.find((source) => source.tier === "tier-1") ??
-							sources.find((source) => source.tier === "tier-0");
-						assert(fallback, "tie with no candidate tiers should be unreachable");
-						winnerTier = fallback.tier;
-						reason = summaryStuckOnTooShort
-							? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
-							: `tie on first save; defaulted to ${fallback.tier}`;
+						if (mediaChanged) {
+							/* Promote the tier this event was raised for — the freshly
+							 * written one — so its new media becomes canonical rather
+							 * than losing to a stale sibling on a prose tie. */
+							const fresh = sources.find((source) => source.tier === detail.tier);
+							assert(fresh, `freshly-written tier ${detail.tier} missing from candidate set`);
+							winnerTier = fresh.tier;
+							reason = `media changed on prose tie; promoted ${fresh.tier}`;
+						} else {
+							/* Either first save (no canonical yet) OR canonical exists
+							 * but its summary is skipped("content-too-short") — i.e.
+							 * the previous canonical's content was inadequate. In both
+							 * cases, by definition of "tie" both tiers carry equivalent
+							 * content; prefer tier-1 (Readability-parsed) when present,
+							 * else tier-0. promoteTier announces CanonicalContentChanged,
+							 * and the subscriber re-primes the summary so it regenerates
+							 * against the new canonical. */
+							const fallback =
+								sources.find((source) => source.tier === "tier-1") ??
+								sources.find((source) => source.tier === "tier-0");
+							assert(fallback, "tie with no candidate tiers should be unreachable");
+							winnerTier = fallback.tier;
+							reason = summaryStuckOnTooShort
+								? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
+								: `tie on first save; defaulted to ${fallback.tier}`;
+						}
 					} else {
 						winnerTier = decision.winner;
 						reason = decision.reason;

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -17,7 +17,7 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
-import { tiersDifferInMedia } from "./tiers-differ-in-media";
+import { resolveTie } from "./resolve-tie";
 import type { TierSource } from "./tier-source.types";
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
@@ -93,58 +93,19 @@ export function initSelectMostCompleteContentHandler(deps: {
 						reason: decision.reason,
 					});
 					if (decision.winner === "tie") {
-						/* A prose tie can still hide a media change — the user
-						 * re-saved after editing media upstream, so the freshly
-						 * written tier carries new <img>/<source> URLs the canonical
-						 * lacks. Treat that as a real change so the new media lands;
-						 * only a genuine wash (identical media) keeps the canonical. */
-						const mediaChanged = tiersDifferInMedia(sources);
-						const existingTier = mediaChanged
-							? undefined
-							: await findContentSourceTier(detail.url);
-						const existingArticle = existingTier
-							? await loadArticle(detail.url)
-							: undefined;
-						const summaryStuckOnTooShort =
-							existingArticle?.summary.kind === "skipped" &&
-							existingArticle.summary.reason === "content-too-short";
-						const canonicalIsHealthy = existingTier && !summaryStuckOnTooShort;
-						if (canonicalIsHealthy) {
-							/* Recrawl tie with identical media: a canonical already
-							 * exists. Promoting the same content again would be a no-op
-							 * write but a real summary regeneration — wasted Deepseek
-							 * tokens. Emit CrawlArticleCompleted directly to settle the
-							 * pipeline and skip; no aggregate transition because
-							 * crawl/summary state is unchanged. */
+						const resolution = await resolveTie({
+							sources,
+							freshTier: detail.tier,
+							url: detail.url,
+							findContentSourceTier,
+							loadArticle,
+						});
+						if (resolution.kind === "keep-canonical") {
 							await publishEvent(CrawlArticleCompletedEvent, { url: detail.url });
 							continue;
 						}
-						if (mediaChanged) {
-							/* Promote the tier this event was raised for — the freshly
-							 * written one — so its new media becomes canonical rather
-							 * than losing to a stale sibling on a prose tie. */
-							const fresh = sources.find((source) => source.tier === detail.tier);
-							assert(fresh, `freshly-written tier ${detail.tier} missing from candidate set`);
-							winnerTier = fresh.tier;
-							reason = `media changed on prose tie; promoted ${fresh.tier}`;
-						} else {
-							/* Either first save (no canonical yet) OR canonical exists
-							 * but its summary is skipped("content-too-short") — i.e.
-							 * the previous canonical's content was inadequate. In both
-							 * cases, by definition of "tie" both tiers carry equivalent
-							 * content; prefer tier-1 (Readability-parsed) when present,
-							 * else tier-0. promoteTier announces CanonicalContentChanged,
-							 * and the subscriber re-primes the summary so it regenerates
-							 * against the new canonical. */
-							const fallback =
-								sources.find((source) => source.tier === "tier-1") ??
-								sources.find((source) => source.tier === "tier-0");
-							assert(fallback, "tie with no candidate tiers should be unreachable");
-							winnerTier = fallback.tier;
-							reason = summaryStuckOnTooShort
-								? `tie + canonical summary skipped on too-short content; promoted ${fallback.tier} to retry`
-								: `tie on first save; defaulted to ${fallback.tier}`;
-						}
+						winnerTier = resolution.tier;
+						reason = resolution.reason;
 					} else {
 						winnerTier = decision.winner;
 						reason = decision.reason;

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.ts
@@ -17,7 +17,7 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import { resolveCanonicalImageUrl } from "./resolve-canonical-image-url";
-import { resolveTie } from "./resolve-tie";
+import { initResolveTie } from "./resolve-tie";
 import type { TierSource } from "./tier-source.types";
 
 /* c8 ignore next -- V8 block coverage phantom on typed-parameter destructuring, see bcoe/c8#319 */
@@ -43,6 +43,8 @@ export function initSelectMostCompleteContentHandler(deps: {
 		now,
 		logger,
 	} = deps;
+
+	const resolveTie = initResolveTie({ findContentSourceTier, loadArticle });
 
 	return async (event): Promise<SQSBatchResponse> => {
 		const batchItemFailures: SQSBatchItemFailure[] = [];
@@ -74,6 +76,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 
 				let winnerTier: TierSource["tier"];
 				let reason: string;
+				let resolvedExistingTier: TierSource["tier"] | undefined;
 				if (sources.length === 1) {
 					winnerTier = sources[0].tier;
 					reason = "only available tier";
@@ -97,8 +100,6 @@ export function initSelectMostCompleteContentHandler(deps: {
 							sources,
 							freshTier: detail.tier,
 							url: detail.url,
-							findContentSourceTier,
-							loadArticle,
 						});
 						if (resolution.kind === "keep-canonical") {
 							await publishEvent(CrawlArticleCompletedEvent, { url: detail.url });
@@ -106,6 +107,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 						}
 						winnerTier = resolution.tier;
 						reason = resolution.reason;
+						resolvedExistingTier = resolution.existingTier;
 					} else {
 						winnerTier = decision.winner;
 						reason = decision.reason;
@@ -120,7 +122,7 @@ export function initSelectMostCompleteContentHandler(deps: {
 				 * silently skip so the bug surfaces as a DLQ. */
 				assert(winnerSource, `winner tier ${winnerTier} missing from candidate set`);
 
-				const currentTier = await findContentSourceTier(detail.url);
+				const currentTier = resolvedExistingTier ?? await findContentSourceTier(detail.url);
 				const canonicalChanged = currentTier !== winnerTier;
 				const canonicalContentHash = computeCanonicalContentHash(winnerSource.html);
 

--- a/projects/save-link/src/runtime/domain/select-content/tiers-differ-in-media.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/tiers-differ-in-media.test.ts
@@ -1,0 +1,43 @@
+import { tiersDifferInMedia } from "./tiers-differ-in-media";
+import type { TierSource } from "./tier-source.types";
+
+function source(html: string): TierSource {
+	return {
+		tier: "tier-0",
+		html,
+		metadata: { title: "", siteName: "", excerpt: "", wordCount: 0, estimatedReadTime: 0 },
+	};
+}
+
+describe("tiersDifferInMedia", () => {
+	it("is false when candidates carry the same media URLs regardless of order or surrounding prose", () => {
+		const result = tiersDifferInMedia([
+			source('<p>one</p><img src="https://cdn.test/a.png"><img src="https://cdn.test/b.png">'),
+			source('<img src="https://cdn.test/b.png"><p>different prose</p><img src="https://cdn.test/a.png">'),
+		]);
+
+		expect(result).toBe(false);
+	});
+
+	it("is false when neither candidate has media", () => {
+		expect(tiersDifferInMedia([source("<p>one</p>"), source("<p>two</p>")])).toBe(false);
+	});
+
+	it("is true when a candidate's image URL changed", () => {
+		const result = tiersDifferInMedia([
+			source('<img src="https://cdn.test/old.png">'),
+			source('<img src="https://cdn.test/new.png">'),
+		]);
+
+		expect(result).toBe(true);
+	});
+
+	it("detects srcset changes, not just src", () => {
+		const result = tiersDifferInMedia([
+			source('<img srcset="https://cdn.test/a.png 1x">'),
+			source('<img srcset="https://cdn.test/a.png 1x, https://cdn.test/b.png 2x">'),
+		]);
+
+		expect(result).toBe(true);
+	});
+});

--- a/projects/save-link/src/runtime/domain/select-content/tiers-differ-in-media.ts
+++ b/projects/save-link/src/runtime/domain/select-content/tiers-differ-in-media.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+import { parseHTML } from "linkedom";
 import type { TierSource } from "./tier-source.types";
 
 /**
@@ -13,6 +15,15 @@ export function tiersDifferInMedia(sources: readonly TierSource[]): boolean {
 }
 
 function mediaSignature(html: string): string {
-	const urls = [...html.matchAll(/(?:src|srcset)\s*=\s*"([^"]*)"/gi)].map((match) => match[1]);
+	const { document } = parseHTML(`<div>${html}</div>`);
+	const wrapper = document.querySelector("div");
+	assert(wrapper, "parseHTML('<div>...') must produce a <div>");
+	const urls: string[] = [];
+	for (const el of wrapper.querySelectorAll("img, source")) {
+		const src = el.getAttribute("src");
+		if (src) urls.push(src);
+		const srcset = el.getAttribute("srcset");
+		if (srcset) urls.push(srcset);
+	}
 	return urls.sort().join("\n");
 }

--- a/projects/save-link/src/runtime/domain/select-content/tiers-differ-in-media.ts
+++ b/projects/save-link/src/runtime/domain/select-content/tiers-differ-in-media.ts
@@ -1,0 +1,18 @@
+import type { TierSource } from "./tier-source.types";
+
+/**
+ * The content selector treats two candidates whose prose is identical as a
+ * "tie". A tie can still hide a media change — an upstream image edit, or an
+ * image-pipeline fix, rewrites `<img>`/`<source>` URLs while the text is
+ * unchanged. Comparing the media URLs across candidates lets the selector
+ * promote the freshly-written tier instead of keeping a stale render.
+ */
+export function tiersDifferInMedia(sources: readonly TierSource[]): boolean {
+	const signatures = sources.map((source) => mediaSignature(source.html));
+	return signatures.some((signature) => signature !== signatures[0]);
+}
+
+function mediaSignature(html: string): string {
+	const urls = [...html.matchAll(/(?:src|srcset)\s*=\s*"([^"]*)"/gi)].map((match) => match[1]);
+	return urls.sort().join("\n");
+}

--- a/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
+++ b/projects/save-link/src/runtime/recrawl-content-extracted.main.ts
@@ -16,7 +16,6 @@ const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 const eventBusName = requireEnv("EVENT_BUS_NAME");
 const deepseekApiKey = requireEnv("DEEPSEEK_API_KEY");
 const generateSummaryQueueUrl = requireEnv("GENERATE_SUMMARY_QUEUE_URL");
-const imagesCdnBaseUrl = requireEnv("IMAGES_CDN_BASE_URL");
 
 const s3Client = new S3Client({});
 const dynamoClient = createDynamoDocumentClient();
@@ -43,7 +42,6 @@ export const handler = initRecrawlContentExtractedHandler({
 	...selectContent,
 	...articleAggregate,
 	loadArticle: articleAggregate.store.load,
-	imagesCdnBaseUrl,
 	now: () => new Date(),
 	logger: consoleLogger,
 });


### PR DESCRIPTION
## Problem

The content selector keeps the existing canonical when the LLM scores a prose **tie**. But a tie can hide a **media change** — an upstream image edit, or an image-pipeline fix — that rewrites `<img>`/`<source>` URLs while the text is identical. When that happens, the corrected media never reaches the reader: a recrawl (or extension re-save) writes a fresh, fixed tier, the prose ties, and the selector keeps the stale render.

This is the selection-layer twin of the duplicated-image bug fixed in `9d4bc132` (srcset scoping) and `f1a1f714` (cap-by-image): even with correct media in the fresh tier, the canonical stayed wrong on a tie.

The recrawl chain compounded it with `breakTieByCdnRewriteCount`, which broke ties by **CDN-host occurrence count**. That heuristic is actively wrong for the srcset-leak fix — the corrected render has *fewer* CDN refs (a leaked CDN URL becomes an origin URL), so it would prefer the **leaked** version.

## Fix

On a prose tie, compare the **media-URL signature** (`src`/`srcset`, order-independent) across the candidate tiers. If the media differs, promote the **freshly-written tier**:

- **recrawl chain** → `tier-1` (the tier a recrawl always writes)
- **save chain** → the event's `detail.tier` (the tier this `TierContentExtracted` was raised for)

A genuine wash (identical media) still keeps the existing canonical, so we don't trigger a redundant summary regeneration.

## Changes

- **new** `tiers-differ-in-media.ts` (+ test) — pure media-signature comparison; no new provider/dependency.
- `recrawl-content-extracted-handler.ts` — replaced `breakTieByCdnRewriteCount`/`countOccurrences`/`cdnHost`/`imagesCdnBaseUrl` with the media-aware tiebreak.
- `recrawl-content-extracted.main.ts` — dropped the now-unused `imagesCdnBaseUrl` wiring (`IMAGES_CDN_BASE_URL` is still set on the Lambda; harmless, no infra change required).
- `select-most-complete-content-handler.ts` — promote `detail.tier` on a media-different tie instead of `continue`-skipping.

## Behavior preserved

All existing tie paths — healthy-canonical keep, `content-too-short` recovery, first-save fallback, `ai-unavailable` keep — are unchanged when media is identical. Their fixtures are media-free, so every existing test passes untouched.

## Verification

- `save-link:check` — 100% coverage (statements/branches/functions/lines).
- full `pnpm check` — green across all 26 projects.