### PR TITLE
test(view): replace share-balloon toBeNull with positive landing-page assertions

### DIFF
--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -892,7 +892,14 @@ describe("View routes", () => {
 			const response = await request(harness.server).get("/view");
 
 			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-share-balloon]")).toBeNull();
+			const form = doc.querySelector("[data-test-view-landing-form]");
+			assert(form, "landing page must render its paste-a-link form");
+			const input = doc.querySelector("[data-test-view-landing-input]");
+			assert(input, "landing page must render its URL input");
+			expect(input.getAttribute("name")).toBe("url");
+			const submit = doc.querySelector("[data-test-view-landing-submit]");
+			assert(submit, "landing page must render its submit button");
+			expect(submit.textContent?.trim()).toBe("Open in reader view");
 		});
 
 		it("includes the founder avatar inside the balloon", async () => {


### PR DESCRIPTION
## What

The test `is not rendered on the /view landing page` in
`projects/hutch/src/runtime/web/pages/view/view.route.test.ts` proved the
share balloon's absence with:

```ts
expect(doc.querySelector("[data-test-share-balloon]")).toBeNull();
```

This is replaced with positive assertions on the elements the landing page
actually renders (the URL form, input, and submit button).

## Why

The **test-driven-design** skill (`.claude/skills/test-driven-design/SKILL.md`
→ "Never Rely on `querySelector(...).toBeNull()` — Assert Existence First,
Then Check State") forbids proving absence with a null DOM lookup: a typo in
the selector also returns `null`, so the assertion passes for the wrong
reason.

The skill offers two remedies. The share balloon is **not** a visible/hidden
toggle on the landing page — `view-landing.template.html` contains no balloon
markup at all; the balloon is a separate partial included only on the article
reader page. So the second remedy applies: assert on the positive elements the
landing page does render. The new assertions look up the landing form, input,
and submit button (by their existing `data-test-*` attributes) and assert they
exist, which confirms the response is the landing page (the only page where the
balloon is absent) — and a selector typo now fails at `assert(...)` instead of
trivially passing.

## Scope

Test-only change. No production code, exported signatures, or other callers are
affected, so `pnpm check` (tsc + biome + knip + coverage + tests) stays green.

🤖 Part of the guidelines & skills audit.