### PR TITLE
fix(email): remove exclamation mark from reader-ready status copy

### DIFF
--- a/projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.test.ts
+++ b/projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.test.ts
@@ -101,7 +101,7 @@ describe("initReaderReadyNotifyHandler", () => {
 			expect(sent.from).toBe("Fayner from Readplace <readplace@readplace.com>");
 			expect(sent.to).toBe("reader@example.com");
 			expect(sent.bcc).toBe("readplace+reader_ready@readplace.com");
-			expect(sent.subject).toBe("An article you saved now has a reader view!");
+			expect(sent.subject).toBe("An article you saved now has a reader view.");
 			expect(sent.html).toContain(`https://readplace.com/queue/${ReaderArticleHashId.from(URL).value}/view`);
 			expect(sent.html).toContain("Distributed systems");
 			expect(deps.markReaderReadyEmailSent).toHaveBeenCalledWith({ userId: USER_ID, url: URL, at: NOW });

--- a/projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.ts
+++ b/projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.ts
@@ -27,7 +27,7 @@ import { buildReaderReadyEmailHtml } from "../web/reader-ready-email";
 
 const EMAIL_FROM = "Fayner from Readplace <readplace@readplace.com>";
 const READER_READY_BCC = "readplace+reader_ready@readplace.com";
-const SUBJECT = "An article you saved now has a reader view!";
+const SUBJECT = "An article you saved now has a reader view.";
 /** The reader view must have taken longer than a minute to qualify — a fast
  * generation means the saver watched it finish live and needs no nudge. */
 const MIN_GENERATION_MS = 60_000;

--- a/projects/hutch/src/runtime/web/reader-ready-email.template.html
+++ b/projects/hutch/src/runtime/web/reader-ready-email.template.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>An article you saved now has a reader view!</title>
+    <title>An article you saved now has a reader view.</title>
   </head>
   <body style="margin:0;padding:0;background-color:{{colors.background}};font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:{{colors.background}};padding:40px 20px;">
@@ -12,7 +12,7 @@
           <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background-color:{{colors.surface}};border-radius:8px;padding:40px;">
             <tr>
               <td>
-                <h1 style="margin:0 0 16px;font-size:24px;color:{{colors.heading}};">An article you saved now has a reader view!</h1>
+                <h1 style="margin:0 0 16px;font-size:24px;color:{{colors.heading}};">An article you saved now has a reader view.</h1>
                 <p style="margin:0 0 8px;font-size:16px;line-height:1.6;color:{{colors.body}};">The clean reader view you opened is done — content extracted and summarised, ready to read in peace:</p>
                 <p style="margin:0 0 24px;font-size:18px;line-height:1.4;color:{{colors.heading}};font-weight:600;">{{title}}</p>
                 <p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:{{colors.muted}};">{{siteName}}</p>

--- a/projects/hutch/src/runtime/web/reader-ready-email.test.ts
+++ b/projects/hutch/src/runtime/web/reader-ready-email.test.ts
@@ -24,7 +24,7 @@ describe("buildReaderReadyEmailHtml", () => {
 		});
 
 		const doc = new JSDOM(html).window.document;
-		expect(doc.querySelector("h1")?.textContent).toBe("An article you saved now has a reader view!");
+		expect(doc.querySelector("h1")?.textContent).toBe("An article you saved now has a reader view.");
 	});
 
 	it("HTML-escapes the article title so a crafted title cannot inject markup", () => {


### PR DESCRIPTION
## What

Removes the exclamation mark from the reader-ready email's `<title>`, in-body `<h1>`, and the email `SUBJECT` constant, changing "An article you saved now has a reader view!" to "An article you saved now has a reader view."

## Why

**Rule:** No exclamation marks in confirmations or status messages
**Source:** `BRAND_GUIDELINES.md` (line 272)

> No exclamation marks in confirmations or status messages. Save those for moments that actually warrant excitement (e.g., "Import complete — 1,247 articles are now in Readplace!").

This email is a routine status notification — an already-saved article finished generating its reader view. It belongs to the same category as the documented "Article saved." confirmation, not the import-complete celebration that warrants excitement.

## Changes

- `projects/hutch/src/runtime/web/reader-ready-email.template.html` — drop `!` in `<title>` (line 6) and `<h1>` (line 15)
- `projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.ts` — drop `!` in the `SUBJECT` constant so the email subject matches the body
- `projects/hutch/src/runtime/web/reader-ready-email.test.ts` — update the `<h1>` text assertion
- `projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.test.ts` — update the subject assertion

🤖 Part of the guidelines & skills audit.