### PR TITLE
refactor(test-phase-runner): stop reading process.env directly

### DIFF
--- a/src/packages/test-phase-runner/src/run-test-phases.ts
+++ b/src/packages/test-phase-runner/src/run-test-phases.ts
@@ -3,6 +3,14 @@ import { execSync as defaultExecSync } from "node:child_process";
 import type { ExecSyncOptions } from "node:child_process";
 import { globSync as defaultGlobSync } from "node:fs";
 
+function getEnv(name: string): string | undefined {
+	return process.env[name];
+}
+
+function parentEnv(): NodeJS.ProcessEnv {
+	return process.env;
+}
+
 interface JestPhase {
 	type: "jest";
 	name: string;
@@ -154,7 +162,7 @@ export const defaultDeps: TestPhaseRunnerDeps = {
 	execSync: defaultExecSync as ExecSyncFn,
 	globSync: defaultGlobSync,
 	log: console.log,
-	shouldSkipE2E: () => process.env.CLAUDE_CODE_REMOTE === "true",
+	shouldSkipE2E: () => getEnv("CLAUDE_CODE_REMOTE") === "true",
 };
 
 export function initTestPhaseRunner(deps: TestPhaseRunnerDeps) {
@@ -163,7 +171,7 @@ export function initTestPhaseRunner(deps: TestPhaseRunnerDeps) {
 		deps.execSync(command, {
 			cwd: options.cwd,
 			stdio: "inherit",
-			env: { ...process.env, ...options.extraEnv },
+			env: { ...parentEnv(), ...options.extraEnv },
 		});
 	}
 
@@ -188,7 +196,7 @@ export function initTestPhaseRunner(deps: TestPhaseRunnerDeps) {
 	function runPlaywrightPhase(displayName: string, phase: ResolvedPlaywrightPhase, projectRoot: string) {
 		deps.log(`\n=== ${displayName} ===\n`);
 
-		const isCI = process.env.CI === "true";
+		const isCI = getEnv("CI") === "true";
 		if (isCI) {
 			deps.log("Installing browsers (output suppressed in CI; errors still shown)...");
 		}
@@ -200,7 +208,7 @@ export function initTestPhaseRunner(deps: TestPhaseRunnerDeps) {
 		deps.execSync(phase.testCommand, {
 			cwd: projectRoot,
 			stdio: "inherit",
-			env: { ...process.env, ...phase.env },
+			env: { ...parentEnv(), ...phase.env },
 		});
 	}
 


### PR DESCRIPTION
## What

`src/packages/test-phase-runner/src/run-test-phases.ts` read `process.env` directly in four places:

- line 157 — `process.env.CLAUDE_CODE_REMOTE === "true"`
- line 166 — `env: { ...process.env, ...options.extraEnv }`
- line 191 — `process.env.CI === "true"`
- line 203 — `env: { ...process.env, ...phase.env }`

## Why

CLAUDE.md **"Environment Variable Access"** states *"Never use `process.env` directly"* and to use `requireEnv`/`getEnv`. The only documented exception is `playwright.config.*.ts` files; this is `run-test-phases.ts`, so the exception does not apply.

- **Rule:** Environment Variable Access
- **Source:** CLAUDE.md

The canonical `getEnv`/`requireEnv` helpers live inside individual projects (`projects/hutch/src/runtime/domain/require-env.ts`, etc.), not in an importable workspace package. Importing them from `@packages/test-phase-runner` would violate the separate **"No Cross-Project Relative Imports"** rule. The established convention for shared `@packages/*` (see `@packages/check-failed-articles/scripts/check-failed-articles.ts`, `@packages/check-stuck-articles`, `@packages/crawl-article`) is to define a **local** helper that confines `process.env[name]` to a single named accessor and read env through it.

## Change

Add two branch-free local helpers to `run-test-phases.ts`:

- `getEnv(name)` — single named-variable reads (`CLAUDE_CODE_REMOTE`, `CI`)
- `parentEnv()` — the full-environment object that `execSync` forwards to child processes (`getEnv`/`requireEnv` model single named vars, not the whole env)

Route all four sites through them. Behavior is byte-for-byte identical, so no test assertions change and 100% coverage holds — the existing `shouldSkipE2E` and `runAllPhases` execution suites already exercise both helpers.

🤖 Part of the guidelines & skills audit.