### PR TITLE
fix(browser-extension-core,chrome-extension,firefox-extension): save against the invoking tab

### DIFF
--- a/projects/browser-extension-core/src/core.test.ts
+++ b/projects/browser-extension-core/src/core.test.ts
@@ -1,0 +1,193 @@
+import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import { initInMemoryAuth } from "./auth/in-memory-auth";
+import { BrowserExtensionCore } from "./core";
+import type { ReadingList } from "./core";
+import { initInMemoryReadingList } from "./reading-list/in-memory-reading-list";
+import type { SaveUrl, SaveUrlResult } from "./reading-list/reading-list.types";
+import type { BrowserShell } from "./shell.types";
+
+interface FakeShell {
+	shell: BrowserShell;
+	showSavedCalls: number[];
+	showDefaultCalls: number[];
+	iconUpdated: Promise<void>;
+}
+
+function createFakeShell(
+	activeTab: { id?: number; url: string; title: string } | null = null,
+): FakeShell {
+	const showSavedCalls: number[] = [];
+	const showDefaultCalls: number[] = [];
+	let resolveIconUpdated!: () => void;
+	const iconUpdated = new Promise<void>((resolve) => {
+		resolveIconUpdated = resolve;
+	});
+	const shell: BrowserShell = {
+		onShortcutPressed: () => {},
+		openPopup: () => {},
+		getActiveTab: async () => activeTab,
+		queryActiveTabs: async () => [],
+		setIcon: {
+			showSaved: async (tabId) => {
+				showSavedCalls.push(tabId);
+				resolveIconUpdated();
+			},
+			showDefault: async (tabId) => {
+				showDefaultCalls.push(tabId);
+				resolveIconUpdated();
+			},
+		},
+		createContextMenus: () => {},
+		onContextMenuClicked: () => {},
+		onTabActivated: () => {},
+		onTabUpdated: () => {},
+	};
+	return { shell, showSavedCalls, showDefaultCalls, iconUpdated };
+}
+
+type SaveArgs = { url: string; title: string; content?: { bytes: ArrayBuffer; mediaType: string } };
+
+function createRecordingReadingList(
+	options: { saveResult?: SaveUrlResult } = {},
+): ReadingList & { saveCalls: SaveArgs[] } {
+	const inner = initInMemoryReadingList();
+	const saveCalls: SaveArgs[] = [];
+	const saveUrl: SaveUrl = async (params) => {
+		saveCalls.push(params);
+		if (options.saveResult) return options.saveResult;
+		return inner.saveUrl(params);
+	};
+	return {
+		saveCalls,
+		saveUrl,
+		removeUrl: inner.removeUrl,
+		findByUrl: inner.findByUrl,
+		getAllItems: inner.getAllItems,
+	};
+}
+
+describe("BrowserExtensionCore save", () => {
+	it("marks the exact invoking tab as saved, ignoring which tab is active now", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell, showSavedCalls, showDefaultCalls, iconUpdated } =
+			createFakeShell({ id: 7, url: "https://other.example", title: "Other" });
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		core.save("current-tab", {
+			url: "https://example.com/article",
+			title: "Article",
+			tabId: 42,
+		});
+
+		await iconUpdated;
+		expect(showSavedCalls).toEqual([42]);
+		expect(showDefaultCalls).toEqual([]);
+	});
+
+	it("threads captured content through to the reading list", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell, iconUpdated } = createFakeShell();
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		const content = { bytes: new TextEncoder().encode("<html><body>captured</body></html>").buffer, mediaType: "text/html" };
+		core.save("current-tab", {
+			url: "https://example.com/article",
+			title: "Article",
+			content,
+			tabId: 42,
+		});
+
+		await iconUpdated;
+		expect(readingList.saveCalls).toHaveLength(1);
+		expect(readingList.saveCalls[0].content).toBe(content);
+	});
+
+	it("saves without content when none was captured", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell, iconUpdated } = createFakeShell();
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		core.save("current-tab", {
+			url: "https://example.com/article",
+			title: "Article",
+			tabId: 42,
+		});
+
+		await iconUpdated;
+		expect(readingList.saveCalls).toHaveLength(1);
+		expect(readingList.saveCalls[0].content).toBeUndefined();
+	});
+
+	it("refreshes the active tab icon when no tabId is provided", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell, showSavedCalls, showDefaultCalls, iconUpdated } =
+			createFakeShell({
+				id: 7,
+				url: "https://active.example",
+				title: "Active",
+			});
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		core.save("current-tab", {
+			url: "https://example.com/article",
+			title: "Article",
+		});
+
+		await iconUpdated;
+		expect(showSavedCalls).toEqual([]);
+		expect(showDefaultCalls).toEqual([7]);
+	});
+
+	it("does not mark the invoking tab as saved when the result is not saveable", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList({
+			saveResult: { ok: false, reason: "not-saveable", items: [] },
+		});
+		const { shell, showSavedCalls, showDefaultCalls, iconUpdated } =
+			createFakeShell({
+				id: 7,
+				url: "https://active.example",
+				title: "Active",
+			});
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		core.save("current-tab", {
+			url: "https://example.com/article",
+			title: "Article",
+			tabId: 42,
+		});
+
+		await iconUpdated;
+		expect(showSavedCalls).toEqual([]);
+		expect(showDefaultCalls).toEqual([7]);
+	});
+});

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -33,7 +33,7 @@ export interface Core {
 	logout(): void;
 	save(
 		resource: "current-tab",
-		data: { url: string; title: string; content?: { bytes: ArrayBuffer; mediaType: string } },
+		data: { url: string; title: string; content?: { bytes: ArrayBuffer; mediaType: string }; tabId?: number },
 	): void;
 	remove(resource: "item", data: { id: ReadingListItemId }): void;
 	fetch(resource: "reading-list"): void;
@@ -163,7 +163,14 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 			);
 			emitResult("saved-current-tab", guarded);
 			if (guarded.ok) {
-				guarded.value.then(() => updateActiveTabIcon()).catch(() => {});
+				const { tabId } = data;
+				guarded.value
+					.then((result) =>
+						tabId != null && result.ok
+							? shell.setIcon.showSaved(tabId)
+							: updateActiveTabIcon(),
+					)
+					.catch(() => {});
 			}
 		},
 

