### PR TITLE
test(hutch): remove `as string` casts from logger test

### DIFF
--- a/projects/hutch/src/runtime/domain/logger.test.ts
+++ b/projects/hutch/src/runtime/domain/logger.test.ts
@@ -6,7 +6,7 @@ describe("logger", () => {
 			const spy = jest.spyOn(console, "log").mockImplementation(() => {});
 			logger().info("hello");
 			expect(spy).toHaveBeenCalledTimes(1);
-			const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+			const parsed = JSON.parse(String(spy.mock.calls[0][0]));
 			expect(parsed.level).toBe("INFO");
 			expect(parsed.message).toBe("hello");
 			expect(parsed.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -19,7 +19,7 @@ describe("logger", () => {
 			const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 			logger().error("something broke", new Error("boom"));
 			expect(spy).toHaveBeenCalledTimes(1);
-			const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+			const parsed = JSON.parse(String(spy.mock.calls[0][0]));
 			expect(parsed.level).toBe("ERROR");
 			expect(parsed.message).toBe("something broke");
 			expect(parsed.stack).toContain("Error: boom");
@@ -29,7 +29,7 @@ describe("logger", () => {
 		it("logs without a stack when no error is passed", () => {
 			const spy = jest.spyOn(console, "error").mockImplementation(() => {});
 			logger().error("just a message");
-			const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+			const parsed = JSON.parse(String(spy.mock.calls[0][0]));
 			expect(parsed.stack).toBeUndefined();
 			spy.mockRestore();
 		});


### PR DESCRIPTION
## What

Remove the three `as string` type assertions in
`projects/hutch/src/runtime/domain/logger.test.ts`, replacing each
`JSON.parse(spy.mock.calls[0][0] as string)` with
`JSON.parse(String(spy.mock.calls[0][0]))`.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`)
- **Source:** CLAUDE.md

The jest mock-call argument is typed `any`, and `JSON.parse` requires a
`string`, so the test used `as string` to bridge the gap. This cast is not one
of the documented exceptions (`as const`, isolated Node wrappers, `requireEnv`
generic), so it is forbidden. `String(...)` performs a genuine runtime
conversion of the value instead of asserting its type, satisfying the rule
without weakening any check.

## Change

- Line 9 (`info` test): `as string` → `String(...)`
- Line 22 (`error` with stack test): `as string` → `String(...)`
- Line 32 (`error` without stack test): same identical pattern in the same file, fixed for consistency

No exported signatures change; the fix is contained to the test file and all
existing positive assertions are preserved.

🤖 Part of the guidelines & skills audit.