### PR TITLE
feat(hutch): scroll-gate the expired-reader blur behind a centred paywall (staging)

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -166,6 +166,25 @@ const BUNDLES = [
 	{
 		entry: path.join(
 			PROJECT_ROOT,
+			"src/runtime/web/pages/view/view-paywall.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "view-paywall.client.js"),
+		globalName: "ViewPaywall",
+		footer: [
+			"document.addEventListener('DOMContentLoaded', function () {",
+			"  ViewPaywall.initViewPaywall({",
+			"    document: window.document,",
+			"    window: window,",
+			"    now: function () { return Date.now(); },",
+			"    setTimeoutFn: function (cb, ms) { return window.setTimeout(cb, ms); },",
+			"    clearTimeoutFn: function (id) { window.clearTimeout(id); }",
+			"  });",
+			"});",
+		].join("\n"),
+	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
 			"src/runtime/web/shared/toast/toast.client.ts",
 		),
 		outfile: path.join(OUT_DIR, "toast.client.js"),

--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.test.ts
@@ -28,15 +28,6 @@ function counterHtml(expiresAt: string): string {
 	</aside>`;
 }
 
-function paywallHtml(): string {
-	return `<div class="view__paywall view__paywall--inactive" data-view-paywall data-test-view-paywall data-paywall-active="false">
-		<div class="view__paywall-fade"></div>
-		<div class="view__paywall-modal">
-			<a class="view__paywall-save" href="/save?url=https%3A%2F%2Fexample.com%2Fpost" data-test-view-paywall-save>Save to My Queue</a>
-		</div>
-	</div>`;
-}
-
 interface FakeTimers {
 	now: number;
 	advance(ms: number): void;
@@ -249,27 +240,6 @@ describe("initExpiryCounter", () => {
 		assert.equal(counter.classList.contains("view__expiry--expired"), true);
 		assert.equal(counter.classList.contains("view__expiry--counting"), false);
 		assert.equal(state.pending().length, 0);
-	});
-
-	it("reveals the inactive paywall overlay when the deadline passes", () => {
-		const startMs = Date.parse("2026-05-01T00:00:00.000Z");
-		const expiresAt = "2026-05-01T00:00:05.000Z";
-		const doc = makeDoc(counterHtml(expiresAt) + paywallHtml());
-		const { state, setIntervalFn, clearIntervalFn } = createFakeTimers(startMs);
-		initExpiryCounter({
-			document: doc,
-			now: () => state.now,
-			setIntervalFn,
-			clearIntervalFn,
-		});
-
-		state.advance(6 * 1000);
-
-		const paywall = doc.querySelector("[data-view-paywall]");
-		assert(paywall, "paywall overlay must remain in the DOM");
-		assert.equal(paywall.getAttribute("data-paywall-active"), "true");
-		assert.equal(paywall.classList.contains("view__paywall--active"), true);
-		assert.equal(paywall.classList.contains("view__paywall--inactive"), false);
 	});
 
 	it("stop() is idempotent — calling it twice does not throw", () => {

--- a/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
+++ b/projects/hutch/src/runtime/web/pages/view/expiry-counter.client.ts
@@ -58,18 +58,6 @@ export function withSaveUtmContent(href: string, stamp: string): string {
 	return url.toString();
 }
 
-/** Flip the SSR-inactive paywall overlay to its visible state when a counting
- * page crosses its deadline while the tab is open. The SSR-already-expired case
- * ships `--active` and needs no JS; pages without an overlay (authenticated,
- * permanent, prod, not-ready) have no element and no-op. */
-function revealPaywall(document: Document): void {
-	const paywall = document.querySelector("[data-view-paywall]");
-	if (paywall === null) return;
-	paywall.classList.remove("view__paywall--inactive");
-	paywall.classList.add("view__paywall--active");
-	paywall.setAttribute("data-paywall-active", "true");
-}
-
 const NOOP_CONTROLLER: ExpiryCounterController = { stop() {} };
 
 export function initExpiryCounter(deps: ExpiryCounterDeps): ExpiryCounterController {
@@ -109,7 +97,6 @@ export function initExpiryCounter(deps: ExpiryCounterDeps): ExpiryCounterControl
 			counter.setAttribute("data-expiry-state", "expired");
 			counter.classList.remove("view__expiry--counting");
 			counter.classList.add("view__expiry--expired");
-			revealPaywall(deps.document);
 			stop();
 			return;
 		}

--- a/projects/hutch/src/runtime/web/pages/view/view-paywall.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-paywall.client.test.ts
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { initViewPaywall } from "./view-paywall.client";
+
+const ACTIVE = "view__paywall--active";
+const INACTIVE = "view__paywall--inactive";
+const START_MS = Date.parse("2026-05-01T00:00:00.000Z");
+const EXPIRED_ISO = "2026-04-30T23:59:59.000Z"; // before START
+const COUNTING_ISO = "2026-05-01T00:00:05.000Z"; // 5s after START
+const ARTICLE_HEIGHT = 1000; // 10% scroll threshold = 100px
+const PAST_THRESHOLD = 250;
+
+function paywallMarkup(expiresAtAttr: string): string {
+	return `<div class="view__paywall view__paywall--inactive" data-view-paywall data-test-view-paywall data-paywall-active="false"${expiresAtAttr}>
+		<div class="view__paywall-fade"></div>
+		<div class="view__paywall-modal">
+			<a class="view__paywall-save" href="/save?url=x" data-test-view-paywall-save>Save to My Queue</a>
+		</div>
+	</div>`;
+}
+
+function articleWith(inner: string): string {
+	return `<article class="view__body" data-article-body>${inner}</article>`;
+}
+
+function makeDocument(bodyHtml: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`).window
+		.document;
+}
+
+function setArticleHeight(doc: Document, value: number): void {
+	const el = doc.querySelector<HTMLElement>("[data-article-body]");
+	assert(el, "[data-article-body] must exist in fixture");
+	Object.defineProperty(el, "offsetHeight", { value, configurable: true });
+}
+
+function paywallEl(doc: Document): Element {
+	const el = doc.querySelector("[data-view-paywall]");
+	assert(el, "paywall element must exist in fixture");
+	return el;
+}
+
+/** A scroll-aware window stub: `scrollTo` moves the position and fires the
+ * registered listener, and `hasListener` lets a test assert the latch detached
+ * it. Kept separate from jsdom so detachment is directly observable. */
+function createFakeWindow() {
+	let scrollY = 0;
+	let listener: (() => void) | null = null;
+	return {
+		win: {
+			get scrollY(): number {
+				return scrollY;
+			},
+			addEventListener(
+				_type: "scroll",
+				l: () => void,
+				_options: { passive: true },
+			): void {
+				listener = l;
+			},
+			removeEventListener(_type: "scroll", _l: () => void): void {
+				listener = null;
+			},
+		},
+		scrollTo(value: number): void {
+			scrollY = value;
+			if (listener !== null) listener();
+		},
+		hasListener(): boolean {
+			return listener !== null;
+		},
+	};
+}
+
+function createClock(startMs: number) {
+	let now = startMs;
+	const timers = new Map<number, { cb: () => void; fireAt: number }>();
+	let nextId = 1;
+	return {
+		now: (): number => now,
+		setTimeoutFn: (cb: () => void, ms: number): unknown => {
+			const id = nextId++;
+			timers.set(id, { cb, fireAt: now + ms });
+			return id;
+		},
+		clearTimeoutFn: (id: unknown): void => {
+			if (typeof id === "number") timers.delete(id);
+		},
+		advance(ms: number): void {
+			now += ms;
+			for (const [id, timer] of [...timers]) {
+				if (timer.fireAt <= now) {
+					timers.delete(id);
+					timer.cb();
+				}
+			}
+		},
+		pending: (): number => timers.size,
+	};
+}
+
+function start(
+	doc: Document,
+	fake: ReturnType<typeof createFakeWindow>,
+	clock: ReturnType<typeof createClock>,
+): void {
+	initViewPaywall({
+		document: doc,
+		window: fake.win,
+		now: clock.now,
+		setTimeoutFn: clock.setTimeoutFn,
+		clearTimeoutFn: clock.clearTimeoutFn,
+	});
+}
+
+describe("initViewPaywall — gating no-ops", () => {
+	it("is a no-op when no [data-view-paywall] element is present", () => {
+		const doc = makeDocument(articleWith(""));
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+
+		start(doc, fake, clock);
+
+		assert.equal(fake.hasListener(), false);
+		assert.equal(clock.pending(), 0);
+	});
+
+	it("is a no-op when the paywall carries no data-expires-at", () => {
+		const doc = makeDocument(articleWith(paywallMarkup("")));
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+
+		assert.equal(fake.hasListener(), false);
+		assert.equal(clock.pending(), 0);
+		assert.equal(paywallEl(doc).classList.contains(ACTIVE), false);
+	});
+
+	it("is a no-op when data-expires-at is not a parseable timestamp", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="not-a-date"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+
+		assert.equal(fake.hasListener(), false);
+		assert.equal(clock.pending(), 0);
+		assert.equal(paywallEl(doc).classList.contains(ACTIVE), false);
+	});
+
+	it("is a no-op when the article body element is absent", () => {
+		const doc = makeDocument(paywallMarkup(` data-expires-at="${EXPIRED_ISO}"`));
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+
+		assert.equal(fake.hasListener(), false);
+		assert.equal(clock.pending(), 0);
+		assert.equal(paywallEl(doc).classList.contains(ACTIVE), false);
+	});
+});
+
+describe("initViewPaywall — scroll + expiry gates", () => {
+	it("does not blur on load and stays hidden while within 10% of the article top", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="${EXPIRED_ISO}"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		assert.equal(paywallEl(doc).classList.contains(INACTIVE), true);
+
+		fake.scrollTo(99); // threshold is 100px
+
+		const el = paywallEl(doc);
+		assert.equal(el.classList.contains(ACTIVE), false);
+		assert.equal(el.classList.contains(INACTIVE), true);
+		assert.equal(el.getAttribute("data-paywall-active"), "false");
+	});
+
+	it("does not reveal once scrolled past 10% while access has not expired", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="${COUNTING_ISO}"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+
+		const el = paywallEl(doc);
+		assert.equal(el.classList.contains(ACTIVE), false);
+		assert.equal(el.classList.contains(INACTIVE), true);
+		assert.equal(clock.pending(), 1); // the deadline timer is still armed
+	});
+
+	it("reveals when an expired reader scrolls past 10%", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="${EXPIRED_ISO}"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+
+		const el = paywallEl(doc);
+		assert.equal(el.classList.contains(ACTIVE), true);
+		assert.equal(el.classList.contains(INACTIVE), false);
+		assert.equal(el.getAttribute("data-paywall-active"), "true");
+		assert.equal(clock.pending(), 0); // no timer armed for an already-expired page
+	});
+
+	it("reveals a scrolled-past reader the instant a counting page's deadline passes", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="${COUNTING_ISO}"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+		assert.equal(paywallEl(doc).classList.contains(ACTIVE), false); // not yet expired
+
+		clock.advance(5000); // deadline reached → timer fires
+
+		const el = paywallEl(doc);
+		assert.equal(el.classList.contains(ACTIVE), true);
+		assert.equal(el.getAttribute("data-paywall-active"), "true");
+		assert.equal(clock.pending(), 0);
+	});
+
+	it("reveals after the deadline timer fires and the reader then scrolls past 10%", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="${COUNTING_ISO}"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		clock.advance(5000); // timer fires while the reader has not scrolled
+		assert.equal(paywallEl(doc).classList.contains(ACTIVE), false);
+
+		fake.scrollTo(PAST_THRESHOLD);
+
+		const el = paywallEl(doc);
+		assert.equal(el.classList.contains(ACTIVE), true);
+		assert.equal(el.getAttribute("data-paywall-active"), "true");
+	});
+});
+
+describe("initViewPaywall — latch", () => {
+	it("detaches the scroll listener, clears the timer, and stays revealed after the reveal", () => {
+		const doc = makeDocument(
+			articleWith(paywallMarkup(` data-expires-at="${COUNTING_ISO}"`)),
+		);
+		const fake = createFakeWindow();
+		const clock = createClock(START_MS);
+		setArticleHeight(doc, ARTICLE_HEIGHT);
+
+		start(doc, fake, clock);
+		fake.scrollTo(PAST_THRESHOLD);
+		clock.advance(5000); // reveal via the deadline timer
+
+		const el = paywallEl(doc);
+		assert.equal(el.classList.contains(ACTIVE), true);
+		assert.equal(fake.hasListener(), false); // listener detached
+		assert.equal(clock.pending(), 0); // timer cleared
+
+		fake.scrollTo(0); // scrolling back up must not un-blur
+		assert.equal(el.classList.contains(ACTIVE), true);
+		assert.equal(el.classList.contains(INACTIVE), false);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/view-paywall.client.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-paywall.client.ts
@@ -1,0 +1,73 @@
+interface ViewPaywallWindow {
+	readonly scrollY: number;
+	addEventListener(
+		type: "scroll",
+		listener: () => void,
+		options: { passive: true },
+	): void;
+	removeEventListener(type: "scroll", listener: () => void): void;
+}
+
+interface ViewPaywallDeps {
+	document: Document;
+	window: ViewPaywallWindow;
+	now: () => number;
+	setTimeoutFn: (cb: () => void, ms: number) => unknown;
+	clearTimeoutFn: (id: unknown) => void;
+}
+
+/** The expired-public-reader paywall is a soft, scroll-gated blur. The element
+ * ships hidden (`--inactive`); this reveals it once two gates are both open:
+ * the reader has scrolled past 10% of the article (so the blur engages over the
+ * content below the current reading line, not on load) AND public access has
+ * expired (data-expires-at is in the past, immediately for SSR-expired pages or
+ * the moment a counting page's deadline arrives). Both orderings are handled —
+ * a reader who scrolls first sees the blur the instant the deadline passes, and
+ * a reader on an already-expired page sees it the moment they scroll. Once
+ * revealed it latches: the scroll listener detaches and the deadline timer
+ * clears, so scrolling back up does not un-blur. Absent on permanent / prod /
+ * not-ready pages (no element) — no-op. */
+export function initViewPaywall(deps: ViewPaywallDeps): void {
+	const root = deps.document.querySelector("[data-view-paywall]");
+	if (root === null) return;
+	const expiresAtRaw = root.getAttribute("data-expires-at");
+	if (expiresAtRaw === null) return;
+	const deadlineMs = Date.parse(expiresAtRaw);
+	if (!Number.isFinite(deadlineMs)) return;
+	const articleEl = deps.document.querySelector<HTMLElement>("[data-article-body]");
+	if (articleEl === null) return;
+	// TS doesn't propagate the null-narrowing above into the nested closures below.
+	const paywall = root;
+	const article = articleEl;
+
+	let scrolledPast = false;
+	let timerId: unknown = null;
+
+	function reveal(): void {
+		if (!scrolledPast) return;
+		if (deps.now() < deadlineMs) return;
+		paywall.classList.remove("view__paywall--inactive");
+		paywall.classList.add("view__paywall--active");
+		paywall.setAttribute("data-paywall-active", "true");
+		deps.window.removeEventListener("scroll", onScroll);
+		if (timerId !== null) {
+			deps.clearTimeoutFn(timerId);
+			timerId = null;
+		}
+	}
+
+	function onScroll(): void {
+		const threshold = article.offsetHeight * 0.1;
+		if (deps.window.scrollY < threshold) return;
+		scrolledPast = true;
+		reveal();
+	}
+
+	deps.window.addEventListener("scroll", onScroll, { passive: true });
+
+	const msUntilDeadline = deadlineMs - deps.now();
+	if (msUntilDeadline > 0) {
+		timerId = deps.setTimeoutFn(reveal, msUntilDeadline);
+	}
+	onScroll();
+}

--- a/projects/hutch/src/runtime/web/pages/view/view-paywall.client.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-paywall.client.ts
@@ -69,5 +69,5 @@ export function initViewPaywall(deps: ViewPaywallDeps): void {
 	if (msUntilDeadline > 0) {
 		timerId = deps.setTimeoutFn(reveal, msUntilDeadline);
 	}
-	onScroll();
+	onScroll(); // page may have loaded mid-scroll
 }

--- a/projects/hutch/src/runtime/web/pages/view/view-paywall.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view-paywall.template.html
@@ -1,4 +1,4 @@
-<div class="view__paywall view__paywall--{{paywallStateClass}}" data-view-paywall data-test-view-paywall data-paywall-active="{{paywallActive}}" role="dialog" aria-modal="false" aria-labelledby="view-paywall-heading">
+<div class="view__paywall view__paywall--inactive" data-view-paywall data-test-view-paywall data-paywall-active="false" data-expires-at="{{expiresAtIso}}" role="dialog" aria-modal="false" aria-labelledby="view-paywall-heading">
   <div class="view__paywall-fade" aria-hidden="true"></div>
   <div class="view__paywall-modal">
     <h2 class="view__paywall-heading" id="view-paywall-heading">Public access expired</h2>

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -523,16 +523,25 @@ describe("ViewPage", () => {
 			crawl: { status: "ready" },
 		};
 
-		it("renders the active paywall overlay for an anonymous, expired, ready article", () => {
+		it("ships the paywall hidden on load carrying the expiry deadline for an expired, ready article", () => {
 			const expiresAt = new Date("2026-04-30T23:59:59.000Z");
 			const doc = render({ ...readyInput, expiresAt, now });
 
 			const paywall = doc.querySelector("[data-test-view-paywall]");
 			assert(paywall, "paywall must be rendered for an expired ready article");
-			assert.equal(paywall.getAttribute("data-paywall-active"), "true");
+			assert.equal(paywall.getAttribute("data-paywall-active"), "false");
 			assert(
+				paywall.classList.contains("view__paywall--inactive"),
+				"the paywall always ships hidden — the client owns the scroll-gated reveal",
+			);
+			assert.equal(
 				paywall.classList.contains("view__paywall--active"),
-				"expired paywall must apply the active modifier",
+				false,
+				"the SSR paywall must not be pre-revealed",
+			);
+			assert.equal(
+				paywall.getAttribute("data-expires-at"),
+				"2026-04-30T23:59:59.000Z",
 			);
 
 			const heading = paywall.querySelector("#view-paywall-heading");
@@ -555,7 +564,7 @@ describe("ViewPage", () => {
 			assert.equal(save.textContent, "Save to My Queue");
 		});
 
-		it("renders the paywall inactive while the article is still counting down", () => {
+		it("ships the paywall hidden carrying the deadline while the article is still counting down", () => {
 			const expiresAt = new Date("2026-05-03T10:05:33.000Z");
 			const doc = render({ ...readyInput, expiresAt, now });
 
@@ -569,6 +578,21 @@ describe("ViewPage", () => {
 				paywall.classList.contains("view__paywall--inactive"),
 				"counting paywall must apply the inactive modifier",
 			);
+			assert.equal(
+				paywall.getAttribute("data-expires-at"),
+				"2026-05-03T10:05:33.000Z",
+			);
+		});
+
+		it("boots the view-paywall client via the external script bundle", () => {
+			const expiresAt = new Date("2026-04-30T23:59:59.000Z");
+			const doc = render({ ...readyInput, expiresAt, now });
+
+			const script = doc.querySelector(
+				'script[src$="/client-dist/view-paywall.client.js"]',
+			);
+			assert(script, "view-paywall client script must be rendered");
+			assert(script.hasAttribute("defer"));
 		});
 
 		it("omits the paywall when the crawl is not ready, even after access expires", () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -26,6 +26,7 @@ const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
 const EXPIRY_COUNTER_SCRIPT = `<script src="/client-dist/expiry-counter.client.js" defer></script>`;
+const VIEW_PAYWALL_SCRIPT = `<script src="/client-dist/view-paywall.client.js" defer></script>`;
 
 /** SEO-only constant: <link rel="canonical"> and JSON-LD url must always point
  * at production so search engines index a single host. The share URL uses the
@@ -56,16 +57,16 @@ const VIEW_PAYWALL_TEMPLATE = readFileSync(
 	"utf-8",
 );
 
-/** The "Public access expired" paywall fades the bottom 40% of the reader
- * region to background and urges the visitor to save the link to their own
- * queue. `active` ships the visible (expired) state; an inactive overlay rides
- * along on a still-counting page so expiry-counter.client.ts can reveal it the
- * instant the deadline passes, without a reload. */
-function renderViewPaywall(input: { active: boolean; saveHref: string }): string {
+/** The "Public access expired" paywall blurs the article below the reader's
+ * scroll position and urges the visitor to save the link to their own queue. It
+ * always ships hidden (`--inactive`) carrying the expiry deadline in
+ * data-expires-at; view-paywall.client.ts reveals it once the reader scrolls
+ * past 10% of the article AND access has expired, so the blur is a soft,
+ * scroll-gated paywall rather than an on-load curtain. */
+function renderViewPaywall(input: { saveHref: string; expiresAtIso: string }): string {
 	return render(VIEW_PAYWALL_TEMPLATE, {
-		paywallStateClass: input.active ? "active" : "inactive",
-		paywallActive: input.active,
 		saveHref: input.saveHref,
+		expiresAtIso: input.expiresAtIso,
 	});
 }
 
@@ -160,13 +161,14 @@ export function ViewPage(input: ViewPageInput): PageBody {
 	 * permanent page (prod, authenticated, founder syndication, valid sharer)
 	 * emits nothing new, and a pending/failed crawl already shows its own
 	 * "Your link is saved" reframe that must not be blurred. */
-	const paywall =
-		expiry.state !== "permanent" && input.crawl?.status === "ready"
-			? renderViewPaywall({
-					active: expiry.state === "expired",
-					saveHref: primarySaveAction.href,
-				})
-			: "";
+	let paywall = "";
+	if (expiry.state !== "permanent" && input.crawl?.status === "ready") {
+		assert(expiry.expiresAtIso, "a non-permanent expiry must carry an ISO deadline");
+		paywall = renderViewPaywall({
+			saveHref: primarySaveAction.href,
+			expiresAtIso: expiry.expiresAtIso,
+		});
+	}
 
 	const content = render(VIEW_TEMPLATE, {
 		innerContent,
@@ -215,6 +217,6 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		styles: VIEW_STYLES,
 		bodyClass: "page-view",
 		content: { html: content },
-		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT + EXPIRY_COUNTER_SCRIPT,
+		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT + EXPIRY_COUNTER_SCRIPT + VIEW_PAYWALL_SCRIPT,
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1640,7 +1640,7 @@ describe("View routes", () => {
 			await fixture.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
 		}
 
-		it("blurs an expired anonymous reader behind the active paywall overlay", async () => {
+		it("ships an expired anonymous reader the hidden, scroll-gated paywall carrying the deadline", async () => {
 			const now = new Date("2026-05-10T00:00:00.000Z");
 			const { fixture, harness } = makeHarness(now);
 			await seedReadyArticle(fixture, new Date("2026-05-01T00:00:00.000Z"));
@@ -1654,11 +1654,25 @@ describe("View routes", () => {
 
 			const paywall = doc.querySelector("[data-test-view-paywall]");
 			assert(paywall, "paywall must be rendered for an expired anonymous reader");
-			expect(paywall.getAttribute("data-paywall-active")).toBe("true");
-			expect(paywall.classList.contains("view__paywall--active")).toBe(true);
+			expect(paywall.getAttribute("data-paywall-active")).toBe("false");
+			expect(paywall.classList.contains("view__paywall--inactive")).toBe(true);
+			expect(paywall.classList.contains("view__paywall--active")).toBe(false);
+
+			const deadline = paywall.getAttribute("data-expires-at");
+			assert(deadline, "paywall must carry the expiry deadline for the client");
+			expect(deadline).toBe(counter.getAttribute("data-expires-at"));
+
+			const modal = paywall.querySelector(".view__paywall-modal");
+			assert(modal, "the centred popup markup must be present");
+
+			const script = doc.querySelector(
+				'script[src$="/client-dist/view-paywall.client.js"]',
+			);
+			assert(script, "the view-paywall client bundle must be wired up");
+			expect(script.hasAttribute("defer")).toBe(true);
 		});
 
-		it("ships the paywall inactive for an anonymous reader still counting down", async () => {
+		it("ships the paywall hidden carrying the deadline for an anonymous reader still counting down", async () => {
 			const now = new Date("2026-05-04T00:00:00.000Z");
 			const { fixture, harness } = makeHarness(now);
 			await seedReadyArticle(fixture, new Date("2026-05-03T13:54:27.000Z"));
@@ -1674,6 +1688,10 @@ describe("View routes", () => {
 			assert(paywall, "paywall element must be present while counting");
 			expect(paywall.getAttribute("data-paywall-active")).toBe("false");
 			expect(paywall.classList.contains("view__paywall--inactive")).toBe(true);
+
+			const deadline = paywall.getAttribute("data-expires-at");
+			assert(deadline, "paywall must carry the expiry deadline for the client");
+			expect(deadline).toBe(counter.getAttribute("data-expires-at"));
 		});
 
 		it("never blurs or counts down for an authenticated reader (full article, permanent state)", async () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.styles.css
+++ b/projects/hutch/src/runtime/web/pages/view/view.styles.css
@@ -103,28 +103,20 @@
 }
 /* purgecss-ignore-end */
 
-.view__body {
-  position: relative;
-}
-
 /**
- * 1. Covers the bottom 40% of the reader region. reader-iframe.client.ts sizes
- *    the srcdoc iframe to the full article height, so 40% of .view__body maps
- *    to the last 40% of the article.
+ * 1. A fixed, full-viewport curtain so the centred popup pins to the middle of
+ *    the screen the moment the blur engages — not at the end of the article.
  * 2. Sits above the iframe content but below the sticky CTA (z 10) and share
  *    row (z 11) so the footer Save button and share balloon stay clickable.
- * 3. The overlay itself is inert so the top 60% scrolls/selects; only the modal
- *    re-enables pointer events.
+ * 3. The curtain itself is inert so the visible content still scrolls/selects;
+ *    only the centred modal re-enables pointer events.
  */
 .view__paywall {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 40%; /* 1 */
+  position: fixed;
+  inset: 0;
   display: flex;
-  align-items: flex-end;
-  justify-content: center;
+  align-items: center; /* 1 */
+  justify-content: center; /* 1 */
   z-index: 5; /* 2 */
   pointer-events: none; /* 3 */
 }
@@ -132,7 +124,9 @@
 /**
  * 1. The gradient to var(--color-background) is the guaranteed obscuring layer
  *    across the srcdoc iframe boundary; backdrop blur is enhancement only —
- *    pure backdrop-filter is unreliable over an iframe.
+ *    pure backdrop-filter is unreliable over an iframe. Transparent at the top
+ *    keeps the reader's current line legible; it ramps to opaque background so
+ *    the content below the fold blurs out.
  */
 .view__paywall-fade {
   position: absolute;
@@ -140,7 +134,7 @@
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    var(--color-background) 55%,
+    var(--color-background) 45%,
     var(--color-background) 100%
   ); /* 1 */
   backdrop-filter: blur(8px);
@@ -150,7 +144,6 @@
 .view__paywall-modal {
   position: relative;
   pointer-events: auto;
-  margin-bottom: 1.5rem;
   max-width: var(--reader-max-width);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -196,7 +189,7 @@
   filter: brightness(0.95);
 }
 
-/* purgecss-ignore-start: modifier suffix is interpolated from paywallStateClass in view-paywall.template.html and toggled in expiry-counter.client.ts */
+/* purgecss-ignore-start: --inactive ships hidden in view-paywall.template.html; --active is toggled in view-paywall.client.ts and appears in no template literally */
 .view__paywall--inactive {
   display: none;
 }


### PR DESCRIPTION
## Why

The public `/view` paywall (added in #485) blurred the bottom 40% of the article **on load** — tied directly to `expiry.state === "expired"` — with the "Public access expired" popup anchored to the *end* of the blurred region (`align-items: flex-end`), so the reader only saw it after scrolling all the way down. This replaces it with a softer, conversion-style paywall.

## What changed

- **No blur on load → scroll-gated reveal.** A new `view-paywall.client.ts` reveals the blur once the reader has scrolled past **10% of the article** *and* public access has **expired**. It handles both orderings:
  - *scroll-then-expire*: a `setTimeout` armed at the deadline reveals the instant a counting page hits zero (no reload);
  - *expire-then-scroll*: the next scroll past 10% reveals it.
  - Once revealed it **latches** — the scroll listener detaches and the timer clears, so scrolling back up does not un-blur.
- **SSR always ships the paywall hidden** (`--inactive`, `data-paywall-active="false"`) carrying the deadline in a new `data-expires-at` attribute; the client owns the reveal. The render gate (`state !== "permanent" && crawl.status === "ready"`) and all test hooks are unchanged.
- **Centred, fixed popup.** `.view__paywall` is now `position: fixed; inset: 0` with the modal centred in the viewport (below the sticky CTA z10 / share row z11, which stay clickable). The fade ramps `transparent → --color-background` (45%) so the current reading line stays legible while content below blurs. The now-unused `.view__body { position: relative }` is removed.
- **`expiry-counter.client.ts` no longer reveals the paywall** (the scroll gate owns that); it keeps flipping the CTA copy to "Public access has expired." so the expired copy and the blur coexist.
- New bundle registered in `build-client-bundles.js` (`view-paywall.client.js`).

## Staging-only by construction

Prod sets `expiryCountdown: disabled` (`Pulumi.prod.yaml`) → `expiresAt` is `null` → `expiry.state === "permanent"` → the paywall element is never rendered. No Pulumi/infra change needed.

## Tests & verification

- New `view-paywall.client.test.ts` covers every branch (no element / missing / unparseable deadline / no article body → no-op; scroll < 10% → hidden; scrolled past but not expired → hidden; expired + scroll → reveal; both timer orderings; latch detaches the listener + clears the timer + stays revealed).
- Updated `view.component.test.ts`, `view.route.test.ts`, and `expiry-counter.client.test.ts` for the hidden-on-load paywall + `data-expires-at`.
- `pnpm nx run hutch:check` passes (lint, type-check, unit+integration, 100% coverage, unused-css, knip); `view-paywall.client.ts` is at 100% on all metrics with no `c8 ignore` comments.

https://claude.ai/code/session_01TG3EBnaiYAEHrd6T166g5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG3EBnaiYAEHrd6T166g5w)_