--- a/projects/browser-extension-core/src/popup-message.types.ts
+++ b/projects/browser-extension-core/src/popup-message.types.ts
@@ -1,7 +1,7 @@
 import type { ReadingListItemId } from "./domain/reading-list-item.types";
 
 export type PopupMessage =
-	| { type: "save-current-tab"; url: string; title: string; rawHtml?: string }
+	| { type: "save-current-tab"; url: string; title: string; rawHtml?: string; tabId?: number }
 	| { type: "remove-item"; id: ReadingListItemId }
 	| { type: "check-url"; url: string }
 	| { type: "get-all-items" }

--- a/projects/extensions/chrome-extension/run-tests.config.js
+++ b/projects/extensions/chrome-extension/run-tests.config.js
@@ -48,5 +48,13 @@ module.exports = {
       env: { E2E_PORT: port },
       e2e: true,
     },
+    {
+      type: 'node-test',
+      name: 'Running tab-switch E2E (local)',
+      files: ['dist/e2e/tab-switch-flow/run.e2e-local.main.js'],
+      timeout: 90000,
+      env: { HEADLESS: 'true', E2E_PORT: port },
+      e2e: true,
+    },
   ],
 };

--- a/projects/extensions/chrome-extension/src/e2e/tab-switch-flow/run.e2e-local.main.ts
+++ b/projects/extensions/chrome-extension/src/e2e/tab-switch-flow/run.e2e-local.main.ts
@@ -1,0 +1,352 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { Builder } from "selenium-webdriver";
+import {
+	Options,
+	ServiceBuilder,
+	type Driver as ChromeDriver,
+} from "selenium-webdriver/chrome";
+import type { WebDriver } from "selenium-webdriver";
+import {
+	FlowRunner,
+	ExtensionStateHandler,
+	obtainAccessToken,
+	type SuccessDetector,
+} from "browser-extension-core/e2e";
+import {
+	createSeleniumElementQueries,
+	createSeleniumNavigation,
+	createLoginActions,
+} from "browser-extension-core/e2e-actions";
+import { initSirenReadingList } from "browser-extension-core";
+
+const EXTENSION_DIR = path.resolve(__dirname, "../../../dist-extension-compiled");
+const CFT_PATH_FILE = path.resolve(__dirname, "../../../.cache/chrome/binary-path");
+const CFT_DRIVER_PATH_FILE = path.resolve(__dirname, "../../../.cache/chrome/driver-path");
+
+const TEST_EMAIL = "tab-switch-e2e-test@example.com";
+const TEST_PASSWORD = "testpassword123";
+assert(process.env.E2E_PORT, "E2E_PORT is required");
+const TEST_PORT = Number(process.env.E2E_PORT);
+const ORIGIN = `http://127.0.0.1:${TEST_PORT}`;
+
+// Per-run-unique labels keep concurrent CI runs from colliding on the same
+// saved row, and make the saved title an unambiguous A-vs-B discriminator:
+// the /e2e/fixtures/links-page/:label fixture renders <title>Test newsletter
+// {label}</title>, so the saved article's extracted title carries the marker
+// of whichever page's HTML was actually captured.
+const RUN_ID = randomUUID().replace(/-/g, "");
+const MARKER_A = `tabswitcha${RUN_ID}`;
+const MARKER_B = `tabswitchb${RUN_ID}`;
+const PAGE_A = `${ORIGIN}/e2e/fixtures/links-page/${MARKER_A}`;
+const PAGE_B = `${ORIGIN}/e2e/fixtures/links-page/${MARKER_B}`;
+
+async function waitForServer(port: number, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+			return;
+		} catch {
+			await new Promise((r) => setTimeout(r, 100));
+		}
+	}
+	throw new Error(`e2e server did not start on port ${port} within ${timeoutMs}ms`);
+}
+
+async function startTestServer(): Promise<ChildProcess> {
+	// Same pnpm-nx invocation and process-group handling as the login-flow and
+	// pdf-save-flow harnesses; see login-flow/run.e2e-local.main.ts for the
+	// rationale on NX_DAEMON=false and detached:true.
+	const child = spawn("pnpm", ["nx", "run", "hutch:e2e-server"], {
+		env: {
+			...process.env,
+			E2E_PORT: String(TEST_PORT),
+			NODE_ENV: "test",
+			NX_DAEMON: "false",
+		},
+		stdio: "inherit",
+		detached: true,
+	});
+	child.on("error", () => {}); // waitForServer will throw on its own timeout
+	await waitForServer(TEST_PORT, 30_000);
+	const userRes = await fetch(`${ORIGIN}/e2e/users`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+	});
+	assert.equal(
+		userRes.status,
+		201,
+		`POST /e2e/users returned ${userRes.status} (expected 201)`,
+	);
+	return child;
+}
+
+async function stopTestServer(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.pid === undefined) return;
+	const pid = child.pid;
+	const killGroup = (signal: NodeJS.Signals) => {
+		try {
+			process.kill(-pid, signal);
+		} catch {
+			child.kill(signal);
+		}
+	};
+	await new Promise<void>((resolve) => {
+		const cleanExit = () => resolve();
+		child.once("exit", cleanExit);
+		killGroup("SIGTERM");
+		setTimeout(() => {
+			killGroup("SIGKILL");
+			child.off("exit", cleanExit);
+			resolve();
+		}, 5_000).unref();
+	});
+}
+
+async function discoverExtensionId(driver: ChromeDriver): Promise<string> {
+	const timeout = 15_000;
+	const interval = 500;
+	const deadline = Date.now() + timeout;
+
+	while (Date.now() < deadline) {
+		const targets = (await (driver as unknown as {
+			sendAndGetDevToolsCommand(cmd: string, params: Record<string, unknown>): Promise<unknown>;
+		}).sendAndGetDevToolsCommand(
+			"Target.getTargets",
+			{},
+		)) as { targetInfos: Array<{ type: string; url: string }> };
+
+		const swTarget = targets.targetInfos.find(
+			(t) =>
+				t.type === "service_worker" &&
+				t.url.startsWith("chrome-extension://"),
+		);
+
+		if (swTarget) {
+			const match = swTarget.url.match(/chrome-extension:\/\/([a-z]+)\//);
+			assert.ok(match, "Could not extract extension ID from service worker URL");
+			return match[1];
+		}
+
+		await new Promise((r) => setTimeout(r, interval));
+	}
+
+	throw new Error("Could not find extension service worker target within 15s");
+}
+
+async function logIn(driver: WebDriver, popupUrl: string): Promise<string> {
+	const elementQueries = createSeleniumElementQueries();
+
+	await driver.get(popupUrl);
+	await driver.wait(
+		() => elementQueries.findVisibleViewById(driver, "login-view"),
+		10_000,
+	);
+
+	const popupWindowHandle = await driver.getWindowHandle();
+	const loginActions = createLoginActions({
+		testEmail: TEST_EMAIL,
+		testPassword: TEST_PASSWORD,
+		popupWindowHandle,
+	});
+
+	// Login completes when the popup returns to a logged-in view. The OAuth dance
+	// passes through the server's own /login and /oauth/authorize pages (where the
+	// extension views don't exist), so keying on a popup-only view avoids a false
+	// "complete" mid-flow.
+	const isLoggedIntoPopup: SuccessDetector<WebDriver> = async (d) =>
+		(await elementQueries.findVisibleViewById(d, "list-view")) ||
+		(await elementQueries.findVisibleViewById(d, "saved-view"));
+
+	const stateHandler = new ExtensionStateHandler(
+		driver,
+		isLoggedIntoPopup,
+		loginActions,
+		elementQueries,
+	);
+	const flowRunner = new FlowRunner(
+		driver,
+		stateHandler,
+		createSeleniumNavigation(),
+	);
+	const result = await flowRunner.run(popupUrl, { maxSteps: 25 });
+	assert.equal(result.success, true, `Login flow failed: ${result.error}`);
+	await driver.switchTo().window(popupWindowHandle);
+	return popupWindowHandle;
+}
+
+/**
+ * Opens `url` in a fresh tab and returns its window handle. The content script
+ * (manifest content_scripts, <all_urls>, document_start) is injected on load,
+ * so the page can answer `capture-html` once `driver.get` resolves.
+ */
+async function openPageInNewTab(driver: WebDriver, url: string): Promise<string> {
+	await driver.switchTo().newWindow("tab");
+	await driver.get(url);
+	return driver.getWindowHandle();
+}
+
+/**
+ * Resolves the extension's tab id for an already-open page, by querying from an
+ * extension page context (the popup) where `chrome.tabs` is available. Selenium
+ * has no notion of extension tab ids — only window handles — so the popup is the
+ * bridge that maps a url back to the id the background needs.
+ */
+async function resolveTabId(driver: WebDriver, url: string): Promise<number> {
+	const raw = await driver.executeAsyncScript(
+		"const url = arguments[0]; const done = arguments[arguments.length - 1];" +
+			"chrome.tabs.query({}, (tabs) => { const t = tabs.find((x) => x.url === url); done(t ? t.id : -1); });",
+		url,
+	);
+	const tabId = Number(raw);
+	assert.ok(
+		Number.isInteger(tabId) && tabId >= 0,
+		`Could not resolve extension tab id for ${url} (got ${String(raw)})`,
+	);
+	return tabId;
+}
+
+/**
+ * Drives the real `save-current-tab` path with an explicit tabId — the same
+ * message the popup sends from its active-tab branch — by dispatching it from
+ * the popup's extension context. The browser-action popup can't be opened with
+ * a web page active under Selenium, and a save triggered via `?url=` query
+ * params deliberately carries no tabId, so neither existing harness path
+ * exercises the tabId capture this regression guards.
+ */
+async function injectSaveCurrentTab(
+	driver: WebDriver,
+	params: { url: string; title: string; tabId: number },
+): Promise<void> {
+	await driver.executeScript(
+		"const [url, title, tabId] = arguments;" +
+			"chrome.runtime.sendMessage({ type: 'save-current-tab', url, title, tabId });",
+		params.url,
+		params.title,
+		params.tabId,
+	);
+}
+
+/**
+ * Polls the saved queue (via an independent Siren walk, as pdf-save-scenario
+ * does) for the item saved under PAGE_A's url and asserts its extracted title
+ * carries A's marker and never B's. The title is derived server-side from the
+ * captured HTML, so it is the observable proof of *which page's* content was
+ * POSTed — the whole point of the fix.
+ */
+async function assertSavedContentIsPageA(): Promise<void> {
+	const accessToken = await obtainAccessToken({
+		serverUrl: ORIGIN,
+		email: TEST_EMAIL,
+		password: TEST_PASSWORD,
+	});
+	const { getAllItems } = initSirenReadingList({
+		serverUrl: ORIGIN,
+		getAccessToken: async () => accessToken,
+		fetchFn: (...args) => fetch(...args),
+		onUnauthorized: async () => {
+			throw new Error("Unauthorized while walking the saved queue");
+		},
+	});
+
+	const deadline = Date.now() + 60_000;
+	let lastTitle = "<no item yet>";
+	while (Date.now() < deadline) {
+		const items = await getAllItems();
+		const saved = items.find((item) => item.url.includes(MARKER_A));
+		if (saved) {
+			lastTitle = saved.title;
+			assert.ok(
+				!saved.title.includes(MARKER_B),
+				`Saved item for page A carried page B's content — title: "${saved.title}"`,
+			);
+			if (saved.title.includes(MARKER_A)) return;
+		}
+		await new Promise((r) => setTimeout(r, 1_000));
+	}
+
+	throw new Error(
+		`Timed out after 60s waiting for page A's saved title to contain "${MARKER_A}". ` +
+			`Last observed title: "${lastTitle}"`,
+	);
+}
+
+const MAX_ATTEMPTS = 3;
+test("save targets the invoking tab even after the active tab switches", async () => {
+	const server = await startTestServer();
+	try {
+		for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			try {
+				await runTest();
+				return;
+			} catch (err) {
+				const isRetryable =
+					err instanceof Error &&
+					(err.message.includes("ECONNREFUSED") ||
+						err.message.includes("Chrome instance exited") ||
+						err.name === "TimeoutError");
+				if (!isRetryable || attempt === MAX_ATTEMPTS) throw err;
+			}
+		}
+	} finally {
+		await stopTestServer(server);
+	}
+});
+
+async function runTest() {
+	const options = new Options();
+	if (process.env.HEADLESS !== "false") {
+		options.addArguments("--headless=new");
+	}
+	options.addArguments(`--load-extension=${EXTENSION_DIR}`);
+	options.addArguments("--disable-search-engine-choice-screen");
+	options.addArguments("--no-sandbox"); // CI container has no user namespace; without this Chrome exits immediately
+	options.addArguments("--disable-dev-shm-usage"); // CI runners have a small /dev/shm partition; without this Chrome crashes with ECONNREFUSED
+	options.addArguments("--disable-gpu"); // CI runners have no GPU drivers; the GPU process crashes intermittently in headless mode
+
+	options.setChromeBinaryPath(fs.readFileSync(CFT_PATH_FILE, "utf8").trim());
+	const serviceBuilder = new ServiceBuilder(
+		fs.readFileSync(CFT_DRIVER_PATH_FILE, "utf8").trim(),
+	);
+
+	const driver = (await new Builder()
+		.forBrowser("chrome")
+		.setChromeOptions(options)
+		.setChromeService(serviceBuilder)
+		.build()) as ChromeDriver;
+
+	try {
+		const extensionId = await discoverExtensionId(driver);
+		const popupUrl = `chrome-extension://${extensionId}/popup/popup.template.html`;
+
+		const popupWindowHandle = await logIn(driver, popupUrl);
+
+		// Open both pages; B is opened last so it is the foreground tab, but the
+		// save is invoked against A — exactly the situation the fix targets.
+		await openPageInNewTab(driver, PAGE_A);
+		const handleB = await openPageInNewTab(driver, PAGE_B);
+
+		await driver.switchTo().window(popupWindowHandle);
+		const tabIdA = await resolveTabId(driver, PAGE_A);
+		await injectSaveCurrentTab(driver, {
+			url: PAGE_A,
+			title: "pending-tab-switch-capture",
+			tabId: tabIdA,
+		});
+
+		// The user moves on: make B the active tab before the background's capture
+		// resolves. The fix keys capture to tabIdA, so this must not change what is
+		// saved; before the fix, capture followed the active tab and would grab B.
+		await driver.switchTo().window(handleB);
+
+		await assertSavedContentIsPageA();
+	} finally {
+		await driver.quit();
+	}
+}

