### PR TITLE
docs(blog): add post on deciding what to skip when reading

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/deciding-what-not-to-read.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/deciding-what-not-to-read.md
@@ -1,0 +1,51 @@
+---
+title: "The Hard Part of Reading Is Deciding What to Skip"
+description: "Saving an article takes one click. The hard part is choosing which of your saved articles earns your evening. Readplace writes a short summary for each one, so you can triage in a minute and set the rest aside without guilt."
+slug: "deciding-what-not-to-read"
+date: "2026-06-18"
+author: "Fayner Brack"
+keywords: "too many saved articles, reading backlog, what to read next, article summary to decide, read it later triage, deciding what not to read, ai tl;dr, reading list overwhelm, saved articles you forget to read"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Saving an article takes one click. The work starts after, when you decide which saved piece is worth your time tonight. Readplace writes a short summary for every article you save, so you can read three sentences, judge the piece, and skip an hour in a minute. The summary points you to the full text, not away from it. Saved links carry no expiry, so the ones you set aside stay readable next month. You read less of the wrong thing and more of the right thing.
+
+</div>
+</details>
+
+You find five good articles before lunch. You save all five. By Friday the list holds thirty. You read four. The rest sit there, and a small guilt sits with them.
+
+Saving an article takes one click. Reading tools handled that part years ago. The real work starts after the save, when you decide which of the thirty earns your evening. That choice is the hard part, and most reading apps leave you to make it alone.
+
+## Saving was the easy half
+
+Readplace grew out of a personal reading system that ran for ten years. Gmail filters, a database table, and a stack of Reddit automations, all built to save and sort the writing I cared about. Over a decade that pipeline read around 40% of what it pulled in, and shared most of what it read.
+
+The lesson from those years was plain. Saving was the easy half. The hard half was deciding what to leave unread. A reading list that only grows is a list that quietly turns into a chore.
+
+So the question worth asking is not how to save faster. It is how to choose well. How do you tell, in a few seconds, which saved article deserves the next thirty minutes of your attention?
+
+## A summary you can decide from
+
+Readplace writes a short summary for each article you save. You read three sentences and you know if the piece fits your evening. You spend a minute to skip an hour.
+
+The summary is for triage, not replacement. It tells you the shape of the article and points you to the full text, instead of standing in for it. You stay in charge of the reading. The tool just hands you the gist first, so the choice costs you seconds.
+
+This matters most on a busy list. Thirty saved links feel heavy when each one is a mystery. The same thirty feel light when you can scan them, read the summaries, and pick the two that earn your time tonight.
+
+## Set the rest aside without guilt
+
+Some articles you keep without reading them this week. That is fine here. Saved links carry no expiry, so a piece you set aside today opens the same way next month, with the same text and pictures.
+
+You can defer an article without losing it. The ones you skip do not vanish, and the ones you keep do not expire. Your list becomes a place you visit on purpose, not a backlog that nags at you.
+
+Deciding what to skip is a skill, and a good tool should respect it. Readplace shows you the gist first, holds your copy for as long as you want it, and keeps the reader clean, so the piece you do choose gets your full attention.
+
+## Try it on the next article
+
+Pick the next article you almost saved out of habit. Save it, read the short summary, then decide. Often you will skip it, and skip it on purpose. That is the point.
+
+[Install the browser extension](https://readplace.com/install) or start at [readplace.com](/).


### PR DESCRIPTION
## What

New blog post: **"The Hard Part of Reading Is Deciding What to Skip"** at `/blog/deciding-what-not-to-read`.

## Why

Reviewed commits on `main` after the most recent published post (`saved-articles-outlast-the-original-page`, 2026-06-17). The strongest unblogged, externally-relevant change is the refreshed homepage backstory (`23b633f`, 2026-06-18), which reframes the core problem: the bottleneck was never saving articles, it was **deciding what not to read**. That triage angle is engaging, search/GEO-relevant, and ties to a real shipped feature (the AI TL;DR summary) plus no-expiry saved copies.

Deliberately skipped the pricing change (`876f7cc`, $3.99/mo → $49/yr) — pricing/promotion copy dates quickly and confuses readers who see different terms later. Remaining post-cutoff commits are CI fixes, internal analytics enrichment, and minor styling, none suitable for an external post.

## Post details

- 608 words (within the 400–800 target)
- Leads with the customer problem, ends with a clear install CTA
- Follows the strict writing-style guidelines (active voice, short sentences, no banned filler, no em dashes/semicolons in prose)
- No pricing or founding-member references

## Verification

`pnpm nx run blog-site:check` passes: lint, type-check, tests, knip, and 100% coverage. The post is discovered and parsed by the blog module and resolves at `/blog/deciding-what-not-to-read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YByYGJf5yyk9dL9tUAy4R

---
_Generated by [Claude Code](https://claude.ai/code/session_013YByYGJf5yyk9dL9tUAy4R)_