### PR TITLE
docs(blog): add post on reading any article in a clean reader

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/read-any-article-clean-reader.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/read-any-article-clean-reader.md
@@ -1,0 +1,45 @@
+---
+title: "Read Any Article in a Clean Reader, No Account Needed"
+description: "Paste any link at readplace.com/view and the article opens in a clean reader with a short summary, no signup. Share the link, and anyone reads it the same way. One button saves it to your own queue."
+slug: "read-any-article-clean-reader"
+date: "2026-06-05"
+author: "Fayner Brack"
+keywords: "reader view, read any article, distraction-free reader, clean reader link, share article, read without an account, read it later, markdown article, no login reader, readplace"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+You can read any article in Readplace without an account. Paste a link at readplace.com/view and the page opens in a clean reader, clutter stripped out, with a short summary on top. Share that link with anyone and they read it the same way, no signup. One button saves the article to your own queue. Readplace can hand back the same article as plain markdown too, which helps notes apps and AI assistants read it cleanly.
+
+</div>
+</details>
+
+Most articles you want to read come wrapped in noise. Popups, cookie banners, autoplay video, and three newsletter prompts before the first paragraph. You came for 800 words and got a fight.
+
+Readplace has a page that skips all of that. Go to [readplace.com/view](/view), paste a link, and the article opens in a clean reader. Just the title, the text, the pictures, and a short summary at the top. You don't need an account to read it.
+
+## Read first, decide later
+
+Here is the part people miss. The reader works for anyone, signed in or not. So you can send a clean link to a friend, a coworker, or a group chat, and they open it with one tap. No login wall, no "create a free account to continue."
+
+That matters for sharing. You read something good and you want one person to read it too. A raw link drops them onto the original page with all its clutter. A Readplace reader link drops them straight into the words.
+
+## It loads right away, then fills in
+
+The first time anyone opens a link, Readplace saves a small record and starts reading the page in the background. The reader shows up at once with the basics. The full text, the summary, and the saved images appear as the work finishes, without a reload.
+
+So the page won't leave you staring at a spinner. You start reading, and the rest catches up.
+
+## One button to keep it
+
+Under every article sits a "Save to My Queue" button. Tap it and the article joins your reading list, summary and images included. The link you shared becomes the link that grows your own queue. That is the loop. Read a clean copy, then save the ones worth keeping.
+
+## A clean copy for your tools
+
+There is a quiet bonus for people who build things. Ask Readplace for an article as markdown, and it hands back the same clean text with a title and a short header. Paste it into notes, or feed it to an AI assistant. The reader strips the ads and scripts first, so what your tool reads is the article, not the page around it.
+
+## Try it
+
+Find an article you keep meaning to read. Copy the link, open [readplace.com/view](/view), and paste it. Read it clean, then save it if it earns a spot. Start at [readplace.com](/).


### PR DESCRIPTION
## What

New blog post: **"Read Any Article in a Clean Reader, No Account Needed"** (`read-any-article-clean-reader.md`).

It covers the public `/view` reader, the live, top-of-funnel feature the recent commits have been instrumenting:

- Paste any link at `readplace.com/view` and read it distraction-free, no account.
- Share that clean reader link, and anyone opens it without signing up.
- The page renders immediately and fills in the full text, summary, and saved images as the crawl finishes.
- A "Save to My Queue" button turns a shared read into a saved article.
- Notes the markdown copy of an article (content negotiation) for notes apps and AI assistants (GEO angle).

## Why this topic

I reviewed commits to `main` after the last published post (`no-third-party-trackers`, dated 2026-06-04). The substantive recent work all targets this funnel:

- `d3bd993` — instrument the `/view` funnel and add a stable visitor id to conversions
- `d2cebe5` — public-reader expiry message (staging only)

The public `/view` reader is live in production and had no blog post. It is the strongest SEO/conversion topic for acquiring readers who then convert to saves.

## Deliberate omissions

- The 3-day public-access expiry / "Public access expired" paywall is **staging only** (`hutch:expiryCountdown: disabled` in `Pulumi.prod.yaml`), so the post does not mention it.
- No pricing or founding-member references (they go stale).

## Verification

- `pnpm nx run hutch:check` passes (lint, types, tests, coverage, knip). The blog discovery module picks up the post and the slug matches the filename.
- Follows the existing post format (frontmatter schema, TL;DR block, CTA) and the requested writing guidelines.

https://claude.ai/code/session_015FBo2in2N4N9vcgXsZ74sm

---
_Generated by [Claude Code](https://claude.ai/code/session_015FBo2in2N4N9vcgXsZ74sm)_