### PR TITLE
feat(reader): add browser-native read-aloud for articles

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -113,6 +113,33 @@ const BUNDLES = [
 	{
 		entry: path.join(
 			PROJECT_ROOT,
+			"src/runtime/web/shared/article-body/article-tts.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "article-tts.client.js"),
+		globalName: "ArticleTts",
+		footer: [
+			// The article body lives inside the sandboxed reader iframe; read its
+			// same-origin contentDocument here so the module stays frame-agnostic.
+			// window.speechSynthesis is undefined on browsers without Web Speech,
+			// which the module surfaces as the unsupported state.
+			"ArticleTts.initArticleTts({",
+			"  document: window.document,",
+			"  synth: window.speechSynthesis,",
+			"  createUtterance: function (text) { return new window.SpeechSynthesisUtterance(text); },",
+			"  getArticleText: function () {",
+			"    var iframe = window.document.querySelector('iframe[data-reader-iframe]');",
+			"    if (!iframe || !iframe.contentDocument) return undefined;",
+			"    return ArticleTts.extractArticleText(iframe.contentDocument);",
+			"  },",
+			"  addSwapListener: function (listener) {",
+			"    window.document.body.addEventListener('htmx:afterSwap', listener);",
+			"  }",
+			"});",
+		].join("\n"),
+	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
 			"src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts",
 		),
 		outfile: path.join(OUT_DIR, "extension-suggestion-banner.client.js"),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
@@ -72,7 +72,7 @@ describe("Queue routes", () => {
 			expect(primary.getAttribute("href")).toBe("https://example.com/empty-page");
 		});
 
-		it("should render audio player when feature=audio query param is present", async () => {
+		it("should render the read-aloud control when feature=audio query param is present", async () => {
 			const articleHtml = `
 			<html><head><title>Audio Article</title></head>
 			<body><article>
@@ -126,11 +126,15 @@ describe("Queue routes", () => {
 			expect(
 				audioSlot.classList.contains("article-body__audio-slot--visible"),
 			).toBe(true);
-			const audioEl = doc.querySelector("[data-audio-element]");
-			assert(audioEl, "audio element must be rendered when audio enabled");
+			const ttsControl = doc.querySelector("[data-article-tts]");
+			assert(ttsControl, "text-to-speech control must be rendered when audio enabled");
+			assert(
+				ttsControl.querySelector("[data-tts-toggle]"),
+				"the control must expose a Listen toggle",
+			);
 		});
 
-		it("should not render audio player without feature=audio query param", async () => {
+		it("should not render the read-aloud control without feature=audio query param", async () => {
 			const articleHtml = `
 			<html><head><title>No Audio Article</title></head>
 			<body><article>

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -19,6 +19,7 @@ import { READER_STYLES } from "./reader.styles";
 const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "utf-8");
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
+const ARTICLE_TTS_SCRIPT = `<script src="/client-dist/article-tts.client.js" defer></script>`;
 
 /**
  * Both the initial SSR <title> and the OOB <title> swap emitted by reader
@@ -110,6 +111,10 @@ export function ReaderPage(
 		styles: READER_STYLES,
 		bodyClass: "page-reader",
 		content: { html: content },
-		scripts: SHARE_BALLOON_SCRIPT + PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT,
+		scripts:
+			SHARE_BALLOON_SCRIPT +
+			PROGRESS_BAR_SCRIPT +
+			READER_IFRAME_SCRIPT +
+			(options.audioEnabled ? ARTICLE_TTS_SCRIPT : ""),
 	};
 }

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
@@ -254,8 +254,12 @@ describe("renderArticleBody", () => {
 		expect(slot.classList.contains("article-body__audio-slot--visible")).toBe(
 			true,
 		);
-		const audio = slot.querySelector("[data-audio-element]");
-		assert(audio, "audio element must be rendered when audioEnabled");
+		const tts = slot.querySelector("[data-article-tts]");
+		assert(tts, "text-to-speech control must be rendered when audioEnabled");
+		assert(
+			tts.querySelector("[data-tts-toggle]"),
+			"the control must expose a Listen toggle",
+		);
 	});
 
 	it("marks the audio slot as hidden when audioEnabled is absent", () => {

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
@@ -3,15 +3,12 @@ import { join } from "node:path";
 import type { Minutes } from "@packages/domain/article";
 import type { ArticleCrawl } from "@packages/provider-contracts/article-crawl";
 import type { GeneratedSummary } from "@packages/provider-contracts/article-summary";
-import { requireEnv } from "../../../domain/require-env";
 import { render } from "../../render";
 import { renderArticleHeader } from "./article-header/article-header.component";
 import { renderProgressBar } from "./progress-bar.component";
 import type { ProgressTick } from "@packages/domain/article";
 import { renderReaderSlot } from "./reader-slot/reader-slot.component";
 import { renderSummarySlot } from "./summary-slot/summary-slot.component";
-
-const STATIC_BASE_URL = requireEnv("STATIC_BASE_URL");
 
 const ARTICLE_BODY_TEMPLATE = readFileSync(
 	join(__dirname, "article-body.template.html"),
@@ -93,7 +90,6 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		summarySlotHtml,
 		progressBarHtml,
 		audioEnabled: input.audioEnabled,
-		staticBaseUrl: STATIC_BASE_URL,
 		backLink: input.backLink,
 		bottomMarkReadAction: bottomMarkRead,
 	});

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -204,12 +204,74 @@
   display: none;
 }
 
-.article-body__audio-player {
-  padding: 0.75rem 0 1rem;
+.article-body__tts {
+  margin: 0 0 1.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
 }
 
-.article-body__audio-player audio {
-  width: 100%;
+.article-body__tts-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+}
+
+.article-body__tts-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-on-brand);
+  background: var(--color-brand);
+  border: 1px solid var(--color-brand);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.article-body__tts-btn:hover {
+  filter: brightness(1.05);
+}
+
+.article-body__tts-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.article-body__tts-btn--stop {
+  color: var(--color-text-secondary);
+  background: transparent;
+  border-color: var(--color-border);
+}
+
+.article-body__tts-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+.article-body__tts-select {
+  max-width: 12rem;
+  padding: 0.3rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  color: var(--color-text-primary);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
+.article-body__tts-status {
+  margin: 0.5rem 0 0;
+  min-height: 1rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
 }
 
 /**

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.template.html
@@ -1,8 +1,14 @@
     {{{headerHtml}}}
     {{{progressBarHtml}}}
     {{{summarySlotHtml}}}
-    {{#if audioEnabled}}<div class="article-body__audio-slot article-body__audio-slot--visible" data-test-audio-player><div class="article-body__audio-player">
-      <audio controls preload="metadata" src="{{staticBaseUrl}}/sample-audio.opus" data-audio-element></audio>
+    {{#if audioEnabled}}<div class="article-body__audio-slot article-body__audio-slot--visible" data-test-audio-player><div class="article-body__tts" data-article-tts hidden>
+      <div class="article-body__tts-bar">
+        <button type="button" class="article-body__tts-btn article-body__tts-btn--toggle" data-tts-toggle><span class="article-body__tts-btn-label" data-tts-toggle-label>Listen</span></button>
+        <button type="button" class="article-body__tts-btn article-body__tts-btn--stop" data-tts-stop>Stop</button>
+        <label class="article-body__tts-field"><span class="article-body__tts-field-label">Voice</span><select class="article-body__tts-select" data-tts-voice></select></label>
+        <label class="article-body__tts-field"><span class="article-body__tts-field-label">Speed</span><select class="article-body__tts-select" data-tts-rate><option value="0.75">0.75×</option><option value="1" selected>1×</option><option value="1.25">1.25×</option><option value="1.5">1.5×</option></select></label>
+      </div>
+      <p class="article-body__tts-status" data-tts-status role="status" aria-live="polite"></p>
     </div></div>{{else}}<div class="article-body__audio-slot article-body__audio-slot--hidden" data-test-audio-player></div>{{/if}}
     {{{readerSlotHtml}}}
     <div class="article-body__actions article-body__actions--bottom">

--- a/projects/hutch/src/runtime/web/shared/article-body/article-tts.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-tts.client.test.ts
@@ -1,0 +1,669 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	type SpeechSynthesisLike,
+	type TtsUtterance,
+	type TtsVoice,
+	extractArticleText,
+	formatVoiceLabel,
+	initArticleTts,
+	parseRate,
+	pickDefaultVoice,
+	scoreVoice,
+	splitIntoChunks,
+} from "./article-tts.client";
+
+const VOICE_SAMANTHA: TtsVoice = {
+	voiceURI: "samantha",
+	name: "Samantha",
+	lang: "en-US",
+	localService: true,
+	default: true,
+};
+const VOICE_GOOGLE: TtsVoice = {
+	voiceURI: "google-us",
+	name: "Google US English",
+	lang: "en-US",
+	localService: false,
+	default: false,
+};
+const VOICE_FRENCH: TtsVoice = {
+	voiceURI: "amelie",
+	name: "Amelie",
+	lang: "fr-FR",
+	localService: true,
+	default: false,
+};
+
+describe("splitIntoChunks", () => {
+	it("returns no chunks for empty or whitespace-only text", () => {
+		assert.deepEqual(splitIntoChunks(""), []);
+		assert.deepEqual(splitIntoChunks("   \n\t  "), []);
+	});
+
+	it("keeps short text as a single chunk and collapses whitespace", () => {
+		assert.deepEqual(splitIntoChunks("Hello   there\nworld."), [
+			"Hello there world.",
+		]);
+	});
+
+	it("splits long text into chunks no longer than maxChars at word boundaries", () => {
+		const text = "alpha bravo charlie delta echo foxtrot golf hotel india";
+		const chunks = splitIntoChunks(text, 20);
+		for (const chunk of chunks) {
+			assert.ok(chunk.length <= 20, `chunk "${chunk}" exceeds 20 chars`);
+		}
+		assert.equal(chunks.join(" "), text);
+		assert.ok(chunks.length > 1, "long text should produce multiple chunks");
+	});
+
+	it("emits a single oversized chunk for a word longer than maxChars", () => {
+		const longWord = "x".repeat(40);
+		assert.deepEqual(splitIntoChunks(longWord, 20), [longWord]);
+	});
+});
+
+describe("extractArticleText", () => {
+	it("separates block boundaries with a space so headings and paragraphs do not jam", () => {
+		const { document } = new JSDOM(
+			"<!doctype html><html><body><h1>Title</h1><p>One.</p>\n\n<p>Two.</p></body></html>",
+		).window;
+		assert.equal(extractArticleText(document), "Title One. Two.");
+	});
+
+	it("keeps words split across inline elements whole", () => {
+		const { document } = new JSDOM(
+			'<!doctype html><html><body><p>So<em>ft</em>ware is <a href="#">great</a>.</p></body></html>',
+		).window;
+		assert.equal(extractArticleText(document), "Software is great.");
+	});
+
+	it("separates list items so they are not spoken as one word", () => {
+		const { document } = new JSDOM(
+			"<!doctype html><html><body><ul><li>One</li><li>Two</li></ul></body></html>",
+		).window;
+		assert.equal(extractArticleText(document), "One Two");
+	});
+
+	it("skips style and script content captured inside the article body", () => {
+		const { document } = new JSDOM(
+			"<!doctype html><html><body><p>Visible.</p><style>.x{color:red}</style><script>var a=1;</script></body></html>",
+		).window;
+		assert.equal(extractArticleText(document), "Visible.");
+	});
+
+	it("returns an empty string for an empty body", () => {
+		const { document } = new JSDOM(
+			"<!doctype html><html><body></body></html>",
+		).window;
+		assert.equal(extractArticleText(document), "");
+	});
+});
+
+describe("scoreVoice", () => {
+	it("rewards a language-prefix match", () => {
+		assert.equal(scoreVoice(VOICE_SAMANTHA, "en-US"), 101);
+		assert.equal(scoreVoice(VOICE_FRENCH, "en-US"), 0);
+	});
+
+	it("rewards fidelity markers, network voices, and the browser default", () => {
+		assert.equal(scoreVoice(VOICE_GOOGLE, "en"), 115);
+		const edgeNatural: TtsVoice = {
+			voiceURI: "natural-de",
+			name: "Microsoft Katja Online (Natural)",
+			lang: "de-DE",
+			localService: false,
+			default: false,
+		};
+		assert.equal(scoreVoice(edgeNatural, "en"), 15);
+	});
+});
+
+describe("pickDefaultVoice", () => {
+	it("returns undefined for an empty list", () => {
+		assert.equal(pickDefaultVoice([], "en"), undefined);
+	});
+
+	it("picks the highest-scoring voice for the language", () => {
+		const picked = pickDefaultVoice(
+			[VOICE_SAMANTHA, VOICE_GOOGLE, VOICE_FRENCH],
+			"en-US",
+		);
+		assert.equal(picked, VOICE_GOOGLE);
+	});
+
+	it("keeps the first voice when a later one does not score higher", () => {
+		const picked = pickDefaultVoice([VOICE_SAMANTHA, VOICE_FRENCH], "en-US");
+		assert.equal(picked, VOICE_SAMANTHA);
+	});
+});
+
+describe("formatVoiceLabel", () => {
+	it("renders the name and language", () => {
+		assert.equal(formatVoiceLabel(VOICE_GOOGLE), "Google US English (en-US)");
+	});
+});
+
+describe("parseRate", () => {
+	it("parses a positive rate", () => {
+		assert.equal(parseRate("1.5"), 1.5);
+	});
+
+	it("falls back to 1 for unparseable, zero, or negative values", () => {
+		assert.equal(parseRate(""), 1);
+		assert.equal(parseRate("not-a-number"), 1);
+		assert.equal(parseRate("0"), 1);
+		assert.equal(parseRate("-2"), 1);
+	});
+});
+
+const SAMPLE_TEXT = "First sentence here. Second sentence follows.";
+
+function audioSlotHtml(): string {
+	return `<div data-article-tts hidden>
+		<div>
+			<button type="button" data-tts-toggle><span data-tts-toggle-label>Listen</span></button>
+			<button type="button" data-tts-stop>Stop</button>
+			<label><select data-tts-voice></select></label>
+			<label><select data-tts-rate>
+				<option value="0.75">0.75×</option>
+				<option value="1" selected>1×</option>
+				<option value="1.25">1.25×</option>
+				<option value="1.5">1.5×</option>
+			</select></label>
+		</div>
+		<p data-tts-status></p>
+	</div>`;
+}
+
+interface SynthHarness {
+	synth: SpeechSynthesisLike;
+	spoken: TtsUtterance[];
+	counts: { cancel: number; pause: number; resume: number };
+	lastUtterance(): TtsUtterance;
+	setVoices(voices: TtsVoice[]): void;
+	fireVoicesChanged(): void;
+}
+
+function makeSynth(initialVoices: TtsVoice[] = []): SynthHarness {
+	let voices = initialVoices;
+	const spoken: TtsUtterance[] = [];
+	const counts = { cancel: 0, pause: 0, resume: 0 };
+	const voicesChangedListeners: Array<() => void> = [];
+	const synth: SpeechSynthesisLike = {
+		speak(utterance) {
+			spoken.push(utterance);
+		},
+		cancel() {
+			counts.cancel += 1;
+		},
+		pause() {
+			counts.pause += 1;
+		},
+		resume() {
+			counts.resume += 1;
+		},
+		getVoices() {
+			return voices;
+		},
+		addEventListener(type, listener) {
+			if (type === "voiceschanged") voicesChangedListeners.push(listener);
+		},
+	};
+	return {
+		synth,
+		spoken,
+		counts,
+		lastUtterance: () => spoken[spoken.length - 1],
+		setVoices: (next) => {
+			voices = next;
+		},
+		fireVoicesChanged: () => {
+			for (const listener of voicesChangedListeners.slice()) listener();
+		},
+	};
+}
+
+function createUtterance(text: string): TtsUtterance {
+	return { text, voice: null, rate: 1, lang: "", onend: null, onerror: null };
+}
+
+interface SetupOptions {
+	html?: string;
+	voices?: TtsVoice[];
+	supported?: boolean;
+	articleText?: string | undefined;
+	lang?: string;
+}
+
+function setup(options: SetupOptions = {}) {
+	const dom = new JSDOM(
+		`<!doctype html><html><body>${options.html ?? audioSlotHtml()}</body></html>`,
+	);
+	const doc = dom.window.document;
+	if (options.lang !== undefined) {
+		doc.documentElement.setAttribute("lang", options.lang);
+	}
+	const synthHarness = makeSynth(options.voices ?? []);
+	const articleText = {
+		value: "articleText" in options ? options.articleText : SAMPLE_TEXT,
+	};
+	const swapListeners: Array<() => void> = [];
+	const controller = initArticleTts({
+		document: doc,
+		synth: options.supported === false ? undefined : synthHarness.synth,
+		createUtterance,
+		getArticleText: () => articleText.value,
+		addSwapListener: (listener) => swapListeners.push(listener),
+	});
+	return {
+		dom,
+		doc,
+		synthHarness,
+		controller,
+		articleText,
+		fireSwap: () => {
+			for (const listener of swapListeners.slice()) listener();
+		},
+	};
+}
+
+function el<E extends Element>(doc: Document, selector: string): E {
+	const found = doc.querySelector<E>(selector);
+	assert.ok(found, `expected ${selector} in fixture`);
+	return found;
+}
+
+function statusText(doc: Document): string | null {
+	return el<HTMLElement>(doc, "[data-tts-status]").textContent;
+}
+
+function toggleLabel(doc: Document): string | null {
+	return el<HTMLElement>(doc, "[data-tts-toggle-label]").textContent;
+}
+
+function clickToggle(doc: Document): void {
+	el<HTMLButtonElement>(doc, "[data-tts-toggle]").click();
+}
+
+function clickStop(doc: Document): void {
+	el<HTMLButtonElement>(doc, "[data-tts-stop]").click();
+}
+
+/** Build a fresh control owned by the same document, mimicking an htmx swap
+ * that replaces the reader chrome with a newly parsed copy. */
+function freshControl(doc: Document): Element {
+	const wrapper = doc.createElement("div");
+	wrapper.innerHTML = audioSlotHtml();
+	const control = wrapper.firstElementChild;
+	assert.ok(control, "audioSlotHtml must yield an element");
+	return control;
+}
+
+describe("initArticleTts", () => {
+	it("is a no-op when no [data-article-tts] control is present", () => {
+		const env = setup({ html: "<p>No control here</p>" });
+		assert.equal(env.synthHarness.spoken.length, 0);
+		env.controller.stop();
+	});
+
+	it("reveals the control and disables it when synthesis is unsupported", () => {
+		const env = setup({ supported: false });
+		const root = el<HTMLElement>(env.doc, "[data-article-tts]");
+		assert.equal(root.hidden, false);
+		assert.equal(statusText(env.doc), "This browser doesn't support read-aloud yet.");
+		assert.equal(el<HTMLButtonElement>(env.doc, "[data-tts-toggle]").disabled, true);
+		assert.equal(el<HTMLButtonElement>(env.doc, "[data-tts-stop]").disabled, true);
+		assert.equal(el<HTMLSelectElement>(env.doc, "[data-tts-voice]").disabled, true);
+		assert.equal(el<HTMLSelectElement>(env.doc, "[data-tts-rate]").disabled, true);
+		env.controller.stop();
+	});
+
+	it("reveals the control and lists available voices when supported", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA, VOICE_GOOGLE], lang: "en-US" });
+		const root = el<HTMLElement>(env.doc, "[data-article-tts]");
+		assert.equal(root.hidden, false);
+		assert.equal(toggleLabel(env.doc), "Listen");
+
+		const voiceSelect = el<HTMLSelectElement>(env.doc, "[data-tts-voice]");
+		const optionValues = Array.from(voiceSelect.options).map((o) => o.value);
+		assert.deepEqual(optionValues, ["samantha", "google-us"]);
+		const optionLabels = Array.from(voiceSelect.options).map((o) => o.textContent);
+		assert.deepEqual(optionLabels, [
+			"Samantha (en-US)",
+			"Google US English (en-US)",
+		]);
+		assert.equal(voiceSelect.value, "google-us");
+		env.controller.stop();
+	});
+
+	it("shows a loading placeholder when no voices are ready yet", () => {
+		const env = setup({ voices: [] });
+		const voiceSelect = el<HTMLSelectElement>(env.doc, "[data-tts-voice]");
+		assert.equal(voiceSelect.options.length, 1);
+		assert.equal(voiceSelect.options[0].textContent, "Loading voices…");
+		env.controller.stop();
+	});
+
+	it("repopulates voices when the browser fires voiceschanged", () => {
+		const env = setup({ voices: [] });
+		const voiceSelect = el<HTMLSelectElement>(env.doc, "[data-tts-voice]");
+		assert.equal(voiceSelect.options.length, 1);
+
+		env.synthHarness.setVoices([VOICE_SAMANTHA, VOICE_GOOGLE]);
+		env.synthHarness.fireVoicesChanged();
+
+		assert.deepEqual(
+			Array.from(voiceSelect.options).map((o) => o.value),
+			["samantha", "google-us"],
+		);
+		env.controller.stop();
+	});
+
+	it("keeps the reader's voice selection when voiceschanged rebuilds the list", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA, VOICE_GOOGLE], lang: "en-US" });
+		const voiceSelect = el<HTMLSelectElement>(env.doc, "[data-tts-voice]");
+		assert.equal(voiceSelect.value, "google-us"); // scored default
+		voiceSelect.value = "samantha"; // reader picks a different voice
+
+		env.synthHarness.fireVoicesChanged();
+
+		assert.equal(voiceSelect.value, "samantha");
+		env.controller.stop();
+	});
+
+	it("ignores voiceschanged when no control is bound", () => {
+		const env = setup({ html: "<p>No control</p>" });
+		assert.doesNotThrow(() => env.synthHarness.fireVoicesChanged());
+		env.controller.stop();
+	});
+
+	it("ignores voiceschanged after the controller is stopped", () => {
+		const env = setup({ voices: [] });
+		env.controller.stop();
+		env.synthHarness.setVoices([VOICE_SAMANTHA]);
+
+		env.synthHarness.fireVoicesChanged();
+
+		const voiceSelect = el<HTMLSelectElement>(env.doc, "[data-tts-voice]");
+		assert.equal(voiceSelect.options.length, 1);
+		assert.equal(voiceSelect.options[0].textContent, "Loading voices…");
+	});
+
+	it("starts read-aloud on the first toggle, speaking the first chunk with the selected voice", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA, VOICE_GOOGLE], lang: "en-US" });
+		clickToggle(env.doc);
+
+		assert.equal(env.synthHarness.spoken.length, 1);
+		const utterance = env.synthHarness.lastUtterance();
+		assert.equal(utterance.text, "First sentence here. Second sentence follows.");
+		assert.equal(utterance.voice, VOICE_GOOGLE);
+		assert.equal(utterance.lang, "en-US");
+		assert.equal(utterance.rate, 1);
+		assert.equal(toggleLabel(env.doc), "Pause");
+		assert.equal(statusText(env.doc), "Reading aloud with Google US English.");
+		env.controller.stop();
+	});
+
+	it("applies the selected playback speed to the utterance", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		el<HTMLSelectElement>(env.doc, "[data-tts-rate]").value = "1.5";
+		clickToggle(env.doc);
+		assert.equal(env.synthHarness.lastUtterance().rate, 1.5);
+		env.controller.stop();
+	});
+
+	it("speaks without a voice (null) when none are available", () => {
+		const env = setup({ voices: [] });
+		clickToggle(env.doc);
+		const utterance = env.synthHarness.lastUtterance();
+		assert.equal(utterance.voice, null);
+		assert.equal(utterance.lang, "");
+		assert.equal(statusText(env.doc), "Reading the article aloud.");
+		env.controller.stop();
+	});
+
+	it("shows a not-ready message and does not speak when the article text is missing", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA], articleText: undefined });
+		clickToggle(env.doc);
+		assert.equal(env.synthHarness.spoken.length, 0);
+		assert.equal(
+			statusText(env.doc),
+			"The article is still loading. Try Listen again in a moment.",
+		);
+		assert.equal(toggleLabel(env.doc), "Listen");
+		env.controller.stop();
+	});
+
+	it("treats whitespace-only article text as not ready", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA], articleText: "   \n  " });
+		clickToggle(env.doc);
+		assert.equal(env.synthHarness.spoken.length, 0);
+		assert.equal(
+			statusText(env.doc),
+			"The article is still loading. Try Listen again in a moment.",
+		);
+		env.controller.stop();
+	});
+
+	it("advances to the next chunk when an utterance ends, then settles back to idle", () => {
+		const env = setup({
+			voices: [VOICE_SAMANTHA],
+			articleText: `${"alpha ".repeat(60)}beta.`,
+		});
+		clickToggle(env.doc);
+		const spokenAfterStart = env.synthHarness.spoken.length;
+		assert.ok(spokenAfterStart >= 1, "first chunk should be spoken on start");
+
+		env.synthHarness.lastUtterance().onend?.();
+		assert.ok(
+			env.synthHarness.spoken.length > spokenAfterStart,
+			"ending a chunk should speak the next one",
+		);
+
+		// Drain the remaining chunks until onend reaches the natural finish.
+		for (let guard = 0; guard < 50; guard += 1) {
+			const before = env.synthHarness.spoken.length;
+			env.synthHarness.lastUtterance().onend?.();
+			if (env.synthHarness.spoken.length === before) break;
+		}
+		assert.equal(toggleLabel(env.doc), "Listen");
+		assert.equal(statusText(env.doc), "");
+		env.controller.stop();
+	});
+
+	it("pauses and resumes around the synthesis engine", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc); // play (start clears any global pause: resume #1)
+		clickToggle(env.doc); // pause
+		assert.equal(env.synthHarness.counts.pause, 1);
+		assert.equal(toggleLabel(env.doc), "Resume");
+		assert.equal(statusText(env.doc), "Paused.");
+
+		clickToggle(env.doc); // resume
+		assert.equal(env.synthHarness.counts.resume, 2);
+		assert.equal(toggleLabel(env.doc), "Pause");
+		assert.equal(statusText(env.doc), "Reading aloud with Samantha.");
+		env.controller.stop();
+	});
+
+	it("clears the engine's global pause when starting after a pause and stop", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc); // play
+		clickToggle(env.doc); // pause — the engine's global paused flag is now set
+		clickStop(env.doc); // cancel() does not clear the paused flag
+		const resumesBefore = env.synthHarness.counts.resume;
+		const spokenBefore = env.synthHarness.spoken.length;
+
+		clickToggle(env.doc); // listen again
+
+		assert.equal(env.synthHarness.counts.resume, resumesBefore + 1);
+		assert.ok(
+			env.synthHarness.spoken.length > spokenBefore,
+			"a fresh Listen after pause+stop must speak again",
+		);
+		assert.equal(toggleLabel(env.doc), "Pause");
+		env.controller.stop();
+	});
+
+	it("stops playback, cancelling synthesis and resetting the UI", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc); // play
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		clickStop(env.doc);
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore + 1);
+		assert.equal(toggleLabel(env.doc), "Listen");
+		assert.equal(statusText(env.doc), "");
+		env.controller.stop();
+	});
+
+	it("does not advance a chunk whose utterance ends after a stop", () => {
+		const env = setup({
+			voices: [VOICE_SAMANTHA],
+			articleText: `${"alpha ".repeat(60)}beta.`,
+		});
+		clickToggle(env.doc);
+		const stale = env.synthHarness.lastUtterance();
+		clickStop(env.doc);
+		const spokenAfterStop = env.synthHarness.spoken.length;
+		stale.onend?.();
+		assert.equal(env.synthHarness.spoken.length, spokenAfterStop);
+		env.controller.stop();
+	});
+
+	it("does not advance when an utterance ends while paused", () => {
+		const env = setup({
+			voices: [VOICE_SAMANTHA],
+			articleText: `${"alpha ".repeat(60)}beta.`,
+		});
+		clickToggle(env.doc); // play
+		clickToggle(env.doc); // pause
+		const current = env.synthHarness.lastUtterance();
+		const spokenBefore = env.synthHarness.spoken.length;
+		current.onend?.();
+		assert.equal(env.synthHarness.spoken.length, spokenBefore);
+		env.controller.stop();
+	});
+
+	it("surfaces an error and resets when an utterance errors", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc);
+		const utterance = env.synthHarness.lastUtterance();
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		utterance.onerror?.();
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore + 1);
+		assert.equal(toggleLabel(env.doc), "Listen");
+		assert.equal(statusText(env.doc), "Read-aloud stopped unexpectedly. Try again?");
+		env.controller.stop();
+	});
+
+	it("ignores an error from an utterance superseded by a stop", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc);
+		const utterance = env.synthHarness.lastUtterance();
+		clickStop(env.doc);
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		utterance.onerror?.();
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore);
+		assert.equal(statusText(env.doc), "");
+		env.controller.stop();
+	});
+
+	it("re-binds to a replacement control after an htmx swap, cancelling prior playback", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc); // playing on the original control
+
+		const root = el<HTMLElement>(env.doc, "[data-article-tts]");
+		const parent = root.parentElement;
+		assert.ok(parent);
+		parent.removeChild(root);
+		parent.appendChild(freshControl(env.doc));
+
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		env.fireSwap();
+		assert.equal(
+			env.synthHarness.counts.cancel,
+			cancelsBefore + 1,
+			"swap should cancel playback bound to the removed control",
+		);
+		// The fresh control is wired: a toggle starts playback again.
+		clickToggle(env.doc);
+		assert.equal(toggleLabel(env.doc), "Pause");
+		env.controller.stop();
+	});
+
+	it("tears down playback when the control disappears after a swap", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc);
+		const root = el<HTMLElement>(env.doc, "[data-article-tts]");
+		root.parentElement?.removeChild(root);
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		env.fireSwap();
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore + 1);
+		env.controller.stop();
+	});
+
+	it("does nothing on a swap that leaves the same control in place", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		env.fireSwap();
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore);
+		env.controller.stop();
+	});
+
+	it("re-reveals a replacement control in the unsupported state after a swap", () => {
+		const env = setup({ supported: false });
+		const root = el<HTMLElement>(env.doc, "[data-article-tts]");
+		const parent = root.parentElement;
+		assert.ok(parent);
+		parent.removeChild(root);
+		parent.appendChild(freshControl(env.doc));
+
+		env.fireSwap();
+		const freshRoot = el<HTMLElement>(env.doc, "[data-article-tts]");
+		assert.equal(freshRoot.hidden, false);
+		assert.equal(el<HTMLButtonElement>(env.doc, "[data-tts-toggle]").disabled, true);
+		env.controller.stop();
+	});
+
+	it("ignores utterance callbacks that fire after the controller is stopped", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc);
+		const inFlight = env.synthHarness.lastUtterance();
+		env.controller.stop();
+		const statusAfterStop = statusText(env.doc);
+		const cancelsAfterStop = env.synthHarness.counts.cancel;
+
+		inFlight.onerror?.();
+		inFlight.onend?.();
+
+		assert.equal(statusText(env.doc), statusAfterStop);
+		assert.equal(env.synthHarness.counts.cancel, cancelsAfterStop);
+	});
+
+	it("stops scanning and cancels synthesis when the controller is stopped", () => {
+		const env = setup({ voices: [VOICE_SAMANTHA] });
+		clickToggle(env.doc);
+		const cancelsBefore = env.synthHarness.counts.cancel;
+		env.controller.stop();
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore + 1);
+		// A later swap must not re-bind or speak.
+		env.fireSwap();
+		assert.equal(env.synthHarness.counts.cancel, cancelsBefore + 1);
+	});
+
+	it("stop() is a no-op for synthesis when unsupported", () => {
+		const env = setup({ supported: false });
+		assert.doesNotThrow(() => env.controller.stop());
+	});
+
+	it("throws a clear error when the control markup is missing a child", () => {
+		assert.throws(
+			() =>
+				setup({
+					html: '<div data-article-tts hidden><button data-tts-toggle></button></div>',
+				}),
+			/missing \[data-tts-toggle-label\]/,
+		);
+	});
+});

