### PR TITLE
refactor(hutch): trim plan-bound comment on completeStripeSignup helper

### DIFF
--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts
@@ -14,15 +14,9 @@ interface StripeBundle {
 	markPaid: (id: CheckoutSessionId) => void;
 }
 
-/** Drives `GET /auth/checkout/success` directly: creates a Stripe checkout
- * session via the in-memory fake, stores a pending signup keyed by that
- * session id, marks the session paid, then GETs the success URL using a shared
- * agent so the resulting session cookie persists.
- *
- * Phase 1 removed Stripe checkout from `POST /signup` (it's a no-card trial
- * now), so this helper no longer drives through the signup form. The
- * `/auth/checkout/success` endpoint remains live — Phase 2 will create
- * pending signups via `POST /account/subscribe` to feed it again. */
+/** Hits `GET /auth/checkout/success` directly rather than through the signup
+ * form, using a shared supertest agent so the session cookie the success
+ * handler sets persists across the test's later requests. */
 export async function completeStripeSignup(params: {
 	server: Server;
 	auth: AuthBundle;


### PR DESCRIPTION
## Audit finding (high priority)

**Rule:** Comments Document Why, Not What — no time/plan-bound comments
**Source:** CLAUDE.md
**File:** `projects/hutch/src/runtime/web/auth/test-helpers/complete-stripe-signup.ts`

The helper's JSDoc carried (1) a step-by-step "what it does" description and (2) a time-bound `Phase 1 removed … Phase 2 will create …` note — the kind of plan-bound comment that rots as the code evolves.

### Change
Condensed to a single "why" docstring: it hits `GET /auth/checkout/success` directly (not through the signup form) using a shared supertest agent so the success handler's session cookie persists across later requests.

---
🤖 Part of the guidelines & skills audit. One PR per file.