### PR TITLE
test(@packages/test-phase-runner): guard against TypeScript 7.0

### DIFF
--- a/src/packages/test-phase-runner/src/typescript-7-migration-guard.test.ts
+++ b/src/packages/test-phase-runner/src/typescript-7-migration-guard.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { version } from "typescript";
+
+describe("TypeScript 7.0 migration guard", () => {
+	it("keeps the workspace below TypeScript 7.0 while the base tsconfig relies on ignoreDeprecations", () => {
+		const [major] = version.split(".").map(Number);
+
+		assert.ok(
+			major < 7,
+			`TypeScript ${version}: 7.0 removes node10 module resolution and the other ` +
+				`6.0-deprecated compiler options, so the "ignoreDeprecations": "6.0" escape hatch ` +
+				`in tsconfig.config.base.json stops silencing anything and the build hard-fails. ` +
+				`Before bumping to 7.x, migrate moduleResolution "node" to "nodenext" (or "bundler") ` +
+				`and remove ignoreDeprecations. The earlier nodenext attempt changed CJS emit and ` +
+				`broke hutch /auth/checkout/success and a password-reset dynamic import — redo it deliberately.`,
+		);
+	});
+});


### PR DESCRIPTION
Addresses the low-priority follow-up from #565: make the nodenext/bundler migration's revisit condition durable instead of only a PR note.

## Background

#565 added `"ignoreDeprecations": "6.0"` to `tsconfig.config.base.json` — the sanctioned escape hatch that lets `moduleResolution: "node"` (node10) keep working under TypeScript 6.0 with identical emit. That bridge is **time-bounded**: TypeScript 7.0 (the Go-native compiler) removes node10 resolution and the other 6.0-deprecated options entirely, at which point `ignoreDeprecations` silences nothing and the build hard-fails.

## What this does

Adds a single guard test in `@packages/test-phase-runner` that reads the installed compiler version and asserts it is below `7.x`. The failure message carries the full migration context (what breaks, why, and the known blocker — the earlier nodenext attempt changed CJS emit and broke hutch `/auth/checkout/success` + a password-reset dynamic import).

```ts
const [major] = version.split(".").map(Number);
assert.ok(major < 7, `TypeScript ${version}: … migrate moduleResolution "node" -> "nodenext" …`);
```

When someone bumps TypeScript to 7.0, this test fails **before** the cryptic compiler errors do, forcing the migration to be done deliberately rather than discovered mid-upgrade.

## Why a failing test rather than a tracked issue

The repo's convention is to encode revisit conditions in code (a failing test / a flag with an owner) rather than leave them implicit. A test lives in the build, can't be closed-and-forgotten, and trips at exactly the right moment. (The review suggested a GitHub issue; this is the stronger, in-repo form of the same intent.)

## Verification

`@packages/test-phase-runner`'s `check` (lint + jest) passes locally with the new test (2 suites / 34 tests). The test is excluded from coverage as a `*.test.ts` file and imports no package source, so nothing else is affected.

Follow-up to #565.
