### PR TITLE
refactor(hutch): log server startup via HutchLogger in server.main.ts

### DIFF
--- a/projects/hutch/src/runtime/server.main.ts
+++ b/projects/hutch/src/runtime/server.main.ts
@@ -1,8 +1,10 @@
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { createHutchApp } from "./app";
 import { PORT } from "./server";
 
+const logger = HutchLogger.from(consoleLogger);
 const { app } = createHutchApp();
 
 app.listen(PORT, () => {
-	console.log(`Server is running on http://localhost:${PORT}`);
+	logger.info(`Server is running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Audit finding (high priority)

**Rule:** Logging — never use raw `console.*`; composition roots use `HutchLogger.from(consoleLogger)`
**Source:** CLAUDE.md
**File:** `projects/hutch/src/runtime/server.main.ts`

The composition root logged the `app.listen` startup message with raw `console.log`, which CLAUDE.md forbids in application code.

### Change
Created `const logger = HutchLogger.from(consoleLogger)` and routed the startup message through `logger.info(...)`.

---
🤖 Part of the guidelines & skills audit. One PR per file.