### PR TITLE
feat: add per-IP rate limiting and a paid-crawl spend budget

### DIFF
--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -30,6 +30,11 @@ config:
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-prod
   hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-prod
+  hutch:dynamodbRateLimitsTable: hutch-rate-limits-prod
+  hutch:rateLimitViewCrawl: 30/3600
+  hutch:rateLimitLogin: 10/900
+  hutch:rateLimitSignup: 10/3600
+  hutch:rateLimitForgotPassword: 5/3600
   hutch:trialSchedulerGroupName: hutch-trial-end-prod
   hutch:contentBucketName: hutch-article-content-prod
   hutch:pendingHtmlBucketName: hutch-pending-html-prod

--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -31,10 +31,12 @@ config:
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-prod
   hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-prod
   hutch:dynamodbRateLimitsTable: hutch-rate-limits-prod
-  hutch:rateLimitViewCrawl: 30/3600
+  hutch:rateLimitViewCrawl: 100/3600
   hutch:rateLimitLogin: 10/900
   hutch:rateLimitSignup: 10/3600
   hutch:rateLimitForgotPassword: 5/3600
+  hutch:apiThrottleBurstLimit: 200
+  hutch:apiThrottleRateLimit: 50
   hutch:trialSchedulerGroupName: hutch-trial-end-prod
   hutch:contentBucketName: hutch-article-content-prod
   hutch:pendingHtmlBucketName: hutch-pending-html-prod

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -24,6 +24,8 @@ config:
   hutch:rateLimitLogin: 300/900
   hutch:rateLimitSignup: 300/3600
   hutch:rateLimitForgotPassword: 100/3600
+  hutch:apiThrottleBurstLimit: 400
+  hutch:apiThrottleRateLimit: 200
   hutch:trialSchedulerGroupName: hutch-trial-end-staging
   hutch:contentBucketName: hutch-article-content-staging
   hutch:pendingHtmlBucketName: hutch-pending-html-staging

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -19,6 +19,11 @@ config:
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-staging
   hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-staging
+  hutch:dynamodbRateLimitsTable: hutch-rate-limits-staging
+  hutch:rateLimitViewCrawl: 500/3600
+  hutch:rateLimitLogin: 300/900
+  hutch:rateLimitSignup: 300/3600
+  hutch:rateLimitForgotPassword: 100/3600
   hutch:trialSchedulerGroupName: hutch-trial-end-staging
   hutch:contentBucketName: hutch-article-content-staging
   hutch:pendingHtmlBucketName: hutch-pending-html-staging

--- a/projects/hutch/src/infra/hutch-storage.ts
+++ b/projects/hutch/src/infra/hutch-storage.ts
@@ -13,6 +13,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 	public readonly pendingSignupsTable: aws.dynamodb.Table;
 	public readonly importSessionsTable: aws.dynamodb.Table;
 	public readonly subscriptionProvidersTable: aws.dynamodb.Table;