--- a/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
@@ -164,13 +164,15 @@ const corePromise = initCore();
 
 const CAPTURE_HTML_TIMEOUT_MS = 5000;
 
-async function captureActiveTabHtml(): Promise<string | undefined> {
-	const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-	const tab = tabs[0];
-	if (tab?.id == null) return undefined;
-	const tabId = tab.id;
+async function captureActiveTabHtml(message: {
+	url: string;
+	tabId?: number;
+}): Promise<string | undefined> {
+	if (message.tabId == null) return undefined;
+	const tab = await browser.tabs.get(message.tabId).catch(() => undefined);
+	if (!tab || tab.url !== message.url) return undefined;
 	const captured = await Promise.race([
-		browser.tabs.sendMessage(tabId, { type: "capture-html" }),
+		browser.tabs.sendMessage(message.tabId, { type: "capture-html" }),
 		new Promise<undefined>((resolve) =>
 			setTimeout(() => resolve(undefined), CAPTURE_HTML_TIMEOUT_MS),
 		),
@@ -221,7 +223,7 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 							failure: (err) => resolve({ ok: false, ...err }),
 						});
 					});
-					captureActiveTabHtml()
+					captureActiveTabHtml(message)
 						.then(async (rawHtml) => {
 							const content = rawHtml
 								? { bytes: new TextEncoder().encode(rawHtml).buffer, mediaType: "text/html" }
@@ -230,12 +232,14 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 								url: message.url,
 								title: message.title,
 								content,
+								tabId: message.tabId,
 							});
 						})
 						.catch(() => {
 							core.save("current-tab", {
 								url: message.url,
 								title: message.title,
+								tabId: message.tabId,
 							});
 						});
 					pending.then(sendResponse);

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -275,7 +275,7 @@ async function showListView() {
 	await loadAllItems();
 }
 
