### PR TITLE
refactor(google-auth): unit-test token exchange and move GoogleIdSchema to provider-contracts

### DIFF
--- a/projects/hutch/src/runtime/providers/google-auth/google-token.test.ts
+++ b/projects/hutch/src/runtime/providers/google-auth/google-token.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { initExchangeGoogleCode } from "./google-token";
+
+function idToken(claims: object): string {
+	const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+	const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+	return `${header}.${payload}.signature`;
+}
+
+function jsonResponse(body: object): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("initExchangeGoogleCode", () => {
+	it("POSTs the authorization code to Google's token endpoint with the configured credentials", async () => {
+		let receivedUrl: string | undefined;
+		let receivedInit: RequestInit | undefined;
+		const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+			receivedUrl = typeof input === "string" ? input : input.toString();
+			receivedInit = init;
+			return jsonResponse({
+				id_token: idToken({ sub: "google-sub-1", email: "user@example.com", email_verified: true }),
+			});
+		};
+
+		const exchange = initExchangeGoogleCode({
+			clientId: "client-id-123",
+			clientSecret: "client-secret-456",
+			redirectUri: "https://app.test/auth/google/callback",
+			fetch: fakeFetch,
+		});
+
+		await exchange("auth-code-789");
+
+		assert.equal(receivedUrl, "https://oauth2.googleapis.com/token");
+		assert.equal(receivedInit?.method, "POST");
+		const headers = receivedInit?.headers as Record<string, string>;
+		assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+		const body = new URLSearchParams(receivedInit?.body as string);
+		assert.equal(body.get("code"), "auth-code-789");
+		assert.equal(body.get("client_id"), "client-id-123");
+		assert.equal(body.get("client_secret"), "client-secret-456");
+		assert.equal(body.get("redirect_uri"), "https://app.test/auth/google/callback");
+		assert.equal(body.get("grant_type"), "authorization_code");
+	});
+
+	it("decodes the id_token payload into the branded google identity", async () => {
+		const fakeFetch: typeof globalThis.fetch = async () =>
+			jsonResponse({
+				id_token: idToken({ sub: "google-sub-42", email: "person@example.com", email_verified: true }),
+			});
+
+		const exchange = initExchangeGoogleCode({
+			clientId: "id",
+			clientSecret: "secret",
+			redirectUri: "https://app.test/cb",
+			fetch: fakeFetch,
+		});
+
+		const result = await exchange("code");
+
+		assert.equal(result.googleId, "google-sub-42");
+		assert.equal(result.email, "person@example.com");
+		assert.equal(result.emailVerified, true);
+	});
+
+	it("carries through an unverified email flag from the id_token claims", async () => {
+		const fakeFetch: typeof globalThis.fetch = async () =>
+			jsonResponse({
+				id_token: idToken({ sub: "google-sub-99", email: "unverified@example.com", email_verified: false }),
+			});
+
+		const exchange = initExchangeGoogleCode({
+			clientId: "id",
+			clientSecret: "secret",
+			redirectUri: "https://app.test/cb",
+			fetch: fakeFetch,
+		});
+
+		const result = await exchange("code");
+
+		assert.equal(result.emailVerified, false);
+	});
+
+	it("rejects a token response that is missing the id_token", async () => {
+		const fakeFetch: typeof globalThis.fetch = async () => jsonResponse({ error: "invalid_grant" });
+
+		const exchange = initExchangeGoogleCode({
+			clientId: "id",
+			clientSecret: "secret",
+			redirectUri: "https://app.test/cb",
+			fetch: fakeFetch,
+		});
+
+		await assert.rejects(exchange("bad-code"));
+	});
+
+	it("rejects an id_token whose claims fail validation", async () => {
+		const fakeFetch: typeof globalThis.fetch = async () =>
+			jsonResponse({ id_token: idToken({ sub: "google-sub", email: "x@example.com" }) });
+
+		const exchange = initExchangeGoogleCode({
+			clientId: "id",
+			clientSecret: "secret",
+			redirectUri: "https://app.test/cb",
+			fetch: fakeFetch,
+		});
+
+		await assert.rejects(exchange("code"));
+	});
+});

--- a/projects/hutch/src/runtime/providers/google-auth/google-token.ts
+++ b/projects/hutch/src/runtime/providers/google-auth/google-token.ts
@@ -1,6 +1,5 @@
-/* c8 ignore start -- thin Google API wrapper, tested via integration */
 import { z } from "zod";