+	public readonly rateLimitsTable: aws.dynamodb.Table;
 
 	constructor(name: string, args: { deletionProtection: boolean; tableNames: {
 		articles: string;
@@ -26,6 +27,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 		pendingSignups: string;
 		importSessions: string;
 		subscriptionProviders: string;
+		rateLimits: string;
 	} }, opts?: pulumi.ComponentResourceOptions) {
 		super("hutch:infra:HutchStorage", name, {}, opts);
 
@@ -189,6 +191,20 @@ export class HutchStorage extends pulumi.ComponentResource {
 				enabled: true,
 			},
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+
+		/* Fixed-window throttle counters (per-IP buckets + the global paid-crawl
+		 * budget), each row one window. Ephemeral by definition — no deletion
+		 * protection or point-in-time recovery; TTL purges expired windows. */
+		this.rateLimitsTable = new aws.dynamodb.Table(`hutch-rate-limits`, {
+			name: args.tableNames.rateLimits,
+			billingMode: "PAY_PER_REQUEST",
+			hashKey: "pk",
+			attributes: [{ name: "pk", type: "S" }],
+			ttl: {
+				attributeName: "expiresAt",
+				enabled: true,
+			},
+		}, { parent: this });
 
 		this.subscriptionProvidersTable = new aws.dynamodb.Table(`hutch-subscription-providers`, {
 			name: args.tableNames.subscriptionProviders,

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -64,6 +64,15 @@ const rateLimitRules = {
 	forgotPassword: config.require("rateLimitForgotPassword"),
 };
 
+/* Blunt TOTAL-rate ceiling (all clients combined) applied by API Gateway before
+ * the Lambda runs — per-stack so staging, whose e2e suite drives the whole run
+ * from one CI egress IP, can lift the ceiling without a code change while prod
+ * stays tight. Per-IP fairness is the application limiter's job. */
+const apiThrottle = {
+	burstLimit: config.requireNumber("apiThrottleBurstLimit"),
+	rateLimit: config.requireNumber("apiThrottleRateLimit"),
+};
+
 const storage = new HutchStorage("hutch", {
 	deletionProtection,
 	tableNames,
@@ -304,10 +313,7 @@ const gateway = new HutchAPIGateway("hutch", {
 	domains: legacyPrimaryDomain ? [legacyPrimaryDomain] : [],
 	zoneId: legacyDomainRegistration.zoneId,
 	certificateArn: legacyDomainRegistration.certificateArn,
-	// Blunt TOTAL-rate ceiling (all clients combined) so a flood can't run the
-	// Lambda bill unbounded; sized far above organic traffic. Per-IP fairness
-	// is the application limiter's job.
-	throttling: { burstLimit: 200, rateLimit: 50 },
+	throttling: apiThrottle,
 });
 
 for (const [i, domain] of additionalDomains.entries()) {

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -51,6 +51,17 @@ const tableNames = {
 	pendingSignups: config.require("dynamodbPendingSignupsTable"),
 	importSessions: config.require("dynamodbImportSessionsTable"),
 	subscriptionProviders: config.require("dynamodbSubscriptionProvidersTable"),
+	rateLimits: config.require("dynamodbRateLimitsTable"),
+};
+
+/* Per-stack "<limit>/<windowSeconds>" rules so staging e2e (one CI egress IP
+ * driving the whole suite) can run with liberal limits while prod stays
+ * strict. Parsed and enforced by the runtime's DynamoDB-backed limiter. */
+const rateLimitRules = {
+	viewCrawl: config.require("rateLimitViewCrawl"),
+	login: config.require("rateLimitLogin"),
+	signup: config.require("rateLimitSignup"),
+	forgotPassword: config.require("rateLimitForgotPassword"),
 };
 
 const storage = new HutchStorage("hutch", {
@@ -122,6 +133,7 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 		{ arn: storage.pendingSignupsTable.arn, includeIndexes: false },
 		{ arn: storage.importSessionsTable.arn, includeIndexes: false },
 		{ arn: storage.subscriptionProvidersTable.arn, includeIndexes: true },
+		{ arn: storage.rateLimitsTable.arn, includeIndexes: false },
 	],
 	actions: [
 		"dynamodb:GetItem",
@@ -250,6 +262,11 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 		DYNAMODB_PENDING_SIGNUPS_TABLE: storage.pendingSignupsTable.name,
 		DYNAMODB_IMPORT_SESSIONS_TABLE: storage.importSessionsTable.name,
 		DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE: storage.subscriptionProvidersTable.name,
+		DYNAMODB_RATE_LIMITS_TABLE: storage.rateLimitsTable.name,
+		RATE_LIMIT_VIEW_CRAWL: rateLimitRules.viewCrawl,
+		RATE_LIMIT_LOGIN: rateLimitRules.login,
+		RATE_LIMIT_SIGNUP: rateLimitRules.signup,
+		RATE_LIMIT_FORGOT_PASSWORD: rateLimitRules.forgotPassword,
 		GOOGLE_LOGIN_CLIENT_ID: requireEnv("GOOGLE_LOGIN_CLIENT_ID"),
 		GOOGLE_LOGIN_CLIENT_SECRET: requireEnv("GOOGLE_LOGIN_CLIENT_SECRET"),
 		RESEND_API_KEY: requireEnv("RESEND_API_KEY"),
@@ -287,6 +304,10 @@ const gateway = new HutchAPIGateway("hutch", {
 	domains: legacyPrimaryDomain ? [legacyPrimaryDomain] : [],
 	zoneId: legacyDomainRegistration.zoneId,
 	certificateArn: legacyDomainRegistration.certificateArn,
+	// Blunt TOTAL-rate ceiling (all clients combined) so a flood can't run the
+	// Lambda bill unbounded; sized far above organic traffic. Per-IP fairness
+	// is the application limiter's job.
+	throttling: { burstLimit: 200, rateLimit: 50 },
 });
 
 for (const [i, domain] of additionalDomains.entries()) {

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -32,6 +32,10 @@ import { initInMemoryEmailVerification } from "@packages/test-fixtures/providers
 import { initDynamoDbEmailVerification } from "./providers/email-verification/dynamodb-email-verification";
 import { initInMemoryPasswordReset } from "@packages/test-fixtures/providers/password-reset";
 import { initDynamoDbPasswordReset } from "./providers/password-reset/dynamodb-password-reset";
+import { initInMemoryRateLimit } from "@packages/test-fixtures/providers/rate-limit";
+import type { RateLimitRules } from "@packages/provider-contracts/rate-limit";
+import { parseRateLimitRule } from "@packages/domain/rate-limit";
+import { initDynamoDbRateLimit } from "./providers/rate-limit/dynamodb-rate-limit";
 import { initDynamoDbGeneratedSummary } from "./providers/article-summary/dynamodb-generated-summary";
 import { devSummariseInline } from "./providers/article-summary/dev-summarise-inline";
 import { initDynamoDbArticleCrawl } from "./providers/article-crawl/dynamodb-article-crawl";
@@ -139,6 +143,7 @@ function initProviders() {
 		const pendingPdfBucketName = requireEnv("PENDING_PDF_BUCKET_NAME");
 		const importSessionsTable = requireEnv("DYNAMODB_IMPORT_SESSIONS_TABLE");
 		const subscriptionProvidersTable = requireEnv("DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE");
+		const rateLimitsTable = requireEnv("DYNAMODB_RATE_LIMITS_TABLE");
 		const trialSchedulerGroupName = requireEnv("TRIAL_SCHEDULER_GROUP_NAME");
 		const trialSchedulerRoleArn = requireEnv("TRIAL_SCHEDULER_ROLE_ARN");
 		const eventBusArn = requireEnv("EVENT_BUS_ARN");
@@ -231,6 +236,20 @@ function initProviders() {
 			tableName: importSessionsTable,
 			now: () => new Date(),
 		});
+		const { consumeRateLimit } = initDynamoDbRateLimit({
+			client,
+			tableName: rateLimitsTable,
+			now: () => new Date(),
+		});
+		// Strict (no defaults) so a deploy missing a limit fails at cold start
+		// instead of silently running unthrottled. Values come from the Pulumi
+		// stack config via the Lambda environment.
+		const rateLimitRules: RateLimitRules = {
+			viewCrawl: parseRateLimitRule(requireEnv("RATE_LIMIT_VIEW_CRAWL")),
+			login: parseRateLimitRule(requireEnv("RATE_LIMIT_LOGIN")),
+			signup: parseRateLimitRule(requireEnv("RATE_LIMIT_SIGNUP")),
+			forgotPassword: parseRateLimitRule(requireEnv("RATE_LIMIT_FORGOT_PASSWORD")),
+		};
 
 		return {
 			auth,
@@ -270,6 +289,8 @@ function initProviders() {
 			markCrawlPending: crawlStore.markCrawlPending,
 			forceMarkCrawlPending: crawlStore.forceMarkCrawlPending,
 			refreshArticleIfStale,
+			consumeRateLimit,
+			rateLimitRules,
 		};
 	}
 
@@ -388,6 +409,17 @@ function initProviders() {
 
 	const importSessionStore = initInMemoryImportSession({ now: () => new Date() });
 
+	// In-process counters are valid here because dev runs a single long-lived
+	// server. Defaults are liberal — every local/e2e request shares 127.0.0.1,
+	// so prod-strength per-IP limits would throttle a full e2e run.
+	const { consumeRateLimit } = initInMemoryRateLimit({ now: () => new Date() });
+	const rateLimitRules: RateLimitRules = {
+		viewCrawl: parseRateLimitRule(requireEnv("RATE_LIMIT_VIEW_CRAWL", { defaultValue: "1000/3600" })),
+		login: parseRateLimitRule(requireEnv("RATE_LIMIT_LOGIN", { defaultValue: "1000/900" })),
+		signup: parseRateLimitRule(requireEnv("RATE_LIMIT_SIGNUP", { defaultValue: "1000/3600" })),
+		forgotPassword: parseRateLimitRule(requireEnv("RATE_LIMIT_FORGOT_PASSWORD", { defaultValue: "1000/3600" })),
+	};
+
 	return {
 		auth,
 		articleStore,
@@ -431,6 +463,8 @@ function initProviders() {
 		markCrawlPending: crawlStore.markCrawlPending,
 		forceMarkCrawlPending: crawlStore.forceMarkCrawlPending,
 		refreshArticleIfStale,
+		consumeRateLimit,
+		rateLimitRules,
 	};
 }
 

--- a/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts
+++ b/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+} from "@packages/hutch-storage-client";
+import { initDynamoDbRateLimit } from "./dynamodb-rate-limit";
+
+type SendFn = DynamoDBDocumentClient["send"];
+
+function createFakeClient(impl: (command: unknown) => unknown): DynamoDBDocumentClient {
+	return {
+		send: (async (command: unknown) => impl(command)) as unknown as SendFn,
+	} as DynamoDBDocumentClient;
+}
+
+interface CapturedUpdate {
+	input: {
+		TableName?: string;
+		Key?: Record<string, unknown>;
+		UpdateExpression?: string;
+		ConditionExpression?: string;
+		ExpressionAttributeValues?: Record<string, unknown>;
+	};
+}
+
+const TABLE = "test-rate-limits";
+const HOUR_RULE = { limit: 30, windowSeconds: 3600 };
+// 02:00:00 UTC + 600s → window start 7200, window end 10800.
+const midWindowNow = () => new Date(7_800_000);
+
+describe("initDynamoDbRateLimit", () => {
+	it("increments the (bucket, key, window) counter with a below-limit condition and TTL", async () => {
+		let received: unknown;
+		const { consumeRateLimit } = initDynamoDbRateLimit({
+			client: createFakeClient((command) => {
+				received = command;
+				return {};
+			}),
+			tableName: TABLE,
+			now: midWindowNow,
+		});
+
+		const decision = await consumeRateLimit({
+			bucket: "view-crawl",
+			key: "203.0.113.9",
+			rule: HOUR_RULE,
+		});
+
+		assert.deepEqual(decision, { allowed: true });
+		const command = received as CapturedUpdate;
+		assert.equal(command.input.TableName, TABLE);
+		assert.deepEqual(command.input.Key, { pk: "view-crawl#203.0.113.9#7200" });
+		expect(command.input.UpdateExpression).toContain("ADD #count :one");
+		expect(command.input.ConditionExpression).toContain("#count < :limit");
+		expect(command.input.ConditionExpression).toContain(
+			"attribute_not_exists(#count)",
+		);
+		expect(command.input.ExpressionAttributeValues?.[":limit"]).toBe(30);
+		expect(command.input.ExpressionAttributeValues?.[":expiresAt"]).toBe(
+			7200 + 2 * 3600,
+		);
+	});
+
+	it("denies with seconds until the window resets when the condition fails", async () => {
+		const { consumeRateLimit } = initDynamoDbRateLimit({
+			client: createFakeClient(() => {
+				throw new ConditionalCheckFailedException({
+					$metadata: {},
+					message: "condition failed",
+				});
+			}),
+			tableName: TABLE,
+			now: midWindowNow,
+		});
+
+		const decision = await consumeRateLimit({
+			bucket: "login",
+			key: "203.0.113.9",
+			rule: HOUR_RULE,
+		});
+
+		assert.deepEqual(decision, { allowed: false, retryAfterSeconds: 3000 });
+	});
+
+	it("rethrows non-conditional errors", async () => {
+		const { consumeRateLimit } = initDynamoDbRateLimit({
+			client: createFakeClient(() => {
+				throw new Error("throttled");
+			}),
+			tableName: TABLE,
+			now: midWindowNow,
+		});
+
+		await expect(
+			consumeRateLimit({ bucket: "login", key: "203.0.113.9", rule: HOUR_RULE }),
+		).rejects.toThrow("throttled");
+	});
+});

--- a/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts
+++ b/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts
@@ -7,10 +7,12 @@ import { initDynamoDbRateLimit } from "./dynamodb-rate-limit";
 
 type SendFn = DynamoDBDocumentClient["send"];
 
-function createFakeClient(impl: (command: unknown) => unknown): DynamoDBDocumentClient {
+function createFakeClient(
+	impl: (command: unknown) => unknown,
+): Partial<DynamoDBDocumentClient> {
 	return {
 		send: (async (command: unknown) => impl(command)) as unknown as SendFn,
-	} as DynamoDBDocumentClient;
+	};
 }
 
 interface CapturedUpdate {
@@ -35,7 +37,7 @@ describe("initDynamoDbRateLimit", () => {
 			client: createFakeClient((command) => {
 				received = command;
 				return {};
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			now: midWindowNow,
 		});
@@ -68,7 +70,7 @@ describe("initDynamoDbRateLimit", () => {
 					$metadata: {},
 					message: "condition failed",
 				});
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			now: midWindowNow,
 		});
@@ -86,7 +88,7 @@ describe("initDynamoDbRateLimit", () => {
 		const { consumeRateLimit } = initDynamoDbRateLimit({
 			client: createFakeClient(() => {
 				throw new Error("throttled");
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			now: midWindowNow,
 		});

--- a/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.ts
+++ b/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.ts
@@ -1,0 +1,70 @@
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import {
+	fixedWindowRetryAfterSeconds,
+	fixedWindowStartSeconds,
+} from "@packages/domain/rate-limit";
+import type { ConsumeRateLimit } from "@packages/provider-contracts/rate-limit";
+
+const RateLimitRow = z.object({ pk: z.string() });
+
+/**
+ * Distributed fixed-window counter. One conditional `ADD` per request against
+ * a row keyed by `(bucket, key, windowStart)`; the condition fails once the
+ * counter reaches the limit, so exactly `rule.limit` requests succeed per
+ * window regardless of how many Lambda instances serve them concurrently.
+ */
+export function initDynamoDbRateLimit(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	now: () => Date;
+}): { consumeRateLimit: ConsumeRateLimit } {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: RateLimitRow,
+	});
+
+	const consumeRateLimit: ConsumeRateLimit = async ({ bucket, key, rule }) => {
+		const nowMs = deps.now().getTime();
+		const windowStartSeconds = fixedWindowStartSeconds({
+			nowMs,
+			windowSeconds: rule.windowSeconds,
+		});
+		try {
+			await table.update({
+				Key: { pk: `${bucket}#${key}#${windowStartSeconds}` },
+				UpdateExpression:
+					"ADD #count :one SET expiresAt = if_not_exists(expiresAt, :expiresAt)",
+				ConditionExpression: "attribute_not_exists(#count) OR #count < :limit",
+				ExpressionAttributeNames: { "#count": "count" },
+				ExpressionAttributeValues: {
+					":one": 1,
+					":limit": rule.limit,
+					// TTL one extra window past the row's own window end: DynamoDB TTL
+					// deletion lags by design, and an early delete would reset a live
+					// counter mid-window.
+					":expiresAt": windowStartSeconds + 2 * rule.windowSeconds,
+				},
+			});
+			return { allowed: true };
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) {
+				return {
+					allowed: false,
+					retryAfterSeconds: fixedWindowRetryAfterSeconds({
+						nowMs,
+						windowSeconds: rule.windowSeconds,
+					}),
+				};
+			}
+			throw error;
+		}
+	};
+
+	return { consumeRateLimit };
+}

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -93,6 +93,10 @@ import type {
 	CreatePasswordResetToken,
 	VerifyPasswordResetToken,
 } from "@packages/provider-contracts/password-reset";
+import type {
+	ConsumeRateLimit,
+	RateLimitRules,
+} from "@packages/provider-contracts/rate-limit";
 import type { OAuthModel, ValidateAccessToken } from "@packages/provider-contracts/oauth";
 import { HutchLogger } from "@packages/hutch-logger";
 import type { AnalyticsEvent } from "./web/middleware/analytics";
@@ -240,6 +244,8 @@ interface AppDependencies {
 	salt: string;
 	foundingAllocation: FoundingAllocation;
 	expiryCountdown: ExpiryCountdown;
+	consumeRateLimit: ConsumeRateLimit;
+	rateLimitRules: RateLimitRules;
 }
 
 function requireAuth(req: Request, res: Response, next: NextFunction): void {
@@ -600,6 +606,11 @@ export function createApp(dependencies: AppDependencies): Express {
 		conversionLogger: deps.conversionLogger,
 		foundingAllocation,
 		buildBannerState,
+		consumeRateLimit: deps.consumeRateLimit,
+		rateLimitRules: {
+			login: deps.rateLimitRules.login,
+			signup: deps.rateLimitRules.signup,
+		},
 	});
 	app.use(authRouter);
 
@@ -635,6 +646,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		verifyPasswordResetToken: deps.verifyPasswordResetToken,
 		baseUrl: deps.baseUrl,
 		logError: deps.logError,
+		consumeRateLimit: deps.consumeRateLimit,
+		rateLimitRule: deps.rateLimitRules.forgotPassword,
 	});
 	app.use(forgotPasswordRouter);
 
@@ -721,6 +734,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		saveArticleGlobally: deps.saveArticleGlobally,
 		publishSaveAnonymousLink: deps.publishSaveAnonymousLink,
 		publishStaleCheckRequested: deps.publishStaleCheckRequested,
+		consumeRateLimit: deps.consumeRateLimit,
+		viewCrawlRateLimit: deps.rateLimitRules.viewCrawl,
 		existsUserByIdPrefix: deps.existsUserByIdPrefix,
 		expiryCountdown: deps.expiryCountdown,
 		now: deps.now,

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -52,6 +52,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			email: fixture.email,
 			emailVerification: fixture.emailVerification,
 			passwordReset: fixture.passwordReset,
+			rateLimit: fixture.rateLimit,
 			google: {
 				exchangeGoogleCode: async () => ({
 					googleId: GoogleIdSchema.parse("google-sub"),

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -145,6 +145,8 @@ function flattenFixtureToAppDependencies(
 		verifyEmailToken: fixture.emailVerification.verifyEmailToken,
 		createPasswordResetToken: fixture.passwordReset.createPasswordResetToken,
 		verifyPasswordResetToken: fixture.passwordReset.verifyPasswordResetToken,
+		consumeRateLimit: fixture.rateLimit.consumeRateLimit,
+		rateLimitRules: fixture.rateLimit.rules,
 		googleAuth: fixture.google,
 		adminEmails: fixture.admin.adminEmails,
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -32,6 +32,11 @@ import type {
 } from "@packages/provider-contracts/trial-scheduler";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import type { RetrieveCheckoutSession } from "@packages/provider-contracts/stripe-checkout";
+import type {
+	ConsumeRateLimit,
+	RateLimitRules,
+} from "@packages/provider-contracts/rate-limit";
+import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { STRIPE_TRIAL_PERIOD_DAYS } from "../../domain/stripe/stripe-trial-config";
 import { Base } from "../base.component";
 import { bannerStateFromRequest, type BuildBannerState } from "../banner-state";
@@ -93,6 +98,8 @@ interface AuthDependencies {
 	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	foundingAllocation: FoundingAllocation;
 	buildBannerState: BuildBannerState;
+	consumeRateLimit: ConsumeRateLimit;
+	rateLimitRules: Pick<RateLimitRules, "login" | "signup">;
 }
 
 export function initAuthRoutes(deps: AuthDependencies): Router {
@@ -141,7 +148,12 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		sendComponent(req, res, Base(LoginPage({ returnUrl, userCount, foundingAllocation: deps.foundingAllocation }), bannerStateFromRequest(req)));
 	});
 
-	router.post("/login", async (req: Request, res: Response) => {
+	const loginRateLimit = createRateLimitMiddleware({
+		consumeRateLimit: deps.consumeRateLimit,
+		bucket: "login",
+		rule: deps.rateLimitRules.login,
+	});
+	router.post("/login", loginRateLimit, async (req: Request, res: Response) => {
 		const returnUrl = extractReturnUrl(req.query);
 		const parsed = LoginSchema.safeParse(req.body);
 
@@ -201,7 +213,12 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		sendComponent(req, res, Base(SignupPage({ returnUrl, userCount, foundingAllocation: deps.foundingAllocation, loadedAt: deps.now().getTime(), email }), bannerStateFromRequest(req)));
 	});
 
-	router.post("/signup", async (req: Request, res: Response) => {
+	const signupRateLimit = createRateLimitMiddleware({
+		consumeRateLimit: deps.consumeRateLimit,
+		bucket: "signup",
+		rule: deps.rateLimitRules.signup,
+	});
+	router.post("/signup", signupRateLimit, async (req: Request, res: Response) => {
 		const returnUrl = extractReturnUrl(req.query);
 		const body = (req.body ?? {}) as Record<string, unknown>;
 

--- a/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
@@ -7,7 +7,10 @@ import type {
 	VerifyPasswordResetToken,
 } from "@packages/provider-contracts/password-reset";
 import { PasswordResetTokenSchema } from "@packages/test-fixtures/providers/password-reset";
+import type { ConsumeRateLimit } from "@packages/provider-contracts/rate-limit";
+import type { RateLimitRule } from "@packages/domain/rate-limit";
 import { z } from "zod";
+import { createRateLimitMiddleware } from "../middleware/rate-limit";
 import { Base } from "../base.component";
 import { bannerStateFromRequest } from "../banner-state";
 import { sendComponent } from "../send-component";
@@ -28,6 +31,8 @@ interface ForgotPasswordDependencies {
 	verifyPasswordResetToken: VerifyPasswordResetToken;
 	baseUrl: string;
 	logError: (message: string, error?: Error) => void;
+	consumeRateLimit: ConsumeRateLimit;
+	rateLimitRule: RateLimitRule;
 }
 
 export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Router {
@@ -37,7 +42,12 @@ export function initForgotPasswordRoutes(deps: ForgotPasswordDependencies): Rout
 		sendComponent(req, res, Base(ForgotPasswordPage(), bannerStateFromRequest(req)));
 	});
 
-	router.post("/forgot-password", async (req: Request, res: Response) => {
+	const forgotPasswordRateLimit = createRateLimitMiddleware({
+		consumeRateLimit: deps.consumeRateLimit,
+		bucket: "forgot-password",
+		rule: deps.rateLimitRule,
+	});
+	router.post("/forgot-password", forgotPasswordRateLimit, async (req: Request, res: Response) => {
 		const parsed = ForgotPasswordSchema.safeParse(req.body);
 
 		if (!parsed.success) {

--- a/projects/hutch/src/runtime/web/middleware/rate-limit.route.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/rate-limit.route.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import request from "supertest";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "@packages/test-fixtures";
+import { initInMemoryRateLimit } from "@packages/test-fixtures/providers/rate-limit";
+import type { RateLimitRules } from "@packages/provider-contracts/rate-limit";
+import { useTestServer } from "../../test-app";
+
+const useApp = useTestServer();
+
+function createMutableClock(startMs: number) {
+	let nowMs = startMs;
+	return {
+		now: () => new Date(nowMs),
+		advanceSeconds: (seconds: number) => {
+			nowMs += seconds * 1000;
+		},
+	};
+}
+
+/** Default fixture with one bucket tightened and the limiter on a test-owned
+ * clock, so window rollover is driven by the test instead of wall time. */
+function fixtureWithTightRules(overrides: Partial<RateLimitRules>) {
+	const clock = createMutableClock(1_700_000_000_000);
+	const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+	fixture.rateLimit = {
+		consumeRateLimit: initInMemoryRateLimit({ now: clock.now }).consumeRateLimit,
+		rules: { ...fixture.rateLimit.rules, ...overrides },
+	};
+	return { fixture, clock };
+}
+
+/** A loadedAt value safely older than the bot-defense minimum submit window
+ * (2.5s), so the form submission passes the timing gate. */
+function freshLoadedAt(): string {
+	return String(Date.now() - 5000);
+}
+
+describe("Per-IP rate limiting", () => {
+	describe("POST /login", () => {
+		it("returns 429 past the limit and stops checking credentials", async () => {
+			const { fixture } = fixtureWithTightRules({ login: { limit: 2, windowSeconds: 900 } });
+			const verifyCredentials = fixture.auth.verifyCredentials;
+			let credentialChecks = 0;
+			fixture.auth.verifyCredentials = async (params) => {
+				credentialChecks += 1;
+				return verifyCredentials(params);
+			};
+			const harness = useApp(fixture);
+			const attemptLogin = () =>
+				request(harness.server)
+					.post("/login")
+					.type("form")
+					.send({ email: "victim@example.com", password: "guess" });
+
+			const underLimit = [await attemptLogin(), await attemptLogin()];
+			const throttled = await attemptLogin();
+
+			assert.deepEqual(underLimit.map((r) => r.status), [422, 422]);
+			assert.equal(throttled.status, 429);
+			assert.match(String(throttled.headers["retry-after"]), /^\d+$/);
+			assert.equal(credentialChecks, 2);
+		});
+
+		it("allows login attempts again once the window resets", async () => {
+			const { fixture, clock } = fixtureWithTightRules({ login: { limit: 1, windowSeconds: 900 } });
+			const harness = useApp(fixture);
+			await harness.auth.createUser({ email: "user@example.com", password: "password123" });
+			const attemptLogin = () =>
+				request(harness.server)
+					.post("/login")
+					.type("form")
+					.send({ email: "user@example.com", password: "password123" });
+
+			await attemptLogin();
+			const throttled = await attemptLogin();
+			clock.advanceSeconds(900);
+			const afterReset = await attemptLogin();
+
+			assert.equal(throttled.status, 429);
+			assert.equal(afterReset.status, 303);
+		});
+	});
+
+	describe("POST /signup", () => {
+		it("returns 429 past the limit and does not create the account", async () => {
+			const { fixture } = fixtureWithTightRules({ signup: { limit: 2, windowSeconds: 3600 } });
+			const harness = useApp(fixture);
+			const attemptSignup = (email: string) =>
+				request(harness.server)
+					.post("/signup")
+					.type("form")
+					.send({
+						email,
+						password: "password123",
+						confirmPassword: "password123",
+						loadedAt: freshLoadedAt(),
+					});
+
+			const first = await attemptSignup("first@example.com");
+			const second = await attemptSignup("second@example.com");
+			const throttled = await attemptSignup("third@example.com");
+
+			assert.deepEqual([first.status, second.status], [303, 303]);
+			assert.equal(throttled.status, 429);
+			assert.match(String(throttled.headers["retry-after"]), /^\d+$/);
+			assert.equal(await harness.auth.findUserByEmail("third@example.com"), null);
+		});
+	});
+
+	describe("POST /forgot-password", () => {
+		it("returns 429 past the limit and sends no further reset emails", async () => {
+			const { fixture } = fixtureWithTightRules({
+				forgotPassword: { limit: 2, windowSeconds: 3600 },
+			});
+			const harness = useApp(fixture);
+			await harness.auth.createUser({ email: "user@example.com", password: "password123" });
+			const requestReset = () =>
+				request(harness.server)
+					.post("/forgot-password")
+					.type("form")
+					.send({ email: "user@example.com" });
+
+			const underLimit = [await requestReset(), await requestReset()];
+			const emailsBeforeThrottle = harness.email.getSentEmails().length;
+			const throttled = await requestReset();
+
+			assert.deepEqual(underLimit.map((r) => r.status), [200, 200]);
+			assert.equal(emailsBeforeThrottle, 2);
+			assert.equal(throttled.status, 429);
+			assert.match(String(throttled.headers["retry-after"]), /^\d+$/);
+			assert.equal(harness.email.getSentEmails().length, 2);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/middleware/rate-limit.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/rate-limit.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import type { NextFunction, Request, Response } from "express";
+import express from "express";
+import request from "supertest";
+import type { ConsumeRateLimit } from "@packages/provider-contracts/rate-limit";
+import { createRateLimitMiddleware, rateLimitKeyFromRequest } from "./rate-limit";
+
+const PROBE_RULE = { limit: 5, windowSeconds: 60 };
+
+function probeAppWith(consumeRateLimit: ConsumeRateLimit) {
+	const app = express();
+	app.post(
+		"/probe",
+		createRateLimitMiddleware({ consumeRateLimit, bucket: "login", rule: PROBE_RULE }),
+		(_req, res) => {
+			res.status(200).type("text/plain").send("through");
+		},
+	);
+	// Express's default error handler console.errors the stack after the
+	// response — in jest that lands after the test ends and fails the run.
+	app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+		res.status(500).type("text/plain").send(`handled: ${err.message}`);
+	});
+	return app;
+}
+
+describe("rateLimitKeyFromRequest", () => {
+	it("uses the socket-derived req.ip as the client key", () => {
+		const req: Partial<Request> = { ip: "203.0.113.9" };
+		assert.equal(rateLimitKeyFromRequest(req as Request), "203.0.113.9");
+	});
+
+	it("collapses requests without a resolvable address onto one shared key", () => {
+		const req: Partial<Request> = { ip: undefined };
+		assert.equal(rateLimitKeyFromRequest(req as Request), "unknown");
+	});
+});
+
+describe("createRateLimitMiddleware", () => {
+	it("passes an allowed request through with the bucket, client IP and rule", async () => {
+		let captured: Parameters<ConsumeRateLimit>[0] | undefined;
+		const app = probeAppWith(async (params) => {
+			captured = params;
+			return { allowed: true };
+		});
+
+		const response = await request(app).post("/probe");
+
+		assert.equal(response.status, 200);
+		assert.equal(response.text, "through");
+		assert(captured, "the limiter must be consulted");
+		assert.equal(captured.bucket, "login");
+		assert.deepEqual(captured.rule, PROBE_RULE);
+		assert.match(captured.key, /127\.0\.0\.1/);
+	});
+
+	it("responds 429 with Retry-After when the limiter denies", async () => {
+		const app = probeAppWith(async () => ({ allowed: false, retryAfterSeconds: 42 }));
+
+		const response = await request(app).post("/probe");
+
+		assert.equal(response.status, 429);
+		assert.equal(response.headers["retry-after"], "42");
+		assert.match(response.text, /Too many requests/);
+	});
+
+	it("routes limiter failures to the error middleware instead of hanging", async () => {
+		const app = probeAppWith(async () => {
+			throw new Error("store unavailable");
+		});
+
+		const response = await request(app).post("/probe");
+
+		assert.equal(response.status, 500);
+		assert.equal(response.text, "handled: store unavailable");
+	});
+});

--- a/projects/hutch/src/runtime/web/middleware/rate-limit.ts
+++ b/projects/hutch/src/runtime/web/middleware/rate-limit.ts
@@ -1,0 +1,53 @@
+import type { Request, RequestHandler, Response } from "express";
+import type { RateLimitRule } from "@packages/domain/rate-limit";
+import type {
+	ConsumeRateLimit,
+	RateLimitBucket,
+} from "@packages/provider-contracts/rate-limit";
+
+/**
+ * Behind API Gateway v2 the serverless adapter seeds the request socket's
+ * remoteAddress from `requestContext.http.sourceIp` — the address API Gateway
+ * itself observed on the TCP connection. With `trust proxy` off (the Express
+ * default) `req.ip` resolves to exactly that value. Never derive the key from
+ * `x-forwarded-for`: the client controls every hop of that chain except the
+ * one API Gateway appends.
+ */
+export function rateLimitKeyFromRequest(req: Request): string {
+	// All clients without a resolvable address share one counter rather than
+	// each receiving a fresh, unenforceable one.
+	return req.ip ?? "unknown";
+}
+
+export function sendRateLimited(res: Response, retryAfterSeconds: number): void {
+	res
+		.status(429)
+		.set("Retry-After", String(retryAfterSeconds))
+		.type("text/plain")
+		.send("Too many requests from your network. Please try again later.");
+}
+
+export function createRateLimitMiddleware(deps: {
+	consumeRateLimit: ConsumeRateLimit;
+	bucket: RateLimitBucket;
+	rule: RateLimitRule;
+}): RequestHandler {
+	return (req, res, next) => {
+		deps
+			.consumeRateLimit({
+				bucket: deps.bucket,
+				key: rateLimitKeyFromRequest(req),
+				rule: deps.rule,
+			})
+			.then((decision) => {
+				if (!decision.allowed) {
+					sendRateLimited(res, decision.retryAfterSeconds);
+					return;
+				}
+				next();
+			})
+			// Express 4 does not forward rejected promises; route store failures
+			// to the error middleware instead of leaving the request hanging.
+			.catch(next);
+	};
+}

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -24,10 +24,13 @@ import type {
 	PublishSaveAnonymousLink,
 	PublishStaleCheckRequested,
 } from "@packages/provider-contracts/events";
+import type { ConsumeRateLimit } from "@packages/provider-contracts/rate-limit";
+import type { RateLimitRule } from "@packages/domain/rate-limit";
 import { isbot } from "isbot";
 import { decomposeTimeLeft } from "@packages/time-left";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { hashIp, type AnalyticsEvent } from "../../middleware/analytics";
+import { rateLimitKeyFromRequest, sendRateLimited } from "../../middleware/rate-limit";
 import { ANALYTICS_EVENTS, STREAMS } from "../../../observability/events";
 import { wantsMarkdown } from "../../content-negotiation";
 import { CacheableComponent } from "../../conditional-get";
@@ -64,6 +67,8 @@ interface ViewDependencies {
 	saveArticleGlobally: SaveArticleGlobally;
 	publishSaveAnonymousLink: PublishSaveAnonymousLink;
 	publishStaleCheckRequested: PublishStaleCheckRequested;
+	consumeRateLimit: ConsumeRateLimit;
+	viewCrawlRateLimit: RateLimitRule;
 	existsUserByIdPrefix: ExistsUserByIdPrefix;
 	expiryCountdown: ExpiryCountdown;
 	now: () => Date;
@@ -145,6 +150,19 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		// has metadata to render and the existing summary/reader pollers see a row.
 		const existing = await deps.findArticleByUrl(articleUrl);
 		if (!existing) {
+			// First visit is the request that triggers the whole crawl cascade
+			// (stub save → crawl → summary → possibly OCR), each leg with real
+			// third-party cost — so the per-IP budget is spent here, not on reads
+			// of already-known articles.
+			const decision = await deps.consumeRateLimit({
+				bucket: "view-crawl",
+				key: rateLimitKeyFromRequest(req),
+				rule: deps.viewCrawlRateLimit,
+			});
+			if (!decision.allowed) {
+				sendRateLimited(res, decision.retryAfterSeconds);
+				return;
+			}
 			const hostname = hostnameFrom(articleUrl);
 			await deps.saveArticleGlobally({
 				url: articleUrl,

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -16,6 +16,7 @@ import {
 	createFakePublishRecrawlLinkInitiated,
 	createFakePublishSaveAnonymousLink,
 } from "@packages/test-fixtures";
+import { initInMemoryRateLimit } from "@packages/test-fixtures/providers/rate-limit";
 import { calculateReadTime } from "@packages/domain/article";
 import { MAX_POLLS } from "../../shared/article-reader/article-reader";
 import type { ViewOpenedEvent } from "../../middleware/analytics";
@@ -1762,6 +1763,89 @@ describe("View routes", () => {
 			expect(counter.getAttribute("data-expiry-state")).toBe("permanent");
 
 			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(0);
+		});
+	});
+
+	describe("anonymous crawl-trigger rate limiting", () => {
+		function createMutableClock(startMs: number) {
+			let nowMs = startMs;
+			return {
+				now: () => new Date(nowMs),
+				advanceSeconds: (seconds: number) => {
+					nowMs += seconds * 1000;
+				},
+			};
+		}
+
+		function buildThrottledHarness(rule: { limit: number; windowSeconds: number }) {
+			const clock = createMutableClock(1_700_000_000_000);
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const publishedUrls: string[] = [];
+			const basePublish = fixture.events.publishSaveAnonymousLink;
+			fixture.events.publishSaveAnonymousLink = async (params) => {
+				publishedUrls.push(params.url);
+				await basePublish(params);
+			};
+			fixture.rateLimit = {
+				consumeRateLimit: initInMemoryRateLimit({ now: clock.now }).consumeRateLimit,
+				rules: { ...fixture.rateLimit.rules, viewCrawl: rule },
+			};
+			const harness = useApp(fixture);
+			return { harness, publishedUrls, clock };
+		}
+
+		it("returns 429 past the per-IP limit and enqueues no crawl for the throttled URL", async () => {
+			const { harness, publishedUrls } = buildThrottledHarness({
+				limit: 2,
+				windowSeconds: 3600,
+			});
+
+			const first = await request(harness.server).get("/view/example.com/first");
+			const second = await request(harness.server).get("/view/example.com/second");
+			const throttled = await request(harness.server).get("/view/example.com/third");
+
+			expect([first.status, second.status]).toEqual([200, 200]);
+			expect(throttled.status).toBe(429);
+			expect(String(throttled.headers["retry-after"])).toMatch(/^\d+$/);
+			expect(publishedUrls).toEqual([
+				"https://example.com/first",
+				"https://example.com/second",
+			]);
+			expect(
+				await harness.articleStore.findArticleByUrl("https://example.com/third"),
+			).toBeNull();
+		});
+
+		it("spends no crawl budget on repeat views of an already-known article", async () => {
+			const { harness, publishedUrls } = buildThrottledHarness({
+				limit: 1,
+				windowSeconds: 3600,
+			});
+
+			const firstVisit = await request(harness.server).get("/view/example.com/only");
+			const repeatVisit = await request(harness.server).get("/view/example.com/only");
+
+			expect([firstVisit.status, repeatVisit.status]).toEqual([200, 200]);
+			expect(publishedUrls).toEqual(["https://example.com/only"]);
+		});
+
+		it("allows new crawl triggers again after the window resets", async () => {
+			const { harness, publishedUrls, clock } = buildThrottledHarness({
+				limit: 1,
+				windowSeconds: 3600,
+			});
+			await request(harness.server).get("/view/example.com/first");
+
+			const throttled = await request(harness.server).get("/view/example.com/second");
+			clock.advanceSeconds(3600);
+			const afterReset = await request(harness.server).get("/view/example.com/second");
+
+			expect(throttled.status).toBe(429);
+			expect(afterReset.status).toBe(200);
+			expect(publishedUrls).toEqual([
+				"https://example.com/first",
+				"https://example.com/second",
+			]);
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-skip-messages.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-skip-messages.ts
@@ -9,6 +9,8 @@ const SUMMARY_SKIP_MESSAGES: Record<SummarySkipReason, string> = {
 		"Our summariser couldn't produce a useful summary for this article.",
 	"crawl-unsupported":
 		"Summary not generated for this link.",
+	"crawl-failed":
+		"Summary not generated for this link.",
 };
 
 const SUMMARY_SKIP_FALLBACK = "No summary was generated for this article.";

--- a/projects/save-link/Pulumi.prod.yaml
+++ b/projects/save-link/Pulumi.prod.yaml
@@ -6,6 +6,9 @@ config:
   save-link:alertEmail: readplace+devops@readplace.com
   save-link:articlesTableName: hutch-articles-cda0a08
   save-link:articlesTableArn: arn:aws:dynamodb:ap-southeast-2:278728209435:table/hutch-articles-cda0a08
+  save-link:rateLimitsTableName: hutch-rate-limits-prod
+  save-link:rateLimitsTableArn: arn:aws:dynamodb:ap-southeast-2:278728209435:table/hutch-rate-limits-prod
+  save-link:paidCrawlBudget: 50/3600
   save-link:contentBucketName: hutch-article-content-prod
   save-link:pendingHtmlBucketName: hutch-pending-html-prod
   save-link:pendingPdfBucketName: hutch-pending-pdf-prod

--- a/projects/save-link/Pulumi.staging.yaml
+++ b/projects/save-link/Pulumi.staging.yaml
@@ -6,6 +6,9 @@ config:
   save-link:alertEmail: readplace+staging@readplace.com
   save-link:articlesTableName: hutch-articles-cda0a08
   save-link:articlesTableArn: arn:aws:dynamodb:ap-southeast-2:572337278115:table/hutch-articles-cda0a08
+  save-link:rateLimitsTableName: hutch-rate-limits-staging
+  save-link:rateLimitsTableArn: arn:aws:dynamodb:ap-southeast-2:572337278115:table/hutch-rate-limits-staging
+  save-link:paidCrawlBudget: 200/3600
   save-link:contentBucketName: hutch-article-content-staging
   save-link:pendingHtmlBucketName: hutch-pending-html-staging
   save-link:pendingPdfBucketName: hutch-pending-pdf-staging

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -55,6 +55,13 @@ const config = new pulumi.Config();
 const alertEmail = config.require("alertEmail");
 const articlesTableName = config.require("articlesTableName");
 const articlesTableArn = config.require("articlesTableArn");
+// Owned by the hutch stack (same convention as the articles table): counters
+// for per-IP throttles and the global paid-crawl budget share one TTL'd table.
+const rateLimitsTableName = config.require("rateLimitsTableName");
+const rateLimitsTableArn = config.require("rateLimitsTableArn");
+// "<budget>/<windowSeconds>" ceiling on comprehensive-crawl runs (OCR + LLM
+// cleanup spend); enforced by the runtime's DynamoDB circuit-breaker.
+const paidCrawlBudget = config.require("paidCrawlBudget");
 const contentBucketName = config.require("contentBucketName");
 const pendingHtmlBucketName = config.require("pendingHtmlBucketName");
 const pendingPdfBucketName = config.require("pendingPdfBucketName");
@@ -625,7 +632,11 @@ const comprehensiveCrawlCommandQueue = new HutchSQS("comprehensive-crawl-command
 });
 
 const comprehensiveCrawlCommandDynamodb = new HutchDynamoDBAccess("comprehensive-crawl-command-dynamodb", {
-	tables: [{ arn: articlesTableArn, includeIndexes: false }],
+	tables: [
+		{ arn: articlesTableArn, includeIndexes: false },
+		// Paid-crawl budget counter (conditional UpdateItem per crawl).
+		{ arn: rateLimitsTableArn, includeIndexes: false },
+	],
 	actions: ["dynamodb:GetItem", "dynamodb:UpdateItem"],
 });
 
@@ -684,6 +695,8 @@ const comprehensiveCrawlCommandLambda = new HutchLambda("comprehensive-crawl-com
 	containerImage: { imageUri: ocrImageTags["comprehensive-crawl-command"] },
 	environment: {
 		DYNAMODB_ARTICLES_TABLE: articlesTableName,
+		DYNAMODB_RATE_LIMITS_TABLE: rateLimitsTableName,
+		PAID_CRAWL_BUDGET: paidCrawlBudget,
 		CONTENT_BUCKET_NAME: contentBucketName,
 		EVENT_BUS_NAME: eventBus.eventBusName,
 		IMAGES_CDN_BASE_URL: contentMediaCdn.baseUrl,

--- a/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
+++ b/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
@@ -87,7 +87,7 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
-const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+const { consumePaidCrawlBudget, refundPaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 	client: dynamoClient,
 	tableName: rateLimitsTable,
 	rule: paidCrawlBudget,
@@ -103,5 +103,6 @@ export const handler = initComprehensiveCrawlHandler({
 	...articleCrawl,
 	...observability,
 	consumePaidCrawlBudget,
+	refundPaidCrawlBudget,
 	now,
 });

--- a/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
+++ b/projects/save-link/src/runtime/comprehensive-crawl-command.main.ts
@@ -7,8 +7,10 @@ import { consoleLogger } from "@packages/hutch-logger";
 import { EventBridgeClient } from "@packages/hutch-infra-components/runtime";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { extractPdfMetadata } from "@packages/crawl-article";
+import { parseRateLimitRule } from "@packages/domain/rate-limit";
 import { requireEnv } from "../require-env";
 import { initComprehensiveCrawlHandler } from "./domain/comprehensive-crawl/comprehensive-crawl-handler";
+import { initDynamoDbPaidCrawlBudget } from "./providers/paid-crawl-budget/dynamodb-paid-crawl-budget";
 import { initSaveLinkPdfExtract } from "./domain/article-parser/init-save-link-pdf-extract";
 import { initStagePdfToS3 } from "./domain/article-parser/init-stage-pdf-to-s3";
 import { initInvokePdfPageOcr } from "./domain/article-parser/init-invoke-pdf-page-ocr";
@@ -33,6 +35,8 @@ const pdfPageOcrFunctionName = requireEnv("PDF_PAGE_OCR_FUNCTION_NAME");
 const pdfPageLlmCleanupFunctionName = requireEnv("PDF_PAGE_LLM_CLEANUP_FUNCTION_NAME");
 const pdfDocumentDiffReviewFunctionName = requireEnv("PDF_DOCUMENT_DIFF_REVIEW_FUNCTION_NAME");
 const pdfPageHtmlConvertFunctionName = requireEnv("PDF_PAGE_HTML_CONVERT_FUNCTION_NAME");
+const rateLimitsTable = requireEnv("DYNAMODB_RATE_LIMITS_TABLE");
+const paidCrawlBudget = parseRateLimitRule(requireEnv("PAID_CRAWL_BUDGET"));
 
 const s3Client = new S3Client({});
 const sqsClient = new SQSClient({});
@@ -83,6 +87,12 @@ const crawlAndFinalize = initCrawlAndFinalizeDepBundle({
 const events = initEventsDepBundle({ eventBridgeClient, eventBusName, sqsClient, generateSummaryQueueUrl });
 const articleAggregate = initArticleAggregateDepBundle({ dynamoClient, articlesTable, events });
 const articleCrawl = initArticleCrawlDepBundle({ dynamoClient, articlesTable });
+const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+	client: dynamoClient,
+	tableName: rateLimitsTable,
+	rule: paidCrawlBudget,
+	now,
+});
 
 export const handler = initComprehensiveCrawlHandler({
 	crawlArticle: parser.crawlArticle,
@@ -92,5 +102,6 @@ export const handler = initComprehensiveCrawlHandler({
 	...articleAggregate,
 	...articleCrawl,
 	...observability,
+	consumePaidCrawlBudget,
 	now,
 });

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -1,6 +1,6 @@
 import { noopLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
-import { markCrawlFailed, markCrawlUnsupported, markSummarySkipped } from "@packages/domain/article-aggregate";
+import { markCrawlBlocked, markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
 import {
 	RecrawlContentExtractedEvent,
 	RefreshContentExtractedEvent,
@@ -529,17 +529,17 @@ describe("initComprehensiveCrawlHandler", () => {
 
 			expect(result).toEqual({ batchItemFailures: [] });
 			expect(crawlArticle).not.toHaveBeenCalled();
-			expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
+			// One atomic cross-axis transition terminalises both axes (crawl=failed,
+			// summary=skipped): the stub save left summary=pending and no
+			// *-ContentExtracted event will fire here, so a partial two-write
+			// terminalisation could strand the row half-terminal (the queue is
+			// maxReceiveCount=1 → DLQ handler only advances crawl) and the
+			// stuck-articles canary would page over a transient cap.
+			expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlBlocked, {
 				url: "https://example.com/doc.pdf",
 				input: { reason: { kind: "blocked", cause: "rate-limited" } },
 			});
-			// Both axes terminalised: the stub save left summary=pending and no
-			// *-ContentExtracted event will fire here, so without this the row sits
-			// half-terminal and the stuck-articles canary pages over a transient cap.
-			expect(transitionAndPersist).toHaveBeenCalledWith(markSummarySkipped, {
-				url: "https://example.com/doc.pdf",
-				input: { reason: "crawl-failed", now: "2026-04-18T12:00:00.000Z" },
-			});
+			expect(transitionAndPersist).toHaveBeenCalledTimes(1);
 			expect(publishEvent).not.toHaveBeenCalled();
 			expect(logParseError).toHaveBeenCalledWith({
 				url: "https://example.com/doc.pdf",

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -1,6 +1,6 @@
 import { noopLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
-import { markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
+import { markCrawlFailed, markCrawlUnsupported, markSummarySkipped } from "@packages/domain/article-aggregate";
 import {
 	RecrawlContentExtractedEvent,
 	RefreshContentExtractedEvent,
@@ -33,19 +33,22 @@ const stubContext: Context = {
 	succeed: () => {},
 };
 
-function createSqsEvent(detail: {
-	url: string;
-	userId?: string;
-	recrawl?: boolean;
-	refresh?: boolean;
-	previousBodyHash?: string;
-}): SQSEvent {
+function createSqsEvent(
+	detail: {
+		url: string;
+		userId?: string;
+		recrawl?: boolean;
+		refresh?: boolean;
+		previousBodyHash?: string;
+	},
+	opts: { receiveCount?: number } = {},
+): SQSEvent {
 	return {
 		Records: [{
 			messageId: "msg-1",
 			receiptHandle: "receipt-1",
 			body: JSON.stringify({ detail }),
-			attributes: stubAttributes,
+			attributes: { ...stubAttributes, ApproximateReceiveCount: String(opts.receiveCount ?? 1) },
 			messageAttributes: {},
 			md5OfBody: "",
 			eventSource: "aws:sqs",
@@ -89,6 +92,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		markCrawlProgress: jest.fn().mockResolvedValue(undefined),
 		consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: true }),
+		refundPaidCrawlBudget: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
 		logger: noopLogger,
@@ -529,6 +533,13 @@ describe("initComprehensiveCrawlHandler", () => {
 				url: "https://example.com/doc.pdf",
 				input: { reason: { kind: "blocked", cause: "rate-limited" } },
 			});
+			// Both axes terminalised: the stub save left summary=pending and no
+			// *-ContentExtracted event will fire here, so without this the row sits
+			// half-terminal and the stuck-articles canary pages over a transient cap.
+			expect(transitionAndPersist).toHaveBeenCalledWith(markSummarySkipped, {
+				url: "https://example.com/doc.pdf",
+				input: { reason: "crawl-failed", now: "2026-04-18T12:00:00.000Z" },
+			});
 			expect(publishEvent).not.toHaveBeenCalled();
 			expect(logParseError).toHaveBeenCalledWith({
 				url: "https://example.com/doc.pdf",
@@ -608,6 +619,76 @@ describe("initComprehensiveCrawlHandler", () => {
 				tier: "tier-1",
 				userId: undefined,
 			});
+		});
+
+		it("does not re-consume the budget on an SQS redelivery — the slot was paid on the first receive", async () => {
+			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true });
+			const crawlArticle = jest.fn(successfulComprehensiveCrawl);
+			const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+			const handler = createHandler({ consumePaidCrawlBudget, crawlArticle, publishEvent });
+
+			const result = await handler(
+				createSqsEvent({ url: "https://example.com/doc.pdf" }, { receiveCount: 2 }),
+				stubContext,
+				() => {},
+			);
+
+			expect(result).toEqual({ batchItemFailures: [] });
+			expect(consumePaidCrawlBudget).not.toHaveBeenCalled();
+			expect(crawlArticle).toHaveBeenCalledTimes(1);
+			expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+				url: "https://example.com/doc.pdf",
+				tier: "tier-1",
+				userId: undefined,
+			});
+		});
+
+		it("refunds the slot when the crawl short-circuits as not-modified (cheap byte-gate, no OCR/LLM spend)", async () => {
+			const refundPaidCrawlBudget = jest.fn().mockResolvedValue(undefined);
+			const crawlArticle: CrawlArticle = async () => ({ status: "not-modified" });
+
+			const handler = createHandler({ refundPaidCrawlBudget, crawlArticle });
+
+			await handler(
+				createSqsEvent({
+					url: "https://example.com/doc.pdf",
+					refresh: true,
+					previousBodyHash: "h".repeat(64),
+				}),
+				stubContext,
+				() => {},
+			);
+
+			expect(refundPaidCrawlBudget).toHaveBeenCalledTimes(1);
+		});
+
+		it("logs a warning and still consumes the message when the budget refund fails (best-effort, fails safe)", async () => {
+			const refundPaidCrawlBudget = jest.fn().mockRejectedValue(new Error("DynamoDB throttled"));
+			const crawlArticle: CrawlArticle = async () => ({ status: "not-modified" });
+			const warn = jest.fn();
+			const logger = { ...noopLogger, warn };
+
+			const handler = createHandler({ refundPaidCrawlBudget, crawlArticle, logger });
+
+			const result = await handler(
+				createSqsEvent({
+					url: "https://example.com/doc.pdf",
+					refresh: true,
+					previousBodyHash: "h".repeat(64),
+				}),
+				stubContext,
+				() => {},
+			);
+
+			expect(result).toEqual({ batchItemFailures: [] });
+			expect(warn).toHaveBeenCalledWith(
+				"[ComprehensiveCrawlCommand] paid-crawl budget refund failed",
+				expect.objectContaining({
+					url: "https://example.com/doc.pdf",
+					error: "Error: DynamoDB throttled",
+				}),
+			);
 		});
 	});
 });

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -88,6 +88,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		markCrawlProgress: jest.fn().mockResolvedValue(undefined),
+		consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: true }),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
 		logger: noopLogger,
@@ -499,5 +500,114 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const result = await handler(invalidEvent, stubContext, () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
+	});
+
+	describe("paid-crawl budget circuit-breaker", () => {
+		it("fails the crawl gracefully past the budget: no crawl, terminal failed row, message consumed", async () => {
+			const crawlArticle = jest.fn(successfulComprehensiveCrawl);
+			const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+			const publishEvent = jest.fn().mockResolvedValue(undefined);
+			const logParseError = jest.fn();
+
+			const handler = createHandler({
+				crawlArticle,
+				transitionAndPersist,
+				publishEvent,
+				logParseError,
+				consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: false }),
+			});
+
+			const result = await handler(
+				createSqsEvent({ url: "https://example.com/doc.pdf" }),
+				stubContext,
+				() => {},
+			);
+
+			expect(result).toEqual({ batchItemFailures: [] });
+			expect(crawlArticle).not.toHaveBeenCalled();
+			expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
+				url: "https://example.com/doc.pdf",
+				input: { reason: { kind: "blocked", cause: "rate-limited" } },
+			});
+			expect(publishEvent).not.toHaveBeenCalled();
+			expect(logParseError).toHaveBeenCalledWith({
+				url: "https://example.com/doc.pdf",
+				reason: "paid-crawl-budget-exhausted",
+			});
+		});
+
+		it("emits a tier-1 failure crawl-outcome when the budget blocks the crawl", async () => {
+			const logCrawlOutcome = jest.fn();
+			const readTierSnapshot = jest.fn().mockResolvedValue({
+				tier0Status: "success",
+				tier1Status: "not_attempted",
+				pickedTier: "tier-0",
+			});
+
+			const handler = createHandler({
+				logCrawlOutcome,
+				readTierSnapshot,
+				consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: false }),
+			});
+
+			await handler(
+				createSqsEvent({ url: "https://example.com/doc.pdf" }),
+				stubContext,
+				() => {},
+			);
+
+			expect(logCrawlOutcome).toHaveBeenCalledWith({
+				url: "https://example.com/doc.pdf",
+				thisTier: "tier-1",
+				thisTierStatus: "failed",
+				otherTierStatus: "success",
+				pickedTier: "tier-0",
+			});
+		});
+
+		it("leaves a refresh's row untouched past the budget — the prior canonical keeps serving", async () => {
+			const crawlArticle = jest.fn(successfulComprehensiveCrawl);
+			const transitionAndPersist = jest.fn().mockResolvedValue(undefined);
+			const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+			const handler = createHandler({
+				crawlArticle,
+				transitionAndPersist,
+				publishEvent,
+				consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: false }),
+			});
+
+			const result = await handler(
+				createSqsEvent({ url: "https://example.com/doc.pdf", refresh: true }),
+				stubContext,
+				() => {},
+			);
+
+			expect(result).toEqual({ batchItemFailures: [] });
+			expect(crawlArticle).not.toHaveBeenCalled();
+			expect(transitionAndPersist).not.toHaveBeenCalled();
+			expect(publishEvent).not.toHaveBeenCalled();
+		});
+
+		it("runs the crawl normally while the budget allows it", async () => {
+			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true });
+			const publishEvent = jest.fn().mockResolvedValue(undefined);
+
+			const handler = createHandler({ consumePaidCrawlBudget, publishEvent });
+
+			const result = await handler(
+				createSqsEvent({ url: "https://example.com/doc.pdf" }),
+				stubContext,
+				() => {},
+			);
+
+			expect(result).toEqual({ batchItemFailures: [] });
+			expect(consumePaidCrawlBudget).toHaveBeenCalledTimes(1);
+			expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
+				url: "https://example.com/doc.pdf",
+				tier: "tier-1",
+				userId: undefined,
+			});
+		});
 	});
 });

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -91,7 +91,7 @@ function createHandler(overrides: Partial<HandlerDeps> = {}) {
 		transitionAndPersist: jest.fn().mockResolvedValue(undefined),
 		markCrawlStage: jest.fn().mockResolvedValue(undefined),
 		markCrawlProgress: jest.fn().mockResolvedValue(undefined),
-		consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: true }),
+		consumePaidCrawlBudget: jest.fn().mockResolvedValue({ allowed: true, consumed: true }),
 		refundPaidCrawlBudget: jest.fn().mockResolvedValue(undefined),
 		publishEvent: jest.fn().mockResolvedValue(undefined),
 		now: fixedNow,
@@ -600,8 +600,8 @@ describe("initComprehensiveCrawlHandler", () => {
 			expect(publishEvent).not.toHaveBeenCalled();
 		});
 
-		it("runs the crawl normally while the budget allows it", async () => {
-			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true });
+		it("runs the crawl normally while the budget allows it, keying the consume on the message id", async () => {
+			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true, consumed: true });
 			const publishEvent = jest.fn().mockResolvedValue(undefined);
 
 			const handler = createHandler({ consumePaidCrawlBudget, publishEvent });
@@ -613,7 +613,7 @@ describe("initComprehensiveCrawlHandler", () => {
 			);
 
 			expect(result).toEqual({ batchItemFailures: [] });
-			expect(consumePaidCrawlBudget).toHaveBeenCalledTimes(1);
+			expect(consumePaidCrawlBudget).toHaveBeenCalledWith({ messageId: "msg-1" });
 			expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
 				url: "https://example.com/doc.pdf",
 				tier: "tier-1",
@@ -621,8 +621,12 @@ describe("initComprehensiveCrawlHandler", () => {
 			});
 		});
 
-		it("does not re-consume the budget on an SQS redelivery — the slot was paid on the first receive", async () => {
-			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true });
+		it("re-runs the budget gate on an SQS redelivery; an idempotent re-consume (consumed=false) still completes the crawl", async () => {
+			// The provider makes a redelivered message's consume a no-op on the
+			// counter (consumed=false). The handler still evaluates the gate every
+			// receive rather than skipping it on ApproximateReceiveCount — so a
+			// transient first-receive error can't let a later receive bypass the cap.
+			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true, consumed: false });
 			const crawlArticle = jest.fn(successfulComprehensiveCrawl);
 			const publishEvent = jest.fn().mockResolvedValue(undefined);
 
@@ -635,13 +639,34 @@ describe("initComprehensiveCrawlHandler", () => {
 			);
 
 			expect(result).toEqual({ batchItemFailures: [] });
-			expect(consumePaidCrawlBudget).not.toHaveBeenCalled();
+			expect(consumePaidCrawlBudget).toHaveBeenCalledWith({ messageId: "msg-1" });
 			expect(crawlArticle).toHaveBeenCalledTimes(1);
 			expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
 				url: "https://example.com/doc.pdf",
 				tier: "tier-1",
 				userId: undefined,
 			});
+		});
+
+		it("does not refund an idempotent re-consume (consumed=false) even when the crawl is not-modified — its slot was accounted on the first receive", async () => {
+			const consumePaidCrawlBudget = jest.fn().mockResolvedValue({ allowed: true, consumed: false });
+			const refundPaidCrawlBudget = jest.fn().mockResolvedValue(undefined);
+			const crawlArticle: CrawlArticle = async () => ({ status: "not-modified" });
+
+			const handler = createHandler({ consumePaidCrawlBudget, refundPaidCrawlBudget, crawlArticle });
+
+			const result = await handler(
+				createSqsEvent({
+					url: "https://example.com/doc.pdf",
+					refresh: true,
+					previousBodyHash: "h".repeat(64),
+				}, { receiveCount: 2 }),
+				stubContext,
+				() => {},
+			);
+
+			expect(result).toEqual({ batchItemFailures: [] });
+			expect(refundPaidCrawlBudget).not.toHaveBeenCalled();
 		});
 
 		it("refunds the slot when the crawl short-circuits as not-modified (cheap byte-gate, no OCR/LLM spend)", async () => {

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -12,6 +12,7 @@ import {
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
 import type { MarkCrawlProgress } from "../../providers/article-crawl/mark-crawl-progress";
+import type { ConsumePaidCrawlBudget } from "../../providers/paid-crawl-budget/dynamodb-paid-crawl-budget";
 import { initProgressThrottle } from "../crawl-article-state/init-progress-throttle";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { UpdateFetchTimestamp } from "../save-link/update-fetch-timestamp-handler";
@@ -39,6 +40,7 @@ export function initComprehensiveCrawlHandler(deps: {
 	transitionAndPersist: TransitionAndPersist;
 	markCrawlStage: MarkCrawlStage;
 	markCrawlProgress: MarkCrawlProgress;
+	consumePaidCrawlBudget: ConsumePaidCrawlBudget;
 	publishEvent: PublishEvent;
 	now: () => Date;
 	logger: HutchLogger;
@@ -55,6 +57,7 @@ export function initComprehensiveCrawlHandler(deps: {
 		transitionAndPersist,
 		markCrawlStage,
 		markCrawlProgress,
+		consumePaidCrawlBudget,
 		publishEvent,
 		now,
 		logger,
@@ -75,6 +78,28 @@ export function initComprehensiveCrawlHandler(deps: {
 			otherTierStatus: snapshot.tier0Status,
 			pickedTier: snapshot.pickedTier,
 		});
+	};
+
+	/* Spend breaker, not a crawl error: the message is consumed (no SQS retry —
+	 * a retry would re-spend the very budget that is exhausted) and the row is
+	 * settled so readers see the terminal "link is saved, content unavailable"
+	 * reframe instead of a forever-pending progress bar. */
+	const resolveBudgetExhausted = async (ctx: {
+		url: string;
+		refresh?: boolean;
+	}): Promise<CrawlTermination> => {
+		logParseError({ url: ctx.url, reason: "paid-crawl-budget-exhausted" });
+		await emitTier1Failure(ctx.url);
+		if (ctx.refresh) {
+			// A refresh re-checks an article that already has served content; the
+			// prior canonical stays valid, its freshness simply doesn't bump.
+			return { via: "already-terminal" };
+		}
+		await transitionAndPersist(markCrawlFailed, {
+			url: ctx.url,
+			input: { reason: { kind: "blocked", cause: "rate-limited" } },
+		});
+		return { via: "committed-in-process" };
 	};
 
 	const resolveCrawlResult = async (
@@ -221,6 +246,13 @@ export function initComprehensiveCrawlHandler(deps: {
 					recrawl: recrawl ? 1 : 0,
 					refresh: refresh ? 1 : 0,
 				});
+
+				const budget = await consumePaidCrawlBudget();
+				if (!budget.allowed) {
+					logger.warn(`${logPrefix} paid-crawl budget exhausted — failing crawl gracefully`, { url });
+					await resolveBudgetExhausted({ url, refresh });
+					continue;
+				}
 
 				/*
 				 * Server commits three coarse stages for the comprehensive path —

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -261,19 +261,19 @@ export function initComprehensiveCrawlHandler(deps: {
 					refresh: refresh ? 1 : 0,
 				});
 
-				/* Consume the spend slot exactly once per message — on the first SQS
-				 * receive. A post-budget crawl that throws is redelivered; consuming
-				 * again on each redelivery would let one persistently-failing crawl
-				 * drain the whole window through retries alone. Redeliveries skip the
-				 * gate and proceed straight to the crawl — the slot is already paid. */
-				const isFirstReceive = Number(record.attributes.ApproximateReceiveCount) === 1;
-				if (isFirstReceive) {
-					const budget = await consumePaidCrawlBudget();
-					if (!budget.allowed) {
-						logger.warn(`${logPrefix} paid-crawl budget exhausted — failing crawl gracefully`, { url });
-						await resolveBudgetExhausted({ url, refresh });
-						continue;
-					}
+				/* Consume one spend slot, keyed on the message so the gate is safe to
+				 * run on every receive: the provider claims a per-message marker in
+				 * the same transaction as the counter increment, so a redelivery of an
+				 * already-counted message re-checks the gate but adds nothing to the
+				 * counter (one persistently-failing crawl can't drain the window
+				 * through retries). A consume that errors — rather than denies —
+				 * rethrows so the gate re-runs next receive (fail closed) instead of
+				 * slipping past an exhausted budget. */
+				const budget = await consumePaidCrawlBudget({ messageId: record.messageId });
+				if (!budget.allowed) {
+					logger.warn(`${logPrefix} paid-crawl budget exhausted — failing crawl gracefully`, { url });
+					await resolveBudgetExhausted({ url, refresh });
+					continue;
 				}
 
 				/*
@@ -318,11 +318,12 @@ export function initComprehensiveCrawlHandler(deps: {
 
 				/* The pre-parse byte gate fired: a not-modified crawl did no OCR/LLM
 				 * work, so the slot it reserved before crawlArticle goes back to the
-				 * window rather than starve a genuinely-expensive crawl. Refund only
-				 * what this invocation consumed (first receive only); best-effort,
+				 * window rather than starve a genuinely-expensive crawl. Refund only a
+				 * freshly-consumed slot — never an idempotent re-consume on redelivery,
+				 * whose slot was already accounted on the first receive; best-effort,
 				 * since a failed refund merely leaves the window slightly over-counted,
 				 * which fails safe toward under-spending. */
-				if (isFirstReceive && crawlResult.status === "not-modified") {
+				if (budget.consumed && crawlResult.status === "not-modified") {
 					await refundPaidCrawlBudget().catch((error: unknown) => {
 						logger.warn(`${logPrefix} paid-crawl budget refund failed`, {
 							url,

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -3,7 +3,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
-import { markCrawlFailed, markCrawlUnsupported, markSummarySkipped } from "@packages/domain/article-aggregate";
+import { markCrawlBlocked, markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
 import {
 	ComprehensiveCrawlCommand,
 	RecrawlContentExtractedEvent,
@@ -88,12 +88,13 @@ export function initComprehensiveCrawlHandler(deps: {
 	/* Spend breaker, not a crawl error: the message is consumed (no SQS retry —
 	 * a retry would re-spend the very budget that is exhausted) and the row is
 	 * settled so readers see the terminal "link is saved, content unavailable"
-	 * reframe instead of a forever-pending progress bar. Both axes are
-	 * terminalised (crawl=failed, summary=skipped) — the stub save set summary
-	 * to `pending` and no *-ContentExtracted event will ever fire to advance it,
-	 * so without the summary write the row sits half-terminal and the
-	 * stuck-articles canary would page an operator over a transient throttle.
-	 * Mirrors markCrawlUnsupported's cross-axis pairing. */
+	 * reframe instead of a forever-pending progress bar. markCrawlBlocked
+	 * terminalises both axes (crawl=failed, summary=skipped) in one atomic save:
+	 * the stub save set summary to `pending` and no *-ContentExtracted event will
+	 * ever fire to advance it, so a partial two-write terminalisation could strand
+	 * the row half-terminal (the comprehensive queue is maxReceiveCount=1, so the
+	 * failed message hits a DLQ handler that only advances the crawl axis) and the
+	 * stuck-articles canary would page an operator over a transient throttle. */
 	const resolveBudgetExhausted = async (ctx: {
 		url: string;
 		refresh?: boolean;
@@ -105,13 +106,9 @@ export function initComprehensiveCrawlHandler(deps: {
 			// prior canonical stays valid, its freshness simply doesn't bump.
 			return { via: "already-terminal" };
 		}
-		await transitionAndPersist(markCrawlFailed, {
+		await transitionAndPersist(markCrawlBlocked, {
 			url: ctx.url,
 			input: { reason: { kind: "blocked", cause: "rate-limited" } },
-		});
-		await transitionAndPersist(markSummarySkipped, {
-			url: ctx.url,
-			input: { reason: "crawl-failed", now: now().toISOString() },
 		});
 		return { via: "committed-in-process" };
 	};

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.ts
@@ -3,7 +3,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
-import { markCrawlFailed, markCrawlUnsupported } from "@packages/domain/article-aggregate";
+import { markCrawlFailed, markCrawlUnsupported, markSummarySkipped } from "@packages/domain/article-aggregate";
 import {
 	ComprehensiveCrawlCommand,
 	RecrawlContentExtractedEvent,
@@ -12,7 +12,10 @@ import {
 } from "@packages/hutch-infra-components";
 import type { MarkCrawlStage } from "../../providers/article-crawl/mark-crawl-stage";
 import type { MarkCrawlProgress } from "../../providers/article-crawl/mark-crawl-progress";
-import type { ConsumePaidCrawlBudget } from "../../providers/paid-crawl-budget/dynamodb-paid-crawl-budget";
+import type {
+	ConsumePaidCrawlBudget,
+	RefundPaidCrawlBudget,
+} from "../../providers/paid-crawl-budget/dynamodb-paid-crawl-budget";
 import { initProgressThrottle } from "../crawl-article-state/init-progress-throttle";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { UpdateFetchTimestamp } from "../save-link/update-fetch-timestamp-handler";
@@ -41,6 +44,7 @@ export function initComprehensiveCrawlHandler(deps: {
 	markCrawlStage: MarkCrawlStage;
 	markCrawlProgress: MarkCrawlProgress;
 	consumePaidCrawlBudget: ConsumePaidCrawlBudget;
+	refundPaidCrawlBudget: RefundPaidCrawlBudget;
 	publishEvent: PublishEvent;
 	now: () => Date;
 	logger: HutchLogger;
@@ -58,6 +62,7 @@ export function initComprehensiveCrawlHandler(deps: {
 		markCrawlStage,
 		markCrawlProgress,
 		consumePaidCrawlBudget,
+		refundPaidCrawlBudget,
 		publishEvent,
 		now,
 		logger,
@@ -83,7 +88,12 @@ export function initComprehensiveCrawlHandler(deps: {
 	/* Spend breaker, not a crawl error: the message is consumed (no SQS retry —
 	 * a retry would re-spend the very budget that is exhausted) and the row is
 	 * settled so readers see the terminal "link is saved, content unavailable"
-	 * reframe instead of a forever-pending progress bar. */
+	 * reframe instead of a forever-pending progress bar. Both axes are
+	 * terminalised (crawl=failed, summary=skipped) — the stub save set summary
+	 * to `pending` and no *-ContentExtracted event will ever fire to advance it,
+	 * so without the summary write the row sits half-terminal and the
+	 * stuck-articles canary would page an operator over a transient throttle.
+	 * Mirrors markCrawlUnsupported's cross-axis pairing. */
 	const resolveBudgetExhausted = async (ctx: {
 		url: string;
 		refresh?: boolean;
@@ -98,6 +108,10 @@ export function initComprehensiveCrawlHandler(deps: {
 		await transitionAndPersist(markCrawlFailed, {
 			url: ctx.url,
 			input: { reason: { kind: "blocked", cause: "rate-limited" } },
+		});
+		await transitionAndPersist(markSummarySkipped, {
+			url: ctx.url,
+			input: { reason: "crawl-failed", now: now().toISOString() },
 		});
 		return { via: "committed-in-process" };
 	};
@@ -247,11 +261,19 @@ export function initComprehensiveCrawlHandler(deps: {
 					refresh: refresh ? 1 : 0,
 				});
 
-				const budget = await consumePaidCrawlBudget();
-				if (!budget.allowed) {
-					logger.warn(`${logPrefix} paid-crawl budget exhausted — failing crawl gracefully`, { url });
-					await resolveBudgetExhausted({ url, refresh });
-					continue;
+				/* Consume the spend slot exactly once per message — on the first SQS
+				 * receive. A post-budget crawl that throws is redelivered; consuming
+				 * again on each redelivery would let one persistently-failing crawl
+				 * drain the whole window through retries alone. Redeliveries skip the
+				 * gate and proceed straight to the crawl — the slot is already paid. */
+				const isFirstReceive = Number(record.attributes.ApproximateReceiveCount) === 1;
+				if (isFirstReceive) {
+					const budget = await consumePaidCrawlBudget();
+					if (!budget.allowed) {
+						logger.warn(`${logPrefix} paid-crawl budget exhausted — failing crawl gracefully`, { url });
+						await resolveBudgetExhausted({ url, refresh });
+						continue;
+					}
 				}
 
 				/*
@@ -293,6 +315,21 @@ export function initComprehensiveCrawlHandler(deps: {
 					},
 				});
 				await progressThrottle.flush({ url });
+
+				/* The pre-parse byte gate fired: a not-modified crawl did no OCR/LLM
+				 * work, so the slot it reserved before crawlArticle goes back to the
+				 * window rather than starve a genuinely-expensive crawl. Refund only
+				 * what this invocation consumed (first receive only); best-effort,
+				 * since a failed refund merely leaves the window slightly over-counted,
+				 * which fails safe toward under-spending. */
+				if (isFirstReceive && crawlResult.status === "not-modified") {
+					await refundPaidCrawlBudget().catch((error: unknown) => {
+						logger.warn(`${logPrefix} paid-crawl budget refund failed`, {
+							url,
+							error: String(error),
+						});
+					});
+				}
 
 				await resolveCrawlResult(crawlResult, {
 					url,

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
@@ -88,4 +88,54 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 
 		await expect(consumePaidCrawlBudget()).rejects.toThrow("throttled");
 	});
+
+	it("refunds a slot to the current window with an underflow-guarding condition", async () => {
+		let received: unknown;
+		const { refundPaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient((command) => {
+				received = command;
+				return {};
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		await refundPaidCrawlBudget();
+
+		const command = received as CapturedUpdate;
+		assert.deepEqual(command.input.Key, { pk: "paid-crawl#global#7200" });
+		expect(command.input.UpdateExpression).toContain("ADD #count :negOne");
+		expect(command.input.ConditionExpression).toContain("#count > :zero");
+		expect(command.input.ExpressionAttributeValues?.[":negOne"]).toBe(-1);
+	});
+
+	it("treats an underflow-blocked refund as a no-op (nothing left to give back)", async () => {
+		const { refundPaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw new ConditionalCheckFailedException({
+					$metadata: {},
+					message: "condition failed",
+				});
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		await expect(refundPaidCrawlBudget()).resolves.toBeUndefined();
+	});
+
+	it("rethrows non-conditional errors on refund", async () => {
+		const { refundPaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw new Error("throttled");
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		await expect(refundPaidCrawlBudget()).rejects.toThrow("throttled");
+	});
 });

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+} from "@packages/hutch-storage-client";
+import { initDynamoDbPaidCrawlBudget } from "./dynamodb-paid-crawl-budget";
+
+type SendFn = DynamoDBDocumentClient["send"];
+
+function createFakeClient(impl: (command: unknown) => unknown): DynamoDBDocumentClient {
+	return {
+		send: (async (command: unknown) => impl(command)) as unknown as SendFn,
+	} as DynamoDBDocumentClient;
+}
+
+interface CapturedUpdate {
+	input: {
+		TableName?: string;
+		Key?: Record<string, unknown>;
+		UpdateExpression?: string;
+		ConditionExpression?: string;
+		ExpressionAttributeValues?: Record<string, unknown>;
+	};
+}
+
+const TABLE = "test-rate-limits";
+const HOUR_BUDGET = { limit: 50, windowSeconds: 3600 };
+// 02:00:00 UTC + 600s → window start 7200.
+const midWindowNow = () => new Date(7_800_000);
+
+describe("initDynamoDbPaidCrawlBudget", () => {
+	it("counts one invocation against the global window with a below-budget condition and TTL", async () => {
+		let received: unknown;
+		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient((command) => {
+				received = command;
+				return {};
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		const decision = await consumePaidCrawlBudget();
+
+		assert.deepEqual(decision, { allowed: true });
+		const command = received as CapturedUpdate;
+		assert.equal(command.input.TableName, TABLE);
+		assert.deepEqual(command.input.Key, { pk: "paid-crawl#global#7200" });
+		expect(command.input.UpdateExpression).toContain("ADD #count :one");
+		expect(command.input.ConditionExpression).toContain("#count < :limit");
+		expect(command.input.ConditionExpression).toContain(
+			"attribute_not_exists(#count)",
+		);
+		expect(command.input.ExpressionAttributeValues?.[":limit"]).toBe(50);
+		expect(command.input.ExpressionAttributeValues?.[":expiresAt"]).toBe(
+			7200 + 2 * 3600,
+		);
+	});
+
+	it("blocks invocations once the window's budget is spent", async () => {
+		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw new ConditionalCheckFailedException({
+					$metadata: {},
+					message: "condition failed",
+				});
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		const decision = await consumePaidCrawlBudget();
+
+		assert.deepEqual(decision, { allowed: false });
+	});
+
+	it("rethrows non-conditional errors", async () => {
+		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw new Error("throttled");
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		await expect(consumePaidCrawlBudget()).rejects.toThrow("throttled");
+	});
+});

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
@@ -8,10 +8,12 @@ import { initDynamoDbPaidCrawlBudget } from "./dynamodb-paid-crawl-budget";
 
 type SendFn = DynamoDBDocumentClient["send"];
 
-function createFakeClient(impl: (command: unknown) => unknown): DynamoDBDocumentClient {
+function createFakeClient(
+	impl: (command: unknown) => unknown,
+): Partial<DynamoDBDocumentClient> {
 	return {
 		send: (async (command: unknown) => impl(command)) as unknown as SendFn,
-	} as DynamoDBDocumentClient;
+	};
 }
 
 interface CapturedTransaction {
@@ -57,7 +59,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 			client: createFakeClient((command) => {
 				received = command;
 				return {};
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -83,7 +85,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw cancelled(["ConditionalCheckFailed", "None"]);
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -98,7 +100,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw cancelled(["None", "ConditionalCheckFailed"]);
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -113,7 +115,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw cancelled(["ConditionalCheckFailed", "ConditionalCheckFailed"]);
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -128,7 +130,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw cancelled(["TransactionConflict", "None"]);
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -143,7 +145,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw new Error("throttled");
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -158,7 +160,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 			client: createFakeClient((command) => {
 				received = command;
 				return {};
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -180,7 +182,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 					$metadata: {},
 					message: "condition failed",
 				});
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
@@ -193,7 +195,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 		const { refundPaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw new Error("throttled");
-			}),
+			}) as DynamoDBDocumentClient,
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
+	TransactionCanceledException,
 } from "@packages/hutch-storage-client";
 import { initDynamoDbPaidCrawlBudget } from "./dynamodb-paid-crawl-budget";
 
@@ -13,9 +14,22 @@ function createFakeClient(impl: (command: unknown) => unknown): DynamoDBDocument
 	} as DynamoDBDocumentClient;
 }
 
+interface CapturedTransaction {
+	input: {
+		TransactItems?: {
+			Update?: {
+				TableName?: string;
+				Key?: Record<string, unknown>;
+				UpdateExpression?: string;
+				ConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		}[];
+	};
+}
+
 interface CapturedUpdate {
 	input: {
-		TableName?: string;
 		Key?: Record<string, unknown>;
 		UpdateExpression?: string;
 		ConditionExpression?: string;
@@ -28,8 +42,16 @@ const HOUR_BUDGET = { limit: 50, windowSeconds: 3600 };
 // 02:00:00 UTC + 600s → window start 7200.
 const midWindowNow = () => new Date(7_800_000);
 
+function cancelled(codes: (string | undefined)[]): TransactionCanceledException {
+	return new TransactionCanceledException({
+		$metadata: {},
+		message: "transaction cancelled",
+		CancellationReasons: codes.map((Code) => ({ Code })),
+	});
+}
+
 describe("initDynamoDbPaidCrawlBudget", () => {
-	it("counts one invocation against the global window with a below-budget condition and TTL", async () => {
+	it("claims the message and counts one invocation against the global window in a single transaction", async () => {
 		let received: unknown;
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient((command) => {
@@ -41,42 +63,83 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 			now: midWindowNow,
 		});
 
-		const decision = await consumePaidCrawlBudget();
+		const decision = await consumePaidCrawlBudget({ messageId: "msg-1" });
 
-		assert.deepEqual(decision, { allowed: true });
-		const command = received as CapturedUpdate;
-		assert.equal(command.input.TableName, TABLE);
-		assert.deepEqual(command.input.Key, { pk: "paid-crawl#global#7200" });
-		expect(command.input.UpdateExpression).toContain("ADD #count :one");
-		expect(command.input.ConditionExpression).toContain("#count < :limit");
-		expect(command.input.ConditionExpression).toContain(
-			"attribute_not_exists(#count)",
-		);
-		expect(command.input.ExpressionAttributeValues?.[":limit"]).toBe(50);
-		expect(command.input.ExpressionAttributeValues?.[":expiresAt"]).toBe(
-			7200 + 2 * 3600,
-		);
+		assert.deepEqual(decision, { allowed: true, consumed: true });
+		const command = received as CapturedTransaction;
+		const [claim, counter] = command.input.TransactItems ?? [];
+		assert.equal(claim?.Update?.TableName, TABLE);
+		assert.deepEqual(claim?.Update?.Key, { pk: "paid-crawl#claim#msg-1#7200" });
+		expect(claim?.Update?.ConditionExpression).toContain("attribute_not_exists(pk)");
+		assert.deepEqual(counter?.Update?.Key, { pk: "paid-crawl#global#7200" });
+		expect(counter?.Update?.UpdateExpression).toContain("ADD #count :one");
+		expect(counter?.Update?.ConditionExpression).toContain("#count < :limit");
+		expect(counter?.Update?.ConditionExpression).toContain("attribute_not_exists(#count)");
+		expect(counter?.Update?.ExpressionAttributeValues?.[":limit"]).toBe(50);
+		expect(counter?.Update?.ExpressionAttributeValues?.[":expiresAt"]).toBe(7200 + 2 * 3600);
 	});
 
-	it("blocks invocations once the window's budget is spent", async () => {
+	it("treats a rejected claim as an idempotent re-consume (redelivery): allowed but not freshly counted", async () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
-				throw new ConditionalCheckFailedException({
-					$metadata: {},
-					message: "condition failed",
-				});
+				throw cancelled(["ConditionalCheckFailed", "None"]);
 			}),
 			tableName: TABLE,
 			rule: HOUR_BUDGET,
 			now: midWindowNow,
 		});
 
-		const decision = await consumePaidCrawlBudget();
+		const decision = await consumePaidCrawlBudget({ messageId: "msg-1" });
+
+		assert.deepEqual(decision, { allowed: true, consumed: false });
+	});
+
+	it("blocks the invocation once the window's budget is spent (counter rejected, claim fresh)", async () => {
+		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw cancelled(["None", "ConditionalCheckFailed"]);
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		const decision = await consumePaidCrawlBudget({ messageId: "msg-1" });
 
 		assert.deepEqual(decision, { allowed: false });
 	});
 
-	it("rethrows non-conditional errors", async () => {
+	it("favours idempotency when a redelivery lands after the budget is also spent (both axes rejected)", async () => {
+		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw cancelled(["ConditionalCheckFailed", "ConditionalCheckFailed"]);
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		const decision = await consumePaidCrawlBudget({ messageId: "msg-1" });
+
+		assert.deepEqual(decision, { allowed: true, consumed: false });
+	});
+
+	it("rethrows a transaction cancelled for a non-budget reason (e.g. throttling) so the gate re-runs (fail closed)", async () => {
+		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
+			client: createFakeClient(() => {
+				throw cancelled(["TransactionConflict", "None"]);
+			}),
+			tableName: TABLE,
+			rule: HOUR_BUDGET,
+			now: midWindowNow,
+		});
+
+		await expect(consumePaidCrawlBudget({ messageId: "msg-1" })).rejects.toThrow(
+			TransactionCanceledException,
+		);
+	});
+
+	it("rethrows non-transaction errors", async () => {
 		const { consumePaidCrawlBudget } = initDynamoDbPaidCrawlBudget({
 			client: createFakeClient(() => {
 				throw new Error("throttled");
@@ -86,7 +149,7 @@ describe("initDynamoDbPaidCrawlBudget", () => {
 			now: midWindowNow,
 		});
 
-		await expect(consumePaidCrawlBudget()).rejects.toThrow("throttled");
+		await expect(consumePaidCrawlBudget({ messageId: "msg-1" })).rejects.toThrow("throttled");
 	});
 
 	it("refunds a slot to the current window with an underflow-guarding condition", async () => {

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.ts
@@ -1,6 +1,8 @@
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
+	TransactWriteCommand,
+	TransactionCanceledException,
 	defineDynamoTable,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
@@ -9,7 +11,12 @@ import {
 	type RateLimitRule,
 } from "@packages/domain/rate-limit";
 
-export type ConsumePaidCrawlBudget = () => Promise<{ allowed: boolean }>;
+/** `consumed` distinguishes a fresh spend (this call incremented the counter)
+ * from an idempotent re-consume of a message already counted this window (a
+ * redelivery): only a fresh spend may later be refunded. */
+export type ConsumePaidCrawlBudget = (input: {
+	messageId: string;
+}) => Promise<{ allowed: false } | { allowed: true; consumed: boolean }>;
 export type RefundPaidCrawlBudget = () => Promise<void>;
 
 const BudgetRow = z.object({ pk: z.string() });
@@ -17,10 +24,13 @@ const BudgetRow = z.object({ pk: z.string() });
 /**
  * Global (not per-client) spend circuit-breaker for the comprehensive crawl —
  * the tier that fans out OCR and LLM cleanup, each invocation carrying real
- * third-party cost. One conditional `ADD` per crawl against the shared
- * rate-limits table; once the window's budget is consumed, the condition fails
- * for every Lambda instance until the window rolls over, bounding worst-case
- * spend even if a caller slips past the per-IP limiter.
+ * third-party cost. Each consume is a two-item transaction against the shared
+ * rate-limits table: a per-message claim marker (so a redelivery of an
+ * already-counted message is a no-op rather than a second spend) committed
+ * atomically with a conditional `ADD` on the global window counter. Once the
+ * window's budget is consumed the counter condition fails for every Lambda
+ * instance until the window rolls over, bounding worst-case spend even if a
+ * caller slips past the per-IP limiter.
  */
 export function initDynamoDbPaidCrawlBudget(deps: {
 	client: DynamoDBDocumentClient;
@@ -37,32 +47,68 @@ export function initDynamoDbPaidCrawlBudget(deps: {
 		schema: BudgetRow,
 	});
 
-	const consumePaidCrawlBudget: ConsumePaidCrawlBudget = async () => {
+	const consumePaidCrawlBudget: ConsumePaidCrawlBudget = async ({ messageId }) => {
 		const nowMs = deps.now().getTime();
 		const windowStartSeconds = fixedWindowStartSeconds({
 			nowMs,
 			windowSeconds: deps.rule.windowSeconds,
 		});
+		// TTL one extra window past the row's own window end: DynamoDB TTL
+		// deletion lags by design, and an early delete would reset a live counter
+		// mid-window. The claim marker shares the counter's window so a message
+		// redelivered after the window rolls re-competes against the new budget.
+		const expiresAt = windowStartSeconds + 2 * deps.rule.windowSeconds;
 		try {
-			await table.update({
-				Key: { pk: `paid-crawl#global#${windowStartSeconds}` },
-				UpdateExpression:
-					"ADD #count :one SET expiresAt = if_not_exists(expiresAt, :expiresAt)",
-				ConditionExpression: "attribute_not_exists(#count) OR #count < :limit",
-				ExpressionAttributeNames: { "#count": "count" },
-				ExpressionAttributeValues: {
-					":one": 1,
-					":limit": deps.rule.limit,
-					// TTL one extra window past the row's own window end: DynamoDB TTL
-					// deletion lags by design, and an early delete would reset a live
-					// counter mid-window.
-					":expiresAt": windowStartSeconds + 2 * deps.rule.windowSeconds,
-				},
-			});
-			return { allowed: true };
+			await deps.client.send(
+				new TransactWriteCommand({
+					TransactItems: [
+						{
+							// Per-message idempotency claim. The create-if-absent condition
+							// fails when this message already consumed a slot this window, so
+							// re-running the gate on a redelivery adds nothing to the counter.
+							Update: {
+								TableName: deps.tableName,
+								Key: { pk: `paid-crawl#claim#${messageId}#${windowStartSeconds}` },
+								UpdateExpression: "SET expiresAt = :expiresAt",
+								ConditionExpression: "attribute_not_exists(pk)",
+								ExpressionAttributeValues: { ":expiresAt": expiresAt },
+							},
+						},
+						{
+							// Global window counter — the conditional ADD fails once the
+							// budget is spent, atomically with the claim above so a denied
+							// crawl never leaves a stranded claim marker behind.
+							Update: {
+								TableName: deps.tableName,
+								Key: { pk: `paid-crawl#global#${windowStartSeconds}` },
+								UpdateExpression:
+									"ADD #count :one SET expiresAt = if_not_exists(expiresAt, :expiresAt)",
+								ConditionExpression: "attribute_not_exists(#count) OR #count < :limit",
+								ExpressionAttributeNames: { "#count": "count" },
+								ExpressionAttributeValues: {
+									":one": 1,
+									":limit": deps.rule.limit,
+									":expiresAt": expiresAt,
+								},
+							},
+						},
+					],
+				}),
+			);
+			return { allowed: true, consumed: true };
 		} catch (error) {
-			if (error instanceof ConditionalCheckFailedException) {
-				return { allowed: false };
+			if (error instanceof TransactionCanceledException) {
+				// CancellationReasons are positional: [0] = claim marker, [1] = counter.
+				const reasons = error.CancellationReasons;
+				const claimRejected = reasons?.[0]?.Code === "ConditionalCheckFailed";
+				const counterRejected = reasons?.[1]?.Code === "ConditionalCheckFailed";
+				// Claim rejected → this message already paid a slot this window (a
+				// redelivery): allow without re-incrementing. Else counter rejected →
+				// the window's budget is spent. Any other cancellation (throttling,
+				// capacity) is not a budget decision, so it rethrows and the SQS gate
+				// re-runs on the next receive (fail closed) rather than slipping past.
+				if (claimRejected) return { allowed: true, consumed: false };
+				if (counterRejected) return { allowed: false };
 			}
 			throw error;
 		}

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.ts
@@ -1,0 +1,68 @@
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import {
+	fixedWindowStartSeconds,
+	type RateLimitRule,
+} from "@packages/domain/rate-limit";
+
+export type ConsumePaidCrawlBudget = () => Promise<{ allowed: boolean }>;
+
+const BudgetRow = z.object({ pk: z.string() });
+
+/**
+ * Global (not per-client) spend circuit-breaker for the comprehensive crawl —
+ * the tier that fans out OCR and LLM cleanup, each invocation carrying real
+ * third-party cost. One conditional `ADD` per crawl against the shared
+ * rate-limits table; once the window's budget is consumed, the condition fails
+ * for every Lambda instance until the window rolls over, bounding worst-case
+ * spend even if a caller slips past the per-IP limiter.
+ */
+export function initDynamoDbPaidCrawlBudget(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	rule: RateLimitRule;
+	now: () => Date;
+}): { consumePaidCrawlBudget: ConsumePaidCrawlBudget } {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: BudgetRow,
+	});
+
+	const consumePaidCrawlBudget: ConsumePaidCrawlBudget = async () => {
+		const nowMs = deps.now().getTime();
+		const windowStartSeconds = fixedWindowStartSeconds({
+			nowMs,
+			windowSeconds: deps.rule.windowSeconds,
+		});
+		try {
+			await table.update({
+				Key: { pk: `paid-crawl#global#${windowStartSeconds}` },
+				UpdateExpression:
+					"ADD #count :one SET expiresAt = if_not_exists(expiresAt, :expiresAt)",
+				ConditionExpression: "attribute_not_exists(#count) OR #count < :limit",
+				ExpressionAttributeNames: { "#count": "count" },
+				ExpressionAttributeValues: {
+					":one": 1,
+					":limit": deps.rule.limit,
+					// TTL one extra window past the row's own window end: DynamoDB TTL
+					// deletion lags by design, and an early delete would reset a live
+					// counter mid-window.
+					":expiresAt": windowStartSeconds + 2 * deps.rule.windowSeconds,
+				},
+			});
+			return { allowed: true };
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) {
+				return { allowed: false };
+			}
+			throw error;
+		}
+	};
+
+	return { consumePaidCrawlBudget };
+}

--- a/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.ts
+++ b/projects/save-link/src/runtime/providers/paid-crawl-budget/dynamodb-paid-crawl-budget.ts
@@ -10,6 +10,7 @@ import {
 } from "@packages/domain/rate-limit";
 
 export type ConsumePaidCrawlBudget = () => Promise<{ allowed: boolean }>;
+export type RefundPaidCrawlBudget = () => Promise<void>;
 
 const BudgetRow = z.object({ pk: z.string() });
 
@@ -26,7 +27,10 @@ export function initDynamoDbPaidCrawlBudget(deps: {
 	tableName: string;
 	rule: RateLimitRule;
 	now: () => Date;
-}): { consumePaidCrawlBudget: ConsumePaidCrawlBudget } {
+}): {
+	consumePaidCrawlBudget: ConsumePaidCrawlBudget;
+	refundPaidCrawlBudget: RefundPaidCrawlBudget;
+} {
 	const table = defineDynamoTable({
 		client: deps.client,
 		tableName: deps.tableName,
@@ -64,5 +68,33 @@ export function initDynamoDbPaidCrawlBudget(deps: {
 		}
 	};
 
-	return { consumePaidCrawlBudget };
+	/* Hand a slot back to the current window when a crawl turns out cheap
+	 * (the byte gate fired — no OCR/LLM spend). Conditioned on a positive count
+	 * so a refund can never drive the counter negative: every refund pairs with
+	 * a prior consume in the same window, so the guard holds in practice, and a
+	 * rare miss (e.g. the window already rolled) is a swallowed no-op that fails
+	 * safe toward under-spending. */
+	const refundPaidCrawlBudget: RefundPaidCrawlBudget = async () => {
+		const nowMs = deps.now().getTime();
+		const windowStartSeconds = fixedWindowStartSeconds({
+			nowMs,
+			windowSeconds: deps.rule.windowSeconds,
+		});
+		try {
+			await table.update({
+				Key: { pk: `paid-crawl#global#${windowStartSeconds}` },
+				UpdateExpression: "ADD #count :negOne",
+				ConditionExpression: "attribute_exists(#count) AND #count > :zero",
+				ExpressionAttributeNames: { "#count": "count" },
+				ExpressionAttributeValues: { ":negOne": -1, ":zero": 0 },
+			});
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) {
+				return;
+			}
+			throw error;
+		}
+	};
+
+	return { consumePaidCrawlBudget, refundPaidCrawlBudget };
 }

--- a/src/packages/article-state-types/src/summary-skip-reason.test.ts
+++ b/src/packages/article-state-types/src/summary-skip-reason.test.ts
@@ -1,7 +1,7 @@
 import { SummarySkipReasonSchema } from "./summary-skip-reason";
 
 describe("SummarySkipReasonSchema", () => {
-	it.each(["content-too-short", "ai-unavailable", "crawl-unsupported"])("accepts %s", (value) => {
+	it.each(["content-too-short", "ai-unavailable", "crawl-unsupported", "crawl-failed"])("accepts %s", (value) => {
 		expect(SummarySkipReasonSchema.parse(value)).toBe(value);
 	});
 

--- a/src/packages/article-state-types/src/summary-skip-reason.ts
+++ b/src/packages/article-state-types/src/summary-skip-reason.ts
@@ -4,5 +4,6 @@ export const SummarySkipReasonSchema = z.enum([
 	"content-too-short",
 	"ai-unavailable",
 	"crawl-unsupported",
+	"crawl-failed",
 ]);
 export type SummarySkipReason = z.infer<typeof SummarySkipReasonSchema>;

--- a/src/packages/check-failed-articles/scripts/collect-failed-rows.test.ts
+++ b/src/packages/check-failed-articles/scripts/collect-failed-rows.test.ts
@@ -175,6 +175,110 @@ describe("collectFailedRows", () => {
 		);
 	});
 
+	it("drops a paid-crawl-budget rate-limited block — a transient cap, not a debuggable failure", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "site.test/throttled",
+					originalUrl: "https://site.test/throttled.pdf",
+					crawlStatus: "failed",
+					crawlFailureReason: '{"kind":"blocked","cause":"rate-limited"}',
+					summaryStatus: "skipped",
+					savedAt: "2026-05-10T00:00:00.000Z",
+				},
+			],
+			Count: 1,
+		}));
+		const failed = await collectFailedRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+			lookbackDays: 0,
+			excludePatterns: NO_EXCLUDES,
+		});
+		assert.deepEqual(failed, []);
+	});
+
+	it("surfaces a non-rate-limited block (e.g. cloudflare) — a real crawler block to investigate", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "site.test/cf",
+					originalUrl: "https://site.test/cf",
+					crawlStatus: "failed",
+					crawlFailureReason: '{"kind":"blocked","cause":"cloudflare"}',
+					summaryStatus: "skipped",
+					savedAt: "2026-05-10T00:00:00.000Z",
+				},
+			],
+			Count: 1,
+		}));
+		const failed = await collectFailedRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+			lookbackDays: 0,
+			excludePatterns: NO_EXCLUDES,
+		});
+		assert.equal(failed.length, 1);
+		assert.deepEqual(failed[0]?.axes, ["crawl-failed"]);
+		assert.equal(failed[0]?.reasons["crawl-failed"], '{"kind":"blocked","cause":"cloudflare"}');
+	});
+
+	it("surfaces a valid non-blocked failure reason (parse-error) — only blocked/rate-limited is dropped", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "site.test/parse",
+					originalUrl: "https://site.test/parse",
+					crawlStatus: "failed",
+					crawlFailureReason: '{"kind":"parse-error","detail":"Readability crashed"}',
+					summaryStatus: "skipped",
+					savedAt: "2026-05-10T00:00:00.000Z",
+				},
+			],
+			Count: 1,
+		}));
+		const failed = await collectFailedRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+			lookbackDays: 0,
+			excludePatterns: NO_EXCLUDES,
+		});
+		assert.equal(failed.length, 1);
+		assert.deepEqual(failed[0]?.axes, ["crawl-failed"]);
+	});
+
+	it("surfaces a crawl-failed row carrying no failure reason (legacy) rather than misreading it as a block", async () => {
+		const { client } = createFakeClient(() => ({
+			Items: [
+				{
+					url: "site.test/noreason",
+					originalUrl: "https://site.test/noreason",
+					crawlStatus: "failed",
+					summaryStatus: "skipped",
+					savedAt: "2026-05-10T00:00:00.000Z",
+				},
+			],
+			Count: 1,
+		}));
+		const failed = await collectFailedRows({
+			client,
+			tableName: TABLE,
+			origin: ORIGIN,
+			now: () => NOW,
+			lookbackDays: 0,
+			excludePatterns: NO_EXCLUDES,
+		});
+		assert.equal(failed.length, 1);
+		assert.deepEqual(failed[0]?.axes, ["crawl-failed"]);
+		assert.equal(failed[0]?.reasons["crawl-failed"], undefined);
+	});
+
 	it("classifies a crawl-unsupported row and surfaces its unsupported reason", async () => {
 		const { client } = createFakeClient(() => ({
 			Items: [

--- a/src/packages/check-failed-articles/scripts/collect-failed-rows.ts
+++ b/src/packages/check-failed-articles/scripts/collect-failed-rows.ts
@@ -14,6 +14,11 @@
  * failed first, etc.). A row whose only "non-ready" axis is summary-skipped
  * is a successful outcome and is not surfaced.
  *
+ * A crawl that `failed` with a `blocked`/`rate-limited` reason is likewise
+ * dropped: that is the paid-crawl-budget circuit-breaker tripping — a
+ * transient, self-inflicted spend cap, not a crawler defect. Re-saving only
+ * re-trips it until the window frees, so it is not a debug-worklist item.
+ *
  * The scan also accepts an optional lookback (in days) that gates rows on
  * `savedAt` — a value of `0` disables the gate and surfaces every historical
  * row, which is the default so the operator gets the full backlog and can
@@ -21,6 +26,7 @@
  */
 import assert from "node:assert/strict";
 import {
+	CrawlFailureReasonSchema,
 	CrawlStatusSchema,
 	SummaryStatusSchema,
 } from "@packages/article-state-types";
@@ -108,13 +114,30 @@ export function buildScanInput(now: Date, lookbackDays: number) {
 	} as const;
 }
 
+/* The crawl-failure reason is persisted as `JSON.stringify(reason)`; parse it
+ * back and recognise the paid-crawl-budget block so the worklist can drop it.
+ * Legacy rows whose reason is a bare (non-JSON) string fall through as "not a
+ * rate-limited block" and surface normally. */
+function isRateLimitedBlock(rawReason: string | undefined): boolean {
+	if (rawReason === undefined) return false;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(rawReason);
+	} catch {
+		return false;
+	}
+	const result = CrawlFailureReasonSchema.safeParse(parsed);
+	if (!result.success) return false;
+	return result.data.kind === "blocked" && result.data.cause === "rate-limited";
+}
+
 function classifyAxes(row: z.infer<typeof FailedArticleRow>): {
 	axes: FailedAxis[];
 	reasons: Partial<Record<FailedAxis, string>>;
 } {
 	const axes: FailedAxis[] = [];
 	const reasons: Partial<Record<FailedAxis, string>> = {};
-	if (row.crawlStatus === "failed") {
+	if (row.crawlStatus === "failed" && !isRateLimitedBlock(row.crawlFailureReason)) {
 		axes.push("crawl-failed");
 		if (row.crawlFailureReason !== undefined) reasons["crawl-failed"] = row.crawlFailureReason;
 	}

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -28,6 +28,10 @@
     "./import-session": {
       "types": "./dist/import-session/index.d.ts",
       "default": "./dist/import-session/index.js"
+    },
+    "./rate-limit": {
+      "types": "./dist/rate-limit/index.d.ts",
+      "default": "./dist/rate-limit/index.js"
     }
   },
   "typesVersions": {
@@ -36,7 +40,8 @@
       "article-aggregate": ["./dist/article-aggregate/index.d.ts"],
       "user": ["./dist/user/index.d.ts"],
       "oauth": ["./dist/oauth/index.d.ts"],
-      "import-session": ["./dist/import-session/index.d.ts"]
+      "import-session": ["./dist/import-session/index.d.ts"],
+      "rate-limit": ["./dist/rate-limit/index.d.ts"]
     }
   },
   "private": true,

--- a/src/packages/domain/src/article-aggregate/index.ts
+++ b/src/packages/domain/src/article-aggregate/index.ts
@@ -43,6 +43,10 @@ export {
 	type MarkCrawlUnsupportedInput,
 } from "./transitions/mark-crawl-unsupported";
 export {
+	markCrawlBlocked,
+	type MarkCrawlBlockedInput,
+} from "./transitions/mark-crawl-blocked";
+export {
 	markSummarySkipped,
 	type MarkSummarySkippedInput,
 } from "./transitions/mark-summary-skipped";

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-blocked.test.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-blocked.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import type { Article } from "../article.types";
+import { markCrawlBlocked } from "./mark-crawl-blocked";
+
+function buildArticle(overrides: Partial<Article> = {}): Article {
+	return {
+		url: "https://example.com/article",
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "Excerpt",
+			wordCount: 100,
+		},
+		freshness: { contentFetchedAt: "2026-01-01T00:00:00.000Z" },
+		estimatedReadTime: 1,
+		crawl: { kind: "pending", pendingSince: "2026-01-01T00:00:00.000Z" },
+		summary: { kind: "pending", pendingSince: "2026-01-01T00:00:00.000Z" },
+		summaryAutoHeal: { attempts: 0 },
+		...overrides,
+	};
+}
+
+describe("markCrawlBlocked", () => {
+	it("flips crawl to failed with the supplied blocked reason", () => {
+		const { article } = markCrawlBlocked(buildArticle(), {
+			reason: { kind: "blocked", cause: "rate-limited" },
+		});
+
+		assert.deepEqual(article.crawl, {
+			kind: "failed",
+			reason: { kind: "blocked", cause: "rate-limited" },
+		});
+	});
+
+	it("flips summary to skipped with reason 'crawl-failed' so the summary canary doesn't keep flagging the row", () => {
+		const { article } = markCrawlBlocked(buildArticle(), {
+			reason: { kind: "blocked", cause: "rate-limited" },
+		});
+
+		assert.deepEqual(article.summary, {
+			kind: "skipped",
+			reason: "crawl-failed",
+		});
+	});
+
+	it("emits no effects (a blocked crawl resolves to a failed reader view, not a succeeded one)", () => {
+		const { effects } = markCrawlBlocked(buildArticle(), {
+			reason: { kind: "blocked", cause: "rate-limited" },
+		});
+
+		assert.deepEqual(effects, []);
+	});
+
+	it("declares writes for crawl and summary so both axes terminalise in one atomic save", () => {
+		const { writes } = markCrawlBlocked(buildArticle(), {
+			reason: { kind: "blocked", cause: "rate-limited" },
+		});
+
+		assert.deepEqual([...writes].sort(), ["crawl", "summary"]);
+	});
+
+	it("preserves metadata and freshness so a concurrent inline writer's values are not clobbered on save", () => {
+		const before = buildArticle({
+			metadata: {
+				title: "kept title",
+				siteName: "kept site",
+				excerpt: "kept excerpt",
+				wordCount: 500,
+			},
+			freshness: {
+				etag: '"kept-etag"',
+				contentFetchedAt: "2026-05-10T12:00:00.000Z",
+			},
+			estimatedReadTime: 3,
+		});
+
+		const { article } = markCrawlBlocked(before, {
+			reason: { kind: "blocked", cause: "rate-limited" },
+		});
+
+		assert.equal(article.metadata.title, "kept title");
+		assert.equal(article.freshness.etag, '"kept-etag"');
+		assert.equal(article.estimatedReadTime, 3);
+	});
+
+	it("does not mutate the input article (pure function)", () => {
+		const before = buildArticle();
+		const snapshot = JSON.parse(JSON.stringify(before));
+
+		markCrawlBlocked(before, { reason: { kind: "blocked", cause: "rate-limited" } });
+
+		assert.deepEqual(before, snapshot);
+	});
+
+	it("exposes its function name so transitionAndPersist can tag the row for the Phase 2 canary measurement", () => {
+		assert.equal(markCrawlBlocked.name, "markCrawlBlocked");
+	});
+});

--- a/src/packages/domain/src/article-aggregate/transitions/mark-crawl-blocked.ts
+++ b/src/packages/domain/src/article-aggregate/transitions/mark-crawl-blocked.ts
@@ -1,0 +1,32 @@
+import type { CrawlFailureReason } from "@packages/article-state-types";
+import type { Article } from "../article.types";
+import type { Effect } from "../effects.types";
+import type { AggregateField } from "../storage.types";
+
+export interface MarkCrawlBlockedInput {
+	reason: Extract<CrawlFailureReason, { kind: "blocked" }>;
+}
+
+/* Cross-axis: pairs the blocked crawl with summary=skipped in one atomic save so
+ * a partial terminalisation can't strand summary=pending. The comprehensive
+ * queue is maxReceiveCount=1, so a throw between two separate writes routes the
+ * message to a DLQ handler that only advances the crawl axis — leaving the
+ * summary pending and paging the stuck-articles canary over a transient spend
+ * cap. Mirrors markCrawlUnsupported's cross-axis pairing. */
+export function markCrawlBlocked(
+	article: Article,
+	input: MarkCrawlBlockedInput,
+): {
+	article: Article;
+	effects: readonly Effect[];
+	writes: readonly AggregateField[];
+} {
+	const next: Article = {
+		...article,
+		crawl: { kind: "failed", reason: input.reason },
+		summary: { kind: "skipped", reason: "crawl-failed" },
+	};
+	const effects: readonly Effect[] = [];
+	const writes: readonly AggregateField[] = ["crawl", "summary"];
+	return { article: next, effects, writes };
+}

--- a/src/packages/domain/src/index.ts
+++ b/src/packages/domain/src/index.ts
@@ -3,3 +3,4 @@ export * from "./article-aggregate";
 export * from "./user";
 export * from "./oauth";
 export * from "./import-session";
+export * from "./rate-limit";

--- a/src/packages/domain/src/rate-limit/fixed-window.test.ts
+++ b/src/packages/domain/src/rate-limit/fixed-window.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import {
+	fixedWindowRetryAfterSeconds,
+	fixedWindowStartSeconds,
+} from "./fixed-window";
+
+describe("fixedWindowStartSeconds", () => {
+	it("floors a mid-window timestamp to the window boundary", () => {
+		const nowMs = 7_000_500; // 7000.5s → window of 3600s starting at 3600s
+		assert.equal(fixedWindowStartSeconds({ nowMs, windowSeconds: 3600 }), 3600);
+	});
+
+	it("maps a timestamp exactly on the boundary to that boundary", () => {
+		assert.equal(
+			fixedWindowStartSeconds({ nowMs: 7_200_000, windowSeconds: 3600 }),
+			7200,
+		);
+	});
+
+	it("maps two timestamps inside the same window to the same start", () => {
+		const first = fixedWindowStartSeconds({ nowMs: 3_600_000, windowSeconds: 3600 });
+		const last = fixedWindowStartSeconds({ nowMs: 7_199_999, windowSeconds: 3600 });
+		assert.equal(first, last);
+	});
+
+	it("maps timestamps in consecutive windows to different starts", () => {
+		const before = fixedWindowStartSeconds({ nowMs: 7_199_999, windowSeconds: 3600 });
+		const after = fixedWindowStartSeconds({ nowMs: 7_200_000, windowSeconds: 3600 });
+		assert.equal(after - before, 3600);
+	});
+});
+
+describe("fixedWindowRetryAfterSeconds", () => {
+	it("returns the full window length at the window start", () => {
+		assert.equal(
+			fixedWindowRetryAfterSeconds({ nowMs: 7_200_000, windowSeconds: 3600 }),
+			3600,
+		);
+	});
+
+	it("returns 1 just before the window rolls over", () => {
+		assert.equal(
+			fixedWindowRetryAfterSeconds({ nowMs: 7_199_999, windowSeconds: 3600 }),
+			1,
+		);
+	});
+
+	it("rounds partial seconds up so Retry-After never undershoots", () => {
+		// 2.5s left in a 60s window → a 2s Retry-After would let the client
+		// retry while still inside the throttled window.
+		assert.equal(
+			fixedWindowRetryAfterSeconds({ nowMs: 57_500, windowSeconds: 60 }),
+			3,
+		);
+	});
+});

--- a/src/packages/domain/src/rate-limit/fixed-window.ts
+++ b/src/packages/domain/src/rate-limit/fixed-window.ts
@@ -1,0 +1,32 @@
+export interface RateLimitRule {
+	limit: number;
+	windowSeconds: number;
+}
+
+export type RateLimitDecision =
+	| { allowed: true }
+	| { allowed: false; retryAfterSeconds: number };
+
+/**
+ * Epoch-aligned start of the fixed window containing `nowMs`. Every request
+ * arriving inside the same window maps to the same value, so counters keyed by
+ * it are shared across independent processes (Lambda instances) without
+ * coordination.
+ */
+export function fixedWindowStartSeconds(params: {
+	nowMs: number;
+	windowSeconds: number;
+}): number {
+	const nowSeconds = Math.floor(params.nowMs / 1000);
+	return nowSeconds - (nowSeconds % params.windowSeconds);
+}
+
+/** Whole seconds until the current window rolls over — the `Retry-After` value. */
+export function fixedWindowRetryAfterSeconds(params: {
+	nowMs: number;
+	windowSeconds: number;
+}): number {
+	const windowStart = fixedWindowStartSeconds(params);
+	const windowEndMs = (windowStart + params.windowSeconds) * 1000;
+	return Math.ceil((windowEndMs - params.nowMs) / 1000);
+}

--- a/src/packages/domain/src/rate-limit/index.ts
+++ b/src/packages/domain/src/rate-limit/index.ts
@@ -1,0 +1,7 @@
+export {
+	fixedWindowRetryAfterSeconds,
+	fixedWindowStartSeconds,
+	type RateLimitDecision,
+	type RateLimitRule,
+} from "./fixed-window";
+export { parseRateLimitRule } from "./parse-rate-limit-rule";

--- a/src/packages/domain/src/rate-limit/parse-rate-limit-rule.test.ts
+++ b/src/packages/domain/src/rate-limit/parse-rate-limit-rule.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { parseRateLimitRule } from "./parse-rate-limit-rule";
+
+describe("parseRateLimitRule", () => {
+	it("parses '<limit>/<windowSeconds>' into a rule", () => {
+		assert.deepEqual(parseRateLimitRule("30/3600"), {
+			limit: 30,
+			windowSeconds: 3600,
+		});
+	});
+
+	it("rejects a missing window component", () => {
+		assert.throws(() => parseRateLimitRule("30"), /must be "<limit>\/<windowSeconds>"/);
+	});
+
+	it("rejects a zero limit", () => {
+		assert.throws(() => parseRateLimitRule("0/3600"), /positive integers/);
+	});
+
+	it("rejects a zero window", () => {
+		assert.throws(() => parseRateLimitRule("30/0"), /positive integers/);
+	});
+
+	it("rejects non-numeric input", () => {
+		assert.throws(() => parseRateLimitRule("lots/sometimes"), /positive integers/);
+	});
+});

--- a/src/packages/domain/src/rate-limit/parse-rate-limit-rule.ts
+++ b/src/packages/domain/src/rate-limit/parse-rate-limit-rule.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert";
+import type { RateLimitRule } from "./fixed-window";
+
+const RULE_PATTERN = /^([1-9]\d*)\/([1-9]\d*)$/;
+
+/**
+ * Parse a `"<limit>/<windowSeconds>"` rule string (e.g. `"30/3600"` = 30
+ * requests per hour). The string form keeps each limit and its window a single
+ * atomic configuration value, so the two numbers cannot drift apart across
+ * separate environment variables.
+ */
+export function parseRateLimitRule(raw: string): RateLimitRule {
+	const match = RULE_PATTERN.exec(raw);
+	assert(
+		match,
+		`Rate-limit rule must be "<limit>/<windowSeconds>" with positive integers (e.g. "30/3600"), got: ${raw}`,
+	);
+	return {
+		limit: Number.parseInt(match[1], 10),
+		windowSeconds: Number.parseInt(match[2], 10),
+	};
+}

--- a/src/packages/hutch-infra-components/src/infra/hutch-api-gateway.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-api-gateway.ts
@@ -18,6 +18,15 @@ export class HutchAPIGateway extends pulumi.ComponentResource {
 			domains: string[];
 			zoneId?: Promise<string>;
 			certificateArn?: pulumi.Output<string>;
+			/**
+			 * Stage-wide token bucket applied by API Gateway before the Lambda is
+			 * invoked. Bounds TOTAL request rate (every caller combined), so it is
+			 * a spend ceiling, not a fairness mechanism — per-client limiting lives
+			 * in the application's DynamoDB-backed limiter. WAFv2 web ACLs cannot
+			 * attach to v2 HTTP APIs, which makes this the only edge-side control
+			 * available without fronting the API with CloudFront.
+			 */
+			throttling: { burstLimit: number; rateLimit: number };
 		},
 		opts?: pulumi.ComponentResourceOptions,
 	) {
@@ -31,6 +40,10 @@ export class HutchAPIGateway extends pulumi.ComponentResource {
 			name: "$default",
 			autoDeploy: true,
 			description: `${args.stage} stage`,
+			defaultRouteSettings: {
+				throttlingBurstLimit: args.throttling.burstLimit,
+				throttlingRateLimit: args.throttling.rateLimit,
+			},
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
 
 		const lambdaIntegration = new aws.apigatewayv2.Integration(

--- a/src/packages/hutch-storage-client/src/index.ts
+++ b/src/packages/hutch-storage-client/src/index.ts
@@ -8,4 +8,8 @@ export {
 	type DynamoDBDocumentClient,
 } from "./define-table";
 export { createDynamoDocumentClient } from "./create-client";
-export { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+export {
+	ConditionalCheckFailedException,
+	TransactionCanceledException,
+} from "@aws-sdk/client-dynamodb";
+export { TransactWriteCommand } from "@aws-sdk/lib-dynamodb";

--- a/src/packages/provider-contracts/package.json
+++ b/src/packages/provider-contracts/package.json
@@ -65,6 +65,10 @@
       "types": "./dist/pending-signup.d.ts",
       "default": "./dist/pending-signup.js"
     },
+    "./rate-limit": {
+      "types": "./dist/rate-limit.d.ts",
+      "default": "./dist/rate-limit.js"
+    },
     "./reader-ready-state": {
       "types": "./dist/reader-ready-state.d.ts",
       "default": "./dist/reader-ready-state.js"
@@ -106,6 +110,7 @@
       "pending-html": ["./dist/pending-html.d.ts"],
       "pending-pdf": ["./dist/pending-pdf.d.ts"],
       "pending-signup": ["./dist/pending-signup.d.ts"],
+      "rate-limit": ["./dist/rate-limit.d.ts"],
       "reader-ready-state": ["./dist/reader-ready-state.d.ts"],
       "refresh-html": ["./dist/refresh-html.d.ts"],
       "stripe-checkout": ["./dist/stripe-checkout.d.ts"],

--- a/src/packages/provider-contracts/src/index.ts
+++ b/src/packages/provider-contracts/src/index.ts
@@ -12,6 +12,7 @@ export type * from "./password-reset";
 export type * from "./pending-html";
 export type * from "./pending-pdf";
 export type * from "./pending-signup";
+export type * from "./rate-limit";
 export type * from "./reader-ready-state";
 export type * from "./refresh-html";
 export type * from "./stripe-checkout";

--- a/src/packages/provider-contracts/src/rate-limit.ts
+++ b/src/packages/provider-contracts/src/rate-limit.ts
@@ -1,0 +1,24 @@
+import type { RateLimitDecision, RateLimitRule } from "@packages/domain/rate-limit";
+
+/** Each bucket carries an independent counter per client key, so exhausting
+ * the crawl allowance never locks the same visitor out of logging in. */
+export type RateLimitBucket = "view-crawl" | "login" | "signup" | "forgot-password";
+
+/**
+ * Atomically count one request against `(bucket, key)` for the rule's current
+ * fixed window and report whether it still fits under `rule.limit`. The store
+ * behind this MUST be shared across processes — on Lambda every concurrent
+ * instance has independent memory, so a per-instance counter enforces nothing.
+ */
+export type ConsumeRateLimit = (params: {
+	bucket: RateLimitBucket;
+	key: string;
+	rule: RateLimitRule;
+}) => Promise<RateLimitDecision>;
+
+export interface RateLimitRules {
+	viewCrawl: RateLimitRule;
+	login: RateLimitRule;
+	signup: RateLimitRule;
+	forgotPassword: RateLimitRule;
+}

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -49,6 +49,10 @@
       "types": "./dist/providers/password-reset/index.d.ts",
       "default": "./dist/providers/password-reset/index.js"
     },
+    "./providers/rate-limit": {
+      "types": "./dist/providers/rate-limit/index.d.ts",
+      "default": "./dist/providers/rate-limit/index.js"
+    },
     "./providers/reader-ready-state": {
       "types": "./dist/providers/reader-ready-state/index.d.ts",
       "default": "./dist/providers/reader-ready-state/index.js"
@@ -118,6 +122,7 @@
       "providers/email": ["./dist/providers/email/index.d.ts"],
       "providers/email-verification": ["./dist/providers/email-verification/index.d.ts"],
       "providers/password-reset": ["./dist/providers/password-reset/index.d.ts"],
+      "providers/rate-limit": ["./dist/providers/rate-limit/index.d.ts"],
       "providers/reader-ready-state": ["./dist/providers/reader-ready-state/index.d.ts"],
       "providers/pending-html": ["./dist/providers/pending-html/index.d.ts"],
       "providers/pending-pdf": ["./dist/providers/pending-pdf/index.d.ts"],

--- a/src/packages/test-fixtures/src/bundle.types.ts
+++ b/src/packages/test-fixtures/src/bundle.types.ts
@@ -16,6 +16,7 @@ export type {
 	OAuthBundle,
 	ParserBundle,
 	PasswordResetBundle,
+	RateLimitBundle,
 	PendingHtmlBundle,
 	PendingPdfBundle,
 	PendingSignupBundle,

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -16,6 +16,7 @@ import { initInMemoryAuth } from "./providers/auth/in-memory-auth";
 import { initInMemoryEmail } from "./providers/email/in-memory-email";
 import { initInMemoryEmailVerification } from "./providers/email-verification/in-memory-email-verification";
 import { initInMemoryPasswordReset } from "./providers/password-reset/in-memory-password-reset";
+import { initInMemoryRateLimit } from "./providers/rate-limit/in-memory-rate-limit";
 import { initInMemoryPendingHtml } from "./providers/pending-html/in-memory-pending-html";
 import { initInMemoryPendingPdf } from "./providers/pending-pdf/in-memory-pending-pdf";
 import { initInMemoryPendingSignup } from "./providers/pending-signup/in-memory-pending-signup";
@@ -241,6 +242,18 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 	const email = initInMemoryEmail();
 	const emailVerification = initInMemoryEmailVerification();
 	const passwordReset = initInMemoryPasswordReset();
+	/* Generous enough that no unrelated suite ever trips a limiter; tests that
+	 * exercise 429 behaviour override the bundle with tight rules. */
+	const unlimitedRule = { limit: 10_000, windowSeconds: 3600 };
+	const rateLimit = {
+		consumeRateLimit: initInMemoryRateLimit({ now: () => new Date() }).consumeRateLimit,
+		rules: {
+			viewCrawl: unlimitedRule,
+			login: unlimitedRule,
+			signup: unlimitedRule,
+			forgotPassword: unlimitedRule,
+		},
+	};
 	const pendingHtml = initInMemoryPendingHtml();
 	const pendingPdf = initInMemoryPendingPdf();
 	const { publishSaveLinkRawHtmlCommand } = initInMemorySaveLinkRawHtmlCommand({
@@ -351,6 +364,7 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		email,
 		emailVerification,
 		passwordReset,
+		rateLimit,
 		google: undefined,
 		admin: {
 			adminEmails: [],

--- a/src/packages/test-fixtures/src/providers/rate-limit/in-memory-rate-limit.test.ts
+++ b/src/packages/test-fixtures/src/providers/rate-limit/in-memory-rate-limit.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { initInMemoryRateLimit } from "./in-memory-rate-limit";
+
+const HOUR_RULE = { limit: 2, windowSeconds: 3600 };
+
+function createMutableClock(startMs: number) {
+	let nowMs = startMs;
+	return {
+		now: () => new Date(nowMs),
+		advanceSeconds: (seconds: number) => {
+			nowMs += seconds * 1000;
+		},
+	};
+}
+
+describe("initInMemoryRateLimit", () => {
+	it("allows requests up to the limit within one window", async () => {
+		const clock = createMutableClock(0);
+		const { consumeRateLimit } = initInMemoryRateLimit({ now: clock.now });
+
+		const first = await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+		const second = await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+
+		assert.deepEqual(first, { allowed: true });
+		assert.deepEqual(second, { allowed: true });
+	});
+
+	it("denies the request past the limit and reports seconds until the window resets", async () => {
+		const clock = createMutableClock(0);
+		const { consumeRateLimit } = initInMemoryRateLimit({ now: clock.now });
+		await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+		await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+
+		clock.advanceSeconds(600);
+		const denied = await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+
+		assert.deepEqual(denied, { allowed: false, retryAfterSeconds: 3000 });
+	});
+
+	it("starts a fresh count once the window rolls over", async () => {
+		const clock = createMutableClock(0);
+		const { consumeRateLimit } = initInMemoryRateLimit({ now: clock.now });
+		await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+		await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+
+		clock.advanceSeconds(HOUR_RULE.windowSeconds);
+		const afterReset = await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+
+		assert.deepEqual(afterReset, { allowed: true });
+	});
+
+	it("counts each client key independently", async () => {
+		const clock = createMutableClock(0);
+		const { consumeRateLimit } = initInMemoryRateLimit({ now: clock.now });
+		const exhaustedKey = "1.2.3.4";
+		await consumeRateLimit({ bucket: "login", key: exhaustedKey, rule: HOUR_RULE });
+		await consumeRateLimit({ bucket: "login", key: exhaustedKey, rule: HOUR_RULE });
+
+		const otherClient = await consumeRateLimit({ bucket: "login", key: "5.6.7.8", rule: HOUR_RULE });
+
+		assert.deepEqual(otherClient, { allowed: true });
+	});
+
+	it("counts each bucket independently for the same client key", async () => {
+		const clock = createMutableClock(0);
+		const { consumeRateLimit } = initInMemoryRateLimit({ now: clock.now });
+		await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+		await consumeRateLimit({ bucket: "login", key: "1.2.3.4", rule: HOUR_RULE });
+
+		const otherBucket = await consumeRateLimit({ bucket: "signup", key: "1.2.3.4", rule: HOUR_RULE });
+
+		assert.deepEqual(otherBucket, { allowed: true });
+	});
+});

--- a/src/packages/test-fixtures/src/providers/rate-limit/in-memory-rate-limit.ts
+++ b/src/packages/test-fixtures/src/providers/rate-limit/in-memory-rate-limit.ts
@@ -1,0 +1,43 @@
+import {
+	fixedWindowRetryAfterSeconds,
+	fixedWindowStartSeconds,
+} from "@packages/domain/rate-limit";
+import type { ConsumeRateLimit } from "@packages/provider-contracts/rate-limit";
+
+/**
+ * Fixed-window counter held in process memory. Same decision semantics as the
+ * DynamoDB provider (exactly `limit` requests succeed per window), but only
+ * valid where a single process serves all traffic — tests and local dev.
+ */
+export function initInMemoryRateLimit(deps: { now: () => Date }): {
+	consumeRateLimit: ConsumeRateLimit;
+} {
+	const windows = new Map<string, { windowStartSeconds: number; count: number }>();
+
+	const consumeRateLimit: ConsumeRateLimit = async ({ bucket, key, rule }) => {
+		const nowMs = deps.now().getTime();
+		const windowStartSeconds = fixedWindowStartSeconds({
+			nowMs,
+			windowSeconds: rule.windowSeconds,
+		});
+		const counterKey = `${bucket}#${key}`;
+		const existing = windows.get(counterKey);
+		const count =
+			existing && existing.windowStartSeconds === windowStartSeconds
+				? existing.count
+				: 0;
+		if (count >= rule.limit) {
+			return {
+				allowed: false,
+				retryAfterSeconds: fixedWindowRetryAfterSeconds({
+					nowMs,
+					windowSeconds: rule.windowSeconds,
+				}),
+			};
+		}
+		windows.set(counterKey, { windowStartSeconds, count: count + 1 });
+		return { allowed: true };
+	};
+
+	return { consumeRateLimit };
+}

--- a/src/packages/test-fixtures/src/providers/rate-limit/index.ts
+++ b/src/packages/test-fixtures/src/providers/rate-limit/index.ts
@@ -1,0 +1,2 @@
+export * from "./rate-limit.types";
+export * from "./in-memory-rate-limit";

--- a/src/packages/test-fixtures/src/providers/rate-limit/rate-limit.types.ts
+++ b/src/packages/test-fixtures/src/providers/rate-limit/rate-limit.types.ts
@@ -1,0 +1,5 @@
+export type {
+	ConsumeRateLimit,
+	RateLimitBucket,
+	RateLimitRules,
+} from "@packages/provider-contracts/rate-limit";

--- a/src/packages/web-test-harness/src/bundle.types.ts
+++ b/src/packages/web-test-harness/src/bundle.types.ts
@@ -10,6 +10,7 @@ import type {
 	BumpArticleSavedAt,
 	CheckoutSessionId,
 	ConsumePendingSignup,
+	ConsumeRateLimit,
 	ContentProvider,
 	ConversionEvent,
 	CountArticlesByUser,
@@ -75,6 +76,7 @@ import type {
 	PublishUpdateFetchTimestamp,
 	PutPendingHtml,
 	PutPendingPdf,
+	RateLimitRules,
 	ReadArticleContent,
 	RefreshArticleIfStale,
 	RetrieveCheckoutSession,
@@ -265,6 +267,11 @@ export interface PasswordResetBundle {
 	verifyPasswordResetToken: VerifyPasswordResetToken;
 }
 
+export interface RateLimitBundle {
+	consumeRateLimit: ConsumeRateLimit;
+	rules: RateLimitRules;
+}
+
 export interface GoogleAuthBundle {
 	exchangeGoogleCode: ExchangeGoogleCode;
 	clientId: string;
@@ -324,6 +331,7 @@ export interface TestAppFixture {
 	email: EmailBundle;
 	emailVerification: EmailVerificationBundle;
 	passwordReset: PasswordResetBundle;
+	rateLimit: RateLimitBundle;
 	google: GoogleAuthBundle | undefined;
 	admin: AdminBundle;
 	importSession: ImportSessionBundle;

--- a/src/packages/web-test-harness/src/index.ts
+++ b/src/packages/web-test-harness/src/index.ts
@@ -16,6 +16,7 @@ export type {
 	OAuthBundle,
 	ParserBundle,
 	PasswordResetBundle,
+	RateLimitBundle,
 	PendingHtmlBundle,
 	PendingPdfBundle,
 	PendingSignupBundle,


### PR DESCRIPTION
## Why

There was no application-level rate limiting anywhere. Two consequences:

1. **Unauthenticated cost-amplification DoS.** A first anonymous visit to `/view/<url>` triggers the full crawl cascade (`saveArticleGlobally` → `markCrawlPending` → `publishSaveAnonymousLink`), which can reach the comprehensive crawl tier — PDF OCR fan-out (up to 300 pages) plus DeepSeek LLM cleanup and summaries — so each anonymous request can cause direct third-party spend.
2. **Auth abuse.** `POST /login`, `/signup`, `/forgot-password` had no throttling → brute force, credential stuffing, and email-bombing (SES/Resend cost + sender reputation). The existing bot-rejected path is telemetry, not enforcement.

In-memory counters don't work on Lambda (each concurrent instance has independent memory), and WAFv2 web ACLs cannot attach to API Gateway **v2 HTTP** APIs — so the limiter is DynamoDB-backed and the edge control is stage throttling.

## What changed

**1. Distributed per-IP limiter (DynamoDB fixed window)**
- New `hutch-rate-limits` table (TTL'd counters, PAY_PER_REQUEST). One conditional `ADD` per request keyed by `(bucket, client IP, window start)`; the condition fails at the limit, so **exactly N requests succeed per window across all concurrent Lambda instances**.
- Applied to:
  - the anonymous crawl trigger on `/view` — checked only inside the first-visit branch (the request that would enqueue `SaveAnonymousLink`). Repeat views of known articles spend nothing. Over-limit → `429` + `Retry-After`, and **no stub save / no enqueue**.
  - `POST /login`, `POST /signup`, `POST /forgot-password` via middleware — throttled requests never reach credential verification or email sends.
- Client IP comes from `requestContext.http.sourceIp`: serverless-http seeds the request socket's `remoteAddress` from it, and with `trust proxy` off (Express default) `req.ip` resolves to exactly that value. The client-supplied `x-forwarded-for` chain is never consulted.
- Limits are env-configurable per stack (Pulumi config → Lambda env), parsed from `"<limit>/<windowSeconds>"`:

| Bucket | prod | staging (one CI IP drives whole e2e runs) |
|---|---|---|
| `RATE_LIMIT_VIEW_CRAWL` | 30/3600 | 500/3600 |
| `RATE_LIMIT_LOGIN` | 10/900 | 300/900 |
| `RATE_LIMIT_SIGNUP` | 10/3600 | 300/3600 |
| `RATE_LIMIT_FORGOT_PASSWORD` | 5/3600 | 100/3600 |

  Prod composition uses `requireEnv` with **no defaults** — a deploy missing a limit fails at cold start rather than running unthrottled. The dev composition uses the in-memory limiter with liberal defaults (single long-lived process; local/e2e traffic all shares 127.0.0.1).

**2. Paid-tier budget circuit-breaker (independent of the IP limiter)**
- `PAID_CRAWL_BUDGET` (prod `50/3600`, staging `200/3600`) caps **global** comprehensive-crawl invocations per window via the same DynamoDB table (`paid-crawl#global#<windowStart>`).
- Checked in the comprehensive-crawl handler before any fetch/OCR work. Past the budget the crawl **fails closed but gracefully**: the row is flipped terminal with `{ kind: "blocked", cause: "rate-limited" }` (readers get the existing "link is saved" reframe), the message is consumed (no SQS retry — a retry would re-spend the exhausted budget), and a tier-1 failure crawl-outcome is logged. `refresh` runs leave the row untouched so the prior canonical keeps serving.

**3. Gateway-level total cap (blunt, complements #1)**
- API Gateway v2 `$default` stage `defaultRouteSettings`: `throttlingBurstLimit: 200`, `throttlingRateLimit: 50` rps — bounds TOTAL request rate before the Lambda is invoked. Per-route settings aren't possible here because the API uses a single `$default` catch-all route.

**4. Not done (documented follow-up):** true per-IP **edge** throttling requires fronting the HTTP API with CloudFront + a WAFv2 (CLOUDFRONT scope) rate-based rule. No CloudFront/WAF currently exists in front of this API in this repo (only the static-assets CDN), so #1–#3 above are the protection.

## Tests

- **Provider units**: fixed-window math (window start, retry-after, rollover), rule parsing, in-memory counting/reset/over-limit/key+bucket isolation, DynamoDB providers via fake clients (condition expression, TTL, denial → `Retry-After`, error rethrow).
- **Integration (supertest)**: N under-limit requests succeed, N+1 from the same IP → `429` with `Retry-After`; the throttled `/view` request performs **no stub save and no enqueue** (publish spy + store assertion); throttled login performs no credential check; throttled forgot-password sends no email; counters reset after the window (test-owned clock).
- **Paid-tier cap**: budget-denied record runs no crawl, flips the row terminal, publishes nothing, consumes the message; refresh variant leaves the row untouched; allowed path unchanged.

`pnpm nx run <project>:check` passes (lint + tests + 100% coverage thresholds) for `@packages/domain`, `@packages/test-fixtures`, `@packages/hutch-infra-components`, `hutch`, `save-link`, and the dependent packages/projects (`article-store`, `extract-links-from-page`, `refresh-article-content`, `platform`, `firefox-extension`).

## Deploy notes

- hutch stack creates the `hutch-rate-limits-{prod,staging}` table and must deploy before save-link's comprehensive-crawl Lambda starts consuming budget (IAM/config reference the table by name/ARN; first deploy order only matters for runtime writes).
- New Pulumi config keys: `hutch:dynamodbRateLimitsTable`, `hutch:rateLimit{ViewCrawl,Login,Signup,ForgotPassword}`, `save-link:rateLimitsTable{Name,Arn}`, `save-link:paidCrawlBudget` — set for prod and staging in this PR.

https://claude.ai/code/session_01QSfgGwVvzomUeRdEP9Y3cU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSfgGwVvzomUeRdEP9Y3cU)_