### PR TITLE
docs(blog): add post on the iPhone app beta and share-sheet saving

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/read-it-later-iphone-app.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/read-it-later-iphone-app.md
@@ -1,0 +1,47 @@
+---
+title: "Read It Later on Your iPhone, From the Share Sheet"
+description: "Readplace now has an iPhone app in beta. Open any page in Safari, Chrome, or another browser, tap Share, and pick Readplace. The link saves to your reading queue and renders in the background, with no copy-paste and no opening the app first."
+slug: "read-it-later-iphone-app"
+date: "2026-06-09"
+author: "Fayner Brack"
+keywords: "read it later iphone app, save articles iphone, ios share sheet, save to read later ios, pocket alternative iphone, save article from safari, testflight, readplace"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Readplace now has an iPhone app in beta. It plugs into the iOS share sheet, the same menu you use to send a link to a friend. Open any page in Safari, Chrome, or another browser, tap Share, and pick Readplace. The link saves to your reading queue and renders in the background, so you stay where you are. The app also lists your saved articles, with pull-to-refresh and swipe-to-delete. For a real reading session, the website on mobile still reads better. The app is on TestFlight, Apple's free app for trying betas, and takes a couple of minutes to set up.
+
+</div>
+</details>
+
+You spot a good article on your phone. You want to read it later, when you have a quiet half hour. Until now, saving it to Readplace from an iPhone meant copy-paste or a trip to the website. That extra step is the kind of friction that loses an article before you ever read it.
+
+The iPhone app removes that step. It hooks into the iOS share sheet, the menu you already use to send a link to a friend. Open the page in Safari, Chrome, or any browser, tap Share, and pick Readplace. The link drops into your reading queue. It takes one tap from the page you already have open, with no copy-paste and no need to open the app first.
+
+## How saving works
+
+Tap Share and choose Readplace, the way you would share a link to WhatsApp. The app reads the page and saves it in the background, so you stay on the page you were reading. Switch back to your browser and carry on. A moment later the article shows up at readplace.com, with its title and clean text pulled out.
+
+This is the part worth testing most. It turns any browser on your phone into a save button for your reading list.
+
+## Browse your queue
+
+The app also shows your saved articles. They appear in order, you pull down to refresh, and you swipe an item left to delete it. So you can check what you have lined up and clear out the ones you no longer want.
+
+For an actual reading session, the website on mobile still gives you the better view. The app stays focused on the two things you do on the move: save fast, and glance at your list.
+
+## It is a beta, and you can join
+
+The app is in beta through TestFlight, Apple's free app for trying out betas. Setup takes a couple of minutes.
+
+Install TestFlight from the App Store, join the Readplace beta, then install and open the app once. Opening it the first time registers the "Share to Readplace" option in iOS, so saving works from then on. Sign in with your account and leave the server set to readplace.com.
+
+If Readplace does not appear in the share row the first time, close the sheet and tap Share again, or tap More to switch it on. You can favourite it so it sits near the top next time.
+
+## Try it
+
+Open the install page on your iPhone and pick the iPhone tab to join the beta. Save a handful of articles from the share sheet this week, then open readplace.com when you have time to read them. Feedback from these early saves shapes what the app does next.
+
+[Join the iPhone beta](https://readplace.com/install?client=iphone) or start at [readplace.com](/).


### PR DESCRIPTION
## What

Adds a new blog post: **Read It Later on Your iPhone, From the Share Sheet** (`read-it-later-iphone-app.md`).

## Why

Reviewing commits landed on `main` since the last published post (`watch-your-article-save-step-by-step`, 2026-06-08), the most conversion- and SEO-relevant uncovered change is the **iPhone app beta** added in #506 (`feat(hutch): add iPhone app beta tab to install page`). A native iOS save path is a core draw for read-it-later customers and a strong search target (e.g. "read it later iphone app", "save articles iphone", "ios share sheet"), so it earns its own post.

The post leads with the customer benefit (save any page from the iOS share sheet, no copy-paste, no opening the app first), explains the background save, covers browsing the queue in-app, documents the TestFlight beta setup, and ends with a clear CTA to `/install?client=iphone`.

Other commits since the last post were lower-value for external communication: in-site click tracking with `utm_source=internal` (#517, internal analytics), a tab-aware empty-state title (#505, minor UX), and BPMN architecture renderings (#511, internal docs).

## Notes

- Follows the existing post conventions: frontmatter schema, slug matches filename, TL;DR block, headings, CTA.
- Body is ~480 words (within the 400–800 target).
- No pricing or founding-member references included (those date quickly).
- Blog tests pass locally (`nx test hutch --testPathPattern=blog`: 40 passed). Full pre-commit checks ran clean.

https://claude.ai/code/session_0151maHTEB2kqosr84sKnqUA

---
_Generated by [Claude Code](https://claude.ai/code/session_0151maHTEB2kqosr84sKnqUA)_