-import { GoogleIdSchema } from "@packages/test-fixtures/providers/google-auth";
+import { GoogleIdSchema } from "@packages/provider-contracts/google-auth";
 import type { ExchangeGoogleCode } from "@packages/provider-contracts/google-auth";
 
 const GoogleTokenResponse = z.object({
@@ -45,4 +44,3 @@ export function initExchangeGoogleCode(deps: {
 		};
 	};
 }
-/* c8 ignore stop */

--- a/src/packages/provider-contracts/src/google-auth.ts
+++ b/src/packages/provider-contracts/src/google-auth.ts
@@ -1,6 +1,9 @@
+import { z } from "zod";
 import type { $brand } from "zod";
 
 export type GoogleId = string & $brand<"GoogleId">;
+
+export const GoogleIdSchema = z.string().brand<"GoogleId">();
 
 export interface GoogleTokenResult {
 	googleId: GoogleId;

--- a/src/packages/test-fixtures/src/providers/google-auth/google-auth.schema.ts
+++ b/src/packages/test-fixtures/src/providers/google-auth/google-auth.schema.ts
@@ -1,6 +1,5 @@
-import { z } from "zod";
+import { GoogleIdSchema } from "@packages/provider-contracts/google-auth";
 import type { GoogleId } from "@packages/provider-contracts/google-auth";
 
 export type { GoogleId };
-
-export const GoogleIdSchema = z.string().brand<"GoogleId">();
+export { GoogleIdSchema };


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/providers/google-auth/google-token.ts` carried a whole-file `/* c8 ignore start -- thin Google API wrapper, tested via integration */` and imported its production branded schema from a test-fixtures package. This PR fixes both.

## Why

- **Forbidden c8-ignore without an approved reason** (source: `CLAUDE.md` → "Allowed c8 ignore Cases"). The sanctioned cases are thin AWS SDK wrappers, CI-only retry callbacks, V8 async-function artifacts, and V8 block-coverage phantoms. `google-token.ts` is none of these: it performs an OAuth token POST, splits the JWT `id_token`, base64url-decodes it, `JSON.parse`s the payload, and runs two zod `.parse` calls. The whole-file ignore suppressed coverage of real, testable logic.
- **Thin wrapper must be unit-tested with an injected fake** (source: `.claude/skills/test-driven-design/SKILL.md` → "Thin AWS SDK Wrappers Are Unit-Tested With Fake Clients"). `fetch` is already dependency-injected, so the token exchange and claim mapping are fully unit-testable. The fix removes the ignore and adds a colocated `google-token.test.ts` using the same fake-`fetch` pattern as `stripe-subscriptions.test.ts`.
- **Production depending on a test-fixtures package** (source: `.claude/skills/test-driven-design/SKILL.md`). `GoogleIdSchema` (the runtime schema validating `claims.sub`) was imported from `@packages/test-fixtures`. It now lives in `@packages/provider-contracts/google-auth`, the package documented as "Provider contract types shared by production code and the in-memory test fixtures" and already the home of the `GoogleId` brand type. test-fixtures re-exports it, so `test-app.test.ts`, `google-auth.route.test.ts`, and `google-auth.schema.test.ts` keep importing it unchanged.

## Changes

- `src/packages/provider-contracts/src/google-auth.ts` — define and export the runtime `GoogleIdSchema` next to its `GoogleId` type.
- `src/packages/test-fixtures/src/providers/google-auth/google-auth.schema.ts` — re-export `GoogleIdSchema` from provider-contracts (single source of truth); keep the `GoogleId` type re-export.
- `projects/hutch/src/runtime/providers/google-auth/google-token.ts` — remove the whole-file c8 ignore; import `GoogleIdSchema` from `@packages/provider-contracts/google-auth`.
- `projects/hutch/src/runtime/providers/google-auth/google-token.test.ts` — new colocated unit test with a fake `fetch` covering request shape, claim mapping, the unverified-email path, and both zod rejection paths, reaching 100% coverage without the ignore.

## Verification

`pnpm check` (tsc + biome + knip + tests + 100% coverage). `GoogleIdSchema` is consumed by production code and re-exported, so knip does not flag it; the existing schema behaviour test resolves through the transparent re-export.

🤖 Part of the guidelines & skills audit.