### PR TITLE
feat(hutch): enrich view_save_intent with content-class, surface & outcome dimensions

### DIFF
--- a/projects/hutch/src/runtime/conversions.test.ts
+++ b/projects/hutch/src/runtime/conversions.test.ts
@@ -195,5 +195,43 @@ describe("emitUserCreated", () => {
 		expect(serialized).not.toContain("first_seen_at");
 		expect(serialized).not.toContain("landing_path");
 		expect(serialized).not.toContain("visitor_id");
+		expect(serialized).not.toContain("pending_save_id");
+	});
+
+	it("includes pending_save_id so a signup-blocked save can be traced to the account it created", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "blocked@example.com",
+				method: "email",
+				tier: "free",
+				attribution: undefined,
+				pendingSaveId: "9f1c0c8e-3b2a-4d6e-8c1f-2a7b5d4e6f10",
+			},
+		);
+
+		expect(captured[0]).toMatchObject({
+			pending_save_id: "9f1c0c8e-3b2a-4d6e-8c1f-2a7b5d4e6f10",
+		});
+	});
+
+	it("omits pending_save_id when the signup did not follow a pending save", () => {
+		const { logger, captured } = createCapturingLogger();
+
+		emitUserCreated(
+			{ logger, now: TEST_NOW },
+			{
+				userId: TEST_USER_ID,
+				email: "organic@example.com",
+				method: "email",
+				tier: "free",
+				attribution: undefined,
+			},
+		);
+
+		expect(JSON.stringify(captured[0])).not.toContain("pending_save_id");
 	});
 });

--- a/projects/hutch/src/runtime/conversions.ts
+++ b/projects/hutch/src/runtime/conversions.ts
@@ -29,6 +29,7 @@ export function emitUserCreated(
 		stripeCheckoutSessionId?: string;
 		attribution: ClickAttribution | undefined;
 		visitorId?: string;
+		pendingSaveId?: string;
 	},
 ): void {
 	const event: ConversionEvent = {
@@ -44,6 +45,7 @@ export function emitUserCreated(
 			: {}),
 		...(params.attribution ?? {}),
 		...(params.visitorId ? { visitor_id: params.visitorId } : {}),
+		...(params.pendingSaveId ? { pending_save_id: params.pendingSaveId } : {}),
 	};
 	deps.logger.info(event);
 }

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -65,9 +65,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 19 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 22 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(19);
+		expect(body.widgets).toHaveLength(22);
 	});
 
 	it("the readers widget counts distinct user_ids from article_read events (not pageviews) — distinguishes opening the reader from explicitly marking-as-read", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -4,6 +4,8 @@ import {
 	CONVERSION_EVENTS,
 	LOG_GROUPS,
 	METRICS,
+	SAVE_OUTCOMES,
+	SAVE_SURFACES,
 	STREAMS,
 	SUBSCRIPTION_EVENTS,
 } from "./events";
@@ -362,9 +364,16 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 			region,
 			title: "Try → Save-intent → Signup (unique visitors by event)",
 			logGroupNames: [hutchLogGroupName],
+			/**
+			 * The save-intent leg is pinned to the anonymous reader surface so this
+			 * funnel keeps its original meaning now that `view_save_intent` also
+			 * fires for authenticated saves on the queue/extension surfaces.
+			 * `not ispresent(surface)` keeps pre-enrichment events (which had no
+			 * surface and were all anonymous reader saves) in the count.
+			 */
 			query: [
 				"fields visitor_id",
-				`| filter (stream = "${STREAMS.analytics}" and event in ["${ANALYTICS_EVENTS.viewOpened}", "${ANALYTICS_EVENTS.viewSaveIntent}"]) or (stream = "${STREAMS.conversions}" and event = "${CONVERSION_EVENTS.userCreated}")`,
+				`| filter (stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.viewOpened}") or (stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.viewSaveIntent}" and (surface = "${SAVE_SURFACES.readerView}" or not ispresent(surface))) or (stream = "${STREAMS.conversions}" and event = "${CONVERSION_EVENTS.userCreated}")`,
 				"| filter ispresent(visitor_id)",
 				...exclude,
 				"| stats count_distinct(visitor_id) as visitors by event",
@@ -396,6 +405,60 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 			].join(" "),
 			x: 0, y: 82, width: 24, height: 8,
 			view: "table",
+		}),
+	);
+
+	// --- Save funnel (content class × surface × outcome) ---
+	// Driven by the enriched view_save_intent event. content_class is derived
+	// from the article's own domain (never the referrer). coalesce() folds
+	// pre-enrichment events — which carried no surface/outcome and were all
+	// anonymous reader saves — into the reader_view / prompted_to_sign_up
+	// buckets so historical data still reads correctly.
+
+	widgets.push(
+		logWidget({
+			region,
+			title: "Save-intent by surface × content class",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				`fields coalesce(surface, "${SAVE_SURFACES.readerView}") as surface, coalesce(content_class, "unclassified") as content_class`,
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.viewSaveIntent}"`,
+				...exclude,
+				"| stats count(*) as saves by surface, content_class",
+				"| sort saves desc",
+				"| limit 50",
+			].join(" "),
+			x: 0, y: 90, width: 12, height: 8,
+			view: "table",
+		}),
+		logWidget({
+			region,
+			title: "Save-intent by content class (own vs third-party, %)",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields coalesce(content_class, \"unclassified\") as content_class",
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.viewSaveIntent}"`,
+				...exclude,
+				"| stats count(*) as saves by content_class",
+				"| sort saves desc",
+			].join(" "),
+			x: 12, y: 90, width: 12, height: 8,
+			view: "pie",
+		}),
+		logWidget({
+			region,
+			title: "Anonymous reader-view save attempts by outcome",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				`fields coalesce(outcome, "${SAVE_OUTCOMES.promptedToSignUp}") as outcome`,
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.viewSaveIntent}"`,
+				`| filter (surface = "${SAVE_SURFACES.readerView}" or not ispresent(surface)) and is_authenticated = 0`,
+				...exclude,
+				"| stats count(*) as attempts by outcome",
+				"| sort attempts desc",
+			].join(" "),
+			x: 0, y: 98, width: 12, height: 8,
+			view: "bar",
 		}),
 	);
 

