### PR TITLE
build: upgrade typescript 5.9.3 to 6.0.3 across the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "knip": "5.85.0",
     "minimatch": "10.2.5",
     "nx": "21.6.10",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 9.1.7
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       knip:
         specifier: 5.85.0
-        version: 5.85.0(@types/node@22.19.19)(typescript@5.9.3)
+        version: 5.85.0(@types/node@22.19.19)(typescript@6.0.3)
       minimatch:
         specifier: 10.2.5
         version: 10.2.5
@@ -33,8 +33,8 @@ importers:
         specifier: 21.6.10
         version: 21.6.10
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/browser-extension-core:
     dependencies:
@@ -68,13 +68,13 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       selenium-webdriver:
         specifier: 4.44.0
         version: 4.44.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/extensions/chrome-extension:
     dependencies:
@@ -99,10 +99,10 @@ importers:
         version: link:../../../src/packages/test-phase-runner
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -120,13 +120,13 @@ importers:
         version: 0.25.4
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       selenium-webdriver:
         specifier: 4.44.0
         version: 4.44.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/extensions/firefox-extension:
     dependencies:
@@ -151,10 +151,10 @@ importers:
         version: link:../../../src/packages/test-phase-runner
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -169,13 +169,13 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       selenium-webdriver:
         specifier: 4.44.0
         version: 4.44.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       web-ext:
         specifier: 10.3.0
         version: 10.3.0(jiti@2.6.1)
@@ -311,10 +311,10 @@ importers:
         version: 1.60.0
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@testing-library/dom':
         specifier: '10'
         version: 10.4.1
@@ -359,7 +359,7 @@ importers:
         version: 0.27.3
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
@@ -373,8 +373,8 @@ importers:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/platform:
     dependencies:
@@ -384,13 +384,13 @@ importers:
     devDependencies:
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/save-link:
     dependencies:
@@ -478,10 +478,10 @@ importers:
         version: link:../../src/packages/test-phase-runner
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/aws-lambda':
         specifier: 8.10.161
         version: 8.10.161
@@ -499,10 +499,10 @@ importers:
         version: 0.25.4
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-parser:
     dependencies:
@@ -536,10 +536,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-resource-unique-id:
     devDependencies:
@@ -554,10 +554,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-state-types:
     dependencies:
@@ -576,10 +576,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-store:
     dependencies:
@@ -610,10 +610,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/check-failed-articles:
     dependencies:
@@ -631,8 +631,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/check-stuck-articles:
     dependencies:
@@ -650,8 +650,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/check-unused-css:
     dependencies:
@@ -691,10 +691,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/domain:
     dependencies:
@@ -719,10 +719,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/extract-links-from-page:
     dependencies:
@@ -747,10 +747,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/finalize-article:
     dependencies:
@@ -781,10 +781,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/hutch-infra-components:
     dependencies:
@@ -800,10 +800,10 @@ importers:
     devDependencies:
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/aws-lambda':
         specifier: 8.10.161
         version: 8.10.161
@@ -818,10 +818,10 @@ importers:
         version: 0.25.4
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/hutch-logger:
     devDependencies:
@@ -829,8 +829,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/hutch-storage-client:
     dependencies:
@@ -848,8 +848,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/onboarding-extension-signal:
     devDependencies:
@@ -857,8 +857,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/provider-contracts:
     dependencies:
@@ -882,8 +882,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/refresh-article-content:
     dependencies:
@@ -911,10 +911,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/retriable:
     devDependencies:
@@ -929,10 +929,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/test-fixtures:
     dependencies:
@@ -981,10 +981,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/test-phase-runner:
     devDependencies:
@@ -996,10 +996,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/time-left:
     devDependencies:
@@ -1014,10 +1014,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/web-shell:
     dependencies:
@@ -1051,13 +1051,13 @@ importers:
         version: 4.22.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/web-test-harness:
     dependencies:
@@ -1106,10 +1106,10 @@ importers:
         version: 4.22.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -5877,8 +5877,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7214,7 +7214,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))':
