### PR TITLE
build: upgrade typescript 5.9.3 to 6.0.3 across the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "knip": "6.14.2",
     "minimatch": "10.2.5",
     "nx": "22.7.5",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       knip:
         specifier: 6.14.2
         version: 6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -39,8 +39,8 @@ importers:
         specifier: 22.7.5
         version: 22.7.5
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/blog-site:
     dependencies:
@@ -74,10 +74,10 @@ importers:
         version: link:../../src/packages/hutch-infra-components
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/aws-lambda':
         specifier: 8.10.161
         version: 8.10.161
@@ -110,7 +110,7 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
@@ -121,8 +121,8 @@ importers:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/browser-extension-core:
     dependencies:
@@ -156,13 +156,13 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       selenium-webdriver:
         specifier: 4.44.0
         version: 4.44.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/extensions/chrome-extension:
     dependencies:
@@ -187,10 +187,10 @@ importers:
         version: link:../../../src/packages/test-phase-runner
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -208,13 +208,13 @@ importers:
         version: 0.28.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       selenium-webdriver:
         specifier: 4.44.0
         version: 4.44.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/extensions/firefox-extension:
     dependencies:
@@ -239,10 +239,10 @@ importers:
         version: link:../../../src/packages/test-phase-runner
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -257,13 +257,13 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       selenium-webdriver:
         specifier: 4.44.0
         version: 4.44.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       web-ext:
         specifier: 10.3.0
         version: 10.3.0(express@5.2.1)(jiti@2.7.0)
@@ -393,10 +393,10 @@ importers:
         version: 1.60.0
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@testing-library/dom':
         specifier: '10'
         version: 10.4.1
@@ -438,7 +438,7 @@ importers:
         version: 0.28.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
@@ -452,8 +452,8 @@ importers:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/platform:
     dependencies:
@@ -463,13 +463,13 @@ importers:
     devDependencies:
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   projects/save-link:
     dependencies:
@@ -557,10 +557,10 @@ importers:
         version: link:../../src/packages/test-phase-runner
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/aws-lambda':
         specifier: 8.10.161
         version: 8.10.161
@@ -578,10 +578,10 @@ importers:
         version: 0.28.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-parser:
     dependencies:
@@ -615,10 +615,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-resource-unique-id:
     devDependencies:
@@ -633,10 +633,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-state-types:
     dependencies:
@@ -655,10 +655,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/article-store:
     dependencies:
@@ -689,10 +689,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/check-failed-articles:
     dependencies:
@@ -710,8 +710,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/check-stuck-articles:
     dependencies:
@@ -729,8 +729,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/check-unused-css:
     dependencies:
@@ -767,10 +767,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/domain:
     dependencies:
@@ -795,10 +795,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/extract-links-from-page:
     dependencies:
@@ -823,10 +823,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/finalize-article:
     dependencies:
@@ -857,10 +857,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/hutch-infra-components:
     dependencies:
@@ -876,10 +876,10 @@ importers:
     devDependencies:
       '@pulumi/aws':
         specifier: 7.32.0
-        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@pulumi/pulumi':
         specifier: 3.244.0
-        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+        version: 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       '@types/aws-lambda':
         specifier: 8.10.161
         version: 8.10.161
@@ -894,10 +894,10 @@ importers:
         version: 0.28.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/hutch-logger:
     devDependencies:
@@ -905,8 +905,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/hutch-storage-client:
     dependencies:
@@ -924,8 +924,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/onboarding-extension-signal:
     devDependencies:
@@ -933,8 +933,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/provider-contracts:
     dependencies:
@@ -958,8 +958,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/refresh-article-content:
     dependencies:
@@ -987,10 +987,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/retriable:
     devDependencies:
@@ -1005,10 +1005,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/test-fixtures:
     dependencies:
@@ -1054,10 +1054,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/test-phase-runner:
     devDependencies:
@@ -1069,10 +1069,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/time-left:
     devDependencies:
