### PR TITLE
fix(hutch): remove emoji from onboarding success title

### DIFF
--- a/projects/hutch/src/runtime/web/onboarding/onboarding.template.html
+++ b/projects/hutch/src/runtime/web/onboarding/onboarding.template.html
@@ -5,7 +5,7 @@
       <button type="submit" class="onboarding__dismiss" aria-label="Dismiss" data-test-onboarding-dismiss>&times;</button>
     </form>
     <img class="onboarding__avatar" src="{{founderAvatarUrl}}" alt="Fayner Brack" width="72" height="72">
-    <h2 class="onboarding__success-title">You did it! ✅</h2>
+    <h2 class="onboarding__success-title">You did it!</h2>
     <p class="onboarding__success-message">You're officially one of us. Welcome to Readplace.</p>
   </div>
   {{else}}


### PR DESCRIPTION
## Audit finding (high priority)

**Rule:** No emojis in UI
**Source:** BRAND_GUIDELINES.md
**File:** `projects/hutch/src/runtime/web/onboarding/onboarding.template.html`

The onboarding success heading rendered `You did it! ✅`. The brand guidelines forbid emojis in the product interface (allowed only in social posts / community replies).

### Change
Removed the trailing `✅`. The component test asserts `/You did it!/`, so it remains green.

---
🤖 Part of the guidelines & skills audit. One PR per file.