### PR TITLE
refactor(firefox-extension): narrow driver via instanceof instead of force cast

### DIFF
--- a/projects/extensions/firefox-extension/src/e2e/login-flow/run.e2e-local.main.ts
+++ b/projects/extensions/firefox-extension/src/e2e/login-flow/run.e2e-local.main.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { Builder, By } from "selenium-webdriver";
-import { Options } from "selenium-webdriver/firefox";
+import { Options, Driver } from "selenium-webdriver/firefox";
 import { FlowRunner, ExtensionStateHandler } from "browser-extension-core/e2e";
 import {
 	createSeleniumElementQueries,
@@ -133,14 +133,8 @@ test("should complete OAuth login flow, save links, and paginate the list", asyn
 			.build();
 
 		try {
-			await (
-				driver as unknown as {
-					installAddon: (
-						path: string,
-						temporary: boolean,
-					) => Promise<void>;
-				}
-			).installAddon(EXTENSION_DIR, true);
+			assert(driver instanceof Driver, "firefox builder must produce a firefox Driver");
+			await driver.installAddon(EXTENSION_DIR, true);
 
 			await driver.get(POPUP_URL);
 


### PR DESCRIPTION
## What

In `projects/extensions/firefox-extension/src/e2e/login-flow/run.e2e-local.main.ts`, the Selenium driver was force-cast to reach `installAddon`:

```ts
await (
  driver as unknown as {
    installAddon: (path: string, temporary: boolean) => Promise<void>;
  }
).installAddon(EXTENSION_DIR, true);
```

This is replaced with a properly-typed narrowing:

```ts
assert(driver instanceof Driver, "firefox builder must produce a firefox Driver");
await driver.installAddon(EXTENSION_DIR, true);
```

`Driver` is imported from the `selenium-webdriver/firefox` module the file already pulls `Options` from.

## Why

The double `as unknown as { ... }` is a compiler-bypassing cast forbidden by the **"Avoid TypeScript Type Assertions (`as`)"** rule in **CLAUDE.md**. It is not one of the documented allowed exceptions (`as const` / isolated Node API wrapper). `installAddon(path, temporary)` is a genuine, typed method on `selenium-webdriver/firefox`'s `Driver` class (`@types/selenium-webdriver` `firefox.d.ts:188`); the cast existed only because `new Builder().build()` is typed as the base `WebDriver`. Narrowing with a real runtime `instanceof Driver` check restores full type checking with no fabricated type. The `assert` (from `node:assert/strict`, already imported) keeps the invariant explicit, and its branch lives inside `node:assert`, so no uncovered branch is introduced.

## Rule
- **Rule:** Avoid TypeScript Type Assertions (`as`) — double `as unknown as`
- **Source:** CLAUDE.md
- **File:** `projects/extensions/firefox-extension/src/e2e/login-flow/run.e2e-local.main.ts`

🤖 Part of the guidelines & skills audit. One PR per file.