@@ -1087,10 +1087,10 @@ importers:
         version: 10.0.0
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/web-shell:
     dependencies:
@@ -1124,13 +1124,13 @@ importers:
         version: 5.2.1
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   src/packages/web-test-harness:
     dependencies:
@@ -1179,10 +1179,10 @@ importers:
         version: 5.2.1
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+        version: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -5896,8 +5896,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7112,7 +7112,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))':
+  '@jest/core@30.4.2(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -7128,7 +7128,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -7819,16 +7819,16 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@pulumi/aws@7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/aws@7.32.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)
+      '@pulumi/pulumi': 3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
       - ts-node
       - typescript
 
-  '@pulumi/pulumi@3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))(typescript@5.9.3)':
+  '@pulumi/pulumi@3.244.0(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@logdna/tail-file': 2.2.0
@@ -7858,8 +7858,8 @@ snapshots:
       tmp: 0.2.5
       upath: 1.2.0
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-node: 10.9.2(@types/node@22.19.19)(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9743,15 +9743,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  jest-cli@30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      '@jest/core': 30.4.2(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -9764,7 +9764,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  jest-config@30.4.2(@types/node@22.19.19)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -9791,7 +9791,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.19
-      ts-node: 10.9.2(@types/node@22.19.19)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.19.19)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10012,12 +10012,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3)):
+  jest@30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      '@jest/core': 30.4.2(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3))
+      jest-cli: 30.4.2(@types/node@22.19.19)(node-notifier@10.0.1)(ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3))
     optionalDependencies:
       node-notifier: 10.0.1
     transitivePeerDependencies:
@@ -11557,7 +11557,7 @@ snapshots:
 
   treeverse@3.0.0: {}
 
-  ts-node@10.9.2(@types/node@22.19.19)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.19.19)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -11571,7 +11571,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -11616,7 +11616,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 

--- a/projects/blog-site/package.json
+++ b/projects/blog-site/package.json
@@ -41,6 +41,6 @@
     "jsdom": "26.1.0",
     "supertest": "7.2.2",
     "tsx": "4.22.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/browser-extension-core/package.json
+++ b/projects/browser-extension-core/package.json
@@ -59,6 +59,6 @@
     "concurrently": "10.0.0",
     "jest": "30.4.2",
     "selenium-webdriver": "4.44.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/extensions/chrome-extension/package.json
+++ b/projects/extensions/chrome-extension/package.json
@@ -38,6 +38,6 @@
     "jest": "30.4.2",
     "@packages/check-unused-css": "workspace:*",
     "selenium-webdriver": "4.44.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/extensions/firefox-extension/package.json
+++ b/projects/extensions/firefox-extension/package.json
@@ -38,7 +38,7 @@
     "jest": "30.4.2",
     "@packages/check-unused-css": "workspace:*",
     "selenium-webdriver": "4.44.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "web-ext": "10.3.0"
   }
 }

--- a/projects/hutch/package.json
+++ b/projects/hutch/package.json
@@ -103,6 +103,6 @@
     "livereload": "0.10.3",
     "supertest": "7.2.2",
     "tsx": "4.22.3",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/platform/package.json
+++ b/projects/platform/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@pulumi/aws": "7.32.0",
     "@pulumi/pulumi": "3.244.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/projects/save-link/package.json
+++ b/projects/save-link/package.json
@@ -54,6 +54,6 @@
     "concurrently": "10.0.0",
     "esbuild": "catalog:",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-parser/package.json
