### PR TITLE
style(hutch): remove plan-bound publish-probe comment from founding-progress css

### DIFF
--- a/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.styles.css
+++ b/projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.styles.css
@@ -2,7 +2,6 @@
   max-width: 480px;
   margin: 0 auto 32px;
   text-align: center;
-  /* tag-based publish probe (test 1/4): hutch-only edit must not publish either extension */
 }
 
 .founding-progress__bar {


### PR DESCRIPTION
## What

Remove the transient publish-probe comment from `.founding-progress` in `projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.styles.css`:

```css
/* tag-based publish probe (test 1/4): hutch-only edit must not publish either extension */
```

## Why

CLAUDE.md's **"Comments Document Why, Not What"** rule forbids time-bound and plan-bound comments — "leftover notes from an implementation plan ('this is a test to do X, remove when Y is concluded'), references to the current task or PR". This comment is a publish-probe note ("test 1/4") describing an experiment, not the styling it sits inside. It conveys nothing about the CSS rule and will rot.

- **Rule:** Comments Document Why, Not What (no time/plan-bound comments)
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/runtime/web/shared/founding-progress/founding-progress.styles.css`
- **Change:** Delete the plan-bound comment line; the three `.founding-progress` properties are unchanged.

🤖 Part of the guidelines & skills audit. One PR per file.