### PR TITLE
feat(hutch): add brand logos and Install nav, refine iPhone beta tab

### DIFF
--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { UserIdSchema } from "@packages/domain/user";
 import {
 	bannerStateFromRequest,
@@ -32,9 +33,15 @@ describe("bannerStateFromRequest", () => {
 });
 
 describe("buildGuestNavItems", () => {
-	it("returns features and signup as a flat list", () => {
+	it("returns install, features, and signup as a flat list with install left of features", () => {
 		const items = buildGuestNavItems();
-		expect(items.map((i) => i.key)).toEqual(["features", "signup"]);
+		expect(items.map((i) => i.key)).toEqual(["install", "features", "signup"]);
+	});
+
+	it("points the install item at the install page", () => {
+		const install = buildGuestNavItems().find((i) => i.key === "install");
+		assert(install, "guest nav must include an install item");
+		expect(install.href).toBe("/install?utm_source=header-nav&utm_medium=internal&utm_content=install");
 	});
 
 	it("assigns a Font Awesome solid icon to every guest item", () => {

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -17,6 +17,7 @@ export type NavItemKey =
 	| "export"
 	| "account"
 	| "logout"
+	| "install"
 	| "features"
 	| "signup";
 
@@ -120,12 +121,13 @@ const NAV_IMPORT = navItem({ key: "import", label: "Import Links", path: "/impor
 const NAV_EXPORT = navItem({ key: "export", label: "Export", path: "/export", method: "GET", icon: "fa-solid fa-file-export" });
 const NAV_ACCOUNT = navItem({ key: "account", label: "Account", path: "/account", method: "GET", icon: "fa-solid fa-user" });
 const NAV_LOGOUT = navItem({ key: "logout", label: "Sign out", path: "/logout", method: "POST", icon: "fa-solid fa-right-from-bracket" });
+const NAV_INSTALL = navItem({ key: "install", label: "Install", path: "/install", method: "GET", icon: "fa-solid fa-download" });
 const NAV_FEATURES = navItem({ key: "features", label: "Features", path: "/#what-works", method: "GET", icon: "fa-solid fa-wand-magic-sparkles" });
 const NAV_SIGNUP = navItem({ key: "signup", label: "Sign up", path: "/signup", method: "GET", icon: "fa-solid fa-user-plus" });
 
 /** Guest nav items rendered as a flat list without group structure. */
 export function buildGuestNavItems(): NavItem[] {
-	return [NAV_FEATURES, NAV_SIGNUP];
+	return [NAV_INSTALL, NAV_FEATURES, NAV_SIGNUP];
 }
 
 /** Builds the grouped header nav for authenticated users. The template

--- a/projects/hutch/src/runtime/web/base.template.html
+++ b/projects/hutch/src/runtime/web/base.template.html
@@ -43,6 +43,8 @@
   <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" integrity="sha384-5t0634b3BeTSoxIIgd8lhUy22xY2BGs89gw0vReAMGcfJXXfA7fblIRGVkRFWRDL" crossorigin="anonymous"></noscript>
   <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/solid.min.css" as="style" integrity="sha384-+CMpNM/Tv3YfWmU43LPsvXlIdOUnxSooWv5fY/Tkap65JU4QTLBHp8nMrEkIEb3u" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/solid.min.css" integrity="sha384-+CMpNM/Tv3YfWmU43LPsvXlIdOUnxSooWv5fY/Tkap65JU4QTLBHp8nMrEkIEb3u" crossorigin="anonymous"></noscript>
+  <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" as="style" integrity="sha384-hu7sKftLeB/8IYmWPfl2Jo6MTRHquwXVmGPT/08RqhuANVZrbNFBIsvWPOiUduYX" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" integrity="sha384-hu7sKftLeB/8IYmWPfl2Jo6MTRHquwXVmGPT/08RqhuANVZrbNFBIsvWPOiUduYX" crossorigin="anonymous"></noscript>
 
   <link rel="icon" type="image/svg+xml" href="{{staticBaseUrl}}/favicon.svg">
   <link rel="icon" type="image/x-icon" href="{{staticBaseUrl}}/favicon.ico">

--- a/projects/hutch/src/runtime/web/nav.component.test.ts
+++ b/projects/hutch/src/runtime/web/nav.component.test.ts
@@ -139,7 +139,7 @@ describe("Nav component", () => {
 		expect(queue.textContent).toBe("Queue");
 	});
 
-	it("renders guest nav items (features, signup) as a flat list without group structure", () => {
+	it("renders guest nav items (install, features, signup) as a flat list without group structure, install left of features", () => {
 		const doc = parse(
 			Nav({
 				variant: "default",
@@ -151,9 +151,15 @@ describe("Nav component", () => {
 		const nav = doc.querySelector("[data-test-nav-variant]");
 		assert(nav, "nav variant marker must render");
 		expect(nav.getAttribute("data-test-nav-variant")).toBe("guest");
-		assert(doc.querySelector('[data-test-nav-item="features"]'));
-		assert(doc.querySelector('[data-test-nav-item="signup"]'));
-		expect(doc.querySelector('[data-test-nav-item="queue"]')).toBeNull();
+
+		const items = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
+			(el) => el.getAttribute("data-test-nav-item"),
+		);
+		expect(items).toEqual(["install", "features", "signup"]);
+
+		const install = doc.querySelector('[data-test-nav-item="install"]');
+		assert(install, "guest nav must render an install item");
+		expect(install.closest("form")?.getAttribute("action")).toBe("/install?utm_source=header-nav&utm_medium=internal&utm_content=install");
 		expect(doc.querySelectorAll("[data-test-nav-group]")).toHaveLength(0);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -14,9 +14,9 @@ const CHROME_WEB_STORE_URL = "https://chromewebstore.google.com/detail/hutch/klb
 const TESTFLIGHT_URL = "https://testflight.apple.com/join/5eng821W";
 
 const TAB_DEFINITIONS = [
-	{ key: "firefox", label: "Firefox" },
-	{ key: "chrome", label: "Chrome" },
-	{ key: "iphone", label: "iPhone" },
+	{ key: "firefox", label: "Firefox", icon: "fa-brands fa-firefox-browser" },
+	{ key: "chrome", label: "Chrome", icon: "fa-brands fa-chrome" },
+	{ key: "iphone", label: "iPhone (beta)", icon: "fa-brands fa-apple" },
 ] as const;
 
 export type InstallClient = (typeof TAB_DEFINITIONS)[number]["key"];
@@ -45,17 +45,19 @@ export async function fetchFirefoxDownloadUrl(): Promise<string | null> {
 interface InstallTab {
 	key: InstallClient;
 	label: string;
+	icon: string;
 	href: string;
 	activeClass: string;
 	ariaCurrent?: "page";
 }
 
 function buildInstallTabs(active: InstallClient): InstallTab[] {
-	return TAB_DEFINITIONS.map(({ key, label }) => {
+	return TAB_DEFINITIONS.map(({ key, label, icon }) => {
 		const isActive = key === active;
 		return {
 			key,
 			label,
+			icon,
 			href: withInternalTracking(`/install?client=${key}`, { source: "install-tabs", content: key }),
 			activeClass: isActive ? " install-page__tab--active" : "",
 			ariaCurrent: isActive ? "page" : undefined,
@@ -96,7 +98,7 @@ const BETA_SETUP_STEPS: BetaSetupStep[] = [
 ];
 
 const BETA_OUTRO =
-	"Use it for a few days or weeks: save the articles you want to read later, then open readplace.com when you have time to read them. I'll check in soon to see how it's going, and any feedback is welcome.";
+	"Use it for a few days or weeks: save the articles you want to read later, then open readplace.com when you have time to read them. I'll check in soon by email to see how it's going, and any feedback is welcome in-app.";
 
 export function InstallPage(params: { firefox: string | null; client: InstallClient }): PageBody {
 	return {

--- a/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.route.test.ts
@@ -57,6 +57,27 @@ describe("GET /install", () => {
 		expect(tabs).toEqual(["firefox", "chrome", "iphone"]);
 	});
 
+	it("should render the platform brand logo as an aria-hidden icon on each tab", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install");
+		const doc = new JSDOM(response.text).window.document;
+
+		const expectedIcons: Record<string, string> = {
+			firefox: "fa-firefox-browser",
+			chrome: "fa-chrome",
+			iphone: "fa-apple",
+		};
+		for (const [client, iconClass] of Object.entries(expectedIcons)) {
+			const icon = doc.querySelector(
+				`[data-test-tab="${client}"] .install-page__tab-icon`,
+			);
+			assert(icon, `${client} tab must render a brand icon`);
+			expect(icon.classList.contains("fa-brands")).toBe(true);
+			expect(icon.classList.contains(iconClass)).toBe(true);
+			expect(icon.getAttribute("aria-hidden")).toBe("true");
+		}
+	});
+
 	it("should default to Chrome tab when no client param is provided", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const response = await request(harness.server).get("/install");
@@ -254,7 +275,7 @@ describe("GET /install", () => {
 
 		const iphoneTab = doc.querySelector('[data-test-tab="iphone"]');
 		expect(iphoneTab?.getAttribute("href")).toBe("/install?client=iphone&utm_source=install-tabs&utm_medium=internal&utm_content=iphone");
-		expect(iphoneTab?.textContent).toBe("iPhone");
+		expect(iphoneTab?.textContent).toBe("iPhone (beta)");
 		expect(iphoneTab?.classList.contains("install-page__tab--active")).toBe(false);
 	});
 
@@ -318,6 +339,17 @@ describe("GET /install", () => {
 		expect(stepsText).toContain("TestFlight");
 		expect(stepsText).toContain("Share");
 		expect(stepsText).toContain("readplace.com");
+	});
+
+	it("should tell beta testers check-ins come by email and feedback is welcome in-app", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/install?client=iphone");
+		const doc = new JSDOM(response.text).window.document;
+
+		const outro = doc.querySelector('[data-test-section="ios-beta-outro"]');
+		assert(outro, "iPhone beta outro must be rendered");
+		expect(outro.textContent).toContain("I'll check in soon by email");
+		expect(outro.textContent).toContain("feedback is welcome in-app");
 	});
 
 	it("returns markdown when Accept: text/markdown is sent", async () => {

--- a/projects/hutch/src/runtime/web/pages/install/install.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.styles.ts
@@ -29,6 +29,9 @@ export const INSTALL_PAGE_STYLES = `
 }
 
 .install-page__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   padding: 12px 24px;
   font-size: 1rem;
   font-weight: 500;
@@ -37,6 +40,10 @@ export const INSTALL_PAGE_STYLES = `
   border-bottom: 2px solid transparent;
   transition: color 0.2s, border-color 0.2s;
   margin-bottom: -1px;
+}
+
+.install-page__tab-icon {
+  font-size: 1.125rem;
 }
 
 .install-page__tab:hover {

--- a/projects/hutch/src/runtime/web/pages/install/install.template.html
+++ b/projects/hutch/src/runtime/web/pages/install/install.template.html
@@ -5,7 +5,7 @@
 
       <nav class="install-page__tabs" aria-label="Platform" data-test-section="tabs">
         {{#each tabs}}
-        <a href="{{href}}" class="install-page__tab{{activeClass}}"{{#if ariaCurrent}} aria-current="{{ariaCurrent}}"{{/if}} data-test-tab="{{key}}">{{label}}</a>
+        <a href="{{href}}" class="install-page__tab{{activeClass}}"{{#if ariaCurrent}} aria-current="{{ariaCurrent}}"{{/if}} data-test-tab="{{key}}"><i class="install-page__tab-icon {{icon}}" aria-hidden="true"></i>{{label}}</a>
         {{/each}}
       </nav>
 
@@ -40,7 +40,7 @@
           {{/each}}
         </ol>
 
-        <p class="install-page__steps-outro">{{betaOutro}}</p>
+        <p class="install-page__steps-outro" data-test-section="ios-beta-outro">{{betaOutro}}</p>
       </section>
       {{/case}}
 


### PR DESCRIPTION
## What & why

Four focused changes to the install experience and logged-out navigation:

1. **iPhone tab renamed to "iPhone (beta)"** — the platform tab on `/install` now reads `iPhone (beta)`, matching the in-panel beta badge so the tab itself signals the app is still in beta.
2. **"Install" item added to the logged-out header nav** — guests now see `Install` to the left of `Features` (order: `Install | Features | Sign up`), linking to `/install`. It only renders for logged-out users; authenticated users are unaffected.
3. **Brand logos on each install tab** — Firefox, Chrome, and Apple logos render next to their labels (`fa-brands fa-firefox-browser`, `fa-chrome`, `fa-apple`), each as an `aria-hidden` icon so the accessible name stays the platform label. This required loading Font Awesome's `brands.min.css` in the base template (only `fontawesome` + `solid` were loaded before).
4. **Reworded iPhone beta outro** — "I'll check in soon to see how it's going, and any feedback is welcome." → "I'll check in soon **by email** to see how it's going, and any feedback is welcome **in-app**."

## Notes

- The new `brands.min.css` `<link>` uses the same preload + `onload` swap + `<noscript>` pattern as the existing Font Awesome links. Its `sha384` SRI hash was computed from the real cdnjs file; the same method reproduced the two existing hashes exactly.
- The guest-nav `Install` item uses a `fa-solid` icon (`fa-download`) to satisfy the existing invariant that every guest nav item is a solid icon; the brand (`fa-brands`) icons are scoped to the install-page tabs.

## Tests

- Updated `install.route.test.ts`: iPhone tab label, plus new tests asserting each tab renders its brand logo (`aria-hidden`) and the reworded beta outro copy.
- Updated `nav.component.test.ts` and `banner-state.test.ts`: guest nav now renders `[install, features, signup]` with `install` linking to `/install`.
- `pnpm nx run hutch:check` (and the full pre-commit `check` across all 25 projects) passes — lint, type-check, tests, 100% coverage on install files, knip, unused-css.

https://claude.ai/code/session_01QtMZ597Z8yoP2ugPrRmSt5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtMZ597Z8yoP2ugPrRmSt5)_