### PR TITLE
style(web-shell): use --color-on-brand token for banner white text

### DIFF
--- a/src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.styles.ts
+++ b/src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.styles.ts
@@ -1,7 +1,7 @@
 export const EXTENSION_SUGGESTION_BANNER_STYLES = `
   .extension-suggestion-banner {
     background: linear-gradient(135deg, #2B3A55 0%, #1E2A40 100%);
-    color: #FFFFFF;
+    color: var(--color-on-brand);
     font-size: 14px;
     line-height: 1.5;
     max-height: 0;
@@ -120,7 +120,7 @@ export const EXTENSION_SUGGESTION_BANNER_STYLES = `
 
   .extension-suggestion-banner__inline:hover,
   .extension-suggestion-banner__inline:focus-visible {
-    text-decoration-color: #FFFFFF;
+    text-decoration-color: var(--color-on-brand);
   }
 
   .extension-suggestion-banner__cta {
@@ -162,7 +162,7 @@ export const EXTENSION_SUGGESTION_BANNER_STYLES = `
 
   .extension-suggestion-banner__close:hover,
   .extension-suggestion-banner__close:focus-visible {
-    color: #FFFFFF;
+    color: var(--color-on-brand);
     background: rgba(255, 255, 255, 0.08);
   }
 


### PR DESCRIPTION
## What

Replace three hardcoded `#FFFFFF` literals in `extension-suggestion-banner.styles.ts` with the existing `var(--color-on-brand)` custom property:

- the banner base `color` (white text on the navy surface)
- the inline link `text-decoration-color` on hover/focus
- the close button `color` on hover/focus

## Why

`BRAND_GUIDELINES.md` ("Don't: Hardcode hex values — always use the CSS custom properties") forbids hardcoded hex outside `base.styles.ts`, the declared source of truth. `--color-on-brand` resolves to `#FFFFFF` and is already the semantic token for white text on the brand surface — this file's CTA rule already uses `var(--color-on-brand)`, so this aligns the rest of the file.

- Rule: Hardcode hex values — always use the CSS custom properties
- Source: `BRAND_GUIDELINES.md`
- File: `src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.styles.ts`

## Not changed

The navy hero gradient `linear-gradient(135deg, #2B3A55 0%, #1E2A40 100%)` is left as-is: the brand palette lists Navy with no CSS variable and `base.styles.ts` defines no navy/gradient token, so tokenising it would require editing a second file (introducing a new token) — out of scope for this per-file change.

🤖 Part of the guidelines & skills audit. One PR per file.