### PR TITLE
docs: remove what-comment on extensionInstallUrlIfMissing

### DIFF
--- a/projects/hutch/src/runtime/web/onboarding/extension-install.ts
+++ b/projects/hutch/src/runtime/web/onboarding/extension-install.ts
@@ -29,7 +29,6 @@ export function buildExtensionInstallUrl(browser: BrowserName): string {
 	return INSTALL_URLS[browser];
 }
 
-/** Install URL the reader-failed slot should link to, or undefined when the user already has the extension. */
 export function extensionInstallUrlIfMissing(req: Request): string | undefined {
 	if (isExtensionInstalled(req)) return undefined;
 	return buildExtensionInstallUrl(detectBrowser(req));


### PR DESCRIPTION
## What

Remove the doc comment on `extensionInstallUrlIfMissing` in `projects/hutch/src/runtime/web/onboarding/extension-install.ts`:

```
/** Install URL the reader-failed slot should link to, or undefined when the user already has the extension. */
```

## Why

- **Rule:** "Comments Document Why, Not What" — an approved comment explains *why*, never *what*.
- **Source:** CLAUDE.md
- The comment restates behaviour already evident from the code: the function name (`extensionInstallUrlIfMissing`), the return type (`string | undefined`), and the two-line body all convey "the install URL, or undefined when the extension is installed". It adds no *why*, so it is removed rather than rewritten.

The genuine why-comment on `isExtensionInstalled` (server-only liveness cookie, not yet expired) is left in place.

🤖 Part of the guidelines & skills audit. One PR per file.