### PR TITLE
fix(auth): use "I" not "we" in account-locked copy

### DIFF
--- a/projects/hutch/src/runtime/web/auth/account-locked.template.html
+++ b/projects/hutch/src/runtime/web/auth/account-locked.template.html
@@ -1,7 +1,7 @@
     <main class="auth-page">
       <div class="auth-card">
         <h1 class="auth-card__title">Your account is locked</h1>
-        <p class="auth-card__subtitle">Your email was never verified within 7 days of signing up, so your account is locked. Email <a class="auth-card__link" href="mailto:{{contactEmail}}">{{contactEmail}}</a> and we'll restore your access.</p>
+        <p class="auth-card__subtitle">Your email was never verified within 7 days of signing up, so your account is locked. Email <a class="auth-card__link" href="mailto:{{contactEmail}}">{{contactEmail}}</a> and I'll restore your access.</p>
         <form method="POST" action="/logout">
           <button class="auth-form__submit" type="submit">Sign out</button>
         </form>


### PR DESCRIPTION
## What

Change the account-locked page subtitle from "we'll restore your access" to "I'll restore your access".

## Why

The brand voice rule **"Use 'I' not 'we.' Readplace is solo-built. 'I' is more honest and personal."** (source: `BRAND_GUIDELINES.md`, Voice & Copy → Writing Principles) requires first-person-singular voice for actions the author/Readplace performs. The phrase "we'll restore your access" refers to the author restoring access, so it should read "I'll".

## Change

- File: `projects/hutch/src/runtime/web/auth/account-locked.template.html`
- `…and we'll restore your access.` → `…and I'll restore your access.`

🤖 Part of the guidelines & skills audit. One PR per file.