### PR TITLE
test(handle-subscription-cancelled): drop `{} as never` Lambda context fake

### DIFF
--- a/projects/hutch/src/runtime/handle-subscription-cancelled/handle-subscription-cancelled-handler.test.ts
+++ b/projects/hutch/src/runtime/handle-subscription-cancelled/handle-subscription-cancelled-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { SQSEvent } from "aws-lambda";
+import type { Context, SQSEvent } from "aws-lambda";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initHandleSubscriptionCancelledHandler } from "./handle-subscription-cancelled-handler";
@@ -24,6 +24,21 @@ function makeNoopEmit(): EmitSubscriptionEvent {
 }
 
 const USER_ID = UserIdSchema.parse("user-cancel");
+
+const stubContext: Context = {
+	callbackWaitsForEmptyEventLoop: true,
+	functionName: "test",
+	functionVersion: "1",
+	invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789:function:test",
+	memoryLimitInMB: "128",
+	awsRequestId: "test-request-id",
+	logGroupName: "/aws/lambda/test",
+	logStreamName: "test-stream",
+	getRemainingTimeInMillis: () => 30000,
+	done: () => {},
+	fail: () => {},
+	succeed: () => {},
+};
 
 function buildSqsEvent(records: Array<{ messageId: string; body: string }>): SQSEvent {
 	return {
@@ -77,7 +92,7 @@ describe("handle-subscription-cancelled-handler", () => {
 					body: buildEventBridgeBody({ userId: USER_ID, subscriptionId: "sub_x", reason: "stripe_webhook" }),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -109,7 +124,7 @@ describe("handle-subscription-cancelled-handler", () => {
 					body: buildEventBridgeBody({ userId: USER_ID, reason: "user_initiated_trial" }),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -127,7 +142,7 @@ describe("handle-subscription-cancelled-handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-fail", body: buildEventBridgeBody({ userId: USER_ID }) }]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -145,7 +160,7 @@ describe("handle-subscription-cancelled-handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "not-json" }]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -163,7 +178,7 @@ describe("handle-subscription-cancelled-handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-schema", body: JSON.stringify({ detail: { reason: "stripe_webhook" } }) }]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -190,7 +205,7 @@ describe("handle-subscription-cancelled-handler", () => {
 				{ messageId: "msg-boom", body: buildEventBridgeBody({ userId: "user-boom" }) },
 				{ messageId: "msg-ok-2", body: buildEventBridgeBody({ userId: "user-ok-2" }) },
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 


### PR DESCRIPTION
## What

Replaces the five `{} as never` Lambda `Context` fakes in `handle-subscription-cancelled-handler.test.ts` with a fully-typed `stubContext: Context` object literal.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`) — faking a partial object with `as` instead of a properly typed value.
- **Source:** `CLAUDE.md` ("Avoid TypeScript Type Assertions (`as`)" section). Its BAD example is `{ status: 200, ok: true } as Response`; the only allowed exceptions are `as const` and isolated Node.js API wrappers, neither of which covers `{} as never`.
- **File:** `projects/hutch/src/runtime/handle-subscription-cancelled/handle-subscription-cancelled-handler.test.ts` (lines 80, 130, 149, 167, 193).

## Change

- Import `Context` alongside `SQSEvent` from `aws-lambda`.
- Add a `stubContext: Context` literal with every required field populated (mirroring the existing compliant `reader-ready-fanout-handler.test.ts` fixture) — no type assertion.
- Pass `stubContext` to all five handler calls instead of `{} as never`.

Test-only change; the handler ignores the context argument, so behaviour and assertions are unchanged.

🤖 Part of the guidelines & skills audit.