### PR TITLE
test(trial-scheduler): type the fake SchedulerClient send seam without `as`

### DIFF
--- a/projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.test.ts
+++ b/projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.test.ts
@@ -13,21 +13,21 @@ const ROLE_ARN = "arn:aws:iam::123456789:role/hutch-scheduler";
 const GROUP_NAME = "hutch-trial-end-test";
 
 interface CapturedSend {
-	commands: unknown[];
+	commands: (CreateScheduleCommand | DeleteScheduleCommand)[];
 }
 
 function buildFakeClient(opts?: {
 	deleteThrows?: Error;
 }): { client: Pick<SchedulerClient, "send">; captured: CapturedSend } {
 	const captured: CapturedSend = { commands: [] };
-	const client = {
-		send: (async (cmd: unknown) => {
+	const client: Pick<SchedulerClient, "send"> = {
+		async send(cmd: CreateScheduleCommand | DeleteScheduleCommand) {
 			captured.commands.push(cmd);
 			if (opts?.deleteThrows && cmd instanceof DeleteScheduleCommand) {
 				throw opts.deleteThrows;
 			}
 			return {};
-		}) as unknown as SchedulerClient["send"],
+		},
 	};
 	return { client, captured };
 }


### PR DESCRIPTION
## What

Remove the `as unknown as SchedulerClient["send"]` double cast from the fake client in `aws-trial-scheduler.test.ts`. Type the fake `client` object as `Pick<SchedulerClient, "send">` (the same type the provider declares for its dependency) with a method-shorthand `send`, and narrow the captured-commands array from `unknown[]` to `(CreateScheduleCommand | DeleteScheduleCommand)[]`.

## Why

- **Rule:** "Avoid TypeScript Type Assertions (`as`)" — CLAUDE.md forbids using `as` to bypass the compiler and lists faking objects via assertion (preferring a typed seam) as a violation. The double `as unknown as ...` is not one of the allowed exceptions (`as const`, isolated Node API wrapper, `requireEnv` generic).
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/runtime/providers/trial-scheduler/aws-trial-scheduler.test.ts`

The provider's dependency is `Pick<SchedulerClient, "send">`, so the fake can match that contract directly rather than force-casting onto the SDK's overloaded `send`.

## Change

- `CapturedSend.commands`: `unknown[]` → `(CreateScheduleCommand | DeleteScheduleCommand)[]`
- `client` object annotated as `Pick<SchedulerClient, "send">` with method-shorthand `send(cmd: CreateScheduleCommand | DeleteScheduleCommand)`; cast removed.
- Existing `instanceof` narrowing in every assertion is unaffected.

## Verification

Applied locally: `tsc --noEmit -p projects/hutch/tsconfig.json` clean, `biome lint` clean, full hutch test suite passes (181 suites / 2077 tests). No callers or other tests reference the fake, so the change is contained to this file.

🤖 Part of the guidelines & skills audit.