### PR TITLE
fix(email): log via injected HutchLogger instead of raw console.log

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -435,7 +435,7 @@ function initProviders() {
 		reverseScheduledCancellation: devStripeSubscriptions.reverseScheduledCancellation,
 		stripePriceId: "price_dev_default",
 
-		...initLogEmail(),
+		...initLogEmail({ logger: HutchLogger.from(consoleLogger) }),
 		...initInMemoryEmailVerification(),
 		...initInMemoryPasswordReset(),
 		createCheckoutSession: devStripe.createCheckoutSession,

--- a/projects/hutch/src/runtime/providers/email/log-email.test.ts
+++ b/projects/hutch/src/runtime/providers/email/log-email.test.ts
@@ -1,9 +1,11 @@
+import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initLogEmail } from "./log-email";
 
 describe("initLogEmail", () => {
-	it("logs the email message to console", async () => {
-		const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-		const { sendEmail } = initLogEmail();
+	it("logs the email message through the injected logger", async () => {
+		const infoSpy = jest.fn();
+		const logger = HutchLogger.from({ ...noopLogger, info: infoSpy });
+		const { sendEmail } = initLogEmail({ logger });
 
 		await sendEmail({
 			from: "sender@example.com",
@@ -12,7 +14,7 @@ describe("initLogEmail", () => {
 			html: "<p>Test</p>",
 		});
 
-		expect(consoleSpy).toHaveBeenCalledWith("[Email]", {
+		expect(infoSpy).toHaveBeenCalledWith("[Email]", {
 			from: "sender@example.com",
 			to: "recipient@example.com",
 			bcc: undefined,
@@ -21,7 +23,5 @@ describe("initLogEmail", () => {
 			html: "<p>Test</p>",
 			text: undefined,
 		});
-
-		consoleSpy.mockRestore();
 	});
 });

--- a/projects/hutch/src/runtime/providers/email/log-email.ts
+++ b/projects/hutch/src/runtime/providers/email/log-email.ts
@@ -1,8 +1,10 @@
+import type { HutchLogger } from "@packages/hutch-logger";
 import type { SendEmail } from "@packages/provider-contracts/email";
 
-export function initLogEmail(): { sendEmail: SendEmail } {
+export function initLogEmail(deps: { logger: HutchLogger }): { sendEmail: SendEmail } {
+	const { logger } = deps;
 	const sendEmail: SendEmail = async (message) => {
-		console.log("[Email]", {
+		logger.info("[Email]", {
 			from: message.from,
 			to: message.to,
 			bcc: message.bcc,


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/providers/email/log-email.ts` logged the email payload with raw `console.log`.

## Why

CLAUDE.md (Logging) requires: "Use `HutchLogger` from `@packages/hutch-logger` for all logging. Never use raw `console.log`/`console.error` in application code." This file is a production provider under `runtime/providers` (not test code), so the raw `console.log` is a direct violation.

## Change

- `log-email.ts`: `initLogEmail` now takes a required `{ logger: HutchLogger }` dependency (no default, per the "No Default Noop Logger in Production Code" rule) and logs via `logger.info`.
- `app.ts` (composition root): pass `{ logger: HutchLogger.from(consoleLogger) }` — `consoleLogger` and `HutchLogger` are already imported here.
- `log-email.test.ts`: inject a fake logger and assert positively that `logger.info` is called with the email payload, replacing the previous `console.log` spy.

- Rule: Logging — use HutchLogger, never raw console
- Source: CLAUDE.md
- File: projects/hutch/src/runtime/providers/email/log-email.ts

🤖 Part of the guidelines & skills audit.