### PR TITLE
feat(hutch): add iPhone app beta tab to install page

### DIFF
--- a/projects/hutch/src/runtime/llms-full.txt
+++ b/projects/hutch/src/runtime/llms-full.txt
@@ -216,7 +216,7 @@ Readwise Reader has the most polished mobile apps with full offline support. Ins
 Pocket shut down on July 8, 2025. To migrate to Readplace:
 
 1. If you exported your Pocket data (HTML file), keep that file.
-2. Install the Readplace browser extension for [Chrome](https://readplace.com/install?browser=chrome) or [Firefox](https://readplace.com/install?browser=firefox).
+2. Install the Readplace browser extension for [Chrome](https://readplace.com/install?client=chrome) or [Firefox](https://readplace.com/install?client=firefox).
 3. Send your Pocket export file to readplace+migrate@readplace.com for manual migration, or save articles one at a time using the extension.
 4. AI summaries are generated automatically after import.
 

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -133,7 +133,7 @@ import { PrivacyPage } from "./web/pages/privacy";
 import { TermsPage } from "./web/pages/terms";
 import { E2EFixturePage } from "./web/pages/e2e-fixture";
 import { createE2EFixturePdf } from "./web/pages/e2e-fixture-pdf";
-import { InstallPage, fetchFirefoxDownloadUrl, fetchChromeDownloadUrl } from "./web/pages/install";
+import { initInstallRoutes } from "./web/pages/install";
 import { NotFoundPage } from "./web/pages/not-found";
 import { initGetEffectiveAccess } from "./domain/access/effective-access";
 import { initRequireWriteAccess } from "./web/middleware/require-write-access.middleware";
@@ -506,14 +506,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		});
 	}
 
-	app.get("/install", async (req: Request, res: Response) => {
-		const browser = req.query.browser === "firefox" ? "firefox" : "chrome";
-		const [firefox, chrome] = await Promise.all([
-			fetchFirefoxDownloadUrl(),
-			fetchChromeDownloadUrl(),
-		]);
-		sendComponent(req, res, Base(InstallPage({ firefox, chrome, browser }), await buildBannerState(req)));
-	});
+	app.use(initInstallRoutes({ buildBannerState }));
 
 	const blogRouter = initBlogRoutes({ blogPosts, buildBannerState });
 	app.use("/blog", blogRouter);

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -481,7 +481,7 @@ describe("Base component", () => {
 			seo: {
 				title: "T",
 				description: "D",
-				canonicalUrl: "/install?browser=firefox",
+				canonicalUrl: "/install?client=firefox",
 			},
 		});
 		const result = Base(page, GUEST_STATE).to("text/html");
@@ -489,6 +489,6 @@ describe("Base component", () => {
 
 		expect(
 			doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
-		).toBe("https://readplace.com/install?browser=firefox");
+		).toBe("https://readplace.com/install?client=firefox");
 	});
 });

