### PR TITLE
fix(hutch): clamp out-of-bounds queue page to the last valid page

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.error.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.error.test.ts
@@ -1,4 +1,4 @@
-import { httpErrorMessageMapping, statusFlashMapping } from "./queue.error";
+import { collectStatusFlashParams, httpErrorMessageMapping, statusFlashMapping } from "./queue.error";
 
 describe("httpErrorMessageMapping", () => {
 	it("returns undefined when error_code is absent", () => {
@@ -49,5 +49,18 @@ describe("statusFlashMapping", () => {
 			undoArticleId: "abc",
 			undoStatus: "read",
 		});
+	});
+});
+
+describe("collectStatusFlashParams", () => {
+	it("returns both status flash pairs when present", () => {
+		expect(collectStatusFlashParams({ status_changed: "read", status_article: "abc" })).toEqual([
+			["status_changed", "read"],
+			["status_article", "abc"],
+		]);
+	});
+
+	it("returns an empty list when the status flash params are absent", () => {
+		expect(collectStatusFlashParams({})).toEqual([]);
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
@@ -36,7 +36,7 @@ export const statusFlashMapping = (
 
 /** Pulls the one-shot status flash params off the query so an intervening
  * redirect — e.g. the out-of-bounds page clamp in GET /queue — carries the Undo
- * toast across the extra hop. statusFlashMapping above renders them. */
+ * toast across the extra hop. statusFlashMapping renders them. */
 export function collectStatusFlashParams(query: Request["query"]): [string, string][] {
 	return (["status_changed", "status_article"] as const).flatMap((key): [string, string][] => {
 		const value = query[key];

--- a/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
@@ -1,3 +1,5 @@
+import type { Request } from "express";
+
 const SAVE_ERROR_MESSAGES: Record<string, string> = {
 	save_failed: "Could not save article. Please try again.",
 };
@@ -31,6 +33,16 @@ export const statusFlashMapping = (
 		undoStatus: changed === "read" ? "unread" : "read",
 	};
 };
+
+/** Pulls the one-shot status flash params off the query so an intervening
+ * redirect — e.g. the out-of-bounds page clamp in GET /queue — carries the Undo
+ * toast across the extra hop. statusFlashMapping above renders them. */
+export function collectStatusFlashParams(query: Request["query"]): [string, string][] {
+	return (["status_changed", "status_article"] as const).flatMap((key): [string, string][] => {
+		const value = query[key];
+		return typeof value === "string" ? [[key, value]] : [];
+	});
+}
 
 export type ImportFlashMapping = (query: Record<string, unknown>) => string | undefined;
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -282,6 +282,22 @@ describe("Queue routes", () => {
 			const pagination = doc.querySelector("[data-test-pagination]");
 			expect(pagination?.querySelector(".queue__pagination-link")?.textContent).toContain("Previous");
 		});
+
+		it("redirects an out-of-bounds page (stale bookmark / manual URL) to the last valid page", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/only" });
+
+			const response = await agent.get("/queue?page=99");
+
+			expect(response.status).toBe(302);
+			expect(response.headers.location).toBe("/queue");
+		});
 	});
 
 	describe("Filter and sort", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -330,6 +330,61 @@ describe("Queue routes", () => {
 			expect(new JSDOM(restoredResponse.text).window.document.querySelectorAll(".queue-article").length).toBe(1);
 		});
 
+		it("lands the user on the last valid page after reading the final item on an out-of-bounds page", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			for (let i = 0; i < 21; i++) {
+				await agent
+					.post("/queue/save")
+					.type("form")
+					.send({ url: `https://example.com/article-${i}` });
+			}
+
+			const page2 = await agent.get("/queue?page=2");
+			const page2Cards = new JSDOM(page2.text).window.document.querySelectorAll(
+				"[data-test-article-list] .queue-article",
+			);
+			assert.equal(page2Cards.length, 1, "page 2 holds the lone 21st unread item");
+			const lastId = page2Cards[0].getAttribute("data-test-article");
+			assert.ok(lastId, "the lone card carries an article id");
+
+			const statusResponse = await agent
+				.post(`/queue/${lastId}/status?page=2`)
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(statusResponse.status, 303);
+			assert.equal(
+				statusResponse.headers.location,
+				`/queue?page=2&status_changed=read&status_article=${lastId}`,
+			);
+
+			const clamp = await agent.get(statusResponse.headers.location);
+			assert.equal(clamp.status, 302);
+			assert.equal(
+				clamp.headers.location,
+				`/queue?status_changed=read&status_article=${lastId}`,
+			);
+
+			const landing = await agent.get(clamp.headers.location);
+			assert.equal(landing.status, 200);
+			const landingDoc = new JSDOM(landing.text).window.document;
+			const renderedIds = Array.from(
+				landingDoc.querySelectorAll("[data-test-article-list] .queue-article"),
+			).map((el) => el.getAttribute("data-test-article"));
+			assert.equal(renderedIds.length, 20, "page 1 now shows the full 20 unread items");
+			assert.ok(!renderedIds.includes(lastId), "the just-read item left the unread list");
+
+			const toast = landingDoc.querySelector("[data-test-toast]");
+			assert.ok(toast, "the Undo toast survives the clamp redirect");
+			assert.equal(
+				toast.querySelector("[data-test-toast-message]")?.textContent,
+				"Marked as read",
+			);
+		});
+
 		it("should redirect to queue when status value is invalid", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const { auth } = harness;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -67,11 +67,11 @@ import type { QuerystringFeatureToggle } from "../../feature-toggle";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
 import { toArticleEntity } from "../../api/article-siren";
-import { parseQueueUrl, buildQueueUrl, QUEUE_PATH } from "./queue.url";
+import { parseQueueUrl, buildQueueUrl, QUEUE_PATH, canonicalQueuePageRedirect } from "./queue.url";
 import { collectUtmParams } from "../../shared/utm";
 import { tabQuery } from "./queue.tabs";
 import type { HttpErrorMessageMapping } from "./queue.error";
-import { importFlashMapping, statusFlashMapping } from "./queue.error";
+import { collectStatusFlashParams, importFlashMapping, statusFlashMapping } from "./queue.error";
 import { MAX_POLLS } from "../../shared/article-reader/article-reader";
 import { toQueueArticleViewModel, toQueueViewModel } from "./queue.viewmodel";
 import { QueuePage } from "./queue.component";
@@ -379,6 +379,23 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					url: filterUrl,
 				}),
 			);
+			return;
+		}
+
+		/** Marking the last item on a page read (or deleting it, or a stale
+		 * bookmark) leaves the requested page beyond the new last page, which the
+		 * store answers with zero rows. Clamp at this read boundary so the empty
+		 * out-of-bounds render is unreachable by navigation; mutation handlers
+		 * stay unchanged because they all redirect back through here. 302 not
+		 * 301/308 — the page becomes valid again once the list refills. */
+		const pageRedirect = canonicalQueuePageRedirect({
+			state: urlState,
+			total: result.total,
+			pageSize: result.pageSize,
+			extraParams: [...collectUtmParams(req.query), ...collectStatusFlashParams(req.query)],
+		});
+		if (pageRedirect) {
+			res.redirect(302, pageRedirect);
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.test.ts
@@ -1,4 +1,4 @@
-import { buildQueueUrl, parseQueueUrl } from "./queue.url";
+import { buildQueueUrl, canonicalQueuePageRedirect, parseQueueUrl } from "./queue.url";
 
 describe("parseQueueUrl", () => {
 	it("should default to queue tab for empty query", () => {
@@ -90,4 +90,51 @@ describe("buildQueueUrl", () => {
 		expect(url).toContain("page=3");
 	});
 
+});
+
+describe("canonicalQueuePageRedirect", () => {
+	it("returns undefined for an in-bounds page", () => {
+		expect(
+			canonicalQueuePageRedirect({ state: { tab: "queue", page: 1 }, total: 20, pageSize: 20 }),
+		).toBeUndefined();
+	});
+
+	it("clamps page 2 of a single-page result back to page 1 (/queue)", () => {
+		expect(
+			canonicalQueuePageRedirect({ state: { tab: "queue", page: 2 }, total: 20, pageSize: 20 }),
+		).toBe("/queue");
+	});
+
+	it("returns undefined for the last valid page", () => {
+		expect(
+			canonicalQueuePageRedirect({ state: { tab: "queue", page: 3 }, total: 60, pageSize: 20 }),
+		).toBeUndefined();
+	});
+
+	it("clamps a page beyond the last to the last valid page", () => {
+		expect(
+			canonicalQueuePageRedirect({ state: { tab: "queue", page: 4 }, total: 60, pageSize: 20 }),
+		).toBe("/queue?page=3");
+	});
+
+	it("preserves extra params (utm + status flash) on the clamped URL", () => {
+		expect(
+			canonicalQueuePageRedirect({
+				state: { tab: "queue", page: 2 },
+				total: 20,
+				pageSize: 20,
+				extraParams: [
+					["utm_source", "queue"],
+					["status_changed", "read"],
+					["status_article", "abc"],
+				],
+			}),
+		).toBe("/queue?utm_source=queue&status_changed=read&status_article=abc");
+	});
+
+	it("clamps page 2 of an empty queue to page 1 so the empty state renders", () => {
+		expect(
+			canonicalQueuePageRedirect({ state: { tab: "queue", page: 2 }, total: 0, pageSize: 20 }),
+		).toBe("/queue");
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -55,3 +55,16 @@ export function buildQueueUrl(
 	const qs = params.toString();
 	return qs ? `${QUEUE_PATH}?${qs}` : QUEUE_PATH;
 }
+
+/** totalPages mirrors queue.viewmodel.ts so this read-boundary clamp and the
+ * rendered pagination agree on where the list ends; they must not diverge. */
+export function canonicalQueuePageRedirect(input: {
+	state: QueueUrlState;
+	total: number;
+	pageSize: number;
+	extraParams?: readonly (readonly [string, string])[];
+}): string | undefined {
+	const totalPages = Math.max(1, Math.ceil(input.total / input.pageSize));
+	if (input.state.page <= totalPages) return undefined;
+	return buildQueueUrl({ ...input.state, page: totalPages }, input.extraParams);
+}


### PR DESCRIPTION
## Problem

Reading (or deleting) the last item on a paginated queue page stranded the user on a blank page.

Scenario: 21 unread items → page 1 has 20, page 2 has 1. On `/queue?page=2` the user marks that last item read:

1. `POST /queue/:id/status?page=2` flips it to read; the unread total drops 21 → 20.
2. The handler redirects (303) preserving `page=2` verbatim — there's no check against the new total. Delete and mark-unread do the same.
3. `GET /queue?page=2` asks the store for page 2 of 20 items → `itemsToSkip = (2-1)*20 = 20` → skips all 20 → **zero articles**. Both stores return an empty list for an out-of-bounds page with no clamp.
4. The view model computes `totalPages = 1`, `currentPage = 2`, `isEmpty = (total === 0) = false`. Result: no cards, `showPagination = totalPages > 1 = false` (no pagination controls), and no empty-state message. htmx swaps `<main>` to this blank fragment.

Net: a blank queue below the save bar. The same defect hit delete, mark-unread, and any manually-edited / bookmarked `?page=N` URL beyond the last page.

## Fix

A single guard in the HTML branch of `GET /queue`: after `result` is fetched, if the requested page is beyond the last valid page, **302-redirect to the last valid page**, preserving the Undo-toast flash params and UTM params. htmx follows the redirect and swaps the now-correct page.

- **One chokepoint.** Every mutation already redirects through `GET /queue`, so this single clamp corrects mark-as-read, delete, and mark-unread together. Mutation handlers, the view model, and the stores are unchanged.
- **Clamp to the last valid page** (emptying page 2 of 2 → page 1; page 3 of 3 → page 2). A truly empty queue (`total = 0` → `totalPages = 1`) redirects `?page=2` to page 1, which renders the proper empty-state.
- **302, not 301/308** — the page becomes valid again once the list refills, so the redirect must not be cached as permanent.
- The `totalPages` formula mirrors `queue.viewmodel.ts` so the clamp and the rendered pagination agree on where the list ends.

### Files

- `queue.url.ts` — new pure helper `canonicalQueuePageRedirect` (returns `undefined` for in-bounds pages; the last-page URL otherwise).
- `queue.error.ts` — new `collectStatusFlashParams` (mirrors `collectUtmParams`) so the Undo toast survives the extra hop.
- `queue.page.ts` — wires the guard into the HTML branch, after the Siren early-return and before the expensive summary/crawl loads.

## Out of scope

The **Siren / browser-extension pagination branch** (`wantsSiren`) is left unchanged. It returns before the guard, and the extension discovers next/prev via published HATEOAS links, so it never walks past the last page. (Confirmed by the existing API route test `GET /queue?page=2` with `Accept: application/vnd.siren+json`, which still returns 200 with `properties.page === 2`.)

## Tests (TDD)

- **Unit** — `canonicalQueuePageRedirect`: in-bounds → `undefined`; page 2 of 1 → `/queue`; last valid page → `undefined`; page beyond last → last page URL; extra params (utm + status flash) preserved; empty queue → `/queue`.
- **Unit** — `collectStatusFlashParams`: both pairs when present; `[]` when absent.
- **Integration** (`queue.mutations.route.test.ts`) — the headline scenario: seed 21 unread, read the lone page-2 item, assert the mutation still 303s to `…?page=2&status_changed=read&status_article=<id>`, that `GET` of that URL 302s to `/queue?status_changed=read&status_article=<id>` (page dropped), and that the landing page renders 20 cards (read id excluded) plus the "Marked as read" Undo toast.
- **Integration** (`queue.listing.route.test.ts`) — general stale-bookmark case: seed 1 article, `GET /queue?page=99` → 302 to `/queue`.

Existing pagination and mark-read/toast tests stay green — the guard is a no-op for in-bounds pages.

## Verification

`pnpm nx run hutch:check` (and the full-monorepo pre-commit `pnpm check`) pass: lint, types, unit + integration tests, and 100% coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1hMoHnWYJDzrd6RFvgKD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1hMoHnWYJDzrd6RFvgKD9)_