### PR TITLE
fix(hutch): mark session, visitor and click cookies Secure on https

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -103,6 +103,7 @@ import { createClickAttributionMiddleware } from "./web/click-attribution.middle
 import { createVisitorIdMiddleware } from "./web/visitor-id.middleware";
 import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { SESSION_COOKIE_NAME } from "./web/auth/session-cookie";
+import { isHttpsOrigin } from "./web/cookie-options";
 import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
 import { initQueueRoutes } from "./web/pages/queue/queue.page";
 import { initImportSessionRoutes } from "./web/pages/import/import.page";
@@ -268,10 +269,12 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	const blogPosts = initBlogPosts();
 
+	const secureCookies = isHttpsOrigin(appOrigin);
+
 	app.use(express.urlencoded({ extended: true }));
 	app.use(cookieParser());
-	app.use(createVisitorIdMiddleware({ generateVisitorId: randomUUID }));
-	app.use(createClickAttributionMiddleware({ now: dependencies.now }));
+	app.use(createVisitorIdMiddleware({ generateVisitorId: randomUUID, secure: secureCookies }));
+	app.use(createClickAttributionMiddleware({ now: dependencies.now, secure: secureCookies }));
 
 	// Same-origin client bundles — the Lambda packaging step copies
 	// src/runtime/web/client-dist/ into the bundle, so `__dirname/web/client-dist`
@@ -594,6 +597,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		},
 		baseUrl: deps.baseUrl,
 		staticBaseUrl,
+		secureCookies,
 		logError: deps.logError,
 		now: deps.now,
 		botDefenseLogger: deps.botDefenseLogger,
@@ -610,6 +614,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			appOrigin,
 			baseUrl: deps.baseUrl,
 			staticBaseUrl,
+			secureCookies,
 			createSession: deps.createSession,
 			createGoogleUser: deps.createGoogleUser,
 			findUserByEmail: deps.findUserByEmail,

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -40,7 +40,8 @@ import type { ComponentError } from "../shared/component-error.types";
 import { LoginSchema } from "./auth.schema";
 import { LoginPage, SignupPage, VerifyEmailPage } from "./auth.component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
-import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "./session-cookie";
+import { baseCookieOptions } from "../cookie-options";
+import { SESSION_COOKIE_NAME } from "./session-cookie";
 import { buildVerificationEmailHtml } from "./verification-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
@@ -87,6 +88,7 @@ interface AuthDependencies {
 	};
 	baseUrl: string;
 	staticBaseUrl: string;
+	secureCookies: boolean;
 	logError: (message: string, error?: Error) => void;
 	now: () => Date;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
