### PR TITLE
fix(hutch): remove emoji from trial-feedback email copy

### DIFF
--- a/projects/hutch/src/runtime/web/auth/trial-feedback-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-feedback-email.test.ts
@@ -30,7 +30,9 @@ describe("TrialFeedbackEmail", () => {
 
 		it("contains no emoji", () => {
 			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			const html = TrialFeedbackEmail(baseParams).to("text/html");
 			expect(text).not.toMatch(/\p{Extended_Pictographic}/u);
+			expect(html).not.toMatch(/\p{Extended_Pictographic}/u);
 		});
 
 		it("contains exactly one question mark — the single 'what was missing?'", () => {

--- a/projects/hutch/src/runtime/web/auth/trial-feedback-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-feedback-email.test.ts
@@ -28,6 +28,11 @@ describe("TrialFeedbackEmail", () => {
 			expect(text).not.toContain("!");
 		});
 
+		it("contains no emoji", () => {
+			const text = TrialFeedbackEmail(baseParams).to("text/plain");
+			expect(text).not.toMatch(/\p{Extended_Pictographic}/u);
+		});
+
 		it("contains exactly one question mark — the single 'what was missing?'", () => {
 			const text = TrialFeedbackEmail(baseParams).to("text/plain");
 			const questionMarks = text.match(/\?/g) ?? [];

--- a/projects/hutch/src/runtime/web/auth/trial-feedback-email.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-feedback-email.ts
@@ -36,7 +36,7 @@ function bodyParagraphs(clause: string): string[] {
 	return [
 		`You started a trial of Readplace${clause} and decided not to continue. Which is completely fine. That decision is one of the most useful things I can learn from right now, so I'm asking directly: what was missing?`,
 		"I'm not trying to change your mind or sell you anything. I'd rather know the real reason it didn't earn a place in how you read — a missing feature, the price, something that didn't work, or just that it didn't fit.",
-		"The honest answer helps more than being nice. A sentence is good enough, and there's nothing to click. I respond to ALL replies personally, this is my promise 🤝 :D",
+		"The honest answer helps more than being nice. A sentence is good enough, and there's nothing to click. I respond to ALL replies personally, this is my promise.",
 	];
 }
 


### PR DESCRIPTION
## Audit finding (low priority)

**Rule:** No emojis in product copy
**Source:** BRAND_GUIDELINES.md
**File:** `projects/hutch/src/runtime/web/auth/trial-feedback-email.ts`

The trial-feedback email body ended a sentence with `🤝 :D`. The brand guidelines forbid emojis/playful punctuation in product copy.

### Change
Removed ` 🤝 :D` and closed the sentence with a period. The wording is otherwise unchanged (minimal edit; the proposal's broader rephrase was not applied).

🤖 Part of the guidelines & skills audit. One PR per file.
