### PR TITLE
style(queue,reader): replace left-border markers

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -250,7 +250,7 @@
 }
 
 .queue-article--unread {
-  border-left: 3px solid var(--primary);
+  background: var(--secondary);
 }
 
 .queue-article__thumbnail-link {

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -115,6 +115,27 @@
   letter-spacing: 0.05em;
   color: var(--color-text-secondary);
   list-style: none;
+  user-select: none;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.article-body__summary[open] .article-body__summary-toggle {
+  border-radius: 8px 8px 0 0;
+}
+
+.article-body__summary-toggle:hover {
+  background: color-mix(in srgb, var(--color-brand) 8%, transparent);
+  color: var(--color-text-primary);
+}
+
+.article-body__summary-toggle:active {
+  background: color-mix(in srgb, var(--color-brand) 14%, transparent);
+}
+
+.article-body__summary-toggle:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
 }
 
 .article-body__summary-toggle::-webkit-details-marker {
@@ -125,7 +146,11 @@
   content: "\25BE";
   font-size: 1.2em;
   color: var(--color-text-muted);
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.article-body__summary-toggle:hover::after {
+  color: var(--color-brand);
 }
 
 .article-body__summary[open] .article-body__summary-toggle::after {
@@ -262,7 +287,7 @@
   padding: 2rem 1.5rem;
   background: var(--color-surface);
   border-radius: 8px;
-  border-left: 3px solid var(--color-brand);
+  border: 1px solid var(--color-border);
   text-align: center;
   font-size: 0.95rem;
   color: var(--color-text-secondary);

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -100,7 +100,7 @@
   margin-bottom: 2rem;
   background: var(--color-surface);
   border-radius: 8px;
-  border-left: 3px solid var(--color-brand);
+  border: 1px solid var(--color-border);
 }
 
 .article-body__summary-toggle {
@@ -148,7 +148,7 @@
   padding: 1.25rem 1.5rem;
   background: var(--color-surface);
   border-radius: 8px;
-  border-left: 3px solid var(--color-brand);
+  border: 1px solid var(--color-border);
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--color-text-secondary);
@@ -174,7 +174,7 @@
   margin: 0 0 2rem;
   padding: 1rem 1.5rem;
   background: var(--color-surface);
-  border-left: 3px solid var(--color-error);
+  border: 1px solid var(--color-error);
   border-radius: 8px;
   font-size: 0.875rem;
   color: var(--color-error);
@@ -190,7 +190,7 @@
   margin: 0 0 2rem;
   padding: 1rem 1.5rem;
   background: var(--color-surface);
-  border-left: 3px solid var(--color-border);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font-size: 0.875rem;
   color: var(--color-text-secondary);


### PR DESCRIPTION
## What

Removes the 3px left-border accents used as markers on the queue and the reader-view summary, replacing them with different markers.

### Queue
- `.queue-article--unread` no longer uses a left border. Unread cards now get a subtle background tint (`var(--secondary)`) so they stand out as a block. The existing "● Unread / ✓ Read" status pill remains the textual read/unread marker.

### Reader view — summary
- The summary box (`.article-body__summary`) and its loading/error/skipped states now use a subtle full `1px` border instead of a left-border accent, reading as a self-contained card. Each state keeps its semantic colour (neutral border for ready/loading/skipped, error colour for the failure notice).

## Notes
- CSS-only change. No template or component logic touched; the `queue-article--unread` class and summary markup are unchanged, so existing class-based tests still pass.
- `pnpm nx run hutch:check` passes (tests, lint, coverage, unused-css).

https://claude.ai/code/session_015ttBRhPcFnvbfCJ8XCKPnq

---
_Generated by [Claude Code](https://claude.ai/code/session_015ttBRhPcFnvbfCJ8XCKPnq)_