### PR TITLE
feat(hutch): track in-site clicks with utm_source=internal

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/password-reset-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/password-reset-actions.ts
@@ -37,7 +37,7 @@ export function createPasswordResetActions(
         await page.locator('[data-test-action="sign-in"]').click()
         await page.waitForSelector('body.page-login')
 
-        await page.locator('a[href="/forgot-password"]').click()
+        await page.locator('a[href^="/forgot-password"]').click()
         await page.waitForSelector('body.page-forgot-password')
         resetProgress.navigatedToForgotPassword = true
       },

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -65,9 +65,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 18 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 19 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(18);
+		expect(body.widgets).toHaveLength(19);
 	});
 
 	it("the readers widget counts distinct user_ids from article_read events (not pageviews) — distinguishes opening the reader from explicitly marking-as-read", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -377,7 +377,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 
 	// --- Internal clicks ("where do readers click most") ---
 	// Driven by the `click` event the analytics middleware emits for any request
-	// carrying utm_source=internal — including HTMX-boosted links and POST
+	// carrying utm_medium=internal — including HTMX-boosted links and POST
 	// actions that never appear as pageviews. utm_source is the section and
 	// utm_content the element.
 

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -375,6 +375,30 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 		}),
 	);
 
+	// --- Internal clicks ("where do readers click most") ---
+	// Driven by the `click` event the analytics middleware emits for any request
+	// carrying utm_source=internal — including HTMX-boosted links and POST
+	// actions that never appear as pageviews. utm_medium is the section and
+	// utm_content the element.
+
+	widgets.push(
+		logWidget({
+			region,
+			title: "Internal clicks by section / element",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields @timestamp, coalesce(utm_medium, \"-\") as section, coalesce(utm_content, \"-\") as element",
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.click}"`,
+				...exclude,
+				"| stats count(*) as clicks by section, element",
+				"| sort clicks desc",
+				"| limit 50",
+			].join(" "),
+			x: 0, y: 82, width: 24, height: 8,
+			view: "table",
+		}),
+	);
+
 	return { widgets };
 }
 

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -378,7 +378,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 	// --- Internal clicks ("where do readers click most") ---
 	// Driven by the `click` event the analytics middleware emits for any request
 	// carrying utm_source=internal — including HTMX-boosted links and POST
