### PR TITLE
docs(blog): add post on clean share-link previews

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/share-a-clean-article-link.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/share-a-clean-article-link.md
@@ -1,0 +1,51 @@
+---
+title: "Share a Saved Article and the Link Preview Comes Out Clean"
+description: "Save an article in Readplace, tap share, and send the link. The preview shows Readplace's clean reader copy with the saved thumbnail, and a tap lands your friend in the quiet version. Search engines still credit the original publisher."
+slug: "share-a-clean-article-link"
+date: "2026-06-13"
+author: "Fayner Brack"
+keywords: "read it later, share article link, link preview, clean reader link, share saved articles, social link preview, open graph preview, share read later"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+You save an article in Readplace and share the link. The preview now shows Readplace's clean reader copy, with the title, a short excerpt, and the thumbnail Readplace already downloaded. The link points back to Readplace, so whoever taps it lands in the quiet reader, not a page full of pop-ups. Search engines still credit the original publisher, so readers see the right source.
+
+</div>
+</details>
+
+You read something good. You want to send it to a friend, a group chat, or your team. So you copy the link and paste it.
+
+On most read-it-later tools you face a small problem. Paste the original link and your friend hits the same wall you did: the cookie banner, the paywall nag, the video that plays on its own. Paste a saved-page link and the preview often comes out blank or broken.
+
+## Readplace shares the clean version
+
+Readplace gives every saved article a share link. Tap the share button on a saved article and you get a link to the clean reader view. Send that link anywhere.
+
+What does your friend see when the link lands in a chat? The right title, a short excerpt, and the thumbnail Readplace saved when it first fetched the page. The card looks finished, not empty.
+
+Whoever taps the link reads the clean version too. Readplace strips the ads and pop-ups and shows the words, plus the short summary it wrote for you.
+
+## The preview points back to Readplace
+
+A link preview carries a hidden address. It tells chat apps and social sites which page the card stands for. Readplace now sets that address to its own reader page.
+
+So the preview card belongs to Readplace, and a tap takes your friend into the clean reader, not the cluttered original. The thumbnail and the reader content travel with the link, and they stay attached to a page you control.
+
+## The original publisher still gets the credit
+
+There is a second hidden tag. It tells search engines who wrote the article. Readplace points that one at the original site.
+
+So Google and the answer engines credit the publisher. Readplace hosts a clean copy for you to read. It does not claim to be the writer. The two tags do two jobs: one keeps your share looking good, the other keeps the source honest.
+
+## Why this matters
+
+Sharing is how good reading spreads. A friend sends you a link, you read it, you save it, and you send it on. Every clean share link carries Readplace with it.
+
+The person who clicks sees what the app does in one tap. A fast, quiet page they can actually read, with a summary up top. That is the clearest pitch we have, and it rides along in a link.
+
+There is a smaller win on your side. You send the clean copy you already trust, so you skip the worry about whether your friend will hit a paywall or a wall of ads. The link you share matches the page you read.
+
+Save an article, tap share, and paste the link into a chat with yourself. Look at the preview. Then send the next good read to someone who will thank you for the clean version. Start at [readplace.com](/) or [install the browser extension](https://readplace.com/install).

--- a/projects/hutch/src/runtime/web/pages/blog/posts/share-a-clean-article-link.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/share-a-clean-article-link.md
@@ -24,7 +24,7 @@ On most read-it-later tools you face a small problem. Paste the original link an
 
 Readplace gives every saved article a share link. Tap the share button on a saved article and you get a link to the clean reader view. Send that link anywhere.
 
-What does your friend see when the link lands in a chat? The right title, a short excerpt, and the thumbnail Readplace saved when it first fetched the page. The card looks finished, not empty.
+What does your friend see when the link lands in a chat? The article's title with a Reader View label, a short excerpt, and the thumbnail Readplace saved when it first fetched the page. The card looks finished, not empty, and the label signals the clean page behind the link.
 
 Whoever taps the link reads the clean version too. Readplace strips the ads and pop-ups and shows the words, plus the short summary it wrote for you.
 
@@ -36,9 +36,9 @@ So the preview card belongs to Readplace, and a tap takes your friend into the c
 
 ## The original publisher still gets the credit
 
-There is a second hidden tag. It tells search engines who wrote the article. Readplace points that one at the original site.
+There is a second hidden tag. It tells search engines where the article really lives. Readplace sets it to the original site, and keeps these reader pages out of search results.
 
-So Google and the answer engines credit the publisher. Readplace hosts a clean copy for you to read. It does not claim to be the writer. The two tags do two jobs: one keeps your share looking good, the other keeps the source honest.
+So the publisher keeps the credit. Search engines and answer engines treat the original as the source, not Readplace. Readplace hosts a clean copy for you to read, and never claims to be the writer. The two tags do two jobs: one keeps your share looking good, the other keeps the source honest.
 
 ## Why this matters
 

--- a/projects/hutch/src/runtime/web/pages/blog/posts/share-a-clean-article-link.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/share-a-clean-article-link.md
@@ -11,7 +11,7 @@ keywords: "read it later, share article link, link preview, clean reader link, s
 <summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
 <div class="blog-tldr__body">
 
-You save an article in Readplace and share the link. The preview now shows Readplace's clean reader copy, with the title, a short excerpt, and the thumbnail Readplace already downloaded. The link points back to Readplace, so whoever taps it lands in the quiet reader, not a page full of pop-ups. Search engines still credit the original publisher, so readers see the right source.
+You save an article in Readplace and share the link. The preview now shows Readplace's clean reader copy: the title with a Reader View label, a short excerpt, and the thumbnail Readplace already downloaded. The link points back to Readplace, so whoever taps it lands in the quiet reader, not a page full of pop-ups. Search engines still credit the original publisher, so readers see the right source.
 
 </div>
 </details>
@@ -38,7 +38,7 @@ So the preview card belongs to Readplace, and a tap takes your friend into the c
 
 There is a second hidden tag. It tells search engines where the article really lives. Readplace sets it to the original site, and keeps these reader pages out of search results.
 
-So the publisher keeps the credit. Search engines and answer engines treat the original as the source, not Readplace. Readplace hosts a clean copy for you to read, and never claims to be the writer. The two tags do two jobs: one keeps your share looking good, the other keeps the source honest.
+So the publisher keeps the credit. Search engines and answer engines treat the original as the source, not Readplace. Readplace hosts a clean copy for you to read, and never claims to be the writer. One tag keeps your share looking good. The other keeps the source honest.
 
 ## Why this matters
 


### PR DESCRIPTION
## What

New blog post: **"Share a Saved Article and the Link Preview Comes Out Clean"** (`share-a-clean-article-link.md`, dated 2026-06-13).

## Why

Reviewed commits to `main` since the last published post (`email-when-your-article-is-ready.md`, 2026-06-11). The standout customer- and conversion-relevant change was #540, which sets `og:url` on `/view` to the Readplace reader wrapper while keeping `<link rel="canonical">` on the original publisher.

The post translates that change into the reader benefit: share a saved article and the social preview shows Readplace's clean reader copy plus the saved thumbnail, a tap lands the recipient in the quiet reader, and search engines still credit the source. Shared links double as a discovery channel, which makes this a strong SEO/GEO and paid-conversion angle.

## Notes

- Followed the house writing rules (short active sentences, plain vocabulary, benefit-led, clear CTA).
- No pricing or founding-member references included.
- `pnpm nx run hutch:check` passed (all coverage thresholds met); the pre-commit `nx run-many --target=check --all` also passed across 28 projects. The post is discovered and rendered by the existing blog infrastructure with no test changes needed.

https://claude.ai/code/session_019vK6KAFFCiPH1CM1chMWPR

---
_Generated by [Claude Code](https://claude.ai/code/session_019vK6KAFFCiPH1CM1chMWPR)_