@@ -97,6 +99,7 @@ interface AuthDependencies {
 
 export function initAuthRoutes(deps: AuthDependencies): Router {
 	const router = express.Router();
+	const sessionCookieOptions = baseCookieOptions(deps.secureCookies);
 
 	const fetchUserCount = initFetchUserCount({
 		countUsers: deps.countUsers,
@@ -185,7 +188,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 
 		const sessionId = await deps.createSession({ userId: credentials.userId, emailVerified: credentials.emailVerified });
-		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+		res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 		res.redirect(303, parseReturnUrl(req.query));
 	});
 
@@ -259,7 +262,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			}
 
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
-			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 			sendVerificationEmail(created.userId, email);
 			emitUserCreated(
 				{ logger: deps.conversionLogger, now: deps.now },
@@ -302,7 +305,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
-		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+		res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 		sendVerificationEmail(created.userId, email);
 		emitUserCreated(
 			{ logger: deps.conversionLogger, now: deps.now },
@@ -383,7 +386,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			await deps.subscriptionProviders.upsertActive({ userId: created.userId, subscriptionId, customerId });
 			await deps.trialScheduler.deleteTrialEndSchedule({ userId: created.userId });
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
-			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 			sendVerificationEmail(created.userId, pending.email);
 			emitUserCreated(
 				{ logger: deps.conversionLogger, now: deps.now },
@@ -428,7 +431,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			await deps.subscriptionProviders.upsertActive({ userId: lookup.userId, subscriptionId, customerId });
 			await deps.trialScheduler.deleteTrialEndSchedule({ userId: lookup.userId });
 			const sessionId = await deps.createSession({ userId: lookup.userId, emailVerified: true });
-			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 			res.redirect(303, returnPath);
 			return;
 		}
@@ -436,7 +439,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		await deps.subscriptionProviders.upsertActive({ userId: created.userId, subscriptionId, customerId });
 		await deps.trialScheduler.deleteTrialEndSchedule({ userId: created.userId });
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
-		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+		res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 		sendWelcomeEmail(pending.email);
 		emitUserCreated(
 			{ logger: deps.conversionLogger, now: deps.now },

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -22,7 +22,8 @@ import { Base } from "../base.component";
 import { bannerStateFromRequest } from "../banner-state";
 import { sendComponent } from "../send-component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
-import { SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS } from "./session-cookie";
+import { baseCookieOptions } from "../cookie-options";
+import { SESSION_COOKIE_NAME } from "./session-cookie";
 import { LoginPage } from "./auth.component";
 import { initFetchUserCount } from "./fetch-user-count";
 import { readClickAttribution } from "../click-attribution.middleware";
@@ -49,6 +50,7 @@ interface GoogleAuthDependencies {
 	appOrigin: string;
 	baseUrl: string;
 	staticBaseUrl: string;
+	secureCookies: boolean;
 	createSession: CreateSession;
 	createGoogleUser: CreateGoogleUser;
 	findUserByEmail: FindUserByEmail;
@@ -82,6 +84,7 @@ const verifyState = (signed: string, secret: string): string | null => {
 
 export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 	const router = express.Router();
+	const sessionCookieOptions = baseCookieOptions(deps.secureCookies);
 	const redirectUri = `${deps.appOrigin}/auth/google/callback`;
 	const fetchUserCount = initFetchUserCount({
 		countUsers: deps.countUsers,
@@ -103,7 +106,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 		const signedState = signState(statePayload, deps.googleClientSecret);
 
 		res.cookie(STATE_COOKIE, signedState, {
-			...SESSION_COOKIE_OPTIONS,
+			...sessionCookieOptions,
 			maxAge: STATE_TTL_MS,
 		});
 
@@ -174,7 +177,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 				await deps.markEmailVerified(tokenResult.email);
 			}
 			const sessionId = await deps.createSession({ userId: existing.userId, emailVerified: true });
-			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 			res.redirect(303, parseReturnUrl({ return: stateData.returnUrl }));
 			return;
 		}
@@ -195,7 +198,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 						await deps.markEmailVerified(tokenResult.email);
 					}
 					const sessionId = await deps.createSession({ userId: lookup.userId, emailVerified: true });
-					res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+					res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 					res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
 					return;
 				}
@@ -204,7 +207,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 			}
 
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
-			res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+			res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 			sendWelcomeEmail(tokenResult.email);
 			emitUserCreated(
 				{ logger: deps.conversionLogger, now: deps.now },
@@ -232,7 +235,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 					await deps.markEmailVerified(tokenResult.email);
 				}
 				const sessionIdRace = await deps.createSession({ userId: lookup.userId, emailVerified: true });
-				res.cookie(SESSION_COOKIE_NAME, sessionIdRace, SESSION_COOKIE_OPTIONS);
+				res.cookie(SESSION_COOKIE_NAME, sessionIdRace, sessionCookieOptions);
 				res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
 				return;
 			}
@@ -257,7 +260,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 		}
 
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: true });
-		res.cookie(SESSION_COOKIE_NAME, sessionId, SESSION_COOKIE_OPTIONS);
+		res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 		sendWelcomeEmail(tokenResult.email);
 		emitUserCreated(
 			{ logger: deps.conversionLogger, now: deps.now },

--- a/projects/hutch/src/runtime/web/auth/session-cookie.ts
+++ b/projects/hutch/src/runtime/web/auth/session-cookie.ts
@@ -1,7 +1,1 @@
 export const SESSION_COOKIE_NAME = "hutch_sid";
-
-export const SESSION_COOKIE_OPTIONS = {
-	httpOnly: true,
-	sameSite: "lax" as const,
-	path: "/",
-};

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.test.ts
@@ -47,10 +47,14 @@ function createRes(): { res: Partial<Response>; cookies: CapturedCookie[] } {
 	return { res, cookies };
 }
 
-function runMiddleware(req: Partial<Request>): { cookies: CapturedCookie[]; nextCalled: boolean } {
+function runMiddleware(
+	req: Partial<Request>,
+	options: { secure: boolean } = { secure: false },
+): { cookies: CapturedCookie[]; nextCalled: boolean } {
 	const { res, cookies } = createRes();
 	const middleware = createClickAttributionMiddleware({
 		now: () => new Date("2026-05-13T10:00:00.000Z"),
+		secure: options.secure,
 	});
 	let nextCalled = false;
 	const next: NextFunction = () => {
@@ -80,6 +84,7 @@ describe("createClickAttributionMiddleware", () => {
 			httpOnly: true,
 			sameSite: "lax",
 			path: "/",
+			secure: false,
 			maxAge: 30 * 24 * 60 * 60 * 1000,
 		});
 		expect(parseCookieValue(cookie.value)).toEqual({
@@ -88,6 +93,20 @@ describe("createClickAttributionMiddleware", () => {
 			utm_campaign: "spring",
 			first_seen_at: "2026-05-13T10:00:00.000Z",
 			landing_path: "/blog/launch",
+		});
+	});
+
+	it("marks the cookie Secure when the app serves over https, leaving the other attributes unchanged", () => {
+		const req = createReq({ path: "/" });
+		const { cookies } = runMiddleware(req, { secure: true });
+
+		expect(cookies).toHaveLength(1);
+		expect(cookies[0].options).toMatchObject({
+			httpOnly: true,
+			sameSite: "lax",
+			path: "/",
+			secure: true,
+			maxAge: 30 * 24 * 60 * 60 * 1000,
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/click-attribution.middleware.ts
+++ b/projects/hutch/src/runtime/web/click-attribution.middleware.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { z } from "zod";
+import { baseCookieOptions } from "./cookie-options";
 
 export const CLICK_COOKIE_NAME = "hutch_click";
 const CLICK_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -16,13 +17,6 @@ const ClickAttributionSchema = z.object({
 });
 
 export type ClickAttribution = z.infer<typeof ClickAttributionSchema>;
-
-const COOKIE_OPTIONS = {
-	httpOnly: true,
-	sameSite: "lax" as const,
-	path: "/",
-	maxAge: CLICK_COOKIE_MAX_AGE_MS,
-};
 
 function extractQueryString(req: Request, name: string): string | undefined {
 	const value = req.query[name];
@@ -62,7 +56,9 @@ export function readClickAttribution(req: Request): ClickAttribution | undefined
 
 export function createClickAttributionMiddleware(deps: {
 	now: () => Date;
+	secure: boolean;
 }): RequestHandler {
+	const cookieOptions = { ...baseCookieOptions(deps.secure), maxAge: CLICK_COOKIE_MAX_AGE_MS };
 	return (req: Request, res: Response, next: NextFunction) => {
 		if (req.method !== "GET") {
 			next();
@@ -93,7 +89,7 @@ export function createClickAttributionMiddleware(deps: {
 			...(referrer_host ? { referrer_host } : {}),
 		};
 
-		res.cookie(CLICK_COOKIE_NAME, JSON.stringify(attribution), COOKIE_OPTIONS);
+		res.cookie(CLICK_COOKIE_NAME, JSON.stringify(attribution), cookieOptions);
 		next();
 	};
 }

--- a/projects/hutch/src/runtime/web/cookie-options.test.ts
+++ b/projects/hutch/src/runtime/web/cookie-options.test.ts
@@ -1,0 +1,31 @@
+import { baseCookieOptions, isHttpsOrigin } from "./cookie-options";
+
+describe("baseCookieOptions", () => {
+	it("marks cookies Secure for HTTPS deployments while keeping httpOnly, sameSite and path unchanged", () => {
+		expect(baseCookieOptions(true)).toEqual({
+			httpOnly: true,
+			sameSite: "lax",
+			path: "/",
+			secure: true,
+		});
+	});
+
+	it("omits Secure for plain-http local dev so browsers still accept the cookie", () => {
+		expect(baseCookieOptions(false)).toEqual({
+			httpOnly: true,
+			sameSite: "lax",
+			path: "/",
+			secure: false,
+		});
+	});
+});
+
+describe("isHttpsOrigin", () => {
+	it("returns true for an https deployment origin", () => {
+		expect(isHttpsOrigin("https://readplace.com")).toBe(true);
+	});
+
+	it("returns false for a local http dev origin", () => {
+		expect(isHttpsOrigin("http://localhost:3000")).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/cookie-options.ts
+++ b/projects/hutch/src/runtime/web/cookie-options.ts
@@ -1,0 +1,11 @@
+/** `secure` must be true in any HTTPS deployment and false for local http dev —
+ * browsers drop Secure cookies over plain HTTP, which would silently break
+ * login on http://localhost. Derive it from the serving origin scheme via
+ * `isHttpsOrigin` rather than NODE_ENV so it follows the actual transport. */
+export function baseCookieOptions(secure: boolean) {
+	return { httpOnly: true, sameSite: "lax" as const, path: "/", secure };
+}
+
+export function isHttpsOrigin(origin: string): boolean {
+	return new URL(origin).protocol === "https:";
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.share-balloon.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.share-balloon.route.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
+import request from "supertest";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -10,7 +11,8 @@ import {
 	createNoopLogError,
 } from "@packages/test-fixtures";
 import { initReadabilityParser } from "@packages/article-parser";
-import { useTestServer, loginAgent } from "../../../test-app";
+import { useTestServer } from "../../../test-app";
+import { SESSION_COOKIE_NAME } from "../../auth/session-cookie";
 
 const ARTICLE_URL = "https://example.com/shareable";
 const ARTICLE_HTML = `
@@ -53,16 +55,24 @@ async function saveAndOpenReader(appOrigin: string): Promise<Document> {
 		},
 		shared: { ...fixture.shared, appOrigin },
 	});
-	const agent = await loginAgent(harness.server, harness.auth);
+	/** Authenticate with an explicit Cookie header instead of the agent's cookie
+	 * jar: an https appOrigin marks the session cookie Secure, and the jar
+	 * (correctly) refuses to replay Secure cookies over supertest's plain-http
+	 * connection. Cookie transport is covered by secure-cookies.route.test.ts —
+	 * this test is about share-URL rendering. */
+	const created = await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+	assert(created.ok, "test user must be created");
+	const sessionId = await harness.auth.createSession({ userId: created.userId, emailVerified: true });
+	const sessionCookie = `${SESSION_COOKIE_NAME}=${sessionId}`;
 
-	await agent.post("/queue/save").type("form").send({ url: ARTICLE_URL });
-	const queueDoc = new JSDOM((await agent.get("/queue")).text).window.document;
+	await request(harness.server).post("/queue/save").set("Cookie", sessionCookie).type("form").send({ url: ARTICLE_URL });
+	const queueDoc = new JSDOM((await request(harness.server).get("/queue").set("Cookie", sessionCookie)).text).window.document;
 	const articleId = queueDoc
 		.querySelector("[data-test-article-list] .queue-article")
 		?.getAttribute("data-test-article");
 	assert(articleId, "saved article must surface in the queue");
 
-	const response = await agent.get(`/queue/${articleId}/view`);
+	const response = await request(harness.server).get(`/queue/${articleId}/view`).set("Cookie", sessionCookie);
 	expect(response.status).toBe(200);
 	return new JSDOM(response.text).window.document;
 }

--- a/projects/hutch/src/runtime/web/secure-cookies.route.test.ts
+++ b/projects/hutch/src/runtime/web/secure-cookies.route.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import request from "supertest";
+import { useTestServer } from "../test-app";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "@packages/test-fixtures";
+import { SESSION_COOKIE_NAME } from "./auth/session-cookie";
+import { CLICK_COOKIE_NAME } from "./click-attribution.middleware";
+import { VISITOR_COOKIE_NAME } from "./visitor-id.middleware";
+
+const HTTPS_APP_ORIGIN = "https://readplace.com";
+
+function findCookie(headers: { [key: string]: string | string[] | undefined }, name: string): string {
+	const raw = headers["set-cookie"];
+	const cookies = Array.isArray(raw) ? raw : raw ? [raw] : [];
+	const cookie = cookies.find((c) => c.startsWith(`${name}=`));
+	assert(cookie, `expected a Set-Cookie header for ${name}`);
+	return cookie;
+}
+
+const useApp = useTestServer();
+
+async function postLogin(harness: ReturnType<typeof useApp>) {
+	await harness.auth.createUser({ email: "test@example.com", password: "password123" });
+	return request(harness.server)
+		.post("/login")
+		.type("form")
+		.send({ email: "test@example.com", password: "password123" });
+}
+
+describe("Cookie Secure attribute", () => {
+	describe("HTTPS deployment origin", () => {
+		it("sets the visitor-id and click-attribution cookies with Secure, HttpOnly and SameSite=Lax", async () => {
+			const harness = useApp(createDefaultTestAppFixture(HTTPS_APP_ORIGIN));
+			const response = await request(harness.server).get("/");
+
+			for (const name of [VISITOR_COOKIE_NAME, CLICK_COOKIE_NAME]) {
+				const cookie = findCookie(response.headers, name);
+				expect(cookie).toContain("; Secure");
+				expect(cookie).toContain("; HttpOnly");
+				expect(cookie).toContain("; SameSite=Lax");
+				expect(cookie).toContain("; Path=/");
+			}
+		});
+
+		it("sets the session cookie with Secure, HttpOnly and SameSite=Lax on login", async () => {
+			const harness = useApp(createDefaultTestAppFixture(HTTPS_APP_ORIGIN));
+			const response = await postLogin(harness);
+
+			expect(response.status).toBe(303);
+			const cookie = findCookie(response.headers, SESSION_COOKIE_NAME);
+			expect(cookie).toContain("; Secure");
+			expect(cookie).toContain("; HttpOnly");
+			expect(cookie).toContain("; SameSite=Lax");
+			expect(cookie).toContain("; Path=/");
+		});
+	});
+
+	describe("local plain-http dev origin", () => {
+		it("still sets the visitor-id and click-attribution cookies, without Secure", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/");
+
+			for (const name of [VISITOR_COOKIE_NAME, CLICK_COOKIE_NAME]) {
+				const cookie = findCookie(response.headers, name);
+				expect(cookie).not.toContain("; Secure");
+				expect(cookie).toContain("; HttpOnly");
+				expect(cookie).toContain("; SameSite=Lax");
+			}
+		});
+
+		it("still sets the session cookie on login, without Secure, so local login keeps working", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await postLogin(harness);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue");
+			const cookie = findCookie(response.headers, SESSION_COOKIE_NAME);
+			expect(cookie).not.toContain("; Secure");
+			expect(cookie).toContain("; HttpOnly");
+			expect(cookie).toContain("; SameSite=Lax");
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/visitor-id.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/visitor-id.middleware.test.ts
@@ -53,7 +53,7 @@ describe("createVisitorIdMiddleware", () => {
 			nexted = true;
 		};
 
-		createVisitorIdMiddleware({ generateVisitorId: () => "unused" })(req, res, next);
+		createVisitorIdMiddleware({ generateVisitorId: () => "unused", secure: false })(req, res, next);
 
 		expect(req.visitorId).toBe(VALID_UUID);
 		expect(cookies).toEqual([]);
@@ -68,23 +68,38 @@ describe("createVisitorIdMiddleware", () => {
 			nexted = true;
 		};
 
-		createVisitorIdMiddleware({ generateVisitorId: () => VALID_UUID })(req, res, next);
+		createVisitorIdMiddleware({ generateVisitorId: () => VALID_UUID, secure: false })(req, res, next);
 
 		expect(req.visitorId).toBe(VALID_UUID);
 		expect(cookies).toHaveLength(1);
 		expect(cookies[0]).toMatchObject({
 			name: VISITOR_COOKIE_NAME,
 			value: VALID_UUID,
-			options: expect.objectContaining({ httpOnly: true, sameSite: "lax", path: "/" }),
+			options: expect.objectContaining({ httpOnly: true, sameSite: "lax", path: "/", secure: false }),
 		});
 		expect(nexted).toBe(true);
+	});
+
+	it("marks the cookie Secure when the app serves over https, leaving the other attributes unchanged", () => {
+		const { res, cookies } = createRes();
+		const req = createReq();
+
+		createVisitorIdMiddleware({ generateVisitorId: () => VALID_UUID, secure: true })(req, res, () => {});
+
+		expect(cookies).toHaveLength(1);
+		expect(cookies[0].options).toMatchObject({
+			httpOnly: true,
+			sameSite: "lax",
+			path: "/",
+			secure: true,
+		});
 	});
 
 	it("re-mints when the existing cookie is corrupt rather than propagating a tampered value", () => {
 		const { res, cookies } = createRes();
 		const req = createReq({ [VISITOR_COOKIE_NAME]: "corrupt" });
 
-		createVisitorIdMiddleware({ generateVisitorId: () => VALID_UUID })(req, res, () => {});
+		createVisitorIdMiddleware({ generateVisitorId: () => VALID_UUID, secure: false })(req, res, () => {});
 
 		expect(req.visitorId).toBe(VALID_UUID);
 		expect(cookies).toHaveLength(1);

--- a/projects/hutch/src/runtime/web/visitor-id.middleware.ts
+++ b/projects/hutch/src/runtime/web/visitor-id.middleware.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { z } from "zod";
+import { baseCookieOptions } from "./cookie-options";
 
 export const VISITOR_COOKIE_NAME = "hutch_vid";
 
@@ -11,16 +12,6 @@ const VISITOR_COOKIE_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
  * raw query string at a call site. */
 const VisitorIdSchema = z.string().uuid().brand<"VisitorId">();
 export type VisitorId = z.infer<typeof VisitorIdSchema>;
-
-/** Mirrors SESSION_COOKIE_OPTIONS / the click cookie: httpOnly + sameSite=lax +
- * path=/. `secure` is intentionally omitted to match the session and click
- * cookies — TLS is terminated at CloudFront and local dev runs over HTTP. */
-const COOKIE_OPTIONS = {
-	httpOnly: true,
-	sameSite: "lax" as const,
-	path: "/",
-	maxAge: VISITOR_COOKIE_MAX_AGE_MS,
-};
 
 /**
  * A cookie that fails validation is treated as absent so the middleware mints a
@@ -35,7 +26,9 @@ export function readVisitorId(req: Request): VisitorId | undefined {
 
 export function createVisitorIdMiddleware(deps: {
 	generateVisitorId: () => string;
+	secure: boolean;
 }): RequestHandler {
+	const cookieOptions = { ...baseCookieOptions(deps.secure), maxAge: VISITOR_COOKIE_MAX_AGE_MS };
 	return (req: Request, res: Response, next: NextFunction) => {
 		const existing = readVisitorId(req);
 		if (existing) {
@@ -45,7 +38,7 @@ export function createVisitorIdMiddleware(deps: {
 		}
 		const visitorId = VisitorIdSchema.parse(deps.generateVisitorId());
 		req.visitorId = visitorId;
-		res.cookie(VISITOR_COOKIE_NAME, visitorId, COOKIE_OPTIONS);
+		res.cookie(VISITOR_COOKIE_NAME, visitorId, cookieOptions);
 		next();
 	};
 }


### PR DESCRIPTION
## Why

The `Secure` attribute was missing from all three app-set cookies (`hutch_sid`, `hutch_vid`, `hutch_click`), so they could be sent in cleartext on any non-HTTPS hop (downgrade, mixed content, misrouted plain HTTP). `Secure` must be set by the application — the CDN/proxy doesn't add it. Low severity, standard defence-in-depth.

## What

- New `web/cookie-options.ts` with `baseCookieOptions(secure)` (`httpOnly: true, sameSite: "lax", path: "/", secure`) and `isHttpsOrigin(origin)`. All three cookies — session (`auth.page.ts` / `google-auth.page.ts`, incl. the Google OAuth state cookie that mirrors the session options), visitor-id middleware, and click-attribution middleware — now build their options from this single helper, so the attributes can never drift between them.
- The `secure` flag is derived in `createApp` from the already-injected `appOrigin` (`https:` scheme → `secure: true`) and injected into the auth routers and both middlewares. Deriving from the serving origin rather than `NODE_ENV` means the attribute follows the actual transport, and prod/staging (https `APP_ORIGIN`) get Secure while local dev (`http://localhost:3000`) and the e2e server (`http://127.0.0.1`) still receive cookies — login keeps working over plain http.
- No other cookie attribute changes; `HttpOnly`, `SameSite=Lax`, `Path=/`, and the existing `maxAge` values are untouched.

## Tests

- Unit: `cookie-options.test.ts` pins both helper branches with exact-shape assertions; middleware unit tests now pin `secure: false`/`true` alongside the unchanged attributes.
- Integration: new `secure-cookies.route.test.ts` boots the app with an https origin (all three cookies carry `Secure; HttpOnly; SameSite=Lax`) and with the http test origin (cookies still set, no `Secure`, login redirect works).
- `queue.share-balloon.route.test.ts` logged in via the supertest cookie jar against an `https://staging.…` origin; the jar correctly refuses to replay the now-Secure session cookie over plain http, so it authenticates with an explicit `Cookie` header instead (its subject is share-URL rendering, not cookie transport).

`pnpm check` passes across all 25 projects.

https://claude.ai/code/session_01UZZUBT6BQoxbAXREUM6FUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZZUBT6BQoxbAXREUM6FUw)_