### PR TITLE
docs(blog): add post on AI agents finding Readplace via DNS-AID

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/ai-assistant-finds-readplace-in-dns.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/ai-assistant-finds-readplace-in-dns.md
@@ -1,0 +1,43 @@
+---
+title: "Your AI Assistant Finds Readplace in DNS, Before It Loads a Page"
+description: "Readplace publishes agent-discovery records in DNS, so an AI assistant can find your reading queue's tools the same way a browser finds the site. The zone is signed with DNSSEC, so the agent trusts the answer it gets back."
+slug: "ai-assistant-finds-readplace-in-dns"
+date: "2026-06-19"
+author: "Fayner Brack"
+keywords: "AI agent discovery, DNS-AID, DNS for AI discovery, SVCB record, MCP server discovery, read it later AI agent, agent discovery DNS, DNSSEC, find API from DNS, AI assistant reading list"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Readplace now answers a question in DNS that AI agents used to guess at: where do my reading tools live? Two records under `_agents.readplace.com` point an assistant to the front door and to the save tool. The agent reads DNS, follows the record, and lands on the right page with no setup from you. Readplace signs the zone with DNSSEC, so the agent gets an answer it can verify rather than a forged one. You ask your assistant to save an article, and it finds Readplace the rest of the way.
+
+</div>
+</details>
+
+You tell your AI assistant to save an article for later. First it has to find the right service. Most apps make the assistant guess, or make you paste an address and copy a key by hand. Readplace now answers that question in DNS, the same system that turns a web address into a server.
+
+## A phone book entry for agents
+
+Every time you open a site, your computer asks DNS for its address. DNS is the web's phone book. Readplace adds two extra entries to its own listing, under a name set aside for agents: `_agents.readplace.com`.
+
+The first record, `_index`, sends an agent to the apex. There it reads the discovery files: the OAuth login, the docs written for machines, and the skills index. The second record, `_mcp`, sends the agent to the MCP endpoint, where it picks up the tools to save a link and list your queue. An agent reads DNS, follows the record, and arrives at the right page with no setup from you.
+
+## Why DNS and not just a link
+
+Readplace already advertises its agent tools in an HTTP header on every page. That works once an agent has the page open. DNS works one step earlier. An assistant can ask DNS where Readplace keeps its tools before it loads a single byte of the site. The answer comes back in a few hundred bytes, so the assistant skips a round of trial and error.
+
+## An answer the agent can trust
+
+A phone book helps only if no one tampers with the entries. Readplace signs its DNS zone with DNSSEC. A signed zone lets a resolver check two things: the answer came from Readplace, and it reached the agent unchanged. So when your assistant asks where to save your reading, it gets a reply it can verify, not one a stranger forged to point somewhere else.
+
+This matters for a read-it-later app. The agent is about to act on your account. A trustworthy answer at the discovery step keeps your saved articles going to your queue and nowhere else.
+
+## What this means for your reading
+
+You use Claude, ChatGPT, or another assistant, and you want it to reach your saved articles and act on them. The less setup that takes, the more often you actually do it. With these records in place, an agent finds Readplace on its own, asks for your approval through OAuth, then saves a page to your queue inside the chat. You stop copying links between apps.
+
+This builds on two things Readplace shipped already. Your assistant can [save articles through the MCP server](/blog/save-articles-with-your-ai-assistant), and it reads the [discovery files](/blog/ai-agents-discover-readplace) that describe the API in plain text. The DNS records put those same tools one step closer, so the agent reaches them before it ever opens the site.
+
+Ask your assistant to save your next article, and let it find Readplace the rest of the way. [Install the browser extension](https://readplace.com/install) or start at [readplace.com](/).


### PR DESCRIPTION
## What

New blog post: **"Your AI Assistant Finds Readplace in DNS, Before It Loads a Page"** (`/blog/ai-assistant-finds-readplace-in-dns`, dated 2026-06-19).

## Why this topic

The last published post was 2026-06-17 (`saved-articles-outlast-the-original-page`). Reviewing commits to main after it:

- `feat: switch pricing from $3.99/month to $49/year` — excluded per the standing guidance against pricing/promotion content that dates quickly.
- A batch of `fix(ci)` commits and `chore(web-embed)` Pulumi salt — internal, not customer-facing.
- `feat(hutch): style homepage hr dividers` — too minor for a post.

The strongest customer-facing, differentiating feature in the recent window is the **DNS for AI Discovery (DNS-AID)** work (`a3872d8`, fixed to the canonical zone in `b9d8195`): SVCB records under `_agents.readplace.com` plus DNSSEC signing, so an AI agent can locate Readplace's agent surface straight from DNS. This is distinct from the two existing AI-agent posts:

- `ai-agents-discover-readplace` (06-10) covers the HTTP `Link` header / api-catalog / `llms.txt`.
- `save-articles-with-your-ai-assistant` (06-16) covers the MCP server and WebMCP.

This post covers the DNS layer those two don't, and links to both for internal SEO.

## Editorial

- 400–800 word target, written to the supplied style and anti-AI guidelines (active voice, short sentences, no banned terms, no em dashes/semicolons).
- Leads with the customer benefit (your assistant finds Readplace on its own), explains DNS and DNSSEC in plain words, ends with a clear CTA.
- No pricing or founding-member references.

## Verification

`pnpm nx run blog-site:check` passes — post is discovered and parsed, tests green, coverage 100%. The pre-commit hook ran `nx run-many --target=check --all` (31 projects) successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTFp7aKJvDmcuw5xQKawm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYTFp7aKJvDmcuw5xQKawm)_