### PR TITLE
feat(hutch): soft-delete queue articles with an undo toast

### DIFF
--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -9,7 +9,12 @@ import {
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import type { SavedArticle } from "@packages/domain/article";
-import { MinutesSchema, ArticleStatusSchema } from "@packages/domain/article";
+import {
+	MinutesSchema,
+	ArticleStatusSchema,
+	VISIBLE_ARTICLE_STATUSES,
+	isVisibleArticleStatus,
+} from "@packages/domain/article";
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import { ReaderArticleHashId, ReaderArticleHashIdSchema } from "@packages/domain/article";
 import { UserIdSchema } from "@packages/domain/user";
@@ -229,7 +234,7 @@ export function initDynamoDbArticleStore(deps: {
 		if (!article) return null;
 
 		const userArticle = await findUserArticle(userId, article.url);
-		if (!userArticle) return null;
+		if (!userArticle || !isVisibleArticleStatus(userArticle.status)) return null;
 
 		return toSavedArticle(article, userArticle);
 	};
@@ -244,13 +249,21 @@ export function initDynamoDbArticleStore(deps: {
 		const expressionValues: Record<string, unknown> = {
 			":userId": query.userId,
 		};
-		let filterExpression: string | undefined;
-		let expressionAttributeNames: Record<string, string> | undefined;
-
+		const expressionAttributeNames = { "#status": "status" };
+		/** A status filter is always applied. With an explicit status we match it
+		 * exactly; without one we still restrict to the visible statuses so a
+		 * tombstoned ("deleted") or otherwise unrecognised row never leaks into a
+		 * listing that "falls back" to no status filter. */
+		let filterExpression: string;
 		if (query.status) {
 			filterExpression = "#status = :status";
 			expressionValues[":status"] = query.status;
-			expressionAttributeNames = { "#status": "status" };
+		} else {
+			const placeholders = VISIBLE_ARTICLE_STATUSES.map((_, i) => `:visibleStatus${i}`);
+			VISIBLE_ARTICLE_STATUSES.forEach((status, i) => {
+				expressionValues[placeholders[i]] = status;
+			});
+			filterExpression = `#status IN (${placeholders.join(", ")})`;
 		}
 
 		let total = 0;
@@ -335,13 +348,20 @@ export function initDynamoDbArticleStore(deps: {
 
 	const deleteArticle: DeleteArticle = async (routeId, userId) => {
 		const article = await findArticleByRouteId(routeId);
-		if (!article) return false;
+		if (!article) return null;
 
 		const ua = await findUserArticle(userId, article.url);
-		if (!ua) return false;
+		if (!ua || !isVisibleArticleStatus(ua.status)) return null;
 
-		await userArticles.delete({ Key: { userId, url: article.url } });
-		return true;
+		/** Tombstone instead of removing the row: readAt/savedAt are preserved so
+		 * an undo can restore the article exactly where it was. */
+		await userArticles.update({
+			Key: { userId, url: article.url },
+			UpdateExpression: "SET #status = :deleted",
+			ExpressionAttributeNames: { "#status": "status" },
+			ExpressionAttributeValues: { ":deleted": "deleted" },
+		});
+		return ua.status;
 	};
 
 	const updateArticleStatus: UpdateArticleStatus = async (routeId, userId, status) => {

--- a/projects/hutch/src/runtime/web/pages/queue/delete-undo-cookie.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/delete-undo-cookie.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { VisibleArticleStatusSchema } from "@packages/domain/article";
+
+export const DELETE_UNDO_COOKIE_NAME = "delete_undo";
+
+/** Short-lived: the toast is consumed on the very next /queue render (the 303
+ * redirect that follows the delete). A small TTL keeps a stale "Link deleted"
+ * toast from resurfacing if that render never happens (e.g. the tab is closed
+ * mid-delete). */
+export const DELETE_UNDO_COOKIE_MAX_AGE_MS = 60_000;
+
+const DeleteUndoSchema = z.object({
+	id: z.string(),
+	previousStatus: VisibleArticleStatusSchema,
+});
+
+export type DeleteUndoFlash = z.infer<typeof DeleteUndoSchema>;
+
+export function encodeDeleteUndoCookie(flash: DeleteUndoFlash): string {
+	return encodeURIComponent(JSON.stringify(flash));
+}
+
+export function decodeDeleteUndoCookie(
+	raw: string | undefined,
+): DeleteUndoFlash | undefined {
+	if (!raw) return undefined;
+	let decoded: unknown;
+	try {
+		decoded = JSON.parse(decodeURIComponent(raw));
+	} catch {
+		return undefined;
+	}
+	const parsed = DeleteUndoSchema.safeParse(decoded);
+	return parsed.success ? parsed.data : undefined;
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -25,6 +25,9 @@ interface QueueDisplayModel {
 	hasImportSkipped: boolean;
 	importSkippedEntries: ReadonlyArray<{ url: string; reasonLabel: string }>;
 	importSkippedAndMore?: number;
+	hasDeletedToast: boolean;
+	deletedToastUndoUrl?: string;
+	deletedToastPreviousStatus?: string;
 	isEmpty: boolean;
 	hasArticles: boolean;
 	onboardingHtml: string;
@@ -99,6 +102,9 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		hasImportSkipped: Boolean(vm.importSkipped && vm.importSkipped.entries.length > 0),
 		importSkippedEntries: vm.importSkipped?.entries ?? [],
 		importSkippedAndMore: vm.importSkipped?.andMore,
+		hasDeletedToast: Boolean(vm.deletedToast),
+		deletedToastUndoUrl: vm.deletedToast?.undoUrl,
+		deletedToastPreviousStatus: vm.deletedToast?.previousStatus,
 		isEmpty: vm.isEmpty,
 		hasArticles: !vm.isEmpty,
 		onboardingHtml,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -480,5 +480,87 @@ describe("Queue routes", () => {
 			expect(deleteResponse.status).toBe(303);
 			expect(deleteResponse.headers.location).toBe("/queue");
 		});
+
+		it("shows a 'Link deleted' undo toast after deleting and restores the article on undo", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/article" });
+			const articleId = new JSDOM((await agent.get("/queue")).text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert.ok(articleId);
+
+			await agent.post(`/queue/${articleId}/delete`);
+
+			const afterDelete = new JSDOM((await agent.get("/queue")).text).window.document;
+			const toast = afterDelete.querySelector("[data-test-deleted-toast]");
+			assert.ok(toast, "the deleted toast should render after a delete");
+			expect(toast.querySelector(".queue-toast__message")?.textContent).toBe("Link deleted");
+			const undoForm = afterDelete.querySelector("[data-test-undo]")?.closest("form");
+			assert.ok(undoForm, "the toast should carry an undo form");
+			expect(undoForm.getAttribute("action")).toBe(`/queue/${articleId}/status`);
+			expect(undoForm.querySelector("input[name='status']")?.getAttribute("value")).toBe("unread");
+			expect(afterDelete.querySelector("[data-test-empty-queue]")).not.toBeNull();
+
+			await agent.post(`/queue/${articleId}/status`).type("form").send({ status: "unread" });
+
+			const afterUndo = new JSDOM((await agent.get("/queue")).text).window.document;
+			const restored = afterUndo.querySelectorAll("[data-test-article-list] .queue-article");
+			expect(restored.length).toBe(1);
+			expect(restored[0].getAttribute("data-test-article")).toBe(articleId);
+		});
+
+		it("carries the prior 'read' status in the undo form when a read article is deleted", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/article" });
+			const articleId = new JSDOM((await agent.get("/queue")).text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert.ok(articleId);
+			await agent.post(`/queue/${articleId}/status`).type("form").send({ status: "read" });
+
+			await agent.post(`/queue/${articleId}/delete`);
+
+			const afterDelete = new JSDOM((await agent.get("/queue")).text).window.document;
+			const undoInput = afterDelete.querySelector("[data-test-deleted-toast] input[name='status']");
+			expect(undoInput?.getAttribute("value")).toBe("read");
+		});
+
+		it("clears the undo toast after one render and the article stays deleted without an undo", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/article" });
+			const articleId = new JSDOM((await agent.get("/queue")).text).window.document
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+			assert.ok(articleId);
+
+			await agent.post(`/queue/${articleId}/delete`);
+
+			const firstRender = new JSDOM((await agent.get("/queue")).text).window.document;
+			assert.ok(firstRender.querySelector("[data-test-deleted-toast]"), "toast shows once");
+
+			const secondRender = new JSDOM((await agent.get("/queue")).text).window.document;
+			expect(secondRender.querySelector("[data-test-deleted-toast]")).toBeNull();
+			expect(secondRender.querySelector("[data-test-empty-queue]")).not.toBeNull();
+		});
+
+		it("does not show a toast when the deleted article does not exist", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent.post("/queue/00000000000000000000000000000000/delete");
+
+			const doc = new JSDOM((await agent.get("/queue")).text).window.document;
+			expect(doc.querySelector("[data-test-deleted-toast]")).toBeNull();
+		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -10,13 +10,20 @@ import express from "express";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
-import { SaveArticleInputSchema, SaveHtmlInputSchema, ArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD, saveableUrlErrorMessage } from "@packages/domain/article";
+import { SaveArticleInputSchema, SaveHtmlInputSchema, VisibleArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD, saveableUrlErrorMessage } from "@packages/domain/article";
 import { hashIp, type AnalyticsEvent } from "../../middleware/analytics";
 import { ANALYTICS_EVENTS, STREAMS } from "../../../observability/events";
 import {
 	IMPORT_SKIPPED_COOKIE_NAME,
 	decodeImportSkippedCookie,
 } from "../import/import-skipped-cookie";
+import {
+	DELETE_UNDO_COOKIE_NAME,
+	DELETE_UNDO_COOKIE_MAX_AGE_MS,
+	decodeDeleteUndoCookie,
+	encodeDeleteUndoCookie,
+	type DeleteUndoFlash,
+} from "./delete-undo-cookie";
 import type { ImportSkippedViewModel } from "./queue.viewmodel";
 import { ReaderArticleHashIdSchema } from "@packages/domain/article";
 import type { RefreshArticleIfStale } from "@packages/test-fixtures/providers/article-freshness";
@@ -98,6 +105,18 @@ function readImportSkippedFlash(
 		})),
 		andMore: decoded.andMore,
 	};
+}
+
+function readDeleteUndoFlash(
+	req: Request,
+	res: Response,
+): DeleteUndoFlash | undefined {
+	const decoded = decodeDeleteUndoCookie(req.cookies?.[DELETE_UNDO_COOKIE_NAME]);
+	if (!decoded) return undefined;
+	/** Read-once: clear it so a refresh of /queue doesn't keep resurfacing the
+	 * "Link deleted" toast for an already-handled delete. */
+	res.clearCookie(DELETE_UNDO_COOKIE_NAME, { path: "/queue" });
+	return decoded;
 }
 
 function markExtensionSavedArticle(res: Response): void {
@@ -310,6 +329,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const importFlash = importFlashMapping(req.query);
 		const statusFlash = statusFlashMapping(req.query);
 		const importSkipped = readImportSkippedFlash(req, res);
+		const deletedToast = readDeleteUndoFlash(req, res);
 		const [summaryByUrl, crawlByUrl, unreadCount, effectiveAccess] = await Promise.all([
 			loadSummaries(deps.findGeneratedSummary, result.articles),
 			loadCrawls(deps.findArticleCrawlStatus, result.articles),
@@ -324,6 +344,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			importFlash,
 			statusFlash,
 			importSkipped,
+			deletedToast,
 			summaryByUrl,
 			crawlByUrl,
 			effectiveAccess,
@@ -647,7 +668,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
 		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
-		const parsedStatus = ArticleStatusSchema.safeParse(req.body.status);
+		const parsedStatus = VisibleArticleStatusSchema.safeParse(req.body.status);
 
 		const flashParams: [string, string][] = [];
 		if (parsedId.success && parsedStatus.success) {
@@ -676,7 +697,21 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
 
 		if (parsedId.success) {
-			await deps.deleteArticle(parsedId.data, userId);
+			const previousStatus = await deps.deleteArticle(parsedId.data, userId);
+			/** Only a row that was actually visible (unread/read) yields an undo
+			 * toast; a missing/not-owned/already-deleted row returns null. */
+			if (previousStatus === "unread" || previousStatus === "read") {
+				res.cookie(
+					DELETE_UNDO_COOKIE_NAME,
+					encodeDeleteUndoCookie({ id: parsedId.data.value, previousStatus }),
+					{
+						path: "/queue",
+						maxAge: DELETE_UNDO_COOKIE_MAX_AGE_MS,
+						sameSite: "lax",
+						httpOnly: true,
+					},
+				);
+			}
 		}
 
 		res.redirect(303, buildQueueUrl(parseQueueUrl(req.query)));

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -509,6 +509,70 @@
   color: var(--muted-foreground);
 }
 
+/**
+ * 1. Auto-dismisses after 5s without JavaScript. The element is freshly
+ *    inserted on the post-delete render (full page load, or the htmx <main>
+ *    swap), so the animation runs once from the start. animation-fill-mode:
+ *    forwards holds the final hidden frame; visibility: hidden also removes it
+ *    from hit-testing so the now-invisible toast cannot swallow clicks.
+ */
+.queue-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  max-width: min(420px, calc(100vw - 32px));
+  padding: 12px 16px;
+  background: var(--card);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  animation: queue-toast-dismiss 5s forwards; /* 1 */
+}
+
+.queue-toast__message {
+  font-size: 0.875rem;
+  color: var(--foreground);
+}
+
+.queue-toast__undo {
+  display: inline;
+  margin: 0;
+}
+
+.queue-toast__undo-btn {
+  background: transparent;
+  border: none;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-brand);
+  cursor: pointer;
+}
+
+.queue-toast__undo-btn:hover {
+  background: var(--color-brand-light);
+  color: var(--color-brand-dark);
+}
+
+@keyframes queue-toast-dismiss {
+  0%,
+  92% {
+    opacity: 1;
+    visibility: visible;
+  }
+  100% {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
 @media (max-width: 600px) {
   .queue-article {
     flex-direction: column;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -59,6 +59,28 @@
   opacity: 0.9;
 }
 
+.queue-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  font-size: 0.875rem;
+}
+
+.queue-toast__message {
+  font-weight: 500;
+}
+
+.queue-toast__undo-form {
+  display: inline;
+  margin: 0;
+}
 .queue__save-form {
   display: flex;
   gap: 8px;
@@ -516,36 +538,16 @@
  *    forwards holds the final hidden frame; visibility: hidden also removes it
  *    from hit-testing so the now-invisible toast cannot swallow clicks.
  */
-.queue-toast {
-  position: fixed;
-  left: 50%;
-  bottom: 24px;
-  transform: translateX(-50%);
+.queue-toast--deleted {
   z-index: 50;
-  display: flex;
-  align-items: center;
-  gap: 16px;
   max-width: min(420px, calc(100vw - 32px));
-  padding: 12px 16px;
   background: var(--card);
   color: var(--foreground);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-md);
   animation: queue-toast-dismiss 5s forwards; /* 1 */
 }
 
-.queue-toast__message {
-  font-size: 0.875rem;
-  color: var(--foreground);
-}
-
-.queue-toast__undo {
-  display: inline;
-  margin: 0;
-}
-
-.queue-toast__undo-btn {
+.queue-toast--deleted .queue-toast__undo-btn {
   background: transparent;
   border: none;
   padding: 4px 8px;
@@ -556,7 +558,7 @@
   cursor: pointer;
 }
 
-.queue-toast__undo-btn:hover {
+.queue-toast--deleted .queue-toast__undo-btn:hover {
   background: var(--color-brand-light);
   color: var(--color-brand-dark);
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.tabs.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.tabs.ts
@@ -1,10 +1,10 @@
-import type { ArticleStatus } from "@packages/domain/article";
+import type { VisibleArticleStatus } from "@packages/domain/article";
 import type { SortField, SortOrder } from "@packages/test-fixtures/providers/article-store";
 
 export type TabId = "queue" | "done";
 
 interface TabQuery {
-	status: ArticleStatus;
+	status: VisibleArticleStatus;
 	sort: SortField;
 	defaultOrder: SortOrder;
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -62,4 +62,13 @@
         {{#if hasNext}}<a class="queue__pagination-link" href="{{nextUrl}}" data-test-pagination-next>Next →</a>{{/if}}
       </nav>
       {{/if}}
+      {{#if hasDeletedToast}}
+      <div class="queue-toast" role="status" data-test-deleted-toast>
+        <span class="queue-toast__message">Link deleted</span>
+        <form class="queue-toast__undo" method="POST" action="{{deletedToastUndoUrl}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
+          <input type="hidden" name="status" value="{{deletedToastPreviousStatus}}">
+          <button class="queue-toast__undo-btn" type="submit" data-test-undo>Undo</button>
+        </form>
+      </div>
+      {{/if}}
     </main>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -63,9 +63,9 @@
       </nav>
       {{/if}}
       {{#if hasDeletedToast}}
-      <div class="queue-toast" role="status" data-test-deleted-toast>
+      <div class="queue-toast queue-toast--deleted" role="status" data-test-deleted-toast>
         <span class="queue-toast__message">Link deleted</span>
-        <form class="queue-toast__undo" method="POST" action="{{deletedToastUndoUrl}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
+        <form class="queue-toast__undo-form" method="POST" action="{{deletedToastUndoUrl}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
           <input type="hidden" name="status" value="{{deletedToastPreviousStatus}}">
           <button class="queue-toast__undo-btn" type="submit" data-test-undo>Undo</button>
         </form>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -357,6 +357,23 @@ describe("toQueueViewModel", () => {
 		expect(methods).toEqual(["POST", "POST"]);
 	});
 
+	it("builds a deleted-toast undo URL that posts the prior status and preserves the current view", () => {
+		const filters = { order: "asc" as const, page: 1, tab: "done" as const };
+		const vm = toQueueViewModel(makeResult([]), filters, {
+			now: NOW,
+			deletedToast: { id: ARTICLE_ID, previousStatus: "read" },
+		});
+
+		expect(vm.deletedToast?.undoUrl).toBe(`/queue/${ARTICLE_ID}/status?tab=done&order=asc`);
+		expect(vm.deletedToast?.previousStatus).toBe("read");
+	});
+
+	it("leaves deletedToast undefined when no delete just happened", () => {
+		const vm = toQueueViewModel(makeResult([makeArticle()]), DEFAULT_FILTERS, { now: NOW });
+
+		expect(vm.deletedToast).toBeUndefined();
+	});
+
 	it("should include unreadCount from options", () => {
 		const vm = toQueueViewModel(makeResult([]), DEFAULT_FILTERS, {
 			now: NOW,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -1,4 +1,4 @@
-import type { SavedArticle, SaveableUrlErrorCode } from "@packages/domain/article";
+import type { SavedArticle, SaveableUrlErrorCode, VisibleArticleStatus } from "@packages/domain/article";
 import type { FindArticlesResult } from "@packages/test-fixtures/providers/article-store";
 import { pickExcerpt } from "../../../providers/article-summary/article-summary.helpers";
 import type { ArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
@@ -67,6 +67,12 @@ export interface ImportSkippedViewModel {
 	readonly andMore: number;
 }
 
+interface DeletedToastViewModel {
+	/** POSTs the article back to its pre-delete status (the "undo"). */
+	readonly undoUrl: string;
+	readonly previousStatus: VisibleArticleStatus;
+}
+
 export interface QueueViewModel {
 	articles: QueueArticleViewModel[];
 	filters: QueueUrlState;
@@ -92,6 +98,7 @@ export interface QueueViewModel {
 		undoUrl: string;
 		undoStatus: "read" | "unread";
 	};
+	deletedToast?: DeletedToastViewModel;
 	subscriptionBanner: SubscriptionBannerState;
 	accessIsReadOnly: boolean;
 }
@@ -222,6 +229,7 @@ export function toQueueViewModel(
 		importFlash?: string;
 		importSkipped?: ImportSkippedViewModel;
 		statusFlash?: StatusFlash;
+		deletedToast?: { id: string; previousStatus: VisibleArticleStatus };
 		unreadCount?: number;
 		summaryByUrl?: ReadonlyMap<string, GeneratedSummary | undefined>;
 		crawlByUrl?: ReadonlyMap<string, ArticleCrawl | undefined>;
@@ -287,6 +295,12 @@ export function toQueueViewModel(
 				message: options.statusFlash.message,
 				undoUrl: `/queue/${options.statusFlash.undoArticleId}/status${returnQuery}`,
 				undoStatus: options.statusFlash.undoStatus,
+			}
+			: undefined,
+		deletedToast: options?.deletedToast
+			? {
+				undoUrl: `/queue/${options.deletedToast.id}/status${returnQuery}`,
+				previousStatus: options.deletedToast.previousStatus,
 			}
 			: undefined,
 		subscriptionBanner: toSubscriptionBannerState(access, now),

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
@@ -165,4 +165,18 @@ describe("saveArticleFromUrl", () => {
 		expect(result.saved.status).toBe("unread");
 		expect(result.saved.readAt).toBeUndefined();
 	});
+
+	it("resurfaces a previously-deleted article as unread after a re-save", async () => {
+		const previouslyDeleted = makeSaved({ status: "deleted" });
+		const tracker = makeTracker(previouslyDeleted);
+
+		const result = await saveArticleFromUrl(tracker.deps, {
+			userId,
+			url: exampleUrl,
+			freshness: { action: "new" },
+		});
+
+		expect(tracker.calls.updateArticleStatusUnread).toBe(1);
+		expect(result.saved.status).toBe("unread");
+	});
 });

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
@@ -18,11 +18,17 @@ export interface SaveArticleFromUrlDependencies {
 	refreshArticleIfStale: RefreshArticleIfStale;
 }
 
-async function markUnreadIfRead(
+/** A save always lands the article back in the unread queue. The existing row
+ * may be "read" (re-saving something already finished) or "deleted" (re-saving
+ * something previously removed) — either way the user is asking to read it
+ * again. saveArticle's `if_not_exists` upsert preserves the prior status, so
+ * without this flip a re-saved read article would stay in Done and a re-saved
+ * deleted article would stay hidden. */
+async function markUnreadOnSave(
 	updateArticleStatus: UpdateArticleStatus,
 	saved: SavedArticle,
 ): Promise<SavedArticle> {
-	if (saved.status === "read") {
+	if (saved.status !== "unread") {
 		await updateArticleStatus(saved.id, saved.userId, "unread");
 		return { ...saved, status: "unread", readAt: undefined };
 	}
@@ -55,7 +61,7 @@ async function saveByFreshness(
 			contentFetchedAt: new Date().toISOString(),
 		});
 		await deps.publishLinkSaved({ url, userId });
-		return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
+		return { saved: await markUnreadOnSave(deps.updateArticleStatus, saved) };
 	}
 
 	const saved = await deps.saveArticle({
@@ -70,7 +76,7 @@ async function saveByFreshness(
 		await deps.publishLinkSaved({ url, userId });
 	}
 
-	return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
+	return { saved: await markUnreadOnSave(deps.updateArticleStatus, saved) };
 }
 
 export function saveArticleFromUrl(

--- a/src/packages/domain/src/article/article.schema.test.ts
+++ b/src/packages/domain/src/article/article.schema.test.ts
@@ -2,6 +2,8 @@ import {
 	SaveArticleInputSchema,
 	SaveHtmlInputSchema,
 	ArticleStatusSchema,
+	VisibleArticleStatusSchema,
+	isVisibleArticleStatus,
 	MinutesSchema,
 } from "./article.schema";
 
@@ -64,8 +66,34 @@ describe("ArticleStatusSchema", () => {
 		expect(ArticleStatusSchema.parse("read")).toBe("read");
 	});
 
+	it("accepts the 'deleted' tombstone so reading a soft-deleted row validates", () => {
+		expect(ArticleStatusSchema.parse("deleted")).toBe("deleted");
+	});
+
 	it("rejects unknown values", () => {
 		expect(ArticleStatusSchema.safeParse("archived").success).toBe(false);
+	});
+});
+
+describe("VisibleArticleStatusSchema", () => {
+	it("accepts 'unread' and 'read'", () => {
+		expect(VisibleArticleStatusSchema.parse("unread")).toBe("unread");
+		expect(VisibleArticleStatusSchema.parse("read")).toBe("read");
+	});
+
+	it("rejects 'deleted' so it can never be set through the status endpoint", () => {
+		expect(VisibleArticleStatusSchema.safeParse("deleted").success).toBe(false);
+	});
+});
+
+describe("isVisibleArticleStatus", () => {
+	it("is true for the reader-visible statuses", () => {
+		expect(isVisibleArticleStatus("unread")).toBe(true);
+		expect(isVisibleArticleStatus("read")).toBe(true);
+	});
+
+	it("is false for the deleted tombstone", () => {
+		expect(isVisibleArticleStatus("deleted")).toBe(false);
 	});
 });
 

--- a/src/packages/domain/src/article/article.schema.ts
+++ b/src/packages/domain/src/article/article.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { Minutes } from "./article.types";
+import type { ArticleStatus, Minutes } from "./article.types";
 
 export const SaveArticleInputSchema = z.object({
 	url: z.url({ message: "Please enter a valid URL" }),
@@ -23,4 +23,26 @@ export const RAW_HTML_FIELD = "rawHtml" satisfies keyof z.infer<typeof SaveHtmlI
 
 export const MinutesSchema = z.number().transform((n): Minutes => n as Minutes);
 
-export const ArticleStatusSchema = z.enum(["unread", "read"]);
+/** "deleted" is a soft-delete tombstone: the row stays in storage so a delete
+ * can be undone, but it is hidden from every listing and single-article fetch.
+ * It is part of the persisted enum so reading a tombstoned row validates
+ * instead of throwing; it is NOT part of VisibleArticleStatusSchema, so it can
+ * never be set through the user-facing mark-read/unread path. */
+export const ArticleStatusSchema = z.enum(["unread", "read", "deleted"]);
+
+/** The only statuses a reader ever sees, and the only ones a user may set via
+ * the status endpoint. Anything outside this set (a "deleted" tombstone, or an
+ * unrecognised value) must be excluded from all views. */
+export const VISIBLE_ARTICLE_STATUSES = ["unread", "read"] as const;
+
+export const VisibleArticleStatusSchema = z.enum(VISIBLE_ARTICLE_STATUSES);
+
+export type VisibleArticleStatus = z.infer<typeof VisibleArticleStatusSchema>;
+
+const VISIBLE_ARTICLE_STATUS_SET: ReadonlySet<string> = new Set(VISIBLE_ARTICLE_STATUSES);
+
+export function isVisibleArticleStatus(
+	status: ArticleStatus,
+): status is VisibleArticleStatus {
+	return VISIBLE_ARTICLE_STATUS_SET.has(status);
+}

--- a/src/packages/domain/src/article/article.types.ts
+++ b/src/packages/domain/src/article/article.types.ts
@@ -3,7 +3,7 @@ import type { ReaderArticleHashId } from "./reader-article-hash-id";
 
 export type Minutes = number & { readonly __brand: "Minutes" };
 
-export type ArticleStatus = "unread" | "read";
+export type ArticleStatus = "unread" | "read" | "deleted";
 
 export interface ArticleMetadata {
 	title: string;

--- a/src/packages/domain/src/article/index.ts
+++ b/src/packages/domain/src/article/index.ts
@@ -26,6 +26,10 @@ export {
 	RAW_HTML_FIELD,
 	MinutesSchema,
 	ArticleStatusSchema,
+	VISIBLE_ARTICLE_STATUSES,
+	VisibleArticleStatusSchema,
+	isVisibleArticleStatus,
+	type VisibleArticleStatus,
 } from "./article.schema";
 export {
 	SaveableUrlSchema,

--- a/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
@@ -89,10 +89,15 @@ export type FindArticlesByUser = (
 	query: FindArticlesQuery,
 ) => Promise<FindArticlesResult>;
 
+/** Soft-deletes the user's relationship to an article: the row is tombstoned
+ * (status → "deleted") rather than removed, so the delete can be undone.
+ * Returns the status the row held before deletion (so the caller can offer an
+ * "undo" that restores it), or `null` when there was nothing to delete — the
+ * article is unknown, not owned by the user, or already deleted. */
 export type DeleteArticle = (
 	id: ReaderArticleHashId,
 	userId: UserId,
-) => Promise<boolean>;
+) => Promise<ArticleStatus | null>;
 
 export type UpdateArticleStatus = (
 	id: ReaderArticleHashId,

--- a/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/article-store.types.ts
@@ -1,6 +1,7 @@
 import type {
 	ArticleStatus,
 	SavedArticle,
+	VisibleArticleStatus,
 } from "@packages/domain/article";
 import type { ReaderArticleHashId } from "@packages/domain/article";
 import type { UserId } from "@packages/domain/user";
@@ -17,7 +18,7 @@ export type SortOrder = "asc" | "desc";
 
 export interface FindArticlesQuery {
 	userId: UserId;
-	status?: ArticleStatus;
+	status?: VisibleArticleStatus;
 	sort?: SortField;
 	order?: SortOrder;
 	page?: number;
@@ -102,7 +103,7 @@ export type DeleteArticle = (
 export type UpdateArticleStatus = (
 	id: ReaderArticleHashId,
 	userId: UserId,
-	status: ArticleStatus,
+	status: VisibleArticleStatus,
 ) => Promise<boolean>;
 
 export interface ArticleFreshnessData {

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.test.ts
@@ -447,14 +447,53 @@ describe("initInMemoryArticleStore", () => {
 	});
 
 	describe("deleteArticle", () => {
-		it("should remove user's relationship to the article", async () => {
+		it("should hide the article from the user and report its prior status", async () => {
 			const store = initInMemoryArticleStore();
 			const saved = await store.saveArticle(makeArticleParams());
 
-			const deleted = await store.deleteArticle(saved.id, USER_A);
+			const previousStatus = await store.deleteArticle(saved.id, USER_A);
 
-			expect(deleted).toBe(true);
+			expect(previousStatus).toBe("unread");
 			expect(await store.findArticleById(saved.id, USER_A)).toBeNull();
+		});
+
+		it("should report 'read' as the prior status when deleting a read article", async () => {
+			const store = initInMemoryArticleStore();
+			const saved = await store.saveArticle(makeArticleParams());
+			await store.updateArticleStatus(saved.id, USER_A, "read");
+
+			const previousStatus = await store.deleteArticle(saved.id, USER_A);
+
+			expect(previousStatus).toBe("read");
+		});
+
+		it("soft-deletes so a tombstoned article is gone from every listing yet can be restored", async () => {
+			const store = initInMemoryArticleStore();
+			const saved = await store.saveArticle(makeArticleParams());
+
+			await store.deleteArticle(saved.id, USER_A);
+
+			const all = await store.findArticlesByUser({ userId: USER_A });
+			const unread = await store.findArticlesByUser({ userId: USER_A, status: "unread" });
+			expect(all.articles).toHaveLength(0);
+			expect(all.total).toBe(0);
+			expect(unread.articles).toHaveLength(0);
+
+			// Undo: restoring the prior status brings it back into view.
+			await store.updateArticleStatus(saved.id, USER_A, "unread");
+			const restored = await store.findArticlesByUser({ userId: USER_A });
+			expect(restored.articles).toHaveLength(1);
+			expect(restored.articles[0].id.value).toBe(saved.id.value);
+		});
+
+		it("should return null when deleting an already-deleted article", async () => {
+			const store = initInMemoryArticleStore();
+			const saved = await store.saveArticle(makeArticleParams());
+			await store.deleteArticle(saved.id, USER_A);
+
+			const secondDelete = await store.deleteArticle(saved.id, USER_A);
+
+			expect(secondDelete).toBeNull();
 		});
 
 		it("should not affect another user's relationship to the same article", async () => {
@@ -472,18 +511,18 @@ describe("initInMemoryArticleStore", () => {
 			const store = initInMemoryArticleStore();
 			const saved = await store.saveArticle(makeArticleParams({ userId: USER_A }));
 
-			const deleted = await store.deleteArticle(saved.id, USER_B);
+			const previousStatus = await store.deleteArticle(saved.id, USER_B);
 
-			expect(deleted).toBe(false);
+			expect(previousStatus).toBeNull();
 		});
 
-		it("should return false when deleting a non-existent article", async () => {
+		it("should return null when deleting a non-existent article", async () => {
 			const store = initInMemoryArticleStore();
 			const fakeId = ReaderArticleHashId.fromHash("0".repeat(32));
 
-			const deleted = await store.deleteArticle(fakeId, USER_A);
+			const previousStatus = await store.deleteArticle(fakeId, USER_A);
 
-			expect(deleted).toBe(false);
+			expect(previousStatus).toBeNull();
 		});
 	});
 

--- a/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
+++ b/src/packages/test-fixtures/src/providers/article-store/in-memory-article-store.ts
@@ -6,7 +6,7 @@ import type {
 	SavedArticle,
 } from "@packages/domain/article";
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
-import { ReaderArticleHashId } from "@packages/domain/article";
+import { ReaderArticleHashId, isVisibleArticleStatus } from "@packages/domain/article";
 import type { UserId } from "@packages/domain/user";
 import type {
 	BumpArticleSavedAt,
@@ -151,7 +151,7 @@ export function initInMemoryArticleStore(): {
 		if (!article) return null;
 
 		const ua = userArticles.get(userArticleKey(userId, article.url));
-		if (!ua) return null;
+		if (!ua || !isVisibleArticleStatus(ua.status)) return null;
 
 		return toSavedArticle(article, ua);
 	};
@@ -188,9 +188,9 @@ export function initInMemoryArticleStore(): {
 			(ua) => ua.userId === query.userId,
 		);
 
-		if (query.status) {
-			userArts = userArts.filter((ua) => ua.status === query.status);
-		}
+		userArts = query.status
+			? userArts.filter((ua) => ua.status === query.status)
+			: userArts.filter((ua) => isVisibleArticleStatus(ua.status));
 
 		userArts.sort((a, b) => {
 			const aValue = sort === "readAt" ? a.readAt : a.savedAt;
@@ -218,13 +218,16 @@ export function initInMemoryArticleStore(): {
 
 	const deleteArticle: DeleteArticle = async (id, userId) => {
 		const article = findArticleByRouteId(id);
-		if (!article) return false;
+		if (!article) return null;
 
 		const uaKey = userArticleKey(userId, article.url);
-		if (!userArticles.has(uaKey)) return false;
+		const ua = userArticles.get(uaKey);
+		if (!ua || !isVisibleArticleStatus(ua.status)) return null;
 
-		userArticles.delete(uaKey);
-		return true;
+		const previousStatus = ua.status;
+		ua.status = "deleted";
+		userArticles.set(uaKey, ua);
+		return previousStatus;
 	};
 
 	const updateArticleStatus: UpdateArticleStatus = async (id, userId, status) => {


### PR DESCRIPTION
## What

Deleting an article from `/queue` now **soft-deletes** it and shows a brief **"Link deleted"** toast with an **Undo** button. The toast sits bottom-centre, auto-dismisses after 5 seconds, and Undo restores the link to exactly the read/unread state it had before.

## Behaviour

- **Delete is now a tombstone.** `deleteArticle` sets the user-article `status` to `"deleted"` instead of removing the row, preserving `savedAt`/`readAt` so the delete can be undone. It returns the prior status (or `null` when there was nothing to delete).
- **Undo toast.** After a delete, a read-once flash cookie (`delete_undo`, mirroring the existing `import_skipped` pattern) drives a `Link deleted` / `Undo` toast on the next `/queue` render. Undo POSTs the article back to its previous status via the existing `/queue/:id/status` endpoint, preserving the current tab/sort/page. If the user does nothing, the link stays deleted.
- **5s auto-dismiss with no client JS.** The toast is plain SSR markup inside `<main>` (so it survives the htmx boosted swap) and fades out via a pure-CSS `animation … forwards` keyframe; `visibility: hidden` at the end drops it from hit-testing. Works with and without JavaScript.
- **No view leaks a tombstone.** `findArticlesByUser` always constrains to the visible statuses (`read`/`unread`) when no explicit status is requested — closing the "falls back to no filter" paths (save-error collection, export). `findArticleById` returns `null` for any non-visible status, so permalinks/card-polls/reader for a deleted article 404 or redirect to the public view. The status endpoint accepts only `read`/`unread`, so `"deleted"` can never be set through it.
- **Re-save resurfaces.** Saving a URL that was previously deleted (or read) flips it back to `unread`, so it reappears in the queue — preventing a regression vs. the old hard-delete.

## Design notes

- `ArticleStatus` gains `"deleted"` (persisted enum) so reading a tombstoned row validates; a separate `VisibleArticleStatusSchema` (`read`/`unread`) gates everything user-settable, with an `isVisibleArticleStatus` guard as the single source of truth for "shows in a view".
- Undo reuses the existing `/status` endpoint rather than adding a new provider method/route. The one edge it accepts: undoing the deletion of an already-read article bumps `readAt` to now (it re-enters Done at the top) and re-emits the `article_read` analytics event — a negligible, rare path.

## Tests

- Domain: `deleted` accepted by `ArticleStatusSchema`, rejected by `VisibleArticleStatusSchema`; `isVisibleArticleStatus` coverage.
- In-memory store: soft-delete returns prior status, hides the row from every listing, can be restored; already-deleted/non-existent/other-user return `null`.
- `saveArticleFromUrl`: a previously-deleted article resurfaces as unread on re-save.
- Queue routes: `Link deleted` toast renders with an Undo form carrying the prior status (unread and read cases); Undo restores the article; the toast clears after one render and the link stays deleted otherwise; no toast for a non-existent delete.
- View model: undo URL is built preserving the current view.

`pnpm check` passes across all 26 projects (lint, types, tests, 100% coverage thresholds, knip, unused-css).

https://claude.ai/code/session_01QgS779LHh6i64Uamp7SFHy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgS779LHh6i64Uamp7SFHy)_