### PR TITLE
docs(reader-slot): drop plan-bound mediaType follow-up comment

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.ts
@@ -42,10 +42,7 @@ export interface ReaderSlotInput {
  * backend uses with `contentType` + `bodyBytes` signals at fetch time. Here
  * we only have the URL pre-fetch, so we pass the `pathname` signal alone;
  * `isPDF` treats `pathname` as the weakest signal and a false negative just
- * shows the standard pending message. When the article aggregate gains a
- * persisted `mediaType` field (follow-up), the hint will read that instead
- * so it stays consistent with the parser branch even for PDF URLs without
- * a `.pdf` suffix and for future uploaded-PDF flows that have no URL. */
+ * shows the standard pending message. */
 const PDF_LOADING_HINT =
 	"We optimise for accuracy over slop — low-quality PDFs may produce some optical scan gibberish.";
 


### PR DESCRIPTION
## What

Remove the plan-bound sentence from the `PDF_LOADING_HINT` comment in `projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-slot.component.ts`.

## Why

**Rule:** "Comments Document Why, Not What" — *Do not leave time-bound or plan-bound comments in the code* (references to a future task such as "(follow-up)").
**Source:** `CLAUDE.md`

The comment read:

> When the article aggregate gains a persisted `mediaType` field (follow-up), the hint will read that instead so it stays consistent with the parser branch even for PDF URLs without a `.pdf` suffix and for future uploaded-PDF flows that have no URL.

This is a plan-bound note describing work that may or may not happen. Such comments rot when the surrounding code changes. If the intent genuinely needs revisiting it belongs in a tracked issue, not a comment.

## Change

Trimmed only the future-looking sentence. The remaining comment still explains why `isPDF` is used, why only the `pathname` signal is passed pre-fetch, and why a false negative is harmless (falls back to the standard pending message). No behavioural, type, lint, or coverage impact.

🤖 Part of the guidelines & skills audit. One PR per file.