### PR TITLE
test(subscription-charge-failed): replace `as never` Lambda context with a typed stub

### DIFF
--- a/projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { Context } from "aws-lambda";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import type { PublishCancelSubscriptionCommand } from "@packages/test-fixtures/providers/events";
@@ -7,6 +8,21 @@ import { initSubscriptionChargeFailedHandler } from "./subscription-charge-faile
 import { initEmitSubscriptionEvent, type SubscriptionLogEvent } from "../observability/subscription-events";
 
 const USER_ID = UserIdSchema.parse("3".repeat(32));
+
+const stubContext: Context = {
+	callbackWaitsForEmptyEventLoop: true,
+	functionName: "test",
+	functionVersion: "1",
+	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
+	memoryLimitInMB: "128",
+	awsRequestId: "test-request-id",
+	logGroupName: "/aws/lambda/test",
+	logStreamName: "test-stream",
+	getRemainingTimeInMillis: () => 30000,
+	done: () => {},
+	fail: () => {},
+	succeed: () => {},
+};
 
 function makeEmit(): { emit: ReturnType<typeof initEmitSubscriptionEvent>; captured: SubscriptionLogEvent[] } {
 	const captured: SubscriptionLogEvent[] = [];
@@ -46,7 +62,7 @@ describe("subscription-charge-failed handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -83,7 +99,7 @@ describe("subscription-charge-failed handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -103,7 +119,7 @@ describe("subscription-charge-failed handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "garbage" }]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -127,7 +143,7 @@ describe("subscription-charge-failed handler", () => {
 					body: JSON.stringify({ detail: { userId: USER_ID, reason: "made_up" } }),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -154,7 +170,7 @@ describe("subscription-charge-failed handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 


### PR DESCRIPTION
## What

Replaces the five `{} as never` Lambda `Context` fakes in
`subscription-charge-failed-handler.test.ts` with a fully-typed
`const stubContext: Context = { ... }`.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`)
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts`

The test asserted `{} as never` for the Lambda `Context` argument at lines
49, 86, 107, 130, and 157. `as never` is a type assertion that bypasses
the compiler and is not among the rule's allowed exceptions (`as const`,
isolated Node wrappers). The guideline specifically calls out faking a
partial object with `as` rather than a properly-typed object.

## Change

Adds `import type { Context } from "aws-lambda"` and a fully-populated
`stubContext: Context`, then replaces every `{} as never` with
`stubContext`. This mirrors the established, type-safe pattern already
used in the same `hutch` project
(`reader-ready-fanout-handler.test.ts`, `reader-ready-notify-handler.test.ts`)
and across ~30 handler tests in `save-link`. The handler implementation
never reads the context argument, so all behaviour and assertions are
unchanged.

🤖 Part of the guidelines & skills audit.