### PR TITLE
feat(hutch): add agent-discovery endpoints (Link header, api-catalog, OAuth metadata)

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -126,7 +126,8 @@ import { Base } from "./web/base.component";
 import { initBuildBannerState } from "./web/banner-state";
 import { sendComponent } from "./web/send-component";
 import { wantsMarkdown, wantsSiren } from "./web/content-negotiation";
-import { contentSignalMiddleware } from "./web/content-signal.middleware";
+import { CONTENT_SIGNAL_VALUE, contentSignalMiddleware } from "./web/content-signal.middleware";
+import { linkHeaderMiddleware } from "./web/link-header.middleware";
 import { QuerystringFeatureToggle } from "./web/feature-toggle";
 import { HomePage } from "./web/pages/home";
 import { PrivacyPage } from "./web/pages/privacy";
@@ -282,6 +283,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	);
 
 	app.use(contentSignalMiddleware);
+	app.use(linkHeaderMiddleware);
 
 	app.use(async (req: Request, _res: Response, next: NextFunction) => {
 		const sessionId = req.cookies?.[SESSION_COOKIE_NAME];
@@ -321,6 +323,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		res.type("text/plain").send(
 			[
 				"User-agent: *",
+				`Content-Signal: ${CONTENT_SIGNAL_VALUE}`,
 				"Allow: /",
 				"Disallow: /queue",
 				"Disallow: /export",
@@ -398,6 +401,57 @@ export function createApp(dependencies: AppDependencies): Express {
 		res.type("application/xml").send(
 			`<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`,
 		);
+	});
+
+	app.get("/health", (_req: Request, res: Response) => {
+		res.json({ status: "ok" });
+	});
+
+	app.get("/.well-known/oauth-authorization-server", (_req: Request, res: Response) => {
+		res.json({
+			issuer: dependencies.baseUrl,
+			authorization_endpoint: `${dependencies.baseUrl}/oauth/authorize`,
+			token_endpoint: `${dependencies.baseUrl}/oauth/token`,
+			revocation_endpoint: `${dependencies.baseUrl}/oauth/revoke`,
+			response_types_supported: ["code"],
+			grant_types_supported: ["authorization_code", "refresh_token"],
+			token_endpoint_auth_methods_supported: ["none"],
+			code_challenge_methods_supported: ["S256"],
+		});
+	});
+
+	app.get("/.well-known/oauth-protected-resource", (_req: Request, res: Response) => {
+		res.json({
+			resource: dependencies.baseUrl,
+			authorization_servers: [dependencies.baseUrl],
+			bearer_methods_supported: ["header"],
+		});
+	});
+
+	app.get("/.well-known/api-catalog", (_req: Request, res: Response) => {
+		res
+			.set("Content-Type", 'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"')
+			.send(
+				JSON.stringify(
+					{
+						linkset: [
+							{
+								anchor: dependencies.baseUrl,
+								"service-doc": [{ href: `${dependencies.baseUrl}/llms-full.txt`, type: "text/plain" }],
+								"service-meta": [
+									{
+										href: `${dependencies.baseUrl}/.well-known/oauth-protected-resource`,
+										type: "application/json",
+									},
+								],
+								status: [{ href: `${dependencies.baseUrl}/health`, type: "application/json" }],
+							},
+						],
+					},
+					null,
+					2,
+				),
+			);
 	});
 
 	const extensionCors = cors({

--- a/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
@@ -57,7 +57,16 @@ describe("contentSignalMiddleware", () => {
 		expect(next).toHaveBeenCalled();
 	});
 
-	it.each(["/robots.txt", "/llms.txt", "/llms-full.txt", "/sitemap.xml", "/health"])(
+	it.each([
+		"/robots.txt",
+		"/llms.txt",
+		"/llms-full.txt",
+		"/sitemap.xml",
+		"/health",
+		"/.well-known/api-catalog",
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/oauth-protected-resource",
+	])(
 		"skips Content-Signal and Vary on non-page GET %s",
 		(path) => {
 			const { headers, varied, res } = createFakeRes();

--- a/projects/hutch/src/runtime/web/content-signal.middleware.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.ts
@@ -2,7 +2,16 @@ import type { NextFunction, Request, Response } from "express";
 
 export const CONTENT_SIGNAL_VALUE = "search=yes, ai-input=yes, ai-train=no";
 
-const NON_PAGE_PREFIXES = ["/robots.txt", "/llms.txt", "/llms-full.txt", "/sitemap.xml", "/health"];
+const NON_PAGE_PREFIXES = [
+	"/robots.txt",
+	"/llms.txt",
+	"/llms-full.txt",
+	"/sitemap.xml",
+	"/health",
+	"/.well-known/api-catalog",
+	"/.well-known/oauth-authorization-server",
+	"/.well-known/oauth-protected-resource",
+];
 
 export function contentSignalMiddleware(
 	req: Request,

--- a/projects/hutch/src/runtime/web/link-header.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/link-header.middleware.test.ts
@@ -1,0 +1,40 @@
+import type { NextFunction, Request, Response } from "express";
+import { API_CATALOG_LINK, linkHeaderMiddleware } from "./link-header.middleware";
+
+interface FakeRes {
+	headers: Record<string, string>;
+	res: Response;
+}
+
+function createFakeRes(): FakeRes {
+	const headers: Record<string, string> = {};
+	const res = {
+		set(name: string, value: string) {
+			headers[name] = value;
+			return res;
+		},
+	} as unknown as Response;
+	return { headers, res };
+}
+
+describe("linkHeaderMiddleware", () => {
+	it("advertises the api-catalog via a Link header on GET responses", () => {
+		const { headers, res } = createFakeRes();
+		const next = jest.fn() as unknown as NextFunction;
+
+		linkHeaderMiddleware({ method: "GET" } as Request, res, next);
+
+		expect(headers.Link).toBe(API_CATALOG_LINK);
+		expect(next).toHaveBeenCalled();
+	});
+
+	it("does not set a Link header on non-GET requests", () => {
+		const { headers, res } = createFakeRes();
+		const next = jest.fn() as unknown as NextFunction;
+
+		linkHeaderMiddleware({ method: "POST" } as Request, res, next);
+
+		expect(headers.Link).toBeUndefined();
+		expect(next).toHaveBeenCalled();
+	});
+});

--- a/projects/hutch/src/runtime/web/link-header.middleware.ts
+++ b/projects/hutch/src/runtime/web/link-header.middleware.ts
@@ -1,0 +1,11 @@
+import type { NextFunction, Request, Response } from "express";
+
+/** RFC 9727 §3 lets agents discover the API catalog from any resource via a Link header, so they need no prior knowledge of the well-known path. rel="api-catalog" is registered in the IANA Link Relations registry by RFC 9727. */
+export const API_CATALOG_LINK = '</.well-known/api-catalog>; rel="api-catalog"';
+
+export function linkHeaderMiddleware(req: Request, res: Response, next: NextFunction): void {
+	if (req.method === "GET") {
+		res.set("Link", API_CATALOG_LINK);
+	}
+	next();
+}

--- a/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
@@ -113,6 +113,12 @@ describe("GET /robots.txt", () => {
 		expect(response.text).toContain("Disallow: /queue");
 		expect(response.text).toContain("Sitemap:");
 	});
+
+	it("declares the same Content-Signal policy as the HTTP header", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/robots.txt");
+		expect(response.text).toContain("Content-Signal: search=yes, ai-input=yes, ai-train=no");
+	});
 });
 
 describe("GET /llms.txt", () => {
@@ -207,6 +213,76 @@ describe("GET /sitemap.xml", () => {
 			"http://localhost:3000/llms-full.txt",
 			...blogPostUrls,
 		]);
+	});
+});
+
+describe("GET / Link header (RFC 9727 api-catalog discovery)", () => {
+	it("advertises the api-catalog so agents can find the well-known entry point", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/");
+		expect(response.headers.link).toBe('</.well-known/api-catalog>; rel="api-catalog"');
+	});
+});
+
+describe("GET /health", () => {
+	it("returns an ok status as JSON", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/health");
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/application\/json/);
+		expect(response.body).toEqual({ status: "ok" });
+	});
+});
+
+describe("GET /.well-known/oauth-authorization-server", () => {
+	it("publishes RFC 8414 metadata for the OAuth 2.0 authorization server", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/.well-known/oauth-authorization-server");
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/application\/json/);
+		expect(response.body).toEqual({
+			issuer: "http://localhost:3000",
+			authorization_endpoint: "http://localhost:3000/oauth/authorize",
+			token_endpoint: "http://localhost:3000/oauth/token",
+			revocation_endpoint: "http://localhost:3000/oauth/revoke",
+			response_types_supported: ["code"],
+			grant_types_supported: ["authorization_code", "refresh_token"],
+			token_endpoint_auth_methods_supported: ["none"],
+			code_challenge_methods_supported: ["S256"],
+		});
+	});
+});
+
+describe("GET /.well-known/oauth-protected-resource", () => {
+	it("publishes RFC 9728 metadata pointing at the authorization server", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/.well-known/oauth-protected-resource");
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/application\/json/);
+		expect(response.body).toEqual({
+			resource: "http://localhost:3000",
+			authorization_servers: ["http://localhost:3000"],
+			bearer_methods_supported: ["header"],
+		});
+	});
+});
+
+describe("GET /.well-known/api-catalog", () => {
+	it("publishes an RFC 9727 linkset pointing at real, fetchable resources", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/.well-known/api-catalog");
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/application\/linkset\+json/);
+
+		const catalog = JSON.parse(response.text);
+		expect(catalog.linkset).toHaveLength(1);
+		const entry = catalog.linkset[0];
+		expect(entry.anchor).toBe("http://localhost:3000");
+		expect(entry["service-doc"][0].href).toBe("http://localhost:3000/llms-full.txt");
+		expect(entry["service-meta"][0].href).toBe(
+			"http://localhost:3000/.well-known/oauth-protected-resource",
+		);
+		expect(entry.status[0].href).toBe("http://localhost:3000/health");
 	});
 });
 


