### PR TITLE
test(oauth): remove `as Token` casts in oauth.routes.test.ts

### DIFF
--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert";
 import { createHash, randomBytes } from "node:crypto";
 import request from "supertest";
-import type { Token } from "@node-oauth/oauth2-server";
 import { useTestServer } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
@@ -329,7 +328,9 @@ describe("OAuth routes", () => {
 					accessTokenExpiresAt: new Date(Date.now() + 3600000),
 					refreshToken: "revoke-refresh",
 					refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
-				} as Token,
+					client,
+					user: { id: TEST_USER_ID },
+				},
 				client,
 				{ id: TEST_USER_ID },
 			);
@@ -368,7 +369,9 @@ describe("OAuth routes", () => {
 					accessTokenExpiresAt: new Date(Date.now() + 3600000),
 					refreshToken: "refresh-for-revoke",
 					refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
-				} as Token,
+					client,
+					user: { id: TEST_USER_ID },
+				},
 				client,
 				{ id: TEST_USER_ID },
 			);


### PR DESCRIPTION
## What

Removes two `as Token` casts in
`projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts` (lines 333 and 371)
by building complete `Token` literals.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`) — faking a partial object with `as` instead of making it complete.
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts`

Each call site casts a partial token literal (omitting the required `client` and `user` fields) to the full `Token` type via `as Token`. CLAUDE.md forbids casting a partial literal with `as`.

`Partial<Token>` is not applicable here because `saveToken(token: Token, ...)` requires a complete `Token`; passing a `Partial<Token>` would fail type-checking. Instead, the only missing required fields (`client` and `user`) are already in scope at each call site, so the literals are completed and the assertion is dropped.

## Change

For both `saveToken` calls, add `client` and `user: { id: TEST_USER_ID }` to the token object literal and drop the `as Token` cast. `saveToken` consumes its separate `oauthClient`/`user` arguments, so the embedded fields do not change behaviour and all existing assertions remain green.

🤖 Part of the guidelines & skills audit.