### PR TITLE
docs(blog): add post on one-tap read/unread with undo

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/mark-articles-read-undo-in-one-tap.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/mark-articles-read-undo-in-one-tap.md
@@ -1,0 +1,45 @@
+---
+title: "Mark Articles Read, Undo in One Tap"
+description: "Your Readplace queue now shows a clear Read or Unread label on every article. Mark an item read or unread with one tap, and undo a mis-tap with a single click."
+slug: "mark-articles-read-undo-in-one-tap"
+date: "2026-06-02"
+author: "Fayner Brack"
+keywords: "read it later, reading queue, mark as read, mark as unread, undo, read status, save articles, reading list, readplace"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Your queue now shows a plain Read or Unread label on every article. Mark an item read or unread with one tap. A short confirmation slides in with an Undo button, so a mis-tap takes one click to fix. The filter tab now reads "Read" instead of "Done", and the status buttons stay quiet until an article finishes saving.
+
+</div>
+</details>
+
+You open your queue to pick the next thing to read. You want a fast answer to one question: what have I read, and what is left?
+
+The old queue marked unread items with a small dot next to the title. The dot was easy to miss. A read article and an unread one looked nearly the same at a glance.
+
+Now every article carries a plain label. "Unread" or "Read" sits right under the title, next to the source and the read time. You scan the list and you know where you stand. No squinting at dots.
+
+## One tap to mark read, one tap to undo
+
+Each card has a clear button. An unread article shows "Mark as read". A read one shows "Mark as unread". Tap it and the article switches state and moves to where it belongs.
+
+People mis-tap. You meant to open an article and you marked it read instead. The old fix was to find the article, open it, and set the state back by hand. Slow, and fiddly on a phone.
+
+So we added a confirmation. Mark an article and a short message appears: "Marked as read", with an Undo button. One tap on Undo puts it back. The message clears itself after a few seconds, so it never sits in your way.
+
+## A clearer filter and fewer surprises
+
+The queue keeps two filters at the top. One shows unread articles, the other shows the ones you have finished. That second tab used to read "Done". It now reads "Read", to match the label on the cards. Same word everywhere, less to decode.
+
+We also closed a small trap. An article you just saved spends a few seconds being fetched and summarised. During that short window the read and unread buttons sit disabled, with a "Processing…" note on the card. You cannot mark an article read before Readplace has finished saving it. The buttons wake up the moment the article is ready.
+
+## Why this matters for your reading
+
+A read-it-later queue earns its keep by being honest about state. You should trust the list. Unread means you have not opened it. Read means you have. The label says so, the filter agrees, and a wrong tap costs you one click to fix.
+
+Small friction adds up. A queue that hides its state makes you re-read pieces you already finished, or lose track of what you meant to get to. Clear labels and a working Undo keep the list trustworthy, so you spend your time reading and not checking.
+
+Open your queue and try it. Mark something read, watch the label change, then hit Undo and watch it come back. Start at [readplace.com](/).


### PR DESCRIPTION
## What

Adds a new blog post: **"Mark Articles Read, Undo in One Tap"** (`mark-articles-read-undo-in-one-tap.md`).

## Why this topic

I reviewed every commit that landed on `main` after the most recent published post (`saved-articles-keep-their-images`, dated 2026-06-01). The strongest customer-facing change in that batch is the **My Queue read/unread clarity** work (#479), which touches the daily reading loop every paying user relies on:

- Plain `Read` / `Unread` label on every queue card (replacing the easy-to-miss dot)
- One-tap **Mark as read** / **Mark as unread** buttons
- A confirmation toast with a working **Undo** for mis-taps
- Filter tab renamed `Done` → `Read` to match the card labels
- Status buttons disabled with a `Processing…` note until an article finishes saving

That combination is concrete, broadly relevant, and good for search/conversion (people search "mark as read", "reading queue", "undo"), so it beat the more niche `text/plain` crawler change for an external post.

## Writing constraints honoured

- Followed the supplied human-voice writing guidelines (active voice, 10–20 word sentences, no banned words/phrases, no semicolons or em dashes, no synthetic-AI patterns).
- **No pricing or founding-member references**, per the standing instruction to avoid point-in-time promotions.

## Verification

- `pnpm nx run hutch:test --testPathPattern="blog"` → 40/40 pass (post is discovered, frontmatter validates, slug matches filename).
- Full pre-commit `pnpm check` passed across all 26 projects.

https://claude.ai/code/session_01NgDNaMv2MaDBn6RyBozZzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgDNaMv2MaDBn6RyBozZzk)_