### PR TITLE
refactor(save-link): remove process.env default and c8-ignore from tesseract OCR provider

### DIFF
--- a/projects/save-link/src/runtime/pdf-page-ocr.main.ts
+++ b/projects/save-link/src/runtime/pdf-page-ocr.main.ts
@@ -1,11 +1,12 @@
 import { S3Client } from "@aws-sdk/client-s3";
+import { spawn } from "node:child_process";
 import { consoleLogger } from "@packages/hutch-logger";
 import { renderPdfPageToPng } from "@packages/crawl-article";
 import { requireEnv } from "../require-env";
 import { initPdfPageOcrHandler } from "./domain/pdf-page-ocr/pdf-page-ocr-handler";
 import { initDownloadStagedPdf } from "./providers/pdf-page-ocr/init-download-staged-pdf";
 import { initLastPdfCache } from "./providers/pdf-page-ocr/init-last-pdf-cache";
-import { initTesseractOcr, resolveTessdataDir } from "./providers/pdf-page-ocr/init-tesseract-ocr";
+import { initTesseractOcr } from "./providers/pdf-page-ocr/init-tesseract-ocr";
 
 const contentBucketName = requireEnv("CONTENT_BUCKET_NAME");
 
@@ -13,7 +14,10 @@ const s3Client = new S3Client({});
 
 const baseDownload = initDownloadStagedPdf({ client: s3Client, bucketName: contentBucketName });
 const { downloadStagedPdf } = initLastPdfCache({ downloadStagedPdf: baseDownload.downloadStagedPdf });