--- a/projects/hutch/src/runtime/web/shared/article-body/article-tts.client.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-tts.client.ts
@@ -1,0 +1,502 @@
+/**
+ * Browser-native read-aloud for the reader's article body.
+ *
+ * Uses the Web Speech API (window.speechSynthesis) — the standard, zero-cost
+ * engine every modern browser ships, with no network round-trip or AI service.
+ * The voice catalogue is browser- and OS-specific: Edge exposes the
+ * "… Online (Natural)" set, Safari the enhanced Siri voices, Chrome the
+ * "Google …" voices, Firefox the installed OS voices. The control reads
+ * whatever getVoices() reports and lets the reader pick, defaulting to the
+ * highest-fidelity match for the page language (see pickDefaultVoice).
+ *
+ * The article HTML lives inside the sandboxed reader <iframe>; the composition
+ * root (build-client-bundles.js footer) reads its same-origin contentDocument
+ * and hands the extracted text in via getArticleText, so this module never
+ * reaches across the frame boundary itself.
+ *
+ * Long articles are split into sentence-sized utterances because Chrome stops
+ * a single long utterance after ~15s and silently truncates text beyond ~32KB;
+ * speakCurrentChunk chains them via onend so playback flows without a gap.
+ */
+
+/**
+ * Inline assertion. Cannot use `node:assert` because esbuild bundles this
+ * module for the browser and `node:assert` is not resolvable in a browser
+ * target.
+ */
+function assert(cond: unknown, message: string): asserts cond {
+	if (!cond) throw new Error(`article-tts: ${message}`);
+}
+
+/** Structural subset of SpeechSynthesisVoice — the real browser objects flow
+ * through unchanged; typing the subset keeps the module free of lib.dom
+ * coupling and trivial to fake in tests. */
+export interface TtsVoice {
+	readonly voiceURI: string;
+	readonly name: string;
+	readonly lang: string;
+	readonly localService: boolean;
+	readonly default: boolean;
+}
+
+/** Structural subset of SpeechSynthesisUtterance carrying only the fields this
+ * module writes and the callbacks it listens on. */
+export interface TtsUtterance {
+	text: string;
+	voice: TtsVoice | null;
+	rate: number;
+	lang: string;
+	onend: (() => void) | null;
+	onerror: (() => void) | null;
+}
+
+/** Structural subset of window.speechSynthesis. */
+export interface SpeechSynthesisLike {
+	speak(utterance: TtsUtterance): void;
+	cancel(): void;
+	pause(): void;
+	resume(): void;
+	getVoices(): ReadonlyArray<TtsVoice>;
+	addEventListener(type: "voiceschanged", listener: () => void): void;
+}
+
+export interface ArticleTtsDeps {
+	document: Document;
+	/** undefined when the browser has no Web Speech synthesis support. */
+	synth: SpeechSynthesisLike | undefined;
+	createUtterance: (text: string) => TtsUtterance;
+	/** Resolves the article body text, or undefined when the reader iframe is
+	 * not yet readable. Kept as a dependency so the iframe-crossing logic stays
+	 * in the composition root and this module is DOM-fake testable. */
+	getArticleText: () => string | undefined;
+	addSwapListener: (listener: () => void) => void;
+}
+
+export interface ArticleTtsController {
+	stop(): void;
+}
+
+const LABEL_LISTEN = "Listen";
+const LABEL_PAUSE = "Pause";
+const LABEL_RESUME = "Resume";
+
+const STATUS_UNSUPPORTED = "This browser doesn't support read-aloud yet.";
+const STATUS_NOT_READY =
+	"The article is still loading. Try Listen again in a moment.";
+const STATUS_PAUSED = "Paused.";
+const STATUS_ERROR = "Read-aloud stopped unexpectedly. Try again?";
+
+/** Voices whose names contain one of these markers are the higher-fidelity
+ * options each browser exposes for free (Edge "Natural", Safari "Enhanced",
+ * Chrome "Google", iOS "Siri"). */
+const PREFERRED_VOICE_MARKERS = [
+	"natural",
+	"enhanced",
+	"premium",
+	"google",
+	"siri",
+];
+
+/** Cap per utterance, in characters. Comfortably under Chrome's ~15s / ~32KB
+ * single-utterance ceiling while staying long enough to avoid choppy pauses. */
+const MAX_CHUNK_CHARS = 200;
+
+function collapseWhitespace(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Split article text into utterance-sized chunks at word boundaries. Greedy:
+ * accumulate words until the next one would exceed maxChars, then start a new
+ * chunk. A single word longer than maxChars becomes its own (oversized) chunk
+ * rather than being broken mid-word.
+ */
+export function splitIntoChunks(
+	text: string,
+	maxChars: number = MAX_CHUNK_CHARS,
+): string[] {
+	const normalized = collapseWhitespace(text);
+	if (normalized.length === 0) return [];
+
+	const chunks: string[] = [];
+	let current = "";
+	for (const word of normalized.split(" ")) {
+		const candidate = current === "" ? word : `${current} ${word}`;
+		if (candidate.length > maxChars && current !== "") {
+			chunks.push(current);
+			current = word;
+		} else {
+			current = candidate;
+		}
+	}
+	chunks.push(current);
+	return chunks;
+}
+
+/** Elements whose text content is never prose — reading captured CSS rules
+ * or leftover inline scripts aloud would be gibberish. */
+const SILENT_NODES = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE"]);
+
+/** Block-level boundaries must become spoken pauses: `</h1><p>Intro` has no
+ * whitespace between the text nodes, so plain textContent would jam the
+ * heading and the first word into one token ("TitleIntro") and the engine
+ * would lose the sentence break. Inline elements (em, a, span) contribute no
+ * separator so words split across them stay whole. */
+const BLOCK_NODES = new Set([
+	"ADDRESS", "ARTICLE", "ASIDE", "BLOCKQUOTE", "BR", "DD", "DIV", "DL", "DT",
+	"FIGCAPTION", "FIGURE", "FOOTER", "H1", "H2", "H3", "H4", "H5", "H6",
+	"HEADER", "HR", "LI", "MAIN", "NAV", "OL", "P", "PRE", "SECTION", "TABLE",
+	"TD", "TH", "TR", "UL",
+]);
+
+function appendSpokenText(node: Node, parts: string[]): void {
+	if (node.nodeType === node.TEXT_NODE) {
+		const text = node.textContent;
+		assert(text !== null, "a text node's textContent is its data string");
+		parts.push(text);
+		return;
+	}
+	if (SILENT_NODES.has(node.nodeName)) return;
+	const isBlock = BLOCK_NODES.has(node.nodeName);
+	if (isBlock) parts.push(" ");
+	for (const child of Array.from(node.childNodes)) {
+		appendSpokenText(child, parts);
+	}
+	if (isBlock) parts.push(" ");
+}
+
+/** Read the article body's speakable text out of an iframe's content
+ * document. */
+export function extractArticleText(doc: Document): string {
+	const body = doc.body;
+	assert(body, "reader iframe document must have a <body>");
+	const parts: string[] = [];
+	appendSpokenText(body, parts);
+	return collapseWhitespace(parts.join(""));
+}
+
+/** Higher score = better default. Language match dominates, then fidelity
+ * markers, then network (non-local) voices, then the browser's own default. */
+export function scoreVoice(voice: TtsVoice, lang: string): number {
+	let score = 0;
+	const langPrefix = lang.slice(0, 2).toLowerCase();
+	if (voice.lang.toLowerCase().startsWith(langPrefix)) score += 100;
+	const name = voice.name.toLowerCase();
+	for (const marker of PREFERRED_VOICE_MARKERS) {
+		if (name.includes(marker)) {
+			score += 10;
+			break;
+		}
+	}
+	if (!voice.localService) score += 5;
+	if (voice.default) score += 1;
+	return score;
+}
+
+export function pickDefaultVoice(
+	voices: ReadonlyArray<TtsVoice>,
+	lang: string,
+): TtsVoice | undefined {
+	let best: TtsVoice | undefined;
+	let bestScore = Number.NEGATIVE_INFINITY;
+	for (const voice of voices) {
+		const score = scoreVoice(voice, lang);
+		if (score > bestScore) {
+			best = voice;
+			bestScore = score;
+		}
+	}
+	return best;
+}
+
+export function formatVoiceLabel(voice: TtsVoice): string {
+	return `${voice.name} (${voice.lang})`;
+}
+
+/** Parse a playback-rate select value, falling back to 1 (normal speed) for
+ * any non-positive or unparseable input. */
+export function parseRate(raw: string): number {
+	const rate = Number.parseFloat(raw);
+	if (Number.isFinite(rate) && rate > 0) return rate;
+	return 1;
+}
+
+interface Controls {
+	root: HTMLElement;
+	toggle: HTMLButtonElement;
+	toggleLabel: HTMLElement;
+	stopButton: HTMLButtonElement;
+	voiceSelect: HTMLSelectElement;
+	rateSelect: HTMLSelectElement;
+	status: HTMLElement;
+}
+
+function pick<E extends Element>(root: ParentNode, selector: string): E {
+	const element = root.querySelector<E>(selector);
+	assert(element, `missing ${selector}`);
+	return element;
+}
+
+function resolveControls(root: HTMLElement): Controls {
+	return {
+		root,
+		toggle: pick<HTMLButtonElement>(root, "[data-tts-toggle]"),
+		toggleLabel: pick<HTMLElement>(root, "[data-tts-toggle-label]"),
+		stopButton: pick<HTMLButtonElement>(root, "[data-tts-stop]"),
+		voiceSelect: pick<HTMLSelectElement>(root, "[data-tts-voice]"),
+		rateSelect: pick<HTMLSelectElement>(root, "[data-tts-rate]"),
+		status: pick<HTMLElement>(root, "[data-tts-status]"),
+	};
+}
+
+function makeOption(
+	doc: Document,
+	option: { value: string; label: string },
+): HTMLOptionElement {
+	const element = doc.createElement("option");
+	element.value = option.value;
+	element.textContent = option.label;
+	return element;
+}
+
+type PlaybackMode = "idle" | "playing" | "paused";
+
+export function initArticleTts(deps: ArticleTtsDeps): ArticleTtsController {
+	const { synth } = deps;
+	let stopped = false;
+	let activeRoot: HTMLElement | null = null;
+	let activeControls: Controls | null = null;
+
+	let mode: PlaybackMode = "idle";
+	let chunks: string[] = [];
+	let index = 0;
+	/** Bumped on every start and stop so a late onend/onerror from a cancelled
+	 * utterance can detect it is stale and not advance playback. */
+	let playToken = 0;
+
+	function findRoot(): HTMLElement | null {
+		return deps.document.querySelector<HTMLElement>("[data-article-tts]");
+	}
+
+	function documentLang(): string {
+		return deps.document.documentElement.getAttribute("lang") || "en";
+	}
+
+	function setStatus(controls: Controls, text: string): void {
+		controls.status.textContent = text;
+	}
+
+	function setIdleUi(controls: Controls): void {
+		controls.toggleLabel.textContent = LABEL_LISTEN;
+	}
+
+	function selectedVoice(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): TtsVoice | null {
+		const uri = controls.voiceSelect.value;
+		const found = activeSynth.getVoices().find((v) => v.voiceURI === uri);
+		return found ?? null;
+	}
+
+	function statusReading(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): string {
+		const voice = selectedVoice(activeSynth, controls);
+		if (voice !== null) return `Reading aloud with ${voice.name}.`;
+		return "Reading the article aloud.";
+	}
+
+	function populateVoices(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): void {
+		const voices = activeSynth.getVoices();
+		/** Browsers fire voiceschanged repeatedly (Chrome fires it on every
+		 * getVoices catalogue refresh); a rebuild must not discard a voice the
+		 * reader explicitly picked. */
+		const previousUri = controls.voiceSelect.value;
+		controls.voiceSelect.textContent = "";
+		if (voices.length === 0) {
+			controls.voiceSelect.appendChild(
+				makeOption(deps.document, { value: "", label: "Loading voices…" }),
+			);
+			return;
+		}
+		for (const voice of voices) {
+			controls.voiceSelect.appendChild(
+				makeOption(deps.document, {
+					value: voice.voiceURI,
+					label: formatVoiceLabel(voice),
+				}),
+			);
+		}
+		const retained = voices.find((voice) => voice.voiceURI === previousUri);
+		if (retained !== undefined) {
+			controls.voiceSelect.value = retained.voiceURI;
+			return;
+		}
+		const preferred = pickDefaultVoice(voices, documentLang());
+		assert(preferred, "a non-empty voice list always yields a default");
+		controls.voiceSelect.value = preferred.voiceURI;
+	}
+
+	function finishNatural(controls: Controls): void {
+		mode = "idle";
+		index = 0;
+		setIdleUi(controls);
+		setStatus(controls, "");
+	}
+
+	function speakCurrentChunk(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): void {
+		const token = playToken;
+		const utterance = deps.createUtterance(chunks[index]);
+		const voice = selectedVoice(activeSynth, controls);
+		utterance.voice = voice;
+		if (voice !== null) utterance.lang = voice.lang;
+		utterance.rate = parseRate(controls.rateSelect.value);
+		utterance.onend = () => {
+			if (token !== playToken || mode !== "playing") return;
+			index += 1;
+			if (index < chunks.length) {
+				speakCurrentChunk(activeSynth, controls);
+			} else {
+				finishNatural(controls);
+			}
+		};
+		utterance.onerror = () => {
+			if (token !== playToken) return;
+			mode = "idle";
+			index = 0;
+			activeSynth.cancel();
+			setIdleUi(controls);
+			setStatus(controls, STATUS_ERROR);
+		};
+		activeSynth.speak(utterance);
+	}
+
+	function startPlayback(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): void {
+		const text = deps.getArticleText();
+		if (text === undefined || collapseWhitespace(text) === "") {
+			setStatus(controls, STATUS_NOT_READY);
+			return;
+		}
+		chunks = splitIntoChunks(text);
+		index = 0;
+		playToken += 1;
+		mode = "playing";
+		activeSynth.cancel();
+		/** cancel() empties the queue but does not clear the engine's global
+		 * paused flag (Web Speech spec) — after Pause then Stop, a fresh Listen
+		 * would queue into a paused engine and play nothing. resume() clears the
+		 * flag and is a no-op when the engine is not paused. */
+		activeSynth.resume();
+		controls.toggleLabel.textContent = LABEL_PAUSE;
+		setStatus(controls, statusReading(activeSynth, controls));
+		speakCurrentChunk(activeSynth, controls);
+	}
+
+	function pausePlayback(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): void {
+		mode = "paused";
+		activeSynth.pause();
+		controls.toggleLabel.textContent = LABEL_RESUME;
+		setStatus(controls, STATUS_PAUSED);
+	}
+
+	function resumePlayback(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): void {
+		mode = "playing";
+		activeSynth.resume();
+		controls.toggleLabel.textContent = LABEL_PAUSE;
+		setStatus(controls, statusReading(activeSynth, controls));
+	}
+
+	function onToggle(
+		activeSynth: SpeechSynthesisLike,
+		controls: Controls,
+	): void {
+		if (mode === "idle") startPlayback(activeSynth, controls);
+		else if (mode === "playing") pausePlayback(activeSynth, controls);
+		else resumePlayback(activeSynth, controls);
+	}
+
+	function onStop(activeSynth: SpeechSynthesisLike, controls: Controls): void {
+		mode = "idle";
+		index = 0;
+		playToken += 1;
+		activeSynth.cancel();
+		setIdleUi(controls);
+		setStatus(controls, "");
+	}
+
+	function teardown(activeSynth: SpeechSynthesisLike): void {
+		mode = "idle";
+		index = 0;
+		playToken += 1;
+		activeSynth.cancel();
+	}
+
+	function setUnsupported(controls: Controls): void {
+		setStatus(controls, STATUS_UNSUPPORTED);
+		controls.toggle.disabled = true;
+		controls.stopButton.disabled = true;
+		controls.voiceSelect.disabled = true;
+		controls.rateSelect.disabled = true;
+	}
+
+	function bind(root: HTMLElement): void {
+		root.hidden = false;
+		const controls = resolveControls(root);
+		if (synth === undefined) {
+			setUnsupported(controls);
+			return;
+		}
+		activeControls = controls;
+		controls.toggle.addEventListener("click", () => onToggle(synth, controls));
+		controls.stopButton.addEventListener("click", () => onStop(synth, controls));
+		setIdleUi(controls);
+		populateVoices(synth, controls);
+	}
+
+	function scan(): void {
+		if (stopped) return;
+		const root = findRoot();
+		if (root === activeRoot) return;
+		if (synth !== undefined && activeRoot !== null) teardown(synth);
+		activeRoot = root;
+		activeControls = null;
+		if (root === null) return;
+		bind(root);
+	}
+
+	if (synth !== undefined) {
+		synth.addEventListener("voiceschanged", () => {
+			if (stopped) return;
+			if (activeControls !== null) populateVoices(synth, activeControls);
+		});
+	}
+	scan();
+	deps.addSwapListener(scan);
+
+	return {
+		stop(): void {
+			stopped = true;
+			/* In-flight utterance callbacks become stale so a late onend/onerror
+			 * cannot mutate the DOM after teardown. */
+			playToken += 1;
+			if (synth !== undefined) synth.cancel();
+		},
+	};
+}


### PR DESCRIPTION
## What

A proof of concept for **read-aloud on the reader page**, using each browser's own built-in text-to-speech — no AI service, no network round-trip, no cost. It replaces the placeholder `sample-audio.opus` element that sat behind the `?feature=audio` toggle with a real control that speaks the article.

The control renders next to the article body when the page is loaded with `?feature=audio` (the existing feature toggle, unchanged):

```
[ Listen ] [ Stop ]   Voice [ ▾ ]   Speed [ 1× ▾ ]
```

## How it works

- **Engine:** the Web Speech API (`window.speechSynthesis`). This is the standard, zero-cost synthesiser every modern browser ships.
- **"Most advanced free voice per browser":** voices come straight from `getVoices()`, so each browser surfaces its own catalogue — Edge's `… Online (Natural)` set, Safari's enhanced Siri voices, Chrome's `Google …` voices, Firefox's installed OS voices. The control defaults to the highest-fidelity match for the page language (prefers a language match, then `Natural`/`Enhanced`/`Premium`/`Google`/`Siri` markers, then network voices, then the browser default) and lets the reader pick any other.
- **Text source:** the article HTML lives inside the sandboxed reader `<iframe>`; the composition root reads its same-origin `contentDocument` and hands the text to the module, so the module itself never reaches across the frame boundary.
- **Chunking:** the text is split into sentence-sized utterances chained via `onend`, because Chrome stops a single long utterance after ~15s and silently truncates beyond ~32KB.
- **Controls:** Play/Pause/Resume, Stop, voice picker, and playback speed (0.75×–1.5×). Voice/speed changes apply to the next sentence.
- **Graceful degradation:** on a browser with no synthesis support the control still renders but is disabled with a plain "This browser doesn't support read-aloud yet." message.

## Scope (it's a POC)

- Gated behind the existing `?feature=audio` toggle on the authenticated reader (`/queue/:id/view`) — exactly where the placeholder lived. Not shown to regular users.
- The public `/view/<url>` page is **not** wired up; that's a deliberate follow-up if we promote this past POC.
- Real-voice quality depends entirely on the reader's browser/OS. Headless CI has no installed voices, so this can't be screenshotted speaking — but the full state machine is exercised in JSDOM tests.

## How to try it

1. Open any saved article's reader view with the feature flag: `/queue/<id>/view?feature=audio`.
2. Pick a voice (Edge/Chrome desktop and Safari give the nicest options) and press **Listen**.

## Files

- `article-tts.client.ts` (+ test) — the controller and pure helpers (chunking, voice scoring, rate parsing, text extraction). 100% coverage.
- `article-body.template.html` / `article-body.styles.css` — the control markup and styling (brand tokens, no emoji/exclamations per the brand guidelines).
- `build-client-bundles.js` — new `article-tts.client.js` bundle + browser-globals wiring.
- `reader.component.ts` — loads the bundle when audio is enabled.
- `article-body.component.ts` — drops the now-unused `sample-audio`/`STATIC_BASE_URL` wiring.
- Test updates in `article-body.component.test.ts` and `queue.reader.advanced.route.test.ts`.

## Verification

- `pnpm nx run hutch:check` passes — types, biome, knip, unused-css, and coverage (`article-tts.client.ts` at 100% statements/branches/functions/lines).
- Rebased onto the latest `main` (picks up #508 `appOrigin` reader changes); the merge was clean with no conflicts, verified semantically and re-run through the full check.

https://claude.ai/code/session_01JEYfAffWYGFLpjpNdNF3Jm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEYfAffWYGFLpjpNdNF3Jm)_