### PR TITLE
fix(view): noindex public /view and point canonical at the original source

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -178,7 +178,9 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		staticBaseUrl: STATIC_BASE_URL,
 		title: seo.title,
 		description: seo.description,
-		canonicalUrl: normalizeCanonicalUrl(seo.canonicalUrl),
+		canonicalUrl: seo.canonicalIsExternal
+			? new URL(seo.canonicalUrl).href
+			: normalizeCanonicalUrl(seo.canonicalUrl),
 		ogType,
 		ogImage: seo.ogImage,
 		ogImageAlt: seo.ogImageAlt,

--- a/projects/hutch/src/runtime/web/page-body.types.ts
+++ b/projects/hutch/src/runtime/web/page-body.types.ts
@@ -2,6 +2,11 @@ export interface SeoMetadata {
 	title: string;
 	description: string;
 	canonicalUrl: string;
+	/** When true, `canonicalUrl` is kept as a cross-origin URL instead of being
+	 * forced onto readplace.com — `/view` points its canonical at the original
+	 * publisher so search/answer engines attribute the text to the source rather
+	 * than reading readplace.com as a scraper proxy. */
+	canonicalIsExternal?: boolean;
 	ogImage?: string;
 	ogImageAlt?: string;
 	ogImageType?: string;

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -132,10 +132,10 @@ describe("ViewPage", () => {
 		expect(links[1]?.getAttribute("href")).toBe("/save?url=x");
 	});
 
-	it("emits OG metadata using the article title and excerpt", () => {
+	it("emits OG metadata using the article title and excerpt, with canonical + og:url pointing at the original source", () => {
 		const doc = render();
 
-		const canonical = `https://readplace.com/view/example.com/post`;
+		const canonical = `https://example.com/post`;
 		expect(
 			doc.querySelector('meta[property="og:title"]')?.getAttribute("content"),
 		).toBe("Hello World | Reader View");
@@ -260,15 +260,15 @@ describe("ViewPage", () => {
 		).toBe("View on Readplace.");
 	});
 
-	it("emits index,follow robots meta", () => {
+	it("emits noindex robots meta so the wrapper is not indexed as a scraper proxy", () => {
 		const doc = render();
 
 		expect(
 			doc.querySelector('meta[name="robots"]')?.getAttribute("content"),
-		).toBe("index, follow");
+		).toBe("noindex, follow");
 	});
 
-	it("emits JSON-LD Article with isBasedOn attributed to the source URL", () => {
+	it("emits JSON-LD Article whose url is the original source (not the /view wrapper)", () => {
 		const doc = render();
 
 		const script = doc.querySelector('script[type="application/ld+json"]');
@@ -276,10 +276,8 @@ describe("ViewPage", () => {
 		const data = JSON.parse(script.textContent ?? "{}");
 		expect(data["@type"]).toBe("Article");
 		expect(data.headline).toBe("Hello World");
-		expect(data.isBasedOn).toEqual({
-			"@type": "Article",
-			url: "https://example.com/post",
-		});
+		expect(data.url).toBe("https://example.com/post");
+		expect(data.isBasedOn).toBeUndefined();
 		expect(data.image).toBe("https://cdn.example.com/hero.jpg");
 	});
 
@@ -494,13 +492,13 @@ describe("ViewPage", () => {
 			assert.equal(copyUrl.origin, "https://staging.readplace.com");
 		});
 
-		it("keeps the SEO canonical URL on https://readplace.com regardless of appOrigin (search indexing must stay on production)", () => {
+		it("pegs the SEO canonical to the original source regardless of appOrigin (we disclaim the wrapper; the publisher is canonical)", () => {
 			const doc = render({
 				...baseInput,
 				appOrigin: "https://staging.readplace.com",
 			});
 
-			const canonical = `https://readplace.com/view/example.com/post`;
+			const canonical = `https://example.com/post`;
 			assert.equal(
 				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
 				canonical,

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -28,11 +28,6 @@ const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js"
 const EXPIRY_COUNTER_SCRIPT = `<script src="/client-dist/expiry-counter.client.js" defer></script>`;
 const VIEW_PAYWALL_SCRIPT = `<script src="/client-dist/view-paywall.client.js" defer></script>`;
 
-/** SEO-only constant: <link rel="canonical"> and JSON-LD url must always point
- * at production so search engines index a single host. The share URL uses the
- * visitor's current origin (input.appOrigin) instead — copying a link on
- * staging should paste the staging URL, not production. */
-const CANONICAL_BASE_URL = "https://readplace.com";
 const DEFAULT_OG_IMAGE = `${STATIC_BASE_URL}/og-image-1200x630.png`;
 const DEFAULT_TWITTER_IMAGE = `${STATIC_BASE_URL}/twitter-card-1200x600.png`;
 const DEFAULT_OG_ALT = "Readplace — A read-it-later app";
@@ -140,7 +135,6 @@ export function ViewPage(input: ViewPageInput): PageBody {
 	});
 
 	const viewPath = viewPathFor(input.articleUrl);
-	const canonicalViewUrl = `${CANONICAL_BASE_URL}${viewPath}`;
 	const shareableViewUrl = `${input.appOrigin}${viewPath}`;
 
 	const shareBalloon = renderShareBalloon({
@@ -196,8 +190,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		"@type": "Article",
 		headline: input.metadata.title,
 		description: description,
-		url: canonicalViewUrl,
-		isBasedOn: { "@type": "Article", url: input.articleUrl },
+		url: input.articleUrl,
 	};
 	if (input.metadata.imageUrl) {
 		structuredData.image = input.metadata.imageUrl;
@@ -207,12 +200,13 @@ export function ViewPage(input: ViewPageInput): PageBody {
 		seo: {
 			title: formatViewDocumentTitle(input.metadata.title),
 			description,
-			canonicalUrl: viewPath,
+			canonicalUrl: input.articleUrl,
+			canonicalIsExternal: true,
 			ogType: "article",
 			ogImage,
 			ogImageAlt,
 			twitterImage,
-			robots: "index, follow",
+			robots: "noindex, follow",
 			structuredData: [structuredData],
 		},
 		styles: VIEW_STYLES,

--- a/projects/hutch/src/runtime/web/pages/view/view.metadata.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.metadata.route.test.ts
@@ -98,7 +98,7 @@ describe("View routes", () => {
 			).toBe("article");
 			expect(
 				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
-			).toBe(`https://readplace.com/view/${CANONICAL_PATH}`);
+			).toBe(ARTICLE_URL);
 			expect(
 				doc
 					.querySelector('meta[name="twitter:description"]')
@@ -159,7 +159,7 @@ describe("View routes", () => {
 			).toMatch(/twitter-card-1200x600\.png$/);
 		});
 
-		it("emits JSON-LD Article with isBasedOn attributed to the source URL", async () => {
+		it("emits JSON-LD Article whose url is the original source URL", async () => {
 			const parseArticle: ParseArticle = async () => buildParseResult();
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const applyParseResult = createFakeApplyParseResult({
@@ -198,11 +198,12 @@ describe("View routes", () => {
 				(s: { "@type": string }) => s["@type"] === "Article",
 			);
 			assert(article, "Article schema must be present");
-			expect(article.isBasedOn).toEqual({ "@type": "Article", url: ARTICLE_URL });
+			expect(article.url).toBe(ARTICLE_URL);
+			expect(article.isBasedOn).toBeUndefined();
 			expect(article.headline).toBe("Hello World");
 		});
 
-		it("emits robots: index, follow", async () => {
+		it("emits robots: noindex, follow", async () => {
 			const parseArticle: ParseArticle = async () => buildParseResult();
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const applyParseResult = createFakeApplyParseResult({
@@ -235,7 +236,7 @@ describe("View routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			expect(
 				doc.querySelector('meta[name="robots"]')?.getAttribute("content"),
-			).toBe("index, follow");
+			).toBe("noindex, follow");
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -698,7 +698,7 @@ describe("View routes", () => {
 
 			expect(
 				doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
-			).toBe(`https://readplace.com/view/${CANONICAL_PATH}`);
+			).toBe(ARTICLE_URL);
 		});
 
 		it("renders a dismiss button with an accessible label", async () => {


### PR DESCRIPTION
## Why

`readplace.com/view/<url>` renders third-party article text. If Google indexes those wrapper pages, the domain starts looking like a scraper proxy, which drags first-party product pages down with it. HN readers also resent interstitial wrappers. The fix is to disclaim the wrapper in our SEO signals and attribute the content to the primary source — direct citations to original sources raise trust with both search and answer engines.

## What changed

Every public `/view` article page now:

- **Emits `robots: noindex, follow`** (was `index, follow`). The page stays crawlable so engines can read the canonical and follow through to the source, but the wrapper itself is kept out of the index.
- **Sets `<link rel="canonical">`, `og:url`, and JSON-LD `url` to the original publisher URL** (was the `https://readplace.com/view/…` wrapper URL). This matches what the `text/markdown` variant of `/view` already did (`Canonical: <source>`).
- **Drops the now self-referential JSON-LD `isBasedOn`** — with `url` already pointing at the source, the Article schema cleanly describes the original.

## How

`base.component.ts`'s `normalizeCanonicalUrl` deliberately forces every canonical onto `readplace.com` (guarded by an existing test, to stop staging URLs leaking into canonicals). Rather than weaken that shared guard, I added an explicit opt-in:

- `SeoMetadata.canonicalIsExternal` — when set, the base layout preserves the cross-origin canonical instead of forcing the origin. Only `/view` sets it.

## Scope / non-goals

- **Share links are unchanged.** The share balloon still produces `…/view/<url>` links against the visitor's `appOrigin` — only the indexing/attribution signals move to the source.
- The `/view` **landing form** (the paste box, no third-party text) stays `index, follow`.
- No sitemap change needed — `/view` paths were never listed in `sitemap.xml`.

## Verification

`pnpm nx run hutch:check` passes (type-check, biome, knip, unused-css, tests, coverage). `view.component.ts` is at 100% coverage; all thresholds met. Updated the affected route/component tests to assert the source URL, `noindex, follow`, and the JSON-LD `url`/absent `isBasedOn`.

https://claude.ai/code/session_01LabRr5Axuqcqz37dttUvEz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LabRr5Axuqcqz37dttUvEz)_