### PR TITLE
ci: rename all-tests job to web-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ permissions:
   contents: read
 
 jobs:
-  all-tests:
+  # Lint/type/test/coverage suite for every Node project (web app, extensions,
+  # packages). The iOS suite cannot live in this job: it needs Xcode on a macOS
+  # runner and is path-gated to iOS changes (see ios-tests below).
+  web-tests:
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -207,7 +210,7 @@ jobs:
   # because other projects depend on platform resources (e.g. event bus ARN)
   deploy-platform:
     if: needs.detect-projects.outputs.platform-affected == 'true'
-    needs: [all-tests, detect-projects]
+    needs: [web-tests, detect-projects]
     uses: ./.github/workflows/project-deployment.yaml
     secrets: inherit
     with:
@@ -220,11 +223,11 @@ jobs:
     name: ${{ matrix.project }}
     if: >-
       always()
-      && needs.all-tests.result == 'success'
+      && needs.web-tests.result == 'success'
       && needs.detect-projects.result == 'success'
       && needs.deploy-platform.result != 'failure'
       && needs.detect-projects.outputs.has-non-platform == 'true'
-    needs: [all-tests, detect-projects, deploy-platform]
+    needs: [web-tests, detect-projects, deploy-platform]
     strategy:
       fail-fast: false
       matrix:
@@ -298,17 +301,17 @@ jobs:
           make test SIM="platform=iOS Simulator,id=$UDID"
 
   # Build + upload the iOS app (and its embedded share extension, in one build)
-  # to TestFlight. Independent of the infra deploy pipeline — gated on the base
+  # to TestFlight. Independent of the infra deploy pipeline — gated on the web
   # test suite passing, the iOS test bundle passing, and the iOS shipping code
   # having changed.
   ios-testflight-publish:
     if: >-
       always()
-      && needs.all-tests.result == 'success'
+      && needs.web-tests.result == 'success'
       && needs.detect-projects.result == 'success'
       && needs.ios-tests.result == 'success'
       && needs.detect-projects.outputs.ios-affected == 'true'
-    needs: [all-tests, detect-projects, ios-tests]
+    needs: [web-tests, detect-projects, ios-tests]
     permissions:
       contents: write
     uses: ./.github/workflows/publish-ios-testflight.yml


### PR DESCRIPTION
## Why

The `all-tests` job name overstated its coverage: it runs only the Node suite (`pnpm check`), while the iOS test bundle runs in the separate `ios-tests` job. Integrating the two into one job was considered first (per the request) but isn't feasible:

- A GitHub Actions job runs on a single runner OS — `pnpm check` runs on `ubuntu-latest`, while the iOS bundle needs Xcode + an iPhone simulator on `macos-15`.
- `ios-tests` is deliberately path-gated to iOS changes on main pushes (via `detect-projects`, which doesn't run on PRs); folding it into the always-on job would either run macOS runners (~10× Linux cost) on every push/PR or change the gating semantics.

So this takes the agreed fallback: rename `all-tests` → `web-tests` and keep `ios-tests` separate.

## Changes

- Rename the `all-tests` job to `web-tests` in `ci.yml`, including all `needs:` lists and `if: needs.all-tests.result` expressions (`deploy-platform`, `pipeline`, `ios-testflight-publish`).
- Document on the job why the iOS suite lives separately.

No behaviour change — same steps, same triggers, same gating. Downstream automation (`claude-PR-*` workflows) keys off the workflow name `"CI"`, not job names, so it is unaffected.

## ⚠️ Action that may be needed outside this PR

If branch protection / rulesets list **`all-tests`** as a required status check, update the required check to **`web-tests`** — otherwise PRs (including this one) will wait forever on a check that no longer reports.

https://claude.ai/code/session_01C2yqm6cgM9UKLX3FBGuSkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2yqm6cgM9UKLX3FBGuSkL)_