### PR TITLE
docs(hutch-infra-components): de-time-bind event doc comments

### DIFF
--- a/src/packages/hutch-infra-components/src/events.ts
+++ b/src/packages/hutch-infra-components/src/events.ts
@@ -453,8 +453,8 @@ export type UpdateFetchTimestampDetail = z.infer<
 	typeof UpdateFetchTimestampCommand.detailSchema
 >;
 
-/** Broadened in Phase 2 to carry `userId` so handlers can update the row by
- * primary key instead of GSI-querying on `subscriptionId`. Emitted by the
+/** Carries `userId` so handlers can update the row by primary key instead of
+ * GSI-querying on `subscriptionId`. Emitted by the
  * `cancel-subscription` Lambda for every user-initiated cancel (trialing →
  * no `subscriptionId`; active and pending_cancellation → with `subscriptionId`)
  * and by `stripe-webhook-receiver` on `customer.subscription.deleted` for
@@ -630,8 +630,8 @@ export type SendTrialFeedbackEmailDetail = z.infer<
  * `hasSummary` is true only for ready summaries; a skipped summary still
  * succeeds the reader view but carries no summary to announce. The reader-ready
  * fan-out Lambda subscribes and stamps a per-user `succeededAt` for every saver
- * of this URL. `contentSourceTier` is reserved for a future
- * "loaded with a more complete version" notification and is not populated yet. */
+ * of this URL. `contentSourceTier` is optional — it backs a "loaded with a more
+ * complete version" notification, so consumers must tolerate its absence. */
 export const ReaderViewLoadingSucceeded = defineEvent({
 	name: "reader-view-loading-succeeded",
 	source: "hutch.save-link",

--- a/src/packages/hutch-infra-components/src/events.ts
+++ b/src/packages/hutch-infra-components/src/events.ts
@@ -630,8 +630,9 @@ export type SendTrialFeedbackEmailDetail = z.infer<
  * `hasSummary` is true only for ready summaries; a skipped summary still
  * succeeds the reader view but carries no summary to announce. The reader-ready
  * fan-out Lambda subscribes and stamps a per-user `succeededAt` for every saver
- * of this URL. `contentSourceTier` is optional — it backs a "loaded with a more
- * complete version" notification, so consumers must tolerate its absence. */
+ * of this URL. `contentSourceTier` is optional — a reserved slot a "loaded with a
+ * more complete version" notification can use to distinguish tiers — so consumers
+ * must tolerate its absence. */
 export const ReaderViewLoadingSucceeded = defineEvent({
 	name: "reader-view-loading-succeeded",
 	source: "hutch.save-link",


### PR DESCRIPTION
## Audit findings (medium priority) — 2 in this file

**Rule:** Comments Document Why, Not What — no time/plan-bound comments
**Source:** CLAUDE.md
**File:** `src/packages/hutch-infra-components/src/events.ts`

- `Broadened in Phase 2 to carry userId` → phase/change-history reference, rewritten to present-tense (it carries `userId` so handlers update by primary key).
- `reserved for a future … notification and is not populated yet` → time-bound, rewritten to a present-tense invariant (`contentSourceTier` is optional; consumers must tolerate its absence).

---
🤖 Part of the guidelines & skills audit.