### PR TITLE
ci(ios): auto-bump TestFlight marketing version as 0.1.&lt;build&gt;

### DIFF
--- a/.github/workflows/publish-ios-testflight.yml
+++ b/.github/workflows/publish-ios-testflight.yml
@@ -64,14 +64,20 @@ jobs:
           bundler-cache: true
           working-directory: projects/ios-readplace-poc
 
-      - name: Compute next build number from the latest tag
+      - name: Compute next build number and marketing version from the latest tag
         id: version
         if: steps.preflight.outputs.configured == 'true'
         run: |
           LATEST=$(git tag --list 'ios-readplace-poc@v*' --sort=-v:refname | head -n1 | sed 's/^ios-readplace-poc@v//')
           [ -z "$LATEST" ] && LATEST=0
-          echo "build=$((LATEST + 1))" >> "$GITHUB_OUTPUT"
-          echo "Next TestFlight build number: $((LATEST + 1))"
+          BUILD=$((LATEST + 1))
+          # major.minor is the human-controlled line in project.yml; the patch is the
+          # build counter, so the published marketing version is <major.minor>.<build>
+          # and the build number equals the patch.
+          BASE=$(grep -E '^[[:space:]]*MARKETING_VERSION:' project.yml | head -n1 | sed -E 's/.*"([0-9]+\.[0-9]+)(\.[0-9]+)?".*/\1/')
+          echo "build=$BUILD"           >> "$GITHUB_OUTPUT"
+          echo "marketing=$BASE.$BUILD" >> "$GITHUB_OUTPUT"
+          echo "Next TestFlight version: $BASE.$BUILD ($BUILD)"
 
       # Reserve the build number by tagging the commit BEFORE the irreversible
       # upload. A failed tag push aborts before any TestFlight side effect; a
@@ -112,3 +118,4 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APP_BUILD_NUMBER: ${{ steps.version.outputs.build }}
+          APP_MARKETING_VERSION: ${{ steps.version.outputs.marketing }}

--- a/projects/ios-readplace-poc/TESTFLIGHT.md
+++ b/projects/ios-readplace-poc/TESTFLIGHT.md
@@ -160,11 +160,21 @@ the chrome/firefox publish workflows it's a reusable workflow invoked by
 changes never ship a build). It's also runnable manually from the **Actions** tab
 (`Publish iOS to TestFlight` → *Run workflow*) for the first publish.
 
-Each run derives the next **build number** from the latest `ios-readplace-poc@v*`
-git tag (TestFlight needs a unique, increasing `CFBundleVersion`), **tags the
-commit `ios-readplace-poc@v<n>` to reserve that number before the irreversible
-upload**, then builds and uploads. Runs are serialized (a `concurrency` group) so
-two runs can't claim the same number.
+Each run derives a single **build counter** `<N>` from the latest
+`ios-readplace-poc@v*` git tag (latest + 1) and drives **both** version numbers
+from it: the **build number** (`CFBundleVersion`) is `<N>`, and the **marketing
+version** (`CFBundleShortVersionString`) is `<major.minor>.<N>`, where
+`<major.minor>` is read from `MARKETING_VERSION` in `project.yml`. So with the
+spec at `0.1`, TestFlight shows e.g. `0.1.4 (4)`, then `0.1.5 (5)`. The run
+**tags the commit `ios-readplace-poc@v<N>` to reserve the counter before the
+irreversible upload**, then builds and uploads. Runs are serialized (a
+`concurrency` group) so two runs can't claim the same counter.
+
+Bump the **minor** (e.g. to `0.2`) by editing `MARKETING_VERSION` in
+`project.yml` in a normal PR. The **patch is the monotonic build counter and
+never resets** (`CFBundleVersion` must always increase), so a later minor bump
+yields `0.2.<current counter>` (e.g. `0.2.9`), not `0.2.0` — a per-minor patch
+reset would need a different counter design.
 
 ### Required repository/`prod`-environment secrets
 

--- a/projects/ios-readplace-poc/fastlane/Fastfile
+++ b/projects/ios-readplace-poc/fastlane/Fastfile
@@ -99,6 +99,18 @@ platform :ios do
     build_number = ENV["APP_BUILD_NUMBER"]
     marketing    = ENV["APP_MARKETING_VERSION"]
 
+    # A TestFlight upload can't be cleanly unpublished, so a malformed version from
+    # CI must abort HERE — before build_app/upload_to_testflight — rather than be
+    # baked into CFBundleVersion/CFBundleShortVersionString and shipped. nil means
+    # "not set" (local make ipa) and correctly falls through to the project.yml
+    # defaults; only a present-but-malformed value is a hard error.
+    if build_number && !build_number.match?(/\A\d+\z/)
+      UI.user_error!("APP_BUILD_NUMBER must be a plain integer (CFBundleVersion), got: #{build_number.inspect}")
+    end
+    if marketing && !marketing.match?(/\A\d+(\.\d+){0,2}\z/)
+      UI.user_error!("APP_MARKETING_VERSION must be 1-3 dot-separated integers (CFBundleShortVersionString), got: #{marketing.inspect}")
+    end
+
     version_args = [
       build_number && "CURRENT_PROJECT_VERSION=#{build_number}",
       marketing    && "MARKETING_VERSION=#{marketing}",

--- a/projects/ios-readplace-poc/fastlane/Fastfile
+++ b/projects/ios-readplace-poc/fastlane/Fastfile
@@ -93,9 +93,16 @@ platform :ios do
       )
     end
 
