### PR TITLE
docs(blog): add post on measuring the site without third-party trackers

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/no-third-party-trackers.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/no-third-party-trackers.md
@@ -49,5 +49,3 @@ Plenty of reading apps promise privacy on the marketing page, then load Google A
 You do not have to take my word for any of this. Open your browser's developer tools, load readplace.com, and read the network and cookie tabs. Count what loads. Count what gets set.
 
 Then start a queue and watch how little it costs you. Save your first article at [readplace.com](/).
-</content>
-</invoke>

--- a/projects/hutch/src/runtime/web/pages/blog/posts/no-third-party-trackers.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/no-third-party-trackers.md
@@ -1,0 +1,53 @@
+---
+title: "How Readplace Measures Its Site Without Third-Party Trackers"
+description: "Readplace runs no Google Analytics, no ad pixels, and no outside scripts. It measures traffic with a salted IP hash and one anonymous first-party cookie that stays on its own servers."
+slug: "no-third-party-trackers"
+date: "2026-06-04"
+author: "Fayner Brack"
+keywords: "privacy read it later, no third-party trackers, no Google Analytics, first-party analytics, anonymous cookie, Pocket alternative privacy, cookieless analytics, read it later privacy"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Readplace runs no third-party analytics. No Google Analytics, no ad pixels, no scripts from other companies. It measures traffic two ways. A salted one-way hash of your IP counts visitors in the server logs. One anonymous first-party cookie connects a first visit to a first saved article. Both stay on Readplace's own servers. A read-it-later app holds a private record of what you read, so the measurement matches that promise.
+
+</div>
+</details>
+
+Open the network tab on most apps and you find a crowd: Google Analytics, a few ad pixels, a session recorder, tag managers that load more tags. Each one ships a little of your behaviour to a company you did not pick.
+
+Open the network tab on Readplace and the list is short. The app loads its own code, and little else.
+
+A read-it-later app sees what you save. Your queue is a record of what you worry about, what you want to learn, and sometimes what you keep to yourself. That list deserves better than an ad network.
+
+I still want to know simple things. Did a Hacker News post send a hundred readers or five? Do people who try the public reader come back and save an article? Plain questions about whether the product works. Two small tools answer them, and both stay on my own servers.
+
+## The IP hash counts visitors
+
+The first tool is a salted hash. Take a visitor's IP address, mix in a secret that lives only on the server, run it through SHA-256, and keep sixteen characters. The same IP makes the same short string, so I can tell a hundred real readers from three people hitting refresh.
+
+The hash runs one way. The logs cannot turn back into an IP, and the secret stays on the server. It counts visits, and it forgets who you are.
+
+## One cookie links a first visit to a first save
+
+The hash has a limit. It cannot follow a single visit from the homepage to the moment someone saves their first article. People share office Wi-Fi and switch from phone to laptop, so the hash blurs those steps.
+
+So I added one cookie. It holds a random id and nothing else, with no name or email attached, and no link to your account until you sign in. It sets on your device, it reports back only to Readplace, and it shows me the path from first visit to first save.
+
+That cookie is first-party. It does not ride along to other sites. It does not feed an ad profile. It answers one question: does the front door lead to a saved article?
+
+## The short list I hold
+
+Here is the full list of what loads in your browser on a Readplace page: the app's own code, one session cookie to keep you logged in, and one anonymous cookie to measure the funnel. That is the whole list. The privacy policy says the same thing in plain words, updated on 3 June 2026.
+
+Plenty of reading apps promise privacy on the marketing page, then load Google Analytics on that same page. The promise and the code disagree. I would rather the code match the promise.
+
+## Check it yourself
+
+You do not have to take my word for any of this. Open your browser's developer tools, load readplace.com, and read the network and cookie tabs. Count what loads. Count what gets set.
+
+Then start a queue and watch how little it costs you. Save your first article at [readplace.com](/).
+</content>
+</invoke>


### PR DESCRIPTION
## What

New blog post: **"How Readplace Measures Its Site Without Third-Party Trackers"** (`/blog/no-third-party-trackers`).

## Why this topic

I reviewed the commits that landed on `main` after the last published post (`mark-articles-read-undo-in-one-tap`, dated 2026-06-02). Two commits qualified:

1. **`f7056bc` — iOS read-it-later POC.** Explicitly a throwaway, dev-only proof of concept: not in the nx/pnpm build, no CI, sideload-only with a 7-day signature. Announcing it as a shipped feature would over-promise to customers, so it is not a publishable topic.
2. **`d3bd993` — `/view` funnel instrumentation + a stable first-party visitor id + privacy-policy update.** This carries a genuine, honest, conversion-relevant angle for Readplace's privacy-minded audience (people leaving Pocket/Instapaper/Omnivore): no Google Analytics, no ad pixels, no third-party scripts. It also builds on the existing `analytics-without-a-vendor` post and the public privacy policy update.

The post explains the privacy-first measurement model in plain language: a salted one-way IP hash for visitor counts, plus one anonymous first-party cookie that links a first visit to a first save, all on Readplace's own servers. It leads with the customer benefit, demonstrates a values/competitive difference, and ends with a check-it-yourself CTA.

## Notes

- Body is ~570 words (within the 400–800 target); sentences average 10–20 words, active voice.
- No pricing or founding-member references (those go stale).
- `slug` matches the filename per the discovery invariant; frontmatter matches the existing schema.

## Verification

- Compiled hutch and ran the blog test suites: `blog.posts.test.js` + `blog.route.test.js`, **40 tests passed**. The post is discovered, parsed, and renders at `/blog/no-third-party-trackers`.

https://claude.ai/code/session_01V4ttqY6hPu968pF9xLp69Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4ttqY6hPu968pF9xLp69Q)_