### PR DESCRIPTION
## What & why

Addresses the "agent readiness" audit by adding standards-based discovery metadata so AI agents can find Readplace's real entry points. Every endpoint reflects a capability the site **actually** has — nothing advertises a service that doesn't exist.

### Implemented

| Audit item | What was added | Spec |
|---|---|---|
| Link response headers | Site-wide middleware sets `Link: </.well-known/api-catalog>; rel="api-catalog"` on every page (incl. the homepage) | RFC 8288 / RFC 9727 §3 |
| API catalog | `GET /.well-known/api-catalog` → `application/linkset+json` linking to product docs (`/llms-full.txt`), the `/health` status endpoint, and the OAuth protected-resource metadata | RFC 9727 / RFC 9264 |
| OAuth/OIDC discovery | `GET /.well-known/oauth-authorization-server` describing the existing OAuth 2.0 server: `code`, `authorization_code` + `refresh_token`, PKCE `S256`, public clients (`none`) | RFC 8414 |
| OAuth protected resource | `GET /.well-known/oauth-protected-resource` for the Bearer-protected Siren API | RFC 9728 |
| Content Signals in robots.txt | `Content-Signal: search=yes, ai-input=yes, ai-train=no` added to `robots.txt`, reusing the same `CONTENT_SIGNAL_VALUE` constant as the existing HTTP header so they can't drift | contentsignals.org |
| (supporting) | `GET /health` JSON endpoint — already anticipated by the content-signal middleware; backs the catalog's `status` link | — |