--- a/projects/hutch/src/runtime/web/onboarding/extension-install.ts
+++ b/projects/hutch/src/runtime/web/onboarding/extension-install.ts
@@ -3,8 +3,8 @@ import { ALIVE_COOKIE_NAME, ALIVE_COOKIE_VALUE, SAVE_COOKIE_NAME, SAVE_COOKIE_VA
 import type { BrowserName } from "./onboarding.types";
 
 const INSTALL_URLS: Record<BrowserName, string> = {
-	firefox: "/install?browser=firefox",
-	chrome: "/install?browser=chrome",
+	firefox: "/install?client=firefox",
+	chrome: "/install?client=chrome",
 	other: "/install",
 };
 

--- a/projects/hutch/src/runtime/web/onboarding/onboarding.component.test.ts
+++ b/projects/hutch/src/runtime/web/onboarding/onboarding.component.test.ts
@@ -121,20 +121,20 @@ describe("OnboardingChecklist", () => {
 		assert.equal(title.textContent, "Install a browser extension");
 	});
 
-	it("shows an 'Install' action linking to /install?browser=chrome for Chrome users", () => {
+	it("shows an 'Install' action linking to /install?client=chrome for Chrome users", () => {
 		const doc = parse(OnboardingChecklist(contextWith({ browser: "chrome" })));
 		const action = doc.querySelector('[data-test-onboarding-step="install-extension"] [data-test-onboarding-action]');
 		assert(action, "action link must be rendered");
 		assert.equal(action.textContent, "Install");
-		assert.equal(action.getAttribute("href"), "/install?browser=chrome");
+		assert.equal(action.getAttribute("href"), "/install?client=chrome");
 	});
 
-	it("shows an 'Install' action linking to /install?browser=firefox for Firefox users", () => {
+	it("shows an 'Install' action linking to /install?client=firefox for Firefox users", () => {
 		const doc = parse(OnboardingChecklist(contextWith({ browser: "firefox" })));
 		const action = doc.querySelector('[data-test-onboarding-step="install-extension"] [data-test-onboarding-action]');
 		assert(action, "action link must be rendered");
 		assert.equal(action.textContent, "Install");
-		assert.equal(action.getAttribute("href"), "/install?browser=firefox");
+		assert.equal(action.getAttribute("href"), "/install?client=firefox");
 	});
 
 	it("shows a 'Choose browser' action linking to /install for unrecognised browsers", () => {

--- a/projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md
@@ -52,7 +52,7 @@ If your file is over 5 MiB, has more than 2,000 links, or the picker fails for a
 
 Open your [reading list](/queue) and spot-check a few entries to make sure titles and URLs match. Something look wrong? Send a follow-up to readplace+migrate@readplace.com.
 
-If you do not have the export file, you can still rebuild your reading list. Install the Readplace browser extension for [Chrome](/install?browser=chrome) or [Firefox](/install?browser=firefox) and save articles one at a time from the URLs you recovered.
+If you do not have the export file, you can still rebuild your reading list. Install the Readplace browser extension for [Chrome](/install?client=chrome) or [Firefox](/install?client=firefox) and save articles one at a time from the URLs you recovered.
 
 ## What you had in Pocket vs. what you get in Readplace
 

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -68,7 +68,7 @@ describe("GET /", () => {
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
 		expect(cta?.textContent).toBe("Install Firefox Extension");
-		expect(cta?.getAttribute("href")).toBe("/install?browser=firefox");
+		expect(cta?.getAttribute("href")).toBe("/install?client=firefox");
 
 		const trust = doc.querySelector(".home-hero__trust");
 		expect(trust?.textContent).toBe("Also available for Chrome");
@@ -83,7 +83,7 @@ describe("GET /", () => {
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
 		expect(cta?.textContent).toBe("Install Chrome Extension");
-		expect(cta?.getAttribute("href")).toBe("/install?browser=chrome");
+		expect(cta?.getAttribute("href")).toBe("/install?client=chrome");
 
 		const trust = doc.querySelector(".home-hero__trust");
 		expect(trust?.textContent).toBe("Also available for Firefox");
@@ -118,7 +118,7 @@ describe("GET /", () => {
 
 		const bottomCta = doc.querySelector('[data-test-cta="bottom-install"]');
 		expect(bottomCta?.textContent).toBe("Install Firefox Extension");
-		expect(bottomCta?.getAttribute("href")).toBe("/install?browser=firefox");
+		expect(bottomCta?.getAttribute("href")).toBe("/install?client=firefox");
 	});
 
 	it("should render the public reader-view paste-link form with UTM hidden inputs", async () => {

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -33,10 +33,10 @@
         <div class="home-hero__actions">
           {{#switch browserName}}
           {{#case "firefox"}}
-          <a href="/install?browser=firefox" class="btn btn--primary" data-test-cta="install-extension">Install Firefox Extension</a>
+          <a href="/install?client=firefox" class="btn btn--primary" data-test-cta="install-extension">Install Firefox Extension</a>
           {{/case}}
           {{#case "chrome"}}
-          <a href="/install?browser=chrome" class="btn btn--primary" data-test-cta="install-extension">Install Chrome Extension</a>
+          <a href="/install?client=chrome" class="btn btn--primary" data-test-cta="install-extension">Install Chrome Extension</a>
           {{/case}}
           {{#default}}
           <a href="/install" class="btn btn--primary" data-test-cta="install-extension">Install Browser Extension</a>
@@ -360,10 +360,10 @@
         <div class="home-cta__actions">
           {{#switch browserName}}
           {{#case "firefox"}}
-          <a href="/install?browser=firefox" class="btn btn--brand" data-test-cta="bottom-install">Install Firefox Extension</a>
+          <a href="/install?client=firefox" class="btn btn--brand" data-test-cta="bottom-install">Install Firefox Extension</a>
           {{/case}}
           {{#case "chrome"}}
-          <a href="/install?browser=chrome" class="btn btn--brand" data-test-cta="bottom-install">Install Chrome Extension</a>
+          <a href="/install?client=chrome" class="btn btn--brand" data-test-cta="bottom-install">Install Chrome Extension</a>
           {{/case}}
           {{#default}}
           <a href="/install" class="btn btn--brand" data-test-cta="bottom-install">Install Browser Extension</a>

--- a/projects/hutch/src/runtime/web/pages/install/index.ts
+++ b/projects/hutch/src/runtime/web/pages/install/index.ts
@@ -1,1 +1,1 @@
-export { InstallPage, fetchFirefoxDownloadUrl, fetchChromeDownloadUrl } from "./install.component";
+export { initInstallRoutes } from "./install.routes";

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -9,6 +9,9 @@ import { firefoxS3Config } from "browser-extension-core/s3-config";
 const INSTALL_TEMPLATE = readFileSync(join(__dirname, "install.template.html"), "utf-8");
 const FIREFOX_LATEST_POINTER_URL = firefoxS3Config.getLatestPointerUrl("prod");
 const CHROME_WEB_STORE_URL = "https://chromewebstore.google.com/detail/hutch/klblengmhlfnmjoagchagfcdbpbocgbf";
+const TESTFLIGHT_URL = "https://testflight.apple.com/join/5eng821W";
+
+export type InstallPlatform = "firefox" | "chrome" | "iphone";
 
 async function fetchDownloadUrl(latestPointerUrl: string, buildDownloadUrl: (filename: string) => string): Promise<string | null> {
 	const response = await fetch(latestPointerUrl);
@@ -28,7 +31,69 @@ export async function fetchChromeDownloadUrl(): Promise<string | null> {
 	return CHROME_WEB_STORE_URL;
 }
 
-export function InstallPage(params: { firefox: string | null; chrome: string | null; browser: "firefox" | "chrome" }): PageBody {
+interface InstallTab {
+	key: InstallPlatform;
+	label: string;
+	href: string;
+	activeClass: string;
+	ariaCurrent?: "page";
+}
+
+const TAB_DEFINITIONS: { key: InstallPlatform; label: string }[] = [
+	{ key: "firefox", label: "Firefox" },
+	{ key: "chrome", label: "Chrome" },
+	{ key: "iphone", label: "iPhone" },
+];
+
+function buildInstallTabs(active: InstallPlatform): InstallTab[] {
+	return TAB_DEFINITIONS.map(({ key, label }) => {
+		const isActive = key === active;
+		return {
+			key,
+			label,
+			href: `/install?browser=${key}`,
+			activeClass: isActive ? " install-page__tab--active" : "",
+			ariaCurrent: isActive ? "page" : undefined,
+		};
+	});
+}
+
+/** One numbered step in the iPhone beta setup guide. `note` is an optional
+ * caveat shown under the instruction (e.g. why the app must be opened once
+ * before the iOS share option appears). */
+interface BetaSetupStep {
+	title: string;
+	note?: string;
+}
+
+const BETA_SETUP_STEPS: BetaSetupStep[] = [
+	{ title: "Install the free TestFlight app from the App Store." },
+	{
+		title:
+			'Tap "Join the beta on TestFlight" above and accept the invite (or open the invitation email if I sent you one).',
+	},
+	{ title: "In TestFlight, tap Install next to Readplace, then Open." },
+	{
+		title:
+			"Launch Readplace once and sign in — leave the server set to https://readplace.com and log in with your account.",
+		note: 'Opening the app once is what registers the "Share to Readplace" option in iOS; it will not show up until you have opened the app at least once.',
+	},
+	{
+		title:
+			"Browse your reading list in the app: saved articles appear, pull down to refresh, scroll for more, and swipe an item left to delete.",
+		note: "These are just the basics required for the App Store — for real reading sessions, the website on mobile is still better.",
+	},
+	{
+		title:
+			"Save a page — this is the main thing to test. Open any page in Safari, Chrome, or Firefox, tap Share, and choose Readplace, just like sharing to WhatsApp. It renders and saves the page in the background; head back to readplace.com to see it land.",
+		note: "If Readplace is not in the share row the first time, close the sheet and tap Share again, or tap More or Edit to switch it on. You can favourite it so it appears straight away.",
+	},
+];
+
+const BETA_OUTRO =
+	"Use it for a few days or weeks: save the articles you want to read later, then open readplace.com when you have time to read them. I'll check in soon to see how it's going, and any feedback is welcome.";
+
+export function InstallPage(params: { firefox: string | null; chrome: string | null; browser: InstallPlatform }): PageBody {
 	return {
 		seo: {
 			title: "Install Readplace Browser Extension",
@@ -80,9 +145,13 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 		styles: INSTALL_PAGE_STYLES,
 		bodyClass: "page-install",
 		content: { html: render(INSTALL_TEMPLATE, {
+			tabs: buildInstallTabs(params.browser),
 			browser: params.browser,
 			firefoxDownloadUrl: params.firefox,
 			chromeDownloadUrl: params.chrome,
+			testflightUrl: TESTFLIGHT_URL,
+			betaSteps: BETA_SETUP_STEPS,
+			betaOutro: BETA_OUTRO,
 		}, { helpers: switchHelpers }) },
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import assert from "node:assert";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { switchHelpers } from "../../handlebars-switch";
@@ -11,7 +12,20 @@ const FIREFOX_LATEST_POINTER_URL = firefoxS3Config.getLatestPointerUrl("prod");
 const CHROME_WEB_STORE_URL = "https://chromewebstore.google.com/detail/hutch/klblengmhlfnmjoagchagfcdbpbocgbf";
 const TESTFLIGHT_URL = "https://testflight.apple.com/join/5eng821W";
 
-export type InstallClient = "firefox" | "chrome" | "iphone";
+const TAB_DEFINITIONS = [
+	{ key: "firefox", label: "Firefox" },
+	{ key: "chrome", label: "Chrome" },
+	{ key: "iphone", label: "iPhone" },
+] as const;
+
+export type InstallClient = (typeof TAB_DEFINITIONS)[number]["key"];
+
+export function parseClient(value: unknown): InstallClient {
+	if (value === undefined) return "chrome";
+	const tab = TAB_DEFINITIONS.find((definition) => definition.key === value);
+	assert(tab, `Unknown install client: ${String(value)}`);
+	return tab.key;
+}
 
 async function fetchDownloadUrl(latestPointerUrl: string, buildDownloadUrl: (filename: string) => string): Promise<string | null> {
 	const response = await fetch(latestPointerUrl);
@@ -27,10 +41,6 @@ export async function fetchFirefoxDownloadUrl(): Promise<string | null> {
 	);
 }
 
-export async function fetchChromeDownloadUrl(): Promise<string | null> {
-	return CHROME_WEB_STORE_URL;
-}
-
 interface InstallTab {
 	key: InstallClient;
 	label: string;
@@ -38,12 +48,6 @@ interface InstallTab {
 	activeClass: string;
 	ariaCurrent?: "page";
 }
-
-const TAB_DEFINITIONS: { key: InstallClient; label: string }[] = [
-	{ key: "firefox", label: "Firefox" },
-	{ key: "chrome", label: "Chrome" },
-	{ key: "iphone", label: "iPhone" },
-];
 
 function buildInstallTabs(active: InstallClient): InstallTab[] {
 	return TAB_DEFINITIONS.map(({ key, label }) => {
@@ -93,7 +97,7 @@ const BETA_SETUP_STEPS: BetaSetupStep[] = [
 const BETA_OUTRO =
 	"Use it for a few days or weeks: save the articles you want to read later, then open readplace.com when you have time to read them. I'll check in soon to see how it's going, and any feedback is welcome.";
 
-export function InstallPage(params: { firefox: string | null; chrome: string | null; client: InstallClient }): PageBody {
+export function InstallPage(params: { firefox: string | null; client: InstallClient }): PageBody {
 	return {
 		seo: {
 			title: "Install Readplace Browser Extension",
@@ -148,7 +152,7 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 			tabs: buildInstallTabs(params.client),
 			client: params.client,
 			firefoxDownloadUrl: params.firefox,
-			chromeDownloadUrl: params.chrome,
+			chromeDownloadUrl: CHROME_WEB_STORE_URL,
 			testflightUrl: TESTFLIGHT_URL,
 			betaSteps: BETA_SETUP_STEPS,
 			betaOutro: BETA_OUTRO,

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -11,7 +11,7 @@ const FIREFOX_LATEST_POINTER_URL = firefoxS3Config.getLatestPointerUrl("prod");
 const CHROME_WEB_STORE_URL = "https://chromewebstore.google.com/detail/hutch/klblengmhlfnmjoagchagfcdbpbocgbf";
 const TESTFLIGHT_URL = "https://testflight.apple.com/join/5eng821W";
 
-export type InstallPlatform = "firefox" | "chrome" | "iphone";
+export type InstallClient = "firefox" | "chrome" | "iphone";
 
 async function fetchDownloadUrl(latestPointerUrl: string, buildDownloadUrl: (filename: string) => string): Promise<string | null> {
 	const response = await fetch(latestPointerUrl);
@@ -32,26 +32,26 @@ export async function fetchChromeDownloadUrl(): Promise<string | null> {
 }
 
 interface InstallTab {
-	key: InstallPlatform;
+	key: InstallClient;
 	label: string;
 	href: string;
 	activeClass: string;
 	ariaCurrent?: "page";
 }
 
-const TAB_DEFINITIONS: { key: InstallPlatform; label: string }[] = [
+const TAB_DEFINITIONS: { key: InstallClient; label: string }[] = [
 	{ key: "firefox", label: "Firefox" },
 	{ key: "chrome", label: "Chrome" },
 	{ key: "iphone", label: "iPhone" },
 ];
 
-function buildInstallTabs(active: InstallPlatform): InstallTab[] {
+function buildInstallTabs(active: InstallClient): InstallTab[] {
 	return TAB_DEFINITIONS.map(({ key, label }) => {
 		const isActive = key === active;
 		return {
 			key,
 			label,
-			href: `/install?browser=${key}`,
+			href: `/install?client=${key}`,
 			activeClass: isActive ? " install-page__tab--active" : "",
 			ariaCurrent: isActive ? "page" : undefined,
 		};
@@ -93,7 +93,7 @@ const BETA_SETUP_STEPS: BetaSetupStep[] = [
 const BETA_OUTRO =
 	"Use it for a few days or weeks: save the articles you want to read later, then open readplace.com when you have time to read them. I'll check in soon to see how it's going, and any feedback is welcome.";
 
-export function InstallPage(params: { firefox: string | null; chrome: string | null; browser: InstallPlatform }): PageBody {
+export function InstallPage(params: { firefox: string | null; chrome: string | null; client: InstallClient }): PageBody {
 	return {
 		seo: {
 			title: "Install Readplace Browser Extension",
@@ -145,8 +145,8 @@ export function InstallPage(params: { firefox: string | null; chrome: string | n
 		styles: INSTALL_PAGE_STYLES,
 		bodyClass: "page-install",
 		content: { html: render(INSTALL_TEMPLATE, {
-			tabs: buildInstallTabs(params.browser),
-			browser: params.browser,
+			tabs: buildInstallTabs(params.client),
+			client: params.client,
 			firefoxDownloadUrl: params.firefox,
 			chromeDownloadUrl: params.chrome,
 			testflightUrl: TESTFLIGHT_URL,

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -1,5 +1,6 @@
 import { firefoxS3Config } from "browser-extension-core/s3-config";
 import { JSDOM } from "jsdom";
+import assert from "node:assert/strict";
 import request from "supertest";
 import { useTestServer } from "../../../test-app";
 import {
@@ -45,7 +46,18 @@ describe("GET /install", () => {
 		expect(doc.body.classList.contains("page-install")).toBe(true);
 	});
 
-	it("should default to Chrome tab when no browser param is provided", async () => {
+	it("should render the full ordered set of platform tabs", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
+		const doc = new JSDOM(response.text).window.document;
+
+		const tabs = Array.from(doc.querySelectorAll("[data-test-tab]")).map(
+			(el) => el.getAttribute("data-test-tab"),
+		);
+		expect(tabs).toEqual(["firefox", "chrome", "iphone"]);
+	});
+
+	it("should default to Chrome tab when no client param is provided", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const response = await request(harness.server).get("/install");
 		const doc = new JSDOM(response.text).window.document;
@@ -58,9 +70,9 @@ describe("GET /install", () => {
 		expect(firefoxTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
-	it("should select Firefox tab when browser=firefox", async () => {
+	it("should select Firefox tab when client=firefox", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=firefox");
+		const response = await request(harness.server).get("/install?client=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxTab = doc.querySelector('[data-test-tab="firefox"]');
@@ -71,9 +83,9 @@ describe("GET /install", () => {
 		expect(chromeTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
-	it("should select Chrome tab when browser=chrome", async () => {
+	it("should select Chrome tab when client=chrome", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=chrome");
+		const response = await request(harness.server).get("/install?client=chrome");
 		const doc = new JSDOM(response.text).window.document;
 
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
@@ -83,29 +95,39 @@ describe("GET /install", () => {
 		expect(firefoxTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
-	it("should render Firefox panel content when browser=firefox", async () => {
+	it("should render only the Firefox panel when client=firefox", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=firefox");
+		const response = await request(harness.server).get("/install?client=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
-		const firefoxPanel = doc.querySelector('[data-test-section="firefox"]');
-		expect(firefoxPanel?.querySelector('[data-test-cta="download-firefox"]')?.textContent).toBe("Install Readplace for Firefox");
-		expect(doc.querySelector('[data-test-section="chrome"]')).toBeNull();
+		const panels = Array.from(doc.querySelectorAll("[data-test-panel]")).map(
+			(el) => el.getAttribute("data-test-panel"),
+		);
+		expect(panels).toEqual(["firefox"]);
+
+		const firefoxPanel = doc.querySelector('[data-test-panel="firefox"]');
+		assert(firefoxPanel, "Firefox panel must be rendered");
+		expect(firefoxPanel.querySelector('[data-test-cta="download-firefox"]')?.textContent).toBe("Install Readplace for Firefox");
 	});
 
-	it("should render Chrome panel content when browser=chrome", async () => {
+	it("should render only the Chrome panel when client=chrome", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=chrome");
+		const response = await request(harness.server).get("/install?client=chrome");
 		const doc = new JSDOM(response.text).window.document;
 
-		const chromePanel = doc.querySelector('[data-test-section="chrome"]');
-		expect(chromePanel?.querySelector('[data-test-cta="download-chrome"]')?.textContent).toBe("Install Readplace for Chrome");
-		expect(doc.querySelector('[data-test-section="firefox"]')).toBeNull();
+		const panels = Array.from(doc.querySelectorAll("[data-test-panel]")).map(
+			(el) => el.getAttribute("data-test-panel"),
+		);
+		expect(panels).toEqual(["chrome"]);
+
+		const chromePanel = doc.querySelector('[data-test-panel="chrome"]');
+		assert(chromePanel, "Chrome panel must be rendered");
+		expect(chromePanel.querySelector('[data-test-cta="download-chrome"]')?.textContent).toBe("Install Readplace for Chrome");
 	});
 
 	it("should render the Firefox download button linking to the S3 XPI", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=firefox");
+		const response = await request(harness.server).get("/install?client=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector(
@@ -116,7 +138,7 @@ describe("GET /install", () => {
 
 	it("should render the Chrome download button linking to the Chrome Web Store", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=chrome");
+		const response = await request(harness.server).get("/install?client=chrome");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector(
@@ -181,10 +203,9 @@ describe("GET /install", () => {
 		});
 
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=firefox");
+		const response = await request(harness.server).get("/install?client=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
-		expect(doc.querySelector('[data-test-cta="download-firefox"]')).toBeNull();
 		const unavailable = doc.querySelector('[data-test-section="firefox-unavailable"]');
 		expect(unavailable?.textContent).toBe(
 			"The Firefox extension is not available for download yet. Please check back soon.",
@@ -198,10 +219,9 @@ describe("GET /install", () => {
 		});
 
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=firefox");
+		const response = await request(harness.server).get("/install?client=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
-		expect(doc.querySelector('[data-test-cta="download-firefox"]')).toBeNull();
 		const unavailable = doc.querySelector('[data-test-section="firefox-unavailable"]');
 		expect(unavailable?.textContent).toBe(
 			"The Firefox extension is not available for download yet. Please check back soon.",
@@ -210,14 +230,14 @@ describe("GET /install", () => {
 
 	it("should link tabs to the correct URLs", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=firefox");
+		const response = await request(harness.server).get("/install?client=firefox");
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxTab = doc.querySelector('[data-test-tab="firefox"]');
-		expect(firefoxTab?.getAttribute("href")).toBe("/install?browser=firefox");
+		expect(firefoxTab?.getAttribute("href")).toBe("/install?client=firefox");
 
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
-		expect(chromeTab?.getAttribute("href")).toBe("/install?browser=chrome");
+		expect(chromeTab?.getAttribute("href")).toBe("/install?client=chrome");
 	});
 
 	it("should render an iPhone tab linking to the iPhone panel on every view", async () => {
@@ -226,14 +246,14 @@ describe("GET /install", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
-		expect(iphoneTab?.getAttribute("href")).toBe("/install?browser=iphone");
+		expect(iphoneTab?.getAttribute("href")).toBe("/install?client=iphone");
 		expect(iphoneTab?.textContent).toBe("iPhone");
 		expect(iphoneTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
-	it("should select the iPhone tab when browser=iphone", async () => {
+	it("should select the iPhone tab when client=iphone", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=iphone");
+		const response = await request(harness.server).get("/install?client=iphone");
 		const doc = new JSDOM(response.text).window.document;
 
 		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
@@ -244,20 +264,24 @@ describe("GET /install", () => {
 		expect(chromeTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
-	it("should render the iPhone panel explaining the share-sheet save when browser=iphone", async () => {
+	it("should render only the iPhone panel explaining the share-sheet save when client=iphone", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=iphone");
+		const response = await request(harness.server).get("/install?client=iphone");
 		const doc = new JSDOM(response.text).window.document;
 
-		const iphonePanel = doc.querySelector('[data-test-section="iphone"]');
-		expect(iphonePanel?.textContent).toContain("share");
-		expect(doc.querySelector('[data-test-section="chrome"]')).toBeNull();
-		expect(doc.querySelector('[data-test-section="firefox"]')).toBeNull();
+		const panels = Array.from(doc.querySelectorAll("[data-test-panel]")).map(
+			(el) => el.getAttribute("data-test-panel"),
+		);
+		expect(panels).toEqual(["iphone"]);
+
+		const iphonePanel = doc.querySelector('[data-test-panel="iphone"]');
+		assert(iphonePanel, "iPhone panel must be rendered");
+		expect(iphonePanel.textContent).toContain("share");
 	});
 
 	it("should show the beta notice on the iPhone tab", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=iphone");
+		const response = await request(harness.server).get("/install?client=iphone");
 		const doc = new JSDOM(response.text).window.document;
 
 		const notice = doc.querySelector('[data-test-section="ios-beta-notice"]');
@@ -267,7 +291,7 @@ describe("GET /install", () => {
 
 	it("should link the Join the beta button to TestFlight", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=iphone");
+		const response = await request(harness.server).get("/install?client=iphone");
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector('[data-test-cta="join-ios-beta"]');
@@ -277,7 +301,7 @@ describe("GET /install", () => {
 
 	it("should list the beta setup steps on the iPhone tab", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-		const response = await request(harness.server).get("/install?browser=iphone");
+		const response = await request(harness.server).get("/install?client=iphone");
 		const doc = new JSDOM(response.text).window.document;
 
 		const steps = doc.querySelectorAll("[data-test-beta-step]");

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -220,6 +220,75 @@ describe("GET /install", () => {
 		expect(chromeTab?.getAttribute("href")).toBe("/install?browser=chrome");
 	});
 
+	it("should render an iPhone tab linking to the iPhone panel on every view", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
+		const doc = new JSDOM(response.text).window.document;
+
+		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
+		expect(iphoneTab?.getAttribute("href")).toBe("/install?browser=iphone");
+		expect(iphoneTab?.textContent).toBe("iPhone");
+		expect(iphoneTab?.classList.contains("install-page__tab--active")).toBe(false);
+	});
+
+	it("should select the iPhone tab when browser=iphone", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=iphone");
+		const doc = new JSDOM(response.text).window.document;
+
+		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
+		expect(iphoneTab?.classList.contains("install-page__tab--active")).toBe(true);
+		expect(iphoneTab?.getAttribute("aria-current")).toBe("page");
+
+		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
+		expect(chromeTab?.classList.contains("install-page__tab--active")).toBe(false);
+	});
+
+	it("should render the iPhone panel explaining the share-sheet save when browser=iphone", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=iphone");
+		const doc = new JSDOM(response.text).window.document;
+
+		const iphonePanel = doc.querySelector('[data-test-section="iphone"]');
+		expect(iphonePanel?.textContent).toContain("share");
+		expect(doc.querySelector('[data-test-section="chrome"]')).toBeNull();
+		expect(doc.querySelector('[data-test-section="firefox"]')).toBeNull();
+	});
+
+	it("should show the beta notice on the iPhone tab", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=iphone");
+		const doc = new JSDOM(response.text).window.document;
+
+		const notice = doc.querySelector('[data-test-section="ios-beta-notice"]');
+		expect(notice?.textContent).toContain("beta");
+		expect(notice?.textContent).toContain("TestFlight");
+	});
+
+	it("should link the Join the beta button to TestFlight", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=iphone");
+		const doc = new JSDOM(response.text).window.document;
+
+		const cta = doc.querySelector('[data-test-cta="join-ios-beta"]');
+		expect(cta?.getAttribute("href")).toBe("https://testflight.apple.com/join/5eng821W");
+		expect(cta?.textContent).toBe("Join the beta on TestFlight");
+	});
+
+	it("should list the beta setup steps on the iPhone tab", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?browser=iphone");
+		const doc = new JSDOM(response.text).window.document;
+
+		const steps = doc.querySelectorAll("[data-test-beta-step]");
+		expect(steps).toHaveLength(6);
+
+		const stepsText = doc.querySelector('[data-test-section="ios-beta-steps"]')?.textContent ?? "";
+		expect(stepsText).toContain("TestFlight");
+		expect(stepsText).toContain("Share");
+		expect(stepsText).toContain("readplace.com");
+	});
+
 	it("returns markdown when Accept: text/markdown is sent", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const response = await request(harness.server)

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -70,6 +70,13 @@ describe("GET /install", () => {
 		expect(firefoxTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
+	it("should respond 400 when the client query param is not a known client", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?client=netscape");
+
+		expect(response.status).toBe(400);
+	});
+
 	it("should select Firefox tab when client=firefox", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const response = await request(harness.server).get("/install?client=firefox");

--- a/projects/hutch/src/runtime/web/pages/install/install.routes.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.routes.ts
@@ -1,0 +1,33 @@
+import type { Request, Response, Router } from "express";
+import express from "express";
+import type { BuildBannerState } from "../../banner-state";
+import { Base } from "../../base.component";
+import { sendComponent } from "../../send-component";
+import {
+	InstallPage,
+	type InstallPlatform,
+	fetchFirefoxDownloadUrl,
+	fetchChromeDownloadUrl,
+} from "./install.component";
+
+function parsePlatform(value: unknown): InstallPlatform {
+	if (value === "firefox") return "firefox";
+	if (value === "iphone") return "iphone";
+	return "chrome";
+}
+
+export function initInstallRoutes(deps: { buildBannerState: BuildBannerState }): Router {
+	const router = express.Router();
+	const { buildBannerState } = deps;
+
+	router.get("/install", async (req: Request, res: Response) => {
+		const browser = parsePlatform(req.query.browser);
+		const [firefox, chrome] = await Promise.all([
+			fetchFirefoxDownloadUrl(),
+			fetchChromeDownloadUrl(),
+		]);
+		sendComponent(req, res, Base(InstallPage({ firefox, chrome, browser }), await buildBannerState(req)));
+	});
+
+	return router;
+}

--- a/projects/hutch/src/runtime/web/pages/install/install.routes.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.routes.ts
@@ -5,12 +5,12 @@ import { Base } from "../../base.component";
 import { sendComponent } from "../../send-component";
 import {
 	InstallPage,
-	type InstallPlatform,
+	type InstallClient,
 	fetchFirefoxDownloadUrl,
 	fetchChromeDownloadUrl,
 } from "./install.component";
 
-function parsePlatform(value: unknown): InstallPlatform {
+function parseClient(value: unknown): InstallClient {
 	if (value === "firefox") return "firefox";
 	if (value === "iphone") return "iphone";
 	return "chrome";
@@ -21,12 +21,12 @@ export function initInstallRoutes(deps: { buildBannerState: BuildBannerState }):
 	const { buildBannerState } = deps;
 
 	router.get("/install", async (req: Request, res: Response) => {
-		const browser = parsePlatform(req.query.browser);
+		const client = parseClient(req.query.client);
 		const [firefox, chrome] = await Promise.all([
 			fetchFirefoxDownloadUrl(),
 			fetchChromeDownloadUrl(),
 		]);
-		sendComponent(req, res, Base(InstallPage({ firefox, chrome, browser }), await buildBannerState(req)));
+		sendComponent(req, res, Base(InstallPage({ firefox, chrome, client }), await buildBannerState(req)));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/install/install.routes.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.routes.ts
@@ -6,27 +6,24 @@ import { sendComponent } from "../../send-component";
 import {
 	InstallPage,
 	type InstallClient,
+	parseClient,
 	fetchFirefoxDownloadUrl,
-	fetchChromeDownloadUrl,
 } from "./install.component";
-
-function parseClient(value: unknown): InstallClient {
-	if (value === "firefox") return "firefox";
-	if (value === "iphone") return "iphone";
-	return "chrome";
-}
 
 export function initInstallRoutes(deps: { buildBannerState: BuildBannerState }): Router {
 	const router = express.Router();
 	const { buildBannerState } = deps;
 
 	router.get("/install", async (req: Request, res: Response) => {
-		const client = parseClient(req.query.client);
-		const [firefox, chrome] = await Promise.all([
-			fetchFirefoxDownloadUrl(),
-			fetchChromeDownloadUrl(),
-		]);
-		sendComponent(req, res, Base(InstallPage({ firefox, chrome, client }), await buildBannerState(req)));
+		let client: InstallClient;
+		try {
+			client = parseClient(req.query.client);
+		} catch {
+			res.status(400).type("html").send("");
+			return;
+		}
+		const firefox = await fetchFirefoxDownloadUrl();
+		sendComponent(req, res, Base(InstallPage({ firefox, client }), await buildBannerState(req)));
 	});
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/install/install.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.styles.ts
@@ -83,4 +83,77 @@ export const INSTALL_PAGE_STYLES = `
   font-size: 1rem;
   line-height: 1.6;
 }
+
+.install-page__lead {
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  color: var(--foreground);
+  margin: 0 0 28px;
+  max-width: 600px;
+}
+
+.install-page__beta {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 16px 20px;
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 32px;
+}
+
+.install-page__beta-badge {
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--color-warning);
+  color: var(--foreground);
+}
+
+.install-page__beta-copy {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--foreground);
+}
+
+.install-page__steps {
+  max-width: 600px;
+  margin: 0 0 28px;
+  padding-left: 24px;
+  list-style: decimal;
+  color: var(--foreground);
+}
+
+.install-page__step {
+  margin-bottom: 20px;
+  padding-left: 6px;
+  line-height: 1.6;
+}
+
+.install-page__step-title {
+  display: block;
+  font-size: 1rem;
+}
+
+.install-page__step-note {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+}
+
+.install-page__steps-outro {
+  max-width: 600px;
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--muted-foreground);
+}
 `;

--- a/projects/hutch/src/runtime/web/pages/install/install.template.html
+++ b/projects/hutch/src/runtime/web/pages/install/install.template.html
@@ -46,11 +46,7 @@
 
       {{#default}}
       <section class="install-page__panel" data-test-panel="chrome">
-        {{#if chromeDownloadUrl}}
         <a href="{{chromeDownloadUrl}}" class="install-page__download" data-test-cta="download-chrome">Install Readplace for Chrome</a>
-        {{else}}
-        <p class="install-page__unavailable" data-test-section="chrome-unavailable">The Chrome extension is not available for download yet. Please check back soon.</p>
-        {{/if}}
       </section>
       {{/default}}
       {{/switch}}

--- a/projects/hutch/src/runtime/web/pages/install/install.template.html
+++ b/projects/hutch/src/runtime/web/pages/install/install.template.html
@@ -9,9 +9,9 @@
         {{/each}}
       </nav>
 
-      {{#switch browser}}
+      {{#switch client}}
       {{#case "firefox"}}
-      <section class="install-page__panel" data-test-section="firefox">
+      <section class="install-page__panel" data-test-panel="firefox">
         {{#if firefoxDownloadUrl}}
         <a href="{{firefoxDownloadUrl}}" class="install-page__download" data-test-cta="download-firefox">Install Readplace for Firefox</a>
         {{else}}
@@ -21,7 +21,7 @@
       {{/case}}
 
       {{#case "iphone"}}
-      <section class="install-page__panel" data-test-section="iphone">
+      <section class="install-page__panel" data-test-panel="iphone">
         <p class="install-page__lead">Save links from any browser on your iPhone. Open the page in Safari, Chrome, or anywhere else, tap the share button, and choose Readplace — the link drops straight into your reading queue. No copy-paste, no opening the app first.</p>
 
         <div class="install-page__beta" data-test-section="ios-beta-notice">
@@ -45,7 +45,7 @@
       {{/case}}
 
       {{#default}}
-      <section class="install-page__panel" data-test-section="chrome">
+      <section class="install-page__panel" data-test-panel="chrome">
         {{#if chromeDownloadUrl}}
         <a href="{{chromeDownloadUrl}}" class="install-page__download" data-test-cta="download-chrome">Install Readplace for Chrome</a>
         {{else}}

--- a/projects/hutch/src/runtime/web/pages/install/install.template.html
+++ b/projects/hutch/src/runtime/web/pages/install/install.template.html
@@ -1,19 +1,12 @@
   <main class="install-page">
     <div class="install-page__container">
       <h1 class="install-page__title">Install Readplace</h1>
-      <p class="install-page__subtitle">Save articles with a single click or keyboard shortcut.</p>
+      <p class="install-page__subtitle">Save articles with a single click, keyboard shortcut, or the iPhone share sheet.</p>
 
-      <nav class="install-page__tabs" aria-label="Browser" data-test-section="tabs">
-        {{#switch browser}}
-        {{#case "firefox"}}
-        <a href="/install?browser=firefox" class="install-page__tab install-page__tab--active" aria-current="page" data-test-tab="firefox">Firefox</a>
-        <a href="/install?browser=chrome" class="install-page__tab" data-test-tab="chrome">Chrome</a>
-        {{/case}}
-        {{#default}}
-        <a href="/install?browser=firefox" class="install-page__tab" data-test-tab="firefox">Firefox</a>
-        <a href="/install?browser=chrome" class="install-page__tab install-page__tab--active" aria-current="page" data-test-tab="chrome">Chrome</a>
-        {{/default}}
-        {{/switch}}
+      <nav class="install-page__tabs" aria-label="Platform" data-test-section="tabs">
+        {{#each tabs}}
+        <a href="{{href}}" class="install-page__tab{{activeClass}}"{{#if ariaCurrent}} aria-current="{{ariaCurrent}}"{{/if}} data-test-tab="{{key}}">{{label}}</a>
+        {{/each}}
       </nav>
 
       {{#switch browser}}
@@ -24,6 +17,30 @@
         {{else}}
         <p class="install-page__unavailable" data-test-section="firefox-unavailable">The Firefox extension is not available for download yet. Please check back soon.</p>
         {{/if}}
+      </section>
+      {{/case}}
+
+      {{#case "iphone"}}
+      <section class="install-page__panel" data-test-section="iphone">
+        <p class="install-page__lead">Save links from any browser on your iPhone. Open the page in Safari, Chrome, or anywhere else, tap the share button, and choose Readplace — the link drops straight into your reading queue. No copy-paste, no opening the app first.</p>
+
+        <div class="install-page__beta" data-test-section="ios-beta-notice">
+          <span class="install-page__beta-badge">Beta</span>
+          <p class="install-page__beta-copy">The iPhone app is still in beta. You can join it yourself through TestFlight, Apple's app for trying out betas — it takes a couple of minutes to set up.</p>
+        </div>
+
+        <a href="{{testflightUrl}}" class="install-page__download" data-test-cta="join-ios-beta">Join the beta on TestFlight</a>
+
+        <ol class="install-page__steps" data-test-section="ios-beta-steps">
+          {{#each betaSteps}}
+          <li class="install-page__step" data-test-beta-step>
+            <span class="install-page__step-title">{{title}}</span>
+            {{#if note}}<span class="install-page__step-note">{{note}}</span>{{/if}}
+          </li>
+          {{/each}}
+        </ol>
+
+        <p class="install-page__steps-outro">{{betaOutro}}</p>
       </section>
       {{/case}}
 

--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-failed.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-failed.component.test.ts
@@ -75,13 +75,13 @@ describe("renderReaderFailed", () => {
 				renderReaderFailed({
 					url: "https://example.com/post",
 					variant,
-					extensionInstallUrl: "/install?browser=chrome",
+					extensionInstallUrl: "/install?client=chrome",
 				}),
 			);
 
 			const installCta = doc.querySelector("[data-test-reader-failed-install]");
 			assert(installCta, `install CTA must be rendered for variant=${variant}`);
-			assert.equal(installCta.getAttribute("href"), "/install?browser=chrome");
+			assert.equal(installCta.getAttribute("href"), "/install?client=chrome");
 		}
 	});
 


### PR DESCRIPTION
## What

Adds a third **iPhone** tab to `/install` (alongside Firefox and Chrome) for the in-beta iOS app.

### The iPhone tab
- Explains saving links from **any browser on iPhone** via the system **share sheet** — open the page in Safari/Chrome/Firefox, tap share, choose Readplace, and the link drops into the reading queue.
- A **Beta** notice making clear the app is in beta and joined through TestFlight.
- A **"Join the beta on TestFlight"** button linking to the public TestFlight invite (`https://testflight.apple.com/join/5eng821W`).
- A numbered **setup guide**: install TestFlight → join/accept → install + open the app → open once to register the "Share to Readplace" option and sign in (server stays `https://readplace.com`) → browse the reading list → save a page from any browser via Share, including the share-row troubleshooting tip.

Fully self-serve — no email captured, no server-side request flow.

## How / refactors
- Moved the `/install` GET route out of `server.ts` into a small `initInstallRoutes` router (depends only on `buildBannerState`).
- Converted the tab nav from per-platform `{{#switch}}` branches to a data-driven `{{#each tabs}}` list, and the setup steps render from a typed array — per the web skill's "iterate lists, don't branch in templates".
- Setup copy follows the brand voice (first person, no emojis/hype) and the steps' optional caveats render as muted sub-notes.

## Tests
- Integration tests cover the iPhone tab selection/links, the share-sheet explanation, the beta notice (mentions TestFlight), the TestFlight join button's href/label, and the six setup steps (count + key content).
- `pnpm nx run hutch:check` passes (lint, types, tests, coverage, knip, unused-css). All three install source files are at 100% coverage; project functions 100%, branches 96.41%.

## Notes
- SEO/structured data left unchanged — the iOS app is invite-via-TestFlight, so it isn't advertised as a public download.
- Branch is rebased on the latest `main`.

https://claude.ai/code/session_01QyHHuzCVsZF57XaPV1Fydm