### PR TITLE
fix(hutch): defer the summary indicator until the reader view is ready

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
@@ -643,6 +643,81 @@ describe("Queue routes", () => {
 			assert(loading, "loading indicator must be rendered when status=pending");
 		});
 
+		it("defers the summary slot (empty, still polling) while the crawl is pending at request time", async () => {
+			const articleHtml = `
+			<html><head><title>Deferred Post</title></head>
+			<body><article>
+				<h1>Deferred Post</h1>
+				<p>Content not yet ready.</p>
+			</article></body></html>`;
+
+			const crawlArticle = async () => ({ status: "fetched" as const, html: articleHtml, bodyHash: "a".repeat(64) });
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const { parseArticle } = initReadabilityParser({ crawlArticle, sitePreParsers: [], logError: createNoopLogError() });
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			const harness = useApp({
+				...fixture,
+				parser: { parseArticle, crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishSaveLinkRawPdfCommand: fixture.events.publishSaveLinkRawPdfCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
+					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
+				},
+				articleCrawl: {
+					...fixture.articleCrawl,
+					findArticleCrawlStatus: async () => ({ status: "pending" as const }),
+				},
+				articleStore: {
+					...fixture.articleStore,
+					readArticleContent: async () => undefined,
+				},
+			});
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "https://example.com/deferred-summary" });
+
+			const queueResponse = await agent.get("/queue");
+			const queueDoc = new JSDOM(queueResponse.text).window.document;
+			const articleId = queueDoc
+				.querySelector("[data-test-article-list] .queue-article")
+				?.getAttribute("data-test-article");
+
+			const readerResponse = await agent.get(`/queue/${articleId}/view`);
+			const doc = new JSDOM(readerResponse.text).window.document;
+
+			const summarySlot = doc.querySelector("[data-test-reader-summary]");
+			assert(summarySlot, "summary slot must be rendered");
+			expect(summarySlot.getAttribute("data-summary-status")).toBe("pending");
+			expect(
+				summarySlot.classList.contains("article-body__summary-slot--deferred"),
+			).toBe(true);
+			expect(summarySlot.getAttribute("hx-get")).toMatch(/^\/queue\/.+\/summary\?poll=1$/);
+			expect(summarySlot.getAttribute("hx-trigger")).toBe("every 3s");
+			expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+
+			const readerSlot = doc.querySelector("[data-test-reader-slot]");
+			assert(readerSlot, "reader slot must be rendered");
+			expect(readerSlot.getAttribute("data-reader-status")).toBe("pending");
+			expect(
+				doc.querySelector(".article-body__reader-loading")?.textContent,
+			).toContain("Generating clean reader view");
+		});
+
 		it("should show an inline error when status=failed", async () => {
 			const articleHtml = `
 			<html><head><title>Failed Post</title></head>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
@@ -704,7 +704,7 @@ describe("Queue routes", () => {
 			assert(summarySlot, "summary slot must be rendered");
 			expect(summarySlot.getAttribute("data-summary-status")).toBe("pending");
 			expect(
-				summarySlot.classList.contains("article-body__summary-slot--deferred"),
+				summarySlot.classList.contains("article-body__summary-slot--hidden"),
 			).toBe(true);
 			expect(summarySlot.getAttribute("hx-get")).toMatch(/^\/queue\/.+\/summary\?poll=1$/);
 			expect(summarySlot.getAttribute("hx-trigger")).toBe("every 3s");

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1305,8 +1305,9 @@ describe("View routes", () => {
 			// deferred and empty rather than showing the misleading
 			// "Still generating — refresh" message; the reader slot carries the
 			// terminal reframe in this state.
+			expect(slot.getAttribute("data-summary-status")).toBe("pending");
 			expect(
-				slot.classList.contains("article-body__summary-slot--deferred"),
+				slot.classList.contains("article-body__summary-slot--hidden"),
 			).toBe(true);
 			expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
 		});

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -1280,7 +1280,7 @@ describe("View routes", () => {
 			expect(slot.getAttribute("hx-get")).toMatch(/poll=6$/);
 		});
 
-		it("stops polling at the cap and renders a terminal message", async () => {
+		it("stops polling at the cap and collapses to an empty deferred slot while the reader view is not ready", async () => {
 			const findGeneratedSummary: FindGeneratedSummary = async () => ({ status: "pending" });
 			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 			const harness = useApp({
@@ -1301,9 +1301,14 @@ describe("View routes", () => {
 			const slot = doc.querySelector("[data-test-reader-summary]");
 			assert(slot, "summary slot must be rendered");
 			expect(slot.hasAttribute("hx-get")).toBe(false);
+			// Reader view never became ready (no content), so the summary stays
+			// deferred and empty rather than showing the misleading
+			// "Still generating — refresh" message; the reader slot carries the
+			// terminal reframe in this state.
 			expect(
-				doc.querySelector(".article-body__summary-loading")?.textContent,
-			).toContain("Still generating");
+				slot.classList.contains("article-body__summary-slot--deferred"),
+			).toBe(true);
+			expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
 		});
 
 		it("returns 400 for an invalid url", async () => {

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
@@ -55,6 +55,43 @@ describe("renderArticleBody", () => {
 		expect(slot.getAttribute("data-summary-status")).toBe("ready");
 	});
 
+	it("defers the summary slot (no 'Generating summary') while the crawl is still pending", () => {
+		const html = renderArticleBody({
+			...baseInput,
+			content: undefined,
+			crawl: { status: "pending" },
+			summary: { status: "pending" },
+			summaryPollUrl: "/queue/abc/summary?poll=1",
+			readerPollUrl: "/queue/abc/reader?poll=1",
+		});
+		const doc = parse(html);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+			true,
+		);
+		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+	});
+
+	it("shows 'Generating summary' once the reader view is ready and the summary is still pending", () => {
+		const html = renderArticleBody({
+			...baseInput,
+			content: "<p>Body</p>",
+			crawl: { status: "ready" },
+			summary: { status: "pending" },
+			summaryPollUrl: "/queue/abc/summary?poll=1",
+		});
+		const doc = parse(html);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(
+			doc.querySelector(".article-body__summary-loading")?.textContent,
+		).toBe("Generating summary");
+	});
+
 	it("renders the back link inside the back slot when backLink is provided", () => {
 		const html = renderArticleBody({
 			...baseInput,

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.test.ts
@@ -68,7 +68,8 @@ describe("renderArticleBody", () => {
 
 		const slot = doc.querySelector("[data-test-reader-summary]");
 		assert(slot, "summary slot must be rendered");
-		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(slot.classList.contains("article-body__summary-slot--hidden")).toBe(
 			true,
 		);
 		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.component.ts
@@ -67,6 +67,7 @@ export function renderArticleBody(input: ArticleBodyInput): string {
 		summary: input.summary,
 		summaryPollUrl: input.summaryPollUrl,
 		summaryOpen: input.summaryOpen,
+		content: input.content,
 	});
 
 	const progressBarHtml = renderProgressBar({ progress: input.progress });

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -96,6 +96,10 @@
   display: none;
 }
 
+.article-body__summary-slot--deferred {
+  display: none;
+}
+
 .article-body__summary {
   margin-bottom: 2rem;
   background: var(--color-surface);

--- a/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/article-body.styles.css
@@ -96,10 +96,6 @@
   display: none;
 }
 
-.article-body__summary-slot--deferred {
-  display: none;
-}
-
 .article-body__summary {
   margin-bottom: 2rem;
   background: var(--color-surface);

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-collapsed.template.html
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-collapsed.template.html
@@ -1,0 +1,1 @@
+<div id="article-body-summary-slot" class="article-body__summary-slot article-body__summary-slot--hidden" data-test-reader-summary data-summary-status="{{status}}"{{#if oob}} hx-swap-oob="outerHTML"{{/if}}{{#if pollUrl}} hx-get="{{pollUrl}}" hx-trigger="every 3s" hx-swap="outerHTML"{{/if}}></div>

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
@@ -34,9 +34,11 @@ describe("renderSummarySlot", () => {
 		expect(details.hasAttribute("open")).toBe(true);
 	});
 
-	it("routes status=pending to the pending component with the poll URL", () => {
+	it("routes status=pending to the pending component with the poll URL once the reader view is ready", () => {
 		const doc = parse(
 			renderSummarySlot({
+				crawl: { status: "ready" },
+				content: "<p>x</p>",
 				summary: { status: "pending" },
 				summaryPollUrl: "/queue/abc/summary?poll=1",
 			}),
@@ -46,6 +48,87 @@ describe("renderSummarySlot", () => {
 		assert(slot, "summary slot must be rendered");
 		expect(slot.getAttribute("data-summary-status")).toBe("pending");
 		expect(slot.getAttribute("hx-get")).toBe("/queue/abc/summary?poll=1");
+		expect(
+			doc.querySelector(".article-body__summary-loading")?.textContent,
+		).toBe("Generating summary");
+	});
+
+	it("defers the summary (empty, still polling) while the crawl is pending and content is absent", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: { status: "pending" },
+				content: undefined,
+				summary: { status: "pending" },
+				summaryPollUrl: "/queue/abc/summary?poll=1",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+			true,
+		);
+		expect(slot.getAttribute("hx-get")).toBe("/queue/abc/summary?poll=1");
+		expect(slot.getAttribute("hx-trigger")).toBe("every 3s");
+		expect(slot.getAttribute("hx-swap")).toBe("outerHTML");
+		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+	});
+
+	it("defers the summary during the promotion race (crawl ready but content not yet copied)", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: { status: "ready" },
+				content: undefined,
+				summary: { status: "pending" },
+				summaryPollUrl: "/queue/abc/summary?poll=1",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+			true,
+		);
+		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+	});
+
+	it("shows the pending indicator for a legacy ready row (crawl undefined, content present)", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: undefined,
+				content: "<p>x</p>",
+				summary: { status: "pending" },
+				summaryPollUrl: "/queue/abc/summary?poll=1",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.classList.contains("article-body__summary-slot--visible")).toBe(
+			true,
+		);
+		expect(
+			doc.querySelector(".article-body__summary-loading")?.textContent,
+		).toBe("Generating summary");
+	});
+
+	it("defers without poll attributes when there is no summary poll URL (e.g. unsupported crawl)", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: { status: "unsupported", reason: "binary content" },
+				content: undefined,
+				summary: { status: "pending" },
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+			true,
+		);
+		expect(slot.hasAttribute("hx-get")).toBe(false);
+		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
 	});
 
 	it("routes status=failed to the failed component and surfaces the reason", () => {
@@ -107,11 +190,33 @@ describe("renderSummarySlot", () => {
 		expect(slot.children.length).toBe(0);
 	});
 
-	it("defaults to pending when summary is undefined", () => {
+	it("defaults to the deferred variant when summary is undefined and the reader view is not ready", () => {
 		const doc = parse(renderSummarySlot({ summary: undefined }));
 
 		const slot = doc.querySelector("[data-test-reader-summary]");
 		assert(slot, "summary slot must be rendered");
 		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+			true,
+		);
+		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+	});
+
+	it("defaults to the pending indicator when summary is undefined but the reader view is ready", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: { status: "ready" },
+				content: "<p>x</p>",
+				summary: undefined,
+				summaryPollUrl: "/queue/abc/summary?poll=1",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(
+			doc.querySelector(".article-body__summary-loading")?.textContent,
+		).toBe("Generating summary");
 	});
 });

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
@@ -95,6 +95,28 @@ describe("renderSummarySlot", () => {
 		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
 	});
 
+	it("defers the summary when content is present but the crawl is back to pending (admin recrawl)", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: { status: "pending" },
+				content: "<p>x</p>",
+				summary: { status: "pending" },
+				summaryPollUrl: "/queue/abc/summary?poll=1",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(slot.classList.contains("article-body__summary-slot--hidden")).toBe(
+			true,
+		);
+		expect(slot.getAttribute("hx-get")).toBe("/queue/abc/summary?poll=1");
+		expect(slot.getAttribute("hx-trigger")).toBe("every 3s");
+		expect(slot.getAttribute("hx-swap")).toBe("outerHTML");
+		expect(slot.children.length).toBe(0);
+	});
+
 	it("shows the pending indicator for a legacy ready row (crawl undefined, content present)", () => {
 		const doc = parse(
 			renderSummarySlot({

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
@@ -66,7 +66,7 @@ describe("renderSummarySlot", () => {
 		const slot = doc.querySelector("[data-test-reader-summary]");
 		assert(slot, "summary slot must be rendered");
 		expect(slot.getAttribute("data-summary-status")).toBe("pending");
-		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+		expect(slot.classList.contains("article-body__summary-slot--hidden")).toBe(
 			true,
 		);
 		expect(slot.getAttribute("hx-get")).toBe("/queue/abc/summary?poll=1");
@@ -87,27 +87,11 @@ describe("renderSummarySlot", () => {
 
 		const slot = doc.querySelector("[data-test-reader-summary]");
 		assert(slot, "summary slot must be rendered");
-		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(slot.classList.contains("article-body__summary-slot--hidden")).toBe(
 			true,
 		);
-		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
-	});
-
-	it("defers the summary when content is an empty string (mirrors renderReaderSlot's truthy content gate)", () => {
-		const doc = parse(
-			renderSummarySlot({
-				crawl: { status: "ready" },
-				content: "",
-				summary: { status: "pending" },
-				summaryPollUrl: "/queue/abc/summary?poll=1",
-			}),
-		);
-
-		const slot = doc.querySelector("[data-test-reader-summary]");
-		assert(slot, "summary slot must be rendered");
-		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
-			true,
-		);
+		expect(slot.getAttribute("hx-get")).toBe("/queue/abc/summary?poll=1");
 		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
 	});
 
@@ -142,11 +126,29 @@ describe("renderSummarySlot", () => {
 
 		const slot = doc.querySelector("[data-test-reader-summary]");
 		assert(slot, "summary slot must be rendered");
-		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+		expect(slot.getAttribute("data-summary-status")).toBe("pending");
+		expect(slot.classList.contains("article-body__summary-slot--hidden")).toBe(
 			true,
 		);
 		expect(slot.hasAttribute("hx-get")).toBe(false);
 		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+	});
+
+	it("HTML-escapes the deferred poll URL, matching the Handlebars-rendered pending slot", () => {
+		const html = renderSummarySlot({
+			crawl: { status: "pending" },
+			content: undefined,
+			summary: { status: "pending" },
+			summaryPollUrl: "/view/summary?url=x&poll=1",
+		});
+
+		// The query-joining '&' must be HTML-escaped in the attribute, exactly as
+		// {{pollUrl}} is escaped in summary-pending.template.html. getAttribute
+		// then decodes it back to the URL htmx polls.
+		expect(html).toContain("&amp;poll");
+		const slot = parse(html).querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.getAttribute("hx-get")).toBe("/view/summary?url=x&poll=1");
 	});
 
 	it("routes status=failed to the failed component and surfaces the reason", () => {
@@ -214,7 +216,7 @@ describe("renderSummarySlot", () => {
 		const slot = doc.querySelector("[data-test-reader-summary]");
 		assert(slot, "summary slot must be rendered");
 		expect(slot.getAttribute("data-summary-status")).toBe("pending");
-		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+		expect(slot.classList.contains("article-body__summary-slot--hidden")).toBe(
 			true,
 		);
 		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.test.ts
@@ -93,6 +93,24 @@ describe("renderSummarySlot", () => {
 		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
 	});
 
+	it("defers the summary when content is an empty string (mirrors renderReaderSlot's truthy content gate)", () => {
+		const doc = parse(
+			renderSummarySlot({
+				crawl: { status: "ready" },
+				content: "",
+				summary: { status: "pending" },
+				summaryPollUrl: "/queue/abc/summary?poll=1",
+			}),
+		);
+
+		const slot = doc.querySelector("[data-test-reader-summary]");
+		assert(slot, "summary slot must be rendered");
+		expect(slot.classList.contains("article-body__summary-slot--deferred")).toBe(
+			true,
+		);
+		expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+	});
+
 	it("shows the pending indicator for a legacy ready row (crawl undefined, content present)", () => {
 		const doc = parse(
 			renderSummarySlot({

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
@@ -46,13 +46,19 @@ function renderCollapsedSlot(input: {
 	return render(COLLAPSED_TEMPLATE, input);
 }
 
-// The reader view is ready exactly when canonical content is present: the
-// pipeline makes content readable only once the crawl has published it (and
-// legacy rows always have it), the same `if (content)` signal renderReaderSlot
-// renders its ready view on. So the summary indicator surfaces precisely when
-// the reader view does.
-function isReaderViewReady(content: string | undefined): boolean {
-	return !!content;
+// The reader view is ready exactly when renderReaderSlot renders its ready
+// view: content present AND the crawl `ready` (or a legacy `crawl === undefined`
+// row). Content presence alone is not enough — renderReaderSlot's `pending`
+// branch ignores content, and content-present-with-crawl-pending is reachable
+// (e.g. an admin recrawl flips the crawl back to `pending` without dropping the
+// already-published content), a state where the reader still shows its pending
+// spinner. Gating on the crawl too keeps the summary deferred there instead of
+// spinning a second, orphaned indicator beside the reader's.
+function isReaderViewReady(
+	crawl: ArticleCrawl | undefined,
+	content: string | undefined,
+): boolean {
+	return !!content && (crawl === undefined || crawl.status === "ready");
 }
 
 export function renderSummarySlot(input: SummarySlotInput): string {
@@ -68,7 +74,7 @@ export function renderSummarySlot(input: SummarySlotInput): string {
 				oob,
 			});
 		case "pending":
-			return isReaderViewReady(input.content)
+			return isReaderViewReady(input.crawl, input.content)
 				? renderSummaryPending({ pollUrl: input.summaryPollUrl, oob })
 				: renderCollapsedSlot({
 						status: "pending",

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
@@ -1,9 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ArticleCrawl } from "@packages/provider-contracts/article-crawl";
 import type { GeneratedSummary } from "@packages/provider-contracts/article-summary";
+import { render } from "@packages/web-shell";
 import { renderSummaryFailed } from "./summary-failed.component";
 import { renderSummaryPending } from "./summary-pending.component";
 import { renderSummaryReady } from "./summary-ready.component";
 import { renderSummarySkipped } from "./summary-skipped.component";
+
+const COLLAPSED_TEMPLATE = readFileSync(
+	join(__dirname, "summary-collapsed.template.html"),
+	"utf-8",
+);
 
 export interface SummarySlotInput {
 	crawl?: ArticleCrawl;
@@ -22,44 +30,35 @@ export interface SummarySlotInput {
 	oob?: boolean;
 }
 
-// When the crawl has failed there is no article to summarise; the
-// reader-failed card already explains the problem so the slot stays hidden
-// rather than competing with it. Inlined here (instead of routing through
-// renderSummarySkipped) because the visible "skipped" card carries copy that
-// would duplicate the reader-failed card. The `id` mirrors the variant
-// templates so an OOB swap can still target this collapsed shape.
-function renderHiddenSlot(oob: boolean): string {
-	const oobAttr = oob ? ' hx-swap-oob="outerHTML"' : "";
-	return `<div id="article-body-summary-slot" class="article-body__summary-slot article-body__summary-slot--hidden" data-test-reader-summary data-summary-status="skipped"${oobAttr}></div>`;
+// An empty, display:none slot that renders no card. Used both when the crawl
+// has failed (the reader-failed card already carries the message, so a visible
+// "skipped" card would duplicate it) and while the reader view is still
+// generating (the summary pipeline has not started yet, so a pending indicator
+// would spin with nothing behind it). The stable `id` keeps OOB swaps targeting
+// it across state transitions; passing a pollUrl keeps the htmx poll alive so
+// the deferred case promotes to the real indicator on the next poll. pollUrl is
+// HTML-escaped by Handlebars, matching the visible pending slot.
+function renderCollapsedSlot(input: {
+	status: "skipped" | "pending";
+	pollUrl?: string;
+	oob: boolean;
+}): string {
+	return render(COLLAPSED_TEMPLATE, input);
 }
 
-// While the reader view is still generating, the pending summary indicator
-// would spin with nothing behind it (the summary pipeline can't start until the
-// crawl publishes canonical content). This variant collapses the slot to an
-// empty, display:none placeholder that keeps the htmx poll alive, so the moment
-// the reader view is ready the next poll reveals the real "Generating summary"
-// indicator. The stable `id` lets the cross-axis OOB swap still target it.
-function renderDeferredSlot(pollUrl: string | undefined, oob: boolean): string {
-	const oobAttr = oob ? ' hx-swap-oob="outerHTML"' : "";
-	const pollAttrs = pollUrl
-		? ` hx-get="${pollUrl}" hx-trigger="every 3s" hx-swap="outerHTML"`
-		: "";
-	return `<div id="article-body-summary-slot" class="article-body__summary-slot article-body__summary-slot--deferred" data-test-reader-summary data-summary-status="pending"${oobAttr}${pollAttrs}></div>`;
-}
-
-// Mirrors renderReaderSlot's ready condition (renderReaderReady fires when
-// content is present and the crawl is a legacy row or has reached ready), so
-// the summary indicator surfaces exactly when the reader view does.
-function isReaderViewReady(
-	crawl: ArticleCrawl | undefined,
-	content: string | undefined,
-): boolean {
-	return !!content && (crawl === undefined || crawl.status === "ready");
+// The reader view is ready exactly when canonical content is present: the
+// pipeline makes content readable only once the crawl has published it (and
+// legacy rows always have it), the same `if (content)` signal renderReaderSlot
+// renders its ready view on. So the summary indicator surfaces precisely when
+// the reader view does.
+function isReaderViewReady(content: string | undefined): boolean {
+	return !!content;
 }
 
 export function renderSummarySlot(input: SummarySlotInput): string {
 	const oob = input.oob === true;
-	if (input.crawl?.status === "failed") return renderHiddenSlot(oob);
+	if (input.crawl?.status === "failed")
+		return renderCollapsedSlot({ status: "skipped", oob });
 	const summary = input.summary ?? { status: "pending" };
 	switch (summary.status) {
 		case "ready":
@@ -69,9 +68,13 @@ export function renderSummarySlot(input: SummarySlotInput): string {
 				oob,
 			});
 		case "pending":
-			return isReaderViewReady(input.crawl, input.content)
+			return isReaderViewReady(input.content)
 				? renderSummaryPending({ pollUrl: input.summaryPollUrl, oob })
-				: renderDeferredSlot(input.summaryPollUrl, oob);
+				: renderCollapsedSlot({
+						status: "pending",
+						pollUrl: input.summaryPollUrl,
+						oob,
+					});
 		case "failed":
 			return renderSummaryFailed({ reason: summary.reason, oob });
 		case "skipped":

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
@@ -10,6 +10,11 @@ export interface SummarySlotInput {
 	summary: GeneratedSummary | undefined;
 	summaryPollUrl?: string;
 	summaryOpen?: boolean;
+	/* The reader content. Gates the pending indicator: the summary pipeline is
+	 * only triggered once the crawl publishes canonical content, so until the
+	 * reader view is ready nothing is generating the summary and the indicator
+	 * would sit stuck. */
+	content?: string;
 	/* When true, the rendered slot carries `hx-swap-oob="outerHTML"` so HTMX
 	 * splices it into a sibling poll response and replaces the live slot. The
 	 * stable `id="article-body-summary-slot"` on every variant gives HTMX a
@@ -28,6 +33,30 @@ function renderHiddenSlot(oob: boolean): string {
 	return `<div id="article-body-summary-slot" class="article-body__summary-slot article-body__summary-slot--hidden" data-test-reader-summary data-summary-status="skipped"${oobAttr}></div>`;
 }
 
+// While the reader view is still generating, the pending summary indicator
+// would spin with nothing behind it (the summary pipeline can't start until the
+// crawl publishes canonical content). This variant collapses the slot to an
+// empty, display:none placeholder that keeps the htmx poll alive, so the moment
+// the reader view is ready the next poll reveals the real "Generating summary"
+// indicator. The stable `id` lets the cross-axis OOB swap still target it.
+function renderDeferredSlot(pollUrl: string | undefined, oob: boolean): string {
+	const oobAttr = oob ? ' hx-swap-oob="outerHTML"' : "";
+	const pollAttrs = pollUrl
+		? ` hx-get="${pollUrl}" hx-trigger="every 3s" hx-swap="outerHTML"`
+		: "";
+	return `<div id="article-body-summary-slot" class="article-body__summary-slot article-body__summary-slot--deferred" data-test-reader-summary data-summary-status="pending"${oobAttr}${pollAttrs}></div>`;
+}
+
+// Mirrors renderReaderSlot's ready condition (renderReaderReady fires when
+// content is present and the crawl is a legacy row or has reached ready), so
+// the summary indicator surfaces exactly when the reader view does.
+function isReaderViewReady(
+	crawl: ArticleCrawl | undefined,
+	content: string | undefined,
+): boolean {
+	return content !== undefined && (crawl === undefined || crawl.status === "ready");
+}
+
 export function renderSummarySlot(input: SummarySlotInput): string {
 	const oob = input.oob === true;
 	if (input.crawl?.status === "failed") return renderHiddenSlot(oob);
@@ -40,7 +69,9 @@ export function renderSummarySlot(input: SummarySlotInput): string {
 				oob,
 			});
 		case "pending":
-			return renderSummaryPending({ pollUrl: input.summaryPollUrl, oob });
+			return isReaderViewReady(input.crawl, input.content)
+				? renderSummaryPending({ pollUrl: input.summaryPollUrl, oob })
+				: renderDeferredSlot(input.summaryPollUrl, oob);
 		case "failed":
 			return renderSummaryFailed({ reason: summary.reason, oob });
 		case "skipped":

--- a/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/summary-slot/summary-slot.component.ts
@@ -54,7 +54,7 @@ function isReaderViewReady(
 	crawl: ArticleCrawl | undefined,
 	content: string | undefined,
 ): boolean {
-	return content !== undefined && (crawl === undefined || crawl.status === "ready");
+	return !!content && (crawl === undefined || crawl.status === "ready");
 }
 
 export function renderSummarySlot(input: SummarySlotInput): string {

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -988,6 +988,33 @@ describe("initArticleReader", () => {
 			expect(summarySlot.getAttribute("hx-get")).toBe("/test/summary?poll=1");
 		});
 
+		it("handleReaderPoll emits a deferred OOB summary slot (no loading span, still polling) while the crawl is pending", async () => {
+			const { deps } = initFakeDeps({
+				crawl: { status: "pending" },
+				summary: { status: "pending" },
+				content: undefined,
+			});
+			const reader = initArticleReader(deps);
+
+			const component = await reader.handleReaderPoll({
+				articleUrl: ARTICLE_URL,
+				pollCount: 0,
+				pollUrlBuilder: makePollUrlBuilder(),
+				extensionInstallUrl: undefined,
+			});
+
+			const doc = parse(toHtml(component));
+			const summarySlot = doc.querySelector("[data-test-reader-summary]");
+			assert(summarySlot, "OOB summary slot must accompany the reader-poll response");
+			expect(summarySlot.getAttribute("hx-swap-oob")).toBe("outerHTML");
+			expect(summarySlot.getAttribute("data-summary-status")).toBe("pending");
+			expect(
+				summarySlot.classList.contains("article-body__summary-slot--deferred"),
+			).toBe(true);
+			expect(summarySlot.getAttribute("hx-get")).toBe("/test/summary?poll=1");
+			expect(doc.querySelector(".article-body__summary-loading")).toBe(null);
+		});
+
 		it("handleSummaryPoll emits an OOB reader slot with hx-get when crawl has gone pending while summary is settling", async () => {
 			const { deps } = initFakeDeps({
 				crawl: { status: "pending", stage: "crawl-fetching" },

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.test.ts
@@ -1009,7 +1009,7 @@ describe("initArticleReader", () => {
 			expect(summarySlot.getAttribute("hx-swap-oob")).toBe("outerHTML");
 			expect(summarySlot.getAttribute("data-summary-status")).toBe("pending");
 			expect(
-				summarySlot.classList.contains("article-body__summary-slot--deferred"),
+				summarySlot.classList.contains("article-body__summary-slot--hidden"),
 			).toBe(true);
 			expect(summarySlot.getAttribute("hx-get")).toBe("/test/summary?poll=1");
 			expect(doc.querySelector(".article-body__summary-loading")).toBe(null);

--- a/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
+++ b/projects/hutch/src/runtime/web/shared/article-reader/article-reader.ts
@@ -79,6 +79,7 @@ function renderPollResponseBody(input: PollResponseBodyInput): string {
 		summary: input.summary,
 		summaryPollUrl: input.summaryPollUrl,
 		summaryOpen: input.summaryOpen,
+		content: input.content,
 		oob: input.primary !== "summary",
 	});
 	const progressBarOob = renderProgressBarOob({ progress: input.progress });


### PR DESCRIPTION
## Problem

When a user opens a saved article that is still processing, the reader page stacked two loading indicators, both polling every 3s:

- **Reader slot** — "Generating clean reader view…" (driven by `crawlStatus`)
- **Summary slot** — "Generating summary…" (driven by `summaryStatus`)

The summary pipeline cannot start until the crawl finishes — summary is only triggered after the crawl publishes canonical content (`CanonicalContentChanged → markSummaryPending → GenerateSummaryCommand`). But the article stub is created with `summary: pending` at t=0, so the "Generating summary" spinner showed from the first render and just sat there spinning while nothing was actually generating it. Two spinners, one stuck-looking, is what made the page "look like it's not working."

## Change

Gate the pending summary slot on the reader view being ready (content present **and** the crawl `ready` or a legacy row — mirroring `renderReaderSlot`'s ready condition). The change is additive and lives entirely in the shared `summary-slot` component, so every surface that renders it gets it automatically (initial SSR via `renderArticleBody`, and poll/OOB responses via `renderPollResponseBody` — covering both `/queue/:id/view` and the public `/view` page).

Summary slot behaviour by phase:

| Crawl / reader state | Summary state | Renders |
|---|---|---|
| Reader not ready (crawl pending, or ready-without-content race) | pending | **Deferred** — empty, `display:none`, but keeps `hx-get`/`hx-trigger` polling |
| Reader ready (content present, crawl ready/undefined) | pending | "Generating summary" indicator (unchanged) |
| any | ready | Summary card (unchanged) |
| any | failed / skipped | Error / info card (unchanged) |
| crawl failed | any | Hidden collapsed slot, no poll (unchanged) |

The new `--deferred` variant keeps its htmx poll alive, so the moment the reader view is ready the next poll's OOB handoff reveals the real "Generating summary" indicator — with no page reload. The unified progress bar is intentionally left as the single "something is happening" signal during the crawl.

As a side benefit, an unsupported/terminal crawl with no summary poll URL now collapses to an empty deferred slot instead of the misleading "Still generating — refresh" message; the reader slot owns the terminal copy in that state.

## Tests

- `summary-slot.component.test.ts` — primary coverage of the gate, the `isReaderViewReady` predicate, and the `renderDeferredSlot` branches (deferred while pending, promotion race, legacy-ready reader, deferred without poll URL); tightened the existing pending test to a reader-ready state.
- `article-reader.test.ts` — `handleReaderPoll` emits a deferred OOB summary slot (no loading span, still polling) while the crawl is pending.
- `article-body.component.test.ts` — deferred while crawl pending; "Generating summary" once reader ready.
- `queue.reader.route.test.ts` — `GET /queue/:id/view` with the crawl held pending at request time renders a deferred, still-polling summary slot while the reader shows "Generating clean reader view".
- `view.route.test.ts` — updated the at-cap test to assert the new empty-deferred behaviour when the reader view never became ready.

`pnpm nx run hutch:check` is green: lint, type-check, 1974 tests, 100% coverage, knip, and check-unused-css.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5gJc5pGEubtkiLx23ghMt

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5gJc5pGEubtkiLx23ghMt)_