### PR TITLE
feat(hutch): blur expired public reader behind a "Public access expired" msg (staging)

### DIFF
--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.test.ts
@@ -28,6 +28,15 @@ function counterHtml(expiresAt: string): string {
 	</aside>`;
 }
 
+function paywallHtml(): string {
+	return `<div class="view__paywall view__paywall--inactive" data-view-paywall data-test-view-paywall data-paywall-active="false">
+		<div class="view__paywall-fade"></div>
+		<div class="view__paywall-modal">
+			<a class="view__paywall-save" href="/save?url=https%3A%2F%2Fexample.com%2Fpost" data-test-view-paywall-save>Save to My Queue</a>
+		</div>
+	</div>`;
+}
+
 interface FakeTimers {
 	now: number;
 	advance(ms: number): void;
@@ -240,6 +249,27 @@ describe("initExpiryCounter", () => {
 		assert.equal(counter.classList.contains("view__expiry--expired"), true);
 		assert.equal(counter.classList.contains("view__expiry--counting"), false);
 		assert.equal(state.pending().length, 0);
+	});
+
+	it("reveals the inactive paywall overlay when the deadline passes", () => {
+		const startMs = Date.parse("2026-05-01T00:00:00.000Z");
+		const expiresAt = "2026-05-01T00:00:05.000Z";
+		const doc = makeDoc(counterHtml(expiresAt) + paywallHtml());
+		const { state, setIntervalFn, clearIntervalFn } = createFakeTimers(startMs);
+		initExpiryCounter({
+			document: doc,
+			now: () => state.now,
+			setIntervalFn,
+			clearIntervalFn,
+		});
+
+		state.advance(6 * 1000);
+
+		const paywall = doc.querySelector("[data-view-paywall]");
+		assert(paywall, "paywall overlay must remain in the DOM");
+		assert.equal(paywall.getAttribute("data-paywall-active"), "true");
+		assert.equal(paywall.classList.contains("view__paywall--active"), true);
+		assert.equal(paywall.classList.contains("view__paywall--inactive"), false);
 	});
 
 	it("stop() is idempotent — calling it twice does not throw", () => {

--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
@@ -58,6 +58,18 @@ export function withSaveUtmContent(href: string, stamp: string): string {
 	return url.toString();
 }
 
+/** Flip the SSR-inactive paywall overlay to its visible state when a counting
+ * page crosses its deadline while the tab is open. The SSR-already-expired case
+ * ships `--active` and needs no JS; pages without an overlay (authenticated,
+ * permanent, prod, not-ready) have no element and no-op. */
+function revealPaywall(document: Document): void {
+	const paywall = document.querySelector("[data-view-paywall]");
+	if (paywall === null) return;
+	paywall.classList.remove("view__paywall--inactive");
+	paywall.classList.add("view__paywall--active");
+	paywall.setAttribute("data-paywall-active", "true");
+}
+
 const NOOP_CONTROLLER: ExpiryCounterController = { stop() {} };
 
 export function initExpiryCounter(deps: ExpiryCounterDeps): ExpiryCounterController {
@@ -97,6 +109,7 @@ export function initExpiryCounter(deps: ExpiryCounterDeps): ExpiryCounterControl
 			counter.setAttribute("data-expiry-state", "expired");
 			counter.classList.remove("view__expiry--counting");
 			counter.classList.add("view__expiry--expired");
+			revealPaywall(deps.document);
 			stop();
 			return;
 		}

--- a/projects/hutch/src/runtime/web/pages/view/view-paywall.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view-paywall.template.html
@@ -1,0 +1,8 @@
+<div class="view__paywall view__paywall--{{paywallStateClass}}" data-view-paywall data-test-view-paywall data-paywall-active="{{paywallActive}}" role="dialog" aria-modal="false" aria-labelledby="view-paywall-heading">
+  <div class="view__paywall-fade" aria-hidden="true"></div>
+  <div class="view__paywall-modal">
+    <h2 class="view__paywall-heading" id="view-paywall-heading">Public access expired</h2>
+    <p class="view__paywall-body">Save this link to your readplace queue to see the full content.</p>
+    <a class="view__paywall-save" href="{{saveHref}}" data-test-view-paywall-save>Save to My Queue</a>
+  </div>
+</div>

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -515,6 +515,88 @@ describe("ViewPage", () => {
 			assert.equal(data.url, canonical);
 		});
 	});
+
+	describe("public access paywall", () => {
+		const now = new Date("2026-05-01T00:00:00.000Z");
+		const readyInput: ViewPageInput = {
+			...baseInput,
+			crawl: { status: "ready" },
+		};
+
+		it("renders the active paywall overlay for an anonymous, expired, ready article", () => {
+			const expiresAt = new Date("2026-04-30T23:59:59.000Z");
+			const doc = render({ ...readyInput, expiresAt, now });
+
+			const paywall = doc.querySelector("[data-test-view-paywall]");
+			assert(paywall, "paywall must be rendered for an expired ready article");
+			assert.equal(paywall.getAttribute("data-paywall-active"), "true");
+			assert(
+				paywall.classList.contains("view__paywall--active"),
+				"expired paywall must apply the active modifier",
+			);
+
+			const heading = paywall.querySelector("#view-paywall-heading");
+			assert(heading, "paywall heading must be rendered");
+			assert.equal(heading.textContent, "Public access expired");
+
+			const body = paywall.querySelector(".view__paywall-body");
+			assert(body, "paywall body must be rendered");
+			assert.equal(
+				body.textContent,
+				"Save this link to your readplace queue to see the full content.",
+			);
+
+			const save = paywall.querySelector("[data-test-view-paywall-save]");
+			assert(save, "paywall save button must be rendered");
+			assert.equal(
+				save.getAttribute("href"),
+				"/save?url=https%3A%2F%2Fexample.com%2Fpost",
+			);
+			assert.equal(save.textContent, "Save to My Queue");
+		});
+
+		it("renders the paywall inactive while the article is still counting down", () => {
+			const expiresAt = new Date("2026-05-03T10:05:33.000Z");
+			const doc = render({ ...readyInput, expiresAt, now });
+
+			const paywall = doc.querySelector("[data-test-view-paywall]");
+			assert(
+				paywall,
+				"paywall element must be present while counting so the client can reveal it live",
+			);
+			assert.equal(paywall.getAttribute("data-paywall-active"), "false");
+			assert(
+				paywall.classList.contains("view__paywall--inactive"),
+				"counting paywall must apply the inactive modifier",
+			);
+		});
+
+		it("omits the paywall when the crawl is not ready, even after access expires", () => {
+			const expiresAt = new Date("2026-04-30T23:59:59.000Z");
+			const doc = render({
+				...baseInput,
+				crawl: { status: "failed", reason: "blocked" },
+				expiresAt,
+				now,
+			});
+
+			const slot = doc.querySelector("[data-test-reader-slot]");
+			assert(slot, "reader slot must be rendered");
+			assert.equal(slot.getAttribute("data-reader-status"), "failed");
+
+			assert.equal(doc.querySelectorAll("[data-test-view-paywall]").length, 0);
+		});
+
+		it("omits the paywall for a permanent (non-expiring) article", () => {
+			const doc = render({ ...readyInput, expiresAt: null, now });
+
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			assert.equal(counter.getAttribute("data-expiry-state"), "permanent");
+
+			assert.equal(doc.querySelectorAll("[data-test-view-paywall]").length, 0);
+		});
+	});
 });
 
 describe("buildExpiryFields", () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type {
@@ -49,6 +50,24 @@ const VIEW_TEMPLATE = readFileSync(
 	join(__dirname, "view.template.html"),
 	"utf-8",
 );
+
+const VIEW_PAYWALL_TEMPLATE = readFileSync(
+	join(__dirname, "view-paywall.template.html"),
+	"utf-8",
+);
+
+/** The "Public access expired" paywall fades the bottom 40% of the reader
+ * region to background and urges the visitor to save the link to their own
+ * queue. `active` ships the visible (expired) state; an inactive overlay rides
+ * along on a still-counting page so expiry-counter.client.ts can reveal it the
+ * instant the deadline passes, without a reload. */
+function renderViewPaywall(input: { active: boolean; saveHref: string }): string {
+	return render(VIEW_PAYWALL_TEMPLATE, {
+		paywallStateClass: input.active ? "active" : "inactive",
+		paywallActive: input.active,
+		saveHref: input.saveHref,
+	});
+}
 
 export interface ViewAction {
 	name: string;
@@ -132,11 +151,29 @@ export function ViewPage(input: ViewPageInput): PageBody {
 
 	const expiry = buildExpiryFields(input.expiresAt, input.now);
 
+	const primarySaveAction = input.actions.find(
+		(action) => action.variant === "primary",
+	);
+	assert(primarySaveAction, "view must render a primary Save action");
+
+	/* The paywall only exists for a non-permanent, fully-rendered reader: a
+	 * permanent page (prod, authenticated, founder syndication, valid sharer)
+	 * emits nothing new, and a pending/failed crawl already shows its own
+	 * "Your link is saved" reframe that must not be blurred. */
+	const paywall =
+		expiry.state !== "permanent" && input.crawl?.status === "ready"
+			? renderViewPaywall({
+					active: expiry.state === "expired",
+					saveHref: primarySaveAction.href,
+				})
+			: "";
+
 	const content = render(VIEW_TEMPLATE, {
 		innerContent,
 		articleUrl: input.articleUrl,
 		actions: input.actions,
 		shareBalloon,
+		paywall,
 		expiryState: expiry.state,
 		expiryMessage: expiry.message,
 		expiresAtIso: expiry.expiresAtIso,

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -187,7 +187,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		const now = deps.now();
 
 		let expiresAt: Date | null = null;
-		if (deps.expiryCountdown === "enabled") {
+		if (deps.expiryCountdown === "enabled" && req.userId === undefined) {
 			const sharerPrefix = sharedUserIdFromQueryParams(utmContent);
 			const isValidSharer = sharerPrefix !== null && await deps.existsUserByIdPrefix(sharerPrefix);
 			const articleDomain = new URL(articleUrl).hostname;

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1538,5 +1538,107 @@ describe("View routes", () => {
 			const shareUrl = new URL(shareBtn.getAttribute("data-share-url") ?? "");
 			expect(shareUrl.searchParams.get("utm_content")).toBe(null);
 		});
+
+		async function seedReadyArticle(
+			fixture: ReturnType<typeof createDefaultTestAppFixture>,
+			savedAt: Date,
+		): Promise<void> {
+			await fixture.articleStore.saveArticleGlobally({
+				url: ARTICLE_URL,
+				metadata: {
+					title: "Hello World",
+					siteName: "example.com",
+					excerpt: "A lovely article.",
+					wordCount: 500,
+				},
+				estimatedReadTime: calculateReadTime(500),
+				savedAt,
+			});
+			await fixture.articleStore.writeContent({
+				url: ARTICLE_URL,
+				content: "<p>Body copy.</p>",
+			});
+			await fixture.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
+		}
+
+		it("blurs an expired anonymous reader behind the active paywall overlay", async () => {
+			const now = new Date("2026-05-10T00:00:00.000Z");
+			const { fixture, harness } = makeHarness(now);
+			await seedReadyArticle(fixture, new Date("2026-05-01T00:00:00.000Z"));
+
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("expired");
+
+			const paywall = doc.querySelector("[data-test-view-paywall]");
+			assert(paywall, "paywall must be rendered for an expired anonymous reader");
+			expect(paywall.getAttribute("data-paywall-active")).toBe("true");
+			expect(paywall.classList.contains("view__paywall--active")).toBe(true);
+		});
+
+		it("ships the paywall inactive for an anonymous reader still counting down", async () => {
+			const now = new Date("2026-05-04T00:00:00.000Z");
+			const { fixture, harness } = makeHarness(now);
+			await seedReadyArticle(fixture, new Date("2026-05-03T13:54:27.000Z"));
+
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("counting");
+
+			const paywall = doc.querySelector("[data-test-view-paywall]");
+			assert(paywall, "paywall element must be present while counting");
+			expect(paywall.getAttribute("data-paywall-active")).toBe("false");
+			expect(paywall.classList.contains("view__paywall--inactive")).toBe(true);
+		});
+
+		it("never blurs or counts down for an authenticated reader (full article, permanent state)", async () => {
+			const now = new Date("2026-05-10T00:00:00.000Z");
+			const { fixture, harness } = makeHarness(now);
+			await harness.auth.createUser({
+				email: "reader@example.com",
+				password: "password123",
+			});
+			await seedReadyArticle(fixture, new Date("2026-05-01T00:00:00.000Z"));
+
+			const agent = request.agent(harness.server);
+			await agent
+				.post("/login")
+				.type("form")
+				.send({ email: "reader@example.com", password: "password123" });
+
+			const response = await agent.get(`/view/${CANONICAL_PATH}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("permanent");
+
+			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(0);
+
+			const iframe = doc.querySelector("iframe[data-reader-iframe]");
+			assert(iframe, "authenticated reader must see the full article iframe");
+		});
+
+		it("never blurs a permanent-domain article", async () => {
+			const now = new Date("2026-05-04T00:00:00.000Z");
+			const { harness } = makeHarness(now);
+
+			const response = await request(harness.server).get(
+				`/view/${PERMANENT_CANONICAL_PATH}`,
+			);
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("permanent");
+
+			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(0);
+		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.styles.css
+++ b/projects/hutch/src/runtime/web/pages/view/view.styles.css
@@ -102,3 +102,112 @@
   color: var(--color-error);
 }
 /* purgecss-ignore-end */
+
+.view__body {
+  position: relative;
+}
+
+/**
+ * 1. Covers the bottom 40% of the reader region. reader-iframe.client.ts sizes
+ *    the srcdoc iframe to the full article height, so 40% of .view__body maps
+ *    to the last 40% of the article.
+ * 2. Sits above the iframe content but below the sticky CTA (z 10) and share
+ *    row (z 11) so the footer Save button and share balloon stay clickable.
+ * 3. The overlay itself is inert so the top 60% scrolls/selects; only the modal
+ *    re-enables pointer events.
+ */
+.view__paywall {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 40%; /* 1 */
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 5; /* 2 */
+  pointer-events: none; /* 3 */
+}
+
+/**
+ * 1. The gradient to var(--color-background) is the guaranteed obscuring layer
+ *    across the srcdoc iframe boundary; backdrop blur is enhancement only —
+ *    pure backdrop-filter is unreliable over an iframe.
+ */
+.view__paywall-fade {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--color-background) 55%,
+    var(--color-background) 100%
+  ); /* 1 */
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.view__paywall-modal {
+  position: relative;
+  pointer-events: auto;
+  margin-bottom: 1.5rem;
+  max-width: var(--reader-max-width);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-md);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.view__paywall-heading {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.view__paywall-body {
+  margin: 0 0 1.25rem;
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+}
+
+.view__paywall-save {
+  display: inline-block;
+  box-sizing: border-box;
+  padding: 0.875rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-on-brand);
+  background: var(--color-brand);
+  border: 1px solid var(--color-brand);
+  border-radius: 8px;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  transition: filter 150ms ease;
+}
+
+.view__paywall-save:hover {
+  filter: brightness(1.05);
+}
+
+.view__paywall-save:active {
+  filter: brightness(0.95);
+}
+
+/* purgecss-ignore-start: modifier suffix is interpolated from paywallStateClass in view-paywall.template.html and toggled in expiry-counter.client.ts */
+.view__paywall--inactive {
+  display: none;
+}
+
+.view__paywall--active {
+  display: flex;
+}
+/* purgecss-ignore-end */
+
+@media (prefers-reduced-motion: reduce) {
+  .view__paywall-save {
+    transition: none;
+  }
+}

