### PR TITLE
refactor(hutch): route domain logger through HutchLogger

### DIFF
--- a/projects/hutch/src/runtime/domain/logger.ts
+++ b/projects/hutch/src/runtime/domain/logger.ts
@@ -1,26 +1,34 @@
+import { HutchLogger } from "@packages/hutch-logger";
+
 export interface Logger {
 	info: (message: string) => void;
 	error: (message: string, error?: Error) => void;
 }
 
-export const logger = (): Logger => ({
-	info: (message: string) => {
-		console.log(
-			JSON.stringify({
+interface LogLine {
+	level: "INFO" | "ERROR";
+	timestamp: string;
+	message: string;
+	stack?: string;
+}
+
+export const logger = (): Logger => {
+	const sink = HutchLogger.fromJSON<LogLine>();
+	return {
+		info: (message: string) => {
+			sink.info({
 				level: "INFO",
 				timestamp: new Date().toISOString(),
 				message,
-			}),
-		);
-	},
-	error: (message: string, error?: Error) => {
-		console.error(
-			JSON.stringify({
+			});
+		},
+		error: (message: string, error?: Error) => {
+			sink.error({
 				level: "ERROR",
 				timestamp: new Date().toISOString(),
 				message,
 				stack: error?.stack,
-			}),
-		);
-	},
-});
+			});
+		},
+	};
+};


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/domain/logger.ts` defined its own `logger()` factory that called raw `console.log` / `console.error` directly. This is application code (imported by `lambda.main.ts` and `app.ts`), so it violates the **Logging** rule in `CLAUDE.md`:

> Use `HutchLogger` from `@packages/hutch-logger` for all logging. Never use raw `console.log`/`console.error` in application code.

## Change

Both `info` and `error` now delegate to `HutchLogger.fromJSON<LogLine>()`, which serializes the structured JSON line to `console.log` / `console.error` internally. The emitted JSON shape (`level`, `timestamp`, `message`, optional `stack`) and the exactly-once console call per invocation are preserved.

## Why it stays green

- `Logger` interface and `logger()` signature are unchanged, so callers `lambda.main.ts` and `app.ts` are untouched.
- `logger.test.ts` asserts the JSON shape and one `console.log`/`console.error` call each; `fromJSON` produces the identical output, so no test edits are required.
- `@packages/hutch-logger` is already a declared workspace dependency of the hutch project.

## Source

- Rule: "Never use raw console.log/console.error in application code" (`CLAUDE.md`, Logging)
- File: `projects/hutch/src/runtime/domain/logger.ts`

🤖 Part of the guidelines & skills audit.