### PR TITLE
feat: add site-wide changelog feature banner

### DIFF
--- a/.claude/skills/blog-post-editor/SKILL.md
+++ b/.claude/skills/blog-post-editor/SKILL.md
@@ -28,6 +28,29 @@ Every post must have YAML frontmatter with the fields that follow the pattern of
 
 The `slug` value in frontmatter **must** match the filename (minus `.md`). For example, a file named `my-post.md` must have `slug: "my-post"`. The discovery module asserts this at load time and will throw if they diverge.
 
+## Highlighting features (changelog banner)
+
+To surface a shipped feature to every user on every page (guests included), tag the announcing post and give it banner copy:
+
+```yaml
+tags: [changelog]
+banner: I added keyboard shortcuts to the reader
+```
+
+- The **newest** post tagged `changelog` drives a site-wide banner (a "NEW" chip, the `banner:` hook, and a "Read more" link to the post). It shows on the app and on `/blog`.
+- A post tagged `changelog` **must** include a `banner:` line — the loader rejects it otherwise.
+- The banner stays dismissed (per reader) until the copy changes; editing `banner:` or publishing a newer changelog post makes it reappear.
+
+Both `tags` (a string array, defaults to `[]`) and `banner` (a string) are optional frontmatter fields; only changelog posts need them.
+
+### Banner copy rules
+
+The banner is a conversion surface, so the copy is deliberate:
+
+- **Concise hook with a curiosity gap.** State *what* changed; let the click reveal *how*. ("I added keyboard shortcuts to the reader" — not "Keyboard shortcuts: press j/k to move, x to archive…".)
+- **Let the NEW chip carry the novelty.** Don't write "New:" or "Just shipped" in the hook.
+- **Brand voice.** No emoji, no exclamation marks, no superlatives. Talk like a person.
+
 ## Ordering
 
 Posts are sorted by `date` in descending order (newest first) automatically by the discovery module. No manual ordering is needed — just set the correct `date` in frontmatter.

--- a/.envrc
+++ b/.envrc
@@ -44,6 +44,10 @@ export TRIAL_SCHEDULER_ROLE_ARN='arn:aws:iam::000000000000:role/hutch-trial-sche
 export ANALYTICS_SALT='local-dev-salt'
 export EXPIRY_COUNTDOWN='enabled'
 export FOUNDING_MEMBER_LIMIT='50'
+# Where hutch fetches the site-wide changelog banner fragment. Points at the
+# local blog-site dev server (`pnpm --filter blog-site dev`, port 3200). hutch
+# fails open if it's unreachable, so the app still runs without blog-site up.
+export CHANGELOG_BANNER_URL='http://localhost:3200/blog/changelog-banner'
 # Comma-separated list of emails allowed to hit /admin/recrawl.
 # Leave empty in local dev to fail-closed; set to your email before testing.
 export ADMIN_EMAILS=''

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.page.ts
@@ -1,5 +1,13 @@
 import express, { type Request, type Response, type Router } from "express";
-import { type BannerState, type RenderBase, sendComponent } from "@packages/web-shell";
+import {
+	type BannerState,
+	CHANGELOG_DISMISS_COOKIE_NAME,
+	type ChangelogBanner,
+	readCookie,
+	type RenderBase,
+	renderChangelogBannerFragment,
+	sendComponent,
+} from "@packages/web-shell";
 import { BlogIndexPage } from "./blog-index.component";
 import { BlogPostPage } from "./blog-post.component";
 import { NotFoundPage } from "../not-found";
@@ -11,6 +19,19 @@ const CANONICAL_ORIGIN = "https://readplace.com";
  * state. Every page renders the guest header; a logged-in reader sees the
  * guest nav on /blog (the session cookie is never read here). */
 const GUEST_STATE: BannerState = { isAuthenticated: false, emailVerified: undefined };
+
+/** Suppresses the banner when the reader's dismissal cookie matches its version.
+ * Read straight off the raw Cookie header — blog-site takes no cookie-parser
+ * dependency — and compared byte-for-byte against the version blog-site itself
+ * produced, so a dismissal on the app also hides it here (shared cookie). */
+function hideIfDismissed(
+	banner: ChangelogBanner | undefined,
+	req: Request,
+): ChangelogBanner | undefined {
+	if (!banner) return undefined;
+	const dismissed = readCookie(req.headers.cookie, CHANGELOG_DISMISS_COOKIE_NAME);
+	return dismissed === banner.version ? undefined : banner;
+}
 
 const SLUG_REDIRECTS: Record<string, string> = {
 	"hutch-vs-readwise-reader": "readplace-vs-readwise-reader",
@@ -59,9 +80,23 @@ export function initBlogRoutes(deps: { blogPosts: BlogPosts; base: RenderBase })
 		res.type("application/xml").send(renderSitemap(blogPosts));
 	});
 
+	/** The HTML contract hutch fetches to render the site-wide banner on its own
+	 * pages. 200 carries the parseable fragment (with the version blog-site
+	 * computed); 204 means there is nothing to announce. Registered before
+	 * `/:slug` so "changelog-banner" is never matched as a post slug. */
+	router.get("/changelog-banner", (_req: Request, res: Response) => {
+		const banner = blogPosts.getLatestChangelogBanner();
+		if (!banner) {
+			res.status(204).end();
+			return;
+		}
+		res.type("html").send(renderChangelogBannerFragment(banner));
+	});
+
 	router.get("/", (req: Request, res: Response) => {
 		const posts = blogPosts.getAllPosts();
-		sendComponent(req, res, base(BlogIndexPage({ posts }), GUEST_STATE));
+		const changelogBanner = hideIfDismissed(blogPosts.getLatestChangelogBanner(), req);
+		sendComponent(req, res, base(BlogIndexPage({ posts }), { ...GUEST_STATE, changelogBanner }));
 	});
 
 	router.get("/:slug", (req: Request<{ slug: string }>, res: Response) => {
@@ -71,11 +106,12 @@ export function initBlogRoutes(deps: { blogPosts: BlogPosts; base: RenderBase })
 			return;
 		}
 		const post = blogPosts.findPostBySlug(req.params.slug);
+		const changelogBanner = hideIfDismissed(blogPosts.getLatestChangelogBanner(), req);
 		if (!post) {
-			sendComponent(req, res, base(NotFoundPage(), GUEST_STATE));
+			sendComponent(req, res, base(NotFoundPage(), { ...GUEST_STATE, changelogBanner }));
 			return;
 		}
-		sendComponent(req, res, base(BlogPostPage({ post }), GUEST_STATE));
+		sendComponent(req, res, base(BlogPostPage({ post }), { ...GUEST_STATE, changelogBanner }));
 	});
 
 	return router;

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.posts.test.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.posts.test.ts
@@ -1,6 +1,15 @@
-import { initBlogPosts } from "./blog.posts";
+import { createHash } from "node:crypto";
+import { deriveChangelogBanner, initBlogPosts, parseBlogFrontmatter } from "./blog.posts";
 
 const blogPosts = initBlogPosts();
+
+const VALID_FRONTMATTER = {
+	title: "A Post",
+	description: "About something",
+	slug: "a-post",
+	date: "2026-01-02",
+	author: "Fagner",
+};
 
 describe("blog posts", () => {
 	const posts = blogPosts.getAllPosts();
@@ -75,5 +84,77 @@ describe("getAllSlugs", () => {
 		const slugs = blogPosts.getAllSlugs();
 		const posts = blogPosts.getAllPosts();
 		expect(slugs).toEqual(posts.map((p) => p.slug));
+	});
+});
+
+describe("parseBlogFrontmatter", () => {
+	it("defaults tags to an empty array when omitted", () => {
+		const parsed = parseBlogFrontmatter(VALID_FRONTMATTER, "a-post.md");
+		expect(parsed.tags).toEqual([]);
+	});
+
+	it("accepts a changelog-tagged post that carries banner copy", () => {
+		const parsed = parseBlogFrontmatter(
+			{ ...VALID_FRONTMATTER, tags: ["changelog"], banner: "I shipped a thing" },
+			"a-post.md",
+		);
+		expect(parsed.tags).toEqual(["changelog"]);
+		expect(parsed.banner).toBe("I shipped a thing");
+	});
+
+	it("rejects a changelog-tagged post with no banner copy", () => {
+		expect(() =>
+			parseBlogFrontmatter({ ...VALID_FRONTMATTER, tags: ["changelog"] }, "a-post.md"),
+		).toThrow(/must include a `banner:`/);
+	});
+
+	it("rejects a post whose slug does not match its filename", () => {
+		expect(() => parseBlogFrontmatter(VALID_FRONTMATTER, "different-name.md")).toThrow(
+			/does not match filename/,
+		);
+	});
+});
+
+describe("deriveChangelogBanner", () => {
+	function expectedVersion(slug: string, banner: string): string {
+		return createHash("sha256").update(`${slug}|${banner}`).digest("hex").slice(0, 8);
+	}
+
+	it("returns undefined when no post is tagged changelog", () => {
+		expect(
+			deriveChangelogBanner([
+				{ slug: "a", tags: [], banner: undefined },
+				{ slug: "b", tags: ["news"], banner: undefined },
+			]),
+		).toBeUndefined();
+	});
+
+	it("builds the banner from the newest changelog post (first in the sorted list)", () => {
+		const banner = deriveChangelogBanner([
+			{ slug: "newer", tags: ["changelog"], banner: "The newest change" },
+			{ slug: "older", tags: ["changelog"], banner: "An older change" },
+		]);
+		expect(banner).toEqual({
+			hook: "The newest change",
+			href: "/blog/newer?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+			version: expectedVersion("newer", "The newest change"),
+		});
+	});
+
+	it("changes the version when the banner copy changes (so the banner reappears)", () => {
+		const a = deriveChangelogBanner([{ slug: "s", tags: ["changelog"], banner: "First copy" }]);
+		const b = deriveChangelogBanner([{ slug: "s", tags: ["changelog"], banner: "Second copy" }]);
+		expect(a?.version).not.toBe(b?.version);
+	});
+});
+
+describe("getLatestChangelogBanner", () => {
+	it("returns either undefined or a well-formed banner for the on-disk posts", () => {
+		const banner = blogPosts.getLatestChangelogBanner();
+		if (banner !== undefined) {
+			expect(banner.version).toMatch(/^[0-9a-f]{8}$/);
+			expect(banner.href.startsWith("/blog/")).toBe(true);
+			expect(banner.hook.length).toBeGreaterThan(0);
+		}
 	});
 });

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.posts.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.posts.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import { z } from "zod";
-import { type ChangelogBanner, withInternalTracking } from "@packages/web-shell";
+import { type ChangelogBanner, isChangelogVersion, withInternalTracking } from "@packages/web-shell";
 import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
 
