### PR TITLE
fix(view): point og:url at the readplace wrapper, assert canonicalIsExternal is absolute

### DIFF
--- a/projects/hutch/src/runtime/web/base.component.test.ts
+++ b/projects/hutch/src/runtime/web/base.component.test.ts
@@ -447,6 +447,78 @@ describe("Base component", () => {
 		).toBe("https://readplace.com/queue");
 	});
 
+	it("preserves a cross-origin canonical (no readplace.com rewrite) when canonicalIsExternal is set", () => {
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "https://example.com/original-post",
+				canonicalIsExternal: true,
+			},
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(
+			doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+		).toBe("https://example.com/original-post");
+	});
+
+	it("throws a clear invariant error when canonicalIsExternal is set with a relative URL (the branch tolerates only absolute http(s) URLs)", () => {
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "/relative-path",
+				canonicalIsExternal: true,
+			},
+		});
+
+		expect(() => Base(page, GUEST_STATE).to("text/html")).toThrow(
+			/canonicalIsExternal requires an absolute http\(s\) URL/,
+		);
+	});
+
+	it("defaults og:url to the canonical when seo.ogUrl is absent (keeps existing pages backward-compatible)", () => {
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "https://readplace.com/login",
+			},
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(
+			doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+		).toBe("https://readplace.com/login");
+		expect(
+			doc.querySelector('meta[property="og:url"]')?.getAttribute("content"),
+		).toBe("https://readplace.com/login");
+	});
+
+	it("decouples og:url from canonical when seo.ogUrl is set, normalizing the OG identity onto readplace.com while canonical stays on the external source", () => {
+		const page = createTestPageBody({
+			seo: {
+				title: "T",
+				description: "D",
+				canonicalUrl: "https://example.com/original-post",
+				canonicalIsExternal: true,
+				ogUrl: "http://localhost:3000/view/example.com/original-post",
+			},
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		expect(
+			doc.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+		).toBe("https://example.com/original-post");
+		expect(
+			doc.querySelector('meta[property="og:url"]')?.getAttribute("content"),
+		).toBe("https://readplace.com/view/example.com/original-post");
+	});
+
 	it("does not render the trial countdown when state.trial is undefined", () => {
 		const page = createTestPageBody();
 		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -72,6 +72,14 @@ function normalizeCanonicalUrl(canonicalUrl: string): string {
 	return `${CANONICAL_ORIGIN}${url.pathname}${url.search}${url.hash}`;
 }
 
+function externalCanonicalUrl(canonicalUrl: string): string {
+	assert(
+		/^https?:\/\//i.test(canonicalUrl),
+		`canonicalIsExternal requires an absolute http(s) URL, received: ${canonicalUrl}`,
+	);
+	return new URL(canonicalUrl).href;
+}
+
 const LIVERELOAD_SCRIPT = getEnv("LIVERELOAD")
 	? `\n<script src="http://localhost:35729/livereload.js?snipver=1"></script>`
 	: "";
@@ -190,13 +198,17 @@ function renderBaseTemplate(body: PageBody, state: BannerState): string {
 	const ogType = seo.ogType || "website";
 	const robots = seo.robots || "index, follow";
 
+	const canonicalUrl = seo.canonicalIsExternal
+		? externalCanonicalUrl(seo.canonicalUrl)
+		: normalizeCanonicalUrl(seo.canonicalUrl);
+	const ogUrl = seo.ogUrl ? normalizeCanonicalUrl(seo.ogUrl) : canonicalUrl;
+
 	return render(BASE_TEMPLATE, {
 		staticBaseUrl: STATIC_BASE_URL,
 		title: seo.title,
 		description: seo.description,
-		canonicalUrl: seo.canonicalIsExternal
-			? new URL(seo.canonicalUrl).href
-			: normalizeCanonicalUrl(seo.canonicalUrl),
+		canonicalUrl,
+		ogUrl,
 		ogType,
 		ogImage: seo.ogImage,
 		ogImageAlt: seo.ogImageAlt,

--- a/projects/hutch/src/runtime/web/base.template.html
+++ b/projects/hutch/src/runtime/web/base.template.html
@@ -16,7 +16,7 @@
   <meta property="og:site_name" content="Readplace">
   <meta property="og:title" content="{{title}}">
   <meta property="og:description" content="{{description}}">
-  <meta property="og:url" content="{{canonicalUrl}}">
+  <meta property="og:url" content="{{ogUrl}}">
   {{#if ogImage}}
   <meta property="og:image" content="{{ogImage}}">
   <meta property="og:image:width" content="1200">

--- a/projects/hutch/src/runtime/web/page-body.types.ts
+++ b/projects/hutch/src/runtime/web/page-body.types.ts
@@ -7,6 +7,12 @@ export interface SeoMetadata {
 	 * publisher so search/answer engines attribute the text to the source rather
 	 * than reading readplace.com as a scraper proxy. */
 	canonicalIsExternal?: boolean;
+	/** Overrides the page's `<meta property="og:url">` independently of
+	 * `canonicalUrl`. Defaults to `canonicalUrl` when absent. `/view` sets this
+	 * to the readplace wrapper so social shares preserve readplace's Open Graph
+	 * object identity (the downloaded thumbnail + reader content), while
+	 * `<link rel="canonical">` stays on the publisher for attribution. */
+	ogUrl?: string;
 	ogImage?: string;
 	ogImageAlt?: string;
 	ogImageType?: string;

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -132,7 +132,7 @@ describe("ViewPage", () => {
 		expect(links[1]?.getAttribute("href")).toBe("/save?url=x");
 	});
 
-	it("emits OG metadata using the article title and excerpt, with canonical + og:url pointing at the original source", () => {
+	it("emits OG metadata using the article title and excerpt, with canonical pegged to the source and og:url pegged to the readplace wrapper so shares carry readplace's downloaded thumbnail + reader content", () => {
 		const doc = render();
 
 		const canonical = `https://example.com/post`;
@@ -157,7 +157,7 @@ describe("ViewPage", () => {
 		).toBe("article");
 		expect(
 			doc.querySelector('meta[property="og:url"]')?.getAttribute("content"),
-		).toBe(canonical);
+		).toBe("https://readplace.com/view/example.com/post");
 		expect(
 			doc
 				.querySelector('meta[property="og:site_name"]')
@@ -515,7 +515,7 @@ describe("ViewPage", () => {
 			assert.equal(copyUrl.origin, "https://staging.readplace.com");
 		});
 
-		it("pegs the SEO canonical to the original source regardless of appOrigin (we disclaim the wrapper; the publisher is canonical)", () => {
+		it("pegs the SEO canonical and JSON-LD url to the original source regardless of appOrigin (we disclaim the wrapper for attribution), and normalizes the readplace wrapper into og:url so the OG object identity always lives on the prod readplace host", () => {
 			const doc = render({
 				...baseInput,
 				appOrigin: "https://staging.readplace.com",
@@ -528,7 +528,7 @@ describe("ViewPage", () => {
 			);
 			assert.equal(
 				doc.querySelector('meta[property="og:url"]')?.getAttribute("content"),
-				canonical,
+				"https://readplace.com/view/example.com/post",
 			);
 			const script = doc.querySelector('script[type="application/ld+json"]');
 			assert(script, "JSON-LD script must be rendered");

--- a/projects/hutch/src/runtime/web/pages/view/view.component.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.ts
@@ -202,6 +202,7 @@ export function ViewPage(input: ViewPageInput): PageBody {
 			description,
 			canonicalUrl: input.articleUrl,
 			canonicalIsExternal: true,
+			ogUrl: shareableViewUrl,
 			ogType: "article",
 			ogImage,
 			ogImageAlt,


### PR DESCRIPTION
Follow-up to the four low-priority review notes on #524.

## Summary

- **Decouples `og:url` from `<link rel="canonical">`** via a new optional `SeoMetadata.ogUrl`. `/view` now sets `ogUrl` to the readplace wrapper URL so social shares preserve readplace's Open Graph object identity — meaning Facebook/LinkedIn render the **downloaded thumbnail + reader content** rather than walking off to the source. `<link rel="canonical">` stays on the publisher for attribution. Pages that don't set `ogUrl` keep their existing behaviour (`og:url === canonical`).
- **Hardens the `canonicalIsExternal` branch** with `assert(/^https?:\/\//i.test(...))` via a new `externalCanonicalUrl()` helper. The non-external branch tolerates relative URLs (`normalizeCanonicalUrl` resolves them against `https://readplace.com`); the external branch did not, and a future caller passing a relative URL would have surfaced as a raw `ERR_INVALID_URL` 500'ing the whole page. Today's only caller (`/view`) already passes an absolute URL from `validateSaveableUrl`, so behaviour is unchanged — this is a fail-fast guard for the next caller.
- **Pins the contracts at the base layer**: positive `canonicalIsExternal` (preserves cross-origin canonical), negative (assert fires fast on relative URL), `og:url` default-to-canonical, and `og:url` decoupled-from-canonical-when-`ogUrl`-set. Sit next to the existing staging-URL canonical-rewrite guard at `base.component.test.ts:434` so the new behaviour is documented at the layer that interprets it.
- Updates two `/view` tests that asserted `og:url === canonical` to reflect the new decoupling (canonical still pegs to the publisher; `og:url` normalizes the wrapper onto the prod readplace host).

## Notes on the original review

Notes ① (noindex + cross-domain `rel=canonical`) and ②'s "decouple or leave it" are confirmed-intent — Google honours the noindex (PR's primary goal) and the cross-origin canonical is only ever a hint, so the canonical serves non-Google consumers (social unfurls, answer engines parsing the markup). Note ② is now implemented because the product call is "preserve readplace's OG object identity on shares so the downloaded thumbnail/content stays on us."

## Test plan

- [x] `pnpm nx run hutch:check` (lint + type-check + tests + coverage + knip + unused-css) — green at 100% coverage across 245 files
- [x] `assert`'s false path lives inside `node:assert`, so caller-side V8 block coverage stays clean — no new ignore comments needed
- [x] Existing `/view` SEO tests at `view.component.test.ts:135` and `:518` updated for the new `og:url` semantics
- [x] New base-level tests cover both branches of `canonicalIsExternal` and both branches of `ogUrl ?? canonical`


---
_Generated by [Claude Code](https://claude.ai/code/session_01GkoPQNjHmUtDj8JBfgrKVz)_