-async function getActiveTab(): Promise<{ url: string; title: string } | null> {
+async function getActiveTab(): Promise<{ url: string; title: string; tabId?: number } | null> {
 	const stored = await browser.storage.session.get("pendingTarget");
 	const pending = stored.pendingTarget;
 	if (pending && typeof pending.url === "string") {
@@ -292,7 +292,7 @@ async function getActiveTab(): Promise<{ url: string; title: string } | null> {
 	const tabs = await browser.tabs.query({ active: true, currentWindow: true });
 	const tab = tabs[0];
 	if (!tab?.url) return null;
-	return { url: tab.url, title: tab.title ?? tab.url };
+	return { url: tab.url, title: tab.title ?? tab.url, tabId: tab.id };
 }
 
 async function saveAndShowList() {
@@ -332,6 +332,7 @@ async function saveAndShowList() {
 		type: "save-current-tab",
 		url: activeTab.url,
 		title: activeTab.title,
+		tabId: activeTab.tabId,
 	})) as GuardedResult<SaveUrlResult>;
 
 	if (isNotLoggedIn(saveResult)) {

--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -175,13 +175,15 @@ const corePromise = initCore();
 
 const CAPTURE_HTML_TIMEOUT_MS = 5000;
 
-async function captureActiveTabHtml(): Promise<string | undefined> {
-	const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-	const tab = tabs[0];
-	if (tab?.id == null) return undefined;
-	const tabId = tab.id;
+async function captureActiveTabHtml(message: {
+	url: string;
+	tabId?: number;
+}): Promise<string | undefined> {
+	if (message.tabId == null) return undefined;
+	const tab = await browser.tabs.get(message.tabId).catch(() => undefined);
+	if (!tab || tab.url !== message.url) return undefined;
 	const captured = await Promise.race([
-		browser.tabs.sendMessage(tabId, { type: "capture-html" }),
+		browser.tabs.sendMessage(message.tabId, { type: "capture-html" }),
 		new Promise<undefined>((resolve) =>
 			setTimeout(() => resolve(undefined), CAPTURE_HTML_TIMEOUT_MS),
 		),
@@ -228,7 +230,7 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 							failure: (err) => resolve({ ok: false, ...err }),
 						});
 					});
-					captureActiveTabHtml()
+					captureActiveTabHtml(message)
 						.then(async (rawHtml) => {
 							const content = rawHtml
 								? { bytes: new TextEncoder().encode(rawHtml).buffer, mediaType: "text/html" }
@@ -237,12 +239,14 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 								url: message.url,
 								title: message.title,
 								content,
+								tabId: message.tabId,
 							});
 						})
 						.catch(() => {
 							core.save("current-tab", {
 								url: message.url,
 								title: message.title,
+								tabId: message.tabId,
 							});
 						});
 					pending.then(sendResponse);

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -274,7 +274,7 @@ async function showListView() {
 	await loadAllItems();
 }
 
-async function getActiveTab(): Promise<{ url: string; title: string } | null> {
+async function getActiveTab(): Promise<{ url: string; title: string; tabId?: number } | null> {
 	const stored = await browser.storage.session.get("pendingTarget");
 	const pending = stored.pendingTarget;
 	if (pending && typeof pending.url === "string") {
@@ -291,7 +291,7 @@ async function getActiveTab(): Promise<{ url: string; title: string } | null> {
 	const tabs = await browser.tabs.query({ active: true, currentWindow: true });
 	const tab = tabs[0];
 	if (!tab?.url) return null;
-	return { url: tab.url, title: tab.title ?? tab.url };
+	return { url: tab.url, title: tab.title ?? tab.url, tabId: tab.id };
 }
 
 async function saveAndShowList() {
@@ -331,6 +331,7 @@ async function saveAndShowList() {
 		type: "save-current-tab",
 		url: activeTab.url,
 		title: activeTab.title,
+		tabId: activeTab.tabId,
 	})) as GuardedResult<SaveUrlResult>;
 
 	if (isNotLoggedIn(saveResult)) {


### PR DESCRIPTION
## Why

The save fetch already runs in the service worker, so it survives the popup closing. But when the user changes tabs mid-save, two real defects surfaced:

1. **Wrong-tab capture** — `captureActiveTabHtml()` grabbed the *currently active* tab's content while the save URL came from the popup's original target. Switching tabs within the 5 s capture window POSTed tab B's content under tab A's URL.
2. **Wrong-tab confirmation** — on success, core re-derived saved-state from whatever tab was active *now* (`updateActiveTabIcon`), so the originally-saved tab never showed the saved icon after a switch.

## What

A save now targets, captures, and confirms against the **specific tab it was invoked on** — so it completes correctly in the background and visibly marks *that* tab as saved even after the user switches tabs or closes the popup.

- **Carry the intended tabId.** The popup's active-tab branch keeps `tab.id` and includes an optional `tabId` on the `save-current-tab` message. It stays optional: the context-menu / link-target branches have no tab id.
- **Capture from that tab.** The background sends `capture-html` to the explicit `tabId`. When `tabId` is absent — or the tab's current url no longer matches the save url (it navigated/closed) — it skips the tab's HTML and degrades safely. Capture is keyed to the intended tab/URL, never the currently-active tab's content.
- **Confirm on the right tab.** On a successful save, mark that exact tab with the saved icon (`setIcon.showSaved(tabId)`) instead of re-querying the active tab. A not-saveable result still falls back to refreshing the active tab, so a tab is never falsely marked saved.
- Mirrored across both Chrome and Firefox.

Rebased onto `main`, which replaced the extension's `rawHtml` save payload with a typed `content: { bytes, mediaType }` model (the client-uploaded-PDF path, #427). The two changes compose: capture from the explicit tab → if HTML, wrap as `text/html` content; otherwise main's `captureActiveTabBytes` fetches the **save URL's** bytes directly. Either way the bytes come from the intended tab/URL, never the wrong page.

No Siren/protocol change — `tabId` is client-internal.

## Testing

**Unit (`browser-extension-core/src/core.test.ts`)** — drives `core.save` with a self-contained fake `shell` (DI, no `jest.mock`) and asserts behaviour, not the active tab:
- the saved icon lands on the **exact** invoking `tabId`, even when a different tab is active;
- captured `content` is threaded through when present and omitted when absent;
- a `not-saveable` result never marks the invoking tab as saved;
- with no `tabId`, the save falls back to refreshing the active tab.

`pnpm check` passes across all projects (lint, type-check, tests, 100% coverage, knip).

**Integration / E2E (`chrome-extension/src/e2e/tab-switch-flow/run.e2e-local.main.ts`, registered in `run-tests.config.js`)** — the tab-switch regression guard:
- logs in, opens page A and page B (distinct `/e2e/fixtures/links-page/:label` fixtures with per-run marker titles);
- invokes the real `save-current-tab` path against **A's tab id**, dispatched from the popup's extension context — Selenium can't open the browser-action popup over a web page, and `?url=` saves deliberately carry no tab id, so this is the only way to drive the tabId capture path;
- switches the active tab to B before capture resolves;
- asserts via a Siren walk (`getAllItems`) that A's saved item carries A's marker in its server-extracted title and **never** B's.

> ⚠️ This E2E **type-checks, lints, and is registered**, but the E2E phase is **skipped in the Claude Code remote environment**, so it could not be executed or verified here. It needs a local/CI run (Chrome-for-Testing + multi-window WebDriver) to confirm; treat selectors/timing/title-extraction assumptions as needing a first green run. Firefox parity (geckodriver + `browser.*`) is a possible follow-up.

https://claude.ai/code/session_01ShHs7n12JzQ4BJEAVpe6KQ