### PR TITLE
chore(deps): bump c8 from 10.1.3 to 11.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 4.35.6
         version: 4.35.6
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -116,8 +116,8 @@ importers:
         specifier: 4.35.6
         version: 4.35.6
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -168,8 +168,8 @@ importers:
         specifier: 4.35.6
         version: 4.35.6
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -355,8 +355,8 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -495,8 +495,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -535,8 +535,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -553,8 +553,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -575,8 +575,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -609,8 +609,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -690,8 +690,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -718,8 +718,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -746,8 +746,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -780,8 +780,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -910,8 +910,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -928,8 +928,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -980,8 +980,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -995,8 +995,8 @@ importers:
   src/packages/test-phase-runner:
     devDependencies:
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -1013,8 +1013,8 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -1047,8 +1047,8 @@ importers:
         specifier: 21.1.7
         version: 21.1.7
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -1102,8 +1102,8 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
       c8:
-        specifier: 10.1.3
-        version: 10.1.3
+        specifier: 11.0.0
+        version: 11.0.0
       concurrently:
         specifier: 10.0.0
         version: 10.0.0
@@ -3050,9 +3050,9 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  c8@10.1.3:
-    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
-    engines: {node: '>=18'}
+  c8@11.0.0:
+    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
+    engines: {node: 20 || >=22}
     hasBin: true
     peerDependencies:
       monocart-coverage-reports: ^2
@@ -5570,9 +5570,9 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -8264,7 +8264,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c8@10.1.3:
+  c8@11.0.0:
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@istanbuljs/schema': 0.1.3
@@ -8273,7 +8273,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      test-exclude: 7.0.2
+      test-exclude: 8.0.0
       v8-to-istanbul: 9.3.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
@@ -11167,10 +11167,10 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  test-exclude@7.0.2:
+  test-exclude@8.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
+      glob: 13.0.6
       minimatch: 10.2.5
 
   thread-stream@4.0.0:

--- a/projects/browser-extension-core/package.json
+++ b/projects/browser-extension-core/package.json
@@ -55,7 +55,7 @@
     "@packages/check-unused-css": "workspace:*",
     "@packages/test-phase-runner": "workspace:*",
     "@types/selenium-webdriver": "4.35.6",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "selenium-webdriver": "4.44.0",

--- a/projects/extensions/chrome-extension/package.json
+++ b/projects/extensions/chrome-extension/package.json
@@ -32,7 +32,7 @@
     "@pulumi/pulumi": "3.244.0",
     "@types/jest": "30.0.0",
     "@types/selenium-webdriver": "4.35.6",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "esbuild": "catalog:",
     "concurrently": "10.0.0",
     "jest": "30.4.2",

--- a/projects/extensions/firefox-extension/package.json
+++ b/projects/extensions/firefox-extension/package.json
@@ -33,7 +33,7 @@
     "@pulumi/pulumi": "3.244.0",
     "@types/jest": "30.0.0",
     "@types/selenium-webdriver": "4.35.6",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "@packages/check-unused-css": "workspace:*",

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -98,7 +98,7 @@
     "@types/markdown-it": "14.1.2",
     "@types/node": "22.19.19",
     "@types/supertest": "7.2.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "esbuild": "catalog:",
     "jest": "30.4.2",

--- a/projects/save-link/package.json
+++ b/projects/save-link/package.json
@@ -50,7 +50,7 @@
     "@pulumi/pulumi": "3.244.0",
     "@types/aws-lambda": "8.10.161",
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "esbuild": "catalog:",
     "jest": "30.4.2",

--- a/src/packages/article-parser/package.json
+++ b/src/packages/article-parser/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/jest": "30.0.0",
     "@types/parse-srcset": "1.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/article-resource-unique-id/package.json
+++ b/src/packages/article-resource-unique-id/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/article-state-types/package.json
+++ b/src/packages/article-state-types/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/article-store/package.json
+++ b/src/packages/article-store/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/crawl-article/package.json
+++ b/src/packages/crawl-article/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/escape-html": "1.0.4",
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/extract-links-from-page/package.json
+++ b/src/packages/extract-links-from-page/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/finalize-article/package.json
+++ b/src/packages/finalize-article/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/refresh-article-content/package.json
+++ b/src/packages/refresh-article-content/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "3.1057.0",
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/retriable/package.json
+++ b/src/packages/retriable/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -163,7 +163,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/test-phase-runner/package.json
+++ b/src/packages/test-phase-runner/package.json
@@ -15,7 +15,7 @@
     "check-infra": "echo 'No infrastructure — shared library'"
   },
   "devDependencies": {
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/time-left/package.json
+++ b/src/packages/time-left/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "typescript": "5.9.3"

--- a/src/packages/web-shell/package.json
+++ b/src/packages/web-shell/package.json
@@ -37,7 +37,7 @@
     "@types/express": "5.0.6",
     "@types/jest": "30.0.0",
     "@types/jsdom": "21.1.7",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "express": "5.2.1",
     "jest": "30.4.2",

--- a/src/packages/web-test-harness/package.json
+++ b/src/packages/web-test-harness/package.json
@@ -33,7 +33,7 @@
     "@types/express": "5.0.6",
     "@types/jest": "30.0.0",
     "@types/supertest": "7.2.0",
-    "c8": "10.1.3",
+    "c8": "11.0.0",
     "concurrently": "10.0.0",
     "express": "5.2.1",
     "jest": "30.4.2",


### PR DESCRIPTION
## Summary

Bumps the `c8` coverage tool **10.1.3 → 11.0.0** across all 20 workspace packages that pin it (the 19 pre-existing pins plus `@packages/web-shell`, which `main` introduced still on 10.1.3).

The only behavioural delta in this major is transitive: c8 11.0.0 moves `test-exclude` 7 → 8 (which bumps `glob` 10 → 13 and drops Node 18). The pieces that actually determine coverage numbers are unchanged:

- `v8-to-istanbul` (the counter) stays at 9.3.0, and the istanbul reporters are unchanged.
- `@istanbuljs/schema` default excludes (incl. `node_modules`, test files, `*.d.ts`) are identical.
- `test-exclude`'s `index.js` is **byte-identical** between 7.0.2 and 8.0.0; only its `glob` (directory walker) changed — the matcher (`minimatch` 10.2.5) is the same.

## Verification

- Snapshotted every `coverage-summary.json` (18 packages) before and after the bump. The **file set is identical**, and **statements / functions / lines percentages are identical** everywhere.
- The only run-to-run difference was the branch metric on two network-dependent crawl-article fetch modules (`aia-fetch.ts`, `h2-fetch.ts`). Reverting to 10.1.3 reproduces the same wobble, so it is pre-existing test non-determinism (V8 only emits branch ranges for functions that actually execute) — **not** a c8 counting change.
- `pnpm check` (the 100% coverage gate) is green on the fully integrated branch.

## Rebased onto latest `main`

This branch is rebased onto the current `main` tip (which includes the `nx` 21.6.10 → 22.7.5, `jsdom` 25 → 26, and `@playwright/test` 1.60 upgrades, and the new `@packages/web-shell`). Each rebase auto-merged every `package.json` (the c8 line is distinct from main's concurrent dependency bumps); the only manual conflict was `pnpm-lock.yaml`, regenerated from main's lockfile via `pnpm install` so `c8@10.1.3` is fully pruned and the tree stays on a single c8 version. `pnpm check` re-verified green after the final rebase (nx 22 + c8 11).

https://claude.ai/code/session_01URdFL9E4hW4WA8Kt3Zt2CF