### PR TITLE
feat: publish auth.md and agent_auth discovery metadata for agent registration

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -134,6 +134,7 @@ import { sendComponent } from "./web/send-component";
 import { wantsMarkdown, wantsSiren } from "./web/content-negotiation";
 import { CONTENT_SIGNAL_VALUE, contentSignalMiddleware } from "./web/content-signal.middleware";
 import { linkHeaderMiddleware } from "./web/link-header.middleware";
+import { AGENT_SCOPES_SUPPORTED, buildAgentAuthMetadata, renderAuthMarkdown } from "./web/agent-auth";
 import { QuerystringFeatureToggle } from "./web/feature-toggle";
 import { HomePage } from "./web/pages/home";
 import { PrivacyPage } from "./web/pages/privacy";
@@ -366,6 +367,10 @@ export function createApp(dependencies: AppDependencies): Express {
 		res.type("text/plain").send(LLMS_FULL_TXT);
 	});
 
+	app.get("/auth.md", (_req: Request, res: Response) => {
+		res.type("text/markdown").send(renderAuthMarkdown(dependencies.baseUrl));
+	});
+
 	if (INDEXNOW_KEY) {
 		app.get(`/${INDEXNOW_KEY}.txt`, (_req: Request, res: Response) => {
 			res.type("text/plain").send(INDEXNOW_KEY);
@@ -393,6 +398,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			{ loc: "/terms", priority: "0.3", changefreq: "yearly", lastmod: "2026-03-01" },
 			{ loc: "/llms.txt", priority: "0.3", changefreq: "monthly", lastmod: "2026-04-08" },
 			{ loc: "/llms-full.txt", priority: "0.3", changefreq: "monthly", lastmod: "2026-04-08" },
+			{ loc: "/auth.md", priority: "0.3", changefreq: "monthly", lastmod: "2026-06-13" },
 		];
 
 		for (const post of blogPosts.getAllPostMetadata()) {
@@ -428,14 +434,18 @@ export function createApp(dependencies: AppDependencies): Express {
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			token_endpoint_auth_methods_supported: ["none"],
 			code_challenge_methods_supported: ["S256"],
+			agent_auth: buildAgentAuthMetadata(dependencies.baseUrl),
 		});
 	});
 
 	app.get("/.well-known/oauth-protected-resource", (_req: Request, res: Response) => {
 		res.json({
 			resource: dependencies.baseUrl,
+			resource_name: "Readplace",
 			authorization_servers: [dependencies.baseUrl],
+			scopes_supported: AGENT_SCOPES_SUPPORTED,
 			bearer_methods_supported: ["header"],
+			resource_documentation: `${dependencies.baseUrl}/auth.md`,
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/agent-auth.test.ts
+++ b/projects/hutch/src/runtime/web/agent-auth.test.ts
@@ -3,10 +3,10 @@ import { AGENT_SCOPES_SUPPORTED, buildAgentAuthMetadata, renderAuthMarkdown } fr
 const BASE_URL = "https://readplace.com";
 
 describe("buildAgentAuthMetadata", () => {
-	it("advertises the auth.md skill and the OAuth registration entry point", () => {
+	it("advertises the auth.md skill and the concierge registration channel", () => {
 		const metadata = buildAgentAuthMetadata(BASE_URL);
 		expect(metadata.skill).toBe("https://readplace.com/auth.md");
-		expect(metadata.register_uri).toBe("https://readplace.com/oauth/authorize");
+		expect(metadata.register_uri).toBe("mailto:readplace+agents@readplace.com");
 	});
 
 	it("declares the delegated-user identity and OAuth token credential types", () => {
@@ -53,9 +53,12 @@ describe("renderAuthMarkdown", () => {
 		expect(markdown).toContain("https://readplace.com/oauth/revoke");
 	});
 
-	it("documents the single coarse queue scope it advertises", () => {
+	it("documents queue as the single full-access level it advertises, without overstating enforcement", () => {
 		expect(AGENT_SCOPES_SUPPORTED).toEqual(["queue"]);
-		expect(renderAuthMarkdown(BASE_URL)).toContain("`queue` scope");
+		const markdown = renderAuthMarkdown(BASE_URL);
+		expect(markdown).toContain("full read/write access");
+		expect(markdown).toContain("does not sub-divide");
+		expect(markdown).toContain("`queue`");
 	});
 
 	it("points agents at the concierge address for client_id provisioning", () => {

--- a/projects/hutch/src/runtime/web/agent-auth.test.ts
+++ b/projects/hutch/src/runtime/web/agent-auth.test.ts
@@ -1,0 +1,64 @@
+import { AGENT_SCOPES_SUPPORTED, buildAgentAuthMetadata, renderAuthMarkdown } from "./agent-auth";
+
+const BASE_URL = "https://readplace.com";
+
+describe("buildAgentAuthMetadata", () => {
+	it("advertises the auth.md skill and the OAuth registration entry point", () => {
+		const metadata = buildAgentAuthMetadata(BASE_URL);
+		expect(metadata.skill).toBe("https://readplace.com/auth.md");
+		expect(metadata.register_uri).toBe("https://readplace.com/oauth/authorize");
+	});
+
+	it("declares the delegated-user identity and OAuth token credential types", () => {
+		const metadata = buildAgentAuthMetadata(BASE_URL);
+		expect(metadata.identity_types_supported).toEqual(["delegated_user"]);
+		expect(metadata.credential_types_supported).toEqual([
+			"oauth2_access_token",
+			"oauth2_refresh_token",
+		]);
+	});
+
+	it("offers a revocation URL but no claim ceremony", () => {
+		const metadata = buildAgentAuthMetadata(BASE_URL);
+		expect(metadata.revocation_uri).toBe("https://readplace.com/oauth/revoke");
+		expect(metadata).not.toHaveProperty("claim_uri");
+	});
+
+	it("describes exactly one complete authorization-code + PKCE registration method", () => {
+		const { registration_methods } = buildAgentAuthMetadata(BASE_URL);
+		expect(registration_methods).toEqual([
+			{
+				type: "oauth2_authorization_code_pkce",
+				authorization_uri: "https://readplace.com/oauth/authorize",
+				token_uri: "https://readplace.com/oauth/token",
+				grant_types_supported: ["authorization_code", "refresh_token"],
+				code_challenge_methods_supported: ["S256"],
+				token_endpoint_auth_methods_supported: ["none"],
+			},
+		]);
+	});
+});
+
+describe("renderAuthMarkdown", () => {
+	it("starts with an `# auth.md` H1 so the discovery validator recognises it", () => {
+		expect(renderAuthMarkdown(BASE_URL).startsWith("# auth.md\n")).toBe(true);
+	});
+
+	it("substitutes every baseUrl placeholder with the deployment origin", () => {
+		const markdown = renderAuthMarkdown(BASE_URL);
+		expect(markdown).not.toContain("{{baseUrl}}");
+		expect(markdown).toContain("https://readplace.com/.well-known/oauth-authorization-server");
+		expect(markdown).toContain("https://readplace.com/oauth/authorize");
+		expect(markdown).toContain("https://readplace.com/oauth/token");
+		expect(markdown).toContain("https://readplace.com/oauth/revoke");
+	});
+
+	it("documents the single coarse queue scope it advertises", () => {
+		expect(AGENT_SCOPES_SUPPORTED).toEqual(["queue"]);
+		expect(renderAuthMarkdown(BASE_URL)).toContain("`queue` scope");
+	});
+
+	it("points agents at the concierge address for client_id provisioning", () => {
+		expect(renderAuthMarkdown(BASE_URL)).toContain("readplace+agents@readplace.com");
+	});
+});

--- a/projects/hutch/src/runtime/web/agent-auth.ts
+++ b/projects/hutch/src/runtime/web/agent-auth.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const AUTH_MD_TEMPLATE = readFileSync(join(__dirname, "auth-md.template.md"), "utf-8");
+
+/**
+ * A Readplace access token grants full read/write access to one user's reading
+ * queue; the authorization flow never sub-divides that access, so a single
+ * coarse scope is the honest description. Advertised in the protected-resource
+ * metadata and documented in auth.md.
+ */
+export const AGENT_SCOPES_SUPPORTED = ["queue"] as const;
+
+interface AgentAuthRegistrationMethod {
+	type: "oauth2_authorization_code_pkce";
+	authorization_uri: string;
+	token_uri: string;
+	grant_types_supported: readonly string[];
+	code_challenge_methods_supported: readonly string[];
+	token_endpoint_auth_methods_supported: readonly string[];
+}
+
+interface AgentAuthMetadata {
+	skill: string;
+	register_uri: string;
+	identity_types_supported: readonly string[];
+	credential_types_supported: readonly string[];
+	revocation_uri: string;
+	registration_methods: readonly AgentAuthRegistrationMethod[];
+}
+
+/**
+ * The `agent_auth` extension to the RFC 8414 authorization-server metadata.
+ * Readplace registers an agent as a delegate of a human user via the standard
+ * authorization-code + PKCE flow, so there is no claim ceremony (`claim_uri` is
+ * omitted) but revocation is offered.
+ */
+export function buildAgentAuthMetadata(baseUrl: string): AgentAuthMetadata {
+	return {
+		skill: `${baseUrl}/auth.md`,
+		register_uri: `${baseUrl}/oauth/authorize`,
+		identity_types_supported: ["delegated_user"],
+		credential_types_supported: ["oauth2_access_token", "oauth2_refresh_token"],
+		revocation_uri: `${baseUrl}/oauth/revoke`,
+		registration_methods: [
+			{
+				type: "oauth2_authorization_code_pkce",
+				authorization_uri: `${baseUrl}/oauth/authorize`,
+				token_uri: `${baseUrl}/oauth/token`,
+				grant_types_supported: ["authorization_code", "refresh_token"],
+				code_challenge_methods_supported: ["S256"],
+				token_endpoint_auth_methods_supported: ["none"],
+			},
+		],
+	};
+}
+
+export function renderAuthMarkdown(baseUrl: string): string {
+	return AUTH_MD_TEMPLATE.replaceAll("{{baseUrl}}", baseUrl);
+}

--- a/projects/hutch/src/runtime/web/agent-auth.ts
+++ b/projects/hutch/src/runtime/web/agent-auth.ts
@@ -30,6 +30,14 @@ interface AgentAuthMetadata {
 }
 
 /**
+ * Registration is concierge-only — there is no self-service Dynamic Client
+ * Registration — so `register_uri` is the email channel auth.md step 3
+ * documents, not `/oauth/authorize` (which rejects an unprovisioned client_id
+ * with 400 invalid_client).
+ */
+const AGENT_REGISTRATION_MAILTO = "mailto:readplace+agents@readplace.com";
+
+/**
  * The `agent_auth` extension to the RFC 8414 authorization-server metadata.
  * Readplace registers an agent as a delegate of a human user via the standard
  * authorization-code + PKCE flow, so there is no claim ceremony (`claim_uri` is
@@ -38,7 +46,7 @@ interface AgentAuthMetadata {
 export function buildAgentAuthMetadata(baseUrl: string): AgentAuthMetadata {
 	return {
 		skill: `${baseUrl}/auth.md`,
-		register_uri: `${baseUrl}/oauth/authorize`,
+		register_uri: AGENT_REGISTRATION_MAILTO,
 		identity_types_supported: ["delegated_user"],
 		credential_types_supported: ["oauth2_access_token", "oauth2_refresh_token"],
 		revocation_uri: `${baseUrl}/oauth/revoke`,

--- a/projects/hutch/src/runtime/web/auth-md.template.md
+++ b/projects/hutch/src/runtime/web/auth-md.template.md
@@ -1,0 +1,114 @@
+# auth.md
+
+Readplace publishes this file so AI agents can obtain delegated access to a
+signed-in user's reading queue. Readplace is both the OAuth 2.0 authorization
+server and the protected resource; its issuer is `{{baseUrl}}`.
+
+## Audience
+
+This recipe is for agents acting **on behalf of a Readplace user** — saving
+links to, reading, and managing that user's queue. Readplace has no machine-only
+or anonymous identity: every credential is bound to a human Readplace account
+that explicitly authorizes the agent.
+
+## 1. Discover
+
+Fetch the two discovery documents:
+
+- Protected resource metadata: `GET {{baseUrl}}/.well-known/oauth-protected-resource`
+- Authorization server metadata: `GET {{baseUrl}}/.well-known/oauth-authorization-server`
+
+The authorization server metadata carries an `agent_auth` block whose `skill`
+points back at this file and whose `registration_methods` describe the flow
+below.
+
+## 2. Pick a method
+
+Readplace supports a single registration method: **OAuth 2.0 Authorization Code
+with PKCE** ([RFC 7636](https://www.rfc-editor.org/rfc/rfc7636)). The client is
+public — there is no client secret. Readplace does not offer ID-JAG,
+verified-email, or anonymous claim flows.
+
+## 3. Get a client_id
+
+Readplace does not yet offer self-service Dynamic Client Registration
+([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)). Email
+[readplace+agents@readplace.com](mailto:readplace+agents@readplace.com) with your
+agent's name and redirect URI to register a `client_id`. (Readplace's own Firefox
+and Chrome extensions are already registered.)
+
+## 4. Authorize
+
+Redirect the user to the authorization endpoint:
+
+```
+GET {{baseUrl}}/oauth/authorize
+  ?response_type=code
+  &client_id=YOUR_CLIENT_ID
+  &redirect_uri=YOUR_REDIRECT_URI
+  &code_challenge=BASE64URL(SHA256(code_verifier))
+  &code_challenge_method=S256
+  &state=OPAQUE_VALUE
+  &scope=queue
+```
+
+`scope` is optional; Readplace issues a single coarse `queue` scope (see step 6)
+whether or not you request it. The user signs in if needed and approves, then
+Readplace redirects to `YOUR_REDIRECT_URI?code=AUTH_CODE&state=OPAQUE_VALUE`.
+
+## 5. Exchange the code
+
+```
+POST {{baseUrl}}/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code=AUTH_CODE&redirect_uri=YOUR_REDIRECT_URI&client_id=YOUR_CLIENT_ID&code_verifier=CODE_VERIFIER
+```
+
+The response is JSON with `access_token`, `refresh_token`, and
+`token_type: "Bearer"`.
+
+## 6. Use the access_token
+
+The queue API is a [Siren](https://github.com/kevinswiber/siren) hypermedia API.
+Send the bearer token on every request, start at the entry point, and follow the
+links and actions it returns:
+
+```
+GET {{baseUrl}}/queue
+Authorization: Bearer ACCESS_TOKEN
+Accept: application/vnd.siren+json
+```
+
+The `queue` scope grants full read/write access to the authenticated user's
+reading queue. When the access token expires, refresh it:
+
+```
+POST {{baseUrl}}/oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token&refresh_token=REFRESH_TOKEN&client_id=YOUR_CLIENT_ID
+```
+
+## 7. Errors
+
+| Response | Meaning |
+| --- | --- |
+| `400 invalid_request` | A required parameter is missing or malformed |
+| `400 invalid_client` | The `client_id` is not registered |
+| `401 access_denied` | The user is not signed in, or denied the request |
+| `401` from the queue API | The bearer token is missing, expired, or revoked |
+
+## 8. Revoke
+
+Revoke an access or refresh token (revoking either drops the paired token):
+
+```
+POST {{baseUrl}}/oauth/revoke
+Content-Type: application/json
+
+{ "token": "ACCESS_OR_REFRESH_TOKEN" }
+```
+
+A user can also revoke an agent's access at any time from their Readplace
+account.

--- a/projects/hutch/src/runtime/web/auth-md.template.md
+++ b/projects/hutch/src/runtime/web/auth-md.template.md
@@ -52,9 +52,11 @@ GET {{baseUrl}}/oauth/authorize
   &scope=queue
 ```
 
-`scope` is optional; Readplace issues a single coarse `queue` scope (see step 6)
-whether or not you request it. The user signs in if needed and approves, then
-Readplace redirects to `YOUR_REDIRECT_URI?code=AUTH_CODE&state=OPAQUE_VALUE`.
+`scope` is optional and makes no difference: Readplace does not sub-divide
+access, so every token carries the same full read/write access to the user's
+queue (see step 6). The discovery metadata labels that single access level
+`queue`. The user signs in if needed and approves, then Readplace redirects to
+`YOUR_REDIRECT_URI?code=AUTH_CODE&state=OPAQUE_VALUE`.
 
 ## 5. Exchange the code
 
@@ -80,8 +82,10 @@ Authorization: Bearer ACCESS_TOKEN
 Accept: application/vnd.siren+json
 ```
 
-The `queue` scope grants full read/write access to the authenticated user's
-reading queue. When the access token expires, refresh it:
+A Readplace access token carries full read/write access to the authenticated
+user's reading queue — the single access level the discovery metadata labels
+`queue`. Readplace does not sub-divide or separately enforce scopes. When the
+access token expires, refresh it:
 
 ```
 POST {{baseUrl}}/oauth/token

--- a/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.test.ts
@@ -61,6 +61,7 @@ describe("contentSignalMiddleware", () => {
 		"/robots.txt",
 		"/llms.txt",
 		"/llms-full.txt",
+		"/auth.md",
 		"/sitemap.xml",
 		"/health",
 		"/.well-known/api-catalog",

--- a/projects/hutch/src/runtime/web/content-signal.middleware.ts
+++ b/projects/hutch/src/runtime/web/content-signal.middleware.ts
@@ -6,6 +6,7 @@ const NON_PAGE_PREFIXES = [
 	"/robots.txt",
 	"/llms.txt",
 	"/llms-full.txt",
+	"/auth.md",
 	"/sitemap.xml",
 	"/health",
 	"/.well-known/api-catalog",

--- a/projects/hutch/src/runtime/web/middleware/naive-bot.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/naive-bot.test.ts
@@ -194,6 +194,18 @@ describe("createBlockNaiveBotMiddleware", () => {
 		expect(run({ ua: "curl/7.88.1", path: "/favicon.ico" }).nextCalled).toBe(true);
 	});
 
+	it("bypasses the block for /auth.md so agents can read the registration recipe", () => {
+		expect(run({ ua: "curl/7.88.1", path: "/auth.md" }).nextCalled).toBe(true);
+	});
+
+	it.each([
+		"/.well-known/oauth-protected-resource",
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/api-catalog",
+	])("bypasses the block for the discovery endpoint %s", (path) => {
+		expect(run({ ua: "curl/7.88.1", path }).nextCalled).toBe(true);
+	});
+
 	it("truncates logged user_agent to 200 chars so a malicious 10KB UA cannot blow up the log line size", () => {
 		const longUa = `curl/${"x".repeat(500)}`;
 		const result = run({ ua: longUa });

--- a/projects/hutch/src/runtime/web/middleware/naive-bot.ts
+++ b/projects/hutch/src/runtime/web/middleware/naive-bot.ts
@@ -40,6 +40,10 @@ const BOT_BYPASS_PATHS: ReadonlySet<string> = new Set([
 	"/llms.txt",
 	"/llms-full.txt",
 	"/favicon.ico",
+	"/auth.md",
+	"/.well-known/oauth-protected-resource",
+	"/.well-known/oauth-authorization-server",
+	"/.well-known/api-catalog",
 ]);
 
 const MAX_LOGGED_UA_LENGTH = 200;

--- a/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
@@ -192,6 +192,24 @@ describe("GET /llms-full.txt", () => {
 	});
 });
 
+describe("GET /auth.md", () => {
+	it("serves the agent registration recipe as markdown", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/auth.md");
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/text\/markdown/);
+		expect(response.text.startsWith("# auth.md")).toBe(true);
+	});
+
+	it("documents the real OAuth endpoints against the configured base URL", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/auth.md");
+		expect(response.text).not.toContain("{{baseUrl}}");
+		expect(response.text).toContain("http://localhost:3000/oauth/authorize");
+		expect(response.text).toContain("http://localhost:3000/.well-known/oauth-protected-resource");
+	});
+});
+
 describe("GET /sitemap.xml", () => {
 	it("should return an XML sitemap with exactly the public pages", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -211,6 +229,7 @@ describe("GET /sitemap.xml", () => {
 			"http://localhost:3000/terms",
 			"http://localhost:3000/llms.txt",
 			"http://localhost:3000/llms-full.txt",
+			"http://localhost:3000/auth.md",
 			...blogPostUrls,
 		]);
 	});
@@ -249,6 +268,23 @@ describe("GET /.well-known/oauth-authorization-server", () => {
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			token_endpoint_auth_methods_supported: ["none"],
 			code_challenge_methods_supported: ["S256"],
+			agent_auth: {
+				skill: "http://localhost:3000/auth.md",
+				register_uri: "http://localhost:3000/oauth/authorize",
+				identity_types_supported: ["delegated_user"],
+				credential_types_supported: ["oauth2_access_token", "oauth2_refresh_token"],
+				revocation_uri: "http://localhost:3000/oauth/revoke",
+				registration_methods: [
+					{
+						type: "oauth2_authorization_code_pkce",
+						authorization_uri: "http://localhost:3000/oauth/authorize",
+						token_uri: "http://localhost:3000/oauth/token",
+						grant_types_supported: ["authorization_code", "refresh_token"],
+						code_challenge_methods_supported: ["S256"],
+						token_endpoint_auth_methods_supported: ["none"],
+					},
+				],
+			},
 		});
 	});
 });
@@ -261,8 +297,11 @@ describe("GET /.well-known/oauth-protected-resource", () => {
 		expect(response.headers["content-type"]).toMatch(/application\/json/);
 		expect(response.body).toEqual({
 			resource: "http://localhost:3000",
+			resource_name: "Readplace",
 			authorization_servers: ["http://localhost:3000"],
+			scopes_supported: ["queue"],
 			bearer_methods_supported: ["header"],
+			resource_documentation: "http://localhost:3000/auth.md",
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
@@ -270,7 +270,7 @@ describe("GET /.well-known/oauth-authorization-server", () => {
 			code_challenge_methods_supported: ["S256"],
 			agent_auth: {
 				skill: "http://localhost:3000/auth.md",
-				register_uri: "http://localhost:3000/oauth/authorize",
+				register_uri: "mailto:readplace+agents@readplace.com",
 				identity_types_supported: ["delegated_user"],
 				credential_types_supported: ["oauth2_access_token", "oauth2_refresh_token"],
 				revocation_uri: "http://localhost:3000/oauth/revoke",


### PR DESCRIPTION
## Why

`isitagentready.com` flagged **"auth.md not found"** — Readplace published no agent-registration discovery surface. This adds the [auth.md](https://workos.com/auth-md) discovery files so AI agents can learn how to obtain delegated access to a user's reading queue.

## What

- **Serve `/auth.md`** at the site root — an OAuth 2.0 Authorization Code + PKCE registration recipe (discover → get a `client_id` → authorize → exchange → use the bearer token → errors → revoke). Rendered from a colocated template with the deployment's base URL substituted in.
- **`/.well-known/oauth-authorization-server`** (RFC 8414) now carries an `agent_auth` block: `skill`, `register_uri`, `identity_types_supported`, `credential_types_supported`, `revocation_uri`, and one complete authorization-code + PKCE `registration_methods` entry. `claim_uri` is omitted — Readplace has no claim ceremony ("where applicable").
- **`/.well-known/oauth-protected-resource`** (RFC 9728) now includes the validator-required `scopes_supported` (`["queue"]`), plus `resource_name` and `resource_documentation` pointing at `/auth.md`.
- **Bot-bypass**: `/auth.md` and the three `.well-known` discovery endpoints now bypass the naive-bot block, so scripted agents (curl, python-requests, node-fetch, …) — not just browsers — can fetch them. They were previously `403`'d, which would have left the published metadata unreachable.

## Honesty notes

- Readplace only supports **delegated user** access via OAuth (no ID-JAG / verified-email / anonymous agent flows), so the recipe and `agent_auth` describe exactly that and nothing more.
- There is no self-service Dynamic Client Registration, so `/auth.md` is upfront that a `client_id` is provisioned via concierge email (`readplace+agents@readplace.com`), following the repo's existing `readplace+<purpose>@` convention.

## Tests

- New unit tests for the `agent_auth` builder and the markdown renderer (100% coverage).
- Updated route tests assert the exact PRM/AS bodies and that `GET /auth.md` serves markdown with the real endpoints.
- New naive-bot tests assert the discovery endpoints bypass the block.
- Full monorepo `check` (lint + tests + coverage + knip) is green.

https://claude.ai/code/session_01FV18sqmyVqukfAfJgGx415

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV18sqmyVqukfAfJgGx415)_