### PR TITLE
refactor(blog-site): log startup via HutchLogger, not raw console

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2242,21 +2242,25 @@ packages:
     resolution: {integrity: sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.5':
     resolution: {integrity: sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.5':
     resolution: {integrity: sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.5':
     resolution: {integrity: sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.5':
     resolution: {integrity: sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   projects/blog-site:
     dependencies:
+      '@packages/hutch-logger':
+        specifier: workspace:*
+        version: link:../../src/packages/hutch-logger
       '@packages/web-shell':
         specifier: workspace:*
         version: link:../../src/packages/web-shell
@@ -2239,25 +2242,21 @@ packages:
     resolution: {integrity: sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.5':
     resolution: {integrity: sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.5':
     resolution: {integrity: sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.5':
     resolution: {integrity: sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.5':
     resolution: {integrity: sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==}

--- a/projects/blog-site/package.json
+++ b/projects/blog-site/package.json
@@ -14,6 +14,7 @@
     "check": "nx run blog-site:check"
   },
   "dependencies": {
+    "@packages/hutch-logger": "workspace:*",
     "@packages/web-shell": "workspace:*",
     "compression": "1.8.1",
     "express": "5.2.1",

--- a/projects/blog-site/src/runtime/lambda.main.ts
+++ b/projects/blog-site/src/runtime/lambda.main.ts
@@ -4,6 +4,7 @@ import express from "express";
 import helmet from "helmet";
 import compression from "compression";
 import serverless from "serverless-http";
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { createBlogApp, PORT } from "./app";
 import { getEnv, requireEnv } from "./require-env";
 
@@ -27,8 +28,9 @@ const application = express()
 	);
 
 if (!lambda) {
+	const logger = HutchLogger.from(consoleLogger);
 	application.listen(PORT, () => {
-		console.log(`blog-site is running on http://localhost:${PORT}`);
+		logger.info(`blog-site is running on http://localhost:${PORT}`);
 	});
 }
 

--- a/projects/blog-site/src/runtime/server.main.ts
+++ b/projects/blog-site/src/runtime/server.main.ts
@@ -1,5 +1,8 @@
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { createBlogApp, PORT } from "./app";
 import { getEnv, requireEnv } from "./require-env";
+
+const logger = HutchLogger.from(consoleLogger);
 
 const app = createBlogApp({
 	staticBaseUrl: requireEnv("STATIC_BASE_URL"),
@@ -7,5 +10,5 @@ const app = createBlogApp({
 });
 
 app.listen(PORT, () => {
-	console.log(`blog-site is running on http://localhost:${PORT}`);
+	logger.info(`blog-site is running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Audit findings (medium priority) — 2 files, grouped

**Rule:** Logging — never use raw `console.*`; composition roots use `HutchLogger.from(consoleLogger)`
**Source:** CLAUDE.md
**Files:** `projects/blog-site/src/runtime/server.main.ts`, `projects/blog-site/src/runtime/lambda.main.ts`

Both composition roots logged their startup line with raw `console.log`.

### Change
Added `@packages/hutch-logger` to blog-site and routed both startup logs through `HutchLogger.from(consoleLogger)`.

### Why grouped (not one-PR-per-file)
Both files need the **same new dependency**, so two separate per-file PRs would conflict on `package.json` / `pnpm-lock.yaml`. Grouping keeps them conflict-free.

---
🤖 Part of the guidelines & skills audit.