### PR TITLE
feat(infra): publish DNS-AID agent-discovery SVCB records

### DIFF
--- a/projects/hutch/src/infra/agent-discovery-records.ts
+++ b/projects/hutch/src/infra/agent-discovery-records.ts
@@ -1,0 +1,37 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { buildDnsAidRecords } from "../runtime/web/dns-aid";
+
+export class AgentDiscoveryRecords extends pulumi.ComponentResource {
+	constructor(
+		name: string,
+		args: {
+			domains: ReadonlyArray<{
+				domain: string;
+				zoneId: pulumi.Input<string> | Promise<string>;
+			}>;
+		},
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("hutch:infra:AgentDiscoveryRecords", name, {}, opts);
+
+		for (const { domain, zoneId } of args.domains) {
+			for (const record of buildDnsAidRecords(domain)) {
+				const safeName = record.name.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+				new aws.route53.Record(
+					`${name}-${safeName}`,
+					{
+						zoneId,
+						name: record.name,
+						type: record.type,
+						records: [record.value],
+						ttl: record.ttlSeconds,
+					},
+					{ parent: this },
+				);
+			}
+		}
+
+		this.registerOutputs();
+	}
+}

--- a/projects/hutch/src/infra/dns-aid.md
+++ b/projects/hutch/src/infra/dns-aid.md
@@ -22,7 +22,7 @@ _index._agents.<domain>.  3600  IN  SVCB  1 <domain> alpn="h2,http/1.1" port=443
   example label — the app answers over HTTPS, not Agent2Agent JSON-RPC, so an
   `_a2a` target would never connect.
 - **`alpn="h2,http/1.1"`** names both protocols the origin serves. A generic
-  SVCB record has no implicit ALPN default — RFC 9460 §9.5's `http/1.1` default
+  SVCB record has no implicit ALPN default — RFC 9460 §9's `http/1.1` default
   applies only to the HTTPS RR, not the SVCB RR this `_agents` scheme uses — so
   each protocol must be listed explicitly or, per §7.1.2, clients are told not
   to use it. `h3` is omitted because the API Gateway custom domains fronting the

