### PR TITLE
refactor(e2e): drop `as` cast in auth-actions loadedAt evaluate

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/auth-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/auth-actions.ts
@@ -41,7 +41,7 @@ export function createAuthActions(
         await page.locator('#password').fill(data.password)
         await page.locator('#confirmPassword').fill(data.password)
         await page.locator('input[name="loadedAt"]').evaluate(
-          (el) => { (el as HTMLInputElement).value = String(Date.now() - 5000) },
+          (el: HTMLInputElement) => { el.value = String(Date.now() - 5000) },
         )
         await clickAndWaitForPageReload(
           page,


### PR DESCRIPTION
## What

Replace a TypeScript type assertion in `projects/hutch/src/e2e/queue-flow/auth-actions.ts` with a typed Playwright `evaluate` callback parameter.

```ts
// Before
await page.locator('input[name="loadedAt"]').evaluate(
  (el) => { (el as HTMLInputElement).value = String(Date.now() - 5000) },
)

// After
await page.locator('input[name="loadedAt"]').evaluate(
  (el: HTMLInputElement) => { el.value = String(Date.now() - 5000) },
)
```

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`)
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/e2e/queue-flow/auth-actions.ts` (lines 43-44)

`(el as HTMLInputElement)` is a type assertion that bypasses the compiler to reach `.value`. It is not one of the allowed exceptions (`as const`, isolated Node API wrappers). Playwright's `locator.evaluate` accepts a typed callback, so typing the parameter as `HTMLInputElement` is the compiler-safe alternative — an upstream type change becomes a compile error instead of being silently hidden. No runtime behaviour or coverage shape changes.

🤖 Part of the guidelines & skills audit. One PR per file.