+++ b/src/packages/article-parser/package.json
@@ -26,6 +26,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-resource-unique-id/package.json
+++ b/src/packages/article-resource-unique-id/package.json
@@ -18,6 +18,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-state-types/package.json
+++ b/src/packages/article-state-types/package.json
@@ -21,6 +21,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/article-store/package.json
+++ b/src/packages/article-store/package.json
@@ -25,6 +25,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/check-failed-articles/package.json
+++ b/src/packages/check-failed-articles/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/crawl-article/package.json
+++ b/src/packages/crawl-article/package.json
@@ -25,6 +25,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -63,6 +63,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/extract-links-from-page/package.json
+++ b/src/packages/extract-links-from-page/package.json
@@ -23,6 +23,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/finalize-article/package.json
+++ b/src/packages/finalize-article/package.json
@@ -31,6 +31,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/hutch-infra-components/package.json
+++ b/src/packages/hutch-infra-components/package.json
@@ -50,6 +50,6 @@
     "@types/jest": "30.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/hutch-logger/package.json
+++ b/src/packages/hutch-logger/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/hutch-storage-client/package.json
+++ b/src/packages/hutch-storage-client/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/onboarding-extension-signal/package.json
+++ b/src/packages/onboarding-extension-signal/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/provider-contracts/package.json
+++ b/src/packages/provider-contracts/package.json
@@ -135,6 +135,6 @@
   },
   "devDependencies": {
     "concurrently": "10.0.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/refresh-article-content/package.json
+++ b/src/packages/refresh-article-content/package.json
@@ -27,6 +27,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/retriable/package.json
+++ b/src/packages/retriable/package.json
@@ -18,6 +18,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -165,6 +165,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/test-phase-runner/package.json
+++ b/src/packages/test-phase-runner/package.json
@@ -18,6 +18,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/time-left/package.json
+++ b/src/packages/time-left/package.json
@@ -18,6 +18,6 @@
     "c8": "11.0.0",
     "concurrently": "10.0.0",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/web-shell/package.json
+++ b/src/packages/web-shell/package.json
@@ -42,6 +42,6 @@
     "express": "5.2.1",
     "jest": "30.4.2",
     "jsdom": "26.1.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/src/packages/web-test-harness/package.json
+++ b/src/packages/web-test-harness/package.json
@@ -37,6 +37,6 @@
     "concurrently": "10.0.0",
     "express": "5.2.1",
     "jest": "30.4.2",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/tsconfig.config.base.json
+++ b/tsconfig.config.base.json
@@ -12,6 +12,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "types": ["node", "jest"],
     "inlineSources": true,
     "incremental": true
   }


### PR DESCRIPTION
Upgrades `typescript` 5.9.3 → 6.0.3 across the workspace.

This is a clean rebuild of #554 on top of current `main`. #554 could not be rebased: every `typescript` bump sat on a `devDependencies` line adjacent to a sibling dep that `main` had since bumped (nx 22.7.5, jest 30.4.2, express 5.2.1, esbuild 0.28.0, c8 11, knip 6.14.2), so the 3-way merge produced 17 unresolvable `package.json` conflicts and the in-CI conflict-fixer repeatedly ran out of time inside the cold `pnpm check` before it could push.

## What changed

- `typescript` 5.9.3 → 6.0.3 in all 30 `package.json` files (including the new `blog-site` from #555).
- `tsconfig.config.base.json` gains two lines to absorb TS 6.0's changed defaults:
  - `"types": ["node", "jest"]` — TS 6.0 no longer auto-includes every `@types/*` package (`compilerOptions.types` now defaults to `[]`). These are the only ambient (un-imported) type packages the code uses; chrome/browser globals come from the imported `webextension-polyfill` and are unaffected.
  - `"ignoreDeprecations": "6.0"` — `moduleResolution: "node"` (node10) is now a hard error. A `nodenext` migration changes CJS emit and breaks runtime interop, so the deprecation is silenced to keep emit identical; the real `nodenext`/`bundler` migration is left as a follow-up.
- `pnpm-lock.yaml` reconciled — churn is typescript-only (117/117 symmetric); `@types/node` held at 22.19.19.

## Verification

Cold `pnpm check` (compile + lint + 100% coverage gate) passes locally across all 30 projects — the exact gate that kept timing out in the conflict-fixer job on #554.

Supersedes #554.
