### PR TITLE
docs(blog): add post on the reader-ready email notification

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/email-when-your-article-is-ready.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/email-when-your-article-is-ready.md
@@ -1,0 +1,51 @@
+---
+title: "Save a Long Article, Get an Email the Moment It's Ready"
+description: "Save a heavy page in Readplace, then close the tab. When the clean reader view and summary finish, Readplace emails you a link. It only emails if you looked and left, and at most once every six hours."
+slug: "email-when-your-article-is-ready"
+date: "2026-06-11"
+author: "Fayner Brack"
+keywords: "read it later, article ready email, reader view notification, save long articles, clean reader view, read later app, article summary email"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+You save a long article. Readplace fetches the page, strips the clutter, and writes a short summary. A heavy page can take a minute or two. If you peek at it before it finishes and then close the tab, Readplace emails you a link once the clean reader view is done. The email is careful: it fires only when you opened the article and left before it finished, only when the work took over a minute, and at most once every six hours.
+
+</div>
+</details>
+
+You save a long article on your way somewhere. Readplace starts working on it right away. It fetches the page, pulls out the real content, drops the ads and pop-ups, and writes a short summary. For a heavy page, that takes a minute or two.
+
+So you open the article, see it still loading, and close the tab to get on with your day. Then what? You used to have to remember it, come back, and refresh until the clean version showed up. That is a small chore, and small chores get forgotten.
+
+## Readplace tells you when it's done
+
+Now Readplace emails you a link the moment the reader view is ready. The subject line reads "An article you saved now has a reader view!" Inside is the title and one button: "Read it now." Tap it and you land in the clean reader, content extracted and summarised, ready to read in peace.
+
+You don't watch a spinner. You don't keep a tab open. You get on with your day, and the email arrives when the work is done.
+
+## It only emails when it should
+
+An inbox full of pings is worse than no pings. So the email follows a few plain rules.
+
+It sends only if you opened the article and left before it finished. If you stayed in the reader until the content arrived, you already have it, and you get nothing.
+
+It sends only if the work took more than a minute. Quick saves finish before you close the tab, so they need no email.
+
+It sends at most one of these every six hours. Import a big batch of links, and your inbox stays calm.
+
+It also checks the basics each time. Marked the article read? No email. Deleted it? No email. Saved it again after it was done? No email. The rules run on every send, so the link you get points to something you still want to read.
+
+## No new app, no extra permission
+
+Here is the part worth saving for paying readers. The whole thing runs on Readplace's servers. There is no new app to install, no browser permission to grant, and no background script eating your battery. Readplace already knows when you opened a loading article, and it already knows the second the reader view turns ready. It puts those two facts together and sends one email.
+
+Your saved articles and reading history stay private. The email goes to the verified address on your account and nowhere else.
+
+## Why it matters
+
+People who save long reads tend to save them in a hurry. A research paper, a deep feature, a slow page behind a heavy site. Those are the saves most likely to take a minute, and the ones you are most likely to walk away from. This email closes the gap between "I saved it" and "I read it."
+
+Save a long article today, peek at it, then close the tab. Check your inbox in a couple of minutes. [Install the browser extension](https://readplace.com/install) or start at [readplace.com](/).


### PR DESCRIPTION
## What

New blog post: **"Save a Long Article, Get an Email the Moment It's Ready"** at `/blog/email-when-your-article-is-ready`.

It covers the reader-ready email feature (#467): when a saved article's clean reader view and summary finish, Readplace emails the saver a link.

## Why this topic

Reviewing commits landed on `main` since the last published post (`ai-agents-discover-readplace`, 2026-06-10), the reader-ready email (#467) is the strongest user-facing feature not yet covered on the blog. The other changes since then are internal refactors, CI work, security hardening (SSRF/XSS), or already-blogged features. The notification is a concrete benefit for people saving long reads, which maps well to paid conversion.

## Content notes

- Leads with the customer benefit (close the tab, get an email when it's ready), not the implementation.
- Explains the gating rules in plain words: only when you opened and left, only when generation took over a minute, at most once per six hours, and re-checked against read/deleted/re-saved state.
- Calls out the privacy and "no new app / no extra permission" angle for paying readers.
- No pricing or founding-member references.
- CTA points to `/install` and the homepage.

## Verification

- `getAllPosts()` discovery, slug-filename invariant, and `/blog/{slug}` route covered by the existing blog suites — both pass (40 tests).
- Pre-commit `check` ran clean across all projects.

https://claude.ai/code/session_01WkzaCRWTRmPYVcQLH1qcZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkzaCRWTRmPYVcQLH1qcZs)_