### PR TITLE
docs(article-store): drop plan-bound comments in dynamodb-article-store

### DIFF
--- a/src/packages/article-store/src/dynamodb-article-store.ts
+++ b/src/packages/article-store/src/dynamodb-article-store.ts
@@ -68,8 +68,6 @@ const AGGREGATE_FIELDS = ArticleAggregateRow.keyof().options;
 /**
  * 1. Legacy rows saved before `pendingSince` existed default to epoch 0 so the
  *    canary's age-gate immediately surfaces them once they cross MIN_AGE_MS.
- *    Fallback is dropped after a follow-up canary scan reports zero legacy
- *    rows still in flight.
  */
 const LEGACY_PENDING_SINCE = new Date(0).toISOString();
 
@@ -77,7 +75,6 @@ const LEGACY_PENDING_SINCE = new Date(0).toISOString();
  * 1. Legacy rows wrote a plain string (free-form, set by save-link-work and
  *    DLQ handlers). Map it onto the closest tagged-union variant so the
  *    reader can render it; new rows write a JSON-encoded discriminated union.
- *    Dropped after a follow-up canary scan reports zero legacy rows.
  */
 function parseCrawlFailureReason(raw: string): import("@packages/article-state-types").CrawlFailureReason {
 	if (raw.startsWith("{")) return CrawlFailureReasonSchema.parse(JSON.parse(raw));


### PR DESCRIPTION
## Audit findings (medium priority) — 2 in this file

**Rule:** Comments Document Why, Not What — no time/plan-bound comments
**Source:** CLAUDE.md
**File:** `src/packages/article-store/src/dynamodb-article-store.ts`

Two doc comments said the legacy-row fallbacks would be *"dropped after a follow-up canary scan reports zero legacy rows"* — plan-bound notes that rot. Removed those sentences; kept the legitimate **why** (legacy rows default to epoch 0; plain-string→union mapping).

**Note:** the L24-33 schema docstring (a *low* 'what-not-why' finding) is intentionally retained — it documents the legacy-compat rationale and the write-ownership boundary, which is genuine *why*, not *what*.

---
🤖 Part of the guidelines & skills audit.