+  '@jest/core@29.7.0(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(node-notifier@10.0.1)
@@ -7228,7 +7228,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -7840,16 +7840,16 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@pulumi/aws@7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/aws@7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/pulumi@3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/pulumi@3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@logdna/tail-file': 2.2.0
@@ -7879,8 +7879,8 @@ snapshots:
       tmp: 0.2.5
       upath: 1.2.0
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-node: 10.9.2(@types/node@22.19.19)(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8746,13 +8746,13 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9788,16 +9788,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      '@jest/core': 29.7.0(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9809,7 +9809,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -9835,7 +9835,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.19
-      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.19.19)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10062,12 +10062,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      '@jest/core': 29.7.0(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
     optionalDependencies:
       node-notifier: 10.0.1
     transitivePeerDependencies:
@@ -10195,7 +10195,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knip@5.85.0(@types/node@22.19.19)(typescript@5.9.3):
+  knip@5.85.0(@types/node@22.19.19)(typescript@6.0.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 22.19.19
@@ -10209,7 +10209,7 @@ snapshots:
       picomatch: 4.0.3
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 4.4.3
 
   ky@1.14.3: {}
@@ -11495,7 +11495,7 @@ snapshots:
 
   treeverse@3.0.0: {}
 
-  ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -11509,7 +11509,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -11559,7 +11559,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 

--- a/projects/browser-extension-core/package.json
+++ b/projects/browser-extension-core/package.json
@@ -59,6 +59,6 @@
     "concurrently": "10.0.0",
     "jest": "29.7.0",
     "selenium-webdriver": "4.44.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/extensions/chrome-extension/package.json
+++ b/projects/extensions/chrome-extension/package.json
@@ -38,6 +38,6 @@
     "jest": "29.7.0",
     "@packages/check-unused-css": "workspace:*",
     "selenium-webdriver": "4.44.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/extensions/firefox-extension/package.json
+++ b/projects/extensions/firefox-extension/package.json
@@ -38,7 +38,7 @@
     "jest": "29.7.0",
     "@packages/check-unused-css": "workspace:*",
     "selenium-webdriver": "4.44.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "web-ext": "10.3.0"
   }
 }

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -106,6 +106,6 @@
     "livereload": "0.10.3",
     "supertest": "7.2.2",
     "tsx": "4.22.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/platform/package.json
+++ b/projects/platform/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@pulumi/aws": "7.32.0",
     "@pulumi/pulumi": "3.244.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/save-link/package.json
+++ b/projects/save-link/package.json
@@ -54,6 +54,6 @@
     "concurrently": "10.0.0",
     "esbuild": "0.25.4",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-parser/package.json
+++ b/src/packages/article-parser/package.json
@@ -26,6 +26,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-resource-unique-id/package.json
+++ b/src/packages/article-resource-unique-id/package.json
@@ -18,6 +18,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-state-types/package.json
+++ b/src/packages/article-state-types/package.json
@@ -21,6 +21,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-store/package.json
+++ b/src/packages/article-store/package.json
@@ -25,6 +25,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/check-failed-articles/package.json
+++ b/src/packages/check-failed-articles/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/crawl-article/package.json
+++ b/src/packages/crawl-article/package.json
@@ -26,6 +26,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -63,6 +63,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/extract-links-from-page/package.json
+++ b/src/packages/extract-links-from-page/package.json
@@ -23,6 +23,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/finalize-article/package.json
+++ b/src/packages/finalize-article/package.json
@@ -31,6 +31,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/hutch-infra-components/package.json
+++ b/src/packages/hutch-infra-components/package.json
@@ -50,6 +50,6 @@
     "@types/jest": "29.5.14",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/hutch-logger/package.json
+++ b/src/packages/hutch-logger/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/hutch-storage-client/package.json
+++ b/src/packages/hutch-storage-client/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/onboarding-extension-signal/package.json
+++ b/src/packages/onboarding-extension-signal/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/provider-contracts/package.json
+++ b/src/packages/provider-contracts/package.json
@@ -135,6 +135,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/refresh-article-content/package.json
+++ b/src/packages/refresh-article-content/package.json
@@ -27,6 +27,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/retriable/package.json
+++ b/src/packages/retriable/package.json
@@ -18,6 +18,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -166,6 +166,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/test-phase-runner/package.json
+++ b/src/packages/test-phase-runner/package.json
@@ -18,6 +18,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/time-left/package.json
+++ b/src/packages/time-left/package.json
@@ -18,6 +18,6 @@
     "c8": "10.1.3",
     "concurrently": "10.0.0",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/web-shell/package.json
+++ b/src/packages/web-shell/package.json
@@ -42,6 +42,6 @@
     "express": "4.22.1",
     "jest": "29.7.0",
     "jsdom": "26.1.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/web-test-harness/package.json
+++ b/src/packages/web-test-harness/package.json
@@ -37,6 +37,6 @@
     "concurrently": "10.0.0",
     "express": "4.22.1",
     "jest": "29.7.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/tsconfig.config.base.json
+++ b/tsconfig.config.base.json
@@ -12,6 +12,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "types": ["node", "jest"],
     "inlineSources": true,
     "incremental": true
   }