-const runPageOcr = initTesseractOcr({ tessdataDir: resolveTessdataDir() });
+const runPageOcr = initTesseractOcr({
+	tessdataDir: requireEnv("TESSDATA_PREFIX"),
+	spawnTesseractProcess: (args) => spawn("tesseract", args),
+});
 
 export const handler = initPdfPageOcrHandler({
 	downloadStagedPdf,

--- a/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.test.ts
+++ b/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,7 +6,8 @@ import {
 	buildLanguageFlag,
 	discoverInstalledScripts,
 	initTesseractOcr,
-	resolveTessdataDir,
+	type SpawnTesseractProcess,
+	type TesseractChildProcess,
 } from "./init-tesseract-ocr";
 
 function makeFakeTessdataDir(scriptTraineddataNames: string[]): string {
@@ -18,15 +20,41 @@ function makeFakeTessdataDir(scriptTraineddataNames: string[]): string {
 	return dir;
 }
 
-describe("resolveTessdataDir", () => {
-	it("returns TESSDATA_PREFIX when the env var is set", () => {
-		expect(resolveTessdataDir({ TESSDATA_PREFIX: "/custom/tessdata" })).toBe("/custom/tessdata");
-	});
+function failingSpawn(): TesseractChildProcess {
+	throw new Error("spawn must not be called");
+}
 
-	it("falls back to the Lambda container's bundled path when TESSDATA_PREFIX is unset", () => {
-		expect(resolveTessdataDir({})).toBe("/opt/tesseract/tessdata");
-	});
-});
+/** A fake `tesseract` child whose stdout/stderr/close are driven on the next
+ * microtask so the wrapper's listeners are registered before they fire. */
+function makeFakeSpawn(outcome: {
+	stdout?: string;
+	stderr?: string;
+	exitCode?: number | null;
+	error?: Error;
+}): SpawnTesseractProcess {
+	return () => {
+		const child = new EventEmitter();
+		const stdout = new EventEmitter();
+		const stderr = new EventEmitter();
+		const fake: TesseractChildProcess = {
+			stdout: { on: (event, listener) => stdout.on(event, listener) },
+			stderr: { on: (event, listener) => stderr.on(event, listener) },
+			on: (event, listener) => {
+				child.on(event, listener);
+			},
+		};
+		queueMicrotask(() => {
+			if (outcome.error) {
+				child.emit("error", outcome.error);
+				return;
+			}
+			if (outcome.stdout) stdout.emit("data", Buffer.from(outcome.stdout, "utf8"));
+			if (outcome.stderr) stderr.emit("data", Buffer.from(outcome.stderr, "utf8"));
+			child.emit("close", outcome.exitCode ?? 0);
+		});
+		return fake;
+	};
+}
 
 describe("discoverInstalledScripts", () => {
 	let dir: string;
@@ -106,21 +134,77 @@ describe("initTesseractOcr", () => {
 	it("initialises against an injected tessdata directory without requiring TESSDATA_PREFIX to be set", () => {
 		dir = makeFakeTessdataDir(["Latin.traineddata", "Arabic.traineddata"]);
 
-		expect(() => initTesseractOcr({ tessdataDir: dir })).not.toThrow();
+		expect(() =>
+			initTesseractOcr({ tessdataDir: dir, spawnTesseractProcess: failingSpawn }),
+		).not.toThrow();
 	});
 
 	it("throws at init time when the injected tessdata script directory is empty", () => {
 		dir = makeFakeTessdataDir([]);
 
-		expect(() => initTesseractOcr({ tessdataDir: dir })).toThrow(/Required tessdata script pack missing/);
+		expect(() =>
+			initTesseractOcr({ tessdataDir: dir, spawnTesseractProcess: failingSpawn }),
+		).toThrow(/Required tessdata script pack missing/);
 	});
 
 	it("returns an empty fragment when invoked with no images (no tesseract spawn)", async () => {
 		dir = makeFakeTessdataDir(["Latin.traineddata"]);
-		const runPageOcr = initTesseractOcr({ tessdataDir: dir });
+		const runPageOcr = initTesseractOcr({ tessdataDir: dir, spawnTesseractProcess: failingSpawn });
 
 		const result = await runPageOcr({ images: [] });
 
 		expect(result).toBe("");
+	});
+
+	it("wraps each recognised paragraph in an ocr-tesseract <p>, escaping HTML and dropping blank blocks", async () => {
+		dir = makeFakeTessdataDir(["Latin.traineddata"]);
+		const runPageOcr = initTesseractOcr({
+			tessdataDir: dir,
+			spawnTesseractProcess: makeFakeSpawn({ stdout: "First & <b>bold</b>\n\n   \n\nSecond" }),
+		});
+
+		const result = await runPageOcr({ images: [{ pngBuffer: Buffer.from("png") }] });
+
+		expect(result).toBe(
+			'<p class="ocr-tesseract">First &amp; &lt;b&gt;bold&lt;/b&gt;</p><p class="ocr-tesseract">Second</p>',
+		);
+	});
+
+	it("concatenates one fragment per image in order", async () => {
+		dir = makeFakeTessdataDir(["Latin.traineddata"]);
+		const runPageOcr = initTesseractOcr({
+			tessdataDir: dir,
+			spawnTesseractProcess: makeFakeSpawn({ stdout: "page" }),
+		});
+
+		const result = await runPageOcr({
+			images: [{ pngBuffer: Buffer.from("a") }, { pngBuffer: Buffer.from("b") }],
+		});
+
+		expect(result).toBe('<p class="ocr-tesseract">page</p><p class="ocr-tesseract">page</p>');
+	});
+
+	it("rejects with the captured stderr when tesseract exits non-zero", async () => {
+		dir = makeFakeTessdataDir(["Latin.traineddata"]);
+		const runPageOcr = initTesseractOcr({
+			tessdataDir: dir,
+			spawnTesseractProcess: makeFakeSpawn({ stderr: "boom", exitCode: 2 }),
+		});
+
+		await expect(runPageOcr({ images: [{ pngBuffer: Buffer.from("png") }] })).rejects.toThrow(
+			"tesseract exited 2: boom",
+		);
+	});
+
+	it("rejects when the tesseract process fails to spawn", async () => {
+		dir = makeFakeTessdataDir(["Latin.traineddata"]);
+		const runPageOcr = initTesseractOcr({
+			tessdataDir: dir,
+			spawnTesseractProcess: makeFakeSpawn({ error: new Error("ENOENT tesseract") }),
+		});
+
+		await expect(runPageOcr({ images: [{ pngBuffer: Buffer.from("png") }] })).rejects.toThrow(
+			"ENOENT tesseract",
+		);
 	});
 });

--- a/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.test.ts
+++ b/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.test.ts
@@ -160,7 +160,7 @@ describe("initTesseractOcr", () => {
 		dir = makeFakeTessdataDir(["Latin.traineddata"]);
 		const runPageOcr = initTesseractOcr({
 			tessdataDir: dir,
-			spawnTesseractProcess: makeFakeSpawn({ stdout: "First & <b>bold</b>\n\n   \n\nSecond" }),
+			spawnTesseractProcess: makeFakeSpawn({ stdout: "First & <b>bold</b>\n\n   \n\nSecond\n\n" }),
 		});
 
 		const result = await runPageOcr({ images: [{ pngBuffer: Buffer.from("png") }] });

--- a/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.ts
+++ b/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.ts
@@ -1,5 +1,3 @@
-/* c8 ignore start -- tested via Jest unit tests + node:test integration; c8 cannot merge V8 coverage from both runners (bcoe/c8#126) */
-import { spawn } from "node:child_process";
 import assert from "node:assert";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
@@ -9,14 +7,22 @@ import { resolve } from "node:path";
 import { escapeHtmlText } from "@packages/crawl-article";
 import type { RunPageOcr } from "../../domain/pdf-page-ocr/pdf-page-ocr-handler.types";
 
-/* Resolve the tessdata directory the Lambda container ships with. The
- * Dockerfile copies the langpacks to /opt/tesseract/tessdata and exports
- * TESSDATA_PREFIX accordingly; falling back to that absolute path keeps
- * the wrapper usable when the env var is unset (e.g. on a developer
- * machine running an integration test against a system tesseract). */
-export function resolveTessdataDir(env: NodeJS.ProcessEnv = process.env): string {
-	return env.TESSDATA_PREFIX ?? "/opt/tesseract/tessdata";
+/** Narrow view of the child returned by `node:child_process` `spawn` — just
+ * the stdout/stderr streams and the error/close events this wrapper consumes.
+ * Narrowing it (rather than depending on the full `ChildProcessWithoutNullStreams`)
+ * lets tests supply a plain fake child without a type assertion. */
+export interface TesseractChildProcess {
+	readonly stdout: { on(event: "data", listener: (chunk: Buffer) => void): void };
+	readonly stderr: { on(event: "data", listener: (chunk: Buffer) => void): void };
+	on(event: "error", listener: (error: Error) => void): void;
+	on(event: "close", listener: (exitCode: number | null) => void): void;
 }
+
+/** Spawns the `tesseract` binary with the given argv and returns the child so
+ * the wrapper can stream stdout/stderr. Injected at the composition root from
+ * `node:child_process` `spawn` so tests can fake the subprocess and exercise
+ * every exit/error branch without a real Tesseract install. */
+export type SpawnTesseractProcess = (args: readonly string[]) => TesseractChildProcess;
 
 /* Tesseract loads every script pack passed via `-l` and `--psm 1` then runs
  * OSD across all of them to decide which model to apply per region. With ~35
@@ -48,40 +54,63 @@ export function buildLanguageFlag(installedScripts: readonly string[]): string {
 	return installedScripts.map((script) => `script/${script}`).join("+");
 }
 
-export function initTesseractOcr(deps: { tessdataDir: string }): RunPageOcr {
+export function initTesseractOcr(deps: {
+	tessdataDir: string;
+	spawnTesseractProcess: SpawnTesseractProcess;
+}): RunPageOcr {
 	const installedScripts = discoverInstalledScripts(deps.tessdataDir);
 	const languageFlag = buildLanguageFlag(installedScripts);
-	return createOcrClosure(languageFlag);
+	return createOcrClosure({ languageFlag, spawnTesseractProcess: deps.spawnTesseractProcess });
 }
 
-function createOcrClosure(languageFlag: string): RunPageOcr {
+function createOcrClosure(deps: {
+	languageFlag: string;
+	spawnTesseractProcess: SpawnTesseractProcess;
+}): RunPageOcr {
 	return async ({ images }) => {
 		const fragments: string[] = [];
 		for (const { pngBuffer } of images) {
-			fragments.push(await ocrOneImage(pngBuffer, languageFlag));
+			fragments.push(await ocrOneImage({ pngBuffer, ...deps }));
 		}
 		return fragments.join("");
 	};
 }
 
-async function ocrOneImage(pngBuffer: Buffer, languageFlag: string): Promise<string> {
-	const text = await runTesseract(pngBuffer, languageFlag);
+async function ocrOneImage(params: {
+	pngBuffer: Buffer;
+	languageFlag: string;
+	spawnTesseractProcess: SpawnTesseractProcess;
+}): Promise<string> {
+	const text = await runTesseract(params);
 	return renderTesseractHtml(text);
 }
 
-async function runTesseract(pngBuffer: Buffer, languageFlag: string): Promise<string> {
+async function runTesseract(params: {
+	pngBuffer: Buffer;
+	languageFlag: string;
+	spawnTesseractProcess: SpawnTesseractProcess;
+}): Promise<string> {
 	const scratchDir = resolve(tmpdir(), `tesseract-${randomUUID()}`);
 	const pngPath = resolve(scratchDir, "page.png");
 	await mkdir(scratchDir, { recursive: true });
-	await writeFile(pngPath, pngBuffer);
+	await writeFile(pngPath, params.pngBuffer);
 	try {
-		return await spawnTesseract(pngPath, languageFlag);
+		return await spawnTesseract({
+			pngPath,
+			languageFlag: params.languageFlag,
+			spawnTesseractProcess: params.spawnTesseractProcess,
+		});
 	} finally {
 		await rm(scratchDir, { recursive: true, force: true });
 	}
 }
 
-function spawnTesseract(pngPath: string, languageFlag: string): Promise<string> {
+function spawnTesseract(params: {
+	pngPath: string;
+	languageFlag: string;
+	spawnTesseractProcess: SpawnTesseractProcess;
+}): Promise<string> {
+	const { pngPath, languageFlag, spawnTesseractProcess } = params;
 	return new Promise((resolvePromise, rejectPromise) => {
 		// --psm 1: auto page segmentation with OSD (orientation + script detection).
 		// --oem 1: pin the OCR engine to the LSTM neural net (the default `--oem 3`
@@ -93,7 +122,7 @@ function spawnTesseract(pngPath: string, languageFlag: string): Promise<string> 
 		//   English/Portuguese/German/etc. — so the flag is short and the recogniser
 		//   only loads the script needed per region (tessdata is mmapped lazily).
 		// `-` as output base writes recognised text to stdout.
-		const child = spawn("tesseract", [pngPath, "-", "--psm", "1", "--oem", "1", "-l", languageFlag]);
+		const child = spawnTesseractProcess([pngPath, "-", "--psm", "1", "--oem", "1", "-l", languageFlag]);
 		const stdoutChunks: Buffer[] = [];
 		const stderrChunks: Buffer[] = [];
 		child.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
@@ -121,4 +150,3 @@ function renderTesseractHtml(text: string): string {
 		.map((paragraph) => `<p class="ocr-tesseract">${escapeHtmlText(paragraph)}</p>`)
 		.join("");
 }
-/* c8 ignore stop */

--- a/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.ts
+++ b/projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.ts
@@ -18,10 +18,9 @@ export interface TesseractChildProcess {
 	on(event: "close", listener: (exitCode: number | null) => void): void;
 }
 
-/** Spawns the `tesseract` binary with the given argv and returns the child so
- * the wrapper can stream stdout/stderr. Injected at the composition root from
- * `node:child_process` `spawn` so tests can fake the subprocess and exercise
- * every exit/error branch without a real Tesseract install. */
+/** Injected at the composition root from `node:child_process` `spawn` so tests
+ * can fake the subprocess and exercise every exit/error branch without a real
+ * Tesseract install. */
 export type SpawnTesseractProcess = (args: readonly string[]) => TesseractChildProcess;
 
 /* Tesseract loads every script pack passed via `-l` and `--psm 1` then runs


### PR DESCRIPTION
## What

Resolves three CLAUDE.md violations in `projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.ts`.

### 1. Direct `process.env` access + defaulted missing env var (Environment Variable Access)
`resolveTessdataDir(env = process.env)` read `process.env` directly and returned `env.TESSDATA_PREFIX ?? "/opt/tesseract/tessdata"`. CLAUDE.md forbids reading `process.env` directly outside the `requireEnv`/`getEnv` helpers and states *"Never default missing environment variables. Always use `requireEnv` and let the process fail."* The Dockerfile sets `ENV TESSDATA_PREFIX=/opt/tesseract/tessdata`, so the value is always present in production. `resolveTessdataDir` is deleted and the composition root (`pdf-page-ocr.main.ts`, which already imports `requireEnv`) now reads `requireEnv("TESSDATA_PREFIX")`.

### 2. Named Parameters Over Positional When Types Repeat
`spawnTesseract(pngPath: string, languageFlag: string)` had two consecutive same-typed positional parameters. The OCR call chain now uses named parameter objects.

### 3. `c8 ignore` without an approved reason (No Coverage Ignore Comments)
The file was wrapped in a whole-file `/* c8 ignore start … */` justified by *"tested via … node:test integration"* — but no such integration test exists in the tree, and the reason is none of the four enumerated allowed cases. The ignore was masking the real `spawn`/exit/error handling and paragraph-rendering branches. The subprocess is now an injected `SpawnTesseractProcess` dependency (required, wired from `node:child_process` `spawn` at the composition root per the no-default-dependencies rule). A narrow `TesseractChildProcess` interface lets the tests supply a fake child without `as`, so the success, non-zero-exit, spawn-error, and multi-paragraph-render branches are all unit-tested. The `c8 ignore` is removed and coverage reaches 100% with no ignores.

## Files changed
- `projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.ts` — remove `resolveTessdataDir`, inject `SpawnTesseractProcess`, named params, drop `c8 ignore`.
- `projects/save-link/src/runtime/pdf-page-ocr.main.ts` — read `requireEnv("TESSDATA_PREFIX")`, inject the real `spawn`.
- `projects/save-link/src/runtime/providers/pdf-page-ocr/init-tesseract-ocr.test.ts` — drop the obsolete `resolveTessdataDir` tests, inject a fake spawn into existing `initTesseractOcr` tests, add spawn success/exit/error coverage.

## Verification
`pnpm nx run save-link:check` (tsc + biome + knip + 100% coverage + tests).

Source: CLAUDE.md (Environment Variable Access; Named Parameters Over Positional When Types Repeat; No Coverage Ignore Comments).

🤖 Part of the guidelines & skills audit.