### PR TITLE
refactor(auth): name session TTL constant instead of what-comment

### DIFF
--- a/projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts
+++ b/projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts
@@ -41,6 +41,8 @@ const UserRow = z.object({
 	userIdPrefix: dynamoField(z.string()),
 });
 
+const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 const SessionRow = z.object({
 	sessionId: z.string(),
 	userId: UserIdSchema,
@@ -183,7 +185,7 @@ export function initDynamoDbAuth(deps: {
 
 	const createSession: CreateSession = async ({ userId, emailVerified }) => {
 		const sessionId = randomBytes(32).toString("hex");
-		const expiresAt = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60; // 7 days in seconds (TTL)
+		const expiresAt = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
 
 		await sessions.put({
 			Item: { sessionId, userId, emailVerified, expiresAt },


### PR DESCRIPTION
## What

Replace the inline what-comment on the DynamoDB session expiry with a named constant.

```ts
// before
const expiresAt = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60; // 7 days in seconds (TTL)

// after
const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
// ...
const expiresAt = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
```

## Why

**Rule:** "Comments Document Why, Not What" — source: `CLAUDE.md`.

The inline comment `// 7 days in seconds (TTL)` restated what the arithmetic computes. A named constant carries the meaning in code instead, which the guideline prefers over a what-comment.

## File

`projects/hutch/src/runtime/providers/auth/dynamodb-auth.ts`

No behaviour change — the TTL value is unchanged.

🤖 Part of the guidelines & skills audit. One PR per file.