### PR TITLE
refactor(domain): brand oauth ids via zod instead of `as`

### DIFF
--- a/src/packages/domain/src/oauth/index.ts
+++ b/src/packages/domain/src/oauth/index.ts
@@ -1,13 +1,13 @@
-export type {
-	OAuthClientId,
-	AuthorizationCode,
-	AccessToken,
-	RefreshToken,
-	OAuthClient,
-} from "./oauth.types";
+export type { OAuthClient } from "./oauth.types";
 export {
 	OAuthClientIdSchema,
 	AccessTokenSchema,
 	RefreshTokenSchema,
 	AuthorizationCodeSchema,
+} from "./oauth.schema";
+export type {
+	OAuthClientId,
+	AuthorizationCode,
+	AccessToken,
+	RefreshToken,
 } from "./oauth.schema";

--- a/src/packages/domain/src/oauth/oauth.schema.ts
+++ b/src/packages/domain/src/oauth/oauth.schema.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
-import type { OAuthClientId, AccessToken, RefreshToken, AuthorizationCode } from "./oauth.types";
 
-export const OAuthClientIdSchema = z.string().transform((s): OAuthClientId => s as OAuthClientId);
+export const OAuthClientIdSchema = z.string().brand<"OAuthClientId">();
+export type OAuthClientId = z.infer<typeof OAuthClientIdSchema>;
 
-export const AccessTokenSchema = z.string().transform((s): AccessToken => s as AccessToken);
+export const AccessTokenSchema = z.string().brand<"AccessToken">();
+export type AccessToken = z.infer<typeof AccessTokenSchema>;
 
-export const RefreshTokenSchema = z.string().transform((s): RefreshToken => s as RefreshToken);
+export const RefreshTokenSchema = z.string().brand<"RefreshToken">();
+export type RefreshToken = z.infer<typeof RefreshTokenSchema>;
 
-export const AuthorizationCodeSchema = z.string().transform((s): AuthorizationCode => s as AuthorizationCode);
+export const AuthorizationCodeSchema = z.string().brand<"AuthorizationCode">();
+export type AuthorizationCode = z.infer<typeof AuthorizationCodeSchema>;

--- a/src/packages/domain/src/oauth/oauth.types.ts
+++ b/src/packages/domain/src/oauth/oauth.types.ts
@@ -1,7 +1,4 @@
-export type OAuthClientId = string & { readonly __brand: "OAuthClientId" };
-export type AuthorizationCode = string & { readonly __brand: "AuthorizationCode" };
-export type AccessToken = string & { readonly __brand: "AccessToken" };
-export type RefreshToken = string & { readonly __brand: "RefreshToken" };
+import type { OAuthClientId } from "./oauth.schema";
 
 export interface OAuthClient {
 	id: OAuthClientId;


### PR DESCRIPTION
## What

Removes the `as` type assertions used to brand the four OAuth identifier schemas in `src/packages/domain/src/oauth/oauth.schema.ts`:

```ts
// before
export const OAuthClientIdSchema = z.string().transform((s): OAuthClientId => s as OAuthClientId);
// after
export const OAuthClientIdSchema = z.string().brand<"OAuthClientId">();
export type OAuthClientId = z.infer<typeof OAuthClientIdSchema>;
```

The same change is applied to `AccessTokenSchema`, `RefreshTokenSchema`, and `AuthorizationCodeSchema`. The brand types are now derived from the schemas with `z.infer`. `oauth.types.ts` keeps the `OAuthClient` interface and imports the brand types from `oauth.schema.ts`; `index.ts` re-points the four type re-exports to `./oauth.schema`.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`) — **Source:** CLAUDE.md
- `as`-branding silently hides any future mismatch between schema output and the brand type. This is not an allowed exception (`as const` / isolated Node API wrapper).
- Matches the idiom already used in the same package: `saveable-url.ts` (`z.string().brand<"SaveableUrl">()`) and `import-session.schema.ts` (`.brand<"ImportSessionId">()`).

## Impact

The `@packages/domain/oauth` public export surface is unchanged, so no consumers change. `oauth.schema.test.ts` stays green: zod `.brand()` preserves runtime value equality (`.parse("client-abc") === "client-abc"`) and still rejects non-strings.

🤖 Part of the guidelines & skills audit.