### PR TITLE
test(observability): drop redundant negative subscription_id assertion

### DIFF
--- a/projects/hutch/src/runtime/observability/subscription-events.test.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.test.ts
@@ -83,6 +83,5 @@ describe("initEmitSubscriptionEvent", () => {
 			user_id: USER_ID,
 			reason: "user_initiated_trial",
 		});
-		expect(JSON.stringify(captured[0])).not.toContain("subscription_id");
 	});
 });


### PR DESCRIPTION
## What

Removes the negative assertion on line 86 of
`projects/hutch/src/runtime/observability/subscription-events.test.ts`:

```ts
expect(JSON.stringify(captured[0])).not.toContain("subscription_id");
```

## Why

The test-driven-design skill's **Avoid Negative Test Assertions** rule
(`.claude/skills/test-driven-design/SKILL.md`) names `.not.toContain()` as the
bad pattern because it goes stale when the serialized format changes and asserts
on what should *not* be present rather than the actual expected value.

The preceding `expect(captured[0]).toEqual({ ... })` (lines 79-85) is an
exact-match assertion that already proves the captured cancelled event contains
**only** `stream`, `event`, `timestamp`, `user_id`, and `reason` — a stray
`subscription_id` key would fail `toEqual`. The implementation
(`subscription-events.ts` line 50) only spreads `subscription_id` when truthy,
so the positive `toEqual` is the complete, format-independent expression of the
expected state. The negative `JSON.stringify` substring check is purely
redundant.

## Change

- Delete the single redundant `.not.toContain` line. No production code or other
  callers are affected; the positive `toEqual` keeps full coverage.

- Rule: Avoid Negative Test Assertions
- Source: `.claude/skills/test-driven-design/SKILL.md`
- File: `projects/hutch/src/runtime/observability/subscription-events.test.ts`

🤖 Part of the guidelines & skills audit.