### PR TITLE
build: clean dist before compile to prevent orphaned build artifacts

### DIFF
--- a/projects/browser-extension-core/package.json
+++ b/projects/browser-extension-core/package.json
@@ -36,7 +36,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "check-unused-css": "node scripts/check-unused-css.js",
     "lint": "tsc --project tsconfig.lint.json && concurrently --kill-others-on-fail \"biome lint src\" \"knip\" \"pnpm check-unused-css\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",

--- a/projects/extensions/chrome-extension/package.json
+++ b/projects/extensions/chrome-extension/package.json
@@ -5,7 +5,7 @@
   "main": "src/infra/index.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc && EXTENSION_VERSION=\"${EXTENSION_VERSION:-0.0.0}\" HUTCH_SERVER_URL=https://readplace.com node scripts/build-extension.js",
+    "compile": "rm -rf dist && tsc && EXTENSION_VERSION=\"${EXTENSION_VERSION:-0.0.0}\" HUTCH_SERVER_URL=https://readplace.com node scripts/build-extension.js",
     "compile-dev": "tsc && HUTCH_SERVER_URL=http://127.0.0.1:3000 node scripts/build-extension.js",
     "check-unused-css": "node scripts/check-unused-css.js",
     "lint": "tsc --project tsconfig.lint.json && concurrently --kill-others-on-fail \"biome lint src\" \"knip\" \"pnpm check-unused-css\"",

--- a/projects/extensions/chrome-extension/package.json
+++ b/projects/extensions/chrome-extension/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "compile": "rm -rf dist && tsc && EXTENSION_VERSION=\"${EXTENSION_VERSION:-0.0.0}\" HUTCH_SERVER_URL=https://readplace.com node scripts/build-extension.js",
-    "compile-dev": "tsc && HUTCH_SERVER_URL=http://127.0.0.1:3000 node scripts/build-extension.js",
+    "compile-dev": "rm -rf dist && tsc && HUTCH_SERVER_URL=http://127.0.0.1:3000 node scripts/build-extension.js",
     "check-unused-css": "node scripts/check-unused-css.js",
     "lint": "tsc --project tsconfig.lint.json && concurrently --kill-others-on-fail \"biome lint src\" \"knip\" \"pnpm check-unused-css\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000 --passWithNoTests",

--- a/projects/extensions/chrome-extension/project.json
+++ b/projects/extensions/chrome-extension/project.json
@@ -8,6 +8,9 @@
     "compile": {
       "outputs": ["{projectRoot}/dist-extension-compiled", "{projectRoot}/dist-extension-files"]
     },
+    "compile-dev": {
+      "dependsOn": ["^compile"]
+    },
     "test:e2e": {
       "dependsOn": ["compile", "hutch:compile"]
     },

--- a/projects/extensions/firefox-extension/package.json
+++ b/projects/extensions/firefox-extension/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "compile": "rm -rf dist && tsc && EXTENSION_VERSION=\"${EXTENSION_VERSION:-0.0.0}\" HUTCH_SERVER_URL=https://readplace.com node scripts/build-extension.js",
-    "compile-dev": "tsc && HUTCH_SERVER_URL=http://127.0.0.1:3000 node scripts/build-extension.js",
+    "compile-dev": "rm -rf dist && tsc && HUTCH_SERVER_URL=http://127.0.0.1:3000 node scripts/build-extension.js",
     "sign": "web-ext sign --channel=unlisted --source-dir dist-extension-compiled --artifacts-dir /tmp/ext-sign-submit --upload-source-code /tmp/extension-source.zip --api-key=\"$AMO_JWT_ISSUER\" --api-secret=\"$AMO_JWT_SECRET\" --approval-timeout 0",
     "check-unused-css": "node scripts/check-unused-css.js",
     "lint": "tsc --project tsconfig.lint.json && concurrently --kill-others-on-fail \"biome lint src\" \"knip\" \"pnpm check-unused-css\"",

--- a/projects/extensions/firefox-extension/package.json
+++ b/projects/extensions/firefox-extension/package.json
@@ -5,7 +5,7 @@
   "main": "src/infra/index.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc && EXTENSION_VERSION=\"${EXTENSION_VERSION:-0.0.0}\" HUTCH_SERVER_URL=https://readplace.com node scripts/build-extension.js",
+    "compile": "rm -rf dist && tsc && EXTENSION_VERSION=\"${EXTENSION_VERSION:-0.0.0}\" HUTCH_SERVER_URL=https://readplace.com node scripts/build-extension.js",
     "compile-dev": "tsc && HUTCH_SERVER_URL=http://127.0.0.1:3000 node scripts/build-extension.js",
     "sign": "web-ext sign --channel=unlisted --source-dir dist-extension-compiled --artifacts-dir /tmp/ext-sign-submit --upload-source-code /tmp/extension-source.zip --api-key=\"$AMO_JWT_ISSUER\" --api-secret=\"$AMO_JWT_SECRET\" --approval-timeout 0",
     "check-unused-css": "node scripts/check-unused-css.js",

--- a/projects/extensions/firefox-extension/project.json
+++ b/projects/extensions/firefox-extension/project.json
@@ -8,6 +8,9 @@
     "compile": {
       "outputs": ["{projectRoot}/dist-extension-compiled", "{projectRoot}/dist-extension-files"]
     },
+    "compile-dev": {
+      "dependsOn": ["^compile"]
+    },
     "test:e2e": {
       "dependsOn": ["compile", "hutch:compile"]
     },

