### PR TITLE
refactor(hutch): route backfill CLI logging through HutchLogger

### DIFF
--- a/projects/hutch/src/runtime/providers/auth/backfill-registered-at.cli.main.ts
+++ b/projects/hutch/src/runtime/providers/auth/backfill-registered-at.cli.main.ts
@@ -1,4 +1,5 @@
 /* c8 ignore start -- one-off backfill script, run manually against staging then prod */
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import {
 	ConditionalCheckFailedException,
 	createDynamoDocumentClient,
@@ -7,6 +8,8 @@ import {
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import { requireEnv } from "../../domain/require-env";
+
+const logger = HutchLogger.from(consoleLogger);
 
 const BackfillRow = z.object({
 	email: z.string(),
@@ -19,7 +22,7 @@ async function main(): Promise<void> {
 	const users = defineDynamoTable({ client, tableName, schema: BackfillRow });
 	const now = new Date().toISOString();
 
-	console.log(`Backfilling registeredAt = ${now} on table ${tableName}`);
+	logger.info(`Backfilling registeredAt = ${now} on table ${tableName}`);
 
 	const { items } = await users.scan({
 		ProjectionExpression: "email, registeredAt",
@@ -50,13 +53,13 @@ async function main(): Promise<void> {
 		}
 	}
 
-	console.log(
+	logger.info(
 		`Done. Scanned ${items.length} rows, set registeredAt on ${updatedTotal}, ${alreadySetTotal} already had a value.`,
 	);
 }
 
 main().catch((err) => {
-	console.error("Backfill failed:", err);
+	logger.error("Backfill failed:", err);
 	process.exit(1);
 });
 /* c8 ignore stop */


### PR DESCRIPTION
## What

Replace raw `console.log`/`console.error` in `projects/hutch/src/runtime/providers/auth/backfill-registered-at.cli.main.ts` with a `HutchLogger`.

## Why

CLAUDE.md **Logging** rule (source: `CLAUDE.md`): "Never use raw `console.log`/`console.error` in application code. In composition roots, create the logger with `HutchLogger.from(consoleLogger)`." This CLI main is application code and was logging via raw console at three sites (lines 22, 53-55, 59).

## Change

- Import `{ HutchLogger, consoleLogger }` from `@packages/hutch-logger` and construct `const logger = HutchLogger.from(consoleLogger)` at module scope, mirroring the established pattern in sibling `*.main.ts` composition roots (e.g. `schedule-trial-feedback-email.main.ts`).
- `console.log(...)` -> `logger.info(...)` for both progress messages.
- `console.error("Backfill failed:", err)` -> `logger.error("Backfill failed:", err)` (`HutchLogger.error` is `(...args: unknown[]) => void`, so this is a drop-in).

Single-file change. The file is already wrapped in `/* c8 ignore start/stop */`, so coverage is unaffected and no new tests are required.

🤖 Part of the guidelines & skills audit. One PR per file.