### PR TITLE
refactor(install): remove redundant what-comment on BetaSetupStep

### DIFF
--- a/projects/hutch/src/runtime/web/pages/install/install.component.ts
+++ b/projects/hutch/src/runtime/web/pages/install/install.component.ts
@@ -66,9 +66,6 @@ function buildInstallTabs(active: InstallClient): InstallTab[] {
 	});
 }
 
-/** One numbered step in the iPhone beta setup guide. `note` is an optional
- * caveat shown under the instruction (e.g. why the app must be opened once
- * before the iOS share option appears). */
 interface BetaSetupStep {
 	title: string;
 	note?: string;


### PR DESCRIPTION
## What

Removes the discretionary doc comment above the `BetaSetupStep` interface in `projects/hutch/src/runtime/web/pages/install/install.component.ts`.

## Why

- **Rule:** "Comments document why, not what" — *An approved comment explains why, never what*; discretionary comments are a last resort requiring explicit human approval.
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/runtime/web/pages/install/install.component.ts` (lines 69-71)

The comment described what the type already conveys — that it is one numbered setup step and that `note` is an optional caveat shown under the instruction. The `BetaSetupStep` interface, with its named `title` and optional `note?` fields, is self-documenting. The single non-obvious "why" the comment hinted at (the app must be opened once before the iOS share option appears) is already encoded in the data itself via the `note` on the sign-in step, so no information is lost.

## Change

Deletes the three-line block comment. No type, caller, test, or coverage impact — the comment text appears only in this file.

🤖 Part of the guidelines & skills audit.