### PR TITLE
test(e2e): assert banner dismissed state positively instead of negating the visible class

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts
@@ -125,7 +125,7 @@ export function createBannerOnReaderActions(
 				// confirm the close button removes it and persists the dismiss
 				// flag so it doesn't re-appear on subsequent visits.
 				await banner.locator('[data-extension-suggestion-close]').click()
-				await expect(banner).not.toHaveClass(/extension-suggestion-banner--visible/)
+				await expect(banner).toHaveClass('extension-suggestion-banner')
 				const dismissed = await page.evaluate(() =>
 					window.localStorage.getItem('readplace.extension-suggestion-dismissed'),
 				)


### PR DESCRIPTION
## What

In `projects/hutch/src/e2e/queue-flow/banner-on-reader-actions.ts`, the close-button check asserted the dismissed state with a negative class assertion:

```ts
await expect(banner).not.toHaveClass(/extension-suggestion-banner--visible/)
```

This is replaced with a positive assertion of the exact expected end state:

```ts
await expect(banner).toHaveClass('extension-suggestion-banner')
```

## Why

The [test-driven-design skill](.claude/skills/test-driven-design/SKILL.md) ("Avoid Negative Test Assertions" and the binary shown/hidden guidance under "Never Rely on `querySelector(...).toBeNull()`") prescribes asserting an explicit positive state rather than the absence of a class. A `.not.toHaveClass(--visible)` regex assertion passes for the wrong reason if the visibility class is ever renamed — the pattern simply never matches, so the test stays green even when the production toggle breaks.

The banner (`extension-suggestion-banner.client.ts`) renders unconditionally with the base class `extension-suggestion-banner` and toggles a single `--visible` modifier; the close handler removes it, so the rendered `class` attribute returns to exactly `extension-suggestion-banner`. Playwright's string form of `toHaveClass` asserts the full class attribute equals that value, so the assertion now proves the modifier was removed and fails loudly under a rename. The persisted dismiss flag remains asserted on the following line as the second positive signal.

## Scope

Single-file change to an E2E action; no production, CSS, route-test, or client-test changes required. The sibling occurrences in `view-page-actions.ts` are tracked separately.

🤖 Part of the guidelines & skills audit.