### PR TITLE
feat: make link import self-serve for logged-out visitors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,11 @@
 
 ## Product Constraints
 
-### Imports are self-serve from /queue, with email as fallback
+### Imports are self-serve and public, with email as fallback
 
-The CTA lives next to the save bar on `/queue` only — do **not** restore the removed "Import Your Data" landing-page card. Flow: the user uploads any file (≤ 5 MiB), the server best-effort-decodes it as text and extracts `http(s)://…` URLs, the user reviews a paginated list with every link checked by default, then clicks "Import N selected". Selected URLs are stub-saved synchronously (hostname-only metadata at t=0) and the existing `SaveLinkCommand` pipeline fills in title/excerpt/content asynchronously, so cards appear immediately and progressively populate. Files larger than 5 MiB or imports above the 2,000-URL cap fall back to the concierge email path (`readplace+migrate@readplace.com`); keep that documented in [pocket-migration.md](./projects/hutch/src/runtime/web/pages/blog/posts/pocket-migration.md).
+Importing is a top-of-funnel acquisition path: it is reachable **logged out**, not gated behind auth. Entry points are the **Import Links** nav item (present for guests and authenticated users via `buildGuestNavItems` in [banner-state.ts](./src/packages/web-shell/src/banner-state.ts), so it also appears on the same-origin blog header) and the CTA next to the save bar on `/queue` — do **not** restore the removed "Import Your Data" landing-page card.
+
+Flow: the visitor uploads any file (≤ 5 MiB) or pastes a link, the server best-effort-decodes it as text and extracts `http(s)://…` URLs, then reviews a paginated list (every link checked by default, selections persisted server-side). Auth is required only at **commit** ("Import N selected" → `POST /import/:id/commit`); an anonymous visitor is redirected to `/signup?return=/import/:id` and returns to the same review with selections intact, because anonymous sessions are reached by **capability** (the unguessable id), not by owner. Only the commit route carries the save gates (`requireNotLocked`, `requireWriteAccess`) — see [import.page.ts](./projects/hutch/src/runtime/web/pages/import/import.page.ts). On commit the selected URLs are stub-saved under the authenticated user (hostname-only metadata at t=0) and the existing `SaveLinkCommand` pipeline fills in title/excerpt/content asynchronously, so cards appear immediately and progressively populate. Files larger than 5 MiB or imports above the 2,000-URL cap fall back to the concierge email path (`readplace+migrate@readplace.com`); keep that documented in [pocket-migration.md](./projects/blog-site/src/runtime/web/pages/blog/posts/pocket-migration.md).
 
 ### Crawler Health Canary Is Load-Bearing
 

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.test.ts
@@ -43,22 +43,26 @@ function storedRow(userId?: UserId): Record<string, unknown> {
  * every command so the write's ConditionExpression / ExpressionAttributeValues can
  * be asserted. A null `row` makes Get return no item (caller is denied). */
 function createFakeClient(row: Record<string, unknown> | null): {
-	client: DynamoDBDocumentClient;
+	client: Partial<DynamoDBDocumentClient>;
 	commands: CapturedCommand[];
 } {
 	const commands: CapturedCommand[] = [];
-	const client = {
+	const client: Partial<DynamoDBDocumentClient> = {
 		send: (async (command: { constructor: { name: string }; input: CapturedCommand["input"] }) => {
 			commands.push({ name: command.constructor.name, input: command.input });
 			if (command.constructor.name === "GetCommand") return row ? { Item: row } : {};
 			return {};
 		}) as DynamoDBDocumentClient["send"],
 	};
-	return { client: client as typeof client & DynamoDBDocumentClient, commands };
+	return { client, commands };
 }
 
-function initStore(client: DynamoDBDocumentClient) {
-	return initDynamoDbImportSession({ client, tableName: TABLE, now: NOW });
+function initStore(client: Partial<DynamoDBDocumentClient>) {
+	return initDynamoDbImportSession({
+		client: client as DynamoDBDocumentClient,
+		tableName: TABLE,
+		now: NOW,
+	});
 }
 
 describe("initDynamoDbImportSession", () => {

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { ImportSessionIdSchema } from "@packages/domain/import-session";
+import { UserIdSchema, type UserId } from "@packages/domain/user";
+import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
+import { initDynamoDbImportSession } from "./dynamodb-import-session";
+
+interface CapturedCommand {
+	name: string;
+	input: {
+		Item?: Record<string, unknown>;
+		Key?: Record<string, unknown>;
+		ConditionExpression?: string;
+		ExpressionAttributeValues?: Record<string, unknown>;
+	};
+}
+
+const TABLE = "test-import-sessions";
+const SESSION_ID = ImportSessionIdSchema.parse("0123456789abcdef0123456789abcdef");
+const OWNER = UserIdSchema.parse("00000000000000000000000000000001");
+const NOW = () => new Date("2026-05-01T00:00:00Z");
+
+const ANON_CONDITION = "attribute_not_exists(userId)";
+const OWNED_CONDITION = "attribute_not_exists(userId) OR userId = :uid";
+
+/** A stored row that survives loadAccessible's expiry check under NOW(). Omitting
+ * `userId` makes it anonymous (capability-accessible); setting it makes it owned. */
+function storedRow(userId?: UserId): Record<string, unknown> {
+	return {
+		sessionId: SESSION_ID,
+		...(userId ? { userId } : {}),
+		createdAt: "2026-05-01T00:00:00.000Z",
+		expiresAt: 9_999_999_999,
+		totalUrls: 2,
+		totalFoundInFile: 2,
+		truncated: false,
+		urls: ["https://example.com/a", "https://example.com/b"],
+		deselected: [],
+		allSelected: true,
+	};
+}
+
+/** Replays `row` for the GetCommand that guarded toggles issue first, and records
+ * every command so the write's ConditionExpression / ExpressionAttributeValues can
+ * be asserted. A null `row` makes Get return no item (caller is denied). */
+function createFakeClient(row: Record<string, unknown> | null): {
+	client: DynamoDBDocumentClient;
+	commands: CapturedCommand[];
+} {
+	const commands: CapturedCommand[] = [];
+	const client = {
+		send: (async (command: { constructor: { name: string }; input: CapturedCommand["input"] }) => {
+			commands.push({ name: command.constructor.name, input: command.input });
+			if (command.constructor.name === "GetCommand") return row ? { Item: row } : {};
+			return {};
+		}) as DynamoDBDocumentClient["send"],
+	};
+	return { client: client as typeof client & DynamoDBDocumentClient, commands };
+}
+
+function initStore(client: DynamoDBDocumentClient) {
+	return initDynamoDbImportSession({ client, tableName: TABLE, now: NOW });
+}
+
+describe("initDynamoDbImportSession", () => {
+	describe("createImportSession", () => {
+		it("omits userId from the put item for an anonymous session", async () => {
+			const { client, commands } = createFakeClient(null);
+
+			await initStore(client).createImportSession({
+				userId: undefined,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			const put = commands.find((c) => c.name === "PutCommand");
+			assert(put?.input.Item, "create must put an item");
+			assert.equal("userId" in put.input.Item, false);
+		});
+
+		it("stores the owner's userId on the put item when authenticated", async () => {
+			const { client, commands } = createFakeClient(null);
+
+			await initStore(client).createImportSession({
+				userId: OWNER,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			const put = commands.find((c) => c.name === "PutCommand");
+			assert(put?.input.Item, "create must put an item");
+			assert.equal(put.input.Item.userId, OWNER);
+		});
+	});
+
+	describe("toggleImportSelection ownership condition", () => {
+		it("guards an anonymous toggle by attribute_not_exists(userId) with no :uid value", async () => {
+			const { client, commands } = createFakeClient(storedRow());
+
+			await initStore(client).toggleImportSelection({
+				id: SESSION_ID,
+				userId: undefined,
+				index: 0,
+				checked: false,
+			});
+
+			const update = commands.find((c) => c.name === "UpdateCommand");
+			assert.equal(update?.input.ConditionExpression, ANON_CONDITION);
+			const values = update?.input.ExpressionAttributeValues;
+			assert(values, "toggle must bind update values");
+			assert.equal(":uid" in values, false);
+			assert(Object.keys(values).length > 0, "must never send an empty ExpressionAttributeValues map");
+		});
+
+		it("guards an authenticated toggle by the owner-or-anon condition with :uid bound", async () => {
+			const { client, commands } = createFakeClient(storedRow());
+
+			await initStore(client).toggleImportSelection({
+				id: SESSION_ID,
+				userId: OWNER,
+				index: 0,
+				checked: false,
+			});
+
+			const update = commands.find((c) => c.name === "UpdateCommand");
+			assert.equal(update?.input.ConditionExpression, OWNED_CONDITION);
+			assert.equal(update?.input.ExpressionAttributeValues?.[":uid"], OWNER);
+		});
+
+		it("issues no write when an anonymous caller targets an owned row", async () => {
+			const { client, commands } = createFakeClient(storedRow(OWNER));
+
+			await initStore(client).toggleImportSelection({
+				id: SESSION_ID,
+				userId: undefined,
+				index: 0,
+				checked: false,
+			});
+
+			assert.equal(
+				commands.some((c) => c.name === "UpdateCommand"),
+				false,
+			);
+		});
+	});
+
+	describe("toggleAllImportSelection ownership condition", () => {
+		it("guards an anonymous bulk toggle by attribute_not_exists(userId) with no :uid value", async () => {
+			const { client, commands } = createFakeClient(storedRow());
+
+			await initStore(client).toggleAllImportSelection({
+				id: SESSION_ID,
+				userId: undefined,
+				checked: false,
+			});
+
+			const update = commands.find((c) => c.name === "UpdateCommand");
+			assert.equal(update?.input.ConditionExpression, ANON_CONDITION);
+			const values = update?.input.ExpressionAttributeValues;
+			assert(values, "bulk toggle must bind update values");
+			assert.equal(":uid" in values, false);
+			assert(Object.keys(values).length > 0, "must never send an empty ExpressionAttributeValues map");
+		});
+
+		it("guards an authenticated bulk toggle by the owner-or-anon condition with :uid bound", async () => {
+			const { client, commands } = createFakeClient(storedRow(OWNER));
+
+			await initStore(client).toggleAllImportSelection({
+				id: SESSION_ID,
+				userId: OWNER,
+				checked: true,
+			});
+
+			const update = commands.find((c) => c.name === "UpdateCommand");
+			assert.equal(update?.input.ConditionExpression, OWNED_CONDITION);
+			assert.equal(update?.input.ExpressionAttributeValues?.[":uid"], OWNER);
+		});
+	});
+
+	describe("deleteImportSession ownership condition", () => {
+		it("guards an anonymous delete by attribute_not_exists(userId) and sends no ExpressionAttributeValues", async () => {
+			const { client, commands } = createFakeClient(null);
+
+			await initStore(client).deleteImportSession({ id: SESSION_ID, userId: undefined });
+
+			const del = commands.find((c) => c.name === "DeleteCommand");
+			assert.equal(del?.input.ConditionExpression, ANON_CONDITION);
+			assert.equal(del?.input.ExpressionAttributeValues, undefined);
+		});
+
+		it("guards an authenticated delete by the owner-or-anon condition with :uid bound", async () => {
+			const { client, commands } = createFakeClient(null);
+
+			await initStore(client).deleteImportSession({ id: SESSION_ID, userId: OWNER });
+
+			const del = commands.find((c) => c.name === "DeleteCommand");
+			assert.equal(del?.input.ConditionExpression, OWNED_CONDITION);
+			assert.deepEqual(del?.input.ExpressionAttributeValues, { ":uid": OWNER });
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -13,17 +13,7 @@ import {
 	ImportSessionIdSchema,
 } from "@packages/domain/import-session";
 import { computeDeselected, toImportSession } from "./import-session-mapping";
-
-/** An anonymous caller (no userId) may only touch anonymous rows; an authenticated
- * caller may touch anonymous rows (adopting a pre-auth review at commit) plus their
- * own. Mirrors the in-memory store's `load` guard at the DynamoDB condition layer.
- * The `:uid` value is supplied separately, only when authenticated, so DynamoDB
- * never sees an empty ExpressionAttributeValues map for the anonymous case. */
-function ownershipCondition(userId: UserId | undefined): string {
-	return userId === undefined
-		? "attribute_not_exists(userId)"
-		: "attribute_not_exists(userId) OR userId = :uid";
-}
+import { isAccessibleBy, ownershipCondition } from "./import-session-ownership";
 
 const SessionRow = z.object({
 	sessionId: ImportSessionIdSchema,
@@ -53,9 +43,7 @@ export function initDynamoDbImportSession(deps: {
 		const row = await table.get({ sessionId: id });
 		if (!row) return undefined;
 		if (row.expiresAt < Math.floor(deps.now().getTime() / 1000)) return undefined;
-		if (row.userId === undefined) return row;
-		if (row.userId === userId) return row;
-		return undefined;
+		return isAccessibleBy({ ownerId: row.userId, callerId: userId }) ? row : undefined;
 	}
 
 	return {

--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -6,7 +6,7 @@ import {
 	dynamoField,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
-import { UserIdSchema } from "@packages/domain/user";
+import { UserIdSchema, type UserId } from "@packages/domain/user";
 import {
 	IMPORT_SESSION_TTL_SECONDS,
 	type ImportSessionStore,
@@ -14,9 +14,20 @@ import {
 } from "@packages/domain/import-session";
 import { computeDeselected, toImportSession } from "./import-session-mapping";
 
+/** An anonymous caller (no userId) may only touch anonymous rows; an authenticated
+ * caller may touch anonymous rows (adopting a pre-auth review at commit) plus their
+ * own. Mirrors the in-memory store's `load` guard at the DynamoDB condition layer.
+ * The `:uid` value is supplied separately, only when authenticated, so DynamoDB
+ * never sees an empty ExpressionAttributeValues map for the anonymous case. */
+function ownershipCondition(userId: UserId | undefined): string {
+	return userId === undefined
+		? "attribute_not_exists(userId)"
+		: "attribute_not_exists(userId) OR userId = :uid";
+}
+
 const SessionRow = z.object({
 	sessionId: ImportSessionIdSchema,
-	userId: UserIdSchema,
+	userId: dynamoField(UserIdSchema),
 	createdAt: z.string(),
 	expiresAt: z.number(),
 	totalUrls: z.number().int().min(0),
@@ -38,12 +49,13 @@ export function initDynamoDbImportSession(deps: {
 		schema: SessionRow,
 	});
 
-	async function loadOwned(owner: { id: string; userId: string }) {
-		const row = await table.get({ sessionId: owner.id });
+	async function loadAccessible(id: string, userId: UserId | undefined) {
+		const row = await table.get({ sessionId: id });
 		if (!row) return undefined;
-		if (row.userId !== owner.userId) return undefined;
 		if (row.expiresAt < Math.floor(deps.now().getTime() / 1000)) return undefined;
-		return row;
+		if (row.userId === undefined) return row;
+		if (row.userId === userId) return row;
+		return undefined;
 	}
 
 	return {
@@ -54,7 +66,7 @@ export function initDynamoDbImportSession(deps: {
 			await table.put({
 				Item: {
 					sessionId: id,
-					userId,
+					...(userId ? { userId } : {}),
 					createdAt,
 					expiresAt,
 					totalUrls: urls.length,
@@ -77,22 +89,22 @@ export function initDynamoDbImportSession(deps: {
 			};
 		},
 		findImportSession: async ({ id, userId }) => {
-			const row = await loadOwned({ id, userId });
+			const row = await loadAccessible(id, userId);
 			return row ? toImportSession(row) : undefined;
 		},
 		loadImportSessionPage: async ({ id, userId, page, pageSize }) => {
-			const row = await loadOwned({ id, userId });
+			const row = await loadAccessible(id, userId);
 			if (!row) return undefined;
 			const start = (page - 1) * pageSize;
 			const pageUrls = row.urls.slice(start, start + pageSize);
 			return { session: toImportSession(row), pageUrls, page, pageSize };
 		},
 		loadAllImportSessionUrls: async ({ id, userId }) => {
-			const row = await loadOwned({ id, userId });
+			const row = await loadAccessible(id, userId);
 			return row?.urls;
 		},
 		toggleImportSelection: async ({ id, userId, index, checked }) => {
-			const row = await loadOwned({ id, userId });
+			const row = await loadAccessible(id, userId);
 			if (!row) return;
 			const allSelected = row.allSelected ?? true;
 			if (!allSelected && !checked) return;
@@ -105,24 +117,24 @@ export function initDynamoDbImportSession(deps: {
 			else current.add(index);
 			await table.update({
 				Key: { sessionId: id },
-				ConditionExpression: "userId = :uid",
+				ConditionExpression: ownershipCondition(userId),
 				UpdateExpression: "SET deselected = :d, allSelected = :a",
 				ExpressionAttributeValues: {
-					":uid": userId,
+					...(userId ? { ":uid": userId } : {}),
 					":d": Array.from(current),
 					":a": true,
 				},
 			});
 		},
 		toggleAllImportSelection: async ({ id, userId, checked }) => {
-			const row = await loadOwned({ id, userId });
+			const row = await loadAccessible(id, userId);
 			if (!row) return;
 			await table.update({
 				Key: { sessionId: id },
-				ConditionExpression: "userId = :uid",
+				ConditionExpression: ownershipCondition(userId),
 				UpdateExpression: "SET deselected = :d, allSelected = :a",
 				ExpressionAttributeValues: {
-					":uid": userId,
+					...(userId ? { ":uid": userId } : {}),
 					":d": [],
 					":a": checked,
 				},
@@ -131,8 +143,8 @@ export function initDynamoDbImportSession(deps: {
 		deleteImportSession: async ({ id, userId }) => {
 			await table.delete({
 				Key: { sessionId: id },
-				ConditionExpression: "userId = :uid",
-				ExpressionAttributeValues: { ":uid": userId },
+				ConditionExpression: ownershipCondition(userId),
+				...(userId ? { ExpressionAttributeValues: { ":uid": userId } } : {}),
 			});
 		},
 	};

--- a/projects/hutch/src/runtime/providers/import-session/import-session-ownership.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/import-session-ownership.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
+import { isAccessibleBy, ownershipCondition } from "./import-session-ownership";
+
+const A = UserIdSchema.parse("00000000000000000000000000000001");
+const B = UserIdSchema.parse("00000000000000000000000000000002");
+
+describe("isAccessibleBy", () => {
+	it("lets an anonymous caller reach an anonymous session (capability)", () => {
+		assert.equal(isAccessibleBy({ ownerId: undefined, callerId: undefined }), true);
+	});
+
+	it("lets an authenticated caller adopt an anonymous session", () => {
+		assert.equal(isAccessibleBy({ ownerId: undefined, callerId: A }), true);
+	});
+
+	it("lets the owner reach their own session", () => {
+		assert.equal(isAccessibleBy({ ownerId: A, callerId: A }), true);
+	});
+
+	it("denies an anonymous caller on an owned session", () => {
+		assert.equal(isAccessibleBy({ ownerId: A, callerId: undefined }), false);
+	});
+
+	it("denies a different authenticated caller on an owned session", () => {
+		assert.equal(isAccessibleBy({ ownerId: A, callerId: B }), false);
+	});
+});
+
+describe("ownershipCondition", () => {
+	it("guards an anonymous write by attribute_not_exists(userId) alone", () => {
+		assert.equal(ownershipCondition(undefined), "attribute_not_exists(userId)");
+	});
+
+	it("guards an authenticated write by the owner-or-anon condition", () => {
+		assert.equal(ownershipCondition(A), "attribute_not_exists(userId) OR userId = :uid");
+	});
+});

--- a/projects/hutch/src/runtime/providers/import-session/import-session-ownership.ts
+++ b/projects/hutch/src/runtime/providers/import-session/import-session-ownership.ts
@@ -1,0 +1,25 @@
+import type { UserId } from "@packages/domain/user";
+
+/** Anonymous sessions (no owner) are reachable by capability — anyone holding the
+ * unguessable id, including a just-signed-up user adopting their pre-auth review.
+ * An owned session stays isolated to its owner; an anonymous caller, or a different
+ * user, is denied. The DynamoDB {@link ownershipCondition} enforces the same rule at
+ * the write-condition layer. */
+export function isAccessibleBy({
+	ownerId,
+	callerId,
+}: {
+	ownerId: UserId | undefined;
+	callerId: UserId | undefined;
+}): boolean {
+	return ownerId === undefined || ownerId === callerId;
+}
+
+/** DynamoDB ConditionExpression form of {@link isAccessibleBy} for guarded writes.
+ * The `:uid` value is bound separately, only when authenticated, so DynamoDB never
+ * sees an empty ExpressionAttributeValues map for the anonymous case. */
+export function ownershipCondition(callerId: UserId | undefined): string {
+	return callerId === undefined
+		? "attribute_not_exists(userId)"
+		: "attribute_not_exists(userId) OR userId = :uid";
+}

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -832,8 +832,14 @@ export function createApp(dependencies: AppDependencies): Express {
 		salt: deps.salt,
 		now: deps.now,
 		buildBannerState,
+		requireNotLocked,
+		requireWriteAccess,
 	});
-	app.use("/import", requireAuth, requireNotLocked, requireWriteAccess, importRouter);
+	/** Public on purpose: a logged-out visitor can upload, review, and toggle a
+	 * selection before being asked to sign up. Auth is enforced only at commit
+	 * (the sole content-creating route), where `redirectAnonymousToSignup` and the
+	 * `requireNotLocked`/`requireWriteAccess` gates run as route middleware. */
+	app.use("/import", importRouter);
 
 	const saveRouter = initSaveRoutes({ buildBannerState, analytics: deps.analytics, salt: deps.salt, now: deps.now, secureCookies, generatePendingSaveId: randomUUID });
 	app.use("/save", saveRouter);

--- a/projects/hutch/src/runtime/web/auth/verification-lockout.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/verification-lockout.route.test.ts
@@ -146,14 +146,28 @@ describe("Email verification lockout", () => {
 		expect(remaining.articles).toHaveLength(0);
 	});
 
-	it("locks /import (a bulk-save tool) but reopens /export and /account for a lapsed account", async () => {
+	it("keeps the /import upload+review public but locks the commit (the bulk save) for a lapsed account", async () => {
 		const harness = useApp(fixtureClockedDaysAhead(8));
 		const agent = await loginAgent(harness.server, harness.auth);
 
-		const importResponse = await agent.get("/import");
-		expect(importResponse.status).toBe(403);
+		// The acquire/review pages are public so a lapsed account still sees the
+		// flow; only the commit, which writes new saves, is gated.
+		const acquire = await agent.get("/import");
+		expect(acquire.status).toBe(200);
 		expect(
-			new JSDOM(importResponse.text).window.document.querySelector("h1")?.textContent,
+			new JSDOM(acquire.text).window.document.querySelector("h1")?.textContent,
+		).not.toBe("Your account is locked");
+
+		const create = await agent
+			.post("/import/from-url")
+			.type("form")
+			.send({ url: "https://news.example/issues/42" });
+		expect(create.status).toBe(303);
+
+		const commit = await agent.post(`${create.headers.location}/commit`);
+		expect(commit.status).toBe(403);
+		expect(
+			new JSDOM(commit.text).window.document.querySelector("h1")?.textContent,
 		).toBe("Your account is locked");
 
 		for (const path of ["/export", "/account"]) {

--- a/projects/hutch/src/runtime/web/middleware/analytics.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.ts
@@ -65,7 +65,7 @@ export interface ImportUploadedEvent {
 	url_count: number;
 	truncated: 0 | 1;
 	visitor_hash: string | null;
-	is_authenticated: 1;
+	is_authenticated: 0 | 1;
 }
 
 export interface ImportCommittedEvent {
@@ -94,7 +94,7 @@ export interface ImportFromUrlAcquiredEvent {
 	url_count: number;
 	truncated: 0 | 1;
 	visitor_hash: string | null;
-	is_authenticated: 1;
+	is_authenticated: 0 | 1;
 }
 
 export interface ArticleReadEvent {

--- a/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.from-url.route.test.ts
@@ -57,14 +57,30 @@ describe("POST /import/from-url routes", () => {
 	});
 
 	describe("POST /import/from-url (unauthenticated)", () => {
-		it("redirects to /login", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		it("creates an anonymous session from the harvested URLs and redirects to the review screen", async () => {
+			const harness = useApp(
+				withExtractor({
+					status: "OK",
+					links: {
+						urls: ["https://example.com/a", "https://example.com/b"],
+						truncated: false,
+						totalFound: 2,
+					},
+				}),
+			);
 			const response = await request(harness.server)
 				.post("/import/from-url")
 				.type("form")
 				.send({ url: "https://news.example/issues/42" });
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/login");
+			assert.match(
+				response.headers.location,
+				/^\/import\/[a-f0-9]{32}$/,
+				"redirect must point at the new session",
+			);
+
+			const review = await request(harness.server).get(response.headers.location);
+			expect(review.status).toBe(200);
 		});
 	});
 
@@ -291,6 +307,32 @@ describe("POST /import/from-url routes", () => {
 			assert.equal(event.utm_medium, "form");
 			assert.equal(event.utm_campaign, "from-url");
 			assert.equal(event.is_authenticated, 1);
+		});
+
+		it("emits import_from_url_acquired with is_authenticated=0 for an anonymous visitor", async () => {
+			const harness = useApp(
+				withExtractor({
+					status: "OK",
+					links: {
+						urls: ["https://example.com/a", "https://example.com/b"],
+						truncated: false,
+						totalFound: 2,
+					},
+				}),
+			);
+
+			await request(harness.server)
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/42" });
+
+			const events = harness.analytics.events.filter(
+				(e) => e.event === "import_from_url_acquired",
+			);
+			assert.equal(events.length, 1, "exactly one import_from_url_acquired event");
+			const event = events[0];
+			assert(event.event === "import_from_url_acquired");
+			assert.equal(event.is_authenticated, 0);
 		});
 
 		it("does not emit import_from_url_acquired on failure paths", async () => {

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import type { ErrorRequestHandler, Request, Response, Router } from "express";
+import type { ErrorRequestHandler, Request, RequestHandler, Response, Router } from "express";
 import express from "express";
 import { extractUrls } from "@packages/domain/import-session";
 import {
@@ -41,6 +41,14 @@ interface ImportRouteDependencies extends SaveArticleFromUrlDependencies {
 	salt: string;
 	now: () => Date;
 	buildBannerState: BuildBannerState;
+	/** Save gates applied only at commit, the sole route that creates content.
+	 * The earlier routes (upload, review, toggle) are public so a logged-out
+	 * visitor can build a review before signing up. `requireNotLocked` blocks a
+	 * locked (unverified-past-window) account; `requireWriteAccess` blocks a
+	 * read-only (trial-expired / cancelled) account. Both assume an authenticated
+	 * identity, so they run after the anonymous-visitor redirect. */
+	requireNotLocked: RequestHandler;
+	requireWriteAccess: RequestHandler;
 }
 
 const UPLOAD_ERROR_REDIRECT = {
@@ -69,8 +77,25 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		next(err);
 	};
 
+	/** Commit is the one route that needs an account: an anonymous visitor who has
+	 * built a review is sent to sign up, carrying the review's id in `?return=` so
+	 * the post-signup redirect lands them back on the same review (selections
+	 * intact, since the session is reached by capability). An unparseable id has no
+	 * review to return to, so it falls back to a bare /signup. */
+	const redirectAnonymousToSignup: RequestHandler = (req, res, next) => {
+		if (req.userId) {
+			next();
+			return;
+		}
+		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
+		if (!parsedId.success) {
+			res.redirect(303, "/signup");
+			return;
+		}
+		res.redirect(303, `/signup?return=${encodeURIComponent(`/import/${parsedId.data}`)}`);
+	};
+
 	router.get("/", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const errorMessage = importErrorMessageMapping(req.query);
 		const mode = typeof req.query.mode === "string" ? req.query.mode : undefined;
 		const vm = toImportAcquireViewModel({
@@ -81,7 +106,6 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 	});
 
 	router.post("/", rawBodyParser, sizeLimitHandler, async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const parsed = parseRequest(req);
 		if (!parsed.ok) {
 			res.redirect(303, UPLOAD_ERROR_REDIRECT.noUrls);
@@ -111,13 +135,12 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			url_count: urls.length,
 			truncated: truncated ? 1 : 0,
 			visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
-			is_authenticated: 1,
+			is_authenticated: req.userId ? 1 : 0,
 		});
 		res.redirect(303, `/import/${session.id}`);
 	});
 
 	router.post("/from-url", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const rawUrl = typeof req.body?.url === "string" ? req.body.url.trim() : "";
 		if (rawUrl === "") {
 			res.redirect(303, FROM_URL_ERROR_REDIRECT.invalid);
@@ -165,13 +188,12 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			url_count: urls.length,
 			truncated: truncated ? 1 : 0,
 			visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
-			is_authenticated: 1,
+			is_authenticated: req.userId ? 1 : 0,
 		});
 		res.redirect(303, `/import/${session.id}`);
 	});
 
 	router.get("/:id", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
 		if (!parsedId.success) {
 			res.redirect(303, QUEUE_PATH);
@@ -198,7 +220,6 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 	});
 
 	router.post("/:id/toggle", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
 		const parsedBody = ImportToggleSchema.safeParse(req.body);
 		if (!parsedId.success || !parsedBody.success) {
@@ -218,7 +239,6 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 	});
 
 	router.post("/:id/toggle-all", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
 		const parsedBody = ImportToggleAllSchema.safeParse(req.body);
 		if (!parsedId.success || !parsedBody.success) {
@@ -236,8 +256,8 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		res.redirect(303, page > 1 ? `/import/${parsedId.data}?page=${page}` : `/import/${parsedId.data}`);
 	});
 
-	router.post("/:id/commit", async (req: Request, res: Response) => {
-		assert(req.userId, "userId required - route must be protected by requireAuth");
+	router.post("/:id/commit", redirectAnonymousToSignup, deps.requireNotLocked, deps.requireWriteAccess, async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - redirectAnonymousToSignup guarantees an authenticated identity here");
 		const userId = req.userId;
 		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
 		if (!parsedId.success) {

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -36,6 +36,7 @@ function multipartBody(filename: string, content: Buffer): { body: Buffer; conte
 }
 
 const useApp = useTestServer();
+const ONE_DAY_MS = 86_400_000;
 
 describe("Import routes", () => {
 	describe("GET /import (unauthenticated)", () => {
@@ -714,6 +715,39 @@ describe("Import routes", () => {
 			const again = await agent.get("/queue");
 			const docAgain = new JSDOM(again.text).window.document;
 			expect(docAgain.querySelectorAll("[data-test-import-skipped-row]").length).toBe(0);
+		});
+	});
+
+	describe("POST /import/:id/commit write-access gating", () => {
+		it("keeps the upload+review public but redirects the commit to /queue?inactive=1 for a trial-expired account", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			const userId = (await harness.auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "seeded login user must exist");
+			// A trial past its window leaves the account read-only: the commit
+			// (the bulk save) is gated by requireWriteAccess while the upload and
+			// review pages stay public — the read-only mirror of the locked case.
+			await harness.subscriptionProviders.upsertTrialing({
+				userId,
+				trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+			});
+
+			const acquire = await agent.get("/import");
+			expect(acquire.status).toBe(200);
+
+			const create = await agent
+				.post("/import/from-url")
+				.type("form")
+				.send({ url: "https://news.example/issues/7" });
+			expect(create.status).toBe(303);
+			const reviewPath = create.headers.location;
+
+			const review = await agent.get(reviewPath);
+			expect(review.status).toBe(200);
+
+			const commit = await agent.post(`${reviewPath}/commit`).set("Accept", "text/html");
+			expect(commit.status).toBe(303);
+			expect(commit.headers.location).toBe("/queue?inactive=1");
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.route.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
+import { ImportSessionIdSchema } from "@packages/domain/import-session";
 import { useTestServer, loginAgent } from "../../../test-app";
 import type { ImportUploadedEvent, ImportCommittedEvent } from "../../middleware/analytics";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
+
+function sessionIdFromLocation(location: string): ReturnType<typeof ImportSessionIdSchema.parse> {
+	return ImportSessionIdSchema.parse(location.replace("/import/", ""));
+}
 
 function summaryText(doc: Document): string {
 	return doc.querySelector("[data-test-import-summary]")?.textContent?.replace(/\s+/g, " ").trim() ?? "";
@@ -34,11 +39,28 @@ const useApp = useTestServer();
 
 describe("Import routes", () => {
 	describe("GET /import (unauthenticated)", () => {
-		it("redirects to /login", async () => {
+		it("renders the acquire page with both tabs for a logged-out visitor", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const response = await request(harness.server).get("/import");
-			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/login");
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const tabKeys = Array.from(doc.querySelectorAll("[data-test-import-tab]")).map(
+				(el) => el.getAttribute("data-test-import-tab"),
+			);
+			expect(tabKeys).toEqual(["upload", "from-url"]);
+		});
+
+		it("renders the guest nav with an Import Links entry", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/import");
+			const doc = new JSDOM(response.text).window.document;
+			const nav = doc.querySelector("[data-test-nav-variant]");
+			assert(nav, "nav must render");
+			expect(nav.getAttribute("data-test-nav-variant")).toBe("guest");
+			const navKeys = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
+				(el) => el.getAttribute("data-test-nav-item"),
+			);
+			expect(navKeys).toContain("import");
 		});
 	});
 
@@ -145,11 +167,27 @@ describe("Import routes", () => {
 	});
 
 	describe("POST /import (unauthenticated)", () => {
-		it("redirects to /login", async () => {
-			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
-			const response = await request(harness.server).post("/import");
+		it("creates an anonymous session (no userId) and redirects to the review page", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const { body, contentType } = multipartBody(
+				"urls.txt",
+				Buffer.from("https://example.com/a https://example.com/b"),
+			);
+
+			const response = await request(harness.server)
+				.post("/import")
+				.set("Content-Type", contentType)
+				.send(body);
+
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/login");
+			assert(response.headers.location.startsWith("/import/"), "expected redirect to /import/:id");
+			const session = await fixture.importSession.importSessionStore.findImportSession({
+				id: sessionIdFromLocation(response.headers.location),
+				userId: undefined,
+			});
+			assert(session, "anonymous session must exist");
+			expect(session.userId).toBeUndefined();
 		});
 	});
 
@@ -679,6 +717,132 @@ describe("Import routes", () => {
 		});
 	});
 
+	describe("Anonymous self-serve flow", () => {
+		async function anonUpload(server: Parameters<typeof request>[0], content: string) {
+			const { body, contentType } = multipartBody("urls.txt", Buffer.from(content));
+			const create = await request(server)
+				.post("/import")
+				.set("Content-Type", contentType)
+				.send(body);
+			return create.headers.location;
+		}
+
+		it("renders the review screen with all URLs checked for an anonymous visitor", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const sessionPath = await anonUpload(
+				harness.server,
+				"https://example.com/a https://example.com/b https://example.com/c",
+			);
+
+			const response = await request(harness.server).get(sessionPath);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const checkboxes = doc.querySelectorAll<HTMLInputElement>("[data-test-import-checkbox]");
+			expect(checkboxes).toHaveLength(3);
+			for (const cb of checkboxes) {
+				expect(cb.hasAttribute("checked")).toBe(true);
+			}
+		});
+
+		it("persists an anonymous toggle across requests (server-side selection state)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const sessionPath = await anonUpload(harness.server, "https://example.com/a https://example.com/b");
+
+			const toggle = await request(harness.server)
+				.post(`${sessionPath}/toggle`)
+				.type("form")
+				.send({ index: 0, checked: "false" });
+			expect(toggle.status).toBe(303);
+
+			const review = await request(harness.server).get(sessionPath);
+			const doc = new JSDOM(review.text).window.document;
+			const first = doc.querySelector<HTMLInputElement>('[data-test-import-checkbox="0"]');
+			assert(first, "first checkbox must exist");
+			expect(first.hasAttribute("checked")).toBe(false);
+			expect(summaryText(doc)).toContain("1 of 2 selected");
+		});
+
+		it("redirects an anonymous commit to /signup carrying the session id in ?return=, without saving or deleting", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const sessionPath = await anonUpload(harness.server, "https://example.com/a https://example.com/b");
+			const id = sessionIdFromLocation(sessionPath);
+
+			const commit = await request(harness.server).post(`${sessionPath}/commit`);
+
+			expect(commit.status).toBe(303);
+			expect(commit.headers.location).toBe(`/signup?return=${encodeURIComponent(`/import/${id}`)}`);
+			const stillThere = await fixture.importSession.importSessionStore.findImportSession({
+				id,
+				userId: undefined,
+			});
+			expect(stillThere).toBeDefined();
+		});
+
+		it("redirects an anonymous commit with an unparseable id to a bare /signup", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const commit = await request(harness.server).post("/import/not-an-id/commit");
+
+			expect(commit.status).toBe(303);
+			expect(commit.headers.location).toBe("/signup");
+		});
+
+		it("lets a just-signed-up user reach the anonymous review with selections intact and commit it", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth, articleStore } = harness;
+			const sessionPath = await anonUpload(
+				harness.server,
+				"https://example.com/a https://example.com/b https://example.com/c",
+			);
+			await request(harness.server)
+				.post(`${sessionPath}/toggle`)
+				.type("form")
+				.send({ index: 1, checked: "false" });
+
+			// Simulate the post-signup return: the same session id, now reached by an
+			// authenticated identity (capability access).
+			const agent = await loginAgent(harness.server, auth);
+
+			const review = await agent.get(sessionPath);
+			expect(review.status).toBe(200);
+			const doc = new JSDOM(review.text).window.document;
+			const second = doc.querySelector<HTMLInputElement>('[data-test-import-checkbox="1"]');
+			assert(second, "deselected checkbox must persist into the authenticated review");
+			expect(second.hasAttribute("checked")).toBe(false);
+			expect(summaryText(doc)).toContain("2 of 3 selected");
+
+			const commit = await agent.post(`${sessionPath}/commit`);
+			expect(commit.status).toBe(303);
+			expect(commit.headers.location).toBe("/queue?import_imported=2&import_total=3&import_skipped=0");
+
+			const userId = (await auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "user must exist");
+			const stored = await articleStore.findArticlesByUser({ userId });
+			expect(stored.articles.map((a) => a.url).sort()).toEqual([
+				"https://example.com/a",
+				"https://example.com/c",
+			]);
+
+			const reuse = await agent.get(sessionPath);
+			expect(reuse.status).toBe(303);
+			expect(reuse.headers.location).toBe("/import?error_code=import_session_not_found");
+		});
+
+		it("refuses an anonymous caller access to a session owned by an authenticated user", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const owner = await loginAgent(harness.server, harness.auth);
+			const { body, contentType } = multipartBody("urls.txt", Buffer.from("https://example.com/owned"));
+			const create = await owner.post("/import").set("Content-Type", contentType).send(body);
+
+			const response = await request(harness.server).get(create.headers.location);
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/import?error_code=import_session_not_found");
+		});
+	});
+
 	describe("Analytics events", () => {
 		it("emits import_uploaded event with url_count after a successful upload", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
@@ -697,6 +861,20 @@ describe("Import routes", () => {
 			assert.equal(uploaded[0].utm_medium, "form");
 			assert.equal(uploaded[0].utm_campaign, "file-upload");
 			assert.equal(uploaded[0].is_authenticated, 1);
+		});
+
+		it("emits import_uploaded with is_authenticated=0 for an anonymous upload", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const file = Buffer.from("https://example.com/post-1 https://example.com/post-2");
+			const { body, contentType } = multipartBody("urls.txt", file);
+
+			await request(harness.server).post("/import").set("Content-Type", contentType).send(body);
+
+			const uploaded = harness.analytics.events.filter(
+				(e): e is ImportUploadedEvent => e.event === "import_uploaded",
+			);
+			assert.equal(uploaded.length, 1, "exactly one import_uploaded event");
+			assert.equal(uploaded[0].is_authenticated, 0);
 		});
 
 		it("emits import_committed event with correct counts after a successful commit", async () => {

--- a/src/packages/domain/src/import-session/import-session.types.ts
+++ b/src/packages/domain/src/import-session/import-session.types.ts
@@ -9,7 +9,12 @@ export interface ImportLinksResult {
 
 export interface ImportSession {
 	readonly id: ImportSessionId;
-	readonly userId: UserId;
+	/** Undefined for a session created by an anonymous visitor. Such sessions are
+	 * accessible by capability (anyone holding the unguessable id), letting a
+	 * logged-out user build a review and then sign up before committing. A session
+	 * created while authenticated carries its owner's id and stays isolated to that
+	 * owner. */
+	readonly userId: UserId | undefined;
 	readonly createdAt: string;
 	readonly expiresAt: number;
 	readonly totalUrls: number;
@@ -26,7 +31,7 @@ export interface ImportSessionPage {
 }
 
 export type CreateImportSession = (params: {
-	userId: UserId;
+	userId: UserId | undefined;
 	urls: readonly string[];
 	truncated: boolean;
 	totalFound: number;
@@ -34,37 +39,37 @@ export type CreateImportSession = (params: {
 
 export type FindImportSession = (params: {
 	id: ImportSessionId;
-	userId: UserId;
+	userId: UserId | undefined;
 }) => Promise<ImportSession | undefined>;
 
 export type LoadImportSessionPage = (params: {
 	id: ImportSessionId;
-	userId: UserId;
+	userId: UserId | undefined;
 	page: number;
 	pageSize: number;
 }) => Promise<ImportSessionPage | undefined>;
 
 export type LoadAllImportSessionUrls = (params: {
 	id: ImportSessionId;
-	userId: UserId;
+	userId: UserId | undefined;
 }) => Promise<readonly string[] | undefined>;
 
 export type ToggleImportSelection = (params: {
 	id: ImportSessionId;
-	userId: UserId;
+	userId: UserId | undefined;
 	index: number;
 	checked: boolean;
 }) => Promise<void>;
 
 export type ToggleAllImportSelection = (params: {
 	id: ImportSessionId;
-	userId: UserId;
+	userId: UserId | undefined;
 	checked: boolean;
 }) => Promise<void>;
 
 export type DeleteImportSession = (params: {
 	id: ImportSessionId;
-	userId: UserId;
+	userId: UserId | undefined;
 }) => Promise<void>;
 
 export interface ImportSessionStore {

--- a/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.test.ts
+++ b/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.test.ts
@@ -39,6 +39,93 @@ describe("initInMemoryImportSession", () => {
 		expect(peek).toBeUndefined();
 	});
 
+	describe("anonymous sessions (capability access)", () => {
+		it("creates an anonymous session with no userId", async () => {
+			const store = initInMemoryImportSession({ now: () => new Date() });
+
+			const session = await store.createImportSession({
+				userId: undefined,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			expect(session.userId).toBeUndefined();
+		});
+
+		it("stores the owner's id when created while authenticated", async () => {
+			const store = initInMemoryImportSession({ now: () => new Date() });
+
+			const session = await store.createImportSession({
+				userId: owner,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			expect(session.userId).toBe(owner);
+		});
+
+		it("lets an anonymous caller read an anonymous session", async () => {
+			const store = initInMemoryImportSession({ now: () => new Date() });
+			const session = await store.createImportSession({
+				userId: undefined,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			const peek = await store.findImportSession({ id: session.id, userId: undefined });
+
+			expect(peek?.id).toBe(session.id);
+		});
+
+		it("lets a just-authenticated caller adopt an anonymous session (post-signup)", async () => {
+			const store = initInMemoryImportSession({ now: () => new Date() });
+			const session = await store.createImportSession({
+				userId: undefined,
+				urls: ["https://example.com/a", "https://example.com/b"],
+				truncated: false,
+				totalFound: 2,
+			});
+			await store.toggleImportSelection({ id: session.id, userId: undefined, index: 0, checked: false });
+
+			const peek = await store.findImportSession({ id: session.id, userId: owner });
+
+			assert(peek, "authenticated caller must reach an anonymous session by capability");
+			expect([...peek.deselected]).toEqual([0]);
+		});
+
+		it("refuses an anonymous caller access to an owned session", async () => {
+			const store = initInMemoryImportSession({ now: () => new Date() });
+			const session = await store.createImportSession({
+				userId: owner,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			const peek = await store.findImportSession({ id: session.id, userId: undefined });
+
+			expect(peek).toBeUndefined();
+		});
+
+		it("expires an anonymous session once its TTL elapses", async () => {
+			let now = new Date("2026-05-01T00:00:00Z");
+			const store = initInMemoryImportSession({ now: () => now });
+			const session = await store.createImportSession({
+				userId: undefined,
+				urls: ["https://example.com/a"],
+				truncated: false,
+				totalFound: 1,
+			});
+
+			now = new Date(now.getTime() + (IMPORT_SESSION_TTL_SECONDS + 1) * 1000);
+
+			expect(await store.findImportSession({ id: session.id, userId: undefined })).toBeUndefined();
+		});
+	});
+
 	it("returns undefined for a non-existent id", async () => {
 		const store = initInMemoryImportSession({ now: () => new Date() });
 		const ghost = ImportSessionIdSchema.parse("00000000000000000000000000000000");

--- a/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.ts
+++ b/src/packages/test-fixtures/src/providers/import-session/in-memory-import-session.ts
@@ -7,6 +7,7 @@ import type {
 	ImportSession,
 	ImportSessionStore,
 } from "@packages/domain/import-session";
+import type { UserId } from "@packages/domain/user";
 
 interface StoredSession {
 	session: ImportSession;
@@ -19,15 +20,20 @@ export function initInMemoryImportSession(deps: {
 }): ImportSessionStore {
 	const sessions = new Map<string, StoredSession>();
 
-	function load(id: string, userId: string): StoredSession | undefined {
+	/** Anonymous sessions (no stored userId) are reachable by capability — anyone
+	 * holding the id, including a just-signed-up user adopting their pre-auth
+	 * review. Owned sessions stay isolated to their owner; a different user (or an
+	 * anonymous caller) gets undefined. */
+	function load(id: string, userId: UserId | undefined): StoredSession | undefined {
 		const row = sessions.get(id);
 		if (!row) return undefined;
-		if (row.session.userId !== userId) return undefined;
 		if (row.session.expiresAt < Math.floor(deps.now().getTime() / 1000)) {
 			sessions.delete(id);
 			return undefined;
 		}
-		return row;
+		if (row.session.userId === undefined) return row;
+		if (row.session.userId === userId) return row;
+		return undefined;
 	}
 
 	return {

--- a/src/packages/web-shell/src/banner-state.test.ts
+++ b/src/packages/web-shell/src/banner-state.test.ts
@@ -40,9 +40,15 @@ describe("bannerStateFromRequest", () => {
 });
 
 describe("buildGuestNavItems", () => {
-	it("returns install, features, and signup as a flat list with install left of features", () => {
+	it("returns install, features, import, and signup as a flat list in that order", () => {
 		const items = buildGuestNavItems();
-		expect(items.map((i) => i.key)).toEqual(["install", "features", "signup"]);
+		expect(items.map((i) => i.key)).toEqual(["install", "features", "import", "signup"]);
+	});
+
+	it("points the import item at the import page so logged-out visitors can start a migration", () => {
+		const item = buildGuestNavItems().find((i) => i.key === "import");
+		assert(item, "guest nav must include an import item");
+		expect(item.href).toBe("/import?utm_source=header-nav&utm_medium=internal&utm_content=import");
 	});
 
 	it("points the install item at the install page", () => {

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -166,9 +166,11 @@ const NAV_INSTALL = navItem({ key: "install", label: "Install", path: "/install"
 const NAV_FEATURES = navItem({ key: "features", label: "Features", path: "/#what-works", method: "GET", icon: "fa-solid fa-wand-magic-sparkles" });
 const NAV_SIGNUP = navItem({ key: "signup", label: "Sign up", path: "/signup", method: "GET", icon: "fa-solid fa-user-plus" });
 
-/** Guest nav items rendered as a flat list without group structure. */
+/** Guest nav items rendered as a flat list without group structure. Import sits
+ * before signup so a logged-out visitor can start a migration from the menu; the
+ * import flow defers account creation until they commit their selection. */
 export function buildGuestNavItems(): NavItem[] {
-	return [NAV_INSTALL, NAV_FEATURES, NAV_SIGNUP];
+	return [NAV_INSTALL, NAV_FEATURES, NAV_IMPORT, NAV_SIGNUP];
 }
 
 /** Builds the grouped header nav for authenticated users. The template

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -133,15 +133,19 @@ describe("Base component", () => {
 		expect(url.searchParams.get("utm_content")).toBe("import");
 	});
 
-	it("hides the Import Links nav item for unauthenticated requests", () => {
+	it("renders the Import Links nav item for unauthenticated requests so guests can start a migration", () => {
 		const page = createTestPageBody();
 		const result = Base(page, { isAuthenticated: false, emailVerified: undefined }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		const navItems = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
-			(el) => el.getAttribute("data-test-nav-item"),
-		);
-		expect(navItems).toEqual(["install", "features", "signup"]);
+		const button = doc.querySelector('[data-test-nav-item="import"]');
+		assert(button, "Import Links nav item must be rendered for guests");
+		expect(button.textContent).toBe("Import Links");
+		const form = button.closest("form");
+		assert(form, "Import Links nav item must be wrapped in a form");
+		const action = form.getAttribute("action");
+		assert(action, "Import Links form must have an action");
+		expect(new URL(action, "https://readplace.com").pathname).toBe("/import");
 	});
 
 	it("renders the Account nav item for authenticated full-access users", () => {
@@ -166,7 +170,7 @@ describe("Base component", () => {
 		const navItems = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
 			(el) => el.getAttribute("data-test-nav-item"),
 		);
-		expect(navItems).toEqual(["install", "features", "signup"]);
+		expect(navItems).toEqual(["install", "features", "import", "signup"]);
 	});
 
 	it("renders the full nav (queue + import + export + account + logout) for an authenticated full-access user", () => {

--- a/src/packages/web-shell/src/nav.component.test.ts
+++ b/src/packages/web-shell/src/nav.component.test.ts
@@ -144,7 +144,7 @@ describe("Nav component", () => {
 		expect(queue.textContent).toBe("Queue");
 	});
 
-	it("renders guest nav items (install, features, signup) as a flat list without group structure, install left of features", () => {
+	it("renders guest nav items (install, features, import, signup) as a flat list without group structure, install left of features", () => {
 		const doc = parse(
 			Nav({
 				variant: "default",
@@ -160,7 +160,7 @@ describe("Nav component", () => {
 		const items = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
 			(el) => el.getAttribute("data-test-nav-item"),
 		);
-		expect(items).toEqual(["install", "features", "signup"]);
+		expect(items).toEqual(["install", "features", "import", "signup"]);
 
 		const install = doc.querySelector('[data-test-nav-item="install"]');
 		assert(install, "guest nav must render an install item");


### PR DESCRIPTION
## Why

Importing was gated behind `requireAuth` + `requireWriteAccess`, so a logged-out visitor could never reach `/import`. This makes importing a top-of-funnel acquisition path: a brand-new visitor can open Import, upload a file (or paste a link), and review + select the extracted URLs **before** being asked to create an account. Auth is only required at the moment they click **Import N selected** — and their review survives signup.

## Flow

1. Logged-out visitor opens **Import Links** (now in the guest menu) → `GET /import` renders the upload / paste-a-link tabs with guest chrome.
2. Upload a file → `POST /import` extracts URLs → an **anonymous** session is created → `303 /import/:id`.
3. Review the paginated list, toggle selections → state persists server-side in the session row (no client state).
4. Click **Import N selected** → `POST /import/:id/commit`. Unauthenticated → `303 /signup?return=%2Fimport%2F<id>`.
5. Create an account → signup redirects via `parseReturnUrl` → `303 /import/:id`.
6. `GET /import/:id` renders the same session, **selections intact** (capability access by id).
7. Click **Import N selected** again → now authenticated → URLs are stub-saved under their `userId` and the existing `SaveLinkCommand` pipeline enriches them → `303 /queue`.

## Ownership model

The session guard generalises from *"must equal userId"* to:

- **Anonymous** sessions (no stored `userId`) are reachable by **capability** — anyone holding the unguessable 128-bit id, including a just-signed-up user adopting their pre-auth review.
- **Owned** sessions stay isolated to their owner; a different user (or an anonymous caller) gets `undefined`.

`userId: UserId | undefined` is threaded through the store ops. No "claim"/transition step is needed — commit reads the anonymous session by capability and saves under whoever is authenticated at that moment.

| caller → row | anon | owned-by-A |
|---|---|---|
| anon | ✅ | ❌ |
| auth A | ✅ (adopt) | ✅ |
| auth B | ✅ (adopt) | ❌ |

## Save gates preserved

`requireNotLocked` and `requireWriteAccess` move from the `/import` mount to the **commit route** (the one route that writes saves), so the locked-account and read-only/trial-expired behaviour is unchanged for the action that matters, while the upload/review pages become public. A `redirectAnonymousToSignup` middleware runs ahead of them so they only see authenticated requests.

## Architecture

Runtime-only. `hutch-import-sessions` already stores `userId` as a non-key attribute (PK is `sessionId`, no GSI on `userId`), so making it optional needs **no Pulumi, no new table, no env var, no IAM change**. Commit still flows through the unchanged `saveArticleFromUrl → publishLinkSaved → SaveLinkCommand` path.

## Security trade-offs (accepted)

- Unthrottled public upload (`POST /import`, ≤5 MiB) and public server-side fetch (`POST /import/from-url`, bounded by the existing private-network validation). No new rate limiting; the drop-in mitigation if abuse appears is the existing `hutch-rate-limits` table + `consumeRateLimit` keyed by `hashIp`.
- A leaked `?return=/import/<id>` lets a third party view and import that URL list into their own queue. Bounded by the 128-bit id + 24h TTL.
- Because the shell's guest nav is shared, **Import Links** also appears on the same-origin blog header and resolves to `readplace.com/import` — intentionally extending the funnel to blog readers.

## Tests

- **In-memory store unit**: full guard matrix (anon↔anon, auth-adopts-anon, anon-on-owned → undefined, B-on-A's-owned → undefined), anonymous create omits `userId`, authenticated create stores it, anon TTL expiry.
- **Route integration**: anon `GET /import` (200 + guest nav includes `import`); anon upload → `303` with `userId === undefined`; anon review + toggle persist; anon commit → `/signup?return=…` without saving or deleting; anon commit with bad id → bare `/signup`; just-signed-up user reaches the anon review with selections intact and commits → `/queue`; anon cannot read an owned session; `is_authenticated` analytics is `0` anon / `1` authed (upload + from-url).
- **Lockout regression** updated: the `/import` upload/review stays public for a lapsed account, but the **commit** returns the locked screen.
- **web-shell**: `buildGuestNavItems()` and the rendered guest Nav include the import item.

`pnpm check` passes across all 31 affected projects — lint, types, unit + integration, 100% coverage, knip.

> [!NOTE]
> Manual Playwright E2E (the plan's step 2/3) was not run: this sandbox lacks the app's runtime env (AWS/Pulumi). The full server-side flow — anonymous upload → review → toggle → commit→signup → post-signup adopt → commit→queue, plus isolation and analytics — is covered by the integration tests above, consistent with the repo's "integration over E2E for route logic" testing strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1bsB3YGkRxAUqgNrjTGNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1bsB3YGkRxAUqgNrjTGNc)_