-	// actions that never appear as pageviews. utm_medium is the section and
+	// actions that never appear as pageviews. utm_source is the section and
 	// utm_content the element.
 
 	widgets.push(
@@ -387,7 +387,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 			title: "Internal clicks by section / element",
 			logGroupNames: [hutchLogGroupName],
 			query: [
-				"fields @timestamp, coalesce(utm_medium, \"-\") as section, coalesce(utm_content, \"-\") as element",
+				"fields @timestamp, coalesce(utm_source, \"-\") as section, coalesce(utm_content, \"-\") as element",
 				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.click}"`,
 				...exclude,
 				"| stats count(*) as clicks by section, element",

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -17,6 +17,7 @@ export const STREAMS = {
 
 export const ANALYTICS_EVENTS = {
 	pageview: "pageview",
+	click: "click",
 	importUploaded: "import_uploaded",
 	importFromUrlAcquired: "import_from_url_acquired",
 	importCommitted: "import_committed",
@@ -24,6 +25,17 @@ export const ANALYTICS_EVENTS = {
 	viewOpened: "view_opened",
 	viewSaveIntent: "view_save_intent",
 } as const;
+
+/**
+ * `utm_source` value stamped on every in-site link and action button so a click
+ * can be counted without an extra request or a client-side beacon. The analytics
+ * middleware emits a `click` event for any request carrying it (GET, HTMX-boosted,
+ * or POST) and keeps it out of `pageview` so acquisition dashboards — which group
+ * by the real `utm_source` (hackernews, newsletter, …) — are not diluted by
+ * internal navigation. Imported by both the link-tagging helper (producer) and
+ * the analytics middleware (consumer) so the two never drift.
+ */
+export const INTERNAL_CLICK_SOURCE = "internal";
 
 export const CONVERSION_EVENTS = {
 	userCreated: "user_created",

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -27,7 +27,7 @@ export const ANALYTICS_EVENTS = {
 } as const;
 
 /**
- * `utm_source` value stamped on every in-site link and action button so a click
+ * `utm_medium` value stamped on every in-site link and action button so a click
  * can be counted without an extra request or a client-side beacon. The analytics
  * middleware emits a `click` event for any request carrying it (GET, HTMX-boosted,
  * or POST) and keeps it out of `pageview` so acquisition dashboards — which group
@@ -35,7 +35,7 @@ export const ANALYTICS_EVENTS = {
  * internal navigation. Imported by both the link-tagging helper (producer) and
  * the analytics middleware (consumer) so the two never drift.
  */
-export const INTERNAL_CLICK_SOURCE = "internal";
+export const INTERNAL_CLICK_MEDIUM = "internal";
 
 export const CONVERSION_EVENTS = {
 	userCreated: "user_created",

--- a/projects/hutch/src/runtime/web/auth/forgot-password.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.route.test.ts
@@ -267,7 +267,7 @@ describe("Forgot password", () => {
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
-			const forgotLink = doc.querySelector('a[href="/forgot-password"]');
+			const forgotLink = doc.querySelector('a[href^="/forgot-password"]');
 			expect(forgotLink?.textContent).toContain("Forgot your password?");
 		});
 	});

--- a/projects/hutch/src/runtime/web/auth/forgot-password.template.html
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.template.html
@@ -3,7 +3,7 @@
         {{#if sent}}
         <h1 class="auth-card__title">Check your email</h1>
         <p class="auth-card__subtitle">If an account exists for that email, you will receive a password reset link shortly.</p>
-        <a class="auth-form__submit" href="/login">Back to login</a>
+        <a class="auth-form__submit" href="{{track '/login' medium='auth-forgot' content='back-to-login'}}">Back to login</a>
         {{else}}
         <h1 class="auth-card__title">Forgot your password?</h1>
         <p class="auth-card__subtitle">Enter your email and we'll send you a link to reset your password</p>
@@ -17,7 +17,7 @@
           <button class="auth-form__submit" type="submit">Send reset link</button>
         </form>
         <p class="auth-card__footer">
-          Remember your password? <a href="/login">Sign in</a>
+          Remember your password? <a href="{{track '/login' medium='auth-forgot' content='sign-in'}}">Sign in</a>
         </p>
         {{/if}}
       </div>

--- a/projects/hutch/src/runtime/web/auth/forgot-password.template.html
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.template.html
@@ -3,7 +3,7 @@
         {{#if sent}}
         <h1 class="auth-card__title">Check your email</h1>
         <p class="auth-card__subtitle">If an account exists for that email, you will receive a password reset link shortly.</p>
-        <a class="auth-form__submit" href="{{track '/login' medium='auth-forgot' content='back-to-login'}}">Back to login</a>
+        <a class="auth-form__submit" href="{{track '/login' source='auth-forgot' content='back-to-login'}}">Back to login</a>
         {{else}}
         <h1 class="auth-card__title">Forgot your password?</h1>
         <p class="auth-card__subtitle">Enter your email and we'll send you a link to reset your password</p>
@@ -17,7 +17,7 @@
           <button class="auth-form__submit" type="submit">Send reset link</button>
         </form>
         <p class="auth-card__footer">
-          Remember your password? <a href="{{track '/login' medium='auth-forgot' content='sign-in'}}">Sign in</a>
+          Remember your password? <a href="{{track '/login' source='auth-forgot' content='sign-in'}}">Sign in</a>
         </p>
         {{/if}}
       </div>

--- a/projects/hutch/src/runtime/web/auth/login.template.html
+++ b/projects/hutch/src/runtime/web/auth/login.template.html
@@ -25,7 +25,7 @@
           </a>
         </div>
         <p class="auth-card__footer auth-card__footer--forgot">
-          <a href="{{track '/forgot-password' medium='auth-login' content='forgot-password'}}">Forgot your password?</a>
+          <a href="{{track '/forgot-password' source='auth-login' content='forgot-password'}}">Forgot your password?</a>
         </p>
         <p class="auth-card__footer">
           Don't have an account? <a href="/signup?utm_source=auth-page&utm_medium=internal&utm_content=create-acc-btn{{#if returnUrl}}&return={{returnUrl}}{{/if}}">Create one</a>

--- a/projects/hutch/src/runtime/web/auth/login.template.html
+++ b/projects/hutch/src/runtime/web/auth/login.template.html
@@ -25,7 +25,7 @@
           </a>
         </div>
         <p class="auth-card__footer auth-card__footer--forgot">
-          <a href="/forgot-password">Forgot your password?</a>
+          <a href="{{track '/forgot-password' medium='auth-login' content='forgot-password'}}">Forgot your password?</a>
         </p>
         <p class="auth-card__footer">
           Don't have an account? <a href="/signup?utm_source=auth-page&utm_medium=internal&utm_content=create-acc-btn{{#if returnUrl}}&return={{returnUrl}}{{/if}}">Create one</a>

--- a/projects/hutch/src/runtime/web/auth/reset-password.template.html
+++ b/projects/hutch/src/runtime/web/auth/reset-password.template.html
@@ -3,11 +3,11 @@
         {{#if success}}
         <h1 class="auth-card__title">Password reset</h1>
         <p class="auth-card__subtitle">Your password has been updated. You can now sign in with your new password.</p>
-        <a class="auth-form__submit" href="/login">Sign in</a>
+        <a class="auth-form__submit" href="{{track '/login' medium='auth-reset' content='sign-in'}}">Sign in</a>
         {{else if error}}
         <h1 class="auth-card__title">Reset failed</h1>
         <p class="auth-card__subtitle">{{error}}</p>
-        <a class="auth-form__submit" href="/forgot-password">Request a new link</a>
+        <a class="auth-form__submit" href="{{track '/forgot-password' medium='auth-reset' content='request-new-link'}}">Request a new link</a>
         {{else}}
         <h1 class="auth-card__title">Set a new password</h1>
         <p class="auth-card__subtitle">Enter your new password below</p>

--- a/projects/hutch/src/runtime/web/auth/reset-password.template.html
+++ b/projects/hutch/src/runtime/web/auth/reset-password.template.html
@@ -3,11 +3,11 @@
         {{#if success}}
         <h1 class="auth-card__title">Password reset</h1>
         <p class="auth-card__subtitle">Your password has been updated. You can now sign in with your new password.</p>
-        <a class="auth-form__submit" href="{{track '/login' medium='auth-reset' content='sign-in'}}">Sign in</a>
+        <a class="auth-form__submit" href="{{track '/login' source='auth-reset' content='sign-in'}}">Sign in</a>
         {{else if error}}
         <h1 class="auth-card__title">Reset failed</h1>
         <p class="auth-card__subtitle">{{error}}</p>
-        <a class="auth-form__submit" href="{{track '/forgot-password' medium='auth-reset' content='request-new-link'}}">Request a new link</a>
+        <a class="auth-form__submit" href="{{track '/forgot-password' source='auth-reset' content='request-new-link'}}">Request a new link</a>
         {{else}}
         <h1 class="auth-card__title">Set a new password</h1>
         <p class="auth-card__subtitle">Enter your new password below</p>

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -3,6 +3,7 @@ import type {
 	EffectiveAccess,
 	GetEffectiveAccess,
 } from "../domain/access/effective-access";
+import { withInternalTracking } from "./internal-link-tracking";
 import { toTrialDisplay, type TrialDisplay } from "./trial-countdown.format";
 
 export interface BannerStateSource {
@@ -29,19 +30,52 @@ export type NavGroupKey = "library" | "account";
 /** Data-driven header nav item. Rendered uniformly as
  * `<form method="{method}" action="{href}"><button>{label}</button></form>`
  * regardless of method — the template never branches on link-vs-form. A
- * `method="GET"` form with no inputs navigates to the action URL on submit
- * (the browser appends `?` and follows), so it behaves exactly like a
- * link; using forms everywhere keeps a single template shape and a single
- * styling target (`.nav__link` already styles `button.nav__link`).
- * Excessive markup is not a performance concern at this scale. The `icon` is a
- * Font Awesome class pair (e.g. "fa-solid fa-inbox") rendered into an empty,
- * `aria-hidden` `<i>` so the glyph reinforces the label without adding text. */
+ * `method="GET"` form with no inputs navigates to the action URL on submit,
+ * so it behaves exactly like a link; using forms everywhere keeps a single
+ * template shape and a single styling target (`.nav__link` already styles
+ * `button.nav__link`). Excessive markup is not a performance concern at this
+ * scale. The `icon` is a Font Awesome class pair (e.g. "fa-solid fa-inbox")
+ * rendered into an empty, `aria-hidden` `<i>` so the glyph reinforces the
+ * label without adding text.
+ *
+ * `trackMedium`/`trackContent` carry the internal-click UTM dimensions. The
+ * template renders them as hidden inputs AND `href` is pre-tagged via
+ * withInternalTracking, because the two form methods transmit query params
+ * differently: a GET submit replaces the action's query with the serialized
+ * fields (so the hidden inputs carry the UTM), while a POST keeps the action's
+ * query (so the tagged `href` carries it). Rendering both keeps every item
+ * tracked under one uniform form shape. */
 export interface NavItem {
 	key: NavItemKey;
 	label: string;
 	href: string;
 	method: "GET" | "POST";
 	icon: string;
+	trackMedium: string;
+	trackContent: string;
+}
+
+const NAV_MEDIUM = "header-nav";
+
+/** Builds a nav item with its href pre-tagged for internal-click tracking and
+ * the matching UTM dimensions exposed for the template's hidden inputs. The
+ * item `key` doubles as `utm_content` so each destination is distinct. */
+function navItem(input: {
+	key: NavItemKey;
+	label: string;
+	path: string;
+	method: "GET" | "POST";
+	icon: string;
+}): NavItem {
+	return {
+		key: input.key,
+		label: input.label,
+		href: withInternalTracking(input.path, { medium: NAV_MEDIUM, content: input.key }),
+		method: input.method,
+		icon: input.icon,
+		trackMedium: NAV_MEDIUM,
+		trackContent: input.key,
+	};
 }
 
 /** A labelled section of the header nav. The template iterates groups, then the
@@ -81,55 +115,13 @@ export interface BannerState {
 	accessIsReadOnly?: boolean;
 }
 
-const NAV_QUEUE: NavItem = {
-	key: "queue",
-	label: "Queue",
-	href: "/queue",
-	method: "GET",
-	icon: "fa-solid fa-inbox",
-};
-const NAV_IMPORT: NavItem = {
-	key: "import",
-	label: "Import Links",
-	href: "/import?utm_source=header-nav&utm_medium=internal&utm_content=import-link",
-	method: "GET",
-	icon: "fa-solid fa-file-import",
-};
-const NAV_EXPORT: NavItem = {
-	key: "export",
-	label: "Export",
-	href: "/export",
-	method: "GET",
-	icon: "fa-solid fa-file-export",
-};
-const NAV_ACCOUNT: NavItem = {
-	key: "account",
-	label: "Account",
-	href: "/account",
-	method: "GET",
-	icon: "fa-solid fa-user",
-};
-const NAV_LOGOUT: NavItem = {
-	key: "logout",
-	label: "Sign out",
-	href: "/logout",
-	method: "POST",
-	icon: "fa-solid fa-right-from-bracket",
-};
-const NAV_FEATURES: NavItem = {
-	key: "features",
-	label: "Features",
-	href: "/#what-works",
-	method: "GET",
-	icon: "fa-solid fa-wand-magic-sparkles",
-};
-const NAV_SIGNUP: NavItem = {
-	key: "signup",
-	label: "Sign up",
-	href: "/signup",
-	method: "GET",
-	icon: "fa-solid fa-user-plus",
-};
+const NAV_QUEUE = navItem({ key: "queue", label: "Queue", path: "/queue", method: "GET", icon: "fa-solid fa-inbox" });
+const NAV_IMPORT = navItem({ key: "import", label: "Import Links", path: "/import", method: "GET", icon: "fa-solid fa-file-import" });
+const NAV_EXPORT = navItem({ key: "export", label: "Export", path: "/export", method: "GET", icon: "fa-solid fa-file-export" });
+const NAV_ACCOUNT = navItem({ key: "account", label: "Account", path: "/account", method: "GET", icon: "fa-solid fa-user" });
+const NAV_LOGOUT = navItem({ key: "logout", label: "Sign out", path: "/logout", method: "POST", icon: "fa-solid fa-right-from-bracket" });
+const NAV_FEATURES = navItem({ key: "features", label: "Features", path: "/#what-works", method: "GET", icon: "fa-solid fa-wand-magic-sparkles" });
+const NAV_SIGNUP = navItem({ key: "signup", label: "Sign up", path: "/signup", method: "GET", icon: "fa-solid fa-user-plus" });
 
 /** Guest nav items rendered as a flat list without group structure. */
 export function buildGuestNavItems(): NavItem[] {

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -38,7 +38,7 @@ export type NavGroupKey = "library" | "account";
  * rendered into an empty, `aria-hidden` `<i>` so the glyph reinforces the
  * label without adding text.
  *
- * `trackMedium`/`trackContent` carry the internal-click UTM dimensions. The
+ * `trackSource`/`trackContent` carry the internal-click UTM dimensions. The
  * template renders them as hidden inputs AND `href` is pre-tagged via
  * withInternalTracking, because the two form methods transmit query params
  * differently: a GET submit replaces the action's query with the serialized
@@ -51,11 +51,11 @@ export interface NavItem {
 	href: string;
 	method: "GET" | "POST";
 	icon: string;
-	trackMedium: string;
+	trackSource: string;
 	trackContent: string;
 }
 
-const NAV_MEDIUM = "header-nav";
+const NAV_SOURCE = "header-nav";
 
 /** Builds a nav item with its href pre-tagged for internal-click tracking and
  * the matching UTM dimensions exposed for the template's hidden inputs. The
@@ -70,10 +70,10 @@ function navItem(input: {
 	return {
 		key: input.key,
 		label: input.label,
-		href: withInternalTracking(input.path, { medium: NAV_MEDIUM, content: input.key }),
+		href: withInternalTracking(input.path, { source: NAV_SOURCE, content: input.key }),
 		method: input.method,
 		icon: input.icon,
-		trackMedium: NAV_MEDIUM,
+		trackSource: NAV_SOURCE,
 		trackContent: input.key,
 	};
 }

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -36,7 +36,7 @@ describe("Base component", () => {
 
 		const brand = doc.querySelector(".header__brand") as HTMLAnchorElement;
 		expect(brand.textContent).toBe("Readplace");
-		expect(brand.getAttribute("href")).toBe("/");
+		expect(brand.getAttribute("href")).toBe("/?utm_source=internal&utm_medium=header&utm_content=brand");
 	});
 
 	it("should include page content in the body", () => {
@@ -101,9 +101,9 @@ describe("Base component", () => {
 		assert(action, "Import Links form must have an action");
 		const url = new URL(action, "https://readplace.com");
 		expect(url.pathname).toBe("/import");
-		expect(url.searchParams.get("utm_source")).toBe("header-nav");
-		expect(url.searchParams.get("utm_medium")).toBe("internal");
-		expect(url.searchParams.get("utm_content")).toBe("import-link");
+		expect(url.searchParams.get("utm_source")).toBe("internal");
+		expect(url.searchParams.get("utm_medium")).toBe("header-nav");
+		expect(url.searchParams.get("utm_content")).toBe("import");
 	});
 
 	it("hides the Import Links nav item for unauthenticated requests", () => {
@@ -125,7 +125,7 @@ describe("Base component", () => {
 		const form = button.closest("form");
 		assert(form, "Account nav item must be wrapped in a form");
 		expect(form.getAttribute("method")?.toUpperCase()).toBe("GET");
-		expect(form.getAttribute("action")).toBe("/account");
+		expect(form.getAttribute("action")).toBe("/account?utm_source=internal&utm_medium=header-nav&utm_content=account");
 	});
 
 	it("hides the Account nav item for unauthenticated requests", () => {
@@ -449,7 +449,7 @@ describe("Base component", () => {
 		const countdown = doc.querySelector("[data-test-trial-countdown]");
 		assert(countdown, "trial countdown must be rendered");
 		expect(countdown.tagName.toLowerCase()).toBe("a");
-		expect(countdown.getAttribute("href")).toBe("/account");
+		expect(countdown.getAttribute("href")).toBe("/account?utm_source=internal&utm_medium=header&utm_content=trial-countdown");
 	});
 
 	it("places the trial countdown directly after the header brand inside .header__content", () => {

--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -36,7 +36,7 @@ describe("Base component", () => {
 
 		const brand = doc.querySelector(".header__brand") as HTMLAnchorElement;
 		expect(brand.textContent).toBe("Readplace");
-		expect(brand.getAttribute("href")).toBe("/?utm_source=internal&utm_medium=header&utm_content=brand");
+		expect(brand.getAttribute("href")).toBe("/?utm_source=header&utm_medium=internal&utm_content=brand");
 	});
 
 	it("should include page content in the body", () => {
@@ -101,8 +101,8 @@ describe("Base component", () => {
 		assert(action, "Import Links form must have an action");
 		const url = new URL(action, "https://readplace.com");
 		expect(url.pathname).toBe("/import");
-		expect(url.searchParams.get("utm_source")).toBe("internal");
-		expect(url.searchParams.get("utm_medium")).toBe("header-nav");
+		expect(url.searchParams.get("utm_source")).toBe("header-nav");
+		expect(url.searchParams.get("utm_medium")).toBe("internal");
 		expect(url.searchParams.get("utm_content")).toBe("import");
 	});
 
@@ -125,7 +125,7 @@ describe("Base component", () => {
 		const form = button.closest("form");
 		assert(form, "Account nav item must be wrapped in a form");
 		expect(form.getAttribute("method")?.toUpperCase()).toBe("GET");
-		expect(form.getAttribute("action")).toBe("/account?utm_source=internal&utm_medium=header-nav&utm_content=account");
+		expect(form.getAttribute("action")).toBe("/account?utm_source=header-nav&utm_medium=internal&utm_content=account");
 	});
 
 	it("hides the Account nav item for unauthenticated requests", () => {
@@ -449,7 +449,7 @@ describe("Base component", () => {
 		const countdown = doc.querySelector("[data-test-trial-countdown]");
 		assert(countdown, "trial countdown must be rendered");
 		expect(countdown.tagName.toLowerCase()).toBe("a");
-		expect(countdown.getAttribute("href")).toBe("/account?utm_source=internal&utm_medium=header&utm_content=trial-countdown");
+		expect(countdown.getAttribute("href")).toBe("/account?utm_source=header&utm_medium=internal&utm_content=trial-countdown");
 	});
 
 	it("places the trial countdown directly after the header brand inside .header__content", () => {

--- a/projects/hutch/src/runtime/web/footer.template.html
+++ b/projects/hutch/src/runtime/web/footer.template.html
@@ -1,9 +1,9 @@
   <footer class="footer">
     <div class="footer__content">
       <ul class="footer__links">
-        <li><a href="{{track '/blog' medium='footer' content='blog'}}" class="footer__link">Blog</a></li>
-        <li><a href="{{track '/privacy' medium='footer' content='privacy'}}" class="footer__link">Privacy</a></li>
-        <li><a href="{{track '/terms' medium='footer' content='terms'}}" class="footer__link">Terms</a></li>
+        <li><a href="{{track '/blog' source='footer' content='blog'}}" class="footer__link">Blog</a></li>
+        <li><a href="{{track '/privacy' source='footer' content='privacy'}}" class="footer__link">Privacy</a></li>
+        <li><a href="{{track '/terms' source='footer' content='terms'}}" class="footer__link">Terms</a></li>
       </ul>
       <p class="footer__copyright">&copy; {{year}} Readplace. Made in Australia.</p>
     </div>

--- a/projects/hutch/src/runtime/web/footer.template.html
+++ b/projects/hutch/src/runtime/web/footer.template.html
@@ -1,9 +1,9 @@
   <footer class="footer">
     <div class="footer__content">
       <ul class="footer__links">
-        <li><a href="/blog" class="footer__link">Blog</a></li>
-        <li><a href="/privacy" class="footer__link">Privacy</a></li>
-        <li><a href="/terms" class="footer__link">Terms</a></li>
+        <li><a href="{{track '/blog' medium='footer' content='blog'}}" class="footer__link">Blog</a></li>
+        <li><a href="{{track '/privacy' medium='footer' content='privacy'}}" class="footer__link">Privacy</a></li>
+        <li><a href="{{track '/terms' medium='footer' content='terms'}}" class="footer__link">Terms</a></li>
       </ul>
       <p class="footer__copyright">&copy; {{year}} Readplace. Made in Australia.</p>
     </div>

--- a/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
@@ -1,0 +1,42 @@
+import { withInternalTracking } from "./internal-link-tracking";
+
+describe("withInternalTracking", () => {
+	it("stamps a root-relative href with utm_source=internal plus the section and element so the click middleware can count it", () => {
+		const href = withInternalTracking("/account", { medium: "queue", content: "subscribe_cta" });
+		const params = new URL(href, "https://internal.invalid").searchParams;
+		expect(params.get("utm_source")).toBe("internal");
+		expect(params.get("utm_medium")).toBe("queue");
+		expect(params.get("utm_content")).toBe("subscribe_cta");
+	});
+
+	it("never emits utm_campaign — two dimensions (section, element) answer the click-volume question", () => {
+		const href = withInternalTracking("/account", { medium: "queue", content: "subscribe_cta" });
+		expect(href).not.toContain("utm_campaign");
+	});
+
+	it("appends to an href that already has a query string instead of replacing it (filter URLs carry tab/order)", () => {
+		const href = withInternalTracking("/queue?tab=read&order=asc", { medium: "queue", content: "filter_read" });
+		const url = new URL(href, "https://internal.invalid");
+		expect(url.searchParams.get("tab")).toBe("read");
+		expect(url.searchParams.get("order")).toBe("asc");
+		expect(url.searchParams.get("utm_medium")).toBe("queue");
+	});
+
+	it("preserves a hash fragment after the appended query string", () => {
+		const href = withInternalTracking("/queue#latest-saved", { medium: "queue", content: "save" });
+		expect(href.endsWith("#latest-saved")).toBe(true);
+		expect(new URL(href, "https://internal.invalid").searchParams.get("utm_source")).toBe("internal");
+	});
+
+	it("overwrites pre-existing utm params so calling it twice is idempotent rather than duplicating keys", () => {
+		const once = withInternalTracking("/account", { medium: "nav", content: "account" });
+		const twice = withInternalTracking(once, { medium: "footer", content: "account" });
+		expect(twice).toBe(withInternalTracking("/account", { medium: "footer", content: "account" }));
+		expect(new URL(twice, "https://internal.invalid").searchParams.getAll("utm_medium")).toEqual(["footer"]);
+	});
+
+	it("leaves an absolute external URL untouched — tagging it would leak our analytics params to another site and the click is not ours to count", () => {
+		const external = "https://github.com/Readplace/readplace.com";
+		expect(withInternalTracking(external, { medium: "home_hero", content: "github" })).toBe(external);
+	});
+});

--- a/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
@@ -2,46 +2,46 @@ import { withInternalTracking } from "./internal-link-tracking";
 
 describe("withInternalTracking", () => {
 	it("stamps a root-relative href with utm_source=internal plus the section and element so the click middleware can count it", () => {
-		const href = withInternalTracking("/account", { medium: "queue", content: "subscribe_cta" });
+		const href = withInternalTracking("/account", { source: "queue", content: "subscribe_cta" });
 		const params = new URL(href, "https://internal.invalid").searchParams;
-		expect(params.get("utm_source")).toBe("internal");
-		expect(params.get("utm_medium")).toBe("queue");
+		expect(params.get("utm_source")).toBe("queue");
+		expect(params.get("utm_medium")).toBe("internal");
 		expect(params.get("utm_content")).toBe("subscribe_cta");
 	});
 
 	it("never emits utm_campaign — two dimensions (section, element) answer the click-volume question", () => {
-		const href = withInternalTracking("/account", { medium: "queue", content: "subscribe_cta" });
+		const href = withInternalTracking("/account", { source: "queue", content: "subscribe_cta" });
 		expect(href).not.toContain("utm_campaign");
 	});
 
 	it("appends to an href that already has a query string instead of replacing it (filter URLs carry tab/order)", () => {
-		const href = withInternalTracking("/queue?tab=read&order=asc", { medium: "queue", content: "filter_read" });
+		const href = withInternalTracking("/queue?tab=read&order=asc", { source: "queue", content: "filter_read" });
 		const url = new URL(href, "https://internal.invalid");
 		expect(url.searchParams.get("tab")).toBe("read");
 		expect(url.searchParams.get("order")).toBe("asc");
-		expect(url.searchParams.get("utm_medium")).toBe("queue");
+		expect(url.searchParams.get("utm_source")).toBe("queue");
 	});
 
 	it("preserves a hash fragment after the appended query string", () => {
-		const href = withInternalTracking("/queue#latest-saved", { medium: "queue", content: "save" });
+		const href = withInternalTracking("/queue#latest-saved", { source: "queue", content: "save" });
 		expect(href.endsWith("#latest-saved")).toBe(true);
-		expect(new URL(href, "https://internal.invalid").searchParams.get("utm_source")).toBe("internal");
+		expect(new URL(href, "https://internal.invalid").searchParams.get("utm_medium")).toBe("internal");
 	});
 
 	it("overwrites pre-existing utm params so calling it twice is idempotent rather than duplicating keys", () => {
-		const once = withInternalTracking("/account", { medium: "nav", content: "account" });
-		const twice = withInternalTracking(once, { medium: "footer", content: "account" });
-		expect(twice).toBe(withInternalTracking("/account", { medium: "footer", content: "account" }));
-		expect(new URL(twice, "https://internal.invalid").searchParams.getAll("utm_medium")).toEqual(["footer"]);
+		const once = withInternalTracking("/account", { source: "nav", content: "account" });
+		const twice = withInternalTracking(once, { source: "footer", content: "account" });
+		expect(twice).toBe(withInternalTracking("/account", { source: "footer", content: "account" }));
+		expect(new URL(twice, "https://internal.invalid").searchParams.getAll("utm_source")).toEqual(["footer"]);
 	});
 
 	it("leaves an absolute external URL untouched — tagging it would leak our analytics params to another site and the click is not ours to count", () => {
 		const external = "https://github.com/Readplace/readplace.com";
-		expect(withInternalTracking(external, { medium: "home_hero", content: "github" })).toBe(external);
+		expect(withInternalTracking(external, { source: "home_hero", content: "github" })).toBe(external);
 	});
 
 	it("leaves a protocol-relative URL untouched — it resolves to another origin, so stamping it would both leak our params and strip the host", () => {
 		const external = "//cdn.example.com/x?a=1";
-		expect(withInternalTracking(external, { medium: "home_hero", content: "cdn" })).toBe(external);
+		expect(withInternalTracking(external, { source: "home_hero", content: "cdn" })).toBe(external);
 	});
 });

--- a/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
@@ -1,21 +1,21 @@
 import { withInternalTracking } from "./internal-link-tracking";
 
 describe("withInternalTracking", () => {
-	it("stamps a root-relative href with utm_source=internal plus the section and element so the click middleware can count it", () => {
-		const href = withInternalTracking("/account", { source: "queue", content: "subscribe_cta" });
+	it("stamps a root-relative href with the section (utm_source), the element (utm_content), and utm_medium=internal so the click middleware can count it", () => {
+		const href = withInternalTracking("/account", { source: "queue", content: "subscribe" });
 		const params = new URL(href, "https://internal.invalid").searchParams;
 		expect(params.get("utm_source")).toBe("queue");
 		expect(params.get("utm_medium")).toBe("internal");
-		expect(params.get("utm_content")).toBe("subscribe_cta");
+		expect(params.get("utm_content")).toBe("subscribe");
 	});
 
 	it("never emits utm_campaign — two dimensions (section, element) answer the click-volume question", () => {
-		const href = withInternalTracking("/account", { source: "queue", content: "subscribe_cta" });
+		const href = withInternalTracking("/account", { source: "queue", content: "subscribe" });
 		expect(href).not.toContain("utm_campaign");
 	});
 
 	it("appends to an href that already has a query string instead of replacing it (filter URLs carry tab/order)", () => {
-		const href = withInternalTracking("/queue?tab=read&order=asc", { source: "queue", content: "filter_read" });
+		const href = withInternalTracking("/queue?tab=read&order=asc", { source: "queue", content: "filter-read" });
 		const url = new URL(href, "https://internal.invalid");
 		expect(url.searchParams.get("tab")).toBe("read");
 		expect(url.searchParams.get("order")).toBe("asc");
@@ -37,11 +37,11 @@ describe("withInternalTracking", () => {
 
 	it("leaves an absolute external URL untouched — tagging it would leak our analytics params to another site and the click is not ours to count", () => {
 		const external = "https://github.com/Readplace/readplace.com";
-		expect(withInternalTracking(external, { source: "home_hero", content: "github" })).toBe(external);
+		expect(withInternalTracking(external, { source: "home-hero", content: "github" })).toBe(external);
 	});
 
 	it("leaves a protocol-relative URL untouched — it resolves to another origin, so stamping it would both leak our params and strip the host", () => {
 		const external = "//cdn.example.com/x?a=1";
-		expect(withInternalTracking(external, { source: "home_hero", content: "cdn" })).toBe(external);
+		expect(withInternalTracking(external, { source: "home-hero", content: "cdn" })).toBe(external);
 	});
 });

--- a/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.test.ts
@@ -39,4 +39,9 @@ describe("withInternalTracking", () => {
 		const external = "https://github.com/Readplace/readplace.com";
 		expect(withInternalTracking(external, { medium: "home_hero", content: "github" })).toBe(external);
 	});
+
+	it("leaves a protocol-relative URL untouched — it resolves to another origin, so stamping it would both leak our params and strip the host", () => {
+		const external = "//cdn.example.com/x?a=1";
+		expect(withInternalTracking(external, { medium: "home_hero", content: "cdn" })).toBe(external);
+	});
 });

--- a/projects/hutch/src/runtime/web/internal-link-tracking.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.ts
@@ -28,7 +28,7 @@ const PARSE_ORIGIN = "https://internal.invalid";
  * correct whether or not the href already has a query string.
  */
 export function withInternalTracking(href: string, tracking: InternalTracking): string {
-	if (!href.startsWith("/")) return href;
+	if (!href.startsWith("/") || href.startsWith("//")) return href;
 	const url = new URL(href, PARSE_ORIGIN);
 	url.searchParams.set("utm_source", INTERNAL_CLICK_SOURCE);
 	url.searchParams.set("utm_medium", tracking.medium);

--- a/projects/hutch/src/runtime/web/internal-link-tracking.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.ts
@@ -1,9 +1,9 @@
 import { INTERNAL_CLICK_MEDIUM } from "../observability/events";
 
 /**
- * `utm_source` is the section a clickable element lives in (`nav`, `footer`,
- * `queue`, `home_hero`, …) and `utm_content` is the element itself (`save`,
- * `subscribe_cta`, `mark_read`, …). `utm_medium` is fixed to
+ * `utm_source` is the section a clickable element lives in (`header-nav`,
+ * `footer`, `queue`, `home-hero`, …) and `utm_content` is the element itself
+ * (`save`, `subscribe`, `mark-read`, …). `utm_medium` is fixed to
  * INTERNAL_CLICK_MEDIUM for every in-site link, and `utm_campaign` is
  * deliberately unused — two dimensions are enough to answer "which button do
  * readers click most, and where".

--- a/projects/hutch/src/runtime/web/internal-link-tracking.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.ts
@@ -1,15 +1,15 @@
-import { INTERNAL_CLICK_SOURCE } from "../observability/events";
+import { INTERNAL_CLICK_MEDIUM } from "../observability/events";
 
 /**
- * `utm_medium` is the section a clickable element lives in (`nav`, `footer`,
+ * `utm_source` is the section a clickable element lives in (`nav`, `footer`,
  * `queue`, `home_hero`, …) and `utm_content` is the element itself (`save`,
- * `subscribe_cta`, `mark_read`, …). `utm_source` is fixed to
- * INTERNAL_CLICK_SOURCE for every in-site link, and `utm_campaign` is
+ * `subscribe_cta`, `mark_read`, …). `utm_medium` is fixed to
+ * INTERNAL_CLICK_MEDIUM for every in-site link, and `utm_campaign` is
  * deliberately unused — two dimensions are enough to answer "which button do
  * readers click most, and where".
  */
 interface InternalTracking {
-	medium: string;
+	source: string;
 	content: string;
 }
 
@@ -30,8 +30,8 @@ const PARSE_ORIGIN = "https://internal.invalid";
 export function withInternalTracking(href: string, tracking: InternalTracking): string {
 	if (!href.startsWith("/") || href.startsWith("//")) return href;
 	const url = new URL(href, PARSE_ORIGIN);
-	url.searchParams.set("utm_source", INTERNAL_CLICK_SOURCE);
-	url.searchParams.set("utm_medium", tracking.medium);
+	url.searchParams.set("utm_source", tracking.source);
+	url.searchParams.set("utm_medium", INTERNAL_CLICK_MEDIUM);
 	url.searchParams.set("utm_content", tracking.content);
 	return `${url.pathname}${url.search}${url.hash}`;
 }

--- a/projects/hutch/src/runtime/web/internal-link-tracking.ts
+++ b/projects/hutch/src/runtime/web/internal-link-tracking.ts
@@ -1,0 +1,37 @@
+import { INTERNAL_CLICK_SOURCE } from "../observability/events";
+
+/**
+ * `utm_medium` is the section a clickable element lives in (`nav`, `footer`,
+ * `queue`, `home_hero`, …) and `utm_content` is the element itself (`save`,
+ * `subscribe_cta`, `mark_read`, …). `utm_source` is fixed to
+ * INTERNAL_CLICK_SOURCE for every in-site link, and `utm_campaign` is
+ * deliberately unused — two dimensions are enough to answer "which button do
+ * readers click most, and where".
+ */
+interface InternalTracking {
+	medium: string;
+	content: string;
+}
+
+/**
+ * Origin for parsing root-relative hrefs. `.invalid` is reserved by RFC 2606 so
+ * it can never resolve, and we only read back `pathname`/`search`/`hash` — the
+ * host is discarded.
+ */
+const PARSE_ORIGIN = "https://internal.invalid";
+
+/**
+ * Appends the internal-click UTM params to a root-relative href. Absolute and
+ * protocol-relative hrefs are returned untouched: tagging an external
+ * destination would leak our analytics params to another site and the click
+ * isn't ours to count. Using URLSearchParams.set makes the call idempotent and
+ * correct whether or not the href already has a query string.
+ */
+export function withInternalTracking(href: string, tracking: InternalTracking): string {
+	if (!href.startsWith("/")) return href;
+	const url = new URL(href, PARSE_ORIGIN);
+	url.searchParams.set("utm_source", INTERNAL_CLICK_SOURCE);
+	url.searchParams.set("utm_medium", tracking.medium);
+	url.searchParams.set("utm_content", tracking.content);
+	return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/projects/hutch/src/runtime/web/middleware/analytics.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.test.ts
@@ -166,9 +166,9 @@ describe("createAnalyticsMiddleware", () => {
 });
 
 describe("createAnalyticsMiddleware — internal click events", () => {
-	const internalQuery = { utm_source: "internal", utm_medium: "queue", utm_content: "subscribe_cta" };
+	const internalQuery = { utm_source: "queue", utm_medium: "internal", utm_content: "subscribe_cta" };
 
-	it("emits a click event carrying the section (utm_medium) and element (utm_content) for a request stamped utm_source=internal", () => {
+	it("emits a click event carrying the section (utm_source) and element (utm_content) for a request stamped utm_medium=internal", () => {
 		const req = createReq({ path: "/account", query: internalQuery, visitorId: "550e8400-e29b-41d4-a716-446655440000" });
 		const [click] = runMiddlewareClicks(req, createRes(200));
 		expect(click).toEqual({
@@ -176,8 +176,8 @@ describe("createAnalyticsMiddleware — internal click events", () => {
 			event: "click",
 			timestamp: "2026-04-21T10:00:00.000Z",
 			path: "/account",
-			utm_source: "internal",
-			utm_medium: "queue",
+			utm_source: "queue",
+			utm_medium: "internal",
 			utm_content: "subscribe_cta",
 			visitor_hash: expect.any(String),
 			visitor_id: "550e8400-e29b-41d4-a716-446655440000",
@@ -211,7 +211,7 @@ describe("createAnalyticsMiddleware — internal click events", () => {
 		expect(runMiddlewareClicks(req, createRes(200))).toEqual([]);
 	});
 
-	it("keeps utm_source=internal out of the pageview so acquisition dashboards are not diluted by in-site navigation, while still emitting the click", () => {
+	it("keeps utm_medium=internal out of the pageview so acquisition dashboards are not diluted by in-site navigation, while still emitting the click", () => {
 		const req = createReq({ path: "/account", query: internalQuery });
 		const [pageview] = runMiddleware(req, createRes(200));
 		const serialized = JSON.stringify(pageview);

--- a/projects/hutch/src/runtime/web/middleware/analytics.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { NextFunction, Request, Response } from "express";
 import type { HutchLogger } from "@packages/hutch-logger";
-import { type AnalyticsEvent, type AnalyticsPageview, createAnalyticsMiddleware, hashIp } from "./analytics";
+import { type AnalyticsClick, type AnalyticsEvent, type AnalyticsPageview, createAnalyticsMiddleware, hashIp } from "./analytics";
 
 function createCapturingLogger(): {
 	logger: HutchLogger.Typed<AnalyticsEvent>;
@@ -49,7 +49,7 @@ function createRes(statusCode = 200): Response & EventEmitter {
 	return emitter;
 }
 
-function runMiddleware(req: Request, res: Response & EventEmitter): AnalyticsPageview[] {
+function captureEvents(req: Request, res: Response & EventEmitter): AnalyticsEvent[] {
 	const { captured, logger } = createCapturingLogger();
 	const middleware = createAnalyticsMiddleware({
 		logger,
@@ -59,7 +59,15 @@ function runMiddleware(req: Request, res: Response & EventEmitter): AnalyticsPag
 	const next: NextFunction = () => {};
 	middleware(req, res, next);
 	res.emit("finish");
-	return captured.filter((e): e is AnalyticsPageview => e.event === "pageview");
+	return captured;
+}
+
+function runMiddleware(req: Request, res: Response & EventEmitter): AnalyticsPageview[] {
+	return captureEvents(req, res).filter((e): e is AnalyticsPageview => e.event === "pageview");
+}
+
+function runMiddlewareClicks(req: Request, res: Response & EventEmitter): AnalyticsClick[] {
+	return captureEvents(req, res).filter((e): e is AnalyticsClick => e.event === "click");
 }
 
 describe("createAnalyticsMiddleware", () => {
@@ -154,6 +162,63 @@ describe("createAnalyticsMiddleware", () => {
 	it("omits medium_post_id from the emitted JSON when the source param is absent", () => {
 		const [event] = runMiddleware(createReq({ query: {} }), createRes(200));
 		expect(JSON.stringify(event)).not.toContain("medium_post_id");
+	});
+});
+
+describe("createAnalyticsMiddleware — internal click events", () => {
+	const internalQuery = { utm_source: "internal", utm_medium: "queue", utm_content: "subscribe_cta" };
+
+	it("emits a click event carrying the section (utm_medium) and element (utm_content) for a request stamped utm_source=internal", () => {
+		const req = createReq({ path: "/account", query: internalQuery, visitorId: "550e8400-e29b-41d4-a716-446655440000" });
+		const [click] = runMiddlewareClicks(req, createRes(200));
+		expect(click).toEqual({
+			stream: "analytics",
+			event: "click",
+			timestamp: "2026-04-21T10:00:00.000Z",
+			path: "/account",
+			utm_source: "internal",
+			utm_medium: "queue",
+			utm_content: "subscribe_cta",
+			visitor_hash: expect.any(String),
+			visitor_id: "550e8400-e29b-41d4-a716-446655440000",
+			is_authenticated: 0,
+		});
+	});
+
+	it("never carries utm_campaign on a click — only the section and element dimensions are tracked", () => {
+		const [click] = runMiddlewareClicks(createReq({ query: internalQuery }), createRes(200));
+		expect(JSON.stringify(click)).not.toContain("utm_campaign");
+	});
+
+	it("counts an HTMX-boosted navigation as a click even though the pageview path drops hx-request — boosted links are still clicks", () => {
+		const req = createReq({ query: internalQuery, headers: { "hx-request": "true" } });
+		expect(runMiddlewareClicks(req, createRes(200))).toHaveLength(1);
+		expect(runMiddleware(req, createRes(200))).toEqual([]);
+	});
+
+	it("counts a POST action (Save / Delete / Mark-read / Logout) as a click even though POST is never a pageview", () => {
+		const req = createReq({ method: "POST", path: "/queue/save", query: internalQuery });
+		expect(runMiddlewareClicks(req, createRes(200))).toHaveLength(1);
+		expect(runMiddleware(req, createRes(200))).toEqual([]);
+	});
+
+	it("does not count a click when the response is a 4xx/5xx error", () => {
+		expect(runMiddlewareClicks(createReq({ query: internalQuery }), createRes(404))).toEqual([]);
+	});
+
+	it("does not count a click when isbot flags the user-agent", () => {
+		const req = createReq({ query: internalQuery, headers: { "user-agent": "Googlebot/2.1 (+http://www.google.com/bot.html)" } });
+		expect(runMiddlewareClicks(req, createRes(200))).toEqual([]);
+	});
+
+	it("keeps utm_source=internal out of the pageview so acquisition dashboards are not diluted by in-site navigation, while still emitting the click", () => {
+		const req = createReq({ path: "/account", query: internalQuery });
+		const [pageview] = runMiddleware(req, createRes(200));
+		const serialized = JSON.stringify(pageview);
+		expect(serialized).not.toContain("utm_source");
+		expect(serialized).not.toContain("utm_medium");
+		expect(serialized).not.toContain("utm_content");
+		expect(runMiddlewareClicks(req, createRes(200))).toHaveLength(1);
 	});
 });
 

--- a/projects/hutch/src/runtime/web/middleware/analytics.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.test.ts
@@ -220,6 +220,16 @@ describe("createAnalyticsMiddleware — internal click events", () => {
 		expect(serialized).not.toContain("utm_content");
 		expect(runMiddlewareClicks(req, createRes(200))).toHaveLength(1);
 	});
+
+	it("strips a real-looking acquisition source (utm_source=homepage) from the pageview when the link carries utm_medium=internal — a pre-existing conversion CTA (homepage Signup → GET /signup) is in-site navigation, not an external source like hackernews, so its pageview must stay out of the acquisition widgets while the click still records section=homepage; conversion attribution is unaffected because it reads first-touch UTM from the hutch_click cookie, not this pageview", () => {
+		const conversionLink = { utm_source: "homepage", utm_medium: "internal", utm_content: "founding-card" };
+		const [pageview] = runMiddleware(createReq({ path: "/signup", query: conversionLink }), createRes(200));
+		const serialized = JSON.stringify(pageview);
+		expect(serialized).not.toContain("utm_source");
+		expect(serialized).not.toContain("homepage");
+		const [click] = runMiddlewareClicks(createReq({ path: "/signup", query: conversionLink }), createRes(200));
+		expect(click).toMatchObject({ utm_source: "homepage", utm_content: "founding-card" });
+	});
 });
 
 describe("hashIp", () => {

--- a/projects/hutch/src/runtime/web/middleware/analytics.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.test.ts
@@ -166,7 +166,7 @@ describe("createAnalyticsMiddleware", () => {
 });
 
 describe("createAnalyticsMiddleware — internal click events", () => {
-	const internalQuery = { utm_source: "queue", utm_medium: "internal", utm_content: "subscribe_cta" };
+	const internalQuery = { utm_source: "queue", utm_medium: "internal", utm_content: "subscribe" };
 
 	it("emits a click event carrying the section (utm_source) and element (utm_content) for a request stamped utm_medium=internal", () => {
 		const req = createReq({ path: "/account", query: internalQuery, visitorId: "550e8400-e29b-41d4-a716-446655440000" });
@@ -178,7 +178,7 @@ describe("createAnalyticsMiddleware — internal click events", () => {
 			path: "/account",
 			utm_source: "queue",
 			utm_medium: "internal",
-			utm_content: "subscribe_cta",
+			utm_content: "subscribe",
 			visitor_hash: expect.any(String),
 			visitor_id: "550e8400-e29b-41d4-a716-446655440000",
 			is_authenticated: 0,
@@ -221,12 +221,18 @@ describe("createAnalyticsMiddleware — internal click events", () => {
 		expect(runMiddlewareClicks(req, createRes(200))).toHaveLength(1);
 	});
 
-	it("strips a real-looking acquisition source (utm_source=homepage) from the pageview when the link carries utm_medium=internal — a pre-existing conversion CTA (homepage Signup → GET /signup) is in-site navigation, not an external source like hackernews, so its pageview must stay out of the acquisition widgets while the click still records section=homepage; conversion attribution is unaffected because it reads first-touch UTM from the hutch_click cookie, not this pageview", () => {
+	it("strips a real-looking acquisition source (utm_source=homepage) from the pageview when the link carries utm_medium=internal, while the click still records section=homepage — a homepage Signup CTA (GET /signup) is in-site navigation, not an external source like hackernews, so it must stay out of the acquisition pageview widgets", () => {
 		const conversionLink = { utm_source: "homepage", utm_medium: "internal", utm_content: "founding-card" };
 		const [pageview] = runMiddleware(createReq({ path: "/signup", query: conversionLink }), createRes(200));
-		const serialized = JSON.stringify(pageview);
-		expect(serialized).not.toContain("utm_source");
-		expect(serialized).not.toContain("homepage");
+		expect(pageview).toEqual({
+			stream: "analytics",
+			event: "pageview",
+			timestamp: "2026-04-21T10:00:00.000Z",
+			path: "/signup",
+			visitor_hash: expect.any(String),
+			visitor_id: null,
+			is_authenticated: 0,
+		});
 		const [click] = runMiddlewareClicks(createReq({ path: "/signup", query: conversionLink }), createRes(200));
 		expect(click).toMatchObject({ utm_source: "homepage", utm_content: "founding-card" });
 	});

--- a/projects/hutch/src/runtime/web/middleware/analytics.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.ts
@@ -3,7 +3,7 @@ import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { isbot } from "isbot";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { UserId } from "@packages/domain/user";
-import { ANALYTICS_EVENTS, INTERNAL_CLICK_SOURCE, STREAMS } from "../../observability/events";
+import { ANALYTICS_EVENTS, INTERNAL_CLICK_MEDIUM, STREAMS } from "../../observability/events";
 
 export interface AnalyticsPageview {
 	stream: typeof STREAMS.analytics;
@@ -23,10 +23,10 @@ export interface AnalyticsPageview {
 
 /**
  * A click on an in-site link or action button. Every internal href/form action
- * carries `utm_source=internal`; this event is emitted for any request bearing
+ * carries `utm_medium=internal`; this event is emitted for any request bearing
  * it — including HTMX-boosted navigations and POST actions (Save / Delete /
  * Mark-read / Logout) that the pageview path drops — so click volume is
- * countable across all surfaces. `utm_medium` is the section and `utm_content`
+ * countable across all surfaces. `utm_source` is the section and `utm_content`
  * the element; `utm_campaign` is intentionally absent.
  */
 export interface AnalyticsClick {
@@ -34,8 +34,8 @@ export interface AnalyticsClick {
 	event: typeof ANALYTICS_EVENTS.click;
 	timestamp: string;
 	path: string;
-	utm_source: typeof INTERNAL_CLICK_SOURCE;
-	utm_medium?: string;
+	utm_source?: string;
+	utm_medium: typeof INTERNAL_CLICK_MEDIUM;
 	utm_content?: string;
 	visitor_hash: string | null;
 	visitor_id: string | null;
@@ -186,13 +186,13 @@ function extractMediumPostId(req: Request): string | undefined {
 }
 
 function isInternalClick(req: Request): boolean {
-	return extractQueryString(req, "utm_source") === INTERNAL_CLICK_SOURCE;
+	return extractQueryString(req, "utm_medium") === INTERNAL_CLICK_MEDIUM;
 }
 
 /**
  * Clicks are counted regardless of method or `hx-request` (HTMX-boosted links
  * and POST actions are clicks too); only bots and error responses are dropped.
- * The precise `utm_source=internal` marker already excludes background polls,
+ * The precise `utm_medium=internal` marker already excludes background polls,
  * which never carry it.
  */
 function shouldCountClick(req: Request, statusCode: number): boolean {
@@ -202,7 +202,7 @@ function shouldCountClick(req: Request, statusCode: number): boolean {
 }
 
 /**
- * Internal navigation is recorded as a `click`; keeping its `utm_source=internal`
+ * Internal navigation is recorded as a `click`; keeping its `utm_medium=internal`
  * out of the pageview preserves the meaning of the acquisition dashboards, which
  * group pageviews by the real campaign source.
  */
@@ -239,8 +239,8 @@ export function createAnalyticsMiddleware(deps: {
 					event: ANALYTICS_EVENTS.click,
 					timestamp: deps.now().toISOString(),
 					path: req.path,
-					utm_source: INTERNAL_CLICK_SOURCE,
-					utm_medium: extractQueryString(req, "utm_medium"),
+					utm_source: extractQueryString(req, "utm_source"),
+					utm_medium: INTERNAL_CLICK_MEDIUM,
 					utm_content: extractQueryString(req, "utm_content"),
 					visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
 					visitor_id: req.visitorId ?? null,

--- a/projects/hutch/src/runtime/web/middleware/analytics.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.ts
@@ -3,7 +3,7 @@ import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { isbot } from "isbot";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { UserId } from "@packages/domain/user";
-import { ANALYTICS_EVENTS, STREAMS } from "../../observability/events";
+import { ANALYTICS_EVENTS, INTERNAL_CLICK_SOURCE, STREAMS } from "../../observability/events";
 
 export interface AnalyticsPageview {
 	stream: typeof STREAMS.analytics;
@@ -16,6 +16,27 @@ export interface AnalyticsPageview {
 	utm_content?: string;
 	referrer_host?: string;
 	medium_post_id?: string;
+	visitor_hash: string | null;
+	visitor_id: string | null;
+	is_authenticated: 0 | 1;
+}
+
+/**
+ * A click on an in-site link or action button. Every internal href/form action
+ * carries `utm_source=internal`; this event is emitted for any request bearing
+ * it — including HTMX-boosted navigations and POST actions (Save / Delete /
+ * Mark-read / Logout) that the pageview path drops — so click volume is
+ * countable across all surfaces. `utm_medium` is the section and `utm_content`
+ * the element; `utm_campaign` is intentionally absent.
+ */
+export interface AnalyticsClick {
+	stream: typeof STREAMS.analytics;
+	event: typeof ANALYTICS_EVENTS.click;
+	timestamp: string;
+	path: string;
+	utm_source: typeof INTERNAL_CLICK_SOURCE;
+	utm_medium?: string;
+	utm_content?: string;
 	visitor_hash: string | null;
 	visitor_id: string | null;
 	is_authenticated: 0 | 1;
@@ -106,6 +127,7 @@ export interface ViewSaveIntentEvent {
 
 export type AnalyticsEvent =
 	| AnalyticsPageview
+	| AnalyticsClick
 	| ImportUploadedEvent
 	| ImportCommittedEvent
 	| ImportFromUrlAcquiredEvent
@@ -163,6 +185,39 @@ function extractMediumPostId(req: Request): string | undefined {
 	return match ? match[1] : undefined;
 }
 
+function isInternalClick(req: Request): boolean {
+	return extractQueryString(req, "utm_source") === INTERNAL_CLICK_SOURCE;
+}
+
+/**
+ * Clicks are counted regardless of method or `hx-request` (HTMX-boosted links
+ * and POST actions are clicks too); only bots and error responses are dropped.
+ * The precise `utm_source=internal` marker already excludes background polls,
+ * which never carry it.
+ */
+function shouldCountClick(req: Request, statusCode: number): boolean {
+	if (statusCode >= 400) return false;
+	if (isbot(req.get("user-agent"))) return false;
+	return true;
+}
+
+/**
+ * Internal navigation is recorded as a `click`; keeping its `utm_source=internal`
+ * out of the pageview preserves the meaning of the acquisition dashboards, which
+ * group pageviews by the real campaign source.
+ */
+function extractPageviewUtm(
+	req: Request,
+): Pick<AnalyticsPageview, "utm_source" | "utm_medium" | "utm_campaign" | "utm_content"> {
+	if (isInternalClick(req)) return {};
+	return {
+		utm_source: extractQueryString(req, "utm_source"),
+		utm_medium: extractQueryString(req, "utm_medium"),
+		utm_campaign: extractQueryString(req, "utm_campaign"),
+		utm_content: extractQueryString(req, "utm_content"),
+	};
+}
+
 export function hashIp(deps: { ip: string | undefined; salt: string }): string | null {
 	if (!deps.ip) return null;
 	return createHash("sha256")
@@ -178,16 +233,27 @@ export function createAnalyticsMiddleware(deps: {
 }): RequestHandler {
 	return (req: Request, res: Response, next: NextFunction) => {
 		res.on("finish", () => {
+			if (isInternalClick(req) && shouldCountClick(req, res.statusCode)) {
+				deps.logger.info({
+					stream: STREAMS.analytics,
+					event: ANALYTICS_EVENTS.click,
+					timestamp: deps.now().toISOString(),
+					path: req.path,
+					utm_source: INTERNAL_CLICK_SOURCE,
+					utm_medium: extractQueryString(req, "utm_medium"),
+					utm_content: extractQueryString(req, "utm_content"),
+					visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
+					visitor_id: req.visitorId ?? null,
+					is_authenticated: req.userId ? 1 : 0,
+				});
+			}
 			if (!shouldLog(req, res.statusCode)) return;
 			deps.logger.info({
 				stream: STREAMS.analytics,
 				event: ANALYTICS_EVENTS.pageview,
 				timestamp: deps.now().toISOString(),
 				path: req.path,
-				utm_source: extractQueryString(req, "utm_source"),
-				utm_medium: extractQueryString(req, "utm_medium"),
-				utm_campaign: extractQueryString(req, "utm_campaign"),
-				utm_content: extractQueryString(req, "utm_content"),
+				...extractPageviewUtm(req),
 				referrer_host: extractReferrerHost(req),
 				medium_post_id: extractMediumPostId(req),
 				visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),

--- a/projects/hutch/src/runtime/web/nav.component.test.ts
+++ b/projects/hutch/src/runtime/web/nav.component.test.ts
@@ -87,7 +87,7 @@ describe("Nav component", () => {
 		assert(account, "account nav item must render for authenticated full-access users");
 		const form = account.closest("form");
 		assert(form, "account nav item must be inside a form");
-		expect(form.getAttribute("action")).toBe("/account");
+		expect(form.getAttribute("action")).toBe("/account?utm_source=internal&utm_medium=header-nav&utm_content=account");
 	});
 
 	it("splits the authenticated nav into a Library section (queue, import, export) and an Account section (account, sign out)", () => {

--- a/projects/hutch/src/runtime/web/nav.component.test.ts
+++ b/projects/hutch/src/runtime/web/nav.component.test.ts
@@ -87,7 +87,7 @@ describe("Nav component", () => {
 		assert(account, "account nav item must render for authenticated full-access users");
 		const form = account.closest("form");
 		assert(form, "account nav item must be inside a form");
-		expect(form.getAttribute("action")).toBe("/account?utm_source=internal&utm_medium=header-nav&utm_content=account");
+		expect(form.getAttribute("action")).toBe("/account?utm_source=header-nav&utm_medium=internal&utm_content=account");
 	});
 
 	it("splits the authenticated nav into a Library section (queue, import, export) and an Account section (account, sign out)", () => {

--- a/projects/hutch/src/runtime/web/nav.template.html
+++ b/projects/hutch/src/runtime/web/nav.template.html
@@ -1,9 +1,9 @@
   <header class="header{{#if transparent}} header--transparent{{/if}}">
     <div class="header__content">
-      <a href="{{track '/' medium='header' content='brand'}}" class="header__brand">Read<span class="header__brand-mark">place</span></a>
+      <a href="{{track '/' source='header' content='brand'}}" class="header__brand">Read<span class="header__brand-mark">place</span></a>
       {{#if trial}}
       <a class="trial-countdown trial-countdown--{{trialEscalationClass}}"
-         href="{{track '/account' medium='header' content='trial-countdown'}}"
+         href="{{track '/account' source='header' content='trial-countdown'}}"
          data-trial-ends-at-iso="{{trialEndsAtIso}}"
          data-server-now-iso="{{serverNowIso}}"
          data-trial-state="{{trialState}}"
@@ -26,8 +26,8 @@
               {{#each items}}
               <li>
                 <form method="{{method}}" action="{{href}}">
-                  <input type="hidden" name="utm_source" value="internal">
-                  <input type="hidden" name="utm_medium" value="{{trackMedium}}">
+                  <input type="hidden" name="utm_source" value="{{trackSource}}">
+                  <input type="hidden" name="utm_medium" value="internal">
                   <input type="hidden" name="utm_content" value="{{trackContent}}">
                   <button type="submit" class="nav__link" data-test-nav-item="{{key}}"><i class="nav__icon {{icon}}" aria-hidden="true"></i><span class="nav__label">{{label}}</span></button>
                 </form>
@@ -40,8 +40,8 @@
           {{#if @first}}<ul class="nav__list">{{/if}}
           <li>
             <form method="{{method}}" action="{{href}}">
-              <input type="hidden" name="utm_source" value="internal">
-              <input type="hidden" name="utm_medium" value="{{trackMedium}}">
+              <input type="hidden" name="utm_source" value="{{trackSource}}">
+              <input type="hidden" name="utm_medium" value="internal">
               <input type="hidden" name="utm_content" value="{{trackContent}}">
               <button type="submit" class="nav__link" data-test-nav-item="{{key}}"><i class="nav__icon {{icon}}" aria-hidden="true"></i><span class="nav__label">{{label}}</span></button>
             </form>

--- a/projects/hutch/src/runtime/web/nav.template.html
+++ b/projects/hutch/src/runtime/web/nav.template.html
@@ -1,9 +1,9 @@
   <header class="header{{#if transparent}} header--transparent{{/if}}">
     <div class="header__content">
-      <a href="/" class="header__brand">Read<span class="header__brand-mark">place</span></a>
+      <a href="{{track '/' medium='header' content='brand'}}" class="header__brand">Read<span class="header__brand-mark">place</span></a>
       {{#if trial}}
       <a class="trial-countdown trial-countdown--{{trialEscalationClass}}"
-         href="/account"
+         href="{{track '/account' medium='header' content='trial-countdown'}}"
          data-trial-ends-at-iso="{{trialEndsAtIso}}"
          data-server-now-iso="{{serverNowIso}}"
          data-trial-state="{{trialState}}"
@@ -26,6 +26,9 @@
               {{#each items}}
               <li>
                 <form method="{{method}}" action="{{href}}">
+                  <input type="hidden" name="utm_source" value="internal">
+                  <input type="hidden" name="utm_medium" value="{{trackMedium}}">
+                  <input type="hidden" name="utm_content" value="{{trackContent}}">
                   <button type="submit" class="nav__link" data-test-nav-item="{{key}}"><i class="nav__icon {{icon}}" aria-hidden="true"></i><span class="nav__label">{{label}}</span></button>
                 </form>
               </li>
@@ -37,6 +40,9 @@
           {{#if @first}}<ul class="nav__list">{{/if}}
           <li>
             <form method="{{method}}" action="{{href}}">
+              <input type="hidden" name="utm_source" value="internal">
+              <input type="hidden" name="utm_medium" value="{{trackMedium}}">
+              <input type="hidden" name="utm_content" value="{{trackContent}}">
               <button type="submit" class="nav__link" data-test-nav-item="{{key}}"><i class="nav__icon {{icon}}" aria-hidden="true"></i><span class="nav__label">{{label}}</span></button>
             </form>
           </li>

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -89,7 +89,7 @@ describe("GET /account (active paid subscription)", () => {
 		expect(actionKeys(doc)).toEqual(["cancel-form"]);
 		const cancelForm = findAction(doc, "cancel-form");
 		expect(cancelForm.tagName.toLowerCase()).toBe("form");
-		expect(cancelForm.getAttribute("action")).toBe("/account/cancel?utm_source=internal&utm_medium=account&utm_content=cancel-form");
+		expect(cancelForm.getAttribute("action")).toBe("/account/cancel?utm_source=account&utm_medium=internal&utm_content=cancel-form");
 		expect(cancelForm.getAttribute("method")?.toUpperCase()).toBe("POST");
 		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
 	});
@@ -148,7 +148,7 @@ describe("GET /account (trialing inside trial window)", () => {
 		expect(actionKeys(doc)).toEqual(["subscribe"]);
 		const subscribe = findAction(doc, "subscribe");
 		expect(subscribe.tagName.toLowerCase()).toBe("form");
-		expect(subscribe.getAttribute("action")).toBe("/account/subscribe?utm_source=internal&utm_medium=account&utm_content=subscribe");
+		expect(subscribe.getAttribute("action")).toBe("/account/subscribe?utm_source=account&utm_medium=internal&utm_content=subscribe");
 	});
 
 	it("renders the global trial countdown in the nav for a trialing user (regression: /account previously dropped it)", async () => {
@@ -617,7 +617,7 @@ describe("GET /account (cancellation-scheduled state)", () => {
 		expect(actionKeys(doc)).toEqual(["reactivate-form"]);
 		const reactivate = findAction(doc, "reactivate-form");
 		expect(reactivate.tagName.toLowerCase()).toBe("form");
-		expect(reactivate.getAttribute("action")).toBe("/account/reactivate?utm_source=internal&utm_medium=account&utm_content=reactivate-form");
+		expect(reactivate.getAttribute("action")).toBe("/account/reactivate?utm_source=account&utm_medium=internal&utm_content=reactivate-form");
 	});
 
 	it("renders the cancellation-scheduled pill in the header (paid + trial) so the user sees the cutoff date globally", async () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -89,7 +89,7 @@ describe("GET /account (active paid subscription)", () => {
 		expect(actionKeys(doc)).toEqual(["cancel-form"]);
 		const cancelForm = findAction(doc, "cancel-form");
 		expect(cancelForm.tagName.toLowerCase()).toBe("form");
-		expect(cancelForm.getAttribute("action")).toBe("/account/cancel");
+		expect(cancelForm.getAttribute("action")).toBe("/account/cancel?utm_source=internal&utm_medium=account&utm_content=cancel-form");
 		expect(cancelForm.getAttribute("method")?.toUpperCase()).toBe("POST");
 		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
 	});
@@ -148,7 +148,7 @@ describe("GET /account (trialing inside trial window)", () => {
 		expect(actionKeys(doc)).toEqual(["subscribe"]);
 		const subscribe = findAction(doc, "subscribe");
 		expect(subscribe.tagName.toLowerCase()).toBe("form");
-		expect(subscribe.getAttribute("action")).toBe("/account/subscribe");
+		expect(subscribe.getAttribute("action")).toBe("/account/subscribe?utm_source=internal&utm_medium=account&utm_content=subscribe");
 	});
 
 	it("renders the global trial countdown in the nav for a trialing user (regression: /account previously dropped it)", async () => {
@@ -617,7 +617,7 @@ describe("GET /account (cancellation-scheduled state)", () => {
 		expect(actionKeys(doc)).toEqual(["reactivate-form"]);
 		const reactivate = findAction(doc, "reactivate-form");
 		expect(reactivate.tagName.toLowerCase()).toBe("form");
-		expect(reactivate.getAttribute("action")).toBe("/account/reactivate");
+		expect(reactivate.getAttribute("action")).toBe("/account/reactivate?utm_source=internal&utm_medium=account&utm_content=reactivate-form");
 	});
 
 	it("renders the cancellation-scheduled pill in the header (paid + trial) so the user sees the cutoff date globally", async () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
@@ -65,7 +65,7 @@ describe("toAccountViewModel — actions", () => {
 		assert.equal(vm.actions[0].key, "cancel-form");
 		assert.equal(vm.actions[0].variant, "destructive");
 		assert.equal(vm.actions[0].method, "POST");
-		assert.equal(vm.actions[0].href, "/account/cancel");
+		assert.equal(vm.actions[0].href, "/account/cancel?utm_source=internal&utm_medium=account&utm_content=cancel-form");
 		assert.equal(vm.actions[0].isLink, false);
 	});
 
@@ -90,7 +90,7 @@ describe("toAccountViewModel — actions", () => {
 		assert.deepEqual(keys, ["subscribe"]);
 		assert.equal(vm.actions[0].variant, "primary");
 		assert.equal(vm.actions[0].method, "POST");
-		assert.equal(vm.actions[0].href, "/account/subscribe");
+		assert.equal(vm.actions[0].href, "/account/subscribe?utm_source=internal&utm_medium=account&utm_content=subscribe");
 	});
 
 	it("inactive users get a primary subscribe action only (export lives in the nav menu)", () => {
@@ -133,7 +133,7 @@ describe("toAccountViewModel — actions", () => {
 		assert.deepEqual(keys, ["reactivate-form"]);
 		assert.equal(vm.actions[0].variant, "primary");
 		assert.equal(vm.actions[0].method, "POST");
-		assert.equal(vm.actions[0].href, "/account/reactivate");
+		assert.equal(vm.actions[0].href, "/account/reactivate?utm_source=internal&utm_medium=account&utm_content=reactivate-form");
 	});
 
 	it("trial cancellation-scheduled state — same shape as paid (reactivate-form, Reactivate label) so the template stays branchless", () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
@@ -65,7 +65,7 @@ describe("toAccountViewModel — actions", () => {
 		assert.equal(vm.actions[0].key, "cancel-form");
 		assert.equal(vm.actions[0].variant, "destructive");
 		assert.equal(vm.actions[0].method, "POST");
-		assert.equal(vm.actions[0].href, "/account/cancel?utm_source=internal&utm_medium=account&utm_content=cancel-form");
+		assert.equal(vm.actions[0].href, "/account/cancel?utm_source=account&utm_medium=internal&utm_content=cancel-form");
 		assert.equal(vm.actions[0].isLink, false);
 	});
 
@@ -90,7 +90,7 @@ describe("toAccountViewModel — actions", () => {
 		assert.deepEqual(keys, ["subscribe"]);
 		assert.equal(vm.actions[0].variant, "primary");
 		assert.equal(vm.actions[0].method, "POST");
-		assert.equal(vm.actions[0].href, "/account/subscribe?utm_source=internal&utm_medium=account&utm_content=subscribe");
+		assert.equal(vm.actions[0].href, "/account/subscribe?utm_source=account&utm_medium=internal&utm_content=subscribe");
 	});
 
 	it("inactive users get a primary subscribe action only (export lives in the nav menu)", () => {
@@ -133,7 +133,7 @@ describe("toAccountViewModel — actions", () => {
 		assert.deepEqual(keys, ["reactivate-form"]);
 		assert.equal(vm.actions[0].variant, "primary");
 		assert.equal(vm.actions[0].method, "POST");
-		assert.equal(vm.actions[0].href, "/account/reactivate?utm_source=internal&utm_medium=account&utm_content=reactivate-form");
+		assert.equal(vm.actions[0].href, "/account/reactivate?utm_source=account&utm_medium=internal&utm_content=reactivate-form");
 	});
 
 	it("trial cancellation-scheduled state — same shape as paid (reactivate-form, Reactivate label) so the template stays branchless", () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
@@ -73,7 +73,7 @@ export function parseAccountQuery(query: Record<string, unknown> | undefined): A
 function action(input: Omit<AccountAction, "isLink">): AccountAction {
 	return {
 		...input,
-		href: withInternalTracking(input.href, { medium: "account", content: input.key }),
+		href: withInternalTracking(input.href, { source: "account", content: input.key }),
 		isLink: input.method === "GET",
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
@@ -1,5 +1,6 @@
 import { decomposeTimeLeft } from "@packages/time-left";
 import type { EffectiveAccess } from "../../../domain/access/effective-access";
+import { withInternalTracking } from "../../internal-link-tracking";
 import {
 	ACCOUNT_CANCEL_URL,
 	ACCOUNT_REACTIVATE_URL,
@@ -70,7 +71,11 @@ export function parseAccountQuery(query: Record<string, unknown> | undefined): A
 }
 
 function action(input: Omit<AccountAction, "isLink">): AccountAction {
-	return { ...input, isLink: input.method === "GET" };
+	return {
+		...input,
+		href: withInternalTracking(input.href, { medium: "account", content: input.key }),
+		isLink: input.method === "GET",
+	};
 }
 
 const SUBSCRIBE_ACTION = action({

--- a/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
@@ -35,7 +35,7 @@ describe("Export routes", () => {
 			const button = doc.querySelector("[data-test-export-start]");
 			expect(button?.tagName.toLowerCase()).toBe("button");
 			const form = button?.closest("form");
-			expect(form?.getAttribute("action")).toBe("/export/start");
+			expect(form?.getAttribute("action")).toBe("/export/start?utm_source=internal&utm_medium=export&utm_content=start");
 			expect(form?.getAttribute("method")?.toUpperCase()).toBe("POST");
 		});
 

--- a/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/export/export.route.test.ts
@@ -35,7 +35,7 @@ describe("Export routes", () => {
 			const button = doc.querySelector("[data-test-export-start]");
 			expect(button?.tagName.toLowerCase()).toBe("button");
 			const form = button?.closest("form");
-			expect(form?.getAttribute("action")).toBe("/export/start?utm_source=internal&utm_medium=export&utm_content=start");
+			expect(form?.getAttribute("action")).toBe("/export/start?utm_source=export&utm_medium=internal&utm_content=start");
 			expect(form?.getAttribute("method")?.toUpperCase()).toBe("POST");
 		});
 

--- a/projects/hutch/src/runtime/web/pages/export/export.template.html
+++ b/projects/hutch/src/runtime/web/pages/export/export.template.html
@@ -24,7 +24,7 @@
         <p class="export__text">We'll prepare your export in the background and email you a download link when it's ready. The link is valid for <strong>{{ttlDays}} days</strong>.</p>
       </section>
 
-      <form action="{{track '/export/start' medium='export' content='start'}}" method="POST" class="export__action">
+      <form action="{{track '/export/start' source='export' content='start'}}" method="POST" class="export__action">
         <button type="submit" class="export__action-btn" data-test-export-start>Email Me My Data</button>
       </form>
     </main>

--- a/projects/hutch/src/runtime/web/pages/export/export.template.html
+++ b/projects/hutch/src/runtime/web/pages/export/export.template.html
@@ -24,7 +24,7 @@
         <p class="export__text">We'll prepare your export in the background and email you a download link when it's ready. The link is valid for <strong>{{ttlDays}} days</strong>.</p>
       </section>
 
-      <form action="/export/start" method="POST" class="export__action">
+      <form action="{{track '/export/start' medium='export' content='start'}}" method="POST" class="export__action">
         <button type="submit" class="export__action-btn" data-test-export-start>Email Me My Data</button>
       </form>
     </main>

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -55,7 +55,7 @@ describe("GET /", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
-		expect(cta?.getAttribute("href")).toBe("/install");
+		expect(cta?.getAttribute("href")).toBe("/install?utm_source=internal&utm_medium=home-hero&utm_content=install");
 		expect(cta?.textContent).toBe("Install Browser Extension");
 	});
 
@@ -68,7 +68,7 @@ describe("GET /", () => {
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
 		expect(cta?.textContent).toBe("Install Firefox Extension");
-		expect(cta?.getAttribute("href")).toBe("/install?client=firefox");
+		expect(cta?.getAttribute("href")).toBe("/install?client=firefox&utm_source=internal&utm_medium=home-hero&utm_content=install");
 
 		const trust = doc.querySelector(".home-hero__trust");
 		expect(trust?.textContent).toBe("Also available for Chrome");
@@ -83,7 +83,7 @@ describe("GET /", () => {
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
 		expect(cta?.textContent).toBe("Install Chrome Extension");
-		expect(cta?.getAttribute("href")).toBe("/install?client=chrome");
+		expect(cta?.getAttribute("href")).toBe("/install?client=chrome&utm_source=internal&utm_medium=home-hero&utm_content=install");
 
 		const trust = doc.querySelector(".home-hero__trust");
 		expect(trust?.textContent).toBe("Also available for Firefox");
@@ -118,7 +118,7 @@ describe("GET /", () => {
 
 		const bottomCta = doc.querySelector('[data-test-cta="bottom-install"]');
 		expect(bottomCta?.textContent).toBe("Install Firefox Extension");
-		expect(bottomCta?.getAttribute("href")).toBe("/install?client=firefox");
+		expect(bottomCta?.getAttribute("href")).toBe("/install?client=firefox&utm_source=internal&utm_medium=home-cta&utm_content=install");
 	});
 
 	it("should render the public reader-view paste-link form with UTM hidden inputs", async () => {

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -55,7 +55,7 @@ describe("GET /", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
-		expect(cta?.getAttribute("href")).toBe("/install?utm_source=internal&utm_medium=home-hero&utm_content=install");
+		expect(cta?.getAttribute("href")).toBe("/install?utm_source=home-hero&utm_medium=internal&utm_content=install");
 		expect(cta?.textContent).toBe("Install Browser Extension");
 	});
 
@@ -68,7 +68,7 @@ describe("GET /", () => {
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
 		expect(cta?.textContent).toBe("Install Firefox Extension");
-		expect(cta?.getAttribute("href")).toBe("/install?client=firefox&utm_source=internal&utm_medium=home-hero&utm_content=install");
+		expect(cta?.getAttribute("href")).toBe("/install?client=firefox&utm_source=home-hero&utm_medium=internal&utm_content=install");
 
 		const trust = doc.querySelector(".home-hero__trust");
 		expect(trust?.textContent).toBe("Also available for Chrome");
@@ -83,7 +83,7 @@ describe("GET /", () => {
 
 		const cta = doc.querySelector('[data-test-cta="install-extension"]');
 		expect(cta?.textContent).toBe("Install Chrome Extension");
-		expect(cta?.getAttribute("href")).toBe("/install?client=chrome&utm_source=internal&utm_medium=home-hero&utm_content=install");
+		expect(cta?.getAttribute("href")).toBe("/install?client=chrome&utm_source=home-hero&utm_medium=internal&utm_content=install");
 
 		const trust = doc.querySelector(".home-hero__trust");
 		expect(trust?.textContent).toBe("Also available for Firefox");
@@ -118,7 +118,7 @@ describe("GET /", () => {
 
 		const bottomCta = doc.querySelector('[data-test-cta="bottom-install"]');
 		expect(bottomCta?.textContent).toBe("Install Firefox Extension");
-		expect(bottomCta?.getAttribute("href")).toBe("/install?client=firefox&utm_source=internal&utm_medium=home-cta&utm_content=install");
+		expect(bottomCta?.getAttribute("href")).toBe("/install?client=firefox&utm_source=home-cta&utm_medium=internal&utm_content=install");
 	});
 
 	it("should render the public reader-view paste-link form with UTM hidden inputs", async () => {

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -33,13 +33,13 @@
         <div class="home-hero__actions">
           {{#switch browserName}}
           {{#case "firefox"}}
-          <a href="{{track '/install?client=firefox' medium='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Firefox Extension</a>
+          <a href="{{track '/install?client=firefox' source='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Firefox Extension</a>
           {{/case}}
           {{#case "chrome"}}
-          <a href="{{track '/install?client=chrome' medium='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Chrome Extension</a>
+          <a href="{{track '/install?client=chrome' source='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Chrome Extension</a>
           {{/case}}
           {{#default}}
-          <a href="{{track '/install' medium='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Browser Extension</a>
+          <a href="{{track '/install' source='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Browser Extension</a>
           {{/default}}
           {{/switch}}
           <a href="https://github.com/Readplace/readplace.com" class="btn btn--secondary" data-test-cta="view-github">View on GitHub</a>
@@ -360,13 +360,13 @@
         <div class="home-cta__actions">
           {{#switch browserName}}
           {{#case "firefox"}}
-          <a href="{{track '/install?client=firefox' medium='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Firefox Extension</a>
+          <a href="{{track '/install?client=firefox' source='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Firefox Extension</a>
           {{/case}}
           {{#case "chrome"}}
-          <a href="{{track '/install?client=chrome' medium='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Chrome Extension</a>
+          <a href="{{track '/install?client=chrome' source='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Chrome Extension</a>
           {{/case}}
           {{#default}}
-          <a href="{{track '/install' medium='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Browser Extension</a>
+          <a href="{{track '/install' source='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Browser Extension</a>
           {{/default}}
           {{/switch}}
           <a href="https://github.com/Readplace/readplace.com" class="home-cta__github-link" data-test-cta="bottom-github">View on GitHub</a>

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -33,13 +33,13 @@
         <div class="home-hero__actions">
           {{#switch browserName}}
           {{#case "firefox"}}
-          <a href="/install?client=firefox" class="btn btn--primary" data-test-cta="install-extension">Install Firefox Extension</a>
+          <a href="{{track '/install?client=firefox' medium='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Firefox Extension</a>
           {{/case}}
           {{#case "chrome"}}
-          <a href="/install?client=chrome" class="btn btn--primary" data-test-cta="install-extension">Install Chrome Extension</a>
+          <a href="{{track '/install?client=chrome' medium='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Chrome Extension</a>
           {{/case}}
           {{#default}}
-          <a href="/install" class="btn btn--primary" data-test-cta="install-extension">Install Browser Extension</a>
+          <a href="{{track '/install' medium='home-hero' content='install'}}" class="btn btn--primary" data-test-cta="install-extension">Install Browser Extension</a>
           {{/default}}
           {{/switch}}
           <a href="https://github.com/Readplace/readplace.com" class="btn btn--secondary" data-test-cta="view-github">View on GitHub</a>
@@ -360,13 +360,13 @@
         <div class="home-cta__actions">
           {{#switch browserName}}
           {{#case "firefox"}}
-          <a href="/install?client=firefox" class="btn btn--brand" data-test-cta="bottom-install">Install Firefox Extension</a>
+          <a href="{{track '/install?client=firefox' medium='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Firefox Extension</a>
           {{/case}}
           {{#case "chrome"}}
-          <a href="/install?client=chrome" class="btn btn--brand" data-test-cta="bottom-install">Install Chrome Extension</a>
+          <a href="{{track '/install?client=chrome' medium='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Chrome Extension</a>
           {{/case}}
           {{#default}}
-          <a href="/install" class="btn btn--brand" data-test-cta="bottom-install">Install Browser Extension</a>
+          <a href="{{track '/install' medium='home-cta' content='install'}}" class="btn btn--brand" data-test-cta="bottom-install">Install Browser Extension</a>
           {{/default}}
           {{/switch}}
           <a href="https://github.com/Readplace/readplace.com" class="home-cta__github-link" data-test-cta="bottom-github">View on GitHub</a>

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -5,6 +5,7 @@ import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
 import { switchHelpers } from "../../handlebars-switch";
 import { INSTALL_PAGE_STYLES } from "./install.styles";
+import { withInternalTracking } from "../../internal-link-tracking";
 import { firefoxS3Config } from "browser-extension-core/s3-config";
 
 const INSTALL_TEMPLATE = readFileSync(join(__dirname, "install.template.html"), "utf-8");
@@ -55,7 +56,7 @@ function buildInstallTabs(active: InstallClient): InstallTab[] {
 		return {
 			key,
 			label,
-			href: `/install?client=${key}`,
+			href: withInternalTracking(`/install?client=${key}`, { medium: "install-tabs", content: key }),
 			activeClass: isActive ? " install-page__tab--active" : "",
 			ariaCurrent: isActive ? "page" : undefined,
 		};

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -56,7 +56,7 @@ function buildInstallTabs(active: InstallClient): InstallTab[] {
 		return {
 			key,
 			label,
-			href: withInternalTracking(`/install?client=${key}`, { medium: "install-tabs", content: key }),
+			href: withInternalTracking(`/install?client=${key}`, { source: "install-tabs", content: key }),
 			activeClass: isActive ? " install-page__tab--active" : "",
 			ariaCurrent: isActive ? "page" : undefined,
 		};

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -241,10 +241,10 @@ describe("GET /install", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxTab = doc.querySelector('[data-test-tab="firefox"]');
-		expect(firefoxTab?.getAttribute("href")).toBe("/install?client=firefox");
+		expect(firefoxTab?.getAttribute("href")).toBe("/install?client=firefox&utm_source=internal&utm_medium=install-tabs&utm_content=firefox");
 
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
-		expect(chromeTab?.getAttribute("href")).toBe("/install?client=chrome");
+		expect(chromeTab?.getAttribute("href")).toBe("/install?client=chrome&utm_source=internal&utm_medium=install-tabs&utm_content=chrome");
 	});
 
 	it("should render an iPhone tab linking to the iPhone panel on every view", async () => {
@@ -253,7 +253,7 @@ describe("GET /install", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
-		expect(iphoneTab?.getAttribute("href")).toBe("/install?client=iphone");
+		expect(iphoneTab?.getAttribute("href")).toBe("/install?client=iphone&utm_source=internal&utm_medium=install-tabs&utm_content=iphone");
 		expect(iphoneTab?.textContent).toBe("iPhone");
 		expect(iphoneTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -241,10 +241,10 @@ describe("GET /install", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const firefoxTab = doc.querySelector('[data-test-tab="firefox"]');
-		expect(firefoxTab?.getAttribute("href")).toBe("/install?client=firefox&utm_source=internal&utm_medium=install-tabs&utm_content=firefox");
+		expect(firefoxTab?.getAttribute("href")).toBe("/install?client=firefox&utm_source=install-tabs&utm_medium=internal&utm_content=firefox");
 
 		const chromeTab = doc.querySelector('[data-test-tab="chrome"]');
-		expect(chromeTab?.getAttribute("href")).toBe("/install?client=chrome&utm_source=internal&utm_medium=install-tabs&utm_content=chrome");
+		expect(chromeTab?.getAttribute("href")).toBe("/install?client=chrome&utm_source=install-tabs&utm_medium=internal&utm_content=chrome");
 	});
 
 	it("should render an iPhone tab linking to the iPhone panel on every view", async () => {
@@ -253,7 +253,7 @@ describe("GET /install", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
-		expect(iphoneTab?.getAttribute("href")).toBe("/install?client=iphone&utm_source=internal&utm_medium=install-tabs&utm_content=iphone");
+		expect(iphoneTab?.getAttribute("href")).toBe("/install?client=iphone&utm_source=install-tabs&utm_medium=internal&utm_content=iphone");
 		expect(iphoneTab?.textContent).toBe("iPhone");
 		expect(iphoneTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { render } from "../../../render";
+import { withInternalTracking } from "../../../internal-link-tracking";
 import type {
 	ArticleAction,
 	QueueArticleViewModel,
@@ -33,6 +34,7 @@ export function toActionDisplayModel(
 		: "queue-article__action-btn queue-article__action-btn--delete";
 	return {
 		...action,
+		url: withInternalTracking(action.url, { medium: "queue-card", content: action.testAction }),
 		buttonClass,
 		disabled: options.isProcessing && isStatusAction,
 	};
@@ -45,7 +47,7 @@ export function toQueueCardDisplayModel(
 	const isProcessing = Boolean(article.cardPollUrl);
 	return {
 		...article,
-		linkUrl: `/queue/${article.id}/view`,
+		linkUrl: withInternalTracking(`/queue/${article.id}/view`, { medium: "queue-card", content: "open-article" }),
 		unreadClass: article.isUnread ? " queue-article--unread" : " queue-article--read",
 		isFirst: options.isFirst,
 		cardStatus: isProcessing ? "pending" : "terminal",

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
@@ -34,7 +34,7 @@ export function toActionDisplayModel(
 		: "queue-article__action-btn queue-article__action-btn--delete";
 	return {
 		...action,
-		url: withInternalTracking(action.url, { medium: "queue-card", content: action.testAction }),
+		url: withInternalTracking(action.url, { source: "queue-card", content: action.testAction }),
 		buttonClass,
 		disabled: options.isProcessing && isStatusAction,
 	};
@@ -47,7 +47,7 @@ export function toQueueCardDisplayModel(
 	const isProcessing = Boolean(article.cardPollUrl);
 	return {
 		...article,
-		linkUrl: withInternalTracking(`/queue/${article.id}/view`, { medium: "queue-card", content: "open-article" }),
+		linkUrl: withInternalTracking(`/queue/${article.id}/view`, { source: "queue-card", content: "open-article" }),
 		unreadClass: article.isUnread ? " queue-article--unread" : " queue-article--read",
 		isFirst: options.isFirst,
 		cardStatus: isProcessing ? "pending" : "terminal",

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -4,6 +4,7 @@ import { OnboardingChecklist, ONBOARDING_STYLES } from "../../onboarding/onboard
 import type { BrowserName } from "../../onboarding/onboarding.types";
 import type { PageBody } from "../../page-body.types";
 import { render } from "../../render";
+import { withInternalTracking } from "../../internal-link-tracking";
 import { QUEUE_STYLES } from "./queue.styles";
 import { renderQueueCard, toQueueCardDisplayModel } from "./queue-card/queue-card.component";
 import { renderToast } from "../../shared/toast/toast.component";
@@ -77,7 +78,10 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 	const effectiveOrder = vm.filters.order ?? tabQuery(activeTab).defaultOrder;
 	const nextOrder = effectiveOrder === "desc" ? "asc" : "desc";
 	const sortLabel = effectiveOrder === "desc" ? "Newest first ↓" : "Oldest first ↑";
-	const sortUrl = buildQueueUrl({ tab: activeTab, order: nextOrder });
+	const sortUrl = withInternalTracking(buildQueueUrl({ tab: activeTab, order: nextOrder }), {
+		medium: "queue-sort",
+		content: "sort",
+	});
 
 	const onboardingHtml = options.onboardingDismissed
 		? ""
@@ -99,7 +103,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 				actions: [
 					{
 						method: "POST",
-						url: vm.statusFlash.undoUrl,
+						url: withInternalTracking(vm.statusFlash.undoUrl, { medium: "queue-toast", content: "undo" }),
 						label: "Undo",
 						fields: [{ name: "status", value: vm.statusFlash.undoStatus }],
 					},
@@ -119,15 +123,19 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		filterUnreadClass: filterLinkClass(activeTab === "queue"),
 		filterUnreadLabel: formatUnreadLabel(vm.unreadCount),
 		filterReadClass: filterLinkClass(activeTab === "done"),
-		filterUnreadUrl: vm.filterUrls.unread,
-		filterReadUrl: vm.filterUrls.read,
+		filterUnreadUrl: withInternalTracking(vm.filterUrls.unread, { medium: "queue-filters", content: "filter-unread" }),
+		filterReadUrl: withInternalTracking(vm.filterUrls.read, { medium: "queue-filters", content: "filter-read" }),
 		sortUrl,
 		sortLabel,
 		showPagination: vm.totalPages > 1,
 		hasPrev: Boolean(vm.paginationUrls.prev),
 		hasNext: Boolean(vm.paginationUrls.next),
-		prevUrl: vm.paginationUrls.prev,
-		nextUrl: vm.paginationUrls.next,
+		prevUrl: vm.paginationUrls.prev
+			? withInternalTracking(vm.paginationUrls.prev, { medium: "queue-pagination", content: "prev" })
+			: undefined,
+		nextUrl: vm.paginationUrls.next
+			? withInternalTracking(vm.paginationUrls.next, { medium: "queue-pagination", content: "next" })
+			: undefined,
 		currentPage: vm.currentPage,
 		totalPages: vm.totalPages,
 		subscriptionBannerStateClass: `queue-banner--${banner.state}`,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -79,7 +79,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 	const nextOrder = effectiveOrder === "desc" ? "asc" : "desc";
 	const sortLabel = effectiveOrder === "desc" ? "Newest first ↓" : "Oldest first ↑";
 	const sortUrl = withInternalTracking(buildQueueUrl({ tab: activeTab, order: nextOrder }), {
-		medium: "queue-sort",
+		source: "queue-sort",
 		content: "sort",
 	});
 
@@ -103,7 +103,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 				actions: [
 					{
 						method: "POST",
-						url: withInternalTracking(vm.statusFlash.undoUrl, { medium: "queue-toast", content: "undo" }),
+						url: withInternalTracking(vm.statusFlash.undoUrl, { source: "queue-toast", content: "undo" }),
 						label: "Undo",
 						fields: [{ name: "status", value: vm.statusFlash.undoStatus }],
 					},
@@ -123,18 +123,18 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		filterUnreadClass: filterLinkClass(activeTab === "queue"),
 		filterUnreadLabel: formatUnreadLabel(vm.unreadCount),
 		filterReadClass: filterLinkClass(activeTab === "done"),
-		filterUnreadUrl: withInternalTracking(vm.filterUrls.unread, { medium: "queue-filters", content: "filter-unread" }),
-		filterReadUrl: withInternalTracking(vm.filterUrls.read, { medium: "queue-filters", content: "filter-read" }),
+		filterUnreadUrl: withInternalTracking(vm.filterUrls.unread, { source: "queue-filters", content: "filter-unread" }),
+		filterReadUrl: withInternalTracking(vm.filterUrls.read, { source: "queue-filters", content: "filter-read" }),
 		sortUrl,
 		sortLabel,
 		showPagination: vm.totalPages > 1,
 		hasPrev: Boolean(vm.paginationUrls.prev),
 		hasNext: Boolean(vm.paginationUrls.next),
 		prevUrl: vm.paginationUrls.prev
-			? withInternalTracking(vm.paginationUrls.prev, { medium: "queue-pagination", content: "prev" })
+			? withInternalTracking(vm.paginationUrls.prev, { source: "queue-pagination", content: "prev" })
 			: undefined,
 		nextUrl: vm.paginationUrls.next
-			? withInternalTracking(vm.paginationUrls.next, { medium: "queue-pagination", content: "next" })
+			? withInternalTracking(vm.paginationUrls.next, { source: "queue-pagination", content: "next" })
 			: undefined,
 		currentPage: vm.currentPage,
 		totalPages: vm.totalPages,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -39,7 +39,7 @@ describe("Queue routes", () => {
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector("[data-test-empty-queue]")?.textContent).toContain("There are no more articles to read");
-			expect(doc.querySelector('[data-test-form="save-article"]')?.getAttribute("action")).toBe("/queue/save?utm_source=internal&utm_medium=queue&utm_content=save");
+			expect(doc.querySelector('[data-test-form="save-article"]')?.getAttribute("action")).toBe("/queue/save?utm_source=queue&utm_medium=internal&utm_content=save");
 		});
 	});
 
@@ -349,7 +349,7 @@ describe("Queue routes", () => {
 			const response = await agent.get("/queue?order=asc");
 			const doc = new JSDOM(response.text).window.document;
 			const sortLink = doc.querySelector("[data-test-sort]");
-			expect(sortLink?.getAttribute("href")).toBe("/queue?utm_source=internal&utm_medium=queue-sort&utm_content=sort");
+			expect(sortLink?.getAttribute("href")).toBe("/queue?utm_source=queue-sort&utm_medium=internal&utm_content=sort");
 			expect(sortLink?.textContent).toContain("Oldest first");
 		});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -39,7 +39,7 @@ describe("Queue routes", () => {
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector("[data-test-empty-queue]")?.textContent).toContain("There are no more articles to read");
-			expect(doc.querySelector('[data-test-form="save-article"]')?.getAttribute("action")).toBe("/queue/save");
+			expect(doc.querySelector('[data-test-form="save-article"]')?.getAttribute("action")).toBe("/queue/save?utm_source=internal&utm_medium=queue&utm_content=save");
 		});
 	});
 
@@ -349,7 +349,7 @@ describe("Queue routes", () => {
 			const response = await agent.get("/queue?order=asc");
 			const doc = new JSDOM(response.text).window.document;
 			const sortLink = doc.querySelector("[data-test-sort]");
-			expect(sortLink?.getAttribute("href")).toBe("/queue");
+			expect(sortLink?.getAttribute("href")).toBe("/queue?utm_source=internal&utm_medium=queue-sort&utm_content=sort");
 			expect(sortLink?.textContent).toContain("Oldest first");
 		});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -322,7 +322,7 @@ describe("Queue routes", () => {
 			expect(toast.querySelector("[data-test-toast-message]")?.textContent).toBe("Marked as read");
 
 			const undoForm = toast.querySelector("[data-test-toast-action]")?.closest("form");
-			expect(undoForm?.getAttribute("action")).toBe(`/queue/${articleId}/status`);
+			expect(undoForm?.getAttribute("action")).toBe(`/queue/${articleId}/status?utm_source=internal&utm_medium=queue-toast&utm_content=undo`);
 			expect(undoForm?.querySelector("input[name='status']")?.getAttribute("value")).toBe("unread");
 
 			await agent.post(`/queue/${articleId}/status`).type("form").send({ status: "unread" });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -322,7 +322,7 @@ describe("Queue routes", () => {
 			expect(toast.querySelector("[data-test-toast-message]")?.textContent).toBe("Marked as read");
 
 			const undoForm = toast.querySelector("[data-test-toast-action]")?.closest("form");
-			expect(undoForm?.getAttribute("action")).toBe(`/queue/${articleId}/status?utm_source=internal&utm_medium=queue-toast&utm_content=undo`);
+			expect(undoForm?.getAttribute("action")).toBe(`/queue/${articleId}/status?utm_source=queue-toast&utm_medium=internal&utm_content=undo`);
 			expect(undoForm?.querySelector("input[name='status']")?.getAttribute("value")).toBe("unread");
 
 			await agent.post(`/queue/${articleId}/status`).type("form").send({ status: "unread" });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -6,18 +6,18 @@
       <aside class="queue-banner {{subscriptionBannerStateClass}}" aria-live="polite" data-test-subscription-banner>
         {{#if subscriptionBannerIsTrialCountdown}}
         <p class="queue-banner__message"><strong data-test-trial-days-left>{{trialDaysLeft}} {{trialDaysLeftWord}} left</strong> in your free trial.</p>
-        <a class="queue-banner__cta" href="{{track '/account' medium='queue-banner' content='subscribe'}}">Subscribe — $3.99/month</a>
+        <a class="queue-banner__cta" href="{{track '/account' source='queue-banner' content='subscribe'}}">Subscribe — $3.99/month</a>
         {{/if}}
         {{#if subscriptionBannerIsCancellationScheduled}}
         <p class="queue-banner__message"><strong>Subscription ending {{cancellationEffectiveAt}}.</strong> You still have full access until then.</p>
-        <a class="queue-banner__cta" href="{{track '/account' medium='queue-banner' content='reactivate'}}">Reactivate</a>
+        <a class="queue-banner__cta" href="{{track '/account' source='queue-banner' content='reactivate'}}">Reactivate</a>
         {{/if}}
         {{#if subscriptionBannerIsInactive}}
         <p class="queue-banner__message"><strong>Subscription not active.</strong> Your saved articles are still here.</p>
         {{/if}}
       </aside>
       {{{statusToastHtml}}}
-      <form class="{{saveFormClass}}" method="POST" action="{{track '/queue/save' medium='queue' content='save'}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>
+      <form class="{{saveFormClass}}" method="POST" action="{{track '/queue/save' source='queue' content='save'}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}"{{#if accessIsReadOnly}} disabled{{/if}}>
         <button class="queue__save-btn" type="submit"{{#if accessIsReadOnly}} disabled{{/if}}><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
       </form>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -6,18 +6,18 @@
       <aside class="queue-banner {{subscriptionBannerStateClass}}" aria-live="polite" data-test-subscription-banner>
         {{#if subscriptionBannerIsTrialCountdown}}
         <p class="queue-banner__message"><strong data-test-trial-days-left>{{trialDaysLeft}} {{trialDaysLeftWord}} left</strong> in your free trial.</p>
-        <a class="queue-banner__cta" href="/account">Subscribe — $3.99/month</a>
+        <a class="queue-banner__cta" href="{{track '/account' medium='queue-banner' content='subscribe'}}">Subscribe — $3.99/month</a>
         {{/if}}
         {{#if subscriptionBannerIsCancellationScheduled}}
         <p class="queue-banner__message"><strong>Subscription ending {{cancellationEffectiveAt}}.</strong> You still have full access until then.</p>
-        <a class="queue-banner__cta" href="/account">Reactivate</a>
+        <a class="queue-banner__cta" href="{{track '/account' medium='queue-banner' content='reactivate'}}">Reactivate</a>
         {{/if}}
         {{#if subscriptionBannerIsInactive}}
         <p class="queue-banner__message"><strong>Subscription not active.</strong> Your saved articles are still here.</p>
         {{/if}}
       </aside>
       {{{statusToastHtml}}}
-      <form class="{{saveFormClass}}" method="POST" action="/queue/save" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>
+      <form class="{{saveFormClass}}" method="POST" action="{{track '/queue/save' medium='queue' content='save'}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}"{{#if accessIsReadOnly}} disabled{{/if}}>
         <button class="queue__save-btn" type="submit"{{#if accessIsReadOnly}} disabled{{/if}}><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
       </form>

--- a/projects/hutch/src/runtime/web/render.test.ts
+++ b/projects/hutch/src/runtime/web/render.test.ts
@@ -35,14 +35,14 @@ describe("render", () => {
 	});
 
 	it("{{track}} stamps internal-click UTM params onto a literal href; Handlebars HTML-escapes the attribute (& → &amp;, = → &#x3D;), which the browser decodes back to a normal query string", () => {
-		const result = render("<a href=\"{{track '/account' source='queue' content='subscribe_cta'}}\">Subscribe</a>", {});
+		const result = render("<a href=\"{{track '/account' source='queue' content='subscribe'}}\">Subscribe</a>", {});
 		expect(result).toBe(
-			'<a href="/account?utm_source&#x3D;queue&amp;utm_medium&#x3D;internal&amp;utm_content&#x3D;subscribe_cta">Subscribe</a>',
+			'<a href="/account?utm_source&#x3D;queue&amp;utm_medium&#x3D;internal&amp;utm_content&#x3D;subscribe">Subscribe</a>',
 		);
 	});
 
 	it("{{track}} leaves an absolute external href untouched so analytics params never leak off-site", () => {
-		const result = render("<a href=\"{{track 'https://github.com/Readplace/readplace.com' source='home_hero' content='github'}}\">GitHub</a>", {});
+		const result = render("<a href=\"{{track 'https://github.com/Readplace/readplace.com' source='home-hero' content='github'}}\">GitHub</a>", {});
 		expect(result).toBe('<a href="https://github.com/Readplace/readplace.com">GitHub</a>');
 	});
 });

--- a/projects/hutch/src/runtime/web/render.test.ts
+++ b/projects/hutch/src/runtime/web/render.test.ts
@@ -33,4 +33,16 @@ describe("render", () => {
 		const result = render(template, { items: ["a", "b"] });
 		expect(result).toBe("<ul><li>a</li><li>b</li></ul>");
 	});
+
+	it("{{track}} stamps internal-click UTM params onto a literal href; Handlebars HTML-escapes the attribute (& → &amp;, = → &#x3D;), which the browser decodes back to a normal query string", () => {
+		const result = render("<a href=\"{{track '/account' medium='queue' content='subscribe_cta'}}\">Subscribe</a>", {});
+		expect(result).toBe(
+			'<a href="/account?utm_source&#x3D;internal&amp;utm_medium&#x3D;queue&amp;utm_content&#x3D;subscribe_cta">Subscribe</a>',
+		);
+	});
+
+	it("{{track}} leaves an absolute external href untouched so analytics params never leak off-site", () => {
+		const result = render("<a href=\"{{track 'https://github.com/Readplace/readplace.com' medium='home_hero' content='github'}}\">GitHub</a>", {});
+		expect(result).toBe('<a href="https://github.com/Readplace/readplace.com">GitHub</a>');
+	});
 });

--- a/projects/hutch/src/runtime/web/render.test.ts
+++ b/projects/hutch/src/runtime/web/render.test.ts
@@ -35,14 +35,14 @@ describe("render", () => {
 	});
 
 	it("{{track}} stamps internal-click UTM params onto a literal href; Handlebars HTML-escapes the attribute (& → &amp;, = → &#x3D;), which the browser decodes back to a normal query string", () => {
-		const result = render("<a href=\"{{track '/account' medium='queue' content='subscribe_cta'}}\">Subscribe</a>", {});
+		const result = render("<a href=\"{{track '/account' source='queue' content='subscribe_cta'}}\">Subscribe</a>", {});
 		expect(result).toBe(
-			'<a href="/account?utm_source&#x3D;internal&amp;utm_medium&#x3D;queue&amp;utm_content&#x3D;subscribe_cta">Subscribe</a>',
+			'<a href="/account?utm_source&#x3D;queue&amp;utm_medium&#x3D;internal&amp;utm_content&#x3D;subscribe_cta">Subscribe</a>',
 		);
 	});
 
 	it("{{track}} leaves an absolute external href untouched so analytics params never leak off-site", () => {
-		const result = render("<a href=\"{{track 'https://github.com/Readplace/readplace.com' medium='home_hero' content='github'}}\">GitHub</a>", {});
+		const result = render("<a href=\"{{track 'https://github.com/Readplace/readplace.com' source='home_hero' content='github'}}\">GitHub</a>", {});
 		expect(result).toBe('<a href="https://github.com/Readplace/readplace.com">GitHub</a>');
 	});
 });

--- a/projects/hutch/src/runtime/web/render.ts
+++ b/projects/hutch/src/runtime/web/render.ts
@@ -3,7 +3,7 @@ import Handlebars from 'handlebars';
 import { withInternalTracking } from './internal-link-tracking';
 
 /**
- * `{{track '/account' source='queue' content='subscribe_cta'}}` stamps the
+ * `{{track '/account' source='queue' content='subscribe'}}` stamps the
  * internal-click UTM params onto a literal href in a template; URLs built in
  * component TS call withInternalTracking directly. Registered once on the
  * shared Handlebars instance so every template can use it without threading a

--- a/projects/hutch/src/runtime/web/render.ts
+++ b/projects/hutch/src/runtime/web/render.ts
@@ -3,7 +3,7 @@ import Handlebars from 'handlebars';
 import { withInternalTracking } from './internal-link-tracking';
 
 /**
- * `{{track '/account' medium='queue' content='subscribe_cta'}}` stamps the
+ * `{{track '/account' source='queue' content='subscribe_cta'}}` stamps the
  * internal-click UTM params onto a literal href in a template; URLs built in
  * component TS call withInternalTracking directly. Registered once on the
  * shared Handlebars instance so every template can use it without threading a
@@ -12,10 +12,10 @@ import { withInternalTracking } from './internal-link-tracking';
  */
 Handlebars.registerHelper('track', (href: unknown, options: Handlebars.HelperOptions): string => {
   assert(typeof href === 'string', '{{track}} requires a string href');
-  const { medium, content } = options.hash;
-  assert(typeof medium === 'string', "{{track}} requires a medium= named arg");
+  const { source, content } = options.hash;
+  assert(typeof source === 'string', "{{track}} requires a source= named arg");
   assert(typeof content === 'string', "{{track}} requires a content= named arg");
-  return withInternalTracking(href, { medium, content });
+  return withInternalTracking(href, { source, content });
 });
 
 const compiledTemplates = new Map<string, HandlebarsTemplateDelegate>();

--- a/projects/hutch/src/runtime/web/render.ts
+++ b/projects/hutch/src/runtime/web/render.ts
@@ -1,4 +1,22 @@
+import assert from "node:assert";
 import Handlebars from 'handlebars';
+import { withInternalTracking } from './internal-link-tracking';
+
+/**
+ * `{{track '/account' medium='queue' content='subscribe_cta'}}` stamps the
+ * internal-click UTM params onto a literal href in a template; URLs built in
+ * component TS call withInternalTracking directly. Registered once on the
+ * shared Handlebars instance so every template can use it without threading a
+ * helper through each render() call. Double-stache escaping turns the joining
+ * `&` into `&amp;`, the correct form inside an HTML attribute.
+ */
+Handlebars.registerHelper('track', (href: unknown, options: Handlebars.HelperOptions): string => {
+  assert(typeof href === 'string', '{{track}} requires a string href');
+  const { medium, content } = options.hash;
+  assert(typeof medium === 'string', "{{track}} requires a medium= named arg");
+  assert(typeof content === 'string', "{{track}} requires a content= named arg");
+  return withInternalTracking(href, { medium, content });
+});
 
 const compiledTemplates = new Map<string, HandlebarsTemplateDelegate>();
 


### PR DESCRIPTION
## What & why

Tracks **which in-site links and action buttons readers click most**, using UTM query params and matching the convention the codebase already uses (`/queue?utm_source=reader&utm_medium=internal&utm_content=back-top`):

| param | value |
|-------|-------|
| `utm_medium` | **`internal`** — the constant marker on every in-site link/button |
| `utm_source` | the **section** the element lives in (`footer`, `queue-filters`, `header-nav`, `home-hero`, `account`, `install-tabs`, …) |
| `utm_content` | the **element** (`save`, `subscribe`, `mark-read`, `delete`, `install`, …) |
| `utm_campaign` | **not used** |

## How it works

The existing pageview logger only records full-page GETs (it drops HTMX-boosted requests and POSTs), which is *most* of the action buttons (Save/Delete/Mark-read/Logout/Subscribe are POST forms; queue filters are boosted). So tagging hrefs alone wouldn't capture them. Instead:

- The analytics middleware emits a dedicated **`click`** event for **any** request carrying `utm_medium=internal` — GET, HTMX-boosted, **and** POST — so every action type is counted with no client-side beacon. (This also picks up the pre-existing `utm_medium=internal` reader/view links for free.)
- `utm_medium=internal` is **stripped from `pageview`** events, so the acquisition dashboards (grouped by the real `utm_source` like `hackernews`) keep their meaning and aren't diluted by internal navigation.
- A new dashboard widget surfaces **"Internal clicks by section / element."**
- `withInternalTracking(href, { source, content })` and a `{{track '/path' source=… content=…}}` Handlebars helper tag any href/form action at render time. Absolute (`https://…`) and protocol-relative (`//host/…`) links pass through untouched.

### Form mechanics (load-bearing)

- **Anchors** and **POST form `action`s** carry the tagged href — POST preserves the action's query string, so `req.query` sees the UTM.
- **GET forms** (the header nav) discard the action's query on submit, so those get **hidden `utm_*` inputs**. (This also fixes the previously markup-only-tested `NAV_IMPORT` tag.)

## Surfaces tagged

- **Chrome:** footer (blog/privacy/terms), header brand + trial countdown, header nav (queue/import/export/account/logout/features/signup).
- **Queue:** subscribe/reactivate CTA, save form, filter/sort/pagination links, card open link, mark-read/unread/delete, undo toast.
- **Home:** hero + bottom Install-Extension CTAs.
- **Account:** Subscribe / Cancel / Reactivate subscription forms.
- **Install page:** Firefox / Chrome tabs.
- **Export:** "Email Me My Data" form.
- **Auth cross-links:** Forgot password, Back to login, Sign in, Request a new link.

## Conversion attribution preserved; in-site hops counted as clicks, not acquisition

Conversion/funnel links keep their existing `utm_source` (`homepage`, `auth-page`, …) — this PR doesn't re-tag them, and **conversion attribution is unaffected**: `user_created` reads first-touch UTM from the `hutch_click` cookie (set on the first GET, never overwritten), which this PR doesn't touch.

These links already carry `utm_medium=internal` (pre-dating this PR — e.g. the reader back-links), so the marker convention now counts a click on them as an **internal click** (homepage Signup → section `homepage`, element `founding-card`) and keeps their `utm_source` out of the **acquisition pageview** widgets. That's intended: clicking the homepage Signup CTA is in-site navigation, not an external source like `hackernews`, so it belongs in the internal-clicks widget rather than inflating `homepage` as a traffic source. Covered: homepage **signup CTAs**, the **"try the reader" form**, and the **login form action**.

## Out of scope (no URL to attach a UTM to)

JS-only buttons (Share / Copy) and blog prose links.

🤖 Generated with [Claude Code](https://claude.ai/code)