--- a/projects/hutch/src/runtime/observability/content-source.test.ts
+++ b/projects/hutch/src/runtime/observability/content-source.test.ts
@@ -1,0 +1,34 @@
+import { articleHostFrom, classifyContentSource, OWN_CONTENT_DOMAINS } from "./content-source";
+
+describe("articleHostFrom", () => {
+	it("returns the lowercased hostname so view_opened and view_save_intent normalize identically", () => {
+		expect(articleHostFrom("https://EN.Wikipedia.ORG/wiki/Foo?x=1#frag")).toBe("en.wikipedia.org");
+	});
+});
+
+describe("classifyContentSource", () => {
+	it("classifies an own apex domain as own", () => {
+		for (const domain of OWN_CONTENT_DOMAINS) {
+			expect(classifyContentSource(domain)).toBe("own");
+		}
+	});
+
+	it("classifies a subdomain of an own domain as own (so www. and blog. count without being listed)", () => {
+		expect(classifyContentSource("www.readplace.com")).toBe("own");
+		expect(classifyContentSource("blog.fagnerbrack.com")).toBe("own");
+	});
+
+	it("classifies a third-party domain as third_party", () => {
+		expect(classifyContentSource("en.wikipedia.org")).toBe("third_party");
+		expect(classifyContentSource("medium.com")).toBe("third_party");
+	});
+
+	it("matches case-insensitively", () => {
+		expect(classifyContentSource("FAGNERBRACK.COM")).toBe("own");
+	});
+
+	it("does not treat a look-alike suffix as own (readplace.com.evil.example is third-party)", () => {
+		expect(classifyContentSource("readplace.com.evil.example")).toBe("third_party");
+		expect(classifyContentSource("notreadplace.com")).toBe("third_party");
+	});
+});

