### PR TITLE
refactor(firefox-extension): use HutchLogger in sync-signed-extension CLI

### DIFF
--- a/projects/extensions/firefox-extension/scripts/sync-signed-extension.js
+++ b/projects/extensions/firefox-extension/scripts/sync-signed-extension.js
@@ -5,8 +5,11 @@ const { execSync } = require("node:child_process");
 const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
+const { HutchLogger, consoleLogger } = require("@packages/hutch-logger");
 const { firefoxS3Config } = require("browser-extension-core/s3-config");
 const { getBucketName, getBucketBaseUrl } = firefoxS3Config;
+
+const logger = HutchLogger.from(consoleLogger);
 
 const AMO_API_BASE = "https://addons.mozilla.org/api/v5";
 
@@ -51,7 +54,7 @@ async function main() {
 	const updatesUrl = `${baseUrl}/updates.json`;
 	const updatesResponse = await fetch(updatesUrl);
 	if (updatesResponse.status === 404) {
-		console.log(`No updates.json on S3 yet (first run): ${updatesUrl} ${updatesResponse.status}`);
+		logger.info(`No updates.json on S3 yet (first run): ${updatesUrl} ${updatesResponse.status}`);
 	} else {
 		assert.ok(
 			updatesResponse.ok,
@@ -79,7 +82,7 @@ async function main() {
 	);
 
 	if (!signedVersion) {
-		console.log("No signed version found on AMO. Nothing to sync.");
+		logger.info("No signed version found on AMO. Nothing to sync.");
 		return;
 	}
 
@@ -88,17 +91,17 @@ async function main() {
 		`Unexpected version format from AMO: ${signedVersion.version}`,
 	);
 
-	console.log(`Latest signed version on AMO: ${signedVersion.version}`);
+	logger.info(`Latest signed version on AMO: ${signedVersion.version}`);
 
 	const signedFilename = `hutch-signed-${signedVersion.version}.xpi`;
 	const expectedLink = `${baseUrl}/${signedFilename}`;
 
 	if (currentUpdateLink === expectedLink) {
-		console.log("S3 already has the latest signed version. Nothing to do.");
+		logger.info("S3 already has the latest signed version. Nothing to do.");
 		return;
 	}
 
-	console.log("Downloading signed XPI from AMO...");
+	logger.info("Downloading signed XPI from AMO...");
 	const xpiResponse = await fetch(signedVersion.file.url, {
 		headers: { Authorization: `JWT ${token}` },
 	});
@@ -115,7 +118,7 @@ async function main() {
 			Buffer.from(await xpiResponse.arrayBuffer()),
 		);
 
-		console.log(`Uploading ${signedFilename} to S3...`);
+		logger.info(`Uploading ${signedFilename} to S3...`);
 		execSync(
 			`aws s3 cp "${tmpXpiPath}" "s3://${bucketName}/${signedFilename}" --content-type "application/x-xpinstall"`,
 			{ stdio: "inherit" },
@@ -155,7 +158,7 @@ async function main() {
 			{ stdio: "inherit" },
 		);
 
-		console.log(
+		logger.info(
 			`Successfully synced signed version ${signedVersion.version} to S3`,
 		);
 	} finally {
@@ -164,6 +167,6 @@ async function main() {
 }
 
 main().catch((error) => {
-	console.error("Sync failed:", error.message);
+	logger.error("Sync failed:", error.message);
 	process.exit(1);
 });


### PR DESCRIPTION
## What

Replace all raw `console.*` calls in
`projects/extensions/firefox-extension/scripts/sync-signed-extension.js`
(the AMO -> S3 signed-XPI sync publish CLI) with `HutchLogger`.

## Why

- **Rule:** CLAUDE.md -> *Logging* — "Use `HutchLogger` from
  `@packages/hutch-logger` for all logging. Never use raw
  `console.log`/`console.error` in application code. In composition
  roots, create the logger with `HutchLogger.from(consoleLogger)`."
- **Source:** CLAUDE.md
- **File:** `projects/extensions/firefox-extension/scripts/sync-signed-extension.js`

## Change

- Import `{ HutchLogger, consoleLogger }` from `@packages/hutch-logger`
  (already a declared dependency of this project; ships CommonJS
  `dist/index.js`, so it `require()`s cleanly from this `.js` CLI —
  verified by running a probe under `scripts/`).
- Create a module-level `logger = HutchLogger.from(consoleLogger)` (this
  CLI's composition root).
- The eight `console.log(...)` status messages now use `logger.info(...)`.
- The top-level failure `console.error("Sync failed:", ...)` now uses
  `logger.error(...)`.

These scripts have no unit tests and are excluded from coverage
(`.c8rc.json` scopes coverage to `src`, and `scripts/sync-signed-extension.js`
is in knip's ignore list), so no test or caller edits are required.

## Deferred within this file: direct `process.env` reads

The same finding flagged the direct `process.env.AMO_JWT_ISSUER` /
`AMO_JWT_SECRET` reads (lines 39-40). These are intentionally left
unchanged: `requireEnv`/`getEnv` live at
`projects/hutch/src/runtime/domain/require-env.ts` and are not exposed as
a workspace package. Adopting them here would require either a
cross-project relative import (forbidden by CLAUDE.md -> *No
Cross-Project Relative Imports*) or a new shared env package — a larger,
rippling change beyond this low-severity fix, and one the other
extension scripts would need too. The script already enforces the same
required-env invariant via `assert.ok(issuer, ...)` /
`assert.ok(secret, ...)` immediately after reading. Recommended
follow-up: extract `require-env` into a shared workspace package
consumable by the extension projects, then switch all extension scripts
over together.

🤖 Part of the guidelines & skills audit.