-    # CI passes an incrementing build number — TestFlight requires CFBundleVersion
-    # to increase on every upload. Locally the project.yml default is used.
+    # CI passes the build counter as both the build number and the marketing patch
+    # (CFBundleVersion must increase per upload; CFBundleShortVersionString tracks it
+    # as 0.1.<build>). Locally neither is set and the project.yml defaults are used.
     build_number = ENV["APP_BUILD_NUMBER"]
+    marketing    = ENV["APP_MARKETING_VERSION"]
+
+    version_args = [
+      build_number && "CURRENT_PROJECT_VERSION=#{build_number}",
+      marketing    && "MARKETING_VERSION=#{marketing}",
+    ].compact.join(" ")
 
     build_app(
       project: PROJECT_PATH,
@@ -106,7 +113,7 @@ platform :ios do
       output_name: OUTPUT_NAME,
       export_method: "app-store",
       skip_profile_detection: true,
-      xcargs: build_number ? "CURRENT_PROJECT_VERSION=#{build_number}" : nil,
+      xcargs: version_args.empty? ? nil : version_args,
       export_options: {
         method: "app-store",
         signingStyle: "manual",

--- a/projects/ios-readplace-poc/fastlane/Fastfile
+++ b/projects/ios-readplace-poc/fastlane/Fastfile
@@ -95,7 +95,7 @@ platform :ios do
 
     # CI passes the build counter as both the build number and the marketing patch
     # (CFBundleVersion must increase per upload; CFBundleShortVersionString tracks it
-    # as 0.1.<build>). Locally neither is set and the project.yml defaults are used.
+    # as <major.minor>.<build>). Locally neither is set and the project.yml defaults are used.
     build_number = ENV["APP_BUILD_NUMBER"]
     marketing    = ENV["APP_MARKETING_VERSION"]
 

--- a/projects/ios-readplace-poc/project.yml
+++ b/projects/ios-readplace-poc/project.yml
@@ -10,7 +10,7 @@ settings:
   base:
     # 0.1 is the major.minor source of truth; bump it here to start a new line.
     # In CI the patch is overridden to the build counter, so TestFlight shows
-    # 0.1.<build>. The literal patch here is only the local `make ipa` default.
+    # <major.minor>.<build>. The literal patch here is only the local `make ipa` default.
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
     SWIFT_VERSION: "5.9"

--- a/projects/ios-readplace-poc/project.yml
+++ b/projects/ios-readplace-poc/project.yml
@@ -8,6 +8,9 @@ options:
 
 settings:
   base:
+    # 0.1 is the major.minor source of truth; bump it here to start a new line.
+    # In CI the patch is overridden to the build counter, so TestFlight shows
+    # 0.1.<build>. The literal patch here is only the local `make ipa` default.
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
     SWIFT_VERSION: "5.9"


### PR DESCRIPTION
## What

The iOS TestFlight marketing version (`CFBundleShortVersionString`) was frozen at `0.1.0` — only the build number moved, so every TestFlight email read **Readplace 0.1.0 (N)**. This drives **both** numbers from the single existing build counter, so the next build is **0.1.4 (4)**, then **0.1.5 (5)** — mirroring how the browser extensions bump their patch.

## How

One monotonic counter (`ios-readplace-poc@v<N>`, latest tag + 1) now feeds both numbers:

- **Build number** (`CFBundleVersion`) = `<N>`
- **Marketing version** (`CFBundleShortVersionString`) = `<major.minor>.<N>`, where `<major.minor>` is read from `MARKETING_VERSION` in `project.yml`

### Changes

- **`.github/workflows/publish-ios-testflight.yml`** — the version step composes `marketing=<major.minor>.<build>` by reading the `0.1` prefix from `project.yml`, and forwards it to Fastlane as `APP_MARKETING_VERSION`.
- **`fastlane/Fastfile`** — the `beta` lane now overrides `MARKETING_VERSION` alongside `CURRENT_PROJECT_VERSION` via `xcargs` when CI provides them; locally (`make ipa`) neither is set and the `project.yml` defaults apply.
- **`project.yml`** — keeps `MARKETING_VERSION: "0.1.0"` as the `major.minor` source of truth, with a why-comment explaining the CI patch override.
- **`TESTFLIGHT.md`** — documents the new versioning scheme.

## Notes

- **No tag migration** — the existing integer counter continues; next tag is `ios-readplace-poc@v4`.
- **Bumping the minor later** (e.g. `0.2`) is a one-line `project.yml` edit. Because the patch is the monotonic build counter, it never resets — a later `0.2` line yields `0.2.<current counter>` (e.g. `0.2.9`), not `0.2.0`. This mirrors the extensions and is intentional/documented.
- Editing `project.yml` flips `ci.yml`'s `ios-affected` gate, so merging this will itself run `ios-tests → ios-testflight-publish` and ship the first new build (`0.1.4 (4)`) when the TestFlight secrets are configured; otherwise the publish workflow skips cleanly.

## Verification

- Version math dry-run and the Fastlane `version_args` fallback both confirmed (CI sets both settings; local `make ipa` falls back to the `project.yml` defaults).
- Ruby syntax (`ruby -c Fastfile`) and workflow YAML validated.
- `pnpm check` green via the pre-commit hook (31 projects / 39 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CszawSfz4YogR65ovH9iF6

---
_Generated by [Claude Code](https://claude.ai/code/session_01CszawSfz4YogR65ovH9iF6)_