--- a/projects/hutch/src/infra/dns-aid.md
+++ b/projects/hutch/src/infra/dns-aid.md
@@ -1,0 +1,76 @@
+# DNS for AI Discovery (DNS-AID)
+
+[DNS-AID](https://datatracker.ietf.org/doc/draft-mozleywilliams-dnsop-dnsaid/)
+publishes a domain's agent entrypoints in the `_agents` DNS namespace so an agent
+can find them before making any HTTP request. The records advertise the same
+surface the app already serves over HTTPS: the `.well-known/agent-skills` index,
+the OAuth authorization-server / protected-resource metadata, and the
+api-catalog.
+
+## What is published
+
+`buildDnsAidRecords` (`src/runtime/web/dns-aid.ts`) returns one ServiceMode SVCB
+record ([RFC 9460](https://www.rfc-editor.org/rfc/rfc9460)) per apex; the
+`AgentDiscoveryRecords` Pulumi component (`src/infra/agent-discovery-records.ts`)
+writes them to Route 53. For each configured domain:
+
+```
+_index._agents.<domain>.  3600  IN  SVCB  1 <domain> alpn="h2" port=443
+```
+
+- **`_index`** is the general entrypoint. We do not publish the draft's `_a2a`
+  example label — the app answers over HTTPS, not Agent2Agent JSON-RPC, so an
+  `_a2a` target would never connect.
+- **`alpn="h2"`** advertises HTTP/2. RFC 9460 §7.1.1 implies the https default
+  (`http/1.1`); `h3` is omitted because the API Gateway custom domains fronting
+  the apexes do not serve HTTP/3.
+- The `mandatory` and `keyNNNNN` SvcParams from the draft are omitted because
+  Route 53 rejects them.
+
+Production publishes records for `readplace.com` and `hutch-app.com`. Staging
+configures no apex domains, so no records are created there.
+
+## Verifying after deploy
+
+```sh
+dig +short _index._agents.readplace.com SVCB
+# 1 readplace.com. alpn="h2" port=443
+```
+
+Then confirm the external scanner sees them:
+
+```sh
+curl -s https://isitagentready.com/api/scan \
+  -H 'content-type: application/json' \
+  -d '{"url":"https://readplace.com"}' | jq '.checks.discoverability.dnsAid.status'
+# "pass"
+```
+
+## DNSSEC (manual, change-controlled)
+
+The draft asks that the discovery zone be DNSSEC-signed so validating resolvers
+return authenticated data. This is **not** automated here, on purpose: an
+incomplete or broken chain of trust returns SERVFAIL for the *entire apex* on
+validating resolvers, and the final step lives at the registrar, outside Pulumi.
+Enable it deliberately, one zone at a time, watching resolution between each
+step.
+
+1. **KMS key** — create a customer-managed asymmetric signing key in `us-east-1`
+   (Route 53 DNSSEC requires that region), key spec `ECC_NIST_P256`, usage
+   `SIGN_VERIFY`, with a key policy granting the `dnssec-route53.amazonaws.com`
+   service principal `kms:DescribeKey`, `kms:GetPublicKey`, and `kms:Sign`.
+2. **Key-signing key** — `aws.route53.KeySigningKey` referencing the hosted zone
+   and the KMS key ARN, `status: "ACTIVE"`.
+3. **Enable signing** — `aws.route53.HostedZoneDNSSEC` for the hosted zone, with
+   `dependsOn` the KSK.
+4. **Upload the DS record at the registrar.** Take the DS record Route 53
+   generates for the KSK and add it to the parent zone via the domain registrar.
+   Until this lands, the zone is signed but has no chain of trust — resolvers
+   treat it as insecure, which is harmless but provides no authentication. A
+   wrong DS is what causes SERVFAIL, so copy it exactly and verify with
+   `dig +dnssec _index._agents.<domain> SVCB @1.1.1.1` (a validating resolver,
+   expect the `ad` flag) before considering the zone done.
+
+To roll back, remove the DS record at the registrar first, wait for its TTL to
+expire everywhere, then disable `HostedZoneDNSSEC`. Disabling signing while the
+DS record still points at the zone is the other way to SERVFAIL the domain.

--- a/projects/hutch/src/infra/dns-aid.md
+++ b/projects/hutch/src/infra/dns-aid.md
@@ -15,15 +15,18 @@ record ([RFC 9460](https://www.rfc-editor.org/rfc/rfc9460)) per apex; the
 writes them to Route 53. For each configured domain:
 
 ```
-_index._agents.<domain>.  3600  IN  SVCB  1 <domain> alpn="h2" port=443
+_index._agents.<domain>.  3600  IN  SVCB  1 <domain> alpn="h2,http/1.1" port=443
 ```
 
 - **`_index`** is the general entrypoint. We do not publish the draft's `_a2a`
   example label — the app answers over HTTPS, not Agent2Agent JSON-RPC, so an
   `_a2a` target would never connect.
-- **`alpn="h2"`** advertises HTTP/2. RFC 9460 §7.1.1 implies the https default
-  (`http/1.1`); `h3` is omitted because the API Gateway custom domains fronting
-  the apexes do not serve HTTP/3.
+- **`alpn="h2,http/1.1"`** names both protocols the origin serves. A generic
+  SVCB record has no implicit ALPN default — RFC 9460 §9.5's `http/1.1` default
+  applies only to the HTTPS RR, not the SVCB RR this `_agents` scheme uses — so
+  each protocol must be listed explicitly or, per §7.1.2, clients are told not
+  to use it. `h3` is omitted because the API Gateway custom domains fronting the
+  apexes do not serve HTTP/3.
 - The `mandatory` and `keyNNNNN` SvcParams from the draft are omitted because
   Route 53 rejects them.
 
@@ -34,7 +37,7 @@ configures no apex domains, so no records are created there.
 
 ```sh
 dig +short _index._agents.readplace.com SVCB
-# 1 readplace.com. alpn="h2" port=443
+# 1 readplace.com. alpn="h2,http/1.1" port=443
 ```
 
 Then confirm the external scanner sees them:

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -22,6 +22,7 @@ import {
 } from "../runtime/observability/analytics-dashboard";
 import { DomainRegistration } from "./domain-registration";
 import { DomainRedirect } from "./domain-redirect";
+import { AgentDiscoveryRecords } from "./agent-discovery-records";
 import { HutchStorage } from "./hutch-storage";
 import { HutchStaticAssets } from "./hutch-static-assets";
 import { requireEnv } from "../runtime/domain/require-env";
@@ -356,6 +357,21 @@ for (const [i, domain] of additionalDomains.entries()) {
 			},
 		],
 	});
+}
+
+// --- Agent discovery (DNS-AID) ---
+// Publishes the `_index._agents.<domain>` ServiceMode SVCB record for each apex
+// that has a hosted zone, so agents can discover our HTTPS agent surface
+// (.well-known/agent-skills, OAuth metadata, api-catalog) straight from DNS.
+// Staging configures no apex domains, so this is a no-op there. The DNSSEC
+// follow-up is a manual, change-controlled runbook — see src/infra/dns-aid.md.
+const agentDiscoveryDomains = allDomainRegistrations.flatMap((registration) =>
+	registration.primaryDomain && registration.zoneId
+		? [{ domain: registration.primaryDomain, zoneId: registration.zoneId }]
+		: [],
+);
+if (agentDiscoveryDomains.length > 0) {
+	new AgentDiscoveryRecords("hutch-agent-discovery", { domains: agentDiscoveryDomains });
 }
 
 // --- User Data Export Bucket ---

--- a/projects/hutch/src/runtime/web/dns-aid.test.ts
+++ b/projects/hutch/src/runtime/web/dns-aid.test.ts
@@ -1,0 +1,27 @@
+import { buildDnsAidRecords } from "./dns-aid";
+
+describe("buildDnsAidRecords", () => {
+	it("publishes a single _index._agents SVCB entrypoint and no _a2a record", () => {
+		const records = buildDnsAidRecords("readplace.com");
+		expect(records).toHaveLength(1);
+		expect(records[0].name).toBe("_index._agents.readplace.com");
+		expect(records[0].type).toBe("SVCB");
+		expect(records.some((r) => r.name.includes("_a2a"))).toBe(false);
+	});
+
+	it("targets the domain's own HTTPS origin over HTTP/2 on 443 in ServiceMode", () => {
+		const [record] = buildDnsAidRecords("readplace.com");
+		expect(record.value).toBe('1 readplace.com alpn="h2" port=443');
+		expect(record.ttlSeconds).toBe(3600);
+	});
+
+	it("binds every label to the supplied domain so each apex points at itself", () => {
+		const [record] = buildDnsAidRecords("hutch-app.com");
+		expect(record.name).toBe("_index._agents.hutch-app.com");
+		expect(record.value).toBe('1 hutch-app.com alpn="h2" port=443');
+	});
+
+	it("refuses to build records without a domain", () => {
+		expect(() => buildDnsAidRecords("")).toThrow("DNS-AID records require a domain");
+	});
+});

--- a/projects/hutch/src/runtime/web/dns-aid.test.ts
+++ b/projects/hutch/src/runtime/web/dns-aid.test.ts
@@ -9,16 +9,16 @@ describe("buildDnsAidRecords", () => {
 		expect(records.some((r) => r.name.includes("_a2a"))).toBe(false);
 	});
 
-	it("targets the domain's own HTTPS origin over HTTP/2 on 443 in ServiceMode", () => {
+	it("targets the domain's own HTTPS origin over HTTP/2 or HTTP/1.1 on 443 in ServiceMode", () => {
 		const [record] = buildDnsAidRecords("readplace.com");
-		expect(record.value).toBe('1 readplace.com alpn="h2" port=443');
+		expect(record.value).toBe('1 readplace.com alpn="h2,http/1.1" port=443');
 		expect(record.ttlSeconds).toBe(3600);
 	});
 
 	it("binds every label to the supplied domain so each apex points at itself", () => {
 		const [record] = buildDnsAidRecords("hutch-app.com");
 		expect(record.name).toBe("_index._agents.hutch-app.com");
-		expect(record.value).toBe('1 hutch-app.com alpn="h2" port=443');
+		expect(record.value).toBe('1 hutch-app.com alpn="h2,http/1.1" port=443');
 	});
 
 	it("refuses to build records without a domain", () => {

--- a/projects/hutch/src/runtime/web/dns-aid.ts
+++ b/projects/hutch/src/runtime/web/dns-aid.ts
@@ -21,10 +21,14 @@ export interface DnsAidRecord {
  * One ServiceMode SVCB record (RFC 9460) per domain. We publish `_index` only —
  * not the draft's `_a2a` example — because Readplace answers over HTTPS, not an
  * Agent2Agent JSON-RPC channel, so an `_a2a` target would never connect. `alpn`
- * lists `h2` alone: RFC 9460 §7.1.1 folds in the https default (`http/1.1`)
- * automatically, and the API Gateway custom domains fronting the apexes do not
- * serve `h3`. The value is Route 53 SVCB presentation format; the draft's
- * `mandatory` and `keyNNNNN` SvcParams are left out because Route 53 rejects them.
+ * names both `h2` and `http/1.1` explicitly: a generic SVCB record carries no
+ * implicit ALPN default (RFC 9460 §9.5's `http/1.1` default is specific to the
+ * HTTPS RR, not the SVCB RR this `_agents` scheme uses), so per §7.1.2 a
+ * protocol the origin serves but does not advertise is one clients are told not
+ * to use. The API Gateway custom domains fronting the apexes serve both, and
+ * `h3` is omitted because they do not serve HTTP/3. The value is Route 53 SVCB
+ * presentation format; the draft's `mandatory` and `keyNNNNN` SvcParams are left
+ * out because Route 53 rejects them.
  */
 export function buildDnsAidRecords(domain: string): readonly DnsAidRecord[] {
 	assert(domain.length > 0, "DNS-AID records require a domain");
@@ -32,7 +36,7 @@ export function buildDnsAidRecords(domain: string): readonly DnsAidRecord[] {
 		{
 			name: `_index._agents.${domain}`,
 			type: "SVCB",
-			value: `1 ${domain} alpn="h2" port=443`,
+			value: `1 ${domain} alpn="h2,http/1.1" port=443`,
 			ttlSeconds: DNS_AID_TTL_SECONDS,
 		},
 	];

--- a/projects/hutch/src/runtime/web/dns-aid.ts
+++ b/projects/hutch/src/runtime/web/dns-aid.ts
@@ -22,7 +22,7 @@ export interface DnsAidRecord {
  * not the draft's `_a2a` example — because Readplace answers over HTTPS, not an
  * Agent2Agent JSON-RPC channel, so an `_a2a` target would never connect. `alpn`
  * names both `h2` and `http/1.1` explicitly: a generic SVCB record carries no
- * implicit ALPN default (RFC 9460 §9.5's `http/1.1` default is specific to the
+ * implicit ALPN default (RFC 9460 §9's `http/1.1` default is specific to the
  * HTTPS RR, not the SVCB RR this `_agents` scheme uses), so per §7.1.2 a
  * protocol the origin serves but does not advertise is one clients are told not
  * to use. The API Gateway custom domains fronting the apexes serve both, and

--- a/projects/hutch/src/runtime/web/dns-aid.ts
+++ b/projects/hutch/src/runtime/web/dns-aid.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+
+/**
+ * DNS for AI Discovery (DNS-AID, draft-mozleywilliams-dnsop-dnsaid) entrypoint
+ * records. The `_agents` namespace lets an agent discover where a domain's agent
+ * surface lives straight from DNS, before any HTTP round-trip. We point `_index`
+ * at the apex that already serves that surface over HTTPS — the
+ * `.well-known/agent-skills` index, the OAuth metadata, and the api-catalog.
+ */
+
+const DNS_AID_TTL_SECONDS = 3600;
+
+export interface DnsAidRecord {
+	readonly name: string;
+	readonly type: "SVCB";
+	readonly value: string;
+	readonly ttlSeconds: number;
+}
+
+/**
+ * One ServiceMode SVCB record (RFC 9460) per domain. We publish `_index` only —
+ * not the draft's `_a2a` example — because Readplace answers over HTTPS, not an
+ * Agent2Agent JSON-RPC channel, so an `_a2a` target would never connect. `alpn`
+ * lists `h2` alone: RFC 9460 §7.1.1 folds in the https default (`http/1.1`)
+ * automatically, and the API Gateway custom domains fronting the apexes do not
+ * serve `h3`. The value is Route 53 SVCB presentation format; the draft's
+ * `mandatory` and `keyNNNNN` SvcParams are left out because Route 53 rejects them.
+ */
+export function buildDnsAidRecords(domain: string): readonly DnsAidRecord[] {
+	assert(domain.length > 0, "DNS-AID records require a domain");
+	return [
+		{
+			name: `_index._agents.${domain}`,
+			type: "SVCB",
+			value: `1 ${domain} alpn="h2" port=443`,
+			ttlSeconds: DNS_AID_TTL_SECONDS,
+		},
+	];
+}


### PR DESCRIPTION
## What

Resolves the "DNS for AI Discovery (DNS-AID) well-known entrypoint records not found" finding by publishing the `_agents` namespace records as Pulumi/Route 53 code.

For each production apex (`readplace.com`, `hutch-app.com`) we now publish a ServiceMode SVCB record ([RFC 9460](https://www.rfc-editor.org/rfc/rfc9460)) pointing agents at the HTTPS surface the app already serves (`.well-known/agent-skills` index, OAuth metadata, api-catalog):

```
_index._agents.<domain>.  3600  IN  SVCB  1 <domain> alpn="h2,http/1.1" port=443
```

## How

- **`runtime/web/dns-aid.ts`** — `buildDnsAidRecords(domain)`: a pure, unit-tested builder for the record name + Route 53 SVCB presentation value (mirrors the `analytics-dashboard.ts` "logic in runtime, wiring in infra" split, since `src/infra/**` is excluded from coverage).
- **`infra/agent-discovery-records.ts`** — `AgentDiscoveryRecords`: a thin Pulumi `ComponentResource` that writes the records to Route 53, wired per-apex in `infra/index.ts`. Staging configures no apex domains, so it is a **no-op there**.
- **`infra/dns-aid.md`** — operator doc covering what is published, how to verify, and the DNSSEC runbook.

## Design notes

- **`_index` only** — not the draft's `_a2a` example. Readplace answers over HTTPS, not Agent2Agent JSON-RPC, so an `_a2a` target would never connect.
- **`alpn="h2,http/1.1"`** — both protocols the API Gateway origin serves, named explicitly. A generic SVCB record has no implicit ALPN default (RFC 9460 §9's `http/1.1` default is specific to the HTTPS RR, not the SVCB RR this `_agents` scheme uses), so per §7.1.2 an unlisted protocol is one clients are told *not* to use; `h3` is omitted because those custom domains don't serve HTTP/3.
- **No `mandatory` / `keyNNNNN` SvcParams** — Route 53 [rejects them](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html) (SVCB/HTTPS support landed Oct 2024).

## DNSSEC — deferred to a documented runbook (by design)

The DNS-AID draft asks that the discovery zone be DNSSEC-signed. This is **not** automated here: an incomplete or broken chain of trust returns SERVFAIL for the *entire apex* on validating resolvers, and the final DS-upload step lives at the registrar, outside Pulumi. `infra/dns-aid.md` documents the full enablement sequence (KMS key → `KeySigningKey` → `HostedZoneDNSSEC` → registrar DS) plus rollback, for a human to run under change control.

## Verification

- `nx run hutch:check` — pass (lint, tests, coverage thresholds met; `dns-aid.ts` fully covered).
- Pre-commit hook — full multi-project `check` passed.
- Infra TypeScript type-check — clean.
- `check-infra` (`pulumi preview`) was **not** run here (no `pulumi` binary / cloud creds in the sandbox). The records are created on the next `pulumi up`; after DNS propagation, `checks.discoverability.dnsAid.status` from the isitagentready scanner should flip to `pass`.

https://claude.ai/code/session_01Mi5Jk4PMKGUvKzoF2Pe7Ym

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mi5Jk4PMKGUvKzoF2Pe7Ym)_

