### PR TITLE
feat(hutch): add MCP server, WebMCP, and DNS-AID agent discovery

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -183,6 +183,23 @@ const BUNDLES = [
 		].join("\n"),
 	},
 	{
+		entry: path.join(PROJECT_ROOT, "src/runtime/web/webmcp.client.ts"),
+		outfile: path.join(OUT_DIR, "webmcp.client.js"),
+		globalName: "WebMcp",
+		footer: [
+			// The WebMCP context lives on navigator in Chrome's preview and on
+			// document in the W3C draft; pass whichever exists. Saving navigates
+			// to the same /save entrypoint the UI uses, so the agent's save and a
+			// human click are one code path.
+			"var mcNav = window.navigator && window.navigator.modelContext;",
+			"var mcDoc = window.document && window.document.modelContext;",
+			"WebMcp.initWebMcp({",
+			"  modelContext: mcNav || mcDoc || null,",
+			"  navigateTo: function (url) { window.location.assign(url); }",
+			"});",
+		].join("\n"),
+	},
+	{
 		entry: path.join(
 			PROJECT_ROOT,
 			"src/runtime/web/shared/toast/toast.client.ts",

--- a/projects/hutch/src/infra/agent-discovery-dns.ts
+++ b/projects/hutch/src/infra/agent-discovery-dns.ts
@@ -1,0 +1,146 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+/**
+ * Publishes DNS for AI Discovery (DNS-AID) records so an agent can find
+ * Readplace's agent surface straight from DNS, and signs the zone with DNSSEC
+ * so a validating resolver returns authenticated answers.
+ *
+ * Two ServiceMode SVCB records are published under the `_agents` namespace:
+ *  - `_index._agents.<domain>` — the discovery entry point. It points at the
+ *    apex, which already serves the `/.well-known/agent-skills` index, the
+ *    OAuth metadata, and `llms.txt`.
+ *  - `_mcp._agents.<domain>`   — the MCP endpoint, whose Server Card and
+ *    Streamable HTTP transport live at `/.well-known/mcp/server-card.json` and
+ *    `/mcp` on the apex.
+ *
+ * Both target the apex over HTTP/2 on 443 with only the IANA-registered SvcParams
+ * (`alpn`, `port`) so Route 53 accepts the RDATA; the protocol-specific paths are
+ * resolved from the well-known documents the records lead an agent to.
+ */
+export class AgentDiscoveryDns extends pulumi.ComponentResource {
+	/** The DS record to hand the domain's registrar to complete the DNSSEC
+	 * chain of trust. Signing is enabled on the zone here, but a resolver only
+	 * validates once this DS is published in the parent zone — a deliberate,
+	 * out-of-band step because a wrong DS breaks resolution for the whole
+	 * domain. */
+	public readonly dsRecord: pulumi.Output<string>;
+
+	constructor(
+		name: string,
+		args: { domain: string; zoneId: pulumi.Input<string> },
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("hutch:infra:AgentDiscoveryDns", name, {}, opts);
+
+		// SVCB ServiceMode RDATA in Route 53's presentation format
+		// (`SvcPriority TargetName SvcParams`). Only IANA-registered SvcParamKeys
+		// are used — Route 53 rejects the experimental `keyNNNNN` form — so the
+		// DNS-AID-specific paths live in the well-known documents these records
+		// point an agent to, not in the RDATA.
+		const serviceValue = `1 ${args.domain} alpn="h2" port=443`;
+
+		new aws.route53.Record(
+			`${name}-agents-index`,
+			{
+				zoneId: args.zoneId,
+				name: `_index._agents.${args.domain}`,
+				type: "SVCB",
+				ttl: 3600,
+				records: [serviceValue],
+			},
+			{ parent: this },
+		);
+
+		new aws.route53.Record(
+			`${name}-agents-mcp`,
+			{
+				zoneId: args.zoneId,
+				name: `_mcp._agents.${args.domain}`,
+				type: "SVCB",
+				ttl: 3600,
+				records: [serviceValue],
+			},
+			{ parent: this },
+		);
+
+		// Route 53 DNSSEC requires the key-signing KMS key to be an asymmetric
+		// ECC_NIST_P256 SIGN_VERIFY key in us-east-1, regardless of where the rest
+		// of the stack runs.
+		const usEast1 = new aws.Provider(
+			`${name}-useast1`,
+			{ region: "us-east-1" },
+			{ parent: this },
+		);
+
+		const accountId = pulumi
+			.output(aws.getCallerIdentity({}))
+			.apply((identity) => identity.accountId);
+
+		// A custom key policy replaces the default, so it must re-grant the
+		// account root (or the deploy role loses access) alongside the Route 53
+		// DNSSEC service principal that signs and creates grants.
+		const keyPolicy = accountId.apply((id) =>
+			JSON.stringify({
+				Version: "2012-10-17",
+				Statement: [
+					{
+						Sid: "Enable IAM User Permissions",
+						Effect: "Allow",
+						Principal: { AWS: `arn:aws:iam::${id}:root` },
+						Action: "kms:*",
+						Resource: "*",
+					},
+					{
+						Sid: "AllowRoute53DnssecService",
+						Effect: "Allow",
+						Principal: { Service: "dnssec-route53.amazonaws.com" },
+						Action: ["kms:DescribeKey", "kms:GetPublicKey", "kms:Sign"],
+						Resource: "*",
+					},
+					{
+						Sid: "AllowRoute53DnssecCreateGrant",
+						Effect: "Allow",
+						Principal: { Service: "dnssec-route53.amazonaws.com" },
+						Action: "kms:CreateGrant",
+						Resource: "*",
+						Condition: { Bool: { "kms:GrantIsForAWSResource": "true" } },
+					},
+				],
+			}),
+		);
+
+		const signingKey = new aws.kms.Key(
+			`${name}-dnssec-kms`,
+			{
+				customerMasterKeySpec: "ECC_NIST_P256",
+				keyUsage: "SIGN_VERIFY",
+				deletionWindowInDays: 7,
+				policy: keyPolicy,
+			},
+			{ parent: this, provider: usEast1 },
+		);
+
+		const keySigningKey = new aws.route53.KeySigningKey(
+			`${name}-ksk`,
+			{
+				hostedZoneId: args.zoneId,
+				keyManagementServiceArn: signingKey.arn,
+				name: "readplace_agents_ksk",
+			},
+			{ parent: this },
+		);
+
+		new aws.route53.HostedZoneDnsSec(
+			`${name}-dnssec`,
+			{
+				hostedZoneId: args.zoneId,
+				signingStatus: "SIGNING",
+			},
+			{ parent: this, dependsOn: [keySigningKey] },
+		);
+
+		this.dsRecord = keySigningKey.dsRecord;
+		this.registerOutputs({ dsRecord: this.dsRecord });
+	}
+}

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -22,6 +22,7 @@ import {
 } from "../runtime/observability/analytics-dashboard";
 import { DomainRegistration } from "./domain-registration";
 import { DomainRedirect } from "./domain-redirect";
+import { AgentDiscoveryDns } from "./agent-discovery-dns";
 import { HutchStorage } from "./hutch-storage";
 import { HutchStaticAssets } from "./hutch-static-assets";
 import { requireEnv } from "../runtime/domain/require-env";
@@ -103,6 +104,18 @@ const additionalDomainRegistrations = additionalDomains.map((domain) =>
 );
 
 const allDomainRegistrations = [legacyDomainRegistration, ...additionalDomainRegistrations];
+
+/** DNS for AI Discovery (DNS-AID) records + DNSSEC on the primary zone. Hand
+ * `agentDnsDsRecord` to the registrar to complete the DNSSEC chain of trust. */
+const agentDiscoveryDns =
+	legacyPrimaryDomain && legacyDomainRegistration.zoneId
+		? new AgentDiscoveryDns("hutch-agent-dns", {
+				domain: legacyPrimaryDomain,
+				zoneId: legacyDomainRegistration.zoneId,
+			})
+		: undefined;
+
+export const agentDnsDsRecord = agentDiscoveryDns?.dsRecord;
 
 if (redirectDomains.length > 0 || redirectSubdomains.length > 0) {
 	assert(canonicalDomain, "redirectDomains requires domains to be configured");

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -127,6 +127,7 @@ import { initAgentSkills } from "./web/agent-skills/agent-skills";
 import { initMcpServer } from "./web/mcp/mcp-server";
 import { initMcpRoutes } from "./web/mcp/mcp.routes";
 import { buildMcpServerCard } from "./web/mcp/server-card";
+import { initResolveSaveAccess } from "./web/mcp/save-access";
 import { saveArticleFromUrl } from "./web/shared/save-article/save-article-from-url";
 import type { FoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import { initDualAuth } from "./web/dual-auth.middleware";
@@ -283,11 +284,29 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	const agentSkills = initAgentSkills();
 
+	const getEffectiveAccess = initGetEffectiveAccess({
+		findSubscriptionByUserId: deps.subscriptionProviders.findByUserId,
+		now: deps.now,
+	});
+
 	/** The MCP server's tools are the same writes/reads the hypermedia `/queue`
 	 * API performs, so an agent acting over MCP and the browser extension take
-	 * the identical save and list paths. */
+	 * the identical save and list paths — including the lockout and write-access
+	 * gates the extension save clears (resolved here from the bearer-derived
+	 * userId, since the request carries no session), so an MCP save is the
+	 * identical write rather than a back door around them. Listing stays open
+	 * while locked, matching `requireNotLocked`, so only `save_link` is gated. */
+	const resolveSaveAccess = initResolveSaveAccess({
+		findUserById: deps.findUserById,
+		getEffectiveAccess,
+		now: deps.now,
+	});
 	const mcpServer = initMcpServer({
 		saveLink: async ({ userId, url }) => {
+			const access = await resolveSaveAccess(userId);
+			if (!access.allowed) {
+				return { ok: false, message: access.message };
+			}
 			const validation = deps.validateSaveableUrl(url);
 			if (validation.status === "ERROR") {
 				return { ok: false, message: validation.error.message };
@@ -368,10 +387,6 @@ export function createApp(dependencies: AppDependencies): Express {
 	const markExtensionInstalled = initMarkExtensionInstalled();
 	app.use(markExtensionInstalled);
 
-	const getEffectiveAccess = initGetEffectiveAccess({
-		findSubscriptionByUserId: deps.subscriptionProviders.findByUserId,
-		now: deps.now,
-	});
 	const requireWriteAccess = initRequireWriteAccess({ getEffectiveAccess });
 	const buildBannerState = initBuildBannerState({
 		getEffectiveAccess,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -124,6 +124,10 @@ import { initEmbedRoutes } from "./web/pages/embed/embed.page";
 import { initExportRoutes } from "./web/pages/export/export.page";
 import { initAccountRoutes } from "./web/pages/account/account.page";
 import { initAgentSkills } from "./web/agent-skills/agent-skills";
+import { initMcpServer } from "./web/mcp/mcp-server";
+import { initMcpRoutes } from "./web/mcp/mcp.routes";
+import { buildMcpServerCard } from "./web/mcp/server-card";
+import { saveArticleFromUrl } from "./web/shared/save-article/save-article-from-url";
 import type { FoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import { initDualAuth } from "./web/dual-auth.middleware";
 import { initMarkExtensionInstalled } from "./web/mark-extension-installed.middleware";
@@ -278,6 +282,48 @@ export function createApp(dependencies: AppDependencies): Express {
 	});
 
 	const agentSkills = initAgentSkills();
+
+	/** The MCP server's tools are the same writes/reads the hypermedia `/queue`
+	 * API performs, so an agent acting over MCP and the browser extension take
+	 * the identical save and list paths. */
+	const mcpServer = initMcpServer({
+		saveLink: async ({ userId, url }) => {
+			const validation = deps.validateSaveableUrl(url);
+			if (validation.status === "ERROR") {
+				return { ok: false, message: validation.error.message };
+			}
+			try {
+				const freshness = await deps.refreshArticleIfStale({ url: validation.url });
+				const { saved } = await saveArticleFromUrl(deps, {
+					userId,
+					url: validation.url,
+					freshness,
+				});
+				return { ok: true, title: saved.metadata.title, url: saved.url };
+			} catch (error) {
+				deps.logError(
+					"MCP save_link failed",
+					error instanceof Error ? error : undefined,
+				);
+				return { ok: false, message: "Could not save the link right now." };
+			}
+		},
+		listQueue: async ({ userId, status }) => {
+			const result = await deps.findArticlesByUser({
+				userId,
+				status,
+				excludeContent: true,
+			});
+			return {
+				total: result.total,
+				articles: result.articles.map((article) => ({
+					url: article.url,
+					title: article.metadata.title,
+					status: article.status,
+				})),
+			};
+		},
+	});
 
 	const secureCookies = isHttpsOrigin(appOrigin);
 
@@ -479,6 +525,19 @@ export function createApp(dependencies: AppDependencies): Express {
 			res.type("text/markdown; charset=utf-8").send(skill.content);
 		});
 	}
+
+	app.get("/.well-known/mcp/server-card.json", (_req: Request, res: Response) => {
+		res.json(buildMcpServerCard(dependencies.baseUrl));
+	});
+
+	app.use(
+		"/mcp",
+		initMcpRoutes({
+			validateAccessToken: deps.validateAccessToken,
+			mcpServer,
+			baseUrl: dependencies.baseUrl,
+		}),
+	);
 
 	const extensionCors = cors({
 		origin: (origin, callback) => {

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -1,6 +1,10 @@
 import { initBase } from "@packages/web-shell";
 import { getEnv, requireEnv } from "../domain/require-env";
 
+/** Loaded on every page so an in-browser AI agent discovers Readplace's
+ * WebMCP tools (save_link) on load, regardless of which page it landed on. */
+const WEBMCP_SCRIPT = `<script src="/client-dist/webmcp.client.js" defer></script>`;
+
 /** Hutch's configured shell renderer. The presentational layout lives in
  * @packages/web-shell; this composition point binds it to hutch's runtime
  * config (the static-asset origin and the dev livereload flag) so every page
@@ -8,4 +12,5 @@ import { getEnv, requireEnv } from "../domain/require-env";
 export const Base = initBase({
 	staticBaseUrl: requireEnv("STATIC_BASE_URL"),
 	liveReload: Boolean(getEnv("LIVERELOAD")),
+	siteScripts: WEBMCP_SCRIPT,
 });

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
@@ -245,6 +245,28 @@ describe("initMcpServer", () => {
 			});
 		});
 
+		it("flags that only the first page is shown when the total exceeds the listed articles", async () => {
+			const listQueue = jest.fn(async () => ({
+				total: 5,
+				articles: [
+					{ url: "https://a.test/", title: "A", status: "unread" as const },
+					{ url: "https://b.test/", title: "B", status: "unread" as const },
+				],
+			}));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await server.handle(
+				{ jsonrpc: "2.0", id: 14, method: "tools/call", params: { name: "list_queue" } },
+				context,
+			);
+			expect(response).toMatchObject({
+				result: {
+					content: [
+						{ text: expect.stringContaining("You have 5 saved article(s); showing the first 2:") },
+					],
+				},
+			});
+		});
+
 		it("returns an error result for an invalid status", async () => {
 			const server = initMcpServer(fakeDeps());
 			const response = await server.handle(

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
@@ -1,0 +1,298 @@
+import { UserIdSchema } from "@packages/domain/user";
+import { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from "./protocol";
+import { initMcpServer, type McpServerDeps } from "./mcp-server";
+
+const userId = UserIdSchema.parse("00000000000000000000000000000001");
+const context = { userId };
+
+function fakeDeps(overrides?: Partial<McpServerDeps>): McpServerDeps {
+	return {
+		saveLink: async () => ({ ok: true, title: "Example", url: "https://example.com/" }),
+		listQueue: async () => ({ total: 0, articles: [] }),
+		...overrides,
+	};
+}
+
+describe("initMcpServer", () => {
+	it("answers initialize with the protocol version, tool capability, and server info", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+			context,
+		);
+		expect(response).toMatchObject({
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				protocolVersion: MCP_PROTOCOL_VERSION,
+				capabilities: { tools: { listChanged: false } },
+				serverInfo: MCP_SERVER_INFO,
+			},
+		});
+	});
+
+	it("answers ping with an empty result", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: "p", method: "ping" },
+			context,
+		);
+		expect(response).toEqual({ jsonrpc: "2.0", id: "p", result: {} });
+	});
+
+	it("lists both tools, in order, with their JSON Schemas", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: 2, method: "tools/list" },
+			context,
+		);
+		expect(response).toMatchObject({
+			id: 2,
+			result: {
+				tools: [
+					{ name: "save_link", inputSchema: { required: ["url"] } },
+					{ name: "list_queue", inputSchema: { type: "object" } },
+				],
+			},
+		});
+	});
+
+	it("returns no response for a notification (a message without an id)", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", method: "notifications/initialized" },
+			context,
+		);
+		expect(response).toBeUndefined();
+	});
+
+	it("treats a message with an explicit null id as a request and echoes null", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: null, method: "ping" },
+			context,
+		);
+		expect(response).toEqual({ jsonrpc: "2.0", id: null, result: {} });
+	});
+
+	it("rejects a structurally invalid message, echoing a string id", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle({ jsonrpc: "2.0", id: "abc" }, context);
+		expect(response).toEqual({
+			jsonrpc: "2.0",
+			id: "abc",
+			error: { code: -32600, message: "Invalid Request" },
+		});
+	});
+
+	it("rejects a structurally invalid message, echoing a numeric id", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle({ jsonrpc: "2.0", id: 42 }, context);
+		expect(response).toMatchObject({ id: 42, error: { code: -32600 } });
+	});
+
+	it("rejects an invalid object that carries no usable id with a null id", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle({ jsonrpc: "2.0" }, context);
+		expect(response).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32600, message: "Invalid Request" },
+		});
+	});
+
+	it("rejects a non-object message with a null id", async () => {
+		const server = initMcpServer(fakeDeps());
+		expect(await server.handle(["not", "an", "object"], context)).toMatchObject({
+			id: null,
+			error: { code: -32600 },
+		});
+		expect(await server.handle("a string", context)).toMatchObject({
+			id: null,
+			error: { code: -32600 },
+		});
+	});
+
+	it("returns method-not-found for an unknown method", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: 3, method: "resources/list" },
+			context,
+		);
+		expect(response).toMatchObject({
+			id: 3,
+			error: { code: -32601, message: "Method not found: resources/list" },
+		});
+	});
+
+	describe("tools/call save_link", () => {
+		it("saves the url for the authenticated user and reports the title", async () => {
+			const saveLink = jest.fn(async () => ({
+				ok: true as const,
+				title: "My Article",
+				url: "https://example.com/a",
+			}));
+			const server = initMcpServer(fakeDeps({ saveLink }));
+			const response = await server.handle(
+				{
+					jsonrpc: "2.0",
+					id: 4,
+					method: "tools/call",
+					params: { name: "save_link", arguments: { url: "https://example.com/a" } },
+				},
+				context,
+			);
+			expect(saveLink).toHaveBeenCalledWith({ userId, url: "https://example.com/a" });
+			expect(response).toMatchObject({
+				id: 4,
+				result: { content: [{ type: "text", text: expect.stringContaining("My Article") }] },
+			});
+			expect(response).not.toMatchObject({ result: { isError: true } });
+		});
+
+		it("surfaces a save rejection as an error result", async () => {
+			const saveLink = jest.fn(async () => ({ ok: false as const, message: "Not a saveable URL" }));
+			const server = initMcpServer(fakeDeps({ saveLink }));
+			const response = await server.handle(
+				{
+					jsonrpc: "2.0",
+					id: 5,
+					method: "tools/call",
+					params: { name: "save_link", arguments: { url: "chrome://x" } },
+				},
+				context,
+			);
+			expect(response).toMatchObject({
+				id: 5,
+				result: { content: [{ type: "text", text: "Not a saveable URL" }], isError: true },
+			});
+		});
+
+		it("returns an error result when the url argument is missing", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await server.handle(
+				{ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "save_link" } },
+				context,
+			);
+			expect(response).toMatchObject({
+				id: 6,
+				result: { isError: true, content: [{ text: expect.stringContaining("url") }] },
+			});
+		});
+
+		it("returns an error result when the save throws", async () => {
+			const saveLink = jest.fn(async () => {
+				throw new Error("boom");
+			});
+			const server = initMcpServer(fakeDeps({ saveLink }));
+			const response = await server.handle(
+				{
+					jsonrpc: "2.0",
+					id: 7,
+					method: "tools/call",
+					params: { name: "save_link", arguments: { url: "https://example.com/a" } },
+				},
+				context,
+			);
+			expect(response).toMatchObject({
+				id: 7,
+				result: { isError: true, content: [{ text: expect.stringContaining("boom") }] },
+			});
+		});
+	});
+
+	describe("tools/call list_queue", () => {
+		it("reports an empty queue", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await server.handle(
+				{ jsonrpc: "2.0", id: 8, method: "tools/call", params: { name: "list_queue" } },
+				context,
+			);
+			expect(response).toMatchObject({
+				id: 8,
+				result: { content: [{ type: "text", text: "Your Readplace queue is empty." }] },
+			});
+		});
+
+		it("formats saved articles and forwards the status filter", async () => {
+			const listQueue = jest.fn(async () => ({
+				total: 2,
+				articles: [
+					{ url: "https://a.test/", title: "A", status: "unread" as const },
+					{ url: "https://b.test/", title: "", status: "read" as const },
+				],
+			}));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await server.handle(
+				{
+					jsonrpc: "2.0",
+					id: 9,
+					method: "tools/call",
+					params: { name: "list_queue", arguments: { status: "unread" } },
+				},
+				context,
+			);
+			expect(listQueue).toHaveBeenCalledWith({ userId, status: "unread" });
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("You have 2 saved article(s)") }] },
+			});
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("https://a.test/") }] },
+			});
+			// Falls back to the url when the title is still empty (content loading).
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("https://b.test/") }] },
+			});
+		});
+
+		it("returns an error result for an invalid status", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await server.handle(
+				{
+					jsonrpc: "2.0",
+					id: 10,
+					method: "tools/call",
+					params: { name: "list_queue", arguments: { status: "archived" } },
+				},
+				context,
+			);
+			expect(response).toMatchObject({ id: 10, result: { isError: true } });
+		});
+
+		it("returns an error result when the listing throws", async () => {
+			const listQueue = jest.fn(async () => {
+				throw new Error("db down");
+			});
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await server.handle(
+				{ jsonrpc: "2.0", id: 11, method: "tools/call", params: { name: "list_queue" } },
+				context,
+			);
+			expect(response).toMatchObject({
+				id: 11,
+				result: { isError: true, content: [{ text: expect.stringContaining("db down") }] },
+			});
+		});
+	});
+
+	it("rejects tools/call with malformed params", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: 12, method: "tools/call", params: { wrong: true } },
+			context,
+		);
+		expect(response).toMatchObject({ id: 12, error: { code: -32602 } });
+	});
+
+	it("rejects tools/call for an unknown tool", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: 13, method: "tools/call", params: { name: "delete_everything" } },
+			context,
+		);
+		expect(response).toMatchObject({
+			id: 13,
+			error: { code: -32602, message: "Unknown tool: delete_everything" },
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.ts
@@ -1,0 +1,251 @@
+import { z } from "zod";
+import type { UserId } from "@packages/domain/user";
+import type { ArticleStatus } from "@packages/domain/article";
+import { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from "./protocol";
+import {
+	LIST_QUEUE_TOOL,
+	ListQueueArgs,
+	SAVE_LINK_TOOL,
+	SaveLinkArgs,
+	TOOL_DEFINITIONS,
+} from "./tool-definitions";
+
+type SaveLinkResult =
+	| { readonly ok: true; readonly title: string; readonly url: string }
+	| { readonly ok: false; readonly message: string };
+
+interface QueueArticle {
+	readonly url: string;
+	readonly title: string;
+	readonly status: ArticleStatus;
+}
+
+interface ListQueueResult {
+	readonly total: number;
+	readonly articles: readonly QueueArticle[];
+}
+
+/** The domain operations the tools delegate to. The composition root wires
+ * these to the same save/list pipeline the hypermedia `/queue` API uses, so an
+ * MCP `save_link` and an extension save are the identical write. */
+export interface McpServerDeps {
+	saveLink: (params: {
+		userId: UserId;
+		url: string;
+	}) => Promise<SaveLinkResult>;
+	listQueue: (params: {
+		userId: UserId;
+		status?: ArticleStatus;
+	}) => Promise<ListQueueResult>;
+}
+
+/** The authenticated caller a request runs as. Resolved from the OAuth bearer
+ * token by the transport before a message reaches the server. */
+interface McpRequestContext {
+	readonly userId: UserId;
+}
+
+type JsonRpcId = string | number | null;
+
+interface JsonRpcSuccess {
+	readonly jsonrpc: "2.0";
+	readonly id: JsonRpcId;
+	readonly result: unknown;
+}
+
+interface JsonRpcFailure {
+	readonly jsonrpc: "2.0";
+	readonly id: JsonRpcId;
+	readonly error: { readonly code: number; readonly message: string };
+}
+
+type JsonRpcResponse = JsonRpcSuccess | JsonRpcFailure;
+
+interface TextContent {
+	readonly type: "text";
+	readonly text: string;
+}
+
+interface ToolResult {
+	readonly content: readonly TextContent[];
+	readonly isError?: boolean;
+}
+
+export interface McpServer {
+	/** Handle one JSON-RPC message. Resolves to the response for a request, or
+	 * `undefined` for a notification (which, per JSON-RPC, gets no reply). */
+	handle: (
+		message: unknown,
+		context: McpRequestContext,
+	) => Promise<JsonRpcResponse | undefined>;
+}
+
+const EnvelopeSchema = z.object({
+	jsonrpc: z.literal("2.0"),
+	id: z.union([z.string(), z.number(), z.null()]).optional(),
+	method: z.string(),
+	params: z.unknown().optional(),
+});
+
+const ToolCallParams = z.object({
+	name: z.string(),
+	arguments: z.unknown().optional(),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Best-effort id for an error reply to a malformed message: echo a string or
+ * number id if one is present, else null (JSON-RPC's "unknown id"). */
+function extractId(raw: unknown): JsonRpcId {
+	if (isRecord(raw)) {
+		const id = raw.id;
+		if (typeof id === "string" || typeof id === "number") return id;
+	}
+	return null;
+}
+
+function success(id: JsonRpcId, result: unknown): JsonRpcSuccess {
+	return { jsonrpc: "2.0", id, result };
+}
+
+function failure(id: JsonRpcId, code: number, message: string): JsonRpcFailure {
+	return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function text(value: string): ToolResult {
+	return { content: [{ type: "text", text: value }] };
+}
+
+function toolError(value: string): ToolResult {
+	return { content: [{ type: "text", text: value }], isError: true };
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export function initMcpServer(deps: McpServerDeps): McpServer {
+	function initializeResult(): unknown {
+		return {
+			protocolVersion: MCP_PROTOCOL_VERSION,
+			capabilities: { tools: { listChanged: false } },
+			serverInfo: MCP_SERVER_INFO,
+			instructions:
+				"Use save_link to add a URL to the user's Readplace reading queue, and list_queue to see what they have saved.",
+		};
+	}
+
+	function toolsList(): unknown {
+		return {
+			tools: TOOL_DEFINITIONS.map((tool) => ({
+				name: tool.name,
+				title: tool.title,
+				description: tool.description,
+				inputSchema: tool.inputSchema,
+			})),
+		};
+	}
+
+	async function runSaveLink(
+		rawArgs: unknown,
+		context: McpRequestContext,
+	): Promise<ToolResult> {
+		const args = SaveLinkArgs.safeParse(rawArgs);
+		if (!args.success) {
+			return toolError("save_link requires a `url` string.");
+		}
+		try {
+			const outcome = await deps.saveLink({
+				userId: context.userId,
+				url: args.data.url,
+			});
+			if (!outcome.ok) return toolError(outcome.message);
+			return text(
+				`Saved "${outcome.title}" to your Readplace queue (${outcome.url}). The reader view is loading in the background.`,
+			);
+		} catch (error) {
+			return toolError(`Could not save the link. ${errorMessage(error)}`);
+		}
+	}
+
+	async function runListQueue(
+		rawArgs: unknown,
+		context: McpRequestContext,
+	): Promise<ToolResult> {
+		const args = ListQueueArgs.safeParse(rawArgs);
+		if (!args.success) {
+			return toolError('list_queue `status` must be "unread" or "read".');
+		}
+		try {
+			const outcome = await deps.listQueue({
+				userId: context.userId,
+				status: args.data.status,
+			});
+			if (outcome.total === 0) {
+				return text("Your Readplace queue is empty.");
+			}
+			const lines = outcome.articles.map(
+				(article) =>
+					`- ${article.title || article.url} [${article.status}] ${article.url}`,
+			);
+			return text(
+				`You have ${outcome.total} saved article(s):\n${lines.join("\n")}`,
+			);
+		} catch (error) {
+			return toolError(`Could not list your queue. ${errorMessage(error)}`);
+		}
+	}
+
+	async function handleToolsCall(
+		id: JsonRpcId,
+		params: unknown,
+		context: McpRequestContext,
+	): Promise<JsonRpcResponse> {
+		const parsed = ToolCallParams.safeParse(params);
+		if (!parsed.success) {
+			return failure(id, -32602, "Invalid params: expected { name, arguments }");
+		}
+		const rawArgs = parsed.data.arguments ?? {};
+		switch (parsed.data.name) {
+			case SAVE_LINK_TOOL.name:
+				return success(id, await runSaveLink(rawArgs, context));
+			case LIST_QUEUE_TOOL.name:
+				return success(id, await runListQueue(rawArgs, context));
+			default:
+				return failure(id, -32602, `Unknown tool: ${parsed.data.name}`);
+		}
+	}
+
+	return {
+		handle: async (message, context) => {
+			const parsed = EnvelopeSchema.safeParse(message);
+			if (!parsed.success) {
+				return failure(extractId(message), -32600, "Invalid Request");
+			}
+
+			// A JSON-RPC notification omits `id` entirely and never gets a reply;
+			// a request (even one with `id: null`) does. Presence, not value, is
+			// the discriminator.
+			const isNotification = !(
+				isRecord(message) && Object.hasOwn(message, "id")
+			);
+			if (isNotification) return undefined;
+
+			const id = parsed.data.id ?? null;
+			switch (parsed.data.method) {
+				case "initialize":
+					return success(id, initializeResult());
+				case "ping":
+					return success(id, {});
+				case "tools/list":
+					return success(id, toolsList());
+				case "tools/call":
+					return handleToolsCall(id, parsed.data.params, context);
+				default:
+					return failure(id, -32601, `Method not found: ${parsed.data.method}`);
+			}
+		},
+	};
+}

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.ts
@@ -190,9 +190,12 @@ export function initMcpServer(deps: McpServerDeps): McpServer {
 				(article) =>
 					`- ${article.title || article.url} [${article.status}] ${article.url}`,
 			);
-			return text(
-				`You have ${outcome.total} saved article(s):\n${lines.join("\n")}`,
-			);
+			const shown = outcome.articles.length;
+			const header =
+				shown < outcome.total
+					? `You have ${outcome.total} saved article(s); showing the first ${shown}:`
+					: `You have ${outcome.total} saved article(s):`;
+			return text(`${header}\n${lines.join("\n")}`);
 		} catch (error) {
 			return toolError(`Could not list your queue. ${errorMessage(error)}`);
 		}

--- a/projects/hutch/src/runtime/web/mcp/mcp.integration.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp.integration.ts
@@ -121,4 +121,25 @@ describe("MCP server over the real app", () => {
 		expect(response.status).toBe(200);
 		expect(response.body.result.isError).toBe(true);
 	});
+
+	it("refuses save_link with a tool error when the caller's subscription is inactive", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
+		const user = await harness.auth.findUserByEmail("mcp@example.com");
+		assert(user, "the authenticated user must exist");
+		await harness.subscriptionProviders.upsertTrialing({
+			userId: user.userId,
+			trialEndsAt: new Date(Date.now() - 86_400_000).toISOString(),
+		});
+
+		const response = await callTool(harness, accessToken, {
+			jsonrpc: "2.0",
+			id: 4,
+			method: "tools/call",
+			params: { name: "save_link", arguments: { url: "https://example.com/blocked" } },
+		});
+		expect(response.status).toBe(200);
+		expect(response.body.result.isError).toBe(true);
+		expect(response.body.result.content[0].text).toContain("subscription");
+	});
 });

--- a/projects/hutch/src/runtime/web/mcp/mcp.integration.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp.integration.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { createHash, randomBytes } from "node:crypto";
+import request from "supertest";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "@packages/test-fixtures";
+import { useTestServer } from "../../test-app";
+import type { TestAppHarness } from "../../test-app";
+
+const CLIENT_ID = "hutch-firefox-extension";
+const REDIRECT_URI = "http://127.0.0.1:3000/oauth/callback";
+
+function generatePkce() {
+	const codeVerifier = randomBytes(32).toString("base64url");
+	const codeChallenge = createHash("sha256")
+		.update(codeVerifier)
+		.digest("base64url");
+	return { codeVerifier, codeChallenge };
+}
+
+async function obtainAccessToken(harness: TestAppHarness): Promise<string> {
+	await harness.auth.createUser({ email: "mcp@example.com", password: "password123" });
+	const agent = request.agent(harness.server);
+	await agent
+		.post("/login")
+		.type("form")
+		.send({ email: "mcp@example.com", password: "password123" });
+
+	const { codeVerifier, codeChallenge } = generatePkce();
+	const authorizeResponse = await agent
+		.post("/oauth/authorize")
+		.type("form")
+		.send({
+			client_id: CLIENT_ID,
+			redirect_uri: REDIRECT_URI,
+			response_type: "code",
+			code_challenge: codeChallenge,
+			code_challenge_method: "S256",
+			state: randomBytes(16).toString("base64url"),
+			action: "approve",
+		});
+
+	const redirectUrl = new URL(authorizeResponse.headers.location);
+	const authorizationCode = redirectUrl.searchParams.get("code");
+	assert(authorizationCode, "authorize endpoint must redirect with a code");
+
+	const tokenResponse = await request(harness.server)
+		.post("/oauth/token")
+		.type("form")
+		.send({
+			grant_type: "authorization_code",
+			code: authorizationCode,
+			redirect_uri: REDIRECT_URI,
+			client_id: CLIENT_ID,
+			code_verifier: codeVerifier,
+		});
+	assert.equal(tokenResponse.status, 200);
+	const accessToken = tokenResponse.body.access_token;
+	assert(accessToken, "token endpoint must return an access_token");
+	return accessToken;
+}
+
+function callTool(harness: TestAppHarness, accessToken: string, body: unknown) {
+	return request(harness.server)
+		.post("/mcp")
+		.set("Authorization", `Bearer ${accessToken}`)
+		.set("Content-Type", "application/json")
+		.send(JSON.stringify(body));
+}
+
+const useApp = useTestServer();
+
+describe("MCP server over the real app", () => {
+	it("serves the discovery card pointing at the /mcp transport", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get(
+			"/.well-known/mcp/server-card.json",
+		);
+		expect(response.status).toBe(200);
+		expect(response.body.transport.endpoint).toContain("/mcp");
+		expect(response.body.serverInfo.name).toBe("Readplace");
+	});
+
+	it("saves a link and then lists it back for the authenticated user", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
+
+		const saveResponse = await callTool(harness, accessToken, {
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/call",
+			params: { name: "save_link", arguments: { url: "https://example.com/article" } },
+		});
+		expect(saveResponse.status).toBe(200);
+		expect(saveResponse.body.result.content[0].text).toContain("Saved");
+		expect(saveResponse.body.result.isError).toBeUndefined();
+
+		const listResponse = await callTool(harness, accessToken, {
+			jsonrpc: "2.0",
+			id: 2,
+			method: "tools/call",
+			params: { name: "list_queue" },
+		});
+		expect(listResponse.status).toBe(200);
+		expect(listResponse.body.result.content[0].text).toContain(
+			"https://example.com/article",
+		);
+	});
+
+	it("returns a tool error result when asked to save an unsaveable URL", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
+
+		const response = await callTool(harness, accessToken, {
+			jsonrpc: "2.0",
+			id: 3,
+			method: "tools/call",
+			params: { name: "save_link", arguments: { url: "not-a-url" } },
+		});
+		expect(response.status).toBe(200);
+		expect(response.body.result.isError).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/mcp.routes.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp.routes.test.ts
@@ -1,0 +1,104 @@
+import express, { type Express } from "express";
+import request from "supertest";
+import { UserIdSchema } from "@packages/domain/user";
+import type { ValidateAccessToken } from "@packages/provider-contracts/oauth";
+import { initMcpRoutes } from "./mcp.routes";
+import { initMcpServer } from "./mcp-server";
+
+const userId = UserIdSchema.parse("00000000000000000000000000000001");
+
+const validateAccessToken: ValidateAccessToken = async (token) =>
+	token === "good-token" ? { userId, emailVerified: true } : null;
+
+function buildApp(): Express {
+	const mcpServer = initMcpServer({
+		saveLink: async ({ url }) => ({ ok: true, title: "Saved", url }),
+		listQueue: async () => ({ total: 0, articles: [] }),
+	});
+	const app = express();
+	app.use(
+		"/mcp",
+		initMcpRoutes({ validateAccessToken, mcpServer, baseUrl: "https://readplace.com" }),
+	);
+	return app;
+}
+
+function post(app: Express, body: unknown) {
+	return request(app)
+		.post("/mcp")
+		.set("Authorization", "Bearer good-token")
+		.set("Content-Type", "application/json")
+		.send(JSON.stringify(body));
+}
+
+describe("MCP transport routes", () => {
+	it("returns 401 with a protected-resource pointer when the bearer token is absent", async () => {
+		const response = await request(buildApp())
+			.post("/mcp")
+			.set("Content-Type", "application/json")
+			.send(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }));
+		expect(response.status).toBe(401);
+		expect(response.headers["www-authenticate"]).toContain(
+			'resource_metadata="https://readplace.com/.well-known/oauth-protected-resource"',
+		);
+		expect(response.body).toMatchObject({ error: { code: -32001 } });
+	});
+
+	it("returns 401 when the Authorization header is not a Bearer token", async () => {
+		const response = await request(buildApp())
+			.post("/mcp")
+			.set("Authorization", "Basic abc")
+			.send(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }));
+		expect(response.status).toBe(401);
+	});
+
+	it("returns 401 when the bearer token is invalid", async () => {
+		const response = await request(buildApp())
+			.post("/mcp")
+			.set("Authorization", "Bearer nope")
+			.send(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }));
+		expect(response.status).toBe(401);
+		expect(response.body).toMatchObject({ error: { message: "Invalid or expired token" } });
+	});
+
+	it("dispatches an authenticated request and returns the JSON-RPC result", async () => {
+		const response = await post(buildApp(), { jsonrpc: "2.0", id: 1, method: "ping" });
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ jsonrpc: "2.0", id: 1, result: {} });
+	});
+
+	it("returns 202 with no body for a notification", async () => {
+		const response = await post(buildApp(), {
+			jsonrpc: "2.0",
+			method: "notifications/initialized",
+		});
+		expect(response.status).toBe(202);
+		expect(response.text).toBe("");
+	});
+
+	it("returns a JSON-RPC parse error for a malformed body", async () => {
+		const response = await request(buildApp())
+			.post("/mcp")
+			.set("Authorization", "Bearer good-token")
+			.set("Content-Type", "application/json")
+			.send("{ not valid json");
+		expect(response.status).toBe(400);
+		expect(response.body).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32700, message: "Parse error" },
+		});
+	});
+
+	it("rejects GET with 405 POST-only", async () => {
+		const response = await request(buildApp()).get("/mcp");
+		expect(response.status).toBe(405);
+		expect(response.headers.allow).toBe("POST");
+	});
+
+	it("rejects DELETE with 405 POST-only", async () => {
+		const response = await request(buildApp()).delete("/mcp");
+		expect(response.status).toBe(405);
+		expect(response.headers.allow).toBe("POST");
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/mcp.routes.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp.routes.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert";
+import express, {
+	type NextFunction,
+	type Request,
+	type Response,
+	type Router,
+} from "express";
+import { AccessTokenSchema } from "@packages/domain/oauth";
+import type { ValidateAccessToken } from "@packages/provider-contracts/oauth";
+import type { McpServer } from "./mcp-server";
+
+interface McpRoutesDeps {
+	validateAccessToken: ValidateAccessToken;
+	mcpServer: McpServer;
+	baseUrl: string;
+}
+
+const PARSE_ERROR = {
+	jsonrpc: "2.0",
+	id: null,
+	error: { code: -32700, message: "Parse error" },
+};
+
+/**
+ * The MCP Streamable HTTP transport. A single `/mcp` endpoint:
+ *  - POST   — a JSON-RPC request/notification, dispatched to the server.
+ *  - GET    — would open a server→client SSE stream; this server initiates
+ *             nothing, so it advertises POST-only per the spec.
+ *  - DELETE — would tear down a session; the server is stateless, so likewise.
+ *
+ * Every call is OAuth-bearer protected. A missing or bad token returns 401 with
+ * a `WWW-Authenticate` pointer to Readplace's existing protected-resource
+ * metadata, which is exactly the discovery step an MCP client performs before
+ * running the authorization-code + PKCE flow.
+ */
+export function initMcpRoutes(deps: McpRoutesDeps): Router {
+	const router = express.Router();
+
+	function unauthorized(res: Response, message: string): void {
+		res
+			.status(401)
+			.set(
+				"WWW-Authenticate",
+				`Bearer resource_metadata="${deps.baseUrl}/.well-known/oauth-protected-resource"`,
+			)
+			.json({ jsonrpc: "2.0", id: null, error: { code: -32001, message } });
+	}
+
+	async function requireBearer(
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> {
+		const header = req.headers.authorization;
+		if (!header?.startsWith("Bearer ")) {
+			unauthorized(res, "Authentication required");
+			return;
+		}
+		const token = AccessTokenSchema.parse(header.slice(7));
+		const validated = await deps.validateAccessToken(token);
+		if (!validated) {
+			unauthorized(res, "Invalid or expired token");
+			return;
+		}
+		req.userId = validated.userId;
+		next();
+	}
+
+	router.post(
+		"/",
+		requireBearer,
+		// Read the raw body ourselves (any content type) and JSON-parse it inside
+		// the handler, so a malformed body becomes a JSON-RPC parse error here
+		// rather than an Express HTML 500 from express.json's thrown SyntaxError.
+		express.text({ type: () => true, limit: "1mb" }),
+		async (req: Request, res: Response) => {
+			assert(req.userId, "requireBearer must set req.userId before the handler");
+			let message: unknown;
+			try {
+				message = JSON.parse(req.body);
+			} catch {
+				res.status(400).json(PARSE_ERROR);
+				return;
+			}
+			const response = await deps.mcpServer.handle(message, {
+				userId: req.userId,
+			});
+			if (!response) {
+				res.status(202).end();
+				return;
+			}
+			res.status(200).json(response);
+		},
+	);
+
+	const methodNotAllowed = (_req: Request, res: Response): void => {
+		res.status(405).set("Allow", "POST").end();
+	};
+	router.get("/", methodNotAllowed);
+	router.delete("/", methodNotAllowed);
+
+	return router;
+}

--- a/projects/hutch/src/runtime/web/mcp/protocol.ts
+++ b/projects/hutch/src/runtime/web/mcp/protocol.ts
@@ -1,0 +1,18 @@
+/**
+ * The MCP protocol revision this server speaks, echoed in the `initialize`
+ * result and advertised on the discovery card. Pinned to a known revision
+ * rather than "latest" so a client that negotiates against it gets a stable
+ * contract.
+ */
+export const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+/**
+ * Identifies the Readplace MCP server software (distinct from
+ * MCP_PROTOCOL_VERSION, which versions the wire protocol). Shared by the
+ * `initialize` handshake and the published server card so the two never drift.
+ */
+export const MCP_SERVER_INFO = {
+	name: "Readplace",
+	title: "Readplace",
+	version: "1.0.0",
+} as const;

--- a/projects/hutch/src/runtime/web/mcp/save-access.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/save-access.test.ts
@@ -1,0 +1,86 @@
+import { UserIdSchema } from "@packages/domain/user";
+import type { FindUserById } from "@packages/provider-contracts/auth";
+import type { GetEffectiveAccess } from "../../domain/access/effective-access";
+import { initResolveSaveAccess } from "./save-access";
+
+const userId = UserIdSchema.parse("00000000000000000000000000000001");
+const NOW = new Date("2026-06-16T00:00:00.000Z");
+const DAY_MS = 86_400_000;
+
+function findUser(
+	user: { emailVerified: boolean; registeredAt?: string } | null,
+): FindUserById {
+	return async () => (user ? { userId, ...user } : null);
+}
+
+const fullAccess: GetEffectiveAccess = async () => ({
+	tier: "founding",
+	access: "full",
+	banner: "none",
+});
+
+const inactiveAccess: GetEffectiveAccess = async () => ({
+	tier: "inactive",
+	access: "read-only",
+	banner: "inactive",
+	reason: "trial-expired",
+});
+
+describe("initResolveSaveAccess", () => {
+	it("refuses a save for a locked account (email unverified past its window)", async () => {
+		const resolve = initResolveSaveAccess({
+			findUserById: findUser({
+				emailVerified: false,
+				registeredAt: new Date(NOW.getTime() - 8 * DAY_MS).toISOString(),
+			}),
+			getEffectiveAccess: fullAccess,
+			now: () => NOW,
+		});
+		expect(await resolve(userId)).toMatchObject({
+			allowed: false,
+			message: expect.stringContaining("locked"),
+		});
+	});
+
+	it("allows a save for an unverified account still inside its countdown window", async () => {
+		const resolve = initResolveSaveAccess({
+			findUserById: findUser({
+				emailVerified: false,
+				registeredAt: new Date(NOW.getTime() - 1 * DAY_MS).toISOString(),
+			}),
+			getEffectiveAccess: fullAccess,
+			now: () => NOW,
+		});
+		expect(await resolve(userId)).toEqual({ allowed: true });
+	});
+
+	it("refuses a save when the caller's subscription is inactive", async () => {
+		const resolve = initResolveSaveAccess({
+			findUserById: findUser({ emailVerified: true }),
+			getEffectiveAccess: inactiveAccess,
+			now: () => NOW,
+		});
+		expect(await resolve(userId)).toMatchObject({
+			allowed: false,
+			message: expect.stringContaining("subscription"),
+		});
+	});
+
+	it("allows a save for a verified account with full access", async () => {
+		const resolve = initResolveSaveAccess({
+			findUserById: findUser({ emailVerified: true }),
+			getEffectiveAccess: fullAccess,
+			now: () => NOW,
+		});
+		expect(await resolve(userId)).toEqual({ allowed: true });
+	});
+
+	it("allows a save when the token is valid but no user record is found", async () => {
+		const resolve = initResolveSaveAccess({
+			findUserById: findUser(null),
+			getEffectiveAccess: fullAccess,
+			now: () => NOW,
+		});
+		expect(await resolve(userId)).toEqual({ allowed: true });
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/save-access.ts
+++ b/projects/hutch/src/runtime/web/mcp/save-access.ts
@@ -1,0 +1,60 @@
+import type { UserId } from "@packages/domain/user";
+import type { FindUserById } from "@packages/provider-contracts/auth";
+import { VERIFICATION_CONTACT_EMAIL } from "@packages/web-shell";
+import type { GetEffectiveAccess } from "../../domain/access/effective-access";
+import { computeVerificationStatus } from "../../domain/access/verification-deadline";
+
+/**
+ * Whether an authenticated agent may save a new link right now. A save over MCP
+ * has to clear the same two gates the hypermedia `/queue` save and `/import`
+ * enforce — `requireNotLocked` (email unverified past its 7-day window) and
+ * `requireWriteAccess` (subscription not `full`) — so an agent save and a
+ * browser-extension save are the identical write rather than a back door around
+ * the lockout and the paywall.
+ *
+ * Those gates are Express middleware keyed off `req`, but an MCP request only
+ * has a `userId` after the bearer is validated inside the transport, so the
+ * status is resolved here from the bearer-derived id instead. The refusal
+ * carries an agent-facing sentence (the transport renders it as a tool error)
+ * in place of the web's locked screen or the API's bare `subscription_inactive`.
+ * Listing stays open while locked, so this gates only `save_link`.
+ */
+type SaveAccess =
+	| { readonly allowed: true }
+	| { readonly allowed: false; readonly message: string };
+
+export function initResolveSaveAccess(deps: {
+	findUserById: FindUserById;
+	getEffectiveAccess: GetEffectiveAccess;
+	now: () => Date;
+}): (userId: UserId) => Promise<SaveAccess> {
+	return async (userId) => {
+		const user = await deps.findUserById(userId);
+		if (user && !user.emailVerified) {
+			const status = computeVerificationStatus({
+				registeredAt: user.registeredAt,
+				now: deps.now(),
+			});
+			if (status.state === "locked") {
+				return {
+					allowed: false,
+					message:
+						"Your Readplace account is locked because its email was never verified. " +
+						`Email ${VERIFICATION_CONTACT_EMAIL} to restore access.`,
+				};
+			}
+		}
+
+		const access = await deps.getEffectiveAccess(userId);
+		if (access.access !== "full") {
+			return {
+				allowed: false,
+				message:
+					"Saving is disabled because the Readplace subscription is not active. " +
+					"Reactivate it from the account page to save links again.",
+			};
+		}
+
+		return { allowed: true };
+	};
+}

--- a/projects/hutch/src/runtime/web/mcp/server-card.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/server-card.test.ts
@@ -1,0 +1,48 @@
+import { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from "./protocol";
+import { buildMcpServerCard } from "./server-card";
+import { TOOL_DEFINITIONS } from "./tool-definitions";
+
+describe("buildMcpServerCard", () => {
+	const card = buildMcpServerCard("https://readplace.com");
+
+	it("advertises the streamable-http /mcp endpoint under the given origin", () => {
+		expect(card).toMatchObject({
+			transport: { type: "streamable-http", endpoint: "https://readplace.com/mcp" },
+		});
+	});
+
+	it("reports protocol version, server info, and tool capability matching the live server", () => {
+		expect(card).toMatchObject({
+			protocolVersion: MCP_PROTOCOL_VERSION,
+			serverInfo: MCP_SERVER_INFO,
+			capabilities: { tools: { listChanged: false } },
+		});
+	});
+
+	it("points authentication at the existing OAuth protected-resource metadata", () => {
+		expect(card).toMatchObject({
+			authentication: {
+				required: true,
+				schemes: ["oauth2"],
+				protectedResourceMetadata:
+					"https://readplace.com/.well-known/oauth-protected-resource",
+			},
+		});
+	});
+
+	it("summarises exactly the tools the server implements", () => {
+		expect(card).toMatchObject({
+			tools: TOOL_DEFINITIONS.map((tool) => ({
+				name: tool.name,
+				description: tool.description,
+			})),
+		});
+	});
+
+	it("derives documentation and endpoint URLs from the provided base url", () => {
+		expect(buildMcpServerCard("https://example.test")).toMatchObject({
+			documentationUrl: "https://example.test/auth.md",
+			transport: { endpoint: "https://example.test/mcp" },
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/server-card.ts
+++ b/projects/hutch/src/runtime/web/mcp/server-card.ts
@@ -1,0 +1,39 @@
+import { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from "./protocol";
+import { TOOL_DEFINITIONS } from "./tool-definitions";
+
+/**
+ * The SEP-2127 MCP Server Card served at `/.well-known/mcp/server-card.json`.
+ * It lets an agent discover the Readplace MCP endpoint, its protocol revision,
+ * its tools, and how to authenticate — without first opening a session.
+ *
+ * Every field is sourced from the same constants the live `/mcp` server uses
+ * (protocol version, server info, tool list) and points at metadata Readplace
+ * already serves (the OAuth protected-resource document), so the card never
+ * advertises a capability the server does not actually have.
+ */
+export function buildMcpServerCard(baseUrl: string): object {
+	return {
+		protocolVersion: MCP_PROTOCOL_VERSION,
+		serverInfo: MCP_SERVER_INFO,
+		description:
+			"Save links to your Readplace reading queue and list what you have saved.",
+		documentationUrl: `${baseUrl}/auth.md`,
+		transport: {
+			type: "streamable-http",
+			endpoint: `${baseUrl}/mcp`,
+		},
+		capabilities: {
+			tools: { listChanged: false },
+		},
+		authentication: {
+			required: true,
+			schemes: ["oauth2"],
+			protectedResourceMetadata: `${baseUrl}/.well-known/oauth-protected-resource`,
+		},
+		tools: TOOL_DEFINITIONS.map((tool) => ({
+			name: tool.name,
+			title: tool.title,
+			description: tool.description,
+		})),
+	};
+}

--- a/projects/hutch/src/runtime/web/mcp/tool-definitions.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/tool-definitions.test.ts
@@ -1,0 +1,40 @@
+import {
+	LIST_QUEUE_TOOL,
+	ListQueueArgs,
+	SAVE_LINK_TOOL,
+	SaveLinkArgs,
+	TOOL_DEFINITIONS,
+} from "./tool-definitions";
+
+describe("MCP tool definitions", () => {
+	it("exposes save_link and list_queue", () => {
+		expect(TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([
+			"save_link",
+			"list_queue",
+		]);
+	});
+
+	describe("save_link", () => {
+		it("requires a non-empty url in both the JSON Schema and the validator", () => {
+			expect(SAVE_LINK_TOOL.inputSchema).toMatchObject({
+				required: ["url"],
+				properties: { url: { type: "string" } },
+			});
+			expect(SaveLinkArgs.safeParse({ url: "https://example.com/" }).success).toBe(true);
+			expect(SaveLinkArgs.safeParse({}).success).toBe(false);
+			expect(SaveLinkArgs.safeParse({ url: "" }).success).toBe(false);
+		});
+	});
+
+	describe("list_queue", () => {
+		it("accepts an optional unread/read status in both shapes", () => {
+			expect(LIST_QUEUE_TOOL.inputSchema).toMatchObject({
+				properties: { status: { enum: ["unread", "read"] } },
+			});
+			expect(ListQueueArgs.safeParse({}).success).toBe(true);
+			expect(ListQueueArgs.safeParse({ status: "unread" }).success).toBe(true);
+			expect(ListQueueArgs.safeParse({ status: "read" }).success).toBe(true);
+			expect(ListQueueArgs.safeParse({ status: "archived" }).success).toBe(false);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/tool-definitions.ts
+++ b/projects/hutch/src/runtime/web/mcp/tool-definitions.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+/**
+ * Public metadata for a Readplace MCP tool: the JSON Schema advertised in
+ * `tools/list` and summarised on the server card. The matching Zod validator
+ * for each tool's payload lives alongside as an exported schema, and
+ * tool-definitions.test.ts keeps the two shapes in lock-step so an agent's
+ * understanding of a tool's input never diverges from what the server accepts.
+ */
+interface McpToolDefinition {
+	readonly name: string;
+	readonly title: string;
+	readonly description: string;
+	readonly inputSchema: Record<string, unknown>;
+}
+
+export const SaveLinkArgs = z.object({
+	url: z.string().min(1),
+});
+
+export const ListQueueArgs = z.object({
+	status: z.enum(["unread", "read"]).optional(),
+});
+
+export const SAVE_LINK_TOOL: McpToolDefinition = {
+	name: "save_link",
+	title: "Save a link to Readplace",
+	description:
+		"Save a web page (article, blog post, or PDF) to the user's Readplace reading queue so they can read it later. The page's title, excerpt, and reader view are fetched in the background after saving.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			url: {
+				type: "string",
+				description: "The absolute http(s) URL of the page to save.",
+			},
+		},
+		required: ["url"],
+		additionalProperties: false,
+	},
+};
+
+export const LIST_QUEUE_TOOL: McpToolDefinition = {
+	name: "list_queue",
+	title: "List saved articles",
+	description:
+		"List the pages the user has saved to their Readplace reading queue, optionally filtered to unread or already-read items.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			status: {
+				type: "string",
+				enum: ["unread", "read"],
+				description:
+					"Filter to only unread or only read items. Omit to list everything.",
+			},
+		},
+		additionalProperties: false,
+	},
+};
+
+export const TOOL_DEFINITIONS: readonly McpToolDefinition[] = [
+	SAVE_LINK_TOOL,
+	LIST_QUEUE_TOOL,
+];

--- a/projects/hutch/src/runtime/web/webmcp.client.test.ts
+++ b/projects/hutch/src/runtime/web/webmcp.client.test.ts
@@ -1,0 +1,88 @@
+import {
+	buildReadplaceTools,
+	initWebMcp,
+	type ModelContextLike,
+} from "./webmcp.client";
+
+describe("buildReadplaceTools", () => {
+	it("exposes a single save_link tool with a url input schema", () => {
+		const tools = buildReadplaceTools(() => {});
+		expect(tools.map((tool) => tool.name)).toEqual(["save_link"]);
+		expect(tools[0].inputSchema).toMatchObject({ required: ["url"] });
+	});
+
+	describe("save_link.execute", () => {
+		it("navigates to the /save entrypoint for a valid http(s) url", async () => {
+			const navigateTo = jest.fn();
+			const [saveLink] = buildReadplaceTools(navigateTo);
+			const result = await saveLink.execute({ url: "https://example.com/post?x=1" });
+			expect(navigateTo).toHaveBeenCalledWith(
+				`/save?url=${encodeURIComponent("https://example.com/post?x=1")}`,
+			);
+			expect(result).toMatchObject({
+				content: [{ type: "text", text: expect.stringContaining("Saving") }],
+			});
+			expect(result.isError).toBeUndefined();
+		});
+
+		it("returns an error result and does not navigate for a non-string url", async () => {
+			const navigateTo = jest.fn();
+			const [saveLink] = buildReadplaceTools(navigateTo);
+			const result = await saveLink.execute({ url: 42 });
+			expect(navigateTo).not.toHaveBeenCalled();
+			expect(result.isError).toBe(true);
+		});
+
+		it("rejects a non-http(s) url scheme", async () => {
+			const navigateTo = jest.fn();
+			const [saveLink] = buildReadplaceTools(navigateTo);
+			const result = await saveLink.execute({ url: "ftp://example.com/x" });
+			expect(navigateTo).not.toHaveBeenCalled();
+			expect(result.isError).toBe(true);
+		});
+
+		it("rejects a malformed url string", async () => {
+			const [saveLink] = buildReadplaceTools(() => {});
+			const result = await saveLink.execute({ url: "not a url" });
+			expect(result.isError).toBe(true);
+		});
+
+		it("rejects input that is not an object", async () => {
+			const [saveLink] = buildReadplaceTools(() => {});
+			const result = await saveLink.execute("https://example.com/");
+			expect(result.isError).toBe(true);
+		});
+	});
+});
+
+describe("initWebMcp", () => {
+	it("returns false when no model context is present", () => {
+		expect(initWebMcp({ modelContext: null, navigateTo: () => {} })).toBe(false);
+		expect(initWebMcp({ modelContext: undefined, navigateTo: () => {} })).toBe(false);
+	});
+
+	it("uses provideContext when available, passing all tools at once", () => {
+		const provideContext = jest.fn();
+		const modelContext: ModelContextLike = { provideContext };
+		expect(initWebMcp({ modelContext, navigateTo: () => {} })).toBe(true);
+		expect(provideContext).toHaveBeenCalledWith({
+			tools: expect.arrayContaining([
+				expect.objectContaining({ name: "save_link" }),
+			]),
+		});
+	});
+
+	it("falls back to registerTool, registering each tool", () => {
+		const registerTool = jest.fn();
+		const modelContext: ModelContextLike = { registerTool };
+		expect(initWebMcp({ modelContext, navigateTo: () => {} })).toBe(true);
+		expect(registerTool).toHaveBeenCalledTimes(1);
+		expect(registerTool).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "save_link" }),
+		);
+	});
+
+	it("returns false when the context exposes neither API", () => {
+		expect(initWebMcp({ modelContext: {}, navigateTo: () => {} })).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/webmcp.client.ts
+++ b/projects/hutch/src/runtime/web/webmcp.client.ts
@@ -1,0 +1,118 @@
+/**
+ * WebMCP exposes Readplace's primary action — saving a link to the reading
+ * queue — to an in-browser AI agent. The agent reads the page, finds the tool,
+ * and can save on the user's behalf.
+ *
+ * The proposal is still split across two API surfaces: Chrome's preview ships
+ * `navigator.modelContext.provideContext({ tools })`, while the W3C draft uses
+ * `registerTool(tool)`. We feature-detect both so the tool shows up whichever
+ * one the runtime implements. The module stays free of browser globals (the
+ * context object and navigation are injected) so it unit-tests without a DOM.
+ */
+interface WebMcpTextContent {
+	type: "text";
+	text: string;
+}
+
+interface WebMcpToolResult {
+	content: WebMcpTextContent[];
+	isError?: boolean;
+}
+
+interface WebMcpTool {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	execute: (input: unknown) => Promise<WebMcpToolResult>;
+}
+
+export interface ModelContextLike {
+	provideContext?: (context: { tools: WebMcpTool[] }) => unknown;
+	registerTool?: (tool: WebMcpTool) => unknown;
+}
+
+interface WebMcpDeps {
+	modelContext: ModelContextLike | null | undefined;
+	navigateTo: (url: string) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseHttpUrl(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	try {
+		const url = new URL(value);
+		if (url.protocol === "http:" || url.protocol === "https:") {
+			return url.toString();
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function buildReadplaceTools(
+	navigateTo: (url: string) => void,
+): WebMcpTool[] {
+	return [
+		{
+			name: "save_link",
+			description:
+				"Save a web page (article, blog post, or PDF) to the user's Readplace reading queue to read later.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					url: {
+						type: "string",
+						description: "The absolute http(s) URL of the page to save.",
+					},
+				},
+				required: ["url"],
+				additionalProperties: false,
+			},
+			execute: async (input) => {
+				const url = isRecord(input) ? parseHttpUrl(input.url) : undefined;
+				if (!url) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: "Provide an absolute http(s) URL to save.",
+							},
+						],
+						isError: true,
+					};
+				}
+				navigateTo(`/save?url=${encodeURIComponent(url)}`);
+				return {
+					content: [
+						{ type: "text", text: `Saving ${url} to your Readplace queue.` },
+					],
+				};
+			},
+		},
+	];
+}
+
+/** Register Readplace's tools with whichever WebMCP surface the browser
+ * exposes. Returns whether a tool surface was found and used. */
+export function initWebMcp(deps: WebMcpDeps): boolean {
+	const context = deps.modelContext;
+	if (!context) return false;
+
+	const tools = buildReadplaceTools(deps.navigateTo);
+
+	if (typeof context.provideContext === "function") {
+		context.provideContext({ tools });
+		return true;
+	}
+	if (typeof context.registerTool === "function") {
+		for (const tool of tools) {
+			context.registerTool(tool);
+		}
+		return true;
+	}
+	return false;
+}

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -713,4 +713,22 @@ describe("initBase config", () => {
 		expect(withReload.body).toContain("livereload.js?snipver=1");
 		expect(withoutReload.body).not.toContain("livereload.js?snipver=1");
 	});
+
+	it("appends siteScripts to every page when configured, and nothing when omitted", () => {
+		const page = createTestPageBody();
+		const marker = '<script src="/client-dist/webmcp.client.js" defer></script>';
+
+		const withScripts = initBase({
+			staticBaseUrl: "",
+			liveReload: false,
+			siteScripts: marker,
+		})(page, GUEST_STATE).to("text/html");
+		const withoutScripts = initBase({ staticBaseUrl: "", liveReload: false })(
+			page,
+			GUEST_STATE,
+		).to("text/html");
+
+		expect(withScripts.body).toContain(marker);
+		expect(withoutScripts.body).not.toContain(marker);
+	});
 });

--- a/src/packages/web-shell/src/base.component.ts
+++ b/src/packages/web-shell/src/base.component.ts
@@ -199,6 +199,11 @@ function renderMarkdown(body: PageBody): string {
 export interface BaseConfig {
 	staticBaseUrl: string;
 	liveReload: boolean;
+	/** Markup appended to every page this site serves, after the page's own
+	 * scripts. Lets a consuming site inject a site-wide script (e.g. hutch's
+	 * WebMCP tool registration) without each page opting in, while a site that
+	 * omits it — like the blog, which ships no such bundle — stays untouched. */
+	siteScripts?: string;
 }
 
 export type RenderBase = (body: PageBody, state: BannerState) => Component;
@@ -207,6 +212,8 @@ export function initBase(config: BaseConfig): RenderBase {
 	const liveReloadScript = config.liveReload
 		? `\n<script src="http://localhost:35729/livereload.js?snipver=1"></script>`
 		: "";
+
+	const siteScripts = config.siteScripts ?? "";
 
 	function renderBaseTemplate(body: PageBody, state: BannerState): string {
 		const headerVariant = body.headerVariant || "default";
@@ -270,6 +277,7 @@ export function initBase(config: BaseConfig): RenderBase {
 				TOAST_SCRIPT +
 				(state.trial?.state === "active" ? TRIAL_COUNTDOWN_SCRIPT : "") +
 				(body.scripts ?? "") +
+				siteScripts +
 				liveReloadScript,
 		});
 	}


### PR DESCRIPTION
## What & why

Three new agent-discovery surfaces so AI agents can find and use Readplace, extending the existing agent-skills / `llms.txt` / OAuth-metadata investment. These resolve the [isitagentready.com](https://isitagentready.com) findings for **DNS-AID records**, an **MCP Server Card**, and **WebMCP**.

The two ambiguous/risky decisions were confirmed up front: build a **real** MCP server (not a card pointing at a non-existent endpoint), and enable DNSSEC now.

## 1. MCP server + Server Card (real, OAuth-protected)

- **`/mcp`** — Streamable HTTP transport speaking JSON-RPC (`initialize`, `ping`, `tools/list`, `tools/call`). Bearer-protected; a `401` returns `WWW-Authenticate` pointing at the existing `/.well-known/oauth-protected-resource` — exactly the discovery step an MCP client runs before the authorization-code + PKCE flow Readplace already implements.
- **Tools** `save_link` and `list_queue` delegate to the **same** `saveArticleFromUrl` / `findArticlesByUser` pipeline the hypermedia `/queue` API uses, so an agent save and a browser-extension save are the identical write.
- **`/.well-known/mcp/server-card.json`** — SEP-2127 shape (serverInfo, transport, capabilities, oauth2 authentication), built from the same constants the live server uses so the card can't drift from reality.

## 2. WebMCP

- `webmcp.client.ts` registers a `save_link` tool via `navigator.modelContext`, feature-detecting **both** Chrome's `provideContext({ tools })` and the W3C draft's `registerTool(tool)`.
- Injected on every hutch page through a new optional `siteScripts` config on the shared web-shell `Base`, so the blog deployable (which ships no such bundle) is untouched.

## 3. DNS-AID (`src/infra/agent-discovery-dns.ts`)

- SVCB ServiceMode records under `_index._agents` and `_mcp._agents`, targeting the apex over `h2`/443. Only IANA-registered SvcParams are used — Route 53 explicitly rejects the experimental `keyNNNNN` form, so DNS-AID-specific paths live in the well-known docs these records lead an agent to.
- Route 53 **DNSSEC** signing via a us-east-1 KMS key-signing key.

## Verification

- `pnpm check` green for `hutch` and `@packages/web-shell` (lint, knip, type-check, **100% function coverage**).
- New unit tests (`mcp-server`, `mcp.routes`, `server-card`, `tool-definitions`, `webmcp.client`) plus an end-to-end `mcp.integration.ts` that drives `/mcp` through the real app over a real OAuth token (save → list round-trip).

## ⚠️ Requires manual follow-up on deploy

- **DNSSEC chain of trust:** signing is enabled on the zone, but a resolver only validates once the **DS record is published at the registrar**. The DS is exported as the `agentDnsDsRecord` stack output. This step is deliberately out-of-band — a wrong DS breaks resolution for the whole domain.
- Infra (`src/infra/**`) is excluded from `pnpm check` and can't be applied here; the Pulumi API was verified against the installed `@pulumi/aws@7.32.0` types, and the SVCB RDATA matches AWS's documented service-mode format. Review `pulumi preview` output before applying.

https://claude.ai/code/session_01DhhdQjbsmkEyJG6srqTHjH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhhdQjbsmkEyJG6srqTHjH)_