### PR TITLE
test(subscription): replace `{} as never` Lambda context with a typed stub

### DIFF
--- a/projects/hutch/src/runtime/handle-subscription-cancellation-scheduled/handle-subscription-cancellation-scheduled-handler.test.ts
+++ b/projects/hutch/src/runtime/handle-subscription-cancellation-scheduled/handle-subscription-cancellation-scheduled-handler.test.ts
@@ -1,10 +1,25 @@
 import assert from "node:assert/strict";
-import type { SQSEvent } from "aws-lambda";
+import type { Context, SQSEvent } from "aws-lambda";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initHandleSubscriptionCancellationScheduledHandler } from "./handle-subscription-cancellation-scheduled-handler";
 
 const USER_ID = UserIdSchema.parse("user-cancel-scheduled");
+
+const stubContext: Context = {
+	callbackWaitsForEmptyEventLoop: true,
+	functionName: "test",
+	functionVersion: "1",
+	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
+	memoryLimitInMB: "128",
+	awsRequestId: "test-request-id",
+	logGroupName: "/aws/lambda/test",
+	logStreamName: "test-stream",
+	getRemainingTimeInMillis: () => 30000,
+	done: () => {},
+	fail: () => {},
+	succeed: () => {},
+};
 
 function buildSqsEvent(records: Array<{ messageId: string; body: string }>): SQSEvent {
 	return {
@@ -62,7 +77,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -92,7 +107,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -121,7 +136,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -147,7 +162,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -166,7 +181,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-schema", body: JSON.stringify({ detail: { userId: USER_ID } }) },
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -194,7 +209,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 				{ messageId: "msg-1", body },
 				{ messageId: "msg-2-dup", body },
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 


### PR DESCRIPTION
## What

`handle-subscription-cancellation-scheduled-handler.test.ts` passed `{} as never` as the AWS Lambda `Context` argument at six handler call sites (lines 65, 95, 124, 150, 169, 197).

## Why

- **Rule:** "Avoid TypeScript Type Assertions (`as`)" — *Faking a partial object with `as`* is BAD (the documented `{ status: 200 } as Response` anti-pattern). `as never` is not one of the allowed exceptions (`as const`, isolated Node.js API wrappers).
- **Source:** `CLAUDE.md`
- **File:** `projects/hutch/src/runtime/handle-subscription-cancellation-scheduled/handle-subscription-cancellation-scheduled-handler.test.ts`

`{} as Partial<Context>` would not type-check because the handler's parameter is the full required `Context` interface. The repo already solves this without an assertion: `reader-ready-fanout-handler.test.ts` and `reader-ready-notify-handler.test.ts` declare a fully-typed `const stubContext: Context = { ... }`.

## Change

- Import `Context` alongside `SQSEvent` from `aws-lambda`.
- Add a `stubContext: Context` fixture mirroring the existing convention.
- Replace all six `{} as never` arguments with `stubContext`.

The handler ignores the context object, so all test assertions and behaviour are unchanged. No coverage impact.

🤖 Part of the guidelines & skills audit.