### PR DESCRIPTION
## Summary

Upgrades TypeScript **5.9.3 → 6.0.3** across all 28 TypeScript projects (every `package.json` that pinned `typescript`, plus the shared base tsconfig). `@types/node` is intentionally held at **22.x** (22.19.19).

TypeScript 6.0 is a transitional release that turns long-standing deprecations into errors and flips two compiler defaults this repo depended on. Both are handled here.

## What 6.0 broke and how it's addressed

### 1. `compilerOptions.types` now defaults to `[]`
Previously TS auto-included every `@types/*` package in `node_modules/@types`. As of 6.0 the default is `[]`, so ambient (un-imported) type packages stop resolving — e.g. `process`/`Buffer`/`__dirname` (`@types/node`) and `describe`/`it`/`expect` (`@types/jest`, used **ambiently** — there are zero `@jest/globals` imports in the repo).

**Fix:** `tsconfig.config.base.json` now sets `"types": ["node", "jest"]` — the only ambient packages the code relies on. `chrome`/`browser` extension globals come from the **imported** `webextension-polyfill` (its `declare global` augmentations load via the import graph, independent of the `types` array), so the extensions need nothing extra.

### 2. `moduleResolution: "node"` (node10) is now a hard error
**Fix (this PR):** `"ignoreDeprecations": "6.0"` on the shared base, keeping `module: commonjs` + `moduleResolution: node`. This keeps the emitted JS **byte-for-byte identical** to 5.9.3, so the 100% c8 coverage gate, jest-on-`dist`, and the esbuild extension bundles are unaffected.

**Why not migrate to `nodenext` now?** I attempted it. It type-checks cleanly (only one source change needed — a relative dynamic `import()` needs a `.js` extension), **but** `moduleResolution: nodenext` forces `module: nodenext`, which changes CJS emit and breaks runtime interop:
- `hutch` `GET /auth/checkout/success` integration tests (4 failures — Google user / Stripe / welcome-email flows)
- the `test-fixtures` password-reset dynamic-import test

These are genuine runtime/interop regressions, and the bits that can't be verified headless here (Playwright/Selenium E2E, esbuild bundle byte-identity) exercise exactly this emit path. Rather than ship an under-verified emit change behind the strict quality gates, the real migration is deferred. (`ignoreDeprecations` is removed in TS 7.0, so this should land before then.)

## Follow-up (separate PR)
Migrate `moduleResolution` `node` → `nodenext` (or `bundler` for the esbuild projects). Known work:
- add `.js` to the one relative dynamic import (`src/packages/test-fixtures/src/providers/password-reset/in-memory-password-reset.test.ts`),
- fix the CJS/ESM interop regressions in the hutch auth/checkout tests and the password-reset dynamic import,
- validate against the full E2E suite and confirm the esbuild bundle fingerprints are unchanged.

## Verification
- Cold `pnpm check` (after `nx reset`) — lint + `test-with-coverage` incl. the 100% c8 gate — **green across all 28 TS projects**.
- Cold `compile` + `lint` — green.
- `@types/node` confirmed still **22.19.19**; `tsc --version` → 6.0.3.
- Pre-commit hook (`pnpm check`) passed.

The iOS PoC (`ios-readplace-poc`) is unaffected: no `typescript` dependency and no `check` target (its `compile` shells out to `xcodegen`, absent on Linux), so `pnpm check` skips it.

### Out of scope (pre-existing)
`@packages/time-left`'s `test-with-coverage` fails independently of this change — its bare `c8 pnpm test` never emits the json-summary that `enforce-coverage` reads (tests themselves pass at 100%). It's dormant because time-left's `check` target runs lint only. Flagged for awareness; not touched here.

https://claude.ai/code/session_01SAo7R8h3BZY4yRtMeJU3Uq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAo7R8h3BZY4yRtMeJU3Uq)_