### PR TITLE
fix(hutch): use HutchLogger instead of raw console.error in app.ts logError

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -117,7 +117,8 @@ function createPdfDeferralStub(publishStaleCheckRequested: PublishStaleCheckRequ
 
 function initProviders() {
 	const persistence = requireEnv<"prod" | "development">("PERSISTENCE");
-	const logError = (message: string, error?: Error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }));
+	const logger = HutchLogger.from(consoleLogger);
+	const logError = (message: string, error?: Error) => logger.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack }));
 
 	const crawlFetch = initCrawlFetch({ fetch: globalThis.fetch, personas: CRAWL_PERSONAS, isBlocked: isBlockedIpAddress });
 	const staleTtlMs = 86400000;
@@ -522,7 +523,7 @@ export function createHutchApp(deps?: {
 		adminEmails,
 		recrawlServiceToken,
 		baseUrl: appOrigin,
-		logError: (message, error) => console.error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack })),
+		logError: (message, error) => HutchLogger.from(consoleLogger).error(JSON.stringify({ level: "ERROR", timestamp: new Date().toISOString(), message, stack: error?.stack })),
 		oauthModel,
 		validateAccessToken,
 		httpErrorMessageMapping,


### PR DESCRIPTION
## What

Route the two `logError` closures in `projects/hutch/src/runtime/app.ts` (the `initProviders` composition root, line 120, and the `createHutchApp` `createApp` call, line 525) through `HutchLogger.from(consoleLogger)` instead of calling `console.error` directly.

## Why

**Rule:** Logging — "Never use raw `console.log`/`console.error` in application code. In composition roots, create the logger with `HutchLogger.from(consoleLogger)`."

**Source:** `CLAUDE.md`

**File:** `projects/hutch/src/runtime/app.ts`

The file already imports `HutchLogger` and `consoleLogger` (line 89) and uses `HutchLogger` elsewhere in the same composition root (the changelog banner, parse-error, bot-defense, conversion, and analytics loggers). Only the two `logError` closures bypassed it with raw `console.error`. The whole-file `c8 ignore` covers coverage, not logging, so it does not exempt the rule.

## Change

Both closures now call `HutchLogger.from(consoleLogger).error(...)`. The `JSON.stringify({ level, timestamp, message, stack })` payload is unchanged and is still written to `console.error` (via `consoleLogger.error`), so runtime output is identical. The `logError: (message: string, error?: Error) => void` signature consumed by `server.ts` is unchanged, so the change is contained to this file.

## Not addressed here

The `getEnv("PORT") || "3000"` fallback (lines 316, 483, 545) also violates the Environment Variable Access rule but is deferred: the correct `requireEnv("PORT")` fix forces PORT to be set across local dev, test harnesses, CI, and Pulumi/Lambda config, which ripples beyond this file. It belongs in a dedicated PR.

🤖 Part of the guidelines & skills audit. One PR per file.