@@ -82,6 +82,7 @@ export function deriveChangelogBanner(
 		.update(`${latest.slug}|${latest.banner}`)
 		.digest("hex")
 		.slice(0, 8);
+	assert(isChangelogVersion(version), "sha256 hex slice is always a valid changelog version");
 	const href = withInternalTracking(`/blog/${latest.slug}`, {
 		source: "changelog-banner",
 		content: "read-more",

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.posts.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.posts.ts
@@ -3,7 +3,12 @@ import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import { z } from "zod";
-import { type ChangelogBanner, isChangelogVersion, withInternalTracking } from "@packages/web-shell";
+import {
+	CHANGELOG_VERSION_LENGTH,
+	type ChangelogBanner,
+	isChangelogVersion,
+	withInternalTracking,
+} from "@packages/web-shell";
 import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
 
@@ -69,9 +74,10 @@ interface ChangelogCandidate {
 }
 
 /** Builds the banner from the newest changelog-tagged post (posts arrive sorted
- * newest-first). The version is sha256("slug|banner")[:8] so any change to the
- * slug or the copy yields a new version and the banner reappears; the href is
- * UTM-tagged here, at the single producer, so hutch echoes it without re-tagging. */
+ * newest-first). The version is the leading `CHANGELOG_VERSION_LENGTH` hex chars of
+ * sha256("slug|banner") so any change to the slug or the copy yields a new version
+ * and the banner reappears; the href is UTM-tagged here, at the single producer, so
+ * hutch echoes it without re-tagging. */
 export function deriveChangelogBanner(
 	posts: readonly ChangelogCandidate[],
 ): ChangelogBanner | undefined {
@@ -81,7 +87,7 @@ export function deriveChangelogBanner(
 	const version = createHash("sha256")
 		.update(`${latest.slug}|${latest.banner}`)
 		.digest("hex")
-		.slice(0, 8);
+		.slice(0, CHANGELOG_VERSION_LENGTH);
 	assert(isChangelogVersion(version), "sha256 hex slice is always a valid changelog version");
 	const href = withInternalTracking(`/blog/${latest.slug}`, {
 		source: "changelog-banner",

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.posts.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.posts.ts
@@ -1,26 +1,93 @@
 import assert from "node:assert";
+import { createHash } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import { z } from "zod";
+import { type ChangelogBanner, withInternalTracking } from "@packages/web-shell";
 import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
 
 const md = new MarkdownIt({ html: true });
 
-const BlogFrontmatter = z.object({
-	title: z.string(),
-	description: z.string(),
-	slug: z.string(),
-	date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-	author: z.string(),
-	keywords: z.string().optional(),
-});
+/** The tag that opts a post into the site-wide changelog banner. The newest
+ * post carrying it drives the banner; the schema below requires such a post to
+ * also supply `banner:` copy. */
+const CHANGELOG_TAG = "changelog";
 
-export type BlogPost = z.infer<typeof BlogFrontmatter> & {
+const BlogFrontmatter = z
+	.object({
+		title: z.string(),
+		description: z.string(),
+		slug: z.string(),
+		date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+		author: z.string(),
+		keywords: z.string().optional(),
+		tags: z.array(z.string()).default([]),
+		/** One-line hook shown in the site-wide banner. Required for a post tagged
+		 * `changelog` (see refine) and ignored otherwise. */
+		banner: z.string().optional(),
+	})
+	.refine(
+		(value) => {
+			if (!value.tags.includes(CHANGELOG_TAG)) return true;
+			return value.banner !== undefined;
+		},
+		{
+			message: 'A post tagged "changelog" must include a `banner:` one-liner for the site-wide banner.',
+			path: ["banner"],
+		},
+	);
+
+type BlogFrontmatterData = z.infer<typeof BlogFrontmatter>;
+
+export type BlogPost = BlogFrontmatterData & {
 	htmlContent: string;
 	markdownContent: string;
 	formattedDate: string;
 };
+
+/** Parses and validates one post's frontmatter, asserting the slug matches the
+ * filename. Extracted (and exported) as a pure function so the schema rules —
+ * the `tags` default, the changelog⇒banner requirement, and the slug invariant —
+ * are covered without reading the posts directory. */
+export function parseBlogFrontmatter(data: unknown, file: string): BlogFrontmatterData {
+	const frontmatter = BlogFrontmatter.parse(data);
+	const expectedSlug = basename(file, ".md");
+	assert(
+		frontmatter.slug === expectedSlug,
+		`Slug "${frontmatter.slug}" in ${file} does not match filename "${expectedSlug}"`,
+	);
+	return frontmatter;
+}
+
+/** What `deriveChangelogBanner` needs from a post — a structural subset of
+ * BlogPost so the derivation is testable without constructing full posts. */
+interface ChangelogCandidate {
+	slug: string;
+	tags: string[];
+	banner?: string;
+}
+
+/** Builds the banner from the newest changelog-tagged post (posts arrive sorted
+ * newest-first). The version is sha256("slug|banner")[:8] so any change to the
+ * slug or the copy yields a new version and the banner reappears; the href is
+ * UTM-tagged here, at the single producer, so hutch echoes it without re-tagging. */
+export function deriveChangelogBanner(
+	posts: readonly ChangelogCandidate[],
+): ChangelogBanner | undefined {
+	const latest = posts.find((post) => post.tags.includes(CHANGELOG_TAG));
+	if (!latest) return undefined;
+	assert(latest.banner !== undefined, "a changelog-tagged post must carry a banner (enforced at load)");
+	const version = createHash("sha256")
+		.update(`${latest.slug}|${latest.banner}`)
+		.digest("hex")
+		.slice(0, 8);
+	const href = withInternalTracking(`/blog/${latest.slug}`, {
+		source: "changelog-banner",
+		content: "read-more",
+	});
+	return { hook: latest.banner, href, version };
+}
 
 function formatDate(isoDate: string): string {
 	const date = new Date(`${isoDate}T00:00:00Z`);
@@ -37,6 +104,7 @@ export interface BlogPosts {
 	findPostBySlug: (slug: string) => BlogPost | undefined;
 	getAllSlugs: () => string[];
 	getAllPostMetadata: () => { slug: string; date: string }[];
+	getLatestChangelogBanner: () => ChangelogBanner | undefined;
 }
 
 export function initBlogPosts(): BlogPosts {
@@ -47,13 +115,7 @@ export function initBlogPosts(): BlogPosts {
 		.map((file) => {
 			const raw = readFileSync(join(postsDir, file), "utf-8");
 			const { data, content } = matter(raw);
-			const frontmatter = BlogFrontmatter.parse(data);
-
-			const expectedSlug = basename(file, ".md");
-			assert(
-				frontmatter.slug === expectedSlug,
-				`Slug "${frontmatter.slug}" in ${file} does not match filename "${expectedSlug}"`,
-			);
+			const frontmatter = parseBlogFrontmatter(data, file);
 
 			return {
 				...frontmatter,
@@ -72,5 +134,6 @@ export function initBlogPosts(): BlogPosts {
 		findPostBySlug: (slug) => posts.find((p) => p.slug === slug),
 		getAllSlugs: () => posts.map((p) => p.slug),
 		getAllPostMetadata: () => posts.map((p) => ({ slug: p.slug, date: p.date })),
+		getLatestChangelogBanner: () => deriveChangelogBanner(posts),
 	};
 }

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
@@ -1,5 +1,6 @@
+import assert from "node:assert/strict";
 import express from "express";
-import { type ChangelogBanner, initBase } from "@packages/web-shell";
+import { type ChangelogBanner, initBase, isChangelogVersion } from "@packages/web-shell";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { createBlogApp } from "../../../app";
@@ -10,10 +11,12 @@ const app = createBlogApp({ staticBaseUrl: "", liveReload: false });
 const blogPosts = initBlogPosts();
 const firstPost = blogPosts.getAllPosts()[0];
 
+const FAKE_VERSION = "a1b2c3d4";
+assert(isChangelogVersion(FAKE_VERSION));
 const FAKE_BANNER: ChangelogBanner = {
 	hook: "I added keyboard shortcuts to the reader",
 	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
-	version: "a1b2c3d4",
+	version: FAKE_VERSION,
 };
 
 /** Builds an app whose blog routes are driven by an injected `blogPosts`, so a

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
@@ -1,11 +1,37 @@
+import express from "express";
+import { type ChangelogBanner, initBase } from "@packages/web-shell";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { createBlogApp } from "../../../app";
-import { initBlogPosts } from "./blog.posts";
+import { initBlogRoutes } from "./blog.page";
+import { type BlogPosts, initBlogPosts } from "./blog.posts";
 
 const app = createBlogApp({ staticBaseUrl: "", liveReload: false });
 const blogPosts = initBlogPosts();
 const firstPost = blogPosts.getAllPosts()[0];
+
+const FAKE_BANNER: ChangelogBanner = {
+	hook: "I added keyboard shortcuts to the reader",
+	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+	version: "a1b2c3d4",
+};
+
+/** Builds an app whose blog routes are driven by an injected `blogPosts`, so a
+ * test can control the changelog banner independently of the on-disk posts. */
+function appWithChangelogBanner(banner: ChangelogBanner | undefined) {
+	const blogPostsStub: BlogPosts = {
+		getAllPosts: () => [],
+		findPostBySlug: () => undefined,
+		getAllSlugs: () => [],
+		getAllPostMetadata: () => [],
+		getLatestChangelogBanner: () => banner,
+	};
+	const expressApp = express();
+	expressApp.disable("x-powered-by");
+	const base = initBase({ staticBaseUrl: "", liveReload: false });
+	expressApp.use("/blog", initBlogRoutes({ blogPosts: blogPostsStub, base }));
+	return expressApp;
+}
 
 describe("GET /blog", () => {
 	it("should return 200 and HTML content", async () => {
@@ -225,6 +251,95 @@ describe("GET /blog/:slug with Accept: text/markdown", () => {
 			.get(`/blog/${firstPost.slug}`)
 			.set("Accept", "text/markdown");
 		expect(response.text).toContain(firstPost.markdownContent.trim().split("\n")[0]);
+	});
+});
+
+describe("GET /blog/changelog-banner", () => {
+	it("returns 200 with a parseable fragment when a changelog banner exists", async () => {
+		const response = await request(appWithChangelogBanner(FAKE_BANNER)).get(
+			"/blog/changelog-banner",
+		);
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/text\/html/);
+		const root = new JSDOM(response.text).window.document.querySelector("[data-changelog-version]");
+		expect(root?.getAttribute("data-changelog-version")).toBe(FAKE_BANNER.version);
+		expect(root?.querySelector("a")?.getAttribute("href")).toBe(FAKE_BANNER.href);
+	});
+
+	it("returns 204 with no body when there is nothing to announce", async () => {
+		const response = await request(appWithChangelogBanner(undefined)).get(
+			"/blog/changelog-banner",
+		);
+		expect(response.status).toBe(204);
+		expect(response.text).toBe("");
+	});
+
+	it("is matched as the fragment endpoint, not as a post slug", async () => {
+		const response = await request(appWithChangelogBanner(FAKE_BANNER)).get(
+			"/blog/changelog-banner",
+		);
+		// A 404 would mean it fell through to the /:slug handler (NotFoundPage).
+		expect(response.status).toBe(200);
+	});
+});
+
+describe("changelog banner on /blog pages", () => {
+	it("renders the visible banner on the index when one exists and is not dismissed", async () => {
+		const response = await request(appWithChangelogBanner(FAKE_BANNER)).get("/blog");
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner?.querySelector(".changelog-banner__hook")?.textContent).toBe(FAKE_BANNER.hook);
+	});
+
+	it("renders the hidden shell on the index when there is nothing to announce", async () => {
+		const response = await request(appWithChangelogBanner(undefined)).get("/blog");
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--hidden")).toBe(true);
+	});
+
+	it("hides the banner when the dismissal cookie matches the banner version", async () => {
+		const response = await request(appWithChangelogBanner(FAKE_BANNER))
+			.get("/blog")
+			.set("Cookie", `rp_changelog_dismissed=${FAKE_BANNER.version}`);
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--hidden")).toBe(true);
+	});
+
+	it("keeps showing the banner when the dismissal cookie is for a different version", async () => {
+		const response = await request(appWithChangelogBanner(FAKE_BANNER))
+			.get("/blog")
+			.set("Cookie", "rp_changelog_dismissed=00000000");
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
+	});
+
+	it("renders the banner on a post page too (same shell, every page)", async () => {
+		const slug = firstPost.slug;
+		const blogPostsStub: BlogPosts = {
+			getAllPosts: () => [firstPost],
+			findPostBySlug: (s) => (s === slug ? firstPost : undefined),
+			getAllSlugs: () => [slug],
+			getAllPostMetadata: () => [{ slug, date: firstPost.date }],
+			getLatestChangelogBanner: () => FAKE_BANNER,
+		};
+		const expressApp = express();
+		expressApp.disable("x-powered-by");
+		const base = initBase({ staticBaseUrl: "", liveReload: false });
+		expressApp.use("/blog", initBlogRoutes({ blogPosts: blogPostsStub, base }));
+
+		const response = await request(expressApp).get(`/blog/${slug}`);
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
 	});
 });
 

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
@@ -321,6 +321,17 @@ describe("changelog banner on /blog pages", () => {
 		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
 	});
 
+	it("shows the banner with 200 (not 500) when the dismissal cookie is a malformed percent-escape", async () => {
+		const response = await request(appWithChangelogBanner(FAKE_BANNER))
+			.get("/blog")
+			.set("Cookie", "rp_changelog_dismissed=%");
+		expect(response.status).toBe(200);
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
+	});
+
 	it("renders the banner on a post page too (same shell, every page)", async () => {
 		const slug = firstPost.slug;
 		const blogPostsStub: BlogPosts = {

--- a/projects/blog-site/src/runtime/web/pages/blog/posts/save-articles-with-your-ai-assistant.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/save-articles-with-your-ai-assistant.md
@@ -5,6 +5,8 @@ slug: "save-articles-with-your-ai-assistant"
 date: "2026-06-16"
 author: "Fayner Brack"
 keywords: "MCP server, Model Context Protocol, Claude MCP, read it later MCP, save articles AI assistant, AI reading queue, save_link tool, OAuth MCP, Readplace MCP"
+tags: ["changelog"]
+banner: "Your AI assistant can now save articles to your queue"
 ---
 
 <details class="blog-tldr">

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -278,6 +278,10 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 		NODE_ENV: stage === "production" ? "production" : "development",
 		PERSISTENCE: "prod",
 		APP_ORIGIN: appOrigin,
+		/** Same-origin fragment endpoint served by blog-site behind this same API
+		 * Gateway (/blog/{proxy+} routes there). The banner source is cached and
+		 * fail-open, so the extra gateway hop is fine for a decorative banner. */
+		CHANGELOG_BANNER_URL: pulumi.interpolate`${appOrigin}/blog/changelog-banner`,
 		DYNAMODB_ARTICLES_TABLE: storage.articlesTable.name,
 		DYNAMODB_USER_ARTICLES_TABLE: storage.userArticlesTable.name,
 		DYNAMODB_USERS_TABLE: storage.usersTable.name,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -90,6 +90,7 @@ import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initLogParseError, type ParseErrorEvent } from "@packages/hutch-infra-components";
 import { isBlockedIpAddress, validateSaveableUrl } from "@packages/domain/article";
 import { createApp } from "./server";
+import { initChangelogBannerSource } from "./web/changelog-banner-source";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
 import type { ConversionEvent } from "./conversions";
 import type { AnalyticsEvent } from "./web/middleware/analytics";
@@ -492,6 +493,18 @@ export function createHutchApp(deps?: {
 	const salt = requireEnv("ANALYTICS_SALT");
 	const analyticsLogger = HutchLogger.fromJSON<AnalyticsEvent>();
 
+	// Decorative, cached, fail-open source for the site-wide changelog banner.
+	// Points at blog-site's fragment endpoint via hutch's own API Gateway (set in
+	// infra); a slow or down source never blocks a page render.
+	const { getChangelogBanner } = initChangelogBannerSource({
+		fetch: globalThis.fetch,
+		sourceUrl: requireEnv("CHANGELOG_BANNER_URL"),
+		now: () => Date.now(),
+		ttlMs: 300_000,
+		timeoutMs: 800,
+		logger: HutchLogger.from(consoleLogger),
+	});
+
 	const { logParseError } = initLogParseError({
 		logger: HutchLogger.fromJSON<ParseErrorEvent>(),
 		now: () => new Date(),
@@ -515,6 +528,7 @@ export function createHutchApp(deps?: {
 		httpErrorMessageMapping,
 		logParseError,
 		importSessionStore,
+		getChangelogBanner,
 		now: () => new Date(),
 		botDefenseLogger: HutchLogger.fromJSON<BotDefenseEvent>(),
 		conversionLogger: HutchLogger.fromJSON<ConversionEvent>(),

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -134,6 +134,9 @@ import { initMarkExtensionInstalled } from "./web/mark-extension-installed.middl
 import { initOAuthRoutes } from "./web/oauth/oauth.routes";
 import { Base } from "./web/base.component";
 import { initBuildBannerState } from "./web/banner-state";
+import type { GetChangelogBanner } from "./web/changelog-banner-source";
+import { changelogDismissMiddleware } from "./web/changelog-dismiss.middleware";
+import { initChangelogDismissRoute } from "./web/pages/banner/changelog-dismiss.route";
 import { sendComponent, wantsMarkdown } from "@packages/web-shell";
 import { wantsSiren } from "./web/content-negotiation";
 import { CONTENT_SIGNAL_VALUE, contentSignalMiddleware } from "./web/content-signal.middleware";
@@ -226,6 +229,7 @@ interface AppDependencies {
 	logParseError: LogParseError;
 	importSessionStore: ImportSessionStore;
 	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
+	getChangelogBanner: GetChangelogBanner;
 	now: () => Date;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
 	createCheckoutSession: CreateCheckoutSession;
@@ -347,6 +351,7 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	app.use(express.urlencoded({ extended: true }));
 	app.use(cookieParser());
+	app.use(changelogDismissMiddleware);
 	app.use(createVisitorIdMiddleware({ generateVisitorId: randomUUID, secure: secureCookies }));
 	app.use(createClickAttributionMiddleware({ now: dependencies.now, secure: secureCookies }));
 
@@ -389,6 +394,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	const requireWriteAccess = initRequireWriteAccess({ getEffectiveAccess });
 	const buildBannerState = initBuildBannerState({
 		getEffectiveAccess,
+		getChangelogBanner: deps.getChangelogBanner,
 		now: deps.now,
 	});
 
@@ -661,6 +667,10 @@ export function createApp(dependencies: AppDependencies): Express {
 	}
 
 	app.use(initInstallRoutes({ buildBannerState }));
+
+	/** Same-origin dismissal endpoint for the site-wide changelog banner; served
+	 * here on $default even when the close button is clicked on a /blog page. */
+	app.use(initChangelogDismissRoute({ appOrigin, secureCookies }));
 
 	const authRouter = initAuthRoutes({
 		hashPassword: deps.hashPassword,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -22,6 +22,7 @@ import type {
 } from "@packages/web-test-harness";
 import { useTestServer as useServerForFixture } from "@packages/web-test-harness";
 import { createApp } from "./server";
+import type { GetChangelogBanner } from "./web/changelog-banner-source";
 import { initFoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import type { AnalyticsEvent } from "./web/middleware/analytics";
 
@@ -187,14 +188,20 @@ function flattenFixtureToAppDependencies(
 	};
 }
 
-export function createTestApp(fixture: TestAppFixture): TestAppResult {
+/** `overrides` lets a test swap a single decorative dependency without rebuilding
+ * the whole fixture — currently just `getChangelogBanner`, which defaults to "no
+ * banner" so the banner stays hidden in every other route test. */
+export function createTestApp(
+	fixture: TestAppFixture,
+	overrides?: { getChangelogBanner?: GetChangelogBanner },
+): TestAppResult {
 	const analyticsEvents: AnalyticsEvent[] = [];
 	const captureAnalytics = (data: AnalyticsEvent) => { analyticsEvents.push(data); };
 	const analyticsBundle: AnalyticsBundle = {
 		logger: { info: captureAnalytics, error: captureAnalytics, warn: captureAnalytics, debug: captureAnalytics },
 		events: analyticsEvents,
 	};
-	const app = createApp(flattenFixtureToAppDependencies(fixture, analyticsBundle));
+	const app = createApp({ ...flattenFixtureToAppDependencies(fixture, analyticsBundle), ...overrides });
 	return {
 		app,
 		auth: fixture.auth,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -153,6 +153,7 @@ function flattenFixtureToAppDependencies(
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,
 		importSessionStore: fixture.importSession.importSessionStore,
 		extractLinksFromPageUrl: fixture.importSession.extractLinksFromPageUrl,
+		getChangelogBanner: async () => undefined,
 		now: fixture.shared.now,
 		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,
 		createCheckoutSession: fixture.stripe.createCheckoutSession,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -189,8 +189,8 @@ function flattenFixtureToAppDependencies(
 }
 
 /** `overrides` lets a test swap a single decorative dependency without rebuilding
- * the whole fixture — currently just `getChangelogBanner`, which defaults to "no
- * banner" so the banner stays hidden in every other route test. */
+ * the whole fixture — `getChangelogBanner`, which defaults to "no banner" so the
+ * banner stays hidden in every other route test. */
 export function createTestApp(
 	fixture: TestAppFixture,
 	overrides?: { getChangelogBanner?: GetChangelogBanner },

--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -1,4 +1,5 @@
-import type { ChangelogBanner } from "@packages/web-shell";
+import assert from "node:assert/strict";
+import { type ChangelogBanner, isChangelogVersion } from "@packages/web-shell";
 import { UserIdSchema } from "@packages/domain/user";
 import { initBuildBannerState } from "./banner-state";
 import type { GetChangelogBanner } from "./changelog-banner-source";
@@ -10,10 +11,12 @@ const FIXED_NOW = new Date("2026-01-01T00:00:00.000Z");
 
 const noChangelogBanner: GetChangelogBanner = async () => undefined;
 
+const CHANGELOG_VERSION = "a1b2c3d4";
+assert(isChangelogVersion(CHANGELOG_VERSION));
 const CHANGELOG: ChangelogBanner = {
 	hook: "I added keyboard shortcuts to the reader",
 	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
-	version: "a1b2c3d4",
+	version: CHANGELOG_VERSION,
 };
 
 describe("initBuildBannerState", () => {

--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -1,16 +1,27 @@
+import type { ChangelogBanner } from "@packages/web-shell";
 import { UserIdSchema } from "@packages/domain/user";
 import { initBuildBannerState } from "./banner-state";
+import type { GetChangelogBanner } from "./changelog-banner-source";
 import type { EffectiveAccess } from "../domain/access/effective-access";
 
 const USER_ID = UserIdSchema.parse("user-1");
 const ONE_DAY_MS = 86_400_000;
 const FIXED_NOW = new Date("2026-01-01T00:00:00.000Z");
 
+const noChangelogBanner: GetChangelogBanner = async () => undefined;
+
+const CHANGELOG: ChangelogBanner = {
+	hook: "I added keyboard shortcuts to the reader",
+	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+	version: "a1b2c3d4",
+};
+
 describe("initBuildBannerState", () => {
 	it("returns isAuthenticated=false with no trial for an unauthenticated request and never fetches access", async () => {
 		const getEffectiveAccess = jest.fn();
 		const buildBannerState = initBuildBannerState({
 			getEffectiveAccess,
+			getChangelogBanner: noChangelogBanner,
 			now: () => FIXED_NOW,
 		});
 
@@ -30,6 +41,7 @@ describe("initBuildBannerState", () => {
 		};
 		const buildBannerState = initBuildBannerState({
 			getEffectiveAccess: async () => access,
+			getChangelogBanner: noChangelogBanner,
 			now: () => FIXED_NOW,
 		});
 
@@ -60,10 +72,12 @@ describe("initBuildBannerState", () => {
 
 		const buildExpired = initBuildBannerState({
 			getEffectiveAccess: async () => trialExpired,
+			getChangelogBanner: noChangelogBanner,
 			now: () => FIXED_NOW,
 		});
 		const buildCancelled = initBuildBannerState({
 			getEffectiveAccess: async () => cancelled,
+			getChangelogBanner: noChangelogBanner,
 			now: () => FIXED_NOW,
 		});
 
@@ -90,6 +104,7 @@ describe("initBuildBannerState", () => {
 		for (const access of [founding, paid]) {
 			const build = initBuildBannerState({
 				getEffectiveAccess: async () => access,
+				getChangelogBanner: noChangelogBanner,
 				now: () => FIXED_NOW,
 			});
 			expect((await build({ userId: USER_ID })).trial).toBeUndefined();
@@ -107,6 +122,7 @@ describe("initBuildBannerState", () => {
 		const getEffectiveAccess = jest.fn();
 		const buildBannerState = initBuildBannerState({
 			getEffectiveAccess,
+			getChangelogBanner: noChangelogBanner,
 			now: () => FIXED_NOW,
 		});
 
@@ -131,6 +147,7 @@ describe("initBuildBannerState", () => {
 		};
 		const buildBannerState = initBuildBannerState({
 			getEffectiveAccess: async () => access,
+			getChangelogBanner: noChangelogBanner,
 			now: () => FIXED_NOW,
 		});
 
@@ -142,5 +159,81 @@ describe("initBuildBannerState", () => {
 			serverNowIso: FIXED_NOW.toISOString(),
 		});
 		expect(result.accessIsReadOnly).toBe(false);
+	});
+
+	describe("changelog banner", () => {
+		it("includes the changelog banner for a guest, folded in before the unauthenticated early-return", async () => {
+			const getEffectiveAccess = jest.fn();
+			const build = initBuildBannerState({
+				getEffectiveAccess,
+				getChangelogBanner: async () => CHANGELOG,
+				now: () => FIXED_NOW,
+			});
+
+			const result = await build({});
+
+			expect(result).toEqual({
+				isAuthenticated: false,
+				emailVerified: undefined,
+				changelogBanner: CHANGELOG,
+			});
+			expect(getEffectiveAccess).not.toHaveBeenCalled();
+		});
+
+		it("drops the changelog banner when the reader has dismissed that exact version", async () => {
+			const build = initBuildBannerState({
+				getEffectiveAccess: jest.fn(),
+				getChangelogBanner: async () => CHANGELOG,
+				now: () => FIXED_NOW,
+			});
+
+			const result = await build({ dismissedChangelogVersion: CHANGELOG.version });
+
+			expect(result.changelogBanner).toBeUndefined();
+		});
+
+		it("keeps the changelog banner when the dismissed version is for a different (older) announcement", async () => {
+			const build = initBuildBannerState({
+				getEffectiveAccess: jest.fn(),
+				getChangelogBanner: async () => CHANGELOG,
+				now: () => FIXED_NOW,
+			});
+
+			const result = await build({ dismissedChangelogVersion: "ffffffff" });
+
+			expect(result.changelogBanner).toEqual(CHANGELOG);
+		});
+
+		it("includes the changelog banner for an authenticated user alongside their trial state", async () => {
+			const trialEndsAt = new Date(FIXED_NOW.getTime() + 3 * ONE_DAY_MS).toISOString();
+			const access: EffectiveAccess = {
+				tier: "trial",
+				access: "full",
+				banner: "trial-countdown",
+				trialEndsAt,
+			};
+			const build = initBuildBannerState({
+				getEffectiveAccess: async () => access,
+				getChangelogBanner: async () => CHANGELOG,
+				now: () => FIXED_NOW,
+			});
+
+			const result = await build({ userId: USER_ID });
+
+			expect(result.changelogBanner).toEqual(CHANGELOG);
+			expect(result.trial?.state).toBe("active");
+		});
+
+		it("leaves the state unchanged when there is nothing to announce", async () => {
+			const build = initBuildBannerState({
+				getEffectiveAccess: jest.fn(),
+				getChangelogBanner: noChangelogBanner,
+				now: () => FIXED_NOW,
+			});
+
+			const result = await build({});
+
+			expect(result.changelogBanner).toBeUndefined();
+		});
 	});
 });

--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -5,6 +5,7 @@ import type {
 	EffectiveAccess,
 	GetEffectiveAccess,
 } from "../domain/access/effective-access";
+import type { GetChangelogBanner } from "./changelog-banner-source";
 import { toTrialDisplay } from "./trial-display";
 
 export type BuildBannerState = (
@@ -14,16 +15,24 @@ export type BuildBannerState = (
 
 export function initBuildBannerState(deps: {
 	getEffectiveAccess: GetEffectiveAccess;
+	getChangelogBanner: GetChangelogBanner;
 	now: () => Date;
 }): BuildBannerState {
 	return async (source, options) => {
 		const base = bannerStateFromRequest(source);
+		const banner = await deps.getChangelogBanner();
+		// Suppress the banner the reader has already dismissed (cookie version,
+		// lifted onto the source by the dismiss middleware). Folded in before the
+		// guest early-return so guests see it too.
+		const changelogBanner =
+			banner && banner.version !== source.dismissedChangelogVersion ? banner : undefined;
+		const withBanner: BannerState = changelogBanner ? { ...base, changelogBanner } : base;
 		const userId: UserId | undefined = source.userId;
-		if (!userId) return base;
+		if (!userId) return withBanner;
 		const access =
 			options?.preFetchedAccess ?? (await deps.getEffectiveAccess(userId));
 		const trial = toTrialDisplay(access, deps.now());
 		const accessIsReadOnly = access.access === "read-only";
-		return { ...base, accessIsReadOnly, ...(trial ? { trial } : {}) };
+		return { ...withBanner, accessIsReadOnly, ...(trial ? { trial } : {}) };
 	};
 }

--- a/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
@@ -97,6 +97,24 @@ describe("initChangelogBannerSource", () => {
 		expect(warnings).toEqual([]);
 	});
 
+	it("retracts a previously good banner when a later refetch returns 204", async () => {
+		let clock = 0;
+		const responses = [okFragment(BANNER), statusOnly(204)];
+		let index = 0;
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger,
+			fetch: async () => responses[index++],
+		});
+
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		clock = 2000; // force a refetch past the TTL
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings).toEqual([]);
+	});
+
 	it("returns undefined when the source has never succeeded", async () => {
 		const { logger, warnings } = capturingLogger();
 		const { getChangelogBanner } = initChangelogBannerSource({

--- a/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
@@ -1,0 +1,196 @@
+import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import {
+	type ChangelogBanner,
+	renderChangelogBannerFragment,
+} from "@packages/web-shell";
+import { initChangelogBannerSource } from "./changelog-banner-source";
+
+const BANNER: ChangelogBanner = {
+	hook: "I added keyboard shortcuts to the reader",
+	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+	version: "a1b2c3d4",
+};
+
+type FetchResult = { status: number; ok: boolean; text: () => Promise<string> };
+
+function okFragment(banner: ChangelogBanner): FetchResult {
+	return { status: 200, ok: true, text: async () => renderChangelogBannerFragment(banner) };
+}
+
+function statusOnly(code: number): FetchResult {
+	return { status: code, ok: code >= 200 && code < 300, text: async () => "" };
+}
+
+function body200(text: string): FetchResult {
+	return { status: 200, ok: true, text: async () => text };
+}
+
+function capturingLogger(): { logger: HutchLogger; warnings: string[] } {
+	const warnings: string[] = [];
+	const logger = HutchLogger.from({
+		...noopLogger,
+		warn: (...args: unknown[]) => {
+			warnings.push(String(args[0]));
+		},
+	});
+	return { logger, warnings };
+}
+
+const FIXED = {
+	sourceUrl: "https://readplace.com/blog/changelog-banner",
+	ttlMs: 1000,
+	timeoutMs: 800,
+};
+
+describe("initChangelogBannerSource", () => {
+	it("fetches on the first call and returns the parsed banner", async () => {
+		let fetchCount = 0;
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return okFragment(BANNER);
+			},
+		});
+
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(1);
+	});
+
+	it("serves from cache within the TTL and refetches once it expires", async () => {
+		let clock = 0;
+		let fetchCount = 0;
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return okFragment(BANNER);
+			},
+		});
+
+		await getChangelogBanner();
+		expect(fetchCount).toBe(1);
+
+		clock = 999; // still inside the 1000ms TTL
+		await getChangelogBanner();
+		expect(fetchCount).toBe(1);
+
+		clock = 1000; // TTL elapsed
+		await getChangelogBanner();
+		expect(fetchCount).toBe(2);
+	});
+
+	it("treats 204 as 'nothing to announce' without logging a failure", async () => {
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: async () => statusOnly(204),
+		});
+
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings).toEqual([]);
+	});
+
+	it("returns undefined when the source has never succeeded", async () => {
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: async () => statusOnly(503),
+		});
+
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings.some((w) => w.includes("503"))).toBe(true);
+	});
+
+	it("keeps serving the last good banner when a later refetch returns an error status", async () => {
+		let clock = 0;
+		const responses = [okFragment(BANNER), statusOnly(500)];
+		let index = 0;
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger,
+			fetch: async () => responses[index++],
+		});
+
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		clock = 2000; // force a refetch
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(warnings.some((w) => w.includes("500"))).toBe(true);
+	});
+
+	it("fails open to the last good value when the fetch rejects (timeout abort)", async () => {
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: async () => {
+				throw new Error("The operation was aborted due to timeout");
+			},
+		});
+
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings.some((w) => w.includes("timeout"))).toBe(true);
+	});
+
+	it("fails open when the fetch rejects with a non-Error value", async () => {
+		const { logger } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: () => Promise.reject("boom"),
+		});
+
+		expect(await getChangelogBanner()).toBeUndefined();
+	});
+
+	it("returns undefined and warns when the body is unparseable", async () => {
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: async () => body200("<div>not a banner</div>"),
+		});
+
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings.some((w) => w.includes("unparseable"))).toBe(true);
+	});
+
+	it("dedupes concurrent misses into a single in-flight fetch", async () => {
+		let resolveFetch: (result: FetchResult) => void = () => {};
+		const pending = new Promise<FetchResult>((resolve) => {
+			resolveFetch = resolve;
+		});
+		let fetchCount = 0;
+		const { getChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return pending;
+			},
+		});
+
+		const first = getChangelogBanner();
+		const second = getChangelogBanner();
+		resolveFetch(okFragment(BANNER));
+		const [a, b] = await Promise.all([first, second]);
+
+		expect(fetchCount).toBe(1);
+		expect(a).toEqual(BANNER);
+		expect(b).toEqual(BANNER);
+	});
+});

--- a/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
@@ -1,14 +1,18 @@
+import assert from "node:assert/strict";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import {
 	type ChangelogBanner,
+	isChangelogVersion,
 	renderChangelogBannerFragment,
 } from "@packages/web-shell";
 import { initChangelogBannerSource } from "./changelog-banner-source";
 
+const VERSION = "a1b2c3d4";
+assert(isChangelogVersion(VERSION));
 const BANNER: ChangelogBanner = {
 	hook: "I added keyboard shortcuts to the reader",
 	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
-	version: "a1b2c3d4",
+	version: VERSION,
 };
 
 type FetchResult = { status: number; ok: boolean; text: () => Promise<string> };

--- a/projects/hutch/src/runtime/web/changelog-banner-source.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.ts
@@ -1,0 +1,83 @@
+import type { ChangelogBanner } from "@packages/web-shell";
+import { parseChangelogBannerFragment } from "@packages/web-shell";
+import type { HutchLogger } from "@packages/hutch-logger";
+
+export type GetChangelogBanner = () => Promise<ChangelogBanner | undefined>;
+
+/** The slice of `fetch` this source needs. `globalThis.fetch` is assignable, so
+ * the composition root passes it directly; tests pass a fake without faking a
+ * whole Response. */
+type ChangelogFetch = (
+	url: string,
+	init: { signal: AbortSignal },
+) => Promise<{ status: number; ok: boolean; text: () => Promise<string> }>;
+
+/** Runtime source for the site-wide banner: hutch holds no blog data in-process,
+ * so it fetches blog-site's HTML fragment over hutch's own API Gateway and parses
+ * it through the shared contract. The banner is decorative, so this fails open —
+ * a slow, down, or malformed source never breaks a page render:
+ *
+ *   - 200 + parseable  → adopt it as the new last-good value.
+ *   - 204 / !ok / unparseable / timeout / throw → keep the last good value
+ *     (undefined only until the first success).
+ *
+ * Results are cached for `ttlMs` so most renders pay nothing, and concurrent
+ * misses share one in-flight fetch. Failures log at warn (no alarm — a missing
+ * promo banner is not an incident). Mirrors the graceful fetchFirefoxDownloadUrl
+ * pattern, with caching added because every page consults it. */
+export function initChangelogBannerSource(deps: {
+	fetch: ChangelogFetch;
+	sourceUrl: string;
+	now: () => number;
+	ttlMs: number;
+	timeoutMs: number;
+	logger: HutchLogger;
+}): { getChangelogBanner: GetChangelogBanner } {
+	const { fetch, sourceUrl, now, ttlMs, timeoutMs, logger } = deps;
+
+	let lastGood: ChangelogBanner | undefined;
+	let cachedAt: number | undefined;
+	let cachedValue: ChangelogBanner | undefined;
+	let inFlight: Promise<ChangelogBanner | undefined> | undefined;
+
+	async function fetchFresh(): Promise<ChangelogBanner | undefined> {
+		try {
+			const response = await fetch(sourceUrl, { signal: AbortSignal.timeout(timeoutMs) });
+			if (response.status === 204) return lastGood;
+			if (!response.ok) {
+				logger.warn(`[changelog-banner] source responded ${response.status}; keeping last good value`);
+				return lastGood;
+			}
+			const banner = parseChangelogBannerFragment(await response.text());
+			if (!banner) {
+				logger.warn("[changelog-banner] source returned an unparseable fragment; keeping last good value");
+				return lastGood;
+			}
+			lastGood = banner;
+			return banner;
+		} catch (error) {
+			logger.warn(
+				`[changelog-banner] source fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return lastGood;
+		}
+	}
+
+	async function getChangelogBanner(): Promise<ChangelogBanner | undefined> {
+		const nowMs = now();
+		if (cachedAt !== undefined && nowMs - cachedAt < ttlMs) return cachedValue;
+		if (inFlight) return inFlight;
+		inFlight = fetchFresh()
+			.then((value) => {
+				cachedValue = value;
+				cachedAt = nowMs;
+				return value;
+			})
+			.finally(() => {
+				inFlight = undefined;
+			});
+		return inFlight;
+	}
+
+	return { getChangelogBanner };
+}

--- a/projects/hutch/src/runtime/web/changelog-banner-source.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.ts
@@ -18,8 +18,10 @@ type ChangelogFetch = (
  * a slow, down, or malformed source never breaks a page render:
  *
  *   - 200 + parseable  → adopt it as the new last-good value.
- *   - 204 / !ok / unparseable / timeout / throw → keep the last good value
- *     (undefined only until the first success).
+ *   - 204 (authoritative "nothing to announce") → clear the banner, so
+ *     untagging the post retracts it even on a warm instance.
+ *   - !ok / unparseable / timeout / throw (transient failure) → keep the last
+ *     good value (undefined only until the first success).
  *
  * Results are cached for `ttlMs` so most renders pay nothing, and concurrent
  * misses share one in-flight fetch. Failures log at warn (no alarm — a missing
@@ -43,7 +45,10 @@ export function initChangelogBannerSource(deps: {
 	async function fetchFresh(): Promise<ChangelogBanner | undefined> {
 		try {
 			const response = await fetch(sourceUrl, { signal: AbortSignal.timeout(timeoutMs) });
-			if (response.status === 204) return lastGood;
+			if (response.status === 204) {
+				lastGood = undefined;
+				return undefined;
+			}
 			if (!response.ok) {
 				logger.warn(`[changelog-banner] source responded ${response.status}; keeping last good value`);
 				return lastGood;

--- a/projects/hutch/src/runtime/web/changelog-banner-source.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.ts
@@ -24,9 +24,13 @@ type ChangelogFetch = (
  *     good value (undefined only until the first success).
  *
  * Results are cached for `ttlMs` so most renders pay nothing, and concurrent
- * misses share one in-flight fetch. Failures log at warn (no alarm — a missing
- * promo banner is not an incident). Mirrors the graceful fetchFirefoxDownloadUrl
- * pattern, with caching added because every page consults it. */
+ * misses share one in-flight fetch. The first render after the TTL lapses awaits
+ * the refetch (bounded by `timeoutMs`), so the source adds latency at most once
+ * per TTL per instance — it blocks-to-revalidate rather than serving stale, which
+ * keeps a 204 retraction immediate; it never errors a render. Failures log at
+ * warn (no alarm — a missing promo banner is not an incident). Mirrors the
+ * graceful fetchFirefoxDownloadUrl pattern, with caching added because every page
+ * consults it. */
 export function initChangelogBannerSource(deps: {
 	fetch: ChangelogFetch;
 	sourceUrl: string;

--- a/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
@@ -1,0 +1,42 @@
+import type { ChangelogBanner } from "@packages/web-shell";
+import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { createTestApp } from "../test-app";
+
+const BANNER: ChangelogBanner = {
+	hook: "I added keyboard shortcuts to the reader",
+	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+	version: "a1b2c3d4",
+};
+
+describe("changelog banner on hutch pages", () => {
+	it("renders the visible banner in the banner area for a guest when the source has one", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN), {
+			getChangelogBanner: async () => BANNER,
+		});
+
+		const response = await request(app).get("/privacy");
+
+		expect(response.status).toBe(200);
+		const doc = new JSDOM(response.text).window.document;
+		const bannerArea = doc.querySelector(".banner-area");
+		const banner = bannerArea?.querySelector("[data-test-changelog-banner]");
+		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner?.querySelector(".changelog-banner__hook")?.textContent).toBe(BANNER.hook);
+		expect(banner?.querySelector(".changelog-banner__link")?.getAttribute("href")).toBe(
+			BANNER.href,
+		);
+	});
+
+	it("renders the hidden shell when the source has nothing to announce", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(app).get("/privacy");
+
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		expect(banner?.classList.contains("changelog-banner--hidden")).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
@@ -1,13 +1,16 @@
-import type { ChangelogBanner } from "@packages/web-shell";
+import assert from "node:assert/strict";
+import { type ChangelogBanner, isChangelogVersion } from "@packages/web-shell";
 import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { createTestApp } from "../test-app";
 
+const VERSION = "a1b2c3d4";
+assert(isChangelogVersion(VERSION));
 const BANNER: ChangelogBanner = {
 	hook: "I added keyboard shortcuts to the reader",
 	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
-	version: "a1b2c3d4",
+	version: VERSION,
 };
 
 describe("changelog banner on hutch pages", () => {

--- a/projects/hutch/src/runtime/web/changelog-dismiss.middleware.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-dismiss.middleware.test.ts
@@ -1,0 +1,28 @@
+import type { NextFunction, Request, Response } from "express";
+import { CHANGELOG_DISMISS_COOKIE_NAME } from "@packages/web-shell";
+import { changelogDismissMiddleware } from "./changelog-dismiss.middleware";
+import "./session.types";
+
+describe("changelogDismissMiddleware", () => {
+	it("lifts the dismissal cookie value onto req.dismissedChangelogVersion", () => {
+		const req = {
+			cookies: { [CHANGELOG_DISMISS_COOKIE_NAME]: "a1b2c3d4" },
+		} as unknown as Request;
+		const next = jest.fn() as unknown as NextFunction;
+
+		changelogDismissMiddleware(req, {} as Response, next);
+
+		expect(req.dismissedChangelogVersion).toBe("a1b2c3d4");
+		expect(next).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves req.dismissedChangelogVersion undefined when the cookie is absent", () => {
+		const req = { cookies: {} } as unknown as Request;
+		const next = jest.fn() as unknown as NextFunction;
+
+		changelogDismissMiddleware(req, {} as Response, next);
+
+		expect(req.dismissedChangelogVersion).toBeUndefined();
+		expect(next).toHaveBeenCalledTimes(1);
+	});
+});

--- a/projects/hutch/src/runtime/web/changelog-dismiss.middleware.ts
+++ b/projects/hutch/src/runtime/web/changelog-dismiss.middleware.ts
@@ -1,0 +1,16 @@
+import type { NextFunction, Request, Response } from "express";
+import { CHANGELOG_DISMISS_COOKIE_NAME } from "@packages/web-shell";
+
+/** Lifts the changelog dismissal cookie onto a typed request field so
+ * buildBannerState — which sees the request structurally as a BannerStateSource —
+ * can suppress an announcement the reader has already dismissed. Mounted after
+ * cookieParser, which always populates req.cookies, so the index needs no
+ * optional chain. */
+export function changelogDismissMiddleware(
+	req: Request,
+	_res: Response,
+	next: NextFunction,
+): void {
+	req.dismissedChangelogVersion = req.cookies[CHANGELOG_DISMISS_COOKIE_NAME];
+	next();
+}

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.test.ts
@@ -28,6 +28,10 @@ describe("safeBackPath", () => {
 		expect(safeBackPath("https://evil.example/queue", ORIGIN)).toBe("/");
 	});
 
+	it("returns / for a protocol-relative path on a same-origin referer", () => {
+		expect(safeBackPath("https://readplace.com//evil.com", ORIGIN)).toBe("/");
+	});
+
 	it("returns / for a malformed referer", () => {
 		expect(safeBackPath("not a url", ORIGIN)).toBe("/");
 	});
@@ -53,6 +57,20 @@ describe("POST /banner/changelog/dismiss", () => {
 		expect(cookie).toContain("HttpOnly");
 		expect(cookie).toContain("SameSite=Lax");
 		expect(cookie).toContain("Path=/");
+	});
+
+	it("redirects to / (never a protocol-relative Location) for a same-origin referer with a // path", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(harness.server)
+			.post("/banner/changelog/dismiss")
+			.type("form")
+			.set("Referer", `${TEST_APP_ORIGIN}//evil.com`)
+			.send({ version: "a1b2c3d4" });
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/");
+		expect(response.headers.location.startsWith("//")).toBe(false);
 	});
 
 	it("redirects to / when no referer is present", async () => {

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.test.ts
@@ -1,0 +1,95 @@
+import request from "supertest";
+import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
+import { useTestServer } from "../../../test-app";
+import { safeBackPath } from "./changelog-dismiss.route";
+
+const useApp = useTestServer();
+const COOKIE = "rp_changelog_dismissed";
+
+function setCookies(headers: { [key: string]: string | string[] | undefined }): string[] {
+	const raw = headers["set-cookie"];
+	return Array.isArray(raw) ? raw : raw ? [raw] : [];
+}
+
+describe("safeBackPath", () => {
+	const ORIGIN = "https://readplace.com";
+
+	it("returns / when there is no referer", () => {
+		expect(safeBackPath(undefined, ORIGIN)).toBe("/");
+	});
+
+	it("returns the path and query for a same-origin referer", () => {
+		expect(safeBackPath("https://readplace.com/queue?filter=unread", ORIGIN)).toBe(
+			"/queue?filter=unread",
+		);
+	});
+
+	it("returns / for a cross-origin referer", () => {
+		expect(safeBackPath("https://evil.example/queue", ORIGIN)).toBe("/");
+	});
+
+	it("returns / for a malformed referer", () => {
+		expect(safeBackPath("not a url", ORIGIN)).toBe("/");
+	});
+});
+
+describe("POST /banner/changelog/dismiss", () => {
+	it("sets the dismissal cookie for a valid version and redirects back to the same-origin referer", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(harness.server)
+			.post("/banner/changelog/dismiss")
+			.type("form")
+			.set("Referer", `${TEST_APP_ORIGIN}/queue`)
+			.send({ version: "a1b2c3d4" });
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
+
+		const setCookie = setCookies(response.headers);
+		const cookie = setCookie.find((c) => c.startsWith(`${COOKIE}=`));
+		expect(cookie).toBeDefined();
+		expect(cookie).toContain(`${COOKIE}=a1b2c3d4`);
+		expect(cookie).toContain("HttpOnly");
+		expect(cookie).toContain("SameSite=Lax");
+		expect(cookie).toContain("Path=/");
+	});
+
+	it("redirects to / when no referer is present", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(harness.server)
+			.post("/banner/changelog/dismiss")
+			.type("form")
+			.send({ version: "a1b2c3d4" });
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/");
+	});
+
+	it("ignores an invalid version (sets no cookie) but still redirects", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(harness.server)
+			.post("/banner/changelog/dismiss")
+			.type("form")
+			.send({ version: "not-hex-value" });
+
+		expect(response.status).toBe(303);
+		const setCookie = setCookies(response.headers);
+		expect(setCookie.some((c) => c.startsWith(`${COOKIE}=`))).toBe(false);
+	});
+
+	it("ignores a missing version (sets no cookie) but still redirects", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(harness.server)
+			.post("/banner/changelog/dismiss")
+			.type("form")
+			.send({});
+
+		expect(response.status).toBe(303);
+		const setCookie = setCookies(response.headers);
+		expect(setCookie.some((c) => c.startsWith(`${COOKIE}=`))).toBe(false);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
@@ -1,8 +1,7 @@
 import express, { type Request, type Response, type Router } from "express";
-import { CHANGELOG_DISMISS_COOKIE_NAME } from "@packages/web-shell";
+import { CHANGELOG_DISMISS_COOKIE_NAME, isChangelogVersion } from "@packages/web-shell";
 import { baseCookieOptions } from "../../cookie-options";
 
-const VERSION_PATTERN = /^[0-9a-f]{8}$/;
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 /** Where to send the reader after dismissing. The Referer is untrusted, so only
@@ -39,7 +38,7 @@ export function initChangelogDismissRoute(deps: {
 
 	router.post("/banner/changelog/dismiss", (req: Request, res: Response) => {
 		const version: unknown = req.body.version;
-		if (typeof version === "string" && VERSION_PATTERN.test(version)) {
+		if (isChangelogVersion(version)) {
 			res.cookie(CHANGELOG_DISMISS_COOKIE_NAME, version, {
 				...baseCookieOptions(deps.secureCookies),
 				maxAge: ONE_YEAR_MS,

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
@@ -1,0 +1,49 @@
+import express, { type Request, type Response, type Router } from "express";
+import { CHANGELOG_DISMISS_COOKIE_NAME } from "@packages/web-shell";
+import { baseCookieOptions } from "../../cookie-options";
+
+const VERSION_PATTERN = /^[0-9a-f]{8}$/;
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Where to send the reader after dismissing. The Referer is untrusted, so only
+ * a same-origin URL is honoured (its path + query); anything absent,
+ * cross-origin, or unparseable falls back to "/". Pure and exported so the
+ * safety rules are covered without an HTTP round-trip. */
+export function safeBackPath(referer: string | undefined, appOrigin: string): string {
+	if (!referer) return "/";
+	try {
+		const target = new URL(referer);
+		if (target.origin !== new URL(appOrigin).origin) return "/";
+		return `${target.pathname}${target.search}`;
+	} catch {
+		return "/";
+	}
+}
+
+/** POST /banner/changelog/dismiss — target of the banner's no-JS close button.
+ * Served by hutch's $default even when the button is clicked on a /blog page,
+ * since both share the readplace.com origin. Records the dismissed version in a
+ * year-long, path:"/" cookie (so both deployables read it) and 303-redirects the
+ * reader back to where they were. The posted version is the one actually
+ * rendered to the reader, so the cookie matches what they saw regardless of
+ * hutch's cache freshness. An invalid or missing version is ignored (no cookie),
+ * still redirecting back so the button never dead-ends. */
+export function initChangelogDismissRoute(deps: {
+	appOrigin: string;
+	secureCookies: boolean;
+}): Router {
+	const router = express.Router();
+
+	router.post("/banner/changelog/dismiss", (req: Request, res: Response) => {
+		const version: unknown = req.body.version;
+		if (typeof version === "string" && VERSION_PATTERN.test(version)) {
+			res.cookie(CHANGELOG_DISMISS_COOKIE_NAME, version, {
+				...baseCookieOptions(deps.secureCookies),
+				maxAge: ONE_YEAR_MS,
+			});
+		}
+		res.redirect(303, safeBackPath(req.get("referer"), deps.appOrigin));
+	});
+
+	return router;
+}

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
@@ -7,14 +7,17 @@ const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 /** Where to send the reader after dismissing. The Referer is untrusted, so only
  * a same-origin URL is honoured (its path + query); anything absent,
- * cross-origin, or unparseable falls back to "/". Pure and exported so the
- * safety rules are covered without an HTTP round-trip. */
+ * cross-origin, protocol-relative (`//host`, which a same-origin Referer can
+ * still yield as a pathname and a browser resolves off-site), or unparseable
+ * falls back to "/". Pure and exported so the safety rules are covered without
+ * an HTTP round-trip. */
 export function safeBackPath(referer: string | undefined, appOrigin: string): string {
 	if (!referer) return "/";
 	try {
 		const target = new URL(referer);
 		if (target.origin !== new URL(appOrigin).origin) return "/";
-		return `${target.pathname}${target.search}`;
+		const path = `${target.pathname}${target.search}`;
+		return path.startsWith("//") ? "/" : path;
 	} catch {
 		return "/";
 	}

--- a/projects/hutch/src/runtime/web/session.types.ts
+++ b/projects/hutch/src/runtime/web/session.types.ts
@@ -11,6 +11,10 @@ declare global {
 			/** Set by resolveVerificationStatus for unverified sessions only.
 			 * Drives the countdown/lockout banner and the lock middleware. */
 			verificationStatus?: VerificationStatus;
+			/** Set by changelogDismissMiddleware from the dismissal cookie. Read
+			 * (structurally, via BannerStateSource) by buildBannerState to suppress
+			 * a changelog banner the reader has already dismissed. */
+			dismissedChangelogVersion?: string;
 		}
 	}
 }

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -1,3 +1,4 @@
+import type { ChangelogBanner } from "./changelog-banner";
 import { withInternalTracking } from "./internal-link-tracking";
 import type { TrialDisplay } from "./trial-countdown.format";
 
@@ -25,6 +26,11 @@ export interface BannerStateSource {
 	userId?: UserId;
 	emailVerified?: boolean;
 	verificationStatus?: VerificationStatus;
+	/** The changelog version the reader has dismissed, lifted from the dismissal
+	 * cookie by the consuming site (hutch via cookie-parser middleware). When it
+	 * equals the live banner's version the banner is suppressed; a newer post
+	 * carries a different version and reappears. */
+	dismissedChangelogVersion?: string;
 }
 
 export type NavItemKey =
@@ -134,6 +140,11 @@ export interface BannerState {
 	 * (without an access lookup); `buildNavGroups` treats undefined as full
 	 * access. */
 	accessIsReadOnly?: boolean;
+	/** The latest feature announcement to surface site-wide, already filtered
+	 * for the reader's dismissal. Undefined when there is nothing to announce or
+	 * the reader has dismissed the current one; the shell then renders the
+	 * hidden, empty banner shell. */
+	changelogBanner?: ChangelogBanner;
 }
 
 const NAV_QUEUE = navItem({ key: "queue", label: "Queue", path: "/queue", method: "GET", icon: "fa-solid fa-inbox" });

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -235,6 +235,38 @@ describe("Base component", () => {
 		expect(script.hasAttribute("defer")).toBe(true);
 	});
 
+	it("renders the changelog banner hidden by default (no announcement in state)", () => {
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-changelog-banner]");
+		assert(banner, "changelog banner element must always be in the DOM");
+		expect(banner.classList.contains("changelog-banner--hidden")).toBe(true);
+	});
+
+	it("renders the changelog banner visible inside the banner area when state carries an announcement", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			...GUEST_STATE,
+			changelogBanner: {
+				hook: "I added keyboard shortcuts to the reader",
+				href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+				version: "a1b2c3d4",
+			},
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const bannerArea = doc.querySelector(".banner-area");
+		assert(bannerArea, "banner area must be rendered");
+		const banner = bannerArea.querySelector("[data-test-changelog-banner]");
+		assert(banner, "changelog banner must render inside the banner area");
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner.querySelector(".changelog-banner__hook")?.textContent).toBe(
+			"I added keyboard shortcuts to the reader",
+		);
+	});
+
 	it("should set meta description from seo", () => {
 		const page = createTestPageBody({ seo: { title: "T", description: "My desc", canonicalUrl: "https://readplace.com" } });
 		const result = Base(page, GUEST_STATE).to("text/html");

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { initBase } from "./base.component";
+import { isChangelogVersion } from "./changelog-banner";
 import type { BannerState } from "./banner-state";
 import type { PageBody } from "./page-body.types";
 
 const Base = initBase({ staticBaseUrl: "", liveReload: false });
+
+const CHANGELOG_VERSION = "a1b2c3d4";
+assert(isChangelogVersion(CHANGELOG_VERSION));
 
 function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
 	return {
@@ -252,7 +256,7 @@ describe("Base component", () => {
 			changelogBanner: {
 				hook: "I added keyboard shortcuts to the reader",
 				href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
-				version: "a1b2c3d4",
+				version: CHANGELOG_VERSION,
 			},
 		}).to("text/html");
 		const doc = new JSDOM(result.body).window.document;

--- a/src/packages/web-shell/src/base.component.ts
+++ b/src/packages/web-shell/src/base.component.ts
@@ -4,6 +4,7 @@ import {
 	BANNER_AREA_STYLES,
 	BASE_CSS_VARIABLES,
 	BASE_RESET_STYLES,
+	CHANGELOG_BANNER_STYLES,
 	FOOTER_STYLES,
 	HEADER_STYLES,
 	NAV_STYLES,
@@ -15,6 +16,7 @@ import {
 import { BASE_TEMPLATE } from "./base.template";
 import { FOOTER_TEMPLATE } from "./footer.template";
 import type { BannerState } from "./banner-state";
+import { renderChangelogBannerShell } from "./changelog-banner";
 import type { Component, ParsedComponent } from "./component.types";
 import { HtmlPage } from "./html-page";
 import { htmlToMarkdown } from "./html-to-markdown";
@@ -247,6 +249,7 @@ export function initBase(config: BaseConfig): RenderBase {
 			resetStyles: BASE_RESET_STYLES,
 			utilityStyles: UTILITY_STYLES,
 			bannerAreaStyles: BANNER_AREA_STYLES,
+			changelogBannerStyles: CHANGELOG_BANNER_STYLES,
 			headerStyles: HEADER_STYLES,
 			navStyles: NAV_STYLES,
 			footerStyles: FOOTER_STYLES,
@@ -255,6 +258,7 @@ export function initBase(config: BaseConfig): RenderBase {
 			verifyBannerStyles: VERIFY_BANNER_STYLES,
 			trialCountdownStyles: TRIAL_COUNTDOWN_STYLES,
 			extensionSuggestionBannerStyles: EXTENSION_SUGGESTION_BANNER_STYLES,
+			changelogBanner: renderChangelogBannerShell(state.changelogBanner),
 			verifyBanner: renderVerifyBanner(state),
 			extensionSuggestionBanner: renderExtensionSuggestionBanner({
 				show: state.showExtensionSuggestionBanner ?? false,

--- a/src/packages/web-shell/src/base.styles.ts
+++ b/src/packages/web-shell/src/base.styles.ts
@@ -564,6 +564,102 @@ export const BANNER_AREA_STYLES = `
   }
 `;
 
+export const CHANGELOG_BANNER_STYLES = `
+  .changelog-banner {
+    background: var(--color-surface-elevated);
+    border-bottom: 1px solid var(--color-border);
+    color: var(--foreground);
+    font-size: 14px;
+    line-height: 1.5;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .changelog-banner--visible { display: block; }
+  .changelog-banner--hidden { display: none; }
+
+  .changelog-banner__inner {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 10px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  /**
+   * 1. A label, not a pill — 6px radius (var(--radius-sm)) keeps it inside the
+   *    brand's "never fully rounded" rule while the brand fill carries novelty.
+   */
+  .changelog-banner__chip {
+    flex: 0 0 auto;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 4px 7px;
+    background: var(--color-brand);
+    color: var(--color-on-brand);
+    border-radius: var(--radius-sm); /* 1 */
+  }
+
+  .changelog-banner__hook {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--color-text-secondary);
+  }
+
+  .changelog-banner__link {
+    flex: 0 0 auto;
+    color: var(--primary);
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .changelog-banner__link:hover,
+  .changelog-banner__link:focus-visible {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  .changelog-banner__arrow { margin-left: 2px; }
+
+  .changelog-banner__dismiss {
+    flex: 0 0 auto;
+    margin: 0;
+    line-height: 1;
+  }
+
+  .changelog-banner__close {
+    background: transparent;
+    border: none;
+    color: var(--color-text-muted);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 6px;
+    border-radius: var(--radius-sm);
+    transition: color 0.15s ease, background 0.15s ease;
+  }
+
+  .changelog-banner__close:hover,
+  .changelog-banner__close:focus-visible {
+    color: var(--foreground);
+    background: var(--color-surface);
+  }
+
+  @media (max-width: 480px) {
+    .changelog-banner__hook {
+      white-space: normal;
+    }
+  }
+`;
+
 
 export const UTILITY_STYLES = `
   .sr-only {

--- a/src/packages/web-shell/src/base.template.ts
+++ b/src/packages/web-shell/src/base.template.ts
@@ -81,6 +81,7 @@ export const BASE_TEMPLATE = `<!DOCTYPE html>
     {{{resetStyles}}}
     {{{utilityStyles}}}
     {{{bannerAreaStyles}}}
+    {{{changelogBannerStyles}}}
     {{{headerStyles}}}
     {{{navStyles}}}
     {{{footerStyles}}}
@@ -93,6 +94,7 @@ export const BASE_TEMPLATE = `<!DOCTYPE html>
 </head>
 <body{{#if bodyClass}} class="{{bodyClass}}"{{/if}}>
   <div class="banner-area">
+    {{{changelogBanner}}}
     <div class="offline-banner" role="alert" aria-live="polite" aria-hidden="true">
       You're offline. Some features may be unavailable.
     </div>

--- a/src/packages/web-shell/src/changelog-banner.test.ts
+++ b/src/packages/web-shell/src/changelog-banner.test.ts
@@ -3,6 +3,7 @@ import { JSDOM } from "jsdom";
 import {
 	CHANGELOG_DISMISS_COOKIE_NAME,
 	type ChangelogBanner,
+	isChangelogVersion,
 	parseChangelogBannerFragment,
 	readCookie,
 	renderChangelogBannerFragment,
@@ -13,10 +14,12 @@ function parse(html: string): Document {
 	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
 }
 
+const VERSION = "a1b2c3d4";
+assert(isChangelogVersion(VERSION));
 const BANNER: ChangelogBanner = {
 	hook: "I added keyboard shortcuts to the reader",
 	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
-	version: "a1b2c3d4",
+	version: VERSION,
 };
 
 describe("renderChangelogBannerFragment", () => {
@@ -112,6 +115,25 @@ describe("parseChangelogBannerFragment", () => {
 				`<div data-changelog-version="a1b2c3d4"><span data-changelog-hook>hi</span><a href="//evil.example/x">Read more</a></div>`,
 			),
 		).toBeUndefined();
+	});
+});
+
+describe("isChangelogVersion", () => {
+	it("accepts exactly eight lowercase hex characters", () => {
+		expect(isChangelogVersion("a1b2c3d4")).toBe(true);
+	});
+
+	it("rejects a non-string value", () => {
+		expect(isChangelogVersion(undefined)).toBe(false);
+		expect(isChangelogVersion(null)).toBe(false);
+		expect(isChangelogVersion(0xa1b2c3d4)).toBe(false);
+	});
+
+	it("rejects the wrong length, uppercase, or non-hex characters", () => {
+		expect(isChangelogVersion("a1b2c3d")).toBe(false);
+		expect(isChangelogVersion("a1b2c3d4e")).toBe(false);
+		expect(isChangelogVersion("A1B2C3D4")).toBe(false);
+		expect(isChangelogVersion("zzzzzzzz")).toBe(false);
 	});
 });
 

--- a/src/packages/web-shell/src/changelog-banner.test.ts
+++ b/src/packages/web-shell/src/changelog-banner.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	CHANGELOG_DISMISS_COOKIE_NAME,
+	type ChangelogBanner,
+	parseChangelogBannerFragment,
+	readCookie,
+	renderChangelogBannerFragment,
+	renderChangelogBannerShell,
+} from "./changelog-banner";
+
+function parse(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window.document;
+}
+
+const BANNER: ChangelogBanner = {
+	hook: "I added keyboard shortcuts to the reader",
+	href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+	version: "a1b2c3d4",
+};
+
+describe("renderChangelogBannerFragment", () => {
+	it("carries the version on the root data attribute", () => {
+		const doc = parse(renderChangelogBannerFragment(BANNER));
+		const root = doc.querySelector("[data-changelog-version]");
+		assert(root, "fragment must have a versioned root");
+		expect(root.getAttribute("data-changelog-version")).toBe("a1b2c3d4");
+	});
+
+	it("escapes the hook as text so markup in the copy cannot break out", () => {
+		const doc = parse(
+			renderChangelogBannerFragment({ ...BANNER, hook: "a <b> & \"c\"" }),
+		);
+		const hook = doc.querySelector("[data-changelog-hook]");
+		assert(hook, "fragment must carry the hook");
+		expect(hook.textContent).toBe('a <b> & "c"');
+	});
+
+	it("renders the href on the link, preserving the query string", () => {
+		const doc = parse(renderChangelogBannerFragment(BANNER));
+		const link = doc.querySelector("a");
+		assert(link, "fragment must carry a link");
+		expect(link.getAttribute("href")).toBe(BANNER.href);
+	});
+
+	it("round-trips through parseChangelogBannerFragment unchanged", () => {
+		expect(parseChangelogBannerFragment(renderChangelogBannerFragment(BANNER))).toEqual(BANNER);
+	});
+});
+
+describe("parseChangelogBannerFragment", () => {
+	it("parses a well-formed fragment", () => {
+		const html = renderChangelogBannerFragment(BANNER);
+		expect(parseChangelogBannerFragment(html)).toEqual(BANNER);
+	});
+
+	it("returns undefined for garbage with no root element", () => {
+		expect(parseChangelogBannerFragment("just text, no element")).toBeUndefined();
+	});
+
+	it("returns undefined when the version attribute is missing", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div><span data-changelog-hook>hi</span><a href="/blog/x">Read more</a></div>`,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the version fails the 8-hex-char shape", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div data-changelog-version="not-hex!"><span data-changelog-hook>hi</span><a href="/blog/x">Read more</a></div>`,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the hook element is missing", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div data-changelog-version="a1b2c3d4"><a href="/blog/x">Read more</a></div>`,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the link is missing", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div data-changelog-version="a1b2c3d4"><span data-changelog-hook>hi</span></div>`,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the link has no href", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div data-changelog-version="a1b2c3d4"><span data-changelog-hook>hi</span><a>Read more</a></div>`,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for an absolute (non-root-relative) href", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div data-changelog-version="a1b2c3d4"><span data-changelog-hook>hi</span><a href="https://evil.example/x">Read more</a></div>`,
+			),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for a protocol-relative href", () => {
+		expect(
+			parseChangelogBannerFragment(
+				`<div data-changelog-version="a1b2c3d4"><span data-changelog-hook>hi</span><a href="//evil.example/x">Read more</a></div>`,
+			),
+		).toBeUndefined();
+	});
+});
+
+describe("renderChangelogBannerShell", () => {
+	it("renders the visible banner with content when a banner is present", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const banner = doc.querySelector(".changelog-banner");
+		assert(banner, "the banner element must always render");
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner.classList.contains("changelog-banner--hidden")).toBe(false);
+	});
+
+	it("renders the hidden, empty banner when no banner is present", () => {
+		const doc = parse(renderChangelogBannerShell(undefined));
+		const banner = doc.querySelector(".changelog-banner");
+		assert(banner, "the banner element must always render so layout stays stable");
+		expect(banner.classList.contains("changelog-banner--hidden")).toBe(true);
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(false);
+		expect(banner.querySelector(".changelog-banner__hook")).toBeNull();
+	});
+
+	it("uses role=status with a polite live region for assistive tech", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const banner = doc.querySelector(".changelog-banner");
+		assert(banner, "the banner element must render");
+		expect(banner.getAttribute("role")).toBe("status");
+		expect(banner.getAttribute("aria-live")).toBe("polite");
+	});
+
+	it("renders the NEW chip as aria-hidden decorative novelty", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const chip = doc.querySelector(".changelog-banner__chip");
+		assert(chip, "the NEW chip must render");
+		expect(chip.textContent).toBe("NEW");
+		expect(chip.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	it("renders the escaped hook as text", () => {
+		const doc = parse(renderChangelogBannerShell({ ...BANNER, hook: "a <b> & c" }));
+		const hook = doc.querySelector(".changelog-banner__hook");
+		assert(hook, "the hook must render");
+		expect(hook.textContent).toBe("a <b> & c");
+	});
+
+	it("links 'Read more' to the banner href", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const link = doc.querySelector(".changelog-banner__link");
+		assert(link, "the read-more link must render");
+		expect(link.getAttribute("href")).toBe(BANNER.href);
+	});
+
+	it("dismisses via a POST form that carries the rendered version", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const form = doc.querySelector(".changelog-banner__dismiss");
+		assert(form, "the dismiss form must render");
+		expect(form.getAttribute("method")).toBe("POST");
+		expect(form.getAttribute("action")).toBe("/banner/changelog/dismiss");
+		const version = form.querySelector('input[name="version"]');
+		assert(version, "the dismiss form must post the version");
+		expect(version.getAttribute("value")).toBe("a1b2c3d4");
+	});
+
+	it("labels the close button for assistive tech", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const close = doc.querySelector(".changelog-banner__close");
+		assert(close, "the close button must render");
+		expect(close.getAttribute("aria-label")).toBe("Dismiss changelog banner");
+	});
+});
+
+describe("readCookie", () => {
+	it("reads a single cookie value", () => {
+		expect(readCookie(`${CHANGELOG_DISMISS_COOKIE_NAME}=a1b2c3d4`, CHANGELOG_DISMISS_COOKIE_NAME)).toBe(
+			"a1b2c3d4",
+		);
+	});
+
+	it("returns undefined when the header is absent", () => {
+		expect(readCookie(undefined, CHANGELOG_DISMISS_COOKIE_NAME)).toBeUndefined();
+	});
+
+	it("finds the named cookie among several", () => {
+		const header = `session=abc; ${CHANGELOG_DISMISS_COOKIE_NAME}=a1b2c3d4; theme=dark`;
+		expect(readCookie(header, CHANGELOG_DISMISS_COOKIE_NAME)).toBe("a1b2c3d4");
+	});
+
+	it("returns undefined when the named cookie is not present", () => {
+		expect(readCookie("session=abc; theme=dark", CHANGELOG_DISMISS_COOKIE_NAME)).toBeUndefined();
+	});
+
+	it("decodes percent-encoded values", () => {
+		expect(readCookie("k=a%20b", "k")).toBe("a b");
+	});
+});

--- a/src/packages/web-shell/src/changelog-banner.test.ts
+++ b/src/packages/web-shell/src/changelog-banner.test.ts
@@ -205,4 +205,8 @@ describe("readCookie", () => {
 	it("decodes percent-encoded values", () => {
 		expect(readCookie("k=a%20b", "k")).toBe("a b");
 	});
+
+	it("returns the raw value rather than throwing when it is not a valid percent-escape", () => {
+		expect(readCookie("k=%", "k")).toBe("%");
+	});
 });

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -2,25 +2,42 @@ import assert from "node:assert";
 import { parseHTML } from "linkedom";
 import { render } from "./render";
 
+/** An opaque 8-lowercase-hex fingerprint of the announcing post, branded so its
+ * shape is single-sourced across the deploy boundary. The only way to obtain one
+ * is `isChangelogVersion`, so the producer (blog-site), the fragment parser here,
+ * and hutch's dismiss route cannot drift to different notions of a valid version
+ * without a type error — they share this contract by name, never a re-declared
+ * regex (connascence of name, compiler-enforced). */
+export type ChangelogVersion = string & { readonly __brand: "ChangelogVersion" };
+
+const VERSION_PATTERN = /^[0-9a-f]{8}$/;
+
+/** The sole validator and narrowing gate for a ChangelogVersion. A value that
+ * crossed a boundary — a fetched fragment's attribute, a posted form field, a
+ * freshly hashed slug — is checked here once; callers narrow to the brand through
+ * this predicate instead of re-testing the shape, so the version contract has a
+ * single definition the compiler keeps every call site honest about. */
+export function isChangelogVersion(value: unknown): value is ChangelogVersion {
+	return typeof value === "string" && VERSION_PATTERN.test(value);
+}
+
 /** A single site-wide feature announcement. `hook` is the human-facing
  * one-liner, `href` the root-relative link to the announcing blog post (already
- * UTM-tagged by the producer), and `version` an opaque 8-hex-char fingerprint of
- * the post that drives dismissal: the close button posts it back, the cookie
- * stores it, and both deployables compare it byte-for-byte. The version is
- * produced only by blog-site and echoed through the fragment — no other code
- * re-hashes it, so a reader's dismissal always matches the banner they saw. */
+ * UTM-tagged by the producer), and `version` an opaque fingerprint of the post
+ * that drives dismissal: the close button posts it back, the cookie stores it,
+ * and both deployables compare it byte-for-byte. The version is produced only by
+ * blog-site and echoed through the fragment — no other code re-hashes it, so a
+ * reader's dismissal always matches the banner they saw. */
 export interface ChangelogBanner {
 	hook: string;
 	href: string;
-	version: string;
+	version: ChangelogVersion;
 }
 
 /** Shared by both deployables: hutch reads it via cookie-parser, blog-site via
  * the raw header. path:"/" + the readplace.com origin make it readable by both
  * Lambdas, so dismissing on /blog also dismisses on the app and vice versa. */
 export const CHANGELOG_DISMISS_COOKIE_NAME = "rp_changelog_dismissed";
-
-const VERSION_PATTERN = /^[0-9a-f]{8}$/;
 
 /** The transport contract between blog-site (producer) and hutch (consumer):
  * minimal HTML that survives a fetch + parse round-trip. Handlebars escapes the
@@ -45,7 +62,7 @@ export function parseChangelogBannerFragment(html: string): ChangelogBanner | un
 	if (!root) return undefined;
 
 	const version = root.getAttribute("data-changelog-version");
-	if (!version || !VERSION_PATTERN.test(version)) return undefined;
+	if (!isChangelogVersion(version)) return undefined;
 
 	const hookEl = root.querySelector("[data-changelog-hook]");
 	if (!hookEl) return undefined;

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -25,9 +25,10 @@ const VERSION_PATTERN = /^[0-9a-f]{8}$/;
 /** The transport contract between blog-site (producer) and hutch (consumer):
  * minimal HTML that survives a fetch + parse round-trip. Handlebars escapes the
  * hook and href; linkedom decodes them back, so the values reconstruct exactly.
- * Data attributes (not BEM classes) carry the machine-read fields because this
- * fragment is never styled — it exists only to be parsed. */
-const CHANGELOG_FRAGMENT_TEMPLATE = `<div data-changelog-version="{{version}}"><span data-changelog-hook>{{hook}}</span><a data-changelog-link href="{{href}}">Read more</a></div>`;
+ * Data attributes mark the version and hook (BEM classes are for the styled
+ * shell, never this); the link is the fragment's only `<a>`, so the parser finds
+ * it by tag. This fragment is never styled — it exists only to be parsed. */
+const CHANGELOG_FRAGMENT_TEMPLATE = `<div data-changelog-version="{{version}}"><span data-changelog-hook>{{hook}}</span><a href="{{href}}">Read more</a></div>`;
 
 export function renderChangelogBannerFragment(banner: ChangelogBanner): string {
 	return render(CHANGELOG_FRAGMENT_TEMPLATE, banner);

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert";
+import { parseHTML } from "linkedom";
+import { render } from "./render";
+
+/** A single site-wide feature announcement. `hook` is the human-facing
+ * one-liner, `href` the root-relative link to the announcing blog post (already
+ * UTM-tagged by the producer), and `version` an opaque 8-hex-char fingerprint of
+ * the post that drives dismissal: the close button posts it back, the cookie
+ * stores it, and both deployables compare it byte-for-byte. The version is
+ * produced only by blog-site and echoed through the fragment — no other code
+ * re-hashes it, so a reader's dismissal always matches the banner they saw. */
+export interface ChangelogBanner {
+	hook: string;
+	href: string;
+	version: string;
+}
+
+/** Shared by both deployables: hutch reads it via cookie-parser, blog-site via
+ * the raw header. path:"/" + the readplace.com origin make it readable by both
+ * Lambdas, so dismissing on /blog also dismisses on the app and vice versa. */
+export const CHANGELOG_DISMISS_COOKIE_NAME = "rp_changelog_dismissed";
+
+const VERSION_PATTERN = /^[0-9a-f]{8}$/;
+
+/** The transport contract between blog-site (producer) and hutch (consumer):
+ * minimal HTML that survives a fetch + parse round-trip. Handlebars escapes the
+ * hook and href; linkedom decodes them back, so the values reconstruct exactly.
+ * Data attributes (not BEM classes) carry the machine-read fields because this
+ * fragment is never styled — it exists only to be parsed. */
+const CHANGELOG_FRAGMENT_TEMPLATE = `<div data-changelog-version="{{version}}"><span data-changelog-hook>{{hook}}</span><a data-changelog-link href="{{href}}">Read more</a></div>`;
+
+export function renderChangelogBannerFragment(banner: ChangelogBanner): string {
+	return render(CHANGELOG_FRAGMENT_TEMPLATE, banner);
+}
+
+/** Reconstructs a ChangelogBanner from a fetched fragment. linkedom (not a
+ * regex) so malformed input degrades to undefined rather than mis-parsing. Every
+ * field is re-validated against the contract — version shape and root-relative
+ * href — because the bytes crossed a network boundary; any miss yields undefined
+ * so the caller simply renders no banner. */
+export function parseChangelogBannerFragment(html: string): ChangelogBanner | undefined {
+	const { document } = parseHTML(`<!DOCTYPE html><html><body>${html}</body></html>`);
+	const root = document.querySelector("body > *");
+	if (!root) return undefined;
+
+	const version = root.getAttribute("data-changelog-version");
+	if (!version || !VERSION_PATTERN.test(version)) return undefined;
+
+	const hookEl = root.querySelector("[data-changelog-hook]");
+	if (!hookEl) return undefined;
+	const hook = hookEl.textContent;
+	assert(hook !== null, "an element's textContent is never null");
+
+	const link = root.querySelector("a");
+	if (!link) return undefined;
+	const href = link.getAttribute("href");
+	if (href === null) return undefined;
+	if (!href.startsWith("/") || href.startsWith("//")) return undefined;
+
+	return { hook, href, version };
+}
+
+/** The visible banner, rendered identically by both deployables through the
+ * shell. Always emits the `.changelog-banner` element — `--visible` with content
+ * when a banner is present, `--hidden` and empty otherwise — so the markup is
+ * stable for tests and SSR (no client JS decides visibility). The close control
+ * is a no-JS POST form carrying the rendered version, so the dismissal records
+ * exactly the announcement the reader saw. */
+const CHANGELOG_SHELL_TEMPLATE = `<div class="changelog-banner {{#if visible}}changelog-banner--visible{{else}}changelog-banner--hidden{{/if}}" role="status" aria-live="polite" data-test-changelog-banner>{{#if visible}}<div class="changelog-banner__inner"><span class="changelog-banner__chip" aria-hidden="true">NEW</span><span class="changelog-banner__hook">{{hook}}</span><a class="changelog-banner__link" href="{{href}}">Read more <span class="changelog-banner__arrow" aria-hidden="true">&rarr;</span></a><form class="changelog-banner__dismiss" method="POST" action="/banner/changelog/dismiss"><input type="hidden" name="version" value="{{version}}"><button type="submit" class="changelog-banner__close" aria-label="Dismiss changelog banner"><span aria-hidden="true">&times;</span></button></form></div>{{/if}}</div>`;
+
+export function renderChangelogBannerShell(banner?: ChangelogBanner): string {
+	return render(CHANGELOG_SHELL_TEMPLATE, {
+		visible: Boolean(banner),
+		hook: banner?.hook,
+		href: banner?.href,
+		version: banner?.version,
+	});
+}
+
+/** Pure reader for a single cookie out of a raw `Cookie:` header. Lets blog-site
+ * check the dismissal cookie without taking a cookie-parser dependency — it
+ * stays stateless and reads one header. hutch uses cookie-parser instead, but
+ * shares this so both deployables agree on the cookie name. */
+export function readCookie(cookieHeader: string | undefined, name: string): string | undefined {
+	if (!cookieHeader) return undefined;
+	for (const cookie of cookieHeader.split(";")) {
+		const [key, ...rest] = cookie.trim().split("=");
+		if (key === name) return decodeURIComponent(rest.join("="));
+	}
+	return undefined;
+}

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -2,15 +2,23 @@ import assert from "node:assert";
 import { parseHTML } from "linkedom";
 import { render } from "./render";
 
-/** An opaque 8-lowercase-hex fingerprint of the announcing post, branded so its
- * shape is single-sourced across the deploy boundary. The only way to obtain one
- * is `isChangelogVersion`, so the producer (blog-site), the fragment parser here,
- * and hutch's dismiss route cannot drift to different notions of a valid version
- * without a type error — they share this contract by name, never a re-declared
- * regex (connascence of name, compiler-enforced). */
+/** An opaque lowercase-hex fingerprint of the announcing post (`CHANGELOG_VERSION_LENGTH`
+ * chars), branded so its shape is single-sourced across the deploy boundary. The
+ * only way to obtain one is `isChangelogVersion`, so the producer (blog-site), the
+ * fragment parser here, and hutch's dismiss route cannot drift to different notions
+ * of a valid version without a type error — they share this contract by name, never
+ * a re-declared regex (connascence of name, compiler-enforced). */
 export type ChangelogVersion = string & { readonly __brand: "ChangelogVersion" };
 
-const VERSION_PATTERN = /^[0-9a-f]{8}$/;
+/** The width, in lowercase-hex characters, of a `ChangelogVersion`. Both the
+ * validator's shape (`VERSION_PATTERN`) and the producer's hash truncation
+ * (blog-site's `deriveChangelogBanner`) derive from this one constant, so the
+ * version length is single-sourced alongside its charset — the blog-site↔hutch
+ * boundary cannot drift to disagreeing widths, and changing the fingerprint width
+ * is a one-line edit here. */
+export const CHANGELOG_VERSION_LENGTH = 8;
+
+const VERSION_PATTERN = new RegExp(`^[0-9a-f]{${CHANGELOG_VERSION_LENGTH}}$`);
 
 /** The sole validator and narrowing gate for a ChangelogVersion. A value that
  * crossed a boundary — a fetched fragment's attribute, a posted form field, a

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -80,12 +80,24 @@ export function renderChangelogBannerShell(banner?: ChangelogBanner): string {
 /** Pure reader for a single cookie out of a raw `Cookie:` header. Lets blog-site
  * check the dismissal cookie without taking a cookie-parser dependency — it
  * stays stateless and reads one header. hutch uses cookie-parser instead, but
- * shares this so both deployables agree on the cookie name. */
+ * shares this so both deployables agree on the cookie name. A value that is not
+ * a valid percent-escape (e.g. an attacker-sent `rp_changelog_dismissed=%`)
+ * decodes to its raw substring rather than throwing — mirroring cookie-parser's
+ * tryDecode, so both deployables read the same malformed cookie identically and
+ * this decorative banner's cookie read can never 500 a page (the raw value just
+ * fails the byte-for-byte version match and the banner stays visible). */
 export function readCookie(cookieHeader: string | undefined, name: string): string | undefined {
 	if (!cookieHeader) return undefined;
 	for (const cookie of cookieHeader.split(";")) {
 		const [key, ...rest] = cookie.trim().split("=");
-		if (key === name) return decodeURIComponent(rest.join("="));
+		if (key === name) {
+			const raw = rest.join("=");
+			try {
+				return decodeURIComponent(raw);
+			} catch {
+				return raw;
+			}
+		}
 	}
 	return undefined;
 }

--- a/src/packages/web-shell/src/index.ts
+++ b/src/packages/web-shell/src/index.ts
@@ -34,6 +34,7 @@ export type {
 } from "./banner-state";
 export {
 	CHANGELOG_DISMISS_COOKIE_NAME,
+	CHANGELOG_VERSION_LENGTH,
 	isChangelogVersion,
 	parseChangelogBannerFragment,
 	readCookie,

--- a/src/packages/web-shell/src/index.ts
+++ b/src/packages/web-shell/src/index.ts
@@ -32,6 +32,14 @@ export type {
 	NavItem,
 	NavItemKey,
 } from "./banner-state";
+export {
+	CHANGELOG_DISMISS_COOKIE_NAME,
+	parseChangelogBannerFragment,
+	readCookie,
+	renderChangelogBannerFragment,
+	renderChangelogBannerShell,
+} from "./changelog-banner";
+export type { ChangelogBanner } from "./changelog-banner";
 export { Nav } from "./nav.component";
 export type { NavProps } from "./nav.component";
 export { initBase } from "./base.component";

--- a/src/packages/web-shell/src/index.ts
+++ b/src/packages/web-shell/src/index.ts
@@ -34,12 +34,13 @@ export type {
 } from "./banner-state";
 export {
 	CHANGELOG_DISMISS_COOKIE_NAME,
+	isChangelogVersion,
 	parseChangelogBannerFragment,
 	readCookie,
 	renderChangelogBannerFragment,
 	renderChangelogBannerShell,
 } from "./changelog-banner";
-export type { ChangelogBanner } from "./changelog-banner";
+export type { ChangelogBanner, ChangelogVersion } from "./changelog-banner";
 export { Nav } from "./nav.component";
 export type { NavProps } from "./nav.component";
 export { initBase } from "./base.component";


### PR DESCRIPTION
## What

A closable, sticky top banner — on **every page, for every user** (guest + authenticated) — highlighting the latest blog post tagged `changelog`, with a short hook and a "Read more" link to the post. It stays dismissed (per reader) until the copy changes, then reappears. The blog becomes the canonical place to announce shipped features.

```
┌──────────────────────────────────────────────────────────────┐
│  NEW   Your AI assistant can now save articles…  Read more →  ✕│
└──────────────────────────────────────────────────────────────┘
```

## Why

Readplace had no way to tell all users about a newly shipped feature. This gives every release a single, brand-safe surface — novelty via the `NEW` chip, a curiosity-gap hook, no fabricated counts or urgency.

## How — cross-deployable, no nx edge

The blog posts are private to **blog-site** (a separate Lambda); hutch holds no blog data in-process. The bridge is a runtime HTTP fragment + a shared contract, both depending only on `@packages/web-shell`:

```
blog-site (producer)                          hutch (consumer)
────────────────────                          ────────────────
post tags:[changelog], banner:"…"
 └ getLatestChangelogBanner()  →  {hook, href(/blog/slug+utm), version=sha256(slug|banner)[:8]}
      GET /blog/changelog-banner ──HTTP──►  initChangelogBannerSource (fetch)
      renderChangelogBannerFragment          parseChangelogBannerFragment (linkedom)
      (HTML, data-changelog-version)         5-min TTL · fail-open-to-stale · in-flight dedupe
                       \                      /
                        ▼  @packages/web-shell  ▼
            Base → renderChangelogBannerShell(state.changelogBanner)
       .banner-area (every page)   close = no-JS <form POST /banner/changelog/dismiss>
```

- **`@packages/web-shell`** owns the wire contract + rendering: `ChangelogBanner`, `renderChangelogBannerFragment` / `parseChangelogBannerFragment` (linkedom, not regex), the single `renderChangelogBannerShell` (always emits `.changelog-banner` — `--visible`+content or `--hidden`+empty), `readCookie`, `CHANGELOG_DISMISS_COOKIE_NAME`. No zod.
- **blog-site** derives the banner from the newest changelog-tagged post and serves `GET /blog/changelog-banner` (200 fragment / 204 none); it hides the banner inline when the dismissal cookie matches the version. Frontmatter gains `tags` + `banner`; a changelog post **must** carry banner copy (enforced at load). Stays stateless — one header read via the shared `readCookie`, no cookie-parser.
- **hutch** fetches the fragment through a cached (5-min TTL), fail-open-to-stale, in-flight-deduped source — a slow or down blog never blocks a render. `POST /banner/changelog/dismiss` stores the **posted** version in a year-long, `path:"/"` cookie shared by both same-origin Lambdas and 303-redirects back to a same-origin referer.

### Invariant: single-sourced version

blog-site computes the version, hutch echoes the fetched value, and the dismiss cookie stores the version **actually rendered** — so a reader's dismissal always matches the banner they saw, independent of hutch's cache freshness.

## Decisions

| Decision | Choice |
|---|---|
| Opt-in | blog frontmatter `tags: [changelog]` |
| Banner copy | dedicated frontmatter `banner:` hook |
| Dismiss persistence | versioned cookie, reappears when version changes |
| Conversion design | `NEW` chip + curiosity gap (no emoji, no pill, 6px radius) |
| Cross-deployable data | hutch runtime-fetches an HTML fragment from blog-site; no nx edge |
| Scope | app pages and `/blog` |

## Wiring

- `CHANGELOG_BANNER_URL` set on the hutch Lambda (infra, `${appOrigin}/blog/changelog-banner` via API Gateway) and in `.envrc` for local dev (`http://localhost:3200/...`).
- `getChangelogBanner` injected through `AppDependencies`, stubbed in `test-app.ts`, so route tests stay network-free.

## Tests

100% coverage across `web-shell`, `blog-site`, and `hutch` (DI over mocks): fragment render/parse round-trip and shell visible/hidden; `parseBlogFrontmatter` + `deriveChangelogBanner` + the `/blog/changelog-banner` endpoint and cookie-hide; the fetch source (cache hit/expiry, 204/!ok/timeout/malformed fail-open, in-flight dedupe); `initBuildBannerState` (guest gets it, version-match drops it); the dismiss route + `safeBackPath` + dismiss middleware.

```
pnpm nx run @packages/web-shell:check && pnpm nx run blog-site:check && pnpm nx run hutch:check
```

## Docs + inaugural post

- The **blog-post-editor** skill documents the new `tags`/`banner` fields and the banner copy rules (concise hook + curiosity gap; the `NEW` chip carries novelty; no emoji/exclamation/superlatives).
- The existing MCP-server post is tagged as the inaugural `changelog` banner (real, published copy — no fabricated content). The author can re-point it by tagging a newer post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FETbQW1dhxrPpyqmfeFPWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FETbQW1dhxrPpyqmfeFPWT)_