### PR TITLE
docs(crawl-article): update isBareImageCapture reference to @packages/finalize-article

### DIFF
--- a/src/packages/crawl-article/src/image-detect.ts
+++ b/src/packages/crawl-article/src/image-detect.ts
@@ -27,7 +27,7 @@ const SUPPORTED_IMAGE_CONTENT_TYPES: ReadonlySet<string> = new Set(
  * URL path suffixes of a direct image link, derived from {@link IMAGE_FORMATS} so
  * they cannot drift from the content-type allowlist. The browser-extension save
  * path matches these against a captured page's own URL to recognise a bare image
- * (see `isBareImageCapture` in save-link).
+ * (see `isBareImageCapture` in @packages/finalize-article).
  */
 export const IMAGE_URL_EXTENSIONS: readonly string[] = IMAGE_FORMATS.flatMap(
 	(format) => format.extensions,


### PR DESCRIPTION
## Summary

- Updates the doc comment in `image-detect.ts` (line 30) to reference `@packages/finalize-article` instead of `save-link`, reflecting where `isBareImageCapture` now lives after the refactor in commit b87420a7 (#535).

## Test plan

- [ ] No logic changes — comment-only update. Verify the reference is accurate by checking `@packages/finalize-article` exports `isBareImageCapture`.

https://claude.ai/code/session_01FxMKwgGxkxhxKfG2V9r4E7

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxMKwgGxkxhxKfG2V9r4E7)_