### PR TITLE
refactor(hutch): render account actions as forms, drop isLink branch

### DIFF
--- a/projects/hutch/src/runtime/web/pages/account/account.styles.css
+++ b/projects/hutch/src/runtime/web/pages/account/account.styles.css
@@ -85,7 +85,6 @@
 /* purgecss-ignore-start: action variants are interpolated from AccountAction.variant in account.template.html */
 .account-card__action {
   display: inline-flex;
-  text-decoration: none;
   cursor: pointer;
   border: 0;
   font-family: inherit;

--- a/projects/hutch/src/runtime/web/pages/account/account.template.html
+++ b/projects/hutch/src/runtime/web/pages/account/account.template.html
@@ -18,17 +18,11 @@
         {{/if}}
         <div class="account-card__actions">
           {{#each actions}}
-          {{#if isLink}}
-          <a class="account-card__action account-card__action--{{variant}}"
-             href="{{href}}"
-             data-test-account-action="{{key}}">{{name}}</a>
-          {{else}}
-          <form method="POST" action="{{href}}" class="account-card__action-form"
+          <form method="{{method}}" action="{{href}}" class="account-card__action-form"
                 hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none"
                 data-test-account-action="{{key}}">
             <button type="submit" class="account-card__action account-card__action--{{variant}}">{{name}}</button>
           </form>
-          {{/if}}
           {{/each}}
         </div>
       </section>

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
@@ -66,7 +66,6 @@ describe("toAccountViewModel — actions", () => {
 		assert.equal(vm.actions[0].variant, "destructive");
 		assert.equal(vm.actions[0].method, "POST");
 		assert.equal(vm.actions[0].href, "/account/cancel?utm_source=account&utm_medium=internal&utm_content=cancel-form");
-		assert.equal(vm.actions[0].isLink, false);
 	});
 
 	it("active paid users with cancelling=1 get no actions — the Cancel command is already in flight", () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
@@ -23,9 +23,8 @@ export interface AccountAction {
 	key: AccountActionKey;
 	name: string;
 	variant: AccountActionVariant;
-	method: "GET" | "POST";
+	method: "POST";
 	href: string;
-	isLink: boolean;
 }
 
 export interface AccountViewModel {
@@ -70,11 +69,10 @@ export function parseAccountQuery(query: Record<string, unknown> | undefined): A
 	};
 }
 
-function action(input: Omit<AccountAction, "isLink">): AccountAction {
+function action(input: AccountAction): AccountAction {
 	return {
 		...input,
 		href: withInternalTracking(input.href, { source: "account", content: input.key }),
-		isLink: input.method === "GET",
 	};
 }
 


### PR DESCRIPTION
## Audit findings — Forms Everywhere (2 × high + 1 × medium)

**Rule:** Forms Everywhere — Don't Split Items Into `<a>` vs `<form>`
**Source:** web/SKILL.md (+ "No Defensive Checks Without Valid Tests")
**Files:** `account.template.html`, `account.view-model.ts`, `account.view-model.test.ts`

The web skill forbids an `isLink: method === "GET"` discriminator that branches the action template between `<a>` and `<form>`. `account.*` did exactly that — and since every account action is `method: "POST"`, the `<a>` branch and the `"GET"` arm of the union were **dead, untested** code.

### Change
- **Template:** collapsed `{{#if isLink}}<a>…{{else}}<form>…{{/if}}` to one shape: `<form method="{{method}}" action="{{href}}"><button>{{name}}</button></form>`.
- **View-model:** removed `AccountAction.isLink`; narrowed `method` to `"POST"` (the GET arm was unreachable).
- **Test:** removed the `isLink` assertion that pinned the deleted field.

Rendered output for the existing POST actions is unchanged (they already rendered as `<form>`), so the route tests are unaffected.

🤖 Part of the guidelines & skills audit (bucket C — theme refactors).
