### PR TITLE
refactor(password-reset): contract-owned token schema + unit-tested dynamodb wrapper

### DIFF
--- a/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.test.ts
+++ b/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.test.ts
@@ -1,0 +1,132 @@
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+} from "@packages/hutch-storage-client";
+import { initDynamoDbPasswordReset } from "./dynamodb-password-reset";
+
+interface CapturedCommand {
+	name: string;
+	input: Record<string, unknown>;
+}
+
+/** Records commands and replays the row a DeleteCommand with ReturnValues:ALL_OLD
+ * would return, or throws a supplied error so the rejection paths can be asserted. */
+function createFakeClient(opts: {
+	deleteAttributes?: Record<string, unknown>;
+	deleteError?: Error;
+}): { client: DynamoDBDocumentClient; commands: CapturedCommand[] } {
+	const commands: CapturedCommand[] = [];
+	const client = {
+		send: (async (command: { constructor: { name: string }; input: Record<string, unknown> }) => {
+			const name = command.constructor.name;
+			commands.push({ name, input: command.input });
+			if (name === "DeleteCommand") {
+				if (opts.deleteError) throw opts.deleteError;
+				return opts.deleteAttributes ? { Attributes: opts.deleteAttributes } : {};
+			}
+			return {};
+		}) as DynamoDBDocumentClient["send"],
+	};
+	return { client: client as typeof client & DynamoDBDocumentClient, commands };
+}
+
+const TABLE = "password-reset-tokens";
+
+function initStore(client: DynamoDBDocumentClient) {
+	return initDynamoDbPasswordReset({ client, tableName: TABLE });
+}
+
+describe("initDynamoDbPasswordReset", () => {
+	describe("createPasswordResetToken", () => {
+		it("puts a 64-hex token keyed by email with a one-hour TTL", async () => {
+			const { client, commands } = createFakeClient({});
+
+			const before = Math.floor(Date.now() / 1000);
+			const token = await initStore(client).createPasswordResetToken({
+				email: "user@example.com",
+			});
+			const after = Math.floor(Date.now() / 1000);
+
+			expect(token).toMatch(/^[0-9a-f]{64}$/);
+			const put = commands.find((c) => c.name === "PutCommand");
+			expect(put?.input.TableName).toBe(TABLE);
+			const item = put?.input.Item as { token: string; email: string; expiresAt: number };
+			expect(item.token).toBe(token);
+			expect(item.email).toBe("user@example.com");
+			expect(item.expiresAt).toBeGreaterThanOrEqual(before + 60 * 60);
+			expect(item.expiresAt).toBeLessThanOrEqual(after + 60 * 60);
+		});
+	});
+
+	describe("verifyPasswordResetToken", () => {
+		it("consumes the token and returns the email when it exists and is unexpired", async () => {
+			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
+				email: "user@example.com",
+			});
+			const future = Math.floor(Date.now() / 1000) + 60 * 60;
+			const { client, commands } = createFakeClient({
+				deleteAttributes: { token, email: "user@example.com", expiresAt: future },
+			});
+
+			const result = await initStore(client).verifyPasswordResetToken(token);
+
+			expect(result).toEqual({ ok: true, email: "user@example.com" });
+			const del = commands.find((c) => c.name === "DeleteCommand");
+			expect(del?.input.Key).toEqual({ token });
+			expect(del?.input.ConditionExpression).toBe("attribute_exists(#tk)");
+			expect(del?.input.ReturnValues).toBe("ALL_OLD");
+		});
+
+		it("rejects an expired token even though the row still existed", async () => {
+			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
+				email: "user@example.com",
+			});
+			const past = Math.floor(Date.now() / 1000) - 1;
+			const { client } = createFakeClient({
+				deleteAttributes: { token, email: "user@example.com", expiresAt: past },
+			});
+
+			expect(await initStore(client).verifyPasswordResetToken(token)).toEqual({
+				ok: false,
+				reason: "invalid-token",
+			});
+		});
+
+		it("rejects when the delete returns no prior attributes", async () => {
+			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
+				email: "user@example.com",
+			});
+			const { client } = createFakeClient({});
+
+			expect(await initStore(client).verifyPasswordResetToken(token)).toEqual({
+				ok: false,
+				reason: "invalid-token",
+			});
+		});
+
+		it("rejects when the attribute_exists condition fails (token already consumed or absent)", async () => {
+			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
+				email: "user@example.com",
+			});
+			const { client } = createFakeClient({
+				deleteError: new ConditionalCheckFailedException({ $metadata: {}, message: "missing" }),
+			});
+
+			expect(await initStore(client).verifyPasswordResetToken(token)).toEqual({
+				ok: false,
+				reason: "invalid-token",
+			});
+		});
+
+		it("rethrows non-conditional delete errors", async () => {
+			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
+				email: "user@example.com",
+			});
+			const { client } = createFakeClient({ deleteError: new Error("throttled") });
+
+			await expect(initStore(client).verifyPasswordResetToken(token)).rejects.toThrow(
+				"throttled",
+			);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.ts
+++ b/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
 import { randomBytes } from "node:crypto";
 import {
 	ConditionalCheckFailedException,
@@ -10,9 +9,9 @@ import type {
 	CreatePasswordResetToken,
 	VerifyPasswordResetToken,
 } from "@packages/provider-contracts/password-reset";
-import { PasswordResetTokenSchema } from "@packages/test-fixtures/providers/password-reset";
+import { PasswordResetTokenSchema } from "@packages/provider-contracts/password-reset";
 
-const TOKEN_TTL_SECONDS = 60 * 60; // 1 hour
+const TOKEN_TTL_SECONDS = 60 * 60;
 
 const PasswordResetRow = z.object({
 	token: z.string(),
@@ -70,4 +69,3 @@ export function initDynamoDbPasswordReset(deps: {
 
 	return { createPasswordResetToken, verifyPasswordResetToken };
 }
-/* c8 ignore stop */

--- a/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
@@ -6,7 +6,7 @@ import type {
 	CreatePasswordResetToken,
 	VerifyPasswordResetToken,
 } from "@packages/provider-contracts/password-reset";
-import { PasswordResetTokenSchema } from "@packages/test-fixtures/providers/password-reset";
+import { PasswordResetTokenSchema } from "@packages/provider-contracts/password-reset";
 import type { ConsumeRateLimit } from "@packages/provider-contracts/rate-limit";
 import type { RateLimitRule } from "@packages/domain/rate-limit";
 import { z } from "zod";

--- a/src/packages/provider-contracts/src/index.ts
+++ b/src/packages/provider-contracts/src/index.ts
@@ -8,7 +8,7 @@ export type * from "./email-verification";
 export type * from "./events";
 export type * from "./google-auth";
 export type * from "./oauth";
-export type * from "./password-reset";
+export * from "./password-reset";
 export type * from "./pending-html";
 export type * from "./pending-pdf";
 export type * from "./pending-signup";

--- a/src/packages/provider-contracts/src/password-reset.ts
+++ b/src/packages/provider-contracts/src/password-reset.ts
@@ -1,4 +1,10 @@
+import { z } from "zod";
+
 export type PasswordResetToken = string & { readonly __brand: "PasswordResetToken" };
+
+export const PasswordResetTokenSchema = z
+	.string()
+	.transform((s): PasswordResetToken => s as PasswordResetToken);
 
 export type CreatePasswordResetToken = (args: { email: string }) => Promise<PasswordResetToken>;
 

--- a/src/packages/test-fixtures/src/providers/password-reset/password-reset.schema.ts
+++ b/src/packages/test-fixtures/src/providers/password-reset/password-reset.schema.ts
@@ -1,4 +1,1 @@
-import { z } from "zod";
-import type { PasswordResetToken } from "@packages/provider-contracts/password-reset";
-
-export const PasswordResetTokenSchema = z.string().transform((s): PasswordResetToken => s as PasswordResetToken);
+export { PasswordResetTokenSchema } from "@packages/provider-contracts/password-reset";


### PR DESCRIPTION
## What

Resolves three guideline findings in `projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.ts`.

### 1. Production must not depend on test-fixtures (high)
- **Rule:** In-memory/test-fixture implementations are for tests only (test-driven-design/SKILL.md).
- The production module imported `PasswordResetTokenSchema` from `@packages/test-fixtures/providers/password-reset`, inverting the dependency direction.
- **Change:** added `PasswordResetTokenSchema` to `@packages/provider-contracts/src/password-reset.ts` (next to the `PasswordResetToken` contract it brands), promoted the barrel export for that module from `export type *` to `export *` so the runtime value is exported, pointed the production import at provider-contracts, and reduced `test-fixtures/.../password-reset.schema.ts` to a re-export so the in-memory fixture and its test are untouched.

### 2. Whole-file `c8 ignore` over branching logic (high)
- **Rule:** Allowed whole-file `c8 ignore` is reserved for truly trivial 3-5 line wrappers with no branching; extract/unit-test branching logic instead (test-driven-design/SKILL.md).
- The file generates a token, computes a TTL, and has three branches (missing `Attributes`, expiry comparison, `ConditionalCheckFailedException`).
- **Change:** removed `/* c8 ignore start/stop */` and added `dynamodb-password-reset.test.ts` using the `Partial<DynamoDBDocumentClient>` fake-client pattern, covering create (Put Item shape, 64-hex token, now+3600 TTL) and all verify paths (valid, expired, missing Attributes, conditional-check failure, and rethrow of other errors).

### 3. What-comment (medium)
- **Rule:** Comments document why, not what (CLAUDE.md).
- **Change:** removed `// 1 hour`; `TOKEN_TTL_SECONDS = 60 * 60` already carries the meaning.

## Why
- **Source:** test-driven-design/SKILL.md, CLAUDE.md
- **File:** projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.ts

No exported signature changes; `initDynamoDbPasswordReset` is unchanged and the in-memory fixture is insulated by the re-export, so no callers break and coverage stays at 100% with positive assertions.

🤖 Part of the guidelines & skills audit.