--- a/projects/hutch/src/runtime/observability/content-source.ts
+++ b/projects/hutch/src/runtime/observability/content-source.ts
@@ -1,0 +1,30 @@
+import { CONTENT_CLASSES } from "./events";
+
+export type ContentClass = (typeof CONTENT_CLASSES)[keyof typeof CONTENT_CLASSES];
+
+/**
+ * The apex domains whose articles are *our own* published content rather than
+ * a third party's. Classification keys off the saved article's own domain (the
+ * host of the URL being saved) — never the referrer or traffic source — so a
+ * visitor who arrives from our own site to save a third-party article is still
+ * a third-party save. A host matches when it equals one of these or is a
+ * subdomain of it, so `www.readplace.com` and `blog.fagnerbrack.com` count as
+ * own without being listed separately. The deployment host (the app's own
+ * origin) is intentionally absent: people save articles, not the app shell.
+ */
+export const OWN_CONTENT_DOMAINS: readonly string[] = ["readplace.com", "fagnerbrack.com"];
+
+/**
+ * The article's own domain. `new URL().hostname` already lowercases the host,
+ * so `view_opened` and `view_save_intent` carry an identically-normalized
+ * `article_host` and the two events join without a normalization mismatch.
+ */
+export function articleHostFrom(url: string): string {
+	return new URL(url).hostname;
+}
+
+export function classifyContentSource(articleHost: string): ContentClass {
+	const host = articleHost.toLowerCase();
+	const owned = OWN_CONTENT_DOMAINS.some((domain) => host === domain || host.endsWith(`.${domain}`));
+	return owned ? CONTENT_CLASSES.own : CONTENT_CLASSES.thirdParty;
+}

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -27,6 +27,32 @@ export const ANALYTICS_EVENTS = {
 } as const;
 
 /**
+ * Dimensions of the `view_save_intent` event. Each is the single source of
+ * truth shared by emitters (the save surfaces) and the dashboard widgets that
+ * slice the save funnel, so a value rename surfaces as a TypeScript error at
+ * every call site rather than silently splitting a metric in two.
+ */
+export const SAVE_SURFACES = {
+	readerView: "reader_view",
+	queueSaveBar: "queue_save_bar",
+	extension: "extension",
+} as const;
+
+export const SAVE_OUTCOMES = {
+	saved: "saved",
+	promptedToSignUp: "prompted_to_sign_up",
+	error: "error",
+} as const;
+
+export const CONTENT_CLASSES = {
+	own: "own",
+	thirdParty: "third_party",
+} as const;
+
+export type SaveSurface = (typeof SAVE_SURFACES)[keyof typeof SAVE_SURFACES];
+export type SaveOutcome = (typeof SAVE_OUTCOMES)[keyof typeof SAVE_OUTCOMES];
+
+/**
  * `utm_medium` value stamped on every in-site link and action button so a click
  * can be counted without an extra request or a client-side beacon. The analytics
  * middleware emits a `click` event for any request carrying it (GET, HTMX-boosted,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -810,7 +810,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	});
 	app.use("/import", requireAuth, requireNotLocked, requireWriteAccess, importRouter);
 
-	const saveRouter = initSaveRoutes({ buildBannerState, analytics: deps.analytics, salt: deps.salt, now: deps.now });
+	const saveRouter = initSaveRoutes({ buildBannerState, analytics: deps.analytics, salt: deps.salt, now: deps.now, secureCookies, generatePendingSaveId: randomUUID });
 	app.use("/save", saveRouter);
 
 	const viewRouter = initViewRoutes({

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -56,7 +56,7 @@ import { createBotDefenseEvent } from "./bot-defense-event";
 import { initValidateSignup } from "./validate-signup";
 import type { FoundingAllocation } from "../shared/founding-progress/founding-allocation";
 import { readClickAttribution } from "../click-attribution.middleware";
-import { readPendingSaveId } from "../pending-save";
+import { consumePendingSaveId } from "../pending-save";
 import type { ConversionEvent } from "../../conversions";
 import { emitUserCreated } from "../../conversions";
 
@@ -292,7 +292,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					tier: "free",
 					attribution: readClickAttribution(req),
 					visitorId: req.visitorId,
-					pendingSaveId: readPendingSaveId(req),
+					pendingSaveId: consumePendingSaveId({ req, res }),
 				},
 			);
 			res.redirect(303, parseReturnUrl({ return: returnUrl }));
@@ -336,7 +336,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				tier: "trial",
 				attribution: readClickAttribution(req),
 				visitorId: req.visitorId,
-				pendingSaveId: readPendingSaveId(req),
+				pendingSaveId: consumePendingSaveId({ req, res }),
 			},
 		);
 		res.redirect(303, parseReturnUrl({ return: returnUrl }));
@@ -419,7 +419,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					stripeCheckoutSessionId: checkoutSessionId,
 					attribution: readClickAttribution(req),
 					visitorId: req.visitorId,
-					pendingSaveId: readPendingSaveId(req),
+					pendingSaveId: consumePendingSaveId({ req, res }),
 				},
 			);
 			res.redirect(303, returnPath);
@@ -473,7 +473,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				stripeCheckoutSessionId: checkoutSessionId,
 				attribution: readClickAttribution(req),
 				visitorId: req.visitorId,
-				pendingSaveId: readPendingSaveId(req),
+				pendingSaveId: consumePendingSaveId({ req, res }),
 			},
 		);
 		res.redirect(303, returnPath);

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -56,6 +56,7 @@ import { createBotDefenseEvent } from "./bot-defense-event";
 import { initValidateSignup } from "./validate-signup";
 import type { FoundingAllocation } from "../shared/founding-progress/founding-allocation";
 import { readClickAttribution } from "../click-attribution.middleware";
+import { readPendingSaveId } from "../pending-save";
 import type { ConversionEvent } from "../../conversions";
 import { emitUserCreated } from "../../conversions";
 
@@ -291,6 +292,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					tier: "free",
 					attribution: readClickAttribution(req),
 					visitorId: req.visitorId,
+					pendingSaveId: readPendingSaveId(req),
 				},
 			);
 			res.redirect(303, parseReturnUrl({ return: returnUrl }));
@@ -334,6 +336,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				tier: "trial",
 				attribution: readClickAttribution(req),
 				visitorId: req.visitorId,
+				pendingSaveId: readPendingSaveId(req),
 			},
 		);
 		res.redirect(303, parseReturnUrl({ return: returnUrl }));
@@ -416,6 +419,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					stripeCheckoutSessionId: checkoutSessionId,
 					attribution: readClickAttribution(req),
 					visitorId: req.visitorId,
+					pendingSaveId: readPendingSaveId(req),
 				},
 			);
 			res.redirect(303, returnPath);
@@ -469,6 +473,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				stripeCheckoutSessionId: checkoutSessionId,
 				attribution: readClickAttribution(req),
 				visitorId: req.visitorId,
+				pendingSaveId: readPendingSaveId(req),
 			},
 		);
 		res.redirect(303, returnPath);

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -27,7 +27,7 @@ import { SESSION_COOKIE_NAME } from "./session-cookie";
 import { LoginPage } from "./auth.component";
 import { initFetchUserCount } from "./fetch-user-count";
 import { readClickAttribution } from "../click-attribution.middleware";
-import { readPendingSaveId } from "../pending-save";
+import { consumePendingSaveId } from "../pending-save";
 import type { ConversionEvent } from "../../conversions";
 import { emitUserCreated } from "../../conversions";
 
@@ -219,7 +219,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 					tier: "free",
 					attribution: readClickAttribution(req),
 					visitorId: req.visitorId,
-					pendingSaveId: readPendingSaveId(req),
+					pendingSaveId: consumePendingSaveId({ req, res }),
 				},
 			);
 			res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
@@ -273,7 +273,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 				tier: "trial",
 				attribution: readClickAttribution(req),
 				visitorId: req.visitorId,
-				pendingSaveId: readPendingSaveId(req),
+				pendingSaveId: consumePendingSaveId({ req, res }),
 			},
 		);
 		res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -27,6 +27,7 @@ import { SESSION_COOKIE_NAME } from "./session-cookie";
 import { LoginPage } from "./auth.component";
 import { initFetchUserCount } from "./fetch-user-count";
 import { readClickAttribution } from "../click-attribution.middleware";
+import { readPendingSaveId } from "../pending-save";
 import type { ConversionEvent } from "../../conversions";
 import { emitUserCreated } from "../../conversions";
 
@@ -218,6 +219,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 					tier: "free",
 					attribution: readClickAttribution(req),
 					visitorId: req.visitorId,
+					pendingSaveId: readPendingSaveId(req),
 				},
 			);
 			res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));
@@ -271,6 +273,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 				tier: "trial",
 				attribution: readClickAttribution(req),
 				visitorId: req.visitorId,
+				pendingSaveId: readPendingSaveId(req),
 			},
 		);
 		res.redirect(303, parseReturnUrl({ return: safeReturnUrl }));

--- a/projects/hutch/src/runtime/web/middleware/analytics.ts
+++ b/projects/hutch/src/runtime/web/middleware/analytics.ts
@@ -1,9 +1,21 @@
+import assert from "node:assert";
 import { createHash } from "node:crypto";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { isbot } from "isbot";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { UserId } from "@packages/domain/user";
-import { ANALYTICS_EVENTS, INTERNAL_CLICK_MEDIUM, STREAMS } from "../../observability/events";
+import {
+	ANALYTICS_EVENTS,
+	INTERNAL_CLICK_MEDIUM,
+	type SaveOutcome,
+	type SaveSurface,
+	STREAMS,
+} from "../../observability/events";
+import {
+	articleHostFrom,
+	classifyContentSource,
+	type ContentClass,
+} from "../../observability/content-source";
 
 export interface AnalyticsPageview {
 	stream: typeof STREAMS.analytics;
@@ -111,15 +123,29 @@ export interface ViewOpenedEvent {
 	is_authenticated: 0 | 1;
 }
 
-/** Emitted when a visitor clicks "Save to My Queue" on the public reader — the
- * warmest moment in the funnel. Anonymous clicks redirect to /login (a separate
- * surface), so this event is the only record that the intent occurred. */
+/**
+ * Emitted when a user signals intent to save an article to their queue. Born on
+ * the public reader's "Save to My Queue" click — the warmest funnel moment,
+ * where an anonymous click redirects to /login and would otherwise vanish — and
+ * since extended additively to every other save surface (queue save bar, browser
+ * extension) so the funnel can be sliced by `surface` and `outcome`. The event
+ * name is kept for backward compatibility even though it now spans surfaces.
+ *
+ * `content_class` is derived solely from `article_host` (where the saved post
+ * lives), never the `referrer_host` (where the click came from): saving a
+ * third-party article from our own reader is a third-party save.
+ */
 export interface ViewSaveIntentEvent {
 	stream: typeof STREAMS.analytics;
 	event: typeof ANALYTICS_EVENTS.viewSaveIntent;
 	timestamp: string;
 	path: string;
 	article_host: string;
+	content_class: ContentClass;
+	surface: SaveSurface;
+	outcome: SaveOutcome;
+	referrer_host?: string;
+	pending_save_id?: string;
 	visitor_hash: string | null;
 	visitor_id: string | null;
 	is_authenticated: 0 | 1;
@@ -224,6 +250,46 @@ export function hashIp(deps: { ip: string | undefined; salt: string }): string |
 		.update(deps.ip + deps.salt)
 		.digest("hex")
 		.slice(0, 16);
+}
+
+/**
+ * Builds a `view_save_intent` event for any save surface. Centralizing the
+ * derivation keeps `article_host` (and therefore `content_class`) normalized
+ * identically across surfaces and joinable with `view_opened`, and keeps the
+ * dedup/exclusion identifiers (`visitor_hash`, `visitor_id`) consistent so the
+ * same dashboard exclusions apply to every emission. `referrer_host` is the
+ * traffic source, captured separately from `article_host` and never used for
+ * `content_class`.
+ */
+export function buildSaveIntentEvent(
+	deps: { now: () => Date; salt: string },
+	params: {
+		req: Request;
+		url: string;
+		path: string;
+		surface: SaveSurface;
+		outcome: SaveOutcome;
+		pendingSaveId?: string;
+	},
+): ViewSaveIntentEvent {
+	assert(params.req.visitorId, "visitor-id middleware must run before a save surface emits view_save_intent");
+	const articleHost = articleHostFrom(params.url);
+	const referrerHost = extractReferrerHost(params.req);
+	return {
+		stream: STREAMS.analytics,
+		event: ANALYTICS_EVENTS.viewSaveIntent,
+		timestamp: deps.now().toISOString(),
+		path: params.path,
+		article_host: articleHost,
+		content_class: classifyContentSource(articleHost),
+		surface: params.surface,
+		outcome: params.outcome,
+		...(referrerHost ? { referrer_host: referrerHost } : {}),
+		...(params.pendingSaveId ? { pending_save_id: params.pendingSaveId } : {}),
+		visitor_hash: hashIp({ ip: params.req.ip, salt: deps.salt }),
+		visitor_id: params.req.visitorId,
+		is_authenticated: params.req.userId ? 1 : 0,
+	};
 }
 
 export function createAnalyticsMiddleware(deps: {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -11,8 +11,8 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
 import { SaveArticleInputSchema, SaveHtmlInputSchema, ArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD, saveableUrlErrorMessage } from "@packages/domain/article";
-import { hashIp, type AnalyticsEvent } from "../../middleware/analytics";
-import { ANALYTICS_EVENTS, STREAMS } from "../../../observability/events";
+import { buildSaveIntentEvent, hashIp, type AnalyticsEvent } from "../../middleware/analytics";
+import { ANALYTICS_EVENTS, SAVE_OUTCOMES, SAVE_SURFACES, STREAMS, type SaveOutcome, type SaveSurface } from "../../../observability/events";
 import {
 	IMPORT_SKIPPED_COOKIE_NAME,
 	decodeImportSkippedCookie,
@@ -207,6 +207,20 @@ async function loadCrawls(
 
 export function initQueueRoutes(deps: QueueDependencies): Router {
 	const router = express.Router();
+
+	/** Records a save-intent for an authenticated save surface. The save has
+	 * already happened (or failed) by the time this is called, so `outcome` is
+	 * `saved` or `error` — never `prompted_to_sign_up`, which is anonymous-only. */
+	const emitSaveIntent = (params: {
+		req: Request;
+		url: string;
+		path: string;
+		surface: SaveSurface;
+		outcome: SaveOutcome;
+	}): void => {
+		deps.analytics.info(buildSaveIntentEvent({ now: deps.now, salt: deps.salt }, params));
+	};
+
 	const reader = initArticleReader({
 		findArticleCrawlStatus: deps.findArticleCrawlStatus,
 		findGeneratedSummary: deps.findGeneratedSummary,
@@ -435,9 +449,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
 			const result = await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
 			markExtensionSavedArticle(res);
+			emitSaveIntent({ req, url: validation.url, path: "/queue", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);
+			emitSaveIntent({ req, url: validation.url, path: "/queue", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
 			res.status(500).type(SIREN_MEDIA_TYPE).json(
 				sirenError({ code: "save-failed", message: "Could not save article" }),
 			);
@@ -515,6 +531,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					const freshness = await deps.refreshArticleIfStale({ url: urlOnlyValidation.url });
 					const result = await saveArticleFromUrl(deps, { userId, url: urlOnlyValidation.url, freshness });
 					markExtensionSavedArticle(res);
+					emitSaveIntent({ req, url: urlOnlyValidation.url, path: "/queue/save-html", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 					res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 					return;
 				}
@@ -544,6 +561,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 			const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
 			markExtensionSavedArticle(res);
+			emitSaveIntent({ req, url: articleUrl, path: "/queue/save-html", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
 			deps.logError("Failed to save article from html", error instanceof Error ? error : undefined);
@@ -689,9 +707,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 				const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
 				markExtensionSavedArticle(res);
+				emitSaveIntent({ req, url: articleUrl, path: "/queue/save-content", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 				res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 			} catch (error) {
 				deps.logError("Failed to save article from content", error instanceof Error ? error : undefined);
+				emitSaveIntent({ req, url: validation.url, path: "/queue/save-content", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
 				res.status(500).type(SIREN_MEDIA_TYPE).json(
 					sirenError({ code: "save-failed", message: "Could not save article" }),
 				);
@@ -727,9 +747,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		try {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
 			await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
+			emitSaveIntent({ req, url: validation.url, path: "/queue/save", surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.saved });
 			res.redirect(303, "/queue#latest-saved");
 		} catch (error) {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);
+			emitSaveIntent({ req, url: validation.url, path: "/queue/save", surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.error });
 			res.redirect(303, "/queue?error_code=save_failed");
 		}
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -504,6 +504,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
 
+		let validatedArticleUrl: string | undefined;
+
 		try {
 			const parsed = SaveHtmlInputSchema.safeParse(req.body);
 
@@ -521,6 +523,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					? deps.validateSaveableUrl(urlOnly.data.url)
 					: undefined;
 				if (urlOnlyValidation?.status === "SUCCESS") {
+					validatedArticleUrl = urlOnlyValidation.url;
 					const rawHtml: unknown = req.body?.rawHtml;
 					const sizeBytes = typeof rawHtml === "string" ? rawHtml.length : 0;
 					/* logError (not warn) on purpose: feeds the alarm so oversize Tier-0
@@ -549,6 +552,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				return;
 			}
 			const articleUrl = urlValidation.url;
+			validatedArticleUrl = articleUrl;
 
 			const freshness = await deps.refreshArticleIfStale({ url: articleUrl });
 
@@ -565,6 +569,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
 			deps.logError("Failed to save article from html", error instanceof Error ? error : undefined);
+			assert(validatedArticleUrl, "save-html reaches the save pipeline only after the article URL is validated");
+			emitSaveIntent({ req, url: validatedArticleUrl, path: "/queue/save-html", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
 			res.status(500).type(SIREN_MEDIA_TYPE).json(
 				sirenError({ code: "save-failed", message: "Could not save article" }),
 			);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-intent.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-intent.route.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import request from "supertest";
+import type { Token, Client } from "@node-oauth/oauth2-server";
+import type { UserId } from "@packages/domain/user";
+import { useTestServer, loginAgent, type TestAppHarness, type TestAppResult } from "../../../test-app";
+import type { ViewSaveIntentEvent } from "../../middleware/analytics";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+	type TestAppFixture,
+} from "@packages/test-fixtures";
+import { SIREN_MEDIA_TYPE } from "../../api/siren";
+
+const TEST_USER_ID = "test-user-save-intent" as UserId;
+
+function createTestToken(): Token {
+	return {
+		accessToken: "test-access-token-save-intent",
+		accessTokenExpiresAt: new Date(Date.now() + 3600000),
+		refreshToken: "test-refresh-token-save-intent",
+		refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
+		client: {
+			id: "hutch-firefox-extension",
+			grants: ["authorization_code", "refresh_token"],
+			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
+		} as Client,
+		user: { id: TEST_USER_ID },
+	};
+}
+
+async function bearerToken(testApp: TestAppResult): Promise<string> {
+	const client = await testApp.oauthModel.getClient("hutch-firefox-extension", "");
+	assert(client, "Test client must exist");
+	const token = await testApp.oauthModel.saveToken(createTestToken(), client, { id: TEST_USER_ID });
+	assert(token, "Token should be saved");
+	return token.accessToken;
+}
+
+/** A fixture whose save pipeline throws so the route's catch branch runs — the
+ * `outcome: "error"` path. refreshArticleIfStale runs after URL validation, so
+ * the emission still has a validated article_host to classify. */
+function failingSaveFixture(): TestAppFixture {
+	return {
+		...createDefaultTestAppFixture(TEST_APP_ORIGIN),
+		freshness: { refreshArticleIfStale: async () => { throw new Error("boom"); } },
+	};
+}
+
+const useApp = useTestServer();
+
+function saveIntents(harness: TestAppHarness): ViewSaveIntentEvent[] {
+	return harness.analytics.events.filter(
+		(e): e is ViewSaveIntentEvent => e.event === "view_save_intent",
+	);
+}
+
+describe("view_save_intent — authenticated save surfaces", () => {
+	describe("POST /queue/save (queue save bar)", () => {
+		it("emits queue_save_bar / saved tagged with is_authenticated=1 and the article's own domain", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/queue/save").type("form").send({ url: "https://example.com/article" });
+
+			expect(response.status).toBe(303);
+			const intents = saveIntents(harness);
+			assert.equal(intents.length, 1, "exactly one view_save_intent");
+			expect(intents[0]).toMatchObject({
+				event: "view_save_intent",
+				path: "/queue/save",
+				article_host: "example.com",
+				content_class: "third_party",
+				surface: "queue_save_bar",
+				outcome: "saved",
+				is_authenticated: 1,
+			});
+			expect(intents[0].pending_save_id).toBeUndefined();
+		});
+
+		it("classifies a save of our own content (fagnerbrack.com) as own", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://fagnerbrack.com/a-post" });
+
+			expect(saveIntents(harness)[0]).toMatchObject({ article_host: "fagnerbrack.com", content_class: "own" });
+		});
+
+		it("emits queue_save_bar / error when the save throws", async () => {
+			const harness = useApp(failingSaveFixture());
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/queue/save").type("form").send({ url: "https://example.com/article" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?error_code=save_failed");
+			expect(saveIntents(harness)[0]).toMatchObject({ surface: "queue_save_bar", outcome: "error", is_authenticated: 1 });
+		});
+	});
+
+	describe("POST /queue (extension save-article)", () => {
+		it("emits extension / saved", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const token = await bearerToken(harness);
+
+			const response = await request(harness.server)
+				.post("/queue")
+				.set("Accept", SIREN_MEDIA_TYPE)
+				.set("Authorization", `Bearer ${token}`)
+				.send({ url: "https://example.com/article" });
+
+			expect(response.status).toBe(201);
+			expect(saveIntents(harness)[0]).toMatchObject({
+				path: "/queue",
+				surface: "extension",
+				outcome: "saved",
+				content_class: "third_party",
+				is_authenticated: 1,
+			});
+		});
+
+		it("emits extension / error when the save throws", async () => {
+			const harness = useApp(failingSaveFixture());
+			const token = await bearerToken(harness);
+
+			const response = await request(harness.server)
+				.post("/queue")
+				.set("Accept", SIREN_MEDIA_TYPE)
+				.set("Authorization", `Bearer ${token}`)
+				.send({ url: "https://example.com/article" });
+
+			expect(response.status).toBe(500);
+			expect(saveIntents(harness)[0]).toMatchObject({ surface: "extension", outcome: "error" });
+		});
+	});
+
+	describe("POST /queue/save-html (extension)", () => {
+		it("emits extension / saved", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const token = await bearerToken(harness);
+
+			const response = await request(harness.server)
+				.post("/queue/save-html")
+				.set("Accept", SIREN_MEDIA_TYPE)
+				.set("Authorization", `Bearer ${token}`)
+				.send({ url: "https://example.com/article", rawHtml: "<html>captured</html>", title: "Captured" });
+
+			expect(response.status).toBe(201);
+			expect(saveIntents(harness)[0]).toMatchObject({ path: "/queue/save-html", surface: "extension", outcome: "saved" });
+		});
+	});
+
+	describe("POST /queue/save-content (extension)", () => {
+		it("emits extension / saved", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const token = await bearerToken(harness);
+
+			const response = await request(harness.server)
+				.post("/queue/save-content")
+				.set("Accept", SIREN_MEDIA_TYPE)
+				.set("Authorization", `Bearer ${token}`)
+				.field("url", "https://example.com/article")
+				.field("mediaType", "text/html")
+				.attach("content", Buffer.from("<html>captured</html>"), "content");
+
+			expect(response.status).toBe(201);
+			expect(saveIntents(harness)[0]).toMatchObject({ path: "/queue/save-content", surface: "extension", outcome: "saved" });
+		});
+
+		it("emits extension / error when the save throws", async () => {
+			const harness = useApp(failingSaveFixture());
+			const token = await bearerToken(harness);
+
+			const response = await request(harness.server)
+				.post("/queue/save-content")
+				.set("Accept", SIREN_MEDIA_TYPE)
+				.set("Authorization", `Bearer ${token}`)
+				.field("url", "https://example.com/article")
+				.field("mediaType", "text/html")
+				.attach("content", Buffer.from("<html>captured</html>"), "content");
+
+			expect(response.status).toBe(500);
+			expect(saveIntents(harness)[0]).toMatchObject({ surface: "extension", outcome: "error" });
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-intent.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-intent.route.test.ts
@@ -148,6 +148,20 @@ describe("view_save_intent — authenticated save surfaces", () => {
 			expect(response.status).toBe(201);
 			expect(saveIntents(harness)[0]).toMatchObject({ path: "/queue/save-html", surface: "extension", outcome: "saved" });
 		});
+
+		it("emits extension / error when the save throws", async () => {
+			const harness = useApp(failingSaveFixture());
+			const token = await bearerToken(harness);
+
+			const response = await request(harness.server)
+				.post("/queue/save-html")
+				.set("Accept", SIREN_MEDIA_TYPE)
+				.set("Authorization", `Bearer ${token}`)
+				.send({ url: "https://example.com/article", rawHtml: "<html>captured</html>", title: "Captured" });
+
+			expect(response.status).toBe(500);
+			expect(saveIntents(harness)[0]).toMatchObject({ path: "/queue/save-html", surface: "extension", outcome: "error" });
+		});
 	});
 
 	describe("POST /queue/save-content (extension)", () => {

--- a/projects/hutch/src/runtime/web/pages/save/save.page.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.page.ts
@@ -8,8 +8,9 @@ import { Base } from "../../base.component";
 import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "@packages/web-shell";
 import { collectUtmParams } from "../../shared/utm";
-import { hashIp, type AnalyticsEvent } from "../../middleware/analytics";
-import { ANALYTICS_EVENTS, STREAMS } from "../../../observability/events";
+import { buildSaveIntentEvent, type AnalyticsEvent } from "../../middleware/analytics";
+import { SAVE_OUTCOMES, SAVE_SURFACES } from "../../../observability/events";
+import { setPendingSaveId } from "../../pending-save";
 import { SaveErrorPage } from "./save-error.component";
 
 const SaveUrlSchema = z.url();
@@ -25,6 +26,8 @@ export function initSaveRoutes(deps: {
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
 	salt: string;
 	now: () => Date;
+	secureCookies: boolean;
+	generatePendingSaveId: () => string;
 }): Router {
 	const router = express.Router();
 
@@ -41,16 +44,21 @@ export function initSaveRoutes(deps: {
 		if (!req.userId) {
 			if (!isbot(req.get("user-agent"))) {
 				assert(req.visitorId, "visitor-id middleware must run before /save");
-				deps.analytics.info({
-					stream: STREAMS.analytics,
-					event: ANALYTICS_EVENTS.viewSaveIntent,
-					timestamp: deps.now().toISOString(),
-					path: req.baseUrl,
-					article_host: new URL(url).hostname,
-					visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
-					visitor_id: req.visitorId,
-					is_authenticated: 0,
-				});
+				const pendingSaveId = deps.generatePendingSaveId();
+				setPendingSaveId({ res, secure: deps.secureCookies }, pendingSaveId);
+				deps.analytics.info(
+					buildSaveIntentEvent(
+						{ now: deps.now, salt: deps.salt },
+						{
+							req,
+							url,
+							path: req.baseUrl,
+							surface: SAVE_SURFACES.readerView,
+							outcome: SAVE_OUTCOMES.promptedToSignUp,
+							pendingSaveId,
+						},
+					),
+				);
 			}
 			res.redirect(303, `/login?return=${encodeURIComponent(req.originalUrl)}`);
 			return;

--- a/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
@@ -315,5 +315,26 @@ describe("Save routes", () => {
 			assert(conversion, "signup must emit a user_created conversion");
 			expect(conversion.pending_save_id).toBe(intent.pending_save_id);
 		});
+
+		it("clears the pending-save cookie once consumed so a second signup on the same browser cannot inherit the id", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = request.agent(harness.server);
+
+			await agent.get("/save?url=https://example.com/article");
+
+			const signup = await agent.post("/signup").type("form").send({
+				email: "clears-pending-save@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: String(Date.now() - 5000),
+			});
+			expect(signup.status).toBe(303);
+
+			const setCookieHeader: string | string[] = signup.headers["set-cookie"];
+			const setCookies = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader];
+			const pendingCookieDirective = setCookies.find((c) => c.startsWith("hutch_psid="));
+			assert(pendingCookieDirective, "signup must send a hutch_psid clear directive");
+			expect(pendingCookieDirective).toMatch(/^hutch_psid=;/);
+		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
@@ -227,10 +227,49 @@ describe("Save routes", () => {
 				event: "view_save_intent",
 				path: "/save",
 				article_host: "example.com",
+				content_class: "third_party",
+				surface: "reader_view",
+				outcome: "prompted_to_sign_up",
 				is_authenticated: 0,
 			});
 			expect(typeof intents[0].visitor_id).toBe("string");
 			expect(typeof intents[0].visitor_hash).toBe("string");
+			expect(typeof intents[0].pending_save_id).toBe("string");
+		});
+
+		it("mints a pending-save cookie carrying the same id as the event so the blocked save links to the eventual signup", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get("/save?url=https://example.com/article");
+
+			const setCookieHeader: string | string[] = response.headers["set-cookie"];
+			const setCookies = Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader];
+			const pendingCookie = setCookies.find((c) => c.startsWith("hutch_psid="));
+			assert(pendingCookie, "a hutch_psid cookie must be set");
+			const cookieValue = decodeURIComponent(pendingCookie.split(";")[0].split("=")[1]);
+			expect(cookieValue).toBe(saveIntents(harness)[0].pending_save_id);
+		});
+
+		it("classifies a save of our own content (readplace.com) as own", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).get("/save?url=https://readplace.com/blog/something");
+
+			expect(saveIntents(harness)[0]).toMatchObject({ article_host: "readplace.com", content_class: "own" });
+		});
+
+		it("classifies by the article's own domain, not the referrer: an own-domain referrer saving a third-party article is still a third-party save", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server)
+				.get("/save?url=https://example.com/article")
+				.set("Referer", "https://readplace.com/some/reader/page");
+
+			expect(saveIntents(harness)[0]).toMatchObject({
+				article_host: "example.com",
+				content_class: "third_party",
+				referrer_host: "readplace.com",
+			});
 		});
 
 		it("does not emit view_save_intent for a bot user-agent (keeps the funnel free of crawler-followed Save links)", async () => {
@@ -252,6 +291,29 @@ describe("Save routes", () => {
 
 			expect(response.status).toBe(303);
 			assert.equal(saveIntents(harness).length, 0, "no view_save_intent when already authenticated");
+		});
+	});
+
+	describe("pending-save linkage (signup-blocked save → account creation)", () => {
+		it("stamps the same pending_save_id on the blocked view_save_intent and the eventual user_created conversion", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = request.agent(harness.server);
+
+			await agent.get("/save?url=https://example.com/article");
+			const intent = saveIntents(harness)[0];
+			assert(intent.pending_save_id, "the blocked save must mint a pending_save_id");
+
+			const signup = await agent.post("/signup").type("form").send({
+				email: "blocked-then-signed-up@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: String(Date.now() - 5000),
+			});
+			expect(signup.status).toBe(303);
+
+			const conversion = harness.conversions.events.find((e) => e.event === "user_created");
+			assert(conversion, "signup must emit a user_created conversion");
+			expect(conversion.pending_save_id).toBe(intent.pending_save_id);
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -32,6 +32,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import { hashIp, type AnalyticsEvent } from "../../middleware/analytics";
 import { rateLimitKeyFromRequest, sendRateLimited } from "../../middleware/rate-limit";
 import { ANALYTICS_EVENTS, STREAMS } from "../../../observability/events";
+import { articleHostFrom } from "../../../observability/content-source";
 import { wantsMarkdown, htmlToMarkdown, buildMarkdownFrontmatter, MarkdownPage, sendComponent } from "@packages/web-shell";
 import { CacheableComponent } from "../../conditional-get";
 
@@ -79,10 +80,6 @@ async function renderError(deps: ViewDependencies, req: Request, res: Response):
 	const redirectUrl = req.userId ? "/queue" : "/";
 	const linkLabel = req.userId ? "Go to your queue" : "Go to homepage";
 	sendComponent(req, res, Base(SaveErrorPage({ redirectUrl, linkLabel }), await deps.buildBannerState(req)));
-}
-
-function hostnameFrom(validatedUrl: string): string {
-	return new URL(validatedUrl).hostname;
 }
 
 function pollUrlBuilderFor(articleUrl: string): PollUrlBuilder {
@@ -161,7 +158,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				sendRateLimited(res, decision.retryAfterSeconds);
 				return;
 			}
-			const hostname = hostnameFrom(articleUrl);
+			const hostname = articleHostFrom(articleUrl);
 			await deps.saveArticleGlobally({
 				url: articleUrl,
 				metadata: {
@@ -212,7 +209,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				event: ANALYTICS_EVENTS.viewOpened,
 				timestamp: deps.now().toISOString(),
 				path: originalPath,
-				article_host: hostnameFrom(articleUrl),
+				article_host: articleHostFrom(articleUrl),
 				visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
 				visitor_id: req.visitorId,
 				is_authenticated: req.userId ? 1 : 0,

--- a/projects/hutch/src/runtime/web/pending-save.test.ts
+++ b/projects/hutch/src/runtime/web/pending-save.test.ts
@@ -1,0 +1,25 @@
+import { PENDING_SAVE_COOKIE_NAME, readPendingSaveId } from "./pending-save";
+
+const VALID_UUID = "123e4567-e89b-12d3-a456-426614174000";
+
+describe("readPendingSaveId", () => {
+	it("returns the id from a valid cookie", () => {
+		expect(readPendingSaveId({ cookies: { [PENDING_SAVE_COOKIE_NAME]: VALID_UUID } })).toBe(VALID_UUID);
+	});
+
+	it("returns undefined when there is no cookie jar", () => {
+		expect(readPendingSaveId({})).toBeUndefined();
+	});
+
+	it("returns undefined when the cookie is absent", () => {
+		expect(readPendingSaveId({ cookies: {} })).toBeUndefined();
+	});
+
+	it("treats a non-string cookie as absent", () => {
+		expect(readPendingSaveId({ cookies: { [PENDING_SAVE_COOKIE_NAME]: 42 } })).toBeUndefined();
+	});
+
+	it("treats a tampered (non-uuid) cookie as absent so it never reaches the conversion event", () => {
+		expect(readPendingSaveId({ cookies: { [PENDING_SAVE_COOKIE_NAME]: "not-a-uuid" } })).toBeUndefined();
+	});
+});

--- a/projects/hutch/src/runtime/web/pending-save.test.ts
+++ b/projects/hutch/src/runtime/web/pending-save.test.ts
@@ -1,6 +1,17 @@
-import { PENDING_SAVE_COOKIE_NAME, readPendingSaveId } from "./pending-save";
+import { PENDING_SAVE_COOKIE_NAME, consumePendingSaveId, readPendingSaveId } from "./pending-save";
 
 const VALID_UUID = "123e4567-e89b-12d3-a456-426614174000";
+
+function recordingRes(): {
+	res: { clearCookie: (name: string, options: { path: string }) => void };
+	cleared: { name: string; options: { path: string } }[];
+} {
+	const cleared: { name: string; options: { path: string } }[] = [];
+	return {
+		res: { clearCookie: (name, options) => { cleared.push({ name, options }); } },
+		cleared,
+	};
+}
 
 describe("readPendingSaveId", () => {
 	it("returns the id from a valid cookie", () => {
@@ -21,5 +32,25 @@ describe("readPendingSaveId", () => {
 
 	it("treats a tampered (non-uuid) cookie as absent so it never reaches the conversion event", () => {
 		expect(readPendingSaveId({ cookies: { [PENDING_SAVE_COOKIE_NAME]: "not-a-uuid" } })).toBeUndefined();
+	});
+});
+
+describe("consumePendingSaveId", () => {
+	it("returns the id and clears the cookie so a held save is consumed exactly once", () => {
+		const { res, cleared } = recordingRes();
+
+		const id = consumePendingSaveId({ req: { cookies: { [PENDING_SAVE_COOKIE_NAME]: VALID_UUID } }, res });
+
+		expect(id).toBe(VALID_UUID);
+		expect(cleared).toEqual([{ name: PENDING_SAVE_COOKIE_NAME, options: { path: "/" } }]);
+	});
+
+	it("clears the cookie even when no valid id is present so a tampered value cannot linger", () => {
+		const { res, cleared } = recordingRes();
+
+		const id = consumePendingSaveId({ req: { cookies: { [PENDING_SAVE_COOKIE_NAME]: "not-a-uuid" } }, res });
+
+		expect(id).toBeUndefined();
+		expect(cleared).toEqual([{ name: PENDING_SAVE_COOKIE_NAME, options: { path: "/" } }]);
 	});
 });

--- a/projects/hutch/src/runtime/web/pending-save.ts
+++ b/projects/hutch/src/runtime/web/pending-save.ts
@@ -4,11 +4,13 @@ import { baseCookieOptions } from "./cookie-options";
 
 export const PENDING_SAVE_COOKIE_NAME = "hutch_psid";
 
-/** An hour is long enough to finish signup (email verification redirects back
- * before then) yet short enough that a stale id cannot attach itself to an
- * unrelated signup days later. The id is minted only when an anonymous save is
- * held behind the sign-in wall, so its mere presence means "a save is pending".
- */
+/** The id is cleared the instant it is consumed at signup (see
+ * consumePendingSaveId), so the TTL only has to bound an *abandoned* save — one
+ * held behind the sign-in wall whose visitor never signs up. An hour is long
+ * enough to finish signup (email verification redirects back before then) yet
+ * short enough that an abandoned id cannot linger and attach itself to an
+ * unrelated signup later. The id is minted only when an anonymous save is held
+ * behind the sign-in wall, so its mere presence means "a save is pending". */
 const PENDING_SAVE_COOKIE_MAX_AGE_MS = 60 * 60 * 1000;
 
 const PendingSaveIdSchema = z.string().uuid();
@@ -27,4 +29,19 @@ export function readPendingSaveId(req: { cookies?: Record<string, unknown> }): s
 	if (typeof raw !== "string") return undefined;
 	const parsed = PendingSaveIdSchema.safeParse(raw);
 	return parsed.success ? parsed.data : undefined;
+}
+
+/** Reads the pending-save id and clears the cookie in the same step so a held
+ * save is consumed exactly once. Without clearing, a second signup on the same
+ * browser within the cookie's TTL would inherit the first save's id and
+ * double-attribute one pending save to two accounts. The clear is
+ * unconditional (matching the logout/oauth-state cookie clears) and uses path
+ * "/" to match the cookie `setPendingSaveId` writes via `baseCookieOptions`. */
+export function consumePendingSaveId(deps: {
+	req: { cookies?: Record<string, unknown> };
+	res: { clearCookie: (name: string, options: { path: string }) => void };
+}): string | undefined {
+	const id = readPendingSaveId(deps.req);
+	deps.res.clearCookie(PENDING_SAVE_COOKIE_NAME, { path: "/" });
+	return id;
 }

--- a/projects/hutch/src/runtime/web/pending-save.ts
+++ b/projects/hutch/src/runtime/web/pending-save.ts
@@ -1,0 +1,30 @@
+import type { Response } from "express";
+import { z } from "zod";
+import { baseCookieOptions } from "./cookie-options";
+
+export const PENDING_SAVE_COOKIE_NAME = "hutch_psid";
+
+/** An hour is long enough to finish signup (email verification redirects back
+ * before then) yet short enough that a stale id cannot attach itself to an
+ * unrelated signup days later. The id is minted only when an anonymous save is
+ * held behind the sign-in wall, so its mere presence means "a save is pending".
+ */
+const PENDING_SAVE_COOKIE_MAX_AGE_MS = 60 * 60 * 1000;
+
+const PendingSaveIdSchema = z.string().uuid();
+
+export function setPendingSaveId(deps: { res: Response; secure: boolean }, id: string): void {
+	deps.res.cookie(PENDING_SAVE_COOKIE_NAME, id, {
+		...baseCookieOptions(deps.secure),
+		maxAge: PENDING_SAVE_COOKIE_MAX_AGE_MS,
+	});
+}
+
+/** A cookie that fails validation is treated as absent so a tampered value
+ * never reaches the conversion event. */
+export function readPendingSaveId(req: { cookies?: Record<string, unknown> }): string | undefined {
+	const raw = req.cookies?.[PENDING_SAVE_COOKIE_NAME];
+	if (typeof raw !== "string") return undefined;
+	const parsed = PendingSaveIdSchema.safeParse(raw);
+	return parsed.success ? parsed.data : undefined;
+}

--- a/src/packages/provider-contracts/src/auth.ts
+++ b/src/packages/provider-contracts/src/auth.ts
@@ -107,4 +107,9 @@ export interface ConversionEvent {
 	landing_path?: string;
 	stripe_checkout_session_id?: string;
 	visitor_id?: string;
+	/** The id minted when an anonymous save was held behind the sign-in wall
+	 * (carried on the matching `view_save_intent`), so a signup-blocked save can
+	 * be traced to the account it eventually created. Absent when the signup did
+	 * not follow a pending save. */
+	pending_save_id?: string;
 }


### PR DESCRIPTION
## What & why

Enriches the existing `view_save_intent` analytics event so the **save funnel can be sliced by content type (our own content vs third-party) and by the surface the save was triggered from**, and so anonymous save attempts that never convert to signup are traceable end-to-end. **Additive only** — no event renamed, no existing field changed, no change to *when* the original anonymous emission fires.

## The load-bearing rule: article domain, not referrer

`content_class` is derived **solely from the article's own domain** (`article_host` — where the saved content lives), *never* from the referrer or traffic source. A visitor arriving from our own site (`readplace.com`) to save a third-party article (`example.com`) is a **third-party** save. The referrer is captured too, but as a **separate** dimension (`referrer_host`) that never feeds the classification. This is enforced by a test: own-domain referrer + third-party article ⇒ `third_party`.

## "Our own content domains" list (please confirm)

New canonical list in `projects/hutch/src/runtime/observability/content-source.ts`:

```
OWN_CONTENT_DOMAINS = ["readplace.com", "fagnerbrack.com"]
```

- A host matches when it equals one of these **or is a subdomain** (`www.readplace.com`, `blog.fagnerbrack.com` ⇒ own), case-insensitive.
- Deliberately **excluded**: `hutch-app.com` (legacy app host, only 301-redirects — no articles published there) and the app shell origin (people save articles, not the app).
- This is a **new** list, kept separate from `PERMANENT_ARTICLE_DOMAINS` (`["fagnerbrack.com"]`), which governs public-view *expiry*, a different concern. They overlap today but shouldn't be coupled. **Tell me if `readplace.com` / other brand domains should be added or removed.**

## Dimensions added to `view_save_intent` (all additive)

| Field | Type | Notes |
|---|---|---|
| `content_class` | `"own" \| "third_party"` | derived from `article_host` only |
| `surface` | `"reader_view" \| "queue_save_bar" \| "extension"` | where the save was triggered |
| `outcome` | `"saved" \| "prompted_to_sign_up" \| "error"` | immediate result of the click |
| `referrer_host` | `string?` | traffic source, distinct from `article_host` |
| `pending_save_id` | `string?` | links a signup-blocked save → the eventual `user_created` |

`article_host`, `visitor_hash` (dedup/exclusion id), `visitor_id`, `is_authenticated` were already present and are unchanged. The shared `article_host` derivation is now factored into `articleHostFrom()` and used by **both** `view_opened` and `view_save_intent`, so the two events join with identical normalization.

## Surfaces enumerated & tagged

| Surface | Emission site | auth | outcome(s) |
|---|---|---|---|
| `reader_view` | `GET /save` (anonymous) — the existing emission | anon | `prompted_to_sign_up` |
| `queue_save_bar` | `POST /queue/save` (save bar / URL-paste input) | auth | `saved`, `error` |
| `extension` | `POST /queue` (save-article), `POST /queue/save-html`, `POST /queue/save-content` | auth | `saved`, `error` |

- The **queue list save bar and the URL-paste input are the same control** in this product, so they share `queue_save_bar`.
- **Mobile share** is not a distinct surface here — capture happens via the browser extension.
- The authenticated reader-view "Save" button forwards through `GET /save` → `/queue?url=…` → `POST /queue/save`, so it is counted once at `queue_save_bar` (no double-count). The anonymous reader-view emission is unchanged.
- Imports stay on their own `import_committed` (bulk) event — not single-save intents.

## `pending_save_id` (intent → signup leak, end-to-end)

When an anonymous save is held behind the sign-in wall, a UUID is minted, set in a short-lived `hutch_psid` cookie, and stamped on the `view_save_intent`. On signup it is read from the cookie and added to the `user_created` conversion event (new optional `pending_save_id`). This makes a specific blocked save joinable to the account it created — sharper than the existing per-device `visitor_id` join, which is preserved.

## Backward compatibility

- Event name, stream, and all prior fields unchanged; the anonymous reader emission fires exactly as before (now with extra fields).
- The "Try → Save-intent → Signup" dashboard widget is pinned to the anonymous reader surface (`surface = "reader_view" or not ispresent(surface)`) so its number is **identical** to today even though `view_save_intent` now also fires for authenticated saves. `not ispresent(surface)` keeps pre-deploy events in the count.

## Verification

- `pnpm nx run hutch:check` green (lint, type-check, unit + integration tests, 100% coverage gate). `provider-contracts:check` green.
- New/extended tests assert every new dimension populates and that `content_class` derives from the article domain (own ⇒ own; third-party ⇒ third-party; **own-referrer + third-party article ⇒ third-party**).
- Breakdowns produced via the project's query mechanism (CloudWatch Logs Insights). Three new dashboard widgets added: **save-intent by surface × content class**, **by content class (%)**, and **anonymous reader-view attempts by outcome**.
- Local end-to-end breakdown over a representative mix of emissions (all surfaces driven through the in-memory app):

  ```
  view_save_intent by surface × content_class
  surface          content_class   saves
  reader_view      third_party     3
  reader_view      own             1
  queue_save_bar   own             1
  queue_save_bar   third_party     1
  extension        third_party     1

  anonymous reader-view save attempts by outcome
  outcome              attempts
  prompted_to_sign_up  4
  ```

- Real prod data for the current funnel (last 30 days, distinct visitors): `view_opened` 1706 → `view_save_intent` 82 → `user_created` 16 — i.e. ~82 anonymous visitors hit the signup prompt. The new `outcome`/`pending_save_id` dimensions formalize and sharpen this.

## Not deployed

Open for review only.
