### PR TITLE
fix(web-embed): use brand CSS custom properties in preview stages

### DIFF
--- a/projects/web-embed/src/runtime/embed/preview.styles.css
+++ b/projects/web-embed/src/runtime/embed/preview.styles.css
@@ -43,7 +43,7 @@
 }
 
 .embed-preview__stage--white {
-  background: #FFFFFF;
+  background: var(--color-background);
   color: var(--color-text-primary);
 }
 
@@ -53,8 +53,8 @@
 }
 
 .embed-preview__stage--dark {
-  background: #1A202C;
-  color: #FFFFFF;
+  background: var(--color-text-primary);
+  color: var(--color-background);
 }
 
 .embed-preview__row {


### PR DESCRIPTION
## What

Replace hardcoded hex literals in `projects/web-embed/src/runtime/embed/preview.styles.css` with the existing CSS custom properties.

- `.embed-preview__stage--white`: `background: #FFFFFF` → `background: var(--color-background)`
- `.embed-preview__stage--dark`: `background: #1A202C` → `background: var(--color-text-primary)`; `color: #FFFFFF` → `color: var(--color-background)`

## Why

**Rule:** "Hardcode hex values — always use the CSS custom properties" (Do's and Don'ts — Quick Reference).
**Source:** `BRAND_GUIDELINES.md`

The embed `:root` in `projects/web-embed/src/runtime/embed/embed-base.styles.css` already defines `--color-background: #FFFFFF` and `--color-text-primary: #1A202C`, the exact literals used here. The sibling `.embed-preview__stage--surface` rule already uses `var(--color-surface)` / `var(--color-text-primary)`, so this restores consistency.

## Impact

No behavioural change — the custom properties resolve to the identical colours. No TypeScript/JS tests reference these classes or hex values, so the change is contained to the CSS file.

🤖 Part of the guidelines & skills audit.