### PR TITLE
refactor(domain): brand UserIdPrefix via zod instead of `as`

### DIFF
--- a/src/packages/domain/src/user/user-id-prefix.ts
+++ b/src/packages/domain/src/user/user-id-prefix.ts
@@ -5,16 +5,14 @@ export const USER_ID_PREFIX_LENGTH = 6;
 
 const USER_ID_PREFIX_PATTERN = /^[0-9a-f]{6}$/;
 
-export type UserIdPrefix = string & { readonly __brand: "UserIdPrefix" };
+const UserIdPrefixBrand = z.string().brand<"UserIdPrefix">();
+export type UserIdPrefix = z.infer<typeof UserIdPrefixBrand>;
 
-export const UserIdPrefixSchema = z
-	.string()
-	.regex(USER_ID_PREFIX_PATTERN)
-	.transform((s): UserIdPrefix => s as UserIdPrefix);
+export const UserIdPrefixSchema = z.string().regex(USER_ID_PREFIX_PATTERN).pipe(UserIdPrefixBrand);
 
 /** Extracts the first 6 characters of a UserId as the prefix for sharing/GSI lookups. */
 export function userIdPrefixFrom(userId: UserId): UserIdPrefix {
-	return userId.slice(0, USER_ID_PREFIX_LENGTH).toLowerCase() as UserIdPrefix;
+	return UserIdPrefixBrand.parse(userId.slice(0, USER_ID_PREFIX_LENGTH).toLowerCase());
 }
 
 /** Validates an external string (e.g. utm_content) as a well-formed 6-hex-char prefix. */


### PR DESCRIPTION
## What

Removes the two `as UserIdPrefix` type assertions in
`src/packages/domain/src/user/user-id-prefix.ts`.

## Why

**Rule:** Avoid TypeScript Type Assertions (`as`)
**Source:** CLAUDE.md

CLAUDE.md mandates producing branded domain IDs through a zod brand schema
(`z.string()...brand<"UserIdPrefix">()`) rather than an inline `as` assertion.
Two lines violated this:

- L13 `.transform((s): UserIdPrefix => s as UserIdPrefix)` — branding the schema output via `as`.
- L17 `... .toLowerCase() as UserIdPrefix` — branding a derived string via `as`.

Neither is an allowed exception (`as const` / isolated Node wrapper).

## Change

- Introduce `UserIdPrefixBrand = z.string().brand<"UserIdPrefix">()` and infer
  `UserIdPrefix` from it (drops the hand-written `string & { __brand }` type).
- `UserIdPrefixSchema` `.pipe()`s the existing 6-hex regex into the brand — same
  validation, no `as`.
- `userIdPrefixFrom` brands its sliced/lowercased value via
  `UserIdPrefixBrand.parse(...)`.

The unbranded brand factory is used for `userIdPrefixFrom` deliberately: the
existing test expects `userIdPrefixFrom("user-123-test-id") === "user-1"` (a
non-hex value), so it must not be run through the hex-pattern schema.

## Impact

`UserIdPrefix` is consumed only as a type import in
`src/packages/provider-contracts/src/auth.ts`; no callers change. All existing
schema and function tests assert on string value / success and remain green.

🤖 Part of the guidelines & skills audit.