### PR TITLE
refactor(rate-limit): remove `as` casts from the rate-limit test fake

### DIFF
--- a/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts
+++ b/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts
@@ -5,13 +5,11 @@ import {
 } from "@packages/hutch-storage-client";
 import { initDynamoDbRateLimit } from "./dynamodb-rate-limit";
 
-type SendFn = DynamoDBDocumentClient["send"];
-
 function createFakeClient(
-	impl: (command: unknown) => unknown,
-): Partial<DynamoDBDocumentClient> {
+	impl: (command: unknown) => Record<string, unknown>,
+): Pick<DynamoDBDocumentClient, "send"> {
 	return {
-		send: (async (command: unknown) => impl(command)) as unknown as SendFn,
+		send: async (command) => impl(command),
 	};
 }
 
@@ -37,7 +35,7 @@ describe("initDynamoDbRateLimit", () => {
 			client: createFakeClient((command) => {
 				received = command;
 				return {};
-			}) as DynamoDBDocumentClient,
+			}),
 			tableName: TABLE,
 			now: midWindowNow,
 		});
@@ -70,7 +68,7 @@ describe("initDynamoDbRateLimit", () => {
 					$metadata: {},
 					message: "condition failed",
 				});
-			}) as DynamoDBDocumentClient,
+			}),
 			tableName: TABLE,
 			now: midWindowNow,
 		});
@@ -88,7 +86,7 @@ describe("initDynamoDbRateLimit", () => {
 		const { consumeRateLimit } = initDynamoDbRateLimit({
 			client: createFakeClient(() => {
 				throw new Error("throttled");
-			}) as DynamoDBDocumentClient,
+			}),
 			tableName: TABLE,
 			now: midWindowNow,
 		});

--- a/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.ts
+++ b/projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.ts
@@ -19,7 +19,7 @@ const RateLimitRow = z.object({ pk: z.string() });
  * window regardless of how many Lambda instances serve them concurrently.
  */
 export function initDynamoDbRateLimit(deps: {
-	client: DynamoDBDocumentClient;
+	client: Pick<DynamoDBDocumentClient, "send">;
 	tableName: string;
 	now: () => Date;
 }): { consumeRateLimit: ConsumeRateLimit } {

--- a/src/packages/hutch-storage-client/src/define-table.ts
+++ b/src/packages/hutch-storage-client/src/define-table.ts
@@ -86,7 +86,7 @@ export type DynamoTable<TSchema extends z.ZodObject> = {
  * accepted and normalized.
  */
 export function defineDynamoTable<TSchema extends z.ZodObject>(config: {
-	client: DynamoDBDocumentClient;
+	client: Pick<DynamoDBDocumentClient, "send">;
 	tableName: string;
 	schema: TSchema;
 }): DynamoTable<TSchema> {


### PR DESCRIPTION
## What

Removes four forbidden TypeScript `as` casts used to fabricate a fake `DynamoDBDocumentClient` in `dynamodb-rate-limit.test.ts`:

- the `(async ...) as unknown as SendFn` double-cast on `send`
- three `... as DynamoDBDocumentClient` up-casts of a `Partial` at the call sites

## Why

**Rule:** Avoid TypeScript Type Assertions (`as`) — source: `CLAUDE.md`.

`as` bypasses the compiler and hides type mismatches; the only allowed exceptions are `as const` and isolated Node-API wrappers, neither of which applies here.

## How

The casts existed only because `initDynamoDbRateLimit` declared it needed a full `DynamoDBDocumentClient`, even though it merely forwards the client to `defineDynamoTable`, which itself only calls `client.send`. This change narrows the dependency to its honest surface, `Pick<DynamoDBDocumentClient, "send">` — exactly what the sibling `batchGetFromTable` helper in the same `define-table.ts` already declares. The test then builds a real, fully-typed fake (`send: async (command) => impl(command)`, with `impl` returning `Record<string, unknown>`) that satisfies the parameter with no casts.

Narrowing is backward-compatible: a full client still satisfies `Pick`, so all `defineDynamoTable` callers and the production `app.ts` wiring keep compiling unchanged.

## Files changed

- `projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.test.ts` — drop the `SendFn` alias and all four `as` casts; type the fake as `Pick<DynamoDBDocumentClient, "send">`.
- `projects/hutch/src/runtime/providers/rate-limit/dynamodb-rate-limit.ts` — narrow the `client` dependency to `Pick<DynamoDBDocumentClient, "send">`.
- `src/packages/hutch-storage-client/src/define-table.ts` — narrow `defineDynamoTable`'s `config.client` to `Pick<DynamoDBDocumentClient, "send">`, matching `batchGetFromTable`.

## Verification

- `tsc --noEmit -p projects/hutch/tsconfig.json` — clean
- `nx run hutch:test` — 181 suites / 2077 tests pass
- biome lint on all three files — clean

🤖 Part of the guidelines & skills audit.