### PR TITLE
docs: add Swift analogs to coding and testing conventions

### DIFF
--- a/.claude/skills/test-driven-design/SKILL.md
+++ b/.claude/skills/test-driven-design/SKILL.md
@@ -63,6 +63,8 @@ export function createApp(deps: AppDependencies) { ... }
 
 For real examples, see `projects/hutch/src/server.ts` which composes all dependencies at startup.
 
+**Swift:** inject the seam, don't swizzle — pass a stub via `URLSessionConfiguration.protocolClasses` (a `URLProtocol` subclass) and an ephemeral `UserDefaults(suiteName:)`, rather than method swizzling or global replacement.
+
 ### Partial Application for Domain Functions
 
 Domain functions with dependencies must use partial application. Use an `init*` prefix for the initialization function.
@@ -248,6 +250,8 @@ expect(subtitleText).not.toContain('–');
 // ✅ GOOD - Test the actual expected value
 expect(subtitleText).toBe('SYD to MEL');
 ```
+
+**Swift:** `XCTAssertNotNil(...)` and `XCTAssertFalse(x.contains(...))` are the XCTest analogs of `.not.toBeNull()` / `.not.toContain()`. Assert the exact value with `XCTAssertEqual` instead (e.g. assert a parsed `Date` equals a known instant, not merely that it is non-nil).
 
 ### Prefer Self-Contained Test Data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ const logger = HutchLogger.from(consoleLogger);
 logger.info("[recovery] Starting…");
 ```
 
+**Swift:** route logging through `os.Logger` (with a subsystem/category) and mark sensitive interpolations `privacy: .private`; raw `NSLog`/`print` is the equivalent of raw `console.log`. Never log credentials, tokens, or user PII (e.g. saved URLs / reading history).
+
 ### Comments Document Why, Not What
 
 Prefer code that explains its own why — a clearer name, an assert, a type, or a test (see the assert example at the end of this section) — over any comment. An approved comment explains **why**, never what.
