### PR TITLE
refactor(queue): derive save-intent analytics paths from shared route constant

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -110,7 +110,7 @@ import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { SESSION_COOKIE_NAME } from "./web/auth/session-cookie";
 import { isHttpsOrigin } from "./web/cookie-options";
 import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
-import { initQueueRoutes } from "./web/pages/queue/queue.page";
+import { initQueueRoutes, QUEUE_PATH } from "./web/pages/queue/queue.page";
 import { initImportSessionRoutes } from "./web/pages/import/import.page";
 import type { ImportSessionStore } from "@packages/domain/import-session";
 import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
@@ -789,7 +789,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	 * stay publicly reachable. Shared reader permalinks (people copy them from
 	 * the browser URL bar) redirect non-owners and anonymous visitors to
 	 * `/view/<url>` instead of bouncing them to /login. */
-	app.use("/queue", extensionCors, queueRouter);
+	app.use(QUEUE_PATH, extensionCors, queueRouter);
 
 	const importRouter = initImportSessionRoutes({
 		validateSaveableUrl: deps.validateSaveableUrl,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -110,7 +110,8 @@ import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { SESSION_COOKIE_NAME } from "./web/auth/session-cookie";
 import { isHttpsOrigin } from "./web/cookie-options";
 import { initForgotPasswordRoutes } from "./web/auth/forgot-password.page";
-import { initQueueRoutes, QUEUE_PATH } from "./web/pages/queue/queue.page";
+import { initQueueRoutes } from "./web/pages/queue/queue.page";
+import { QUEUE_PATH } from "./web/pages/queue/queue.url";
 import { initImportSessionRoutes } from "./web/pages/import/import.page";
 import type { ImportSessionStore } from "@packages/domain/import-session";
 import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
@@ -407,7 +408,7 @@ export function createApp(dependencies: AppDependencies): Express {
 				"User-agent: *",
 				`Content-Signal: ${CONTENT_SIGNAL_VALUE}`,
 				"Allow: /",
-				"Disallow: /queue",
+				`Disallow: ${QUEUE_PATH}`,
 				"Disallow: /export",
 				"Disallow: /oauth",
 				"Disallow: /forgot-password",
@@ -575,7 +576,7 @@ export function createApp(dependencies: AppDependencies): Express {
 	app.options("/", extensionCors);
 	app.get("/", extensionCors, async (req: Request, res: Response) => {
 		if (wantsSiren(req) && !wantsMarkdown(req)) {
-			res.redirect(303, "/queue");
+			res.redirect(303, QUEUE_PATH);
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -25,6 +25,7 @@ import {
 	IMPORT_SKIPPED_COOKIE_NAME,
 	encodeImportSkippedCookie,
 } from "./import-skipped-cookie";
+import { QUEUE_PATH } from "../queue/queue.url";
 import { ImportAcquirePage, ImportPage } from "./import.component";
 import { importErrorMessageMapping } from "./import.error";
 import { toImportAcquireViewModel, toImportViewModel } from "./import.viewmodel";
@@ -173,7 +174,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const parsedId = ImportSessionIdSchema.safeParse(req.params.id);
 		if (!parsedId.success) {
-			res.redirect(303, "/queue");
+			res.redirect(303, QUEUE_PATH);
 			return;
 		}
 
@@ -296,7 +297,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 			 * queue render. Capped at MAX_COOKIE_ITEMS to stay under the 4 KiB
 			 * cookie limit on large skip volumes. */
 			res.cookie(IMPORT_SKIPPED_COOKIE_NAME, encodeImportSkippedCookie(skipped), {
-				path: "/queue",
+				path: QUEUE_PATH,
 				maxAge: 5 * 60 * 1000,
 				sameSite: "lax",
 				httpOnly: true,
@@ -319,7 +320,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 		});
 		res.redirect(
 			303,
-			`/queue?import_imported=${saveable.length}&import_total=${session.totalUrls}&import_skipped=${skipped.length}`,
+			`${QUEUE_PATH}?import_imported=${saveable.length}&import_total=${session.totalUrls}&import_skipped=${skipped.length}`,
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -205,6 +205,26 @@ async function loadCrawls(
 	}));
 }
 
+/** Mount path of the queue router (`app.use(QUEUE_PATH, …)` in server.ts). The
+ * save surfaces build their analytics `path` from QUEUE_PATH and the same
+ * relative routes registered on the router, so the recorded path can't drift
+ * from where saves actually land. */
+export const QUEUE_PATH = "/queue";
+
+const SAVE_ROUTE = {
+	saveArticle: "/",
+	save: "/save",
+	saveHtml: "/save-html",
+	saveContent: "/save-content",
+} as const;
+
+const SAVE_INTENT_PATH = {
+	saveArticle: QUEUE_PATH,
+	save: `${QUEUE_PATH}${SAVE_ROUTE.save}`,
+	saveHtml: `${QUEUE_PATH}${SAVE_ROUTE.saveHtml}`,
+	saveContent: `${QUEUE_PATH}${SAVE_ROUTE.saveContent}`,
+} as const;
+
 export function initQueueRoutes(deps: QueueDependencies): Router {
 	const router = express.Router();
 
@@ -410,7 +430,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		res.redirect(303, "/queue");
 	});
 
-	router.post("/", requireNotLocked, deps.requireWriteAccess, express.json(), async (req: Request, res: Response) => {
+	router.post(SAVE_ROUTE.saveArticle, requireNotLocked, deps.requireWriteAccess, express.json(), async (req: Request, res: Response) => {
 		if (!wantsSiren(req)) {
 			res.status(406).send("Not Acceptable");
 			return;
@@ -449,11 +469,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
 			const result = await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
 			markExtensionSavedArticle(res);
-			emitSaveIntent({ req, url: validation.url, path: "/queue", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
+			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.saveArticle, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);
-			emitSaveIntent({ req, url: validation.url, path: "/queue", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
+			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.saveArticle, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
 			res.status(500).type(SIREN_MEDIA_TYPE).json(
 				sirenError({ code: "save-failed", message: "Could not save article" }),
 			);
@@ -495,7 +515,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		next(err);
 	};
 
-	router.post("/save-html", requireNotLocked, deps.requireWriteAccess, express.json({ limit: MAX_RAW_HTML_REQUEST_BYTES }), saveHtmlLimitHandler, async (req: Request, res: Response) => {
+	router.post(SAVE_ROUTE.saveHtml, requireNotLocked, deps.requireWriteAccess, express.json({ limit: MAX_RAW_HTML_REQUEST_BYTES }), saveHtmlLimitHandler, async (req: Request, res: Response) => {
 		if (!wantsSiren(req)) {
 			res.status(406).send("Not Acceptable");
 			return;
@@ -534,7 +554,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					const freshness = await deps.refreshArticleIfStale({ url: urlOnlyValidation.url });
 					const result = await saveArticleFromUrl(deps, { userId, url: urlOnlyValidation.url, freshness });
 					markExtensionSavedArticle(res);
-					emitSaveIntent({ req, url: urlOnlyValidation.url, path: "/queue/save-html", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
+					emitSaveIntent({ req, url: urlOnlyValidation.url, path: SAVE_INTENT_PATH.saveHtml, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 					res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 					return;
 				}
@@ -565,12 +585,12 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 			const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
 			markExtensionSavedArticle(res);
-			emitSaveIntent({ req, url: articleUrl, path: "/queue/save-html", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
+			emitSaveIntent({ req, url: articleUrl, path: SAVE_INTENT_PATH.saveHtml, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 		} catch (error) {
 			deps.logError("Failed to save article from html", error instanceof Error ? error : undefined);
 			assert(validatedArticleUrl, "save-html reaches the save pipeline only after the article URL is validated");
-			emitSaveIntent({ req, url: validatedArticleUrl, path: "/queue/save-html", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
+			emitSaveIntent({ req, url: validatedArticleUrl, path: SAVE_INTENT_PATH.saveHtml, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
 			res.status(500).type(SIREN_MEDIA_TYPE).json(
 				sirenError({ code: "save-failed", message: "Could not save article" }),
 			);
@@ -604,7 +624,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 	};
 
 	router.post(
-		"/save-content",
+		SAVE_ROUTE.saveContent,
 		requireNotLocked,
 		deps.requireWriteAccess,
 		contentUpload.rawBodyParser,
@@ -713,11 +733,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 				const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
 				markExtensionSavedArticle(res);
-				emitSaveIntent({ req, url: articleUrl, path: "/queue/save-content", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
+				emitSaveIntent({ req, url: articleUrl, path: SAVE_INTENT_PATH.saveContent, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 				res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
 			} catch (error) {
 				deps.logError("Failed to save article from content", error instanceof Error ? error : undefined);
-				emitSaveIntent({ req, url: validation.url, path: "/queue/save-content", surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
+				emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.saveContent, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.error });
 				res.status(500).type(SIREN_MEDIA_TYPE).json(
 					sirenError({ code: "save-failed", message: "Could not save article" }),
 				);
@@ -725,7 +745,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		},
 	);
 
-	router.post("/save", requireNotLocked, deps.requireWriteAccess, async (req: Request, res: Response) => {
+	router.post(SAVE_ROUTE.save, requireNotLocked, deps.requireWriteAccess, async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
 		const submittedUrl = typeof req.body?.url === "string" ? req.body.url : "";
@@ -753,11 +773,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		try {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
 			await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
-			emitSaveIntent({ req, url: validation.url, path: "/queue/save", surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.saved });
+			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.save, surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.saved });
 			res.redirect(303, "/queue#latest-saved");
 		} catch (error) {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);
-			emitSaveIntent({ req, url: validation.url, path: "/queue/save", surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.error });
+			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.save, surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.error });
 			res.redirect(303, "/queue?error_code=save_failed");
 		}
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -67,7 +67,7 @@ import type { QuerystringFeatureToggle } from "../../feature-toggle";
 import { SIREN_MEDIA_TYPE, sirenError } from "../../api/siren";
 import { toArticleCollectionEntity } from "../../api/collection-siren";
 import { toArticleEntity } from "../../api/article-siren";
-import { parseQueueUrl, buildQueueUrl } from "./queue.url";
+import { parseQueueUrl, buildQueueUrl, QUEUE_PATH } from "./queue.url";
 import { collectUtmParams } from "../../shared/utm";
 import { tabQuery } from "./queue.tabs";
 import type { HttpErrorMessageMapping } from "./queue.error";
@@ -98,7 +98,7 @@ function readImportSkippedFlash(
 	if (!decoded || decoded.entries.length === 0) return undefined;
 	/** Cookie is read-once: clear it so a refresh of /queue doesn't keep
 	 * surfacing the "couldn't import" banner. */
-	res.clearCookie(IMPORT_SKIPPED_COOKIE_NAME, { path: "/queue" });
+	res.clearCookie(IMPORT_SKIPPED_COOKIE_NAME, { path: QUEUE_PATH });
 	return {
 		entries: decoded.entries.map((e) => ({
 			url: e.url,
@@ -205,12 +205,6 @@ async function loadCrawls(
 	}));
 }
 
-/** Mount path of the queue router (`app.use(QUEUE_PATH, …)` in server.ts). The
- * save surfaces build their analytics `path` from QUEUE_PATH and the same
- * relative routes registered on the router, so the recorded path can't drift
- * from where saves actually land. */
-export const QUEUE_PATH = "/queue";
-
 const SAVE_ROUTE = {
 	saveArticle: "/",
 	save: "/save",
@@ -218,11 +212,15 @@ const SAVE_ROUTE = {
 	saveContent: "/save-content",
 } as const;
 
+/** Root ("/") maps to QUEUE_PATH alone; appending it would record a spurious "/queue/" trailing slash. */
+const saveIntentPath = (route: string): string =>
+	route === "/" ? QUEUE_PATH : `${QUEUE_PATH}${route}`;
+
 const SAVE_INTENT_PATH = {
-	saveArticle: QUEUE_PATH,
-	save: `${QUEUE_PATH}${SAVE_ROUTE.save}`,
-	saveHtml: `${QUEUE_PATH}${SAVE_ROUTE.saveHtml}`,
-	saveContent: `${QUEUE_PATH}${SAVE_ROUTE.saveContent}`,
+	saveArticle: saveIntentPath(SAVE_ROUTE.saveArticle),
+	save: saveIntentPath(SAVE_ROUTE.save),
+	saveHtml: saveIntentPath(SAVE_ROUTE.saveHtml),
+	saveContent: saveIntentPath(SAVE_ROUTE.saveContent),
 } as const;
 
 export function initQueueRoutes(deps: QueueDependencies): Router {
@@ -248,7 +246,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		findArticleByUrl: deps.findArticleByUrl,
 		appOrigin: deps.appOrigin,
 		formatDocumentTitle: formatReaderDocumentTitle,
-		backLink: { href: "/queue", label: "← Back to queue" },
+		backLink: { href: QUEUE_PATH, label: "← Back to queue" },
 		markReadAction: (articleId) => ({
 			postUrl: markReadPostUrl(articleId, "top"),
 			label: "Mark as read",
@@ -263,8 +261,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 	function pollUrlBuilderForId(articleId: string): PollUrlBuilder {
 		return {
-			summary: (n) => `/queue/${articleId}/summary?poll=${n}`,
-			reader: (n) => `/queue/${articleId}/reader?poll=${n}`,
+			summary: (n) => `${QUEUE_PATH}/${articleId}/summary?poll=${n}`,
+			reader: (n) => `${QUEUE_PATH}/${articleId}/reader?poll=${n}`,
 		};
 	}
 
@@ -285,7 +283,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 	router.get("/:id/read", (req: Request, res: Response) => {
 		const queryIndex = req.originalUrl.indexOf("?");
 		const queryString = queryIndex !== -1 ? req.originalUrl.slice(queryIndex) : "";
-		res.redirect(301, `/queue/${req.params.id}/view${queryString}`);
+		res.redirect(301, `${QUEUE_PATH}/${req.params.id}/view${queryString}`);
 	});
 
 	router.get("/:id/view", async (req: Request<{ id: string }>, res: Response) => {
@@ -427,7 +425,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 	router.post("/dismiss-onboarding", (_req: Request, res: Response) => {
 		res.cookie(DISMISS_COOKIE_NAME, ONBOARDING_VERSION, { path: "/", maxAge: 365 * 24 * 60 * 60 * 1000, sameSite: "lax", httpOnly: true });
-		res.redirect(303, "/queue");
+		res.redirect(303, QUEUE_PATH);
 	});
 
 	router.post(SAVE_ROUTE.saveArticle, requireNotLocked, deps.requireWriteAccess, express.json(), async (req: Request, res: Response) => {
@@ -502,7 +500,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					actions: [
 						{
 							name: "save-article",
-							href: "/queue",
+							href: QUEUE_PATH,
 							method: "POST",
 							type: "application/json",
 							fields: [{ name: "url", type: "url" }],
@@ -640,7 +638,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 			const buildFallbackAction = () => ({
 				name: "save-article",
-				href: "/queue",
+				href: QUEUE_PATH,
 				method: "POST",
 				type: "application/json",
 				fields: [{ name: "url", type: "url" }],
@@ -774,11 +772,11 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
 			await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
 			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.save, surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.saved });
-			res.redirect(303, "/queue#latest-saved");
+			res.redirect(303, `${QUEUE_PATH}#latest-saved`);
 		} catch (error) {
 			deps.logError("Failed to save article", error instanceof Error ? error : undefined);
 			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.save, surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.error });
-			res.redirect(303, "/queue?error_code=save_failed");
+			res.redirect(303, `${QUEUE_PATH}?error_code=save_failed`);
 		}
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 import type { SortOrder } from "@packages/provider-contracts/article-store";
 import { type TabId, tabQuery } from "./queue.tabs";
 
+/** Mount path of the queue router (`app.use(QUEUE_PATH, …)` in server.ts) and
+ * the single source every queue URL derives from — analytics paths, redirects,
+ * links, the skipped-import cookie scope, and the query strings `buildQueueUrl`
+ * produces — so none can drift from where the router is actually mounted. */
+export const QUEUE_PATH = "/queue";
+
 export interface QueueUrlState {
 	tab: TabId;
 	order?: SortOrder;
@@ -47,5 +53,5 @@ export function buildQueueUrl(
 	}
 
 	const qs = params.toString();
-	return qs ? `/queue?${qs}` : "/queue";
+	return qs ? `${QUEUE_PATH}?${qs}` : QUEUE_PATH;
 }

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -2,10 +2,10 @@ import { z } from "zod";
 import type { SortOrder } from "@packages/provider-contracts/article-store";
 import { type TabId, tabQuery } from "./queue.tabs";
 
-/** Mount path of the queue router (`app.use(QUEUE_PATH, …)` in server.ts) and
- * the single source every queue URL derives from — analytics paths, redirects,
- * links, the skipped-import cookie scope, and the query strings `buildQueueUrl`
- * produces — so none can drift from where the router is actually mounted. */
+/** Mount path of the queue router (`app.use(QUEUE_PATH, …)` in server.ts). The
+ * queue router builds its redirects, links and analytics paths — plus the
+ * skipped-import cookie scope and the query strings `buildQueueUrl` produces —
+ * from this constant so they can't drift from where the router is mounted. */
 export const QUEUE_PATH = "/queue";
 
 export interface QueueUrlState {


### PR DESCRIPTION
## What

The `view_save_intent` analytics `path` was hardcoded as a string literal at every `emitSaveIntent` call site in `queue.page.ts` — `"/queue"`, `"/queue/save"`, `"/queue/save-html"`, `"/queue/save-content"` (9 occurrences). Nothing tied those literals to where the router is actually mounted (`app.use("/queue", …)` in `server.ts`) or to the relative routes registered with `router.post(…)`, so a rename of the mount or a route would silently desync the recorded analytics path from reality.

This replaces the literals with shared constants:

- **`QUEUE_PATH`** — single source of truth for the mount path, now used both at the real `server.ts` mount (`app.use(QUEUE_PATH, …)`) and to build the analytics paths.
- **`SAVE_ROUTE`** — the relative routes (`/`, `/save`, `/save-html`, `/save-content`) defined once and used in the `router.post(…)` registrations.
- **`SAVE_INTENT_PATH`** — the analytics paths, derived from `QUEUE_PATH` + `SAVE_ROUTE` so they cannot drift from where saves actually land.

## Why

A rename of the mount point or a save route now updates the Express registration and the recorded analytics `path` in lockstep, instead of leaving the analytics literal stale and the drift invisible until someone audits a dashboard.

## Behaviour

No behaviour change — the derived paths resolve to exactly the same `/queue`, `/queue/save`, `/queue/save-html`, `/queue/save-content` values. The existing `queue.save-intent.route.test.ts` suite (which independently hardcodes the expected paths and POSTs to the real URLs) acts as the drift guard and passes unchanged.

## Verification

`pnpm nx run hutch:check` passes (lint, type-check, tests, coverage, knip); all coverage thresholds met. The full `nx run-many --target=check --all` pre-commit hook also passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LCLXRB4nqA83Nq52mbqpc

---
_Generated by [Claude Code](https://claude.ai/code/session_017LCLXRB4nqA83Nq52mbqpc)_