### PR TITLE
feat(hutch): show all UTM params on the analytics dashboard

### DIFF
--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -65,9 +65,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 17 widgets (6 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 18 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(17);
+		expect(body.widgets).toHaveLength(18);
 	});
 
 	it("the readers widget counts distinct user_ids from article_read events (not pageviews) — distinguishes opening the reader from explicitly marking-as-read", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -171,6 +171,22 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 			x: 12, y: 16, width: 12, height: 8,
 			view: "timeSeries",
 		}),
+		logWidget({
+			region,
+			title: "Pageviews — UTM detail (all params)",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields coalesce(utm_source, \"(none)\") as source, coalesce(utm_medium, \"(none)\") as medium, coalesce(utm_campaign, \"(none)\") as campaign, coalesce(utm_content, \"(none)\") as content",
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.pageview}"`,
+				...exclude,
+				"| filter ispresent(utm_source) or ispresent(utm_medium) or ispresent(utm_campaign) or ispresent(utm_content)",
+				"| stats count(*) as visits by source, medium, campaign, content",
+				"| sort visits desc",
+				"| limit 50",
+			].join(" "),
+			x: 0, y: 24, width: 24, height: 8,
+			view: "table",
+		}),
 	);
 
 	// --- Conversions ---
@@ -188,7 +204,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| sort unique_users desc",
 				"| limit 20",
 			].join(" "),
-			x: 0, y: 24, width: 12, height: 8,
+			x: 0, y: 32, width: 12, height: 8,
 			view: "pie",
 		}),
 		logWidget({
@@ -202,7 +218,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| sort unique_users desc",
 				"| limit 30",
 			].join(" "),
-			x: 12, y: 24, width: 12, height: 8,
+			x: 12, y: 32, width: 12, height: 8,
 			view: "table",
 		}),
 		logWidget({
@@ -215,7 +231,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| sort @timestamp desc",
 				"| limit 50",
 			].join(" "),
-			x: 0, y: 32, width: 24, height: 8,
+			x: 0, y: 40, width: 24, height: 8,
 			view: "table",
 		}),
 	);