--- a/projects/hutch/src/runtime/web/pages/view/view.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view.template.html
@@ -1,6 +1,7 @@
     <main class="view">
       <article class="view__body" data-article-body>
         {{{innerContent}}}
+        {{{paywall}}}
       </article>
       <div class="view__share-row">
         {{{shareBalloon}}}


### PR DESCRIPTION
## What

When public access to an anonymous reader view (`/view/*`) expires, the page now reframes as a paywall instead of leaving the full article readable: the bottom 40% of the reader region fades to the page background (with a backdrop blur layered on top) and a non‑dismissible **"Public access expired"** modal urges the visitor to *"Save this link to your readplace queue to see the full content."*, with its own **Save to My Queue** button reusing the existing save href.

Authenticated viewers now skip the expiry mechanic entirely — full article, no countdown, no paywall — by gating the expiry computation on anonymity in the handler (this also fixes a latent gap where a logged‑in user already hit `state="expired"`).

## Why staging‑only (and prod stays byte‑for‑byte unchanged)

The feature reuses the existing per‑environment `expiryCountdown` flag rather than adding a new one. In prod the flag is disabled → `expiresAt` is always `null` → the state is always `permanent` → the paywall's precondition is unreachable. No `Pulumi.*.yaml`, `src/infra/**`, `app.ts`, `server.ts`, or `test-app.ts` files are touched, so staging‑only is guaranteed by construction.

