### PR TITLE
fix(auth): use "I" not "we" in forgot-password copy

### DIFF
--- a/projects/hutch/src/runtime/web/auth/forgot-password.template.html
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.template.html
@@ -6,7 +6,7 @@
         <a class="auth-form__submit" href="{{track '/login' source='auth-forgot' content='back-to-login'}}">Back to login</a>
         {{else}}
         <h1 class="auth-card__title">Forgot your password?</h1>
-        <p class="auth-card__subtitle">Enter your email and we'll send you a link to reset your password</p>
+        <p class="auth-card__subtitle">Enter your email and I'll send you a link to reset your password</p>
         {{#if globalError}}<div class="auth-form__global-error" data-test-global-error>{{globalError}}</div>{{/if}}
         <form class="auth-form" method="POST" action="/forgot-password" data-test-form="forgot-password">
           <div class="auth-form__field">


### PR DESCRIPTION
## What

Change the forgot-password subtitle from "Enter your email and we'll send you a link to reset your password" to "Enter your email and I'll send you a link to reset your password".

## Why

The brand voice rule states: **"Use 'I' not 'we.' Readplace is solo-built. 'I' is more honest and personal."** The "Don't" quick reference reiterates: *Use "we" — Readplace is solo-built; use "I" or speak from the product's perspective.*

The user-facing copy used "we'll", where "we" refers to the product/author sending the reset email — exactly the case the rule covers.

- **Rule:** Use "I" not "we" (solo-built voice)
- **Source:** `BRAND_GUIDELINES.md` (Voice & Copy → Writing Principles; Do's and Don'ts)
- **File:** `projects/hutch/src/runtime/web/auth/forgot-password.template.html` (line 9)
- **Change:** `we'll` → `I'll`

🤖 Part of the guidelines & skills audit. One PR per file.