### PR TITLE
docs(blog): add post on saved articles outlasting the original page

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/saved-articles-outlast-the-original-page.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/saved-articles-outlast-the-original-page.md
@@ -1,0 +1,43 @@
+---
+title: "Read It Later, Even After the Original Page Is Gone"
+description: "Save a link to Readplace and it builds a clean copy on its own servers. The source page can change, hide behind a paywall, or go offline, and your saved article stays readable, with no expiry on the link."
+slug: "saved-articles-outlast-the-original-page"
+date: "2026-06-17"
+author: "Fayner Brack"
+keywords: "read it later no expiry, saved article disappeared, link rot, save a copy of a web page, article deleted read later, page went offline, Pocket alternative, read it later that keeps your copy, save article before it changes"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Save a link to Readplace and it opens the page on its own servers, then stores a clean copy of the text and images. The source can edit the article, drop a paywall in front of it, or go offline, and your saved copy stays readable. Saved links carry no expiry, so an article you keep today opens the same way next month. You read on your own schedule, off your own copy.
+
+</div>
+</details>
+
+You find a good article and you have no time to read it. So you save it for the weekend. You come back, click the link, and the page is gone. The site moved it, a paywall slid in, or the link now returns a 404. The thing you set aside took itself away.
+
+The web edits and deletes itself under you. Articles get rewritten. Domains lapse. A free post turns into a members-only one. People call this link rot, and saved reading takes the worst of it. The gap between saving and reading is exactly when a page has time to change.
+
+Whole services vanish too. Pocket shut down on July 8, 2025. Omnivore shut down in November 2024. Readers who saved into those apps got a short window to pull their data out before it went dark. The same risk lives at the level of one page, one link at a time.
+
+## What saving does here
+
+When you save a link, Readplace opens the page on its own servers and builds a clean reader copy. It downloads the images and stores them on its own host, so your reader loads from us and not from the source site. Your saved article does not phone home to the original page every time you open it. It reads off the copy Readplace holds. A source that goes offline next week does not empty your queue.
+
+## The link does not run out
+
+Saved links carry no expiry countdown. The article you keep today opens the same way next month, with the same text and pictures. Your queue holds what you put in it, on your timetable, not the source site's.
+
+## When the source updates, so can your copy
+
+Readplace re-checks saved articles over time. If the source corrects a typo or swaps a photo, your copy can pick up the better version for as long as the page stays up. If the source disappears, your stored copy stays. You get the current good version for as long as one exists, and a kept version once it does not.
+
+## Why this matters to you
+
+A reading list is a note to your future self. Read this later. The worth of that note sits in the days or months between the save and the read. A list that quietly loses items breaks the promise, and you find out at the worst moment, when you finally sit down to read.
+
+Readplace keeps your copy on its side, so a page going dark stays the source site's problem and not yours. If you came over from a service that shut down, the same idea drove those moves too, and you can read the longer story in [the Pocket recovery guide](/blog/pocket-migration) or [the Omnivore writeup](/blog/omnivore-alternative).
+
+Save one article today and open it again next month. [Install the browser extension](https://readplace.com/install) or start at [readplace.com](/).


### PR DESCRIPTION
## What

Adds a new blog post: **"Read It Later, Even After the Original Page Is Gone"** (`saved-articles-outlast-the-original-page.md`).

## Why this topic

Reviewed commits landed on `main` after the most recent published post (`save-articles-with-your-ai-assistant.md`, dated 2026-06-16). The fresh customer-facing changes since then are:

- MCP server, WebMCP, and DNS-AID agent discovery (#575) — already covered by two existing posts (`save-articles-with-your-ai-assistant`, `ai-agents-discover-readplace`).
- Embed kit extracted into a standalone `web-embed` project (#570) — internal refactor, no new capability.
- 7-day verification countdown + account lockout (#561) — account-security mechanics, negative framing for marketing.
- `copy(view): clarify paywall CTA mentions no-expiry access` (3d33ccc) — the freshest customer-facing signal: saved links carry no expiry.

The post builds on that no-expiry signal plus the existing stored-copy mechanics (Readplace fetches and stores its own clean copy and images on its own host). It addresses link rot and disappearing pages, which is strong for SEO/GEO in a space where Pocket and Omnivore both shut down. The angle stays distinct from existing posts: `omnivore-alternative` covers company durability, `saved-articles-keep-their-images` covers images only, this one covers the saved article surviving when the source page changes or goes offline.

## Notes

- Follows the strict writing-style guidelines (short active sentences, plain words, no banned filler, no em dashes or semicolons).
- Deliberately avoids pricing and founding-member language so it does not go stale.
- Internal links to `/blog/pocket-migration` and `/blog/omnivore-alternative` for SEO.
- `pnpm nx run blog-site:check` passes with 100% coverage; the post is discovered and parsed by the existing blog infrastructure (no test changes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuxPCERS3y87mmUmRxrwm8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuxPCERS3y87mmUmRxrwm8)_