### PR TITLE
refactor(test-fixtures): remove plan-bound TODO from verifyScope

### DIFF
--- a/src/packages/test-fixtures/src/providers/oauth/oauth-model.ts
+++ b/src/packages/test-fixtures/src/providers/oauth/oauth-model.ts
@@ -271,9 +271,6 @@ export function createOAuthModel(
 			return true;
 		},
 
-		// TODO: Update this function when scopes are added. Currently returns true
-		// because no scopes are implemented. Once scopes are added, this must
-		// validate that the token has the requested scope(s).
 		async verifyScope(_token: Token, _scope: string | string[]): Promise<boolean> {
 			return true;
 		},


### PR DESCRIPTION
## Audit finding (high priority)

**Rule:** Comments Document Why, Not What — no time/plan-bound comments
**Source:** CLAUDE.md
**File:** \`src/packages/test-fixtures/src/providers/oauth/oauth-model.ts\`

A plan-bound \`TODO\` described future scope-validation work in time-bound language ("Currently returns true", "when scopes are added", "Once scopes are added"). CLAUDE.md forbids such comments: they rot when the code changes, and a condition to revisit belongs in code (a failing test / tracked issue), not a comment.

### Change
Removed the 3-line comment. The no-op intent is already carried by the unused \`_token\`/\`_scope\` parameters and the explicit \`return true\`.

---
🤖 Part of the guidelines & skills audit. One PR per file; this file's only finding was the comment.