### PR TITLE
refactor(progress-bar): use named params for computeRate

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.test.ts
@@ -21,21 +21,21 @@ describe("computeRate", () => {
 		const prev: BarTick = { tickAtMs: 1000, pct: 25 };
 		const next: BarTick = { tickAtMs: 4000, pct: 55 };
 
-		expect(computeRate(prev, next)).toBeCloseTo(0.01);
+		expect(computeRate({ prev, next })).toBeCloseTo(0.01);
 	});
 
 	it("floors at 0 when the server reports a regression (worker redelivery)", () => {
 		const prev: BarTick = { tickAtMs: 1000, pct: 90 };
 		const next: BarTick = { tickAtMs: 4000, pct: 55 };
 
-		expect(computeRate(prev, next)).toBe(0);
+		expect(computeRate({ prev, next })).toBe(0);
 	});
 
 	it("returns 0 when both ticks share a timestamp (clock skew)", () => {
 		const prev: BarTick = { tickAtMs: 1000, pct: 25 };
 		const next: BarTick = { tickAtMs: 1000, pct: 55 };
 
-		expect(computeRate(prev, next)).toBe(0);
+		expect(computeRate({ prev, next })).toBe(0);
 	});
 });
 

--- a/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.ts
@@ -33,7 +33,10 @@ function assert(cond: unknown, message: string): asserts cond {
  * Linear rate between two ticks, floored at 0 so a regression (worker
  * redelivery) doesn't pull the bar backwards mid-frame.
  */
-export function computeRate(prev: BarTick, next: BarTick): number {
+export function computeRate({
+	prev,
+	next,
+}: { prev: BarTick; next: BarTick }): number {
 	const dt = next.tickAtMs - prev.tickAtMs;
 	if (dt <= 0) return 0;
 	const rate = (next.pct - prev.pct) / dt;
@@ -159,7 +162,7 @@ export function initProgressBars(deps: ProgressBarDeps): ProgressBarController {
 		states.set(bar, {
 			prev: existing.last,
 			last: newTick,
-			rate: computeRate(existing.last, newTick),
+			rate: computeRate({ prev: existing.last, next: newTick }),
 			fill,
 		});
 	}


### PR DESCRIPTION
## What

`computeRate` in `projects/hutch/src/runtime/web/shared/article-body/progress-bar.client.ts` accepted two consecutive parameters of the same type (`prev: BarTick`, `next: BarTick`) positionally. They are trivial to transpose at a call site.

## Why

The **Named Parameters Over Positional When Types Repeat** rule (`.claude/skills/test-driven-design/SKILL.md`) requires a named parameter object when a signature has 2+ consecutive same-typed parameters — connascence of position is weaker than connascence of name.

## Change

- `computeRate(prev: BarTick, next: BarTick)` → `computeRate({ prev, next }: { prev: BarTick; next: BarTick })`
- Updated the single production caller (`syncBar`) to pass `{ prev: existing.last, next: newTick }`.
- Updated the three call sites in `progress-bar.client.test.ts` to pass the named object.

No behaviour change; tests and 100% coverage preserved.

🤖 Part of the guidelines & skills audit.