### PR TITLE
refactor(hutch): use requireEnv for E2E_PORT in queue-flow local spec

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/run.e2e-local.ts
+++ b/projects/hutch/src/e2e/queue-flow/run.e2e-local.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import { test } from '@playwright/test'
 import { createBannerOnReaderActions, type BannerOnReaderProgress } from './banner-on-reader-actions'
 import { createCleanupActions, type CleanupProgress } from './cleanup-actions'
@@ -11,9 +10,9 @@ import { createSeedActions, type SeedProgress } from './seed-actions'
 import { createAnonymousViewPageActions, type ViewPageProgress } from './view-page-actions'
 import { createLocalTestArticles, type QueueProgress } from './queue-actions'
 import { runQueueFlow } from './queue-flow'
+import { requireEnv } from '../../runtime/domain/require-env'
 
-assert(process.env.E2E_PORT, "E2E_PORT is required")
-const BASE_URL = `http://localhost:${process.env.E2E_PORT}`
+const BASE_URL = `http://localhost:${requireEnv('E2E_PORT')}`
 
 test.describe('Queue management flow (local)', () => {
   test('signup, logout, reset password, login, add articles, pagination, sort, read, delete, verify tabs', async ({ page }) => {


### PR DESCRIPTION
## What

Replace direct `process.env.E2E_PORT` access in
`projects/hutch/src/e2e/queue-flow/run.e2e-local.ts` with `requireEnv`
from `../../runtime/domain/require-env`.

## Why

- **Rule:** Environment Variable Access — "Never use `process.env`
  directly. Use `requireEnv`/`getEnv`."
- **Source:** `CLAUDE.md`
- The documented `process.env` exception is worded strictly for
  `playwright.config.*.ts`. This file is a `.e2e-local.ts` spec, so it
  falls outside the literal exception.
- The established e2e composition root
  `projects/hutch/src/e2e/e2e-server.main.ts` already uses
  `requireEnv('E2E_PORT')`, so this aligns the spec with project convention.

## Change

- Import `requireEnv` from `../../runtime/domain/require-env`.
- Replace `assert(process.env.E2E_PORT, …)` + the `BASE_URL` template
  literal with `const BASE_URL = http://localhost:${requireEnv('E2E_PORT')}`.
- Remove the now-unused `node:assert` import (`requireEnv` throws when
  the variable is unset, preserving the prior fail-fast behaviour).

🤖 Part of the guidelines & skills audit.