@@ -163,6 +165,8 @@ Use [zod](https://zod.dev/) for validating external input at system boundaries (
 | `.parse()` | Invalid data indicates a bug |
 | `z.infer<>` | Derive TypeScript type from schema |
 
+**Swift:** the analog is `Codable`/`Decodable` decoded at the boundary with `JSONDecoder().decode` — return `nil`/throw on malformed input rather than force-decoding. Model evolving wire fields as optionals so one bad entity doesn't fail the whole decode.
+
 ### Prefer Wrappers Over Global Modifications
 
 When extending functionality (e.g., adding proxy support to fetch), create a wrapper module that exports a decorated version as the default export.
@@ -189,6 +193,8 @@ class ArticleService { ... }
 type SaveArticle = (article: Article) => Promise<void>;
 type FindArticleById = (id: ArticleId) => Promise<Article | undefined>;
 ```
+
+**Swift:** SwiftUI/UIKit platform vocabulary — `View`, `ViewModel`, `ViewController` (a `UIViewController` subclass is framework-mandated) — is an allowed exception. The rule still applies to discretionary domain types: prefer a domain name or free functions over `…Service`/`…Manager`/`…Factory`/`…Repository`.
 
 ### Named Parameters Over Positional When Types Repeat
 
@@ -239,6 +245,8 @@ function createWidget(deps: { logger: HutchLogger }) {
 const widget = createWidget({ logger: HutchLogger.from(noopLogger) });
 ```
 
+**Swift:** same rule — require the caller to pass the logger (e.g. `os.Logger`) rather than defaulting one internally; a silenced logger hides failures identically in any language.
+
 ### Use `assert` for Runtime Invariants
 
 Use `assert` from `node:assert` for runtime invariant checks instead of `if`/`throw`. Assert is more concise, communicates intent clearly, and integrates with coverage tooling (no uncovered branches for the truthy path).
@@ -260,6 +268,8 @@ assert.equal(actual, expected, "Values should match");
 
 Use `assert` from `node:assert` in production code (non-strict, allows falsy checking). Use `assert` from `node:assert/strict` in test code for strict equality semantics.
 
+**Swift:** use `assert` (debug-only) or `precondition` (also fatal in release) for invariants instead of ignoring an impossible-failure path; prefer `precondition` when the check must hold in shipped/sideloaded builds (e.g. the `SecRandomCopyBytes` status, a required `UserDefaults(suiteName:)`). `guard … else { throw }` remains correct for recoverable / external-input failures.
+
 ### No Default In-Memory Implementations
 
 Never default a dependency to an in-memory implementation in production code. All dependencies MUST be mandatory and the in-memory or production implementations are explicitly set at the entry point (composition root). In-memory implementations are for tests only.
@@ -276,6 +286,8 @@ function createWidget(deps: { store: Store }) {
 }
 ```
 
+**Swift:** inject the real store at the composition root; do not silently fall back to a degraded one (`UserDefaults(suiteName:) ?? .standard`, an internally-constructed `URLSession.shared`, or a `TokenStore()` newed up at the use site). An injectable `init(...)` seam is for tests only.
+
 ### Branded Types for Domain IDs
 
 Use branded types to prevent mixing up identifiers.
@@ -284,6 +296,8 @@ Use branded types to prevent mixing up identifiers.
 type ArticleId = string & { readonly __brand: 'ArticleId' };
 type UserId = string & { readonly __brand: 'UserId' };
 ```
+
+**Swift:** the analog is a single-field wrapper struct — `struct ArticleId: Hashable { let raw: String }` — instead of a raw `String`. Especially valuable for two same-typed fields that are easy to transpose (e.g. an access token vs a refresh token).
 
 ### Avoid TypeScript Type Assertions (`as`)
 
@@ -326,6 +340,8 @@ function createFakeResponse(): Partial<Response> {
 |-----------|--------|
 | `as const` | Not a type assertion — narrows literal types |
 | Isolated Node.js API wrappers (e.g., `promisify(scrypt)` returning `Buffer`, `requireEnv` generic) | The `as` is already contained in a single wrapper function with no better alternative from the type definitions |
+
+**Swift:** the analog of `as` is force-cast `as!`, force-try `try!`, force-unwrap `!`, and `fatalError` — all bypass the compiler. Use `guard let … else { throw }` / `as?` for anything from external input (user-typed URLs, network bodies). Allowed, mirroring `as const` / isolated-wrapper above: force-unwrapping a compile-time-constant literal, and Apple's implicitly-unwrapped delegate parameters (e.g. `WKNavigation!`), which are framework-defined, not your assertions.
 
 ## CLI Commands
 


### PR DESCRIPTION
## What

Records the Swift equivalents of the existing TypeScript coding-style and testing conventions, inline in the rules they map to. The iOS Readplace PoC (commit `f7056bc`) is written in Swift, but every convention in `CLAUDE.md` and the skills is phrased for the TS/web codebase — so a reviewer (human or agent) had no in-repo mapping from a TS rule to its Swift analog. These notes give future Swift work and Swift code review the same governance without maintaining a separate ruleset.

## Changes

Documentation only — no PoC Swift code is touched.

**`CLAUDE.md`** — 8 inline `**Swift:**` notes appended under:
- **Logging** — `os.Logger` with a subsystem/category; `privacy: .private`; `NSLog`/`print` ≈ raw `console.log`
- **Runtime Validation with Zod** — `Codable`/`Decodable` decoded at the boundary; optionals for evolving wire fields
- **No Design Pattern Names in Identifiers** — SwiftUI/UIKit vocabulary (`View`/`ViewModel`/`ViewController`) as the allowed exception
- **No Default Noop Logger in Production Code** — require the caller to pass the logger
- **Use `assert` for Runtime Invariants** — `assert`/`precondition` vs `guard … else { throw }`
- **No Default In-Memory Implementations** — inject the real store at the composition root
- **Branded Types for Domain IDs** — single-field wrapper struct
- **Avoid TypeScript Type Assertions (`as`)** — `as!`/`try!`/`!`/`fatalError`, with `as const`/isolated-wrapper analogs

**`.claude/skills/test-driven-design/SKILL.md`** — 2 inline `**Swift:**` notes appended under:
- **Dependency Injection Over Mocks** — `URLProtocol` + ephemeral `UserDefaults(suiteName:)`, not method swizzling
- **Avoid Negative Test Assertions** — XCTest analogs; assert the exact value

## Out of scope (deliberately)

- No coverage-exemption text added anywhere
- No `experiments/` entry in Project Structure / Runtime-vs-Infra
- No duplication into the skill's own copies of Naming / No-Default-In-Memory / Named-Parameters (CLAUDE.md stays the single source)

## Verification

`pnpm check` passes — all 25 projects, coverage thresholds met. Each note renders as a standalone paragraph before the next heading, and the nx-managed block is untouched.

https://claude.ai/code/session_01UvmVXnPxnBjWt1dLScWBLN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvmVXnPxnBjWt1dLScWBLN)_