@@ -224,7 +240,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 
 	widgets.push({
 		type: "metric",
-		x: 0, y: 40, width: 6, height: 4,
+		x: 0, y: 48, width: 6, height: 4,
 		properties: {
 			region,
 			title: "Imports completed (lifetime)",
@@ -257,7 +273,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| sort clicks desc",
 				"| limit 10",
 			].join(" "),
-			x: 6, y: 40, width: 12, height: 4,
+			x: 6, y: 48, width: 12, height: 4,
 			view: "pie",
 		}),
 		/** Stacked counts of acquire events vs import_committed surface
@@ -272,7 +288,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				`| filter event in ["${ANALYTICS_EVENTS.importUploaded}", "${ANALYTICS_EVENTS.importFromUrlAcquired}", "${ANALYTICS_EVENTS.importCommitted}"]`,
 				"| stats count(*) as imports by bin(1d), event",
 			].join(" "),
-			x: 0, y: 44, width: 24, height: 6,
+			x: 0, y: 52, width: 24, height: 6,
 			view: "timeSeries",
 		}),
 	);
@@ -290,7 +306,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				`| filter event in ["${SUBSCRIPTION_EVENTS.chargeSucceeded}", "${SUBSCRIPTION_EVENTS.chargeFailed}"]`,
 				"| stats count(*) as charges by bin(1d), event",
 			].join(" "),
-			x: 0, y: 50, width: 12, height: 8,
+			x: 0, y: 58, width: 12, height: 8,
 			view: "timeSeries",
 		}),
 		logWidget({
@@ -303,7 +319,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| stats count(*) as cancels by reason",
 				"| sort cancels desc",
 			].join(" "),
-			x: 12, y: 50, width: 12, height: 8,
+			x: 12, y: 58, width: 12, height: 8,
 			view: "pie",
 		}),
 		logWidget({
@@ -316,7 +332,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| sort @timestamp desc",
 				"| limit 50",
 			].join(" "),
-			x: 0, y: 58, width: 24, height: 8,
+			x: 0, y: 66, width: 24, height: 8,
 			view: "table",
 		}),
 	);
@@ -339,7 +355,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				...exclude,
 				"| stats count_distinct(visitor_id) as reader_tries by bin(1d)",
 			].join(" "),
-			x: 0, y: 66, width: 12, height: 8,
+			x: 0, y: 74, width: 12, height: 8,
 			view: "timeSeries",
 		}),
 		logWidget({
@@ -354,7 +370,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| stats count_distinct(visitor_id) as visitors by event",
 				"| sort visitors desc",
 			].join(" "),
-			x: 12, y: 66, width: 12, height: 8,
+			x: 12, y: 74, width: 12, height: 8,
 			view: "bar",
 		}),
 	);


### PR DESCRIPTION
## Problem

On the public reader (`/view`), the "Save to my queue" CTA stamps a time-left value into `utm_content` (e.g. `2d_5h_left`) and forwards any inbound `utm_*`. That click **is** recorded to CloudWatch — the analytics middleware logs all four UTM params on every full-page GET pageview ([`analytics.ts:187-190`](projects/hutch/src/runtime/web/middleware/analytics.ts)) — but it rarely surfaced in any dashboard widget.

The only pageview widget showing `utm_content` ("Pageviews by Source / Medium / Content (%)") had three defects:

1. `| filter ispresent(utm_source) and utm_source != ""` dropped any pageview that carries other UTMs but no `utm_source` — exactly the Save-CTA case (only `utm_content` present when the reader URL had no source).
2. It omitted `utm_campaign` entirely.
3. It folded source/medium/content into one `utm_path` pie slice, so high-cardinality `utm_content` (per-click time-left values) fragmented the pie.

## Change

Add a full-width **"Pageviews — UTM detail (all params)"** table to the Traffic + Audience block. It:

- Shows all four UTM params as columns, with absent ones rendered as `(none)` via `coalesce(...)`.
- Includes a record when **any** UTM param is present (`ispresent(utm_source) or ... or ispresent(utm_content)`), so source-less Save-CTA clicks and `utm_campaign`-only landings now appear. Pure-direct traffic (no UTM at all) stays excluded so the table isn't dominated by one all-`(none)` bucket.
- Aggregates by the `(source, medium, campaign, content)` tuple (`stats count(*) ... by ...`), so no matching pageview is dropped — only long-tail tuples beyond the top 50 are hidden.

The query reuses the existing widget's proven idiom (define coalesced columns in `fields ... as`, filter on the raw parsed fields, group by the derived columns) and the shared `STREAMS.analytics` / `ANALYTICS_EVENTS.pageview` constants, so the drift tests still pass.

The new widget occupies `y: 24` (full width, 24 cols); the 11 downstream widgets shift down 8 rows (cohesive-shift layout). No recording-side change is needed — the middleware already captures all four UTM params on every full-page GET pageview.

## Tests

- Updated the drift test: 17 → 18 widgets (6 → 7 traffic+audience).
- `pnpm nx run hutch:check` passes (lint, types, unit/integration tests, 100% function coverage, knip, unused-css). The overlap and 24-column-grid invariants still hold after the uniform shift.

## Follow-up (out of scope, not fixed here)

- The `view_save_intent` funnel event carries no `utm_content`, so the funnel widgets still won't show the time-left value — that needs the event payload + type extended.
- The "Pageviews by utm_source (%)" pie stays source-only by design; the new table is the all-UTM view.

## Verification still to do on staging

The CloudWatch Logs Insights query validity (inline `coalesce` in `fields`) and the end-to-end Save-CTA round-trip can only be confirmed against a deployed dashboard. If the dashboard validator rejects the inline `coalesce`-in-`fields`, the fallback is to move the `filter ispresent(...)` chain before the `fields coalesce` line.

https://claude.ai/code/session_019arT6tjuAuBnCvNfzQ4XNd

---
_Generated by [Claude Code](https://claude.ai/code/session_019arT6tjuAuBnCvNfzQ4XNd)_