## How

- **Handler** (`view.page.ts`): fold an anonymity gate (`req.userId === undefined`) into the existing `expiryCountdown === "enabled"` condition.
- **Component** (`view.component.ts`): derive eligibility (`state !== "permanent" && crawl.status === "ready"`) and active state (`state === "expired"`); render a new `view-paywall.template.html` partial, reusing the primary Save action's href.
- **CSS** (`view.styles.css`): a parent‑painted `linear-gradient` fade to `var(--color-background)` is the guaranteed obscuring layer across the sandboxed `srcdoc` iframe boundary; `backdrop-filter: blur()` is enhancement only. The overlay is `pointer-events: none` (top 60% stays scrollable/selectable) except the modal card; `z-index` keeps the sticky footer + share balloon clickable; a `prefers-reduced-motion` guard disables the button transition.
- **Client** (`expiry-counter.client.ts`): reveal the overlay live on the counting→expired tick so an open tab flips without a reload.

Content stays fully in the DOM, the `.md` content‑negotiation path, and the SEO output — the masking is purely cosmetic, so indexing/markdown are unaffected.

## Testing

- Component, client, and integration tests cover: anonymous + expired (active overlay), anonymous + counting (inactive overlay), authenticated (no paywall, full iframe, permanent state), permanent‑domain (no paywall), and not‑ready crawl (no paywall) — all via positive assertions.
- `pnpm nx run hutch:check` passes (lint, types, unit + integration, 100% function coverage, knip, unused‑css), including after rebasing onto the latest `main` (30 commits; no conflicts).

https://claude.ai/code/session_01VUB7mCEeEKwnFVv5M8mgTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUB7mCEeEKwnFVv5M8mgTK)_