### PR TITLE
fix(export): use "I" not "we" in export copy

### DIFF
--- a/projects/hutch/src/runtime/web/pages/export/export.template.html
+++ b/projects/hutch/src/runtime/web/pages/export/export.template.html
@@ -21,7 +21,7 @@
 
       <section class="export__section">
         <h2 class="export__section-title">How it works</h2>
-        <p class="export__text">We'll prepare your export in the background and email you a download link when it's ready. The link is valid for <strong>{{ttlDays}} days</strong>.</p>
+        <p class="export__text">I'll prepare your export in the background and email you a download link when it's ready. The link is valid for <strong>{{ttlDays}} days</strong>.</p>
       </section>
 
       <form action="{{track '/export/start' source='export' content='start'}}" method="POST" class="export__action">


### PR DESCRIPTION
## What

The export page's "How it works" copy used first-person-plural:

> We'll prepare your export in the background and email you a download link when it's ready.

Changed to:

> I'll prepare your export in the background and email you a download link when it's ready.

## Why

`BRAND_GUIDELINES.md` (Voice & Copy → Writing Principles) states: **"Use 'I' not 'we.' Readplace is solo-built. 'I' is more honest and personal."** The Do's and Don'ts quick reference also explicitly forbids using "we". This copy is spoken in the author/product's voice to the user, so first-person-singular is correct.

- **Rule:** Use "I" not "we" — Readplace is solo-built
- **Source:** `BRAND_GUIDELINES.md`
- **File:** `projects/hutch/src/runtime/web/pages/export/export.template.html` (line 24)
- **Change:** "We'll prepare your export…" → "I'll prepare your export…"

🤖 Part of the guidelines & skills audit. One PR per file.