### PR TITLE
fix(admin): move recrawl mutations off GET to POST-Redirect-GET

### DIFF
--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts
@@ -12,6 +12,31 @@ import { RECRAWL_STYLES } from "./recrawl.styles";
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
 
+// POST-Redirect-GET: the recrawl is a state mutation, so the operator's
+// browser submits it via POST instead of firing it on the read-only GET.
+const RECRAWL_TRIGGER_SCRIPT = `
+<script>
+	(function () {
+		function run() {
+			var form = document.querySelector('[data-auto-submit]');
+			if (form) form.requestSubmit();
+		}
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', run, { once: true });
+		} else {
+			run();
+		}
+	})();
+</script>
+`;
+
+function renderRecrawlForm(action: string | undefined): string {
+	if (action === undefined) {
+		return "";
+	}
+	return `<form method="POST" action="${action}" data-auto-submit data-test-admin-recrawl-trigger></form>`;
+}
+
 /**
  * Both the initial SSR <title> and the OOB <title> swap emitted by recrawl
  * polls have to use the same format — otherwise the browser tab flickers
@@ -35,6 +60,7 @@ export interface AdminRecrawlPageInput {
 	contentSourceTier?: "tier-0" | "tier-1";
 	extensionInstallUrl?: string;
 	appOrigin: string;
+	recrawlFormAction?: string;
 }
 
 /**
@@ -68,7 +94,10 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 	});
 
 	const tierBadge = renderTierBadge(input.contentSourceTier);
-	const content = `<main class="admin-recrawl" data-test-admin-recrawl>${tierBadge}<article class="admin-recrawl__body">${innerContent}</article></main>`;
+	const recrawlForm = renderRecrawlForm(input.recrawlFormAction);
+	const content = `<main class="admin-recrawl" data-test-admin-recrawl>${tierBadge}${recrawlForm}<article class="admin-recrawl__body">${innerContent}</article></main>`;
+	const triggerScript =
+		input.recrawlFormAction === undefined ? "" : RECRAWL_TRIGGER_SCRIPT;
 
 	return {
 		seo: {
@@ -80,7 +109,7 @@ export function AdminRecrawlPage(input: AdminRecrawlPageInput): PageBody {
 		styles: RECRAWL_STYLES,
 		bodyClass: "page-admin-recrawl",
 		content: { html: content },
-		scripts: PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT,
+		scripts: PROGRESS_BAR_SCRIPT + READER_IFRAME_SCRIPT + triggerScript,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import type { NextFunction, Request, Response, Router } from "express";
 import express from "express";
 import { z } from "zod";
@@ -86,7 +85,39 @@ function handleLanding(deps: AdminRecrawlDependencies) {
 	};
 }
 
-function handleRecrawlArticle(
+async function resolveArticleUrl(
+	deps: AdminRecrawlDependencies,
+	req: Request<{ splat: string[] }>,
+	res: Response,
+): Promise<string | undefined> {
+	const rawPath = req.params.splat.join("/");
+	// API Gateway v2 HTTP API decodes %2F to /, restore https:/ → https://
+	// (same normalisation as /view).
+	const restoredScheme = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
+	// Admin pastes the bare article URL (`fagnerbrack.com/post`) without a
+	// scheme. Default to https:// so the path resolves to the same DB row
+	// as the canonical save.
+	const normalizedUrl = /^https?:\/\//i.test(restoredScheme)
+		? restoredScheme
+		: `https://${restoredScheme}`;
+	const parsed = RecrawlUrlSchema.safeParse(normalizedUrl);
+	if (!parsed.success) {
+		await renderNotFound(deps, req, res);
+		return undefined;
+	}
+	/* API Gateway HTTP API decodes the path segment once before Express
+	 * sees it, so `parsed.data` arrives with literal spaces and brackets
+	 * where the rest of the system (save-anonymous-link, stale-check
+	 * refresh, /view) carries the URL-encoded form (%20, %5B). DynamoDB
+	 * keys articles by URL string — running through `new URL().toString()`
+	 * canonicalises to the encoded form so the recrawl writes land on the
+	 * same row the view reads. Without this, an admin recrawl of a URL
+	 * with spaces creates a parallel "decoded-URL" row that nothing else
+	 * in the system ever reads or updates. */
+	return new URL(parsed.data).toString();
+}
+
+function handleShowRecrawlPage(
 	deps: AdminRecrawlDependencies,
 	reader: ReturnType<typeof initArticleReader>,
 ) {
@@ -94,31 +125,64 @@ function handleRecrawlArticle(
 		req: Request<{ splat: string[] }>,
 		res: Response,
 	): Promise<void> => {
-		const rawPath = req.params.splat.join("/");
-		// API Gateway v2 HTTP API decodes %2F to /, restore https:/ → https://
-		// (same normalisation as /view).
-		const restoredScheme = rawPath.replace(/^(https?):\/(?!\/)/i, "$1://");
-		// Admin pastes the bare article URL (`fagnerbrack.com/post`) without a
-		// scheme. Default to https:// so the path resolves to the same DB row
-		// as the canonical save.
-		const normalizedUrl = /^https?:\/\//i.test(restoredScheme)
-			? restoredScheme
-			: `https://${restoredScheme}`;
-		const parsed = RecrawlUrlSchema.safeParse(normalizedUrl);
-		if (!parsed.success) {
+		const articleUrl = await resolveArticleUrl(deps, req, res);
+		if (articleUrl === undefined) {
+			return;
+		}
+
+		const existing = await deps.findArticleByUrl(articleUrl);
+		if (!existing) {
+			// The endpoint is explicitly for human intervention on an existing
+			// saved URL. Do not create a stub; surface 404.
 			await renderNotFound(deps, req, res);
 			return;
 		}
-		/* API Gateway HTTP API decodes the path segment once before Express
-		 * sees it, so `parsed.data` arrives with literal spaces and brackets
-		 * where the rest of the system (save-anonymous-link, stale-check
-		 * refresh, /view) carries the URL-encoded form (%20, %5B). DynamoDB
-		 * keys articles by URL string — running through `new URL().toString()`
-		 * canonicalises to the encoded form so the recrawl writes land on the
-		 * same row the view reads. Without this, an admin recrawl of a URL
-		 * with spaces creates a parallel "decoded-URL" row that nothing else
-		 * in the system ever reads or updates. */
-		const articleUrl = new URL(parsed.data).toString();
+
+		const state = await reader.resolveReaderState({
+			article: {
+				url: articleUrl,
+				metadata: existing.metadata,
+				estimatedReadTime: existing.estimatedReadTime,
+			},
+			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
+		});
+
+		// `?started=1` is set by the POST-Redirect-GET landing after the recrawl
+		// has already been triggered, so the result view must not re-emit the
+		// auto-submitting form (which would fire the mutation again on load).
+		const recrawlFormAction =
+			req.query.started === "1"
+				? undefined
+				: `/admin/recrawl/${encodeURIComponent(articleUrl)}`;
+
+		const html = Base(AdminRecrawlPage({
+			articleUrl,
+			appOrigin: deps.appOrigin,
+			metadata: existing.metadata,
+			estimatedReadTime: existing.estimatedReadTime,
+			content: state.content,
+			crawl: state.crawl,
+			readerPollUrl: state.readerPollUrl,
+			summary: state.summary,
+			summaryPollUrl: state.summaryPollUrl,
+			progress: state.progress,
+			contentSourceTier: existing.contentSourceTier,
+			extensionInstallUrl: extensionInstallUrlIfMissing(req),
+			recrawlFormAction,
+		}), await deps.buildBannerState(req)).to("text/html");
+		res.status(html.statusCode).type("html").send(html.body);
+	};
+}
+
+function handleTriggerRecrawl(deps: AdminRecrawlDependencies) {
+	return async (
+		req: Request<{ splat: string[] }>,
+		res: Response,
+	): Promise<void> => {
+		const articleUrl = await resolveArticleUrl(deps, req, res);
+		if (articleUrl === undefined) {
+			return;
+		}
 
 		const existing = await deps.findArticleByUrl(articleUrl);
 		if (!existing) {
@@ -136,34 +200,10 @@ function handleRecrawlArticle(
 		await deps.forceMarkCrawlPending({ url: articleUrl });
 		await deps.publishRecrawlLinkInitiated({ url: articleUrl });
 
-		const state = await reader.resolveReaderState({
-			article: {
-				url: articleUrl,
-				metadata: existing.metadata,
-				estimatedReadTime: existing.estimatedReadTime,
-			},
-			pollUrlBuilder: pollUrlBuilderFor(articleUrl),
-		});
-
-		const html = Base(AdminRecrawlPage({
-			articleUrl,
-			appOrigin: deps.appOrigin,
-			metadata: existing.metadata,
-			estimatedReadTime: existing.estimatedReadTime,
-			content: state.content,
-			crawl: state.crawl,
-			readerPollUrl: state.readerPollUrl,
-			summary: state.summary,
-			summaryPollUrl: state.summaryPollUrl,
-			progress: state.progress,
-			contentSourceTier: existing.contentSourceTier,
-			extensionInstallUrl: extensionInstallUrlIfMissing(req),
-		}), await deps.buildBannerState(req)).to("text/html");
-		assert(
-			state.crawl?.status === "pending",
-			"force-pending + resolveReaderState must leave the crawl in 'pending'",
+		res.redirect(
+			303,
+			`/admin/recrawl/${encodeURIComponent(articleUrl)}?started=1`,
 		);
-		res.status(html.statusCode).type("html").send(html.body);
 	};
 }
 
@@ -231,9 +271,13 @@ export function initAdminRecrawlRoutes(deps: AdminRecrawlDependencies): Router {
 	router.get("/", handleLanding(deps));
 	router.get("/summary", handleSummaryPoll(reader));
 	router.get("/reader", handleReaderPoll(reader));
+	router.post<string, { splat: string[] }>(
+		"/*splat",
+		handleTriggerRecrawl(deps),
+	);
 	router.get<string, { splat: string[] }>(
 		"/*splat",
-		handleRecrawlArticle(deps, reader),
+		handleShowRecrawlPage(deps, reader),
 	);
 
 	return router;

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts
@@ -250,7 +250,45 @@ describe("Admin recrawl routes", () => {
 			expect(badge?.textContent).toContain("legacy");
 		});
 
-		it("triggers a fresh recrawl for a known URL and renders the page in pending state", async () => {
+		it("renders the page read-only with an auto-submitting POST form (no mutation on GET)", async () => {
+			const harness = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			await harness.auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+			await harness.articleStore.saveArticleGlobally({
+				url: ARTICLE_URL,
+				metadata: {
+					title: "Stale Title",
+					siteName: "example.com",
+					excerpt: "Stale excerpt",
+					wordCount: 10,
+				},
+				estimatedReadTime: MinutesSchema.parse(1),
+				savedAt: new Date(),
+			});
+			await harness.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
+
+			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
+
+			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
+
+			expect(response.status).toBe(200);
+			expect(response.headers["cache-control"]).toBe("no-store");
+			// GET is read-only: the recrawl must not have been triggered.
+			expect(harness.recrawlPublishedCalls).toEqual([]);
+			const doc = new JSDOM(response.text).window.document;
+			const form = doc.querySelector("[data-test-admin-recrawl-trigger]");
+			expect(form?.getAttribute("method")).toBe("POST");
+			expect(form?.getAttribute("action")).toBe(`/admin/recrawl/${ENCODED}`);
+			expect(form?.hasAttribute("data-auto-submit")).toBe(true);
+			expect(response.text).toContain("requestSubmit");
+			expect(doc.querySelector("[data-test-admin-recrawl]")).not.toBeNull();
+			expect(doc.querySelector("[data-share-balloon]")).toBeNull();
+			expect(doc.querySelector("[data-test-view-cta]")).toBeNull();
+			expect(doc.querySelector('meta[name="robots"]')?.getAttribute("content")).toBe(
+				"noindex, nofollow",
+			);
+		});
+
+		it("triggers a fresh recrawl on POST and redirects (303) to the started result view rendered in pending state", async () => {
 			const harness = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await harness.auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
 			// Seed an article so the admin path has something to recrawl.
@@ -271,23 +309,36 @@ describe("Admin recrawl routes", () => {
 
 			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
-			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
+			const postResponse = await agent.post(`/admin/recrawl/${ENCODED}`);
+
+			expect(postResponse.status).toBe(303);
+			expect(postResponse.headers.location).toBe(
+				`/admin/recrawl/${ENCODED}?started=1`,
+			);
+			expect(harness.recrawlPublishedCalls).toEqual([{ url: ARTICLE_URL }]);
+
+			const response = await agent.get(`/admin/recrawl/${ENCODED}?started=1`);
 
 			expect(response.status).toBe(200);
 			expect(response.headers["cache-control"]).toBe("no-store");
-			expect(harness.recrawlPublishedCalls).toEqual([{ url: ARTICLE_URL }]);
 			const doc = new JSDOM(response.text).window.document;
 			const readerSlot = doc.querySelector("[data-test-reader-slot]");
 			expect(readerSlot?.getAttribute("data-reader-status")).toBe("pending");
-			expect(doc.querySelector("[data-test-admin-recrawl]")).not.toBeNull();
-			expect(doc.querySelector("[data-share-balloon]")).toBeNull();
-			expect(doc.querySelector("[data-test-view-cta]")).toBeNull();
-			expect(doc.querySelector('meta[name="robots"]')?.getAttribute("content")).toBe(
-				"noindex, nofollow",
-			);
+			// The result view must not re-emit the auto-submit form.
+			expect(doc.querySelector("[data-test-admin-recrawl-trigger]")).toBeNull();
 		});
 
-		it("treats a schemeless path segment as https:// so admins can paste `host/path` without typing the scheme", async () => {
+		it("returns 404 on POST when the URL is not already in the articles DB", async () => {
+			const { server, auth } = buildHarness({ adminEmails: [ADMIN_EMAIL] });
+			await auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+			const agent = await loginAs(server, ADMIN_EMAIL, ADMIN_PASSWORD);
+
+			const response = await agent.post(`/admin/recrawl/${ENCODED}`);
+
+			expect(response.status).toBe(404);
+		});
+
+		it("treats a schemeless POST path segment as https:// so admins can paste `host/path` without typing the scheme", async () => {
 			const harness = buildHarness({ adminEmails: [ADMIN_EMAIL] });
 			await harness.auth.createUser({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
 			await harness.articleStore.saveArticleGlobally({
@@ -301,9 +352,9 @@ describe("Admin recrawl routes", () => {
 			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 			// Mirrors the real bug report: /admin/recrawl/example.com/post (no scheme)
 			// previously rendered the "No article URL provided" error page.
-			const response = await agent.get("/admin/recrawl/example.com/post");
+			const response = await agent.post("/admin/recrawl/example.com/post");
 
-			expect(response.status).toBe(200);
+			expect(response.status).toBe(303);
 			expect(harness.recrawlPublishedCalls).toEqual([{ url: ARTICLE_URL }]);
 		});
 
@@ -333,9 +384,9 @@ describe("Admin recrawl routes", () => {
 
 			const agent = await loginAs(harness.server, ADMIN_EMAIL, ADMIN_PASSWORD);
 
-			const response = await agent.get(`/admin/recrawl/${ENCODED}`);
+			const response = await agent.post(`/admin/recrawl/${ENCODED}`);
 
-			expect(response.status).toBe(200);
+			expect(response.status).toBe(303);
 			const summaryAfter = await harness.summary.findGeneratedSummary(ARTICLE_URL);
 			expect(summaryAfter).toEqual({
 				status: "ready",

--- a/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
+++ b/src/packages/crawl-article/scripts/tier-1-plus-pipeline-health.ts
@@ -52,6 +52,7 @@ type TerminalReaderStatus = Exclude<ReaderStatus, "pending">;
 
 async function forceRecrawl(url: string): Promise<void> {
 	const res = await fetch(`${ORIGIN}/admin/recrawl/${encodeURIComponent(url)}`, {
+		method: "POST",
 		headers: { "x-service-token": SERVICE_TOKEN },
 	});
 	assert.equal(


### PR DESCRIPTION
## What

`/admin/recrawl/:url` was registered with `router.get("/*splat", ...)` but performed two state mutations inside the GET handler:

```ts
await deps.forceMarkCrawlPending({ url: articleUrl });
await deps.publishRecrawlLinkInitiated({ url: articleUrl });
```

## Why

The web skill's **No Side Effects on GET** rule (`.claude/skills/web/SKILL.md`) states: *"Never mutate state on a GET — proxies cache them, prefetchers fire them, crawlers hit them."* It prescribes either an auto-submitting `<form method="POST">` or the POST-Redirect-GET pattern for mutation-triggering URLs. The recrawl permalink could otherwise be fired by a proxy prefetch or crawler with no operator intent.

## Change

- **GET `/admin/recrawl/:url`** is now read-only: it resolves the existing article and renders the page in its current crawl state, emitting an auto-submitting `<form method="POST">` (mirroring the existing queue auto-submit script) when `?started` is absent.
- **POST `/admin/recrawl/*splat`** (new) performs `forceMarkCrawlPending` + `publishRecrawlLinkInitiated`, then `303`-redirects to `/admin/recrawl/:url?started=1`, which renders the now-pending result without re-triggering.
- URL normalization/canonicalisation is extracted into a shared `resolveArticleUrl` helper used by both handlers.
- Removed the `assert(state.crawl?.status === "pending")` (no longer valid for a read-only render) and its now-unused `node:assert` import.
- `AdminRecrawlPage` gains an optional `recrawlFormAction`; when set it renders the POST form and the auto-submit trigger script.
- Route tests that previously asserted the mutation via a GET now POST (asserting `303` + the recorded publish call) followed by a GET asserting pending state; a new test asserts the read-only GET emits the auto-submit POST form.

## Files

- `projects/hutch/src/runtime/web/pages/admin/recrawl.page.ts`
- `projects/hutch/src/runtime/web/pages/admin/recrawl.component.ts`
- `projects/hutch/src/runtime/web/pages/admin/recrawl.route.test.ts`

🤖 Part of the guidelines & skills audit.