### PR TITLE
fix(hutch): use "I" not "we" in export-preparing copy

### DIFF
--- a/projects/hutch/src/runtime/web/pages/export/export-preparing.template.html
+++ b/projects/hutch/src/runtime/web/pages/export/export-preparing.template.html
@@ -1,11 +1,11 @@
     <main class="export" data-test-export-preparing>
       <div class="export__header">
-        <h1 class="export__title">We're preparing your export</h1>
+        <h1 class="export__title">I'm preparing your export</h1>
         <p class="export__subtitle">Check your inbox shortly.</p>
       </div>
 
       <section class="export__section">
-        <p class="export__text">Building your archive can take a few minutes if you have a lot of saved articles. We'll email you a link as soon as it's ready.</p>
+        <p class="export__text">Building your archive can take a few minutes if you have a lot of saved articles. I'll email you a link as soon as it's ready.</p>
         <p class="export__text">The download link will be valid for <strong>{{ttlDays}} days</strong>.</p>
       </section>
 


### PR DESCRIPTION
## What

Update first-person-plural copy to first-person-singular on the export-preparing page.

- `projects/hutch/src/runtime/web/pages/export/export-preparing.template.html`
  - Heading: "We're preparing your export" → "I'm preparing your export"
  - Body: "We'll email you a link as soon as it's ready." → "I'll email you a link as soon as it's ready."

## Why

BRAND_GUIDELINES Voice & Copy: **"Use 'I' not 'we.' Readplace is solo-built. 'I' is more honest and personal."** Both phrases refer to the author/system, not the user plus author, so the singular form is correct.

**Source:** BRAND_GUIDELINES.md

🤖 Part of the guidelines & skills audit. One PR per file.