### PR TITLE
refactor(hutch): route e2e-server logging + CI flag through proper APIs

### DIFF
--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -12,7 +12,7 @@ import {
   createFakePublishSaveAnonymousLink,
   createFakeSummaryProvider,
 } from '@packages/test-fixtures'
-import { requireEnv } from '../runtime/domain/require-env'
+import { getEnv, requireEnv } from '../runtime/domain/require-env'
 import { initRefreshArticleIfStale } from '@packages/test-fixtures/providers/article-freshness'
 import type { ExtractPdf, IsBlockedAddress } from '@packages/crawl-article'
 import { CRAWL_PERSONAS, initCrawlArticle, initCrawlFetch } from '@packages/crawl-article'
@@ -31,7 +31,7 @@ const PORT = Number(requireEnv('E2E_PORT'))
 const origin = `http://127.0.0.1:${PORT}`
 const logger = HutchLogger.from(consoleLogger)
 
-const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }))
+const logError = (message: string, error?: Error) => logger.error(message, error)
 /** The e2e harness crawls its own fixtures, all served from the loopback server
  * below, so block nothing — otherwise the SSRF guard refuses every loopback
  * address. Mirrors e2eValidateSaveableUrl relaxing the string-level
@@ -90,7 +90,7 @@ const summary = createFakeSummaryProvider({ readyAfterReads: 3 })
 // and publishUpdateFetchTimestamp) end-to-end. In CI, swap to noopLogger so
 // per-request "in-memory no-op" lines don't flood the build log; locally keep
 // the consoleLogger so the lines are visible for debugging.
-const eventLogger = process.env.CI === 'true' ? noopLogger : logger
+const eventLogger = getEnv('CI') === 'true' ? noopLogger : logger
 const { publishRefreshArticleContent } = initInMemoryRefreshArticleContent({ logger: eventLogger })
 const { publishUpdateFetchTimestamp } = initInMemoryUpdateFetchTimestamp({ logger: eventLogger })
 const { refreshArticleIfStale } = initRefreshArticleIfStale({


### PR DESCRIPTION
## Audit findings (high priority) — 2 in this file

**File:** `projects/hutch/src/e2e/e2e-server.main.ts`

1. **Raw console instead of HutchLogger** (CLAUDE.md, Logging) — `logError` emitted via `console.error`. A `HutchLogger` already exists in this file (`HutchLogger.from(consoleLogger)`); `logError` now delegates to `logger.error`.
2. **Direct process.env access** (CLAUDE.md, Environment Variable Access) — `process.env.CI` read directly. Now `getEnv('CI')` from `domain/require-env` (only `playwright.config.*.ts` is exempt from the rule; this is a composition root).

---
🤖 Part of the guidelines & skills audit. One PR per file (both findings live in this file).