The OAuth metadata is genuine: the site already runs `@node-oauth/express-oauth-server` at `/oauth/authorize`, `/oauth/token`, `/oauth/revoke` (used by the browser extensions), and the Siren queue API at `/queue` is protected by Bearer tokens.

### Deliberately NOT implemented (would advertise capabilities the site doesn't have)

- **MCP Server Card** — there is no MCP server; a card would point agents at a dead endpoint.
- **Agent Skills index** — the only skills in the repo are internal *developer* skills under `.claude/skills/` (git-commit, web, e2e-testing…), not public tools for interacting with Readplace.
- **WebMCP** — requires shipping client-side executable tools (`navigator.modelContext.provideContext()`); that's a new product surface, not discovery metadata.
- **auth.md** — assumes dynamic client registration (`register_uri`); this server uses statically-configured clients, so registration instructions would be misleading.
- **DNS-AID** — needs SVCB/HTTPS records + DNSSEC signing in the Route53/Pulumi infra; it's an Internet-Draft and an ops/registrar change that the app test suite can't verify.

Happy to follow up on any of these if you'd like them built for real (e.g. an actual MCP server or a WebMCP "save link" tool).

## Notes

- The three `/.well-known/*` metadata endpoints join `robots.txt`/`sitemap.xml` in the content-signal middleware's non-page exclusion list, so the page-oriented `Content-Signal` header isn't attached to machine-metadata responses.
- Discovery docs are built from `dependencies.baseUrl`, so they resolve correctly per environment.

## Verification

`pnpm nx run hutch:check` passes (lint, type-check, tests, 100% function coverage, knip). New tests cover the Link header on `/`, the robots.txt directive, `/health`, and all three well-known documents.

https://claude.ai/code/session_01Rp6bSmhYuqKHfmjS1c4TsG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp6bSmhYuqKHfmjS1c4TsG)_