### PR TITLE
docs(blog): add post on saving LinkedIn posts with paragraphs intact

### DIFF
--- a/projects/hutch/src/runtime/web/pages/blog/posts/save-linkedin-posts-to-read-later.md
+++ b/projects/hutch/src/runtime/web/pages/blog/posts/save-linkedin-posts-to-read-later.md
@@ -1,0 +1,47 @@
+---
+title: "Save a LinkedIn Post and Keep Its Paragraphs"
+description: "Readplace now saves LinkedIn posts with their paragraph breaks intact. The page hides its paragraphs inside an inline tag split by double line breaks, and most readers flatten that into one block. Readplace rebuilds the paragraphs, so a saved post reads the way it was written. The same fix helps Substack notes and plain blog posts."
+slug: "save-linkedin-posts-to-read-later"
+date: "2026-06-14"
+author: "Fayner Brack"
+keywords: "save linkedin posts, read it later linkedin, save linkedin post to read later, linkedin post reader, save substack notes, clean reader view, readplace, read it later app, save articles for later"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Readplace now saves LinkedIn posts with their paragraph breaks intact. A LinkedIn post separates thoughts with blank lines, but the page builds those breaks in a way most readers flatten into one block of text. Readplace spots that layout and rebuilds the paragraphs, so a saved post reads the way the author spaced it. The same fix helps Substack notes and plain blog posts built the same way. You save the link as usual, and the reader does the rest.
+
+</div>
+</details>
+
+You read a sharp LinkedIn post. You want it later, away from the feed and the noise around it. So you save it to Readplace. The post used to land in your reader as one solid block of text, every paragraph break gone, the rhythm of the writing lost.
+
+That gap is closed. A saved LinkedIn post now keeps its paragraphs, the way the author spaced them out.
+
+## Why the paragraphs went missing
+
+LinkedIn writes a post in a way that looks fine on LinkedIn and falls apart elsewhere. It wraps the whole post in an inline tag, the kind meant for a few words inside a sentence, not for a stack of paragraphs. Between each thought it drops two line breaks in place of real paragraph markup.
+
+Most reader tools count on real paragraph tags. Hand them two line breaks inside an inline wrapper and they give up, pour the words into one paragraph, and hand you a wall of text. The post reads like a run-on note.
+
+## What Readplace does now
+
+Readplace reads the shape of the page first. It looks for that exact pattern: an inline wrapper that holds only text and line breaks, with a double break between each chunk. It finds a match and re-tags the wrapper as a block. The reader engine then rebuilds the paragraphs on its own, the same engine behind every saved article.
+
+The check looks at structure, not at the website name. A page built with proper paragraph tags is left untouched. So the fix helps any post shaped this way, not one site.
+
+## Substack notes and plain blogs too
+
+Plenty of writing tools build pages the same way. Substack notes use it. A lot of simple blog editors do too. Save one of those and you used to get the same flat block. Now they come through with clean paragraphs, the same as a LinkedIn post.
+
+## Why this matters to you
+
+You save a post to read it well, not to fight the layout. Spacing carries meaning. Three short lines read as three points. A blank line before a closing thought gives that thought weight. Lose the spacing and you lose part of what the writer meant.
+
+Readplace does this work on its side, on every save. You paste the link the same way as before.
+
+## Try it
+
+Find a LinkedIn post worth a second read. Copy its link and paste it into your Readplace queue. It opens with its paragraphs intact, a title on top, and a short summary. Start at [readplace.com](/) or [install the browser extension](https://readplace.com/install).


### PR DESCRIPTION
## What

Adds a new blog post: **"Save a LinkedIn Post and Keep Its Paragraphs"** (`save-linkedin-posts-to-read-later.md`, dated 2026-06-14).

## Why

Reviewed commits that landed on `main` after the last published post (2026-06-13). The standout customer-facing change since then is the article-parser fix in #559, which promotes `<br><br>`-separated paragraph hosts to block elements so Mozilla Readability rebuilds paragraph structure. This keeps saved LinkedIn posts (and Substack notes and plain WYSIWYG blogs) readable instead of collapsing them into one wall of text.

Other post-2026-06-13 commits were dependency/build bumps (express, esbuild, nx, jsdom, playwright), CI changes, and internal refactors (web-shell extraction), none suited to external communication. Agent-discovery work was already covered by two recent posts.

## Topic selection

"Save LinkedIn posts to read later" is a strong SEO/conversion topic. Professionals who save LinkedIn posts map directly to paying customers, and LinkedIn is hard to save cleanly elsewhere.

## Notes

- Body is ~520 words (400–800 range), follows the house voice and frontmatter conventions of existing posts.
- No pricing or founding-member references included.
- `pnpm nx run hutch:check` passes: blog discovery, rendering, SEO, lint, type-check, and 100% coverage thresholds all green.

https://claude.ai/code/session_01JXepe2bK5e9Y8gy3kZ3MFx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXepe2bK5e9Y8gy3kZ3MFx)_