### PR TITLE
chore(browser-extension-core): remove leftover CI-probe comment

### DIFF
--- a/projects/browser-extension-core/src/zod-config.ts
+++ b/projects/browser-extension-core/src/zod-config.ts
@@ -1,7 +1,6 @@
 // Zod 4.x JIT-compiles validators with new Function(), which browser extension
 // CSPs block. Zod catches the error and falls back, but Firefox still logs a
 // noisy CSP violation on every popup open. Disabling JIT avoids the attempt.
-// (test 2/4 probe: extension-core edit must publish BOTH chrome and firefox)
 //
 // This module must be imported before any module-level z.object() call so that
 // globalConfig.jitless is set before Zod's $ZodObjectJIT constructor reads it.


### PR DESCRIPTION
## Audit finding (medium priority)

**Rule:** Comments Document Why, Not What — no time/plan-bound comments
**Source:** CLAUDE.md
**File:** `projects/browser-extension-core/src/zod-config.ts`

Line 4 was a stray release-pipeline probe marker (`(test 2/4 probe: extension-core edit must publish BOTH chrome and firefox)`) — one of a set of leftover CI probes across the extension packages. Removed it; the Zod JIT/CSP rationale comments stay.

---
🤖 Part of the guidelines & skills audit. One PR per file.