### PR TITLE
refactor(subscription-charge-succeeded): replace `as never` context fakes with typed stubContext

### DIFF
--- a/projects/hutch/src/runtime/subscription-charge-succeeded/subscription-charge-succeeded-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-charge-succeeded/subscription-charge-succeeded-handler.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { Context } from "aws-lambda";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initInMemorySubscriptionProviders } from "@packages/test-fixtures/providers/subscription-providers";
@@ -7,6 +8,21 @@ import { initSubscriptionChargeSucceededHandler } from "./subscription-charge-su
 import { initEmitSubscriptionEvent, type SubscriptionLogEvent } from "../observability/subscription-events";
 
 const USER_ID = UserIdSchema.parse("2".repeat(32));
+
+const stubContext: Context = {
+	callbackWaitsForEmptyEventLoop: true,
+	functionName: "test",
+	functionVersion: "1",
+	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
+	memoryLimitInMB: "128",
+	awsRequestId: "test-request-id",
+	logGroupName: "/aws/lambda/test",
+	logStreamName: "test-stream",
+	getRemainingTimeInMillis: () => 30000,
+	done: () => {},
+	fail: () => {},
+	succeed: () => {},
+};
 
 function buildBody(detail: {
 	userId: string;
@@ -52,7 +68,7 @@ describe("subscription-charge-succeeded handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -77,7 +93,7 @@ describe("subscription-charge-succeeded handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "{not-json" }]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 
@@ -94,7 +110,7 @@ describe("subscription-charge-succeeded handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-schema", body: JSON.stringify({ detail: { userId: USER_ID, customerId: "cus_x" } }) },
 			]),
-			{} as never,
+			stubContext,
 			() => {},
 		);
 


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/subscription-charge-succeeded/subscription-charge-succeeded-handler.test.ts` faked the AWS Lambda `context` argument three times (lines 55, 81, 98) with `{} as never`.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`) — fake a partial object with a typed value, not a cast.
- **Source:** CLAUDE.md.
- **Problem:** `as never` is a type assertion used to fabricate the `context` object. The rule's `as Response` BAD example forbids exactly this, and `as never` is not one of the allowed exceptions (`as const`, isolated Node wrappers).

## Change

The returned handler is typed `Handler<SQSEvent, SQSBatchResponse>`, so its second argument must be a full `aws-lambda` `Context` (a `Partial<Context>` would not be assignable). The codebase already solves this with a fully type-checked `const stubContext: Context = { ... }` literal (see `reader-ready-fanout-handler.test.ts` and `reader-ready-notify-handler.test.ts`).

- Import `Context` from `aws-lambda`.
- Declare a typed `stubContext: Context`.
- Replace all three `{} as never` arguments with `stubContext`.

The handler never reads its context argument, so behaviour, all assertions, and coverage are unchanged.

🤖 Part of the guidelines & skills audit.