### PR TITLE
test(stripe-webhook): remove `as never` Lambda Context fake

### DIFF
--- a/projects/hutch/src/runtime/stripe-webhook-receiver/stripe-webhook-receiver-handler.test.ts
+++ b/projects/hutch/src/runtime/stripe-webhook-receiver/stripe-webhook-receiver-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { APIGatewayProxyEventV2 } from "aws-lambda";
+import type { APIGatewayProxyEventV2, Context } from "aws-lambda";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import type { StripeEventType } from "@packages/hutch-infra-components";
 import {
@@ -10,6 +10,21 @@ import { UnconfiguredStripeEventError } from "./unconfigured-stripe-event-error"
 import { signStripeWebhookHeader } from "./sign-stripe-webhook-header.test-helper";
 
 const TEST_SECRET = "whsec_test_handler_secret";
+
+const stubContext: Context = {
+	callbackWaitsForEmptyEventLoop: true,
+	functionName: "test",
+	functionVersion: "1",
+	invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789:function:test",
+	memoryLimitInMB: "128",
+	awsRequestId: "test-request-id",
+	logGroupName: "/aws/lambda/test",
+	logStreamName: "test-stream",
+	getRemainingTimeInMillis: () => 30000,
+	done: () => {},
+	fail: () => {},
+	succeed: () => {},
+};
 
 function buildApiGatewayEvent(params: {
 	body: string;
@@ -76,7 +91,7 @@ describe("stripe-webhook-receiver-handler", () => {
 		});
 
 		const body = buildStripeEvent({ type: "customer.subscription.deleted", subscriptionId: "sub_1" });
-		const result = await handler(buildApiGatewayEvent({ body }), {} as never, () => {});
+		const result = await handler(buildApiGatewayEvent({ body }), stubContext, () => {});
 
 		assert(result);
 		assert.equal(result.statusCode, 400);
@@ -97,7 +112,7 @@ describe("stripe-webhook-receiver-handler", () => {
 				body,
 				signatureHeader: buildSignature(rawBody, { secret: "whsec_wrong" }),
 			}),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -122,7 +137,7 @@ describe("stripe-webhook-receiver-handler", () => {
 		const rawBody = Buffer.from(body);
 		const result = await handler(
 			buildApiGatewayEvent({ body, signatureHeader: buildSignature(rawBody) }),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -146,7 +161,7 @@ describe("stripe-webhook-receiver-handler", () => {
 			async () => {
 				await handler(
 					buildApiGatewayEvent({ body, signatureHeader: buildSignature(rawBody) }),
-					{} as never,
+					stubContext,
 					() => {},
 				);
 			},
@@ -175,7 +190,7 @@ describe("stripe-webhook-receiver-handler", () => {
 			async () => {
 				await handler(
 					buildApiGatewayEvent({ body, signatureHeader: buildSignature(rawBody) }),
-					{} as never,
+					stubContext,
 					() => {},
 				);
 			},
@@ -201,7 +216,7 @@ describe("stripe-webhook-receiver-handler", () => {
 		const b64Body = rawBody.toString("base64");
 		const result = await handler(
 			{ ...buildApiGatewayEvent({ body: b64Body, signatureHeader: buildSignature(rawBody) }), isBase64Encoded: true },
-			{} as never,
+			stubContext,
 			() => {},
 		);
 


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/stripe-webhook-receiver/stripe-webhook-receiver-handler.test.ts` faked the Lambda `Context` argument with `{} as never` in six call sites (lines 79, 100, 125, 149, 178, 204).

## Why

CLAUDE.md — **Avoid TypeScript Type Assertions (`as`)** — forbids `as` outside the documented exceptions (`as const`, isolated Node.js API wrappers, `requireEnv` generic). `as never` is not an allowed exception. The guideline prescribes faking a subset of an object's shape rather than asserting it.

`{} as Partial<Context>` would not type-check against the handler's `Context` parameter without a further assertion, so the contained, codebase-consistent fix is to use the fully-typed `stubContext: Context` literal already established in `reader-ready-fanout-handler.test.ts` and `reader-ready-notify-handler.test.ts`.

## Change

- Add `Context` to the `aws-lambda` type import.
- Add a `const stubContext: Context = { ... }` literal.
- Replace all six `{} as never` occurrences with `stubContext`.

The handler under test ignores the context/callback arguments, so behaviour and every assertion are unchanged; tests stay green and coverage is unaffected.

- Rule: Avoid TypeScript type assertions (`as`); fake partial objects with `Partial<T>`
- Source: CLAUDE.md
- File: `projects/hutch/src/runtime/stripe-webhook-receiver/stripe-webhook-receiver-handler.test.ts`

🤖 Part of the guidelines & skills audit.