--- a/src/packages/article-parser/package.json
+++ b/src/packages/article-parser/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc && node scripts/copy-static-assets.js",
+    "compile": "rm -rf dist && tsc && node scripts/copy-static-assets.js",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/article-resource-unique-id/package.json
+++ b/src/packages/article-resource-unique-id/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js'",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/article-state-types/package.json
+++ b/src/packages/article-state-types/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js'",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/article-store/package.json
+++ b/src/packages/article-store/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/check-failed-articles/package.json
+++ b/src/packages/check-failed-articles/package.json
@@ -5,7 +5,7 @@
   "main": "dist/scripts/check-failed-articles.js",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint scripts\" \"knip\"",
     "test": "node --test dist/scripts/collect-failed-rows.test.js dist/scripts/exclude-patterns.test.js",
     "check": "pnpm lint && pnpm test",

--- a/src/packages/check-stuck-articles/package.json
+++ b/src/packages/check-stuck-articles/package.json
@@ -5,7 +5,7 @@
   "main": "dist/scripts/check-stuck-articles.js",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint scripts\" \"knip\"",
     "test": "node --test dist/scripts/classify-row.test.js dist/scripts/check-reachable.test.js dist/scripts/check-terminal-state.test.js dist/scripts/collect-stuck-rows.test.js",
     "check": "pnpm lint && pnpm test",

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -46,7 +46,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/extract-links-from-page/package.json
+++ b/src/packages/extract-links-from-page/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/hutch-infra-components/package.json
+++ b/src/packages/hutch-infra-components/package.json
@@ -31,7 +31,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js'",
     "check": "pnpm lint",

--- a/src/packages/hutch-logger/package.json
+++ b/src/packages/hutch-logger/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "echo 'No testable logic — trivial bindings and pass-through factory'",
     "check": "nx run @packages/hutch-logger:check",

--- a/src/packages/hutch-storage-client/package.json
+++ b/src/packages/hutch-storage-client/package.json
@@ -12,7 +12,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "echo 'No testable logic — thin wrapper over AWS SDK, tested via consumers'",
     "check": "pnpm lint",

--- a/src/packages/onboarding-extension-signal/package.json
+++ b/src/packages/onboarding-extension-signal/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "echo 'No testable logic — trivial localStorage wrappers'",
     "check": "nx run @packages/onboarding-extension-signal:check",

--- a/src/packages/provider-contracts/package.json
+++ b/src/packages/provider-contracts/package.json
@@ -121,7 +121,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "check": "pnpm lint",
     "check-infra": "echo 'No infrastructure — shared library'"

--- a/src/packages/refresh-article-content/package.json
+++ b/src/packages/refresh-article-content/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js'",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -141,7 +141,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/test-phase-runner/package.json
+++ b/src/packages/test-phase-runner/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/web-shell/package.json
+++ b/src/packages/web-shell/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",

--- a/src/packages/web-test-harness/package.json
+++ b/src/packages/web-test-harness/package.json
@@ -12,7 +12,7 @@
   },
   "private": true,
   "scripts": {
-    "compile": "tsc",
+    "compile": "rm -rf dist && tsc",
     "lint": "concurrently --kill-others-on-fail \"tsc --project tsconfig.lint.json\" \"biome lint src\" \"knip\"",
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 pnpm test && node enforce-coverage.config.js",


### PR DESCRIPTION
## What

Prefix every package `compile` script that ran a bare `tsc` (or `tsc && <step>` without a clean) with `rm -rf dist &&`, so each build starts from a clean `dist/`. This converges the 21 remaining packages onto the clean-before-compile convention already used by `hutch`, `save-link`, `blog-site`, `web-embed`, `crawl-article`, `finalize-article`, `retriable`, and `time-left`.

## Why

`tsc` never prunes outputs that are orphaned when a source file is moved, renamed, or deleted. Packages whose `compile` was a bare `tsc` accumulated stale files under `dist/` in local working trees. Because the jest target globs `**/dist/**/*.test.js`, orphaned compiled `*.test.js` were executed as **phantom tests**, and c8 attributed coverage to deleted sources.

This surfaced as a code-review finding that `medium-pre-parser.ts` appeared to be duplicated in two locations. The source duplication does **not** exist — commit `d6ecd38e` extracted every parser into the shared `@packages/article-parser` workspace package, and both consumers (`hutch`, `save-link`) import from there. The phantom "duplicate" was stale, gitignored `dist/` output left over from before the extraction. Fresh CI was never affected (it builds `dist/` from current `src`); this only bit dirty local working trees and the nx cache.

## Scope

21 packages converged:
- **18** with a bare `"compile": "tsc"` → `"compile": "rm -rf dist && tsc"`
- **3** with post-`tsc` steps, prepended with `rm -rf dist &&` (tail preserved):
  - `@packages/article-parser` — keeps its `copy-static-assets` step
  - `chrome-extension` / `firefox-extension` — keep their `build-extension` step

The 8 packages already on the convention, the infra-only `platform`, and the root aggregator are untouched. No source changes — the parsers already live in a single canonical package.

## Verification

`pnpm check` across the full workspace: **Successfully ran target check for 31 projects and 39 tasks**, with all 100% coverage thresholds met. Additionally ran `@packages/test-fixtures` (the flagship case) and `@packages/article-parser` (exercises the prepend-with-tail form) with `--skip-nx-cache` to confirm clean rebuilds from a wiped `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnk23Cc6z2i75jcMKydbir

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gnk23Cc6z2i75jcMKydbir)_