### PR TITLE
fix(hutch): escape JSON-LD output to prevent XSS via crawled metadata

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -278,6 +278,85 @@ describe("Base component", () => {
 		expect(data.name).toBe("Readplace");
 	});
 
+	function extractJsonLdBlock(html: string): string {
+		const openTag = '<script type="application/ld+json">';
+		const start = html.indexOf(openTag);
+		assert(start >= 0, "JSON-LD script block must be rendered");
+		const innerStart = start + openTag.length;
+		const innerEnd = html.indexOf("</script>", innerStart);
+		assert(innerEnd >= 0, "JSON-LD script block must be closed");
+		return html.slice(innerStart, innerEnd);
+	}
+
+	it("escapes a </script> payload in structured data so it cannot terminate the JSON-LD block", () => {
+		const hostileHeadline = "</script><script>alert(1)</script>";
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "https://readplace.com",
+				structuredData: [{ "@type": "Article", headline: hostileHeadline }],
+			},
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+
+		// Everything up to the first real closing tag must be the complete JSON,
+		// with the payload's tags emitted only in their JSON-escaped form.
+		const inner = extractJsonLdBlock(result.body);
+		expect(inner).toBe(
+			'{"@type":"Article","headline":"\\u003c/script\\u003e\\u003cscript\\u003ealert(1)\\u003c/script\\u003e"}',
+		);
+		expect(JSON.parse(inner)).toEqual({ "@type": "Article", headline: hostileHeadline });
+	});
+
+	it("escapes <!-- and the U+2028/U+2029 line separators in structured data", () => {
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "https://readplace.com",
+				structuredData: [
+					{
+						"@type": "Article",
+						headline: "line\u2028paragraph\u2029end",
+						description: "<!-- sneaky comment -->",
+					},
+				],
+			},
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+
+		const inner = extractJsonLdBlock(result.body);
+		expect(inner).toBe(
+			'{"@type":"Article","headline":"line\\u2028paragraph\\u2029end","description":"\\u003c!-- sneaky comment --\\u003e"}',
+		);
+	});
+
+	it("round-trips structured data through escaping: parsing the JSON-LD block deep-equals the input", () => {
+		const original = {
+			"@context": "https://schema.org",
+			"@type": "Article",
+			headline: '</script><!--<script>alert(1)</script>-->',
+			description: 'Ampersands & angle <brackets> with "quotes", back\\slashes and line\u2028paragraph\u2029separators',
+			isBasedOn: { "@type": "Article", url: "https://example.com/a?b=1&c=<2>" },
+			keywords: ["a<b", "c>d", "e&f"],
+		};
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "https://readplace.com",
+				structuredData: [original],
+			},
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const ldJson = doc.querySelector('script[type="application/ld+json"]');
+		assert(ldJson?.textContent, "JSON-LD script must survive HTML parsing as a single block");
+		expect(JSON.parse(ldJson.textContent)).toEqual(original);
+	});
+
 	it("should show verification banner when authenticated and email not verified", () => {
 		const page = createTestPageBody();
 		const result = Base(page, { isAuthenticated: true, emailVerified: false }).to("text/html");

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -155,14 +155,30 @@ function injectPageStylesIntoMain(content: string, styles: string): string {
 	return document.body.innerHTML;
 }
 
+/**
+ * Escape HTML-significant code points inside a JSON string before embedding it
+ * in a <script>. JSON.stringify does NOT escape `<`, `>`, `&`, or the Unicode
+ * line separators, so a value containing `</script>` would break out of the
+ * JSON-LD block and inject executable markup. Structured-data values can come
+ * from crawled, attacker-controlled metadata (e.g. an article's <title> on
+ * /view), so this is mandatory. The escaped sequences decode back during JSON
+ * parsing; schema.org consumers are unaffected.
+ */
+function escapeJsonForScript(json: string): string {
+	return json
+		.replace(/</g, "\\u003c")
+		.replace(/>/g, "\\u003e")
+		.replace(/&/g, "\\u0026")
+		.replace(/\u2028/g, "\\u2028")
+		.replace(/\u2029/g, "\\u2029");
+}
+
 function renderStructuredData(data: object[] | undefined): string {
 	if (!data || data.length === 0) return "";
-	// SECURITY: JSON.stringify is safe for server-controlled data.
-	// WARNING: Never interpolate user input into structured data objects.
 	return data
 		.map(
 			(item) =>
-				`<script type="application/ld+json">${JSON.stringify(item)}</script>`,
+				`<script type="application/ld+json">${escapeJsonForScript(JSON.stringify(item))}</script>`,
 		)
 		.join("\n  ");
 }

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -293,6 +293,29 @@ describe("ViewPage", () => {
 		expect(data.image).toBeUndefined();
 	});
 
+	it("keeps a hostile crawled title inert inside the JSON-LD block (no script breakout)", () => {
+		const hostileTitle = "</script><script>window.__pwned=true</script>";
+		const doc = render({
+			...baseInput,
+			metadata: { ...baseInput.metadata, title: hostileTitle },
+		});
+
+		// If the title escaped the JSON-LD block, the script element would end at
+		// the payload's closing tag and this parse would fail on truncated JSON.
+		const ldJson = doc.querySelector('script[type="application/ld+json"]');
+		assert(ldJson?.textContent, "JSON-LD script must survive HTML parsing as a single block");
+		const data = JSON.parse(ldJson.textContent);
+		assert.equal(data.headline, hostileTitle);
+
+		const executableScripts = Array.from(doc.querySelectorAll("script")).filter(
+			(script) => script.getAttribute("type") !== "application/ld+json",
+		);
+		const breakoutScripts = executableScripts.filter((script) =>
+			(script.textContent ?? "").includes("__pwned"),
+		);
+		assert.equal(breakoutScripts.length, 0, "the payload must never become an executable script");
+	});
+
 	it("toggles the summary slot visibility based on status", () => {
 		const skipped = render();
 		const slotSkipped = skipped.querySelector("[data-test-reader-summary]");


### PR DESCRIPTION
## The vulnerability

`renderStructuredData` in `base.component.ts` interpolated `JSON.stringify(item)` directly into a `<script type="application/ld+json">` block. `JSON.stringify` escapes `"` and `\` but **not** `<`, `>`, `&`, or U+2028/U+2029 — so a structured-data value containing `</script>` terminated the JSON-LD block early and injected executable markup.

The `/view` page feeds this chokepoint with **crawled, attacker-controlled** article metadata (`headline` from the source page's `<title>`/`og:title`, `description` from the crawled excerpt, `image` from crawled metadata). A source page titled `</script><script>…</script>` therefore executed script in the readplace.com origin, in the parent document, outside the reader-iframe sandbox — on a public, indexable page that anonymous visitors can seed via `/view/<url>`. The comment claiming "JSON.stringify is safe for server-controlled data" was false for this call site and has been removed.

## The fix

Centralized in `renderStructuredData` (the single chokepoint every caller routes through — verified no other code path emits `application/ld+json`): the serialized JSON is passed through `escapeJsonForScript`, which rewrites `<`, `>`, `&`, U+2028, and U+2029 as `\uXXXX` JSON escape sequences. Those sequences decode back to the original characters during JSON parsing, so schema.org consumers see byte-identical data; no call sites changed, no other output changes.

## Tests

- A headline containing `</script><script>alert(1)</script>` renders so the block's inner text — everything up to the first real `</script>` — is the complete JSON with the payload only in `<…>` form, and `JSON.parse` of it returns the original headline.
- `<!--` is emitted as `<!--` and U+2028/U+2029 as ` `/` `.
- Round-trip: parsing the rendered JSON-LD block deep-equals the input object (covering `<`, `>`, `&`, quotes, backslashes, both line separators, nested objects and arrays).
- `/view` component test renders with a hostile crawled `metadata.title` and asserts the JSON-LD survives HTML parsing as a single block with the headline intact, and that the payload never appears in any executable (non-JSON-LD) script element.

Red/green verified: all four new tests fail against the unescaped code and pass with the fix; the full `hutch:check` (lint + tests + enforced coverage) passes.

https://claude.ai/code/session_012A8426zZzrCB8teCAGLMyL

---
_Generated by [Claude Code](https://claude.ai/code/session_012A8426zZzrCB8teCAGLMyL)_