### PR TITLE
refactor(save): serve save-error countdown as a same-origin bundle

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -166,6 +166,23 @@ const BUNDLES = [
 	{
 		entry: path.join(
 			PROJECT_ROOT,
+			"src/runtime/web/pages/save/save-error.client.ts",
+		),
+		outfile: path.join(OUT_DIR, "save-error.client.js"),
+		globalName: "SaveErrorCountdown",
+		footer: [
+			"document.addEventListener('DOMContentLoaded', function () {",
+			"  SaveErrorCountdown.initSaveErrorCountdown({",
+			"    document: window.document,",
+			"    setIntervalFn: function (cb, ms) { return window.setInterval(cb, ms); },",
+			"    clearIntervalFn: function (id) { window.clearInterval(id); }",
+			"  });",
+			"});",
+		].join("\n"),
+	},
+	{
+		entry: path.join(
+			PROJECT_ROOT,
 			"src/runtime/web/pages/view/view-paywall.client.ts",
 		),
 		outfile: path.join(OUT_DIR, "view-paywall.client.js"),

--- a/projects/hutch/src/runtime/web/pages/save/save-error.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-error.client.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { initSaveErrorCountdown } from "./save-error.client";
+
+function makeDoc(html: string): Document {
+	return new JSDOM(`<!doctype html><html><body>${html}</body></html>`).window
+		.document;
+}
+
+function createFakeTimers() {
+	const timers: Array<{ id: number; cb: () => void }> = [];
+	let nextId = 1;
+	return {
+		setIntervalFn(cb: () => void) {
+			const id = nextId++;
+			timers.push({ id, cb });
+			return id;
+		},
+		clearIntervalFn(id: unknown) {
+			const idx = timers.findIndex((t) => t.id === id);
+			if (idx !== -1) timers.splice(idx, 1);
+		},
+		tick(times: number) {
+			for (let i = 0; i < times; i++) {
+				for (const timer of [...timers]) timer.cb();
+			}
+		},
+		pending() {
+			return timers.length;
+		},
+	};
+}
+
+describe("initSaveErrorCountdown", () => {
+	it("is a no-op when no .save-error__seconds element is present", () => {
+		const doc = makeDoc(`<p>nothing here</p>`);
+		const fake = createFakeTimers();
+		const controller = initSaveErrorCountdown({
+			document: doc,
+			setIntervalFn: fake.setIntervalFn,
+			clearIntervalFn: fake.clearIntervalFn,
+		});
+		assert.equal(fake.pending(), 0);
+		controller.stop();
+	});
+
+	it("is a no-op when the counter element has no data-countdown-seconds attribute", () => {
+		const doc = makeDoc(`<span class="save-error__seconds">5</span>`);
+		const fake = createFakeTimers();
+		const controller = initSaveErrorCountdown({
+			document: doc,
+			setIntervalFn: fake.setIntervalFn,
+			clearIntervalFn: fake.clearIntervalFn,
+		});
+		assert.equal(fake.pending(), 0);
+		controller.stop();
+	});
+
+	it("is a no-op when data-countdown-seconds is not a parseable number", () => {
+		const doc = makeDoc(
+			`<span class="save-error__seconds" data-countdown-seconds="soon">5</span>`,
+		);
+		const fake = createFakeTimers();
+		const controller = initSaveErrorCountdown({
+			document: doc,
+			setIntervalFn: fake.setIntervalFn,
+			clearIntervalFn: fake.clearIntervalFn,
+		});
+		assert.equal(fake.pending(), 0);
+		controller.stop();
+	});
+
+	it("decrements the displayed seconds on each tick", () => {
+		const doc = makeDoc(
+			`<span class="save-error__seconds" data-countdown-seconds="5">5</span>`,
+		);
+		const fake = createFakeTimers();
+		initSaveErrorCountdown({
+			document: doc,
+			setIntervalFn: fake.setIntervalFn,
+			clearIntervalFn: fake.clearIntervalFn,
+		});
+
+		fake.tick(1);
+		const counter = doc.querySelector(".save-error__seconds");
+		assert(counter, "counter must remain in the DOM");
+		assert.equal(counter.textContent, "4");
+
+		fake.tick(1);
+		assert.equal(counter.textContent, "3");
+	});
+
+	it("stops the interval once the countdown reaches zero", () => {
+		const doc = makeDoc(
+			`<span class="save-error__seconds" data-countdown-seconds="2">2</span>`,
+		);
+		const fake = createFakeTimers();
+		initSaveErrorCountdown({
+			document: doc,
+			setIntervalFn: fake.setIntervalFn,
+			clearIntervalFn: fake.clearIntervalFn,
+		});
+
+		fake.tick(2);
+		const counter = doc.querySelector(".save-error__seconds");
+		assert(counter, "counter must remain in the DOM");
+		assert.equal(counter.textContent, "0");
+		assert.equal(fake.pending(), 0);
+	});
+
+	it("stop() clears the interval so no further ticks fire", () => {
+		const doc = makeDoc(
+			`<span class="save-error__seconds" data-countdown-seconds="5">5</span>`,
+		);
+		const fake = createFakeTimers();
+		const controller = initSaveErrorCountdown({
+			document: doc,
+			setIntervalFn: fake.setIntervalFn,
+			clearIntervalFn: fake.clearIntervalFn,
+		});
+
+		controller.stop();
+		assert.equal(fake.pending(), 0);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/save/save-error.client.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-error.client.ts
@@ -1,0 +1,43 @@
+interface SaveErrorCountdownDeps {
+	document: Document;
+	setIntervalFn: (cb: () => void, ms: number) => unknown;
+	clearIntervalFn: (id: unknown) => void;
+}
+
+export interface SaveErrorCountdownController {
+	stop(): void;
+}
+
+const SELECTOR = ".save-error__seconds";
+const SECONDS_ATTRIBUTE = "data-countdown-seconds";
+const TICK_INTERVAL_MS = 1000;
+const NOOP_CONTROLLER: SaveErrorCountdownController = { stop() {} };
+
+export function initSaveErrorCountdown(
+	deps: SaveErrorCountdownDeps,
+): SaveErrorCountdownController {
+	const el = deps.document.querySelector(SELECTOR);
+	if (el === null) return NOOP_CONTROLLER;
+	const counter = el;
+
+	const startRaw = counter.getAttribute(SECONDS_ATTRIBUTE);
+	if (startRaw === null) return NOOP_CONTROLLER;
+	const startSeconds = Number.parseInt(startRaw, 10);
+	if (!Number.isFinite(startSeconds)) return NOOP_CONTROLLER;
+
+	let seconds = startSeconds;
+	let intervalId: unknown;
+
+	function tick(): void {
+		seconds--;
+		counter.textContent = String(seconds);
+		if (seconds <= 0) deps.clearIntervalFn(intervalId);
+	}
+
+	intervalId = deps.setIntervalFn(tick, TICK_INTERVAL_MS);
+	return {
+		stop() {
+			deps.clearIntervalFn(intervalId);
+		},
+	};
+}

--- a/projects/hutch/src/runtime/web/pages/save/save-error.component.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save-error.component.ts
@@ -9,18 +9,7 @@ const SAVE_ERROR_TEMPLATE = readFileSync(join(__dirname, "save-error.template.ht
 
 const COUNTDOWN_SECONDS = 5;
 
-const COUNTDOWN_SCRIPT = `<script>
-(function() {
-  var el = document.querySelector('.save-error__seconds');
-  if (!el) return;
-  var seconds = ${COUNTDOWN_SECONDS};
-  var interval = setInterval(function() {
-    seconds--;
-    el.textContent = seconds;
-    if (seconds <= 0) clearInterval(interval);
-  }, 1000);
-})();
-</script>`;
+const COUNTDOWN_SCRIPT = `<script src="/client-dist/save-error.client.js" defer></script>`;
 
 export function SaveErrorPage(input: { redirectUrl: string; linkLabel: string }): PageBody {
 	return {

--- a/projects/hutch/src/runtime/web/pages/save/save-error.template.html
+++ b/projects/hutch/src/runtime/web/pages/save/save-error.template.html
@@ -2,7 +2,7 @@
     <main class="save-error">
       <div class="save-error__container">
         <h1 class="save-error__title">No article URL provided</h1>
-        <p class="save-error__text">Redirecting in <span class="save-error__seconds">{{seconds}}</span> seconds...</p>
+        <p class="save-error__text">Redirecting in <span class="save-error__seconds" data-countdown-seconds="{{seconds}}">{{seconds}}</span> seconds...</p>
         <a href="{{redirectUrl}}" class="save-error__link">{{linkLabel}}</a>
       </div>
     </main>


### PR DESCRIPTION
## What

The `/save` error page's 5-second redirect countdown was emitted as a hand-written **inline `<script>` string** injected via `PageBody.scripts`:

```ts
const COUNTDOWN_SCRIPT = `<script>
(function() {
  var el = document.querySelector('.save-error__seconds');
  ...
})();
</script>`;
```

This is the inlining pattern the web skill steers away from.

## Why

`.claude/skills/web/SKILL.md` — **"Browser JS Is Bundled and Served Same-Origin"** / **"Client-Side JavaScript Conventions"**: behaviour htmx cannot express (here, the countdown animation) must live in a compiled `*.client.ts` IIFE bundle referenced via a relative same-origin `<script src="/...">`, shipped atomically with the HTML — not inlined.

## Change

Mirrors the existing, well-tested `pages/view/expiry-counter.client.ts` precedent:

- **New `save-error.client.ts`** — `initSaveErrorCountdown(deps)` with dependency-injected `setIntervalFn`/`clearIntervalFn`/`document`. It reads the start value from a `data-countdown-seconds` attribute (a genuinely-nullable DOM read) so every branch is reachable and 100% coverable — no `??` or assert-throw phantom branches.
- **New `save-error.client.test.ts`** — covers no-element, missing-attribute, non-numeric-attribute, per-tick decrement, stop-at-zero, and `stop()`.
- **Template** gains `data-countdown-seconds="{{seconds}}"` while keeping the visible `{{seconds}}` text, so `save.route.test.ts`'s `countdown.textContent === "5"` assertion stays green.
- **Component** references `<script src="/client-dist/save-error.client.js" defer></script>`.
- **`scripts/build-client-bundles.js`** registers the new bundle (globalName `SaveErrorCountdown`, DOMContentLoaded footer wiring real browser timers) so Lambda packaging + `express.static` serve it same-origin.

No test asserted the old inline script content, so nothing else ripples. `client-dist/` is gitignored and rebuilt by the build step.

## Source

- Rule: Browser JS must be a same-origin bundled `<script src>`, not inlined
- Doc: `.claude/skills/web/SKILL.md`
- File: `projects/hutch/src/runtime/web/pages/save/save-error.component.ts`

🤖 Part of the guidelines & skills audit.