### PR TITLE
test(queue): assert exact share-balloon hints instead of negative match

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts
@@ -664,8 +664,10 @@ describe("Queue routes", () => {
 				const hints = Array.from(
 					doc.querySelectorAll("[data-test-share-balloon-hint]"),
 				).map((el) => el.textContent?.trim());
-				expect(hints).toContain("Click here to share this post!");
-				expect(hints).not.toContain("Click here to share this view!");
+				expect(hints).toEqual([
+					"Thanks for trying Readplace.",
+					"Click here to share this post!",
+				]);
 			});
 
 			it("boots the share balloon client via the same bundle as /view", async () => {


### PR DESCRIPTION
## What

In `projects/hutch/src/runtime/web/pages/queue/queue.reader.advanced.route.test.ts`, the test "uses the 'share this post' hint copy (not the /view 'share this view' copy)" asserted the share-balloon hints with a positive `toContain` plus a brittle negative `.not.toContain("Click here to share this view!")`.

## Why

The [test-driven-design skill](.claude/skills/test-driven-design/SKILL.md) — "Avoid Negative Test Assertions" — states that `.not.toContain()` becomes stale when code is refactored and should be replaced by asserting the exact expected value.

## Change

The share-balloon template (`projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.template.html`) renders exactly two `[data-test-share-balloon-hint]` spans: the static `"Thanks for trying Readplace."` and the dynamic `{{shareHint}}`, which resolves to `"Click here to share this post!"` in the reader/queue context (`projects/hutch/src/runtime/web/pages/reader/reader.component.ts`). The two assertions are replaced with a single exact-array assertion:

```ts
expect(hints).toEqual([
	"Thanks for trying Readplace.",
	"Click here to share this post!",
]);
```

This pins the real expected output (and therefore proves the /view "share this view" copy is absent) without a negative assertion that would silently survive a copy refactor.

🤖 Part of the guidelines & skills audit.