### PR TITLE
feat(hutch): show the next three priorities in the homepage roadmap

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -269,7 +269,7 @@ export function HomePage(params: {
 							name: "What features does Readplace have?",
 							acceptedAnswer: {
 								"@type": "Answer",
-								text: "Readplace offers browser extensions for Firefox and Chrome, a web app for managing saved articles, a distraction-free reader view, TL;DR summaries, dark mode, and secure OAuth with PKCE. Planned features include personalised AI summaries, preference learning, Gmail integration, and highlights and notes.",
+								text: "Readplace offers browser extensions for Firefox and Chrome, a web app for managing saved articles, a distraction-free reader view, TL;DR summaries, dark mode, and secure OAuth with PKCE. Planned features include share-to-save on mobile, a 'what to read next' view that sorts and filters your unread pile, and listening to saved articles as audio.",
 							},
 						},
 						{
@@ -345,19 +345,19 @@ export function HomePage(params: {
 			],
 			plannedFeatures: [
 				{
-					name: "Save from Mobile",
+					name: "Share to Save on Mobile",
 					description:
-						"An iPhone app that allows you to save a link on the go.",
+						"Save to Readplace from any app with one tap from the share sheet — no copy-paste.",
 				},
 				{
-					name: "Preference Learning",
+					name: "What to Read Next",
 					description:
-						"Resurface previously saved articles that match what's interesting to you. You can change your preferences over time.",
+						"Sort and filter your unread pile by recently saved, reading time, and tags, so the time you have goes to what matters most.",
 				},
 				{
-					name: "Highlights & Notes",
+					name: "Listen to Articles",
 					description:
-						"Highlight passages and add notes as you read to help learning usingthe science of Blocked Practice.",
+						"Play any saved article as audio — for the commute, the walk, or doing chores.",
 				},
 			],
 			trustItems: [


### PR DESCRIPTION
## What

Replaces the three items in the homepage **"What's Next"** roadmap (`plannedFeatures` in `home.component.ts`) with the next three prioritised features, in ranked order.

| Before | After |
|--------|-------|
| Save from Mobile | **Share to Save on Mobile** — save from any app with one tap from the share sheet, no copy-paste |
| Preference Learning | **What to Read Next** — sort and filter the unread pile by recently saved, reading time, and tags |
| Highlights & Notes | **Listen to Articles** — play any saved article as audio for the commute, walking, or chores |

## Why

These are the next three priorities. Highlights/notes (and spaced repetition) are deliberately dropped from the roadmap, so the old "Highlights & Notes" entry is replaced.

## Notes

- Also updated the matching "planned features" sentence in the homepage **FAQ structured data** (JSON-LD) so the page doesn't advertise the old roadmap (preference learning / highlights and notes) in its rich-results markup.
- Copy is written in the brand voice (specific, modest, no exclamation marks); the internal strategy rationale (cheap-version-first, validation plan, user names) is intentionally kept out of the public page.
- Blog-post comparison tables that mention highlights are left untouched — they describe competitors / comparisons, not this roadmap, and are out of scope for "the homepage list".
- No test changes needed: no route/E2E test asserts on the roadmap item names or descriptions. `pnpm check` passes across all projects (the one flaky failure during pre-commit, `@packages/test-fixtures:check`, passed on retry and was flagged flaky by Nx — it is unrelated to this string-only change).

https://claude.ai/code/session_01KpkhE8yawj1YJMC2z16twF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpkhE8yawj1YJMC2z16twF)_