### PR TITLE
test(crawl-article): remove `as unknown as` casts from aia-fetch mocks

### DIFF
--- a/src/packages/crawl-article/src/aia-fetch.test.ts
+++ b/src/packages/crawl-article/src/aia-fetch.test.ts
@@ -102,10 +102,12 @@ describe("derOrPemToPem", () => {
 });
 
 describe("withAiaChasing", () => {
+	type FetchAia = ReturnType<typeof initFetchAia>;
+
 	it("passes responses through unchanged when baseFetch succeeds", async () => {
 		const baseFetch: typeof fetch = async () => new Response("ok", { status: 200 });
-		const fetchAia = jest.fn();
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>();
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		const response = await wrapped("https://example.com");
 
@@ -118,8 +120,8 @@ describe("withAiaChasing", () => {
 		const baseFetch: typeof fetch = async () => {
 			throw new Error("network boom");
 		};
-		const fetchAia = jest.fn();
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>();
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		await expect(wrapped("https://example.com")).rejects.toThrow("network boom");
 		expect(fetchAia).not.toHaveBeenCalled();
@@ -130,8 +132,8 @@ describe("withAiaChasing", () => {
 			const cause = Object.assign(new Error("leaf"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" });
 			throw Object.assign(new TypeError("fetch failed"), { cause });
 		};
-		const fetchAia = jest.fn(async () => new Response("<html>real</html>", { status: 200 }));
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>(async () => new Response("<html>real</html>", { status: 200 }));
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		const response = await wrapped("https://example.com", {
 			headers: { "user-agent": "Test/1.0" },
@@ -150,8 +152,8 @@ describe("withAiaChasing", () => {
 			const cause = Object.assign(new Error("x"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" });
 			throw Object.assign(new TypeError("fetch failed"), { cause });
 		};
-		const fetchAia = jest.fn(async () => new Response("ok"));
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>(async () => new Response("ok"));
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		await wrapped(new URL("https://example.com/a?b=1"));
 
@@ -163,8 +165,8 @@ describe("withAiaChasing", () => {
 			const cause = Object.assign(new Error("x"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" });
 			throw Object.assign(new TypeError("fetch failed"), { cause });
 		};
-		const fetchAia = jest.fn(async () => new Response("ok"));
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>(async () => new Response("ok"));
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		await wrapped(new Request("https://example.com/r"));
 
@@ -176,8 +178,8 @@ describe("withAiaChasing", () => {
 			const cause = Object.assign(new Error("x"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" });
 			throw Object.assign(new TypeError("fetch failed"), { cause });
 		};
-		const fetchAia = jest.fn(async () => new Response("ok"));
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>(async () => new Response("ok"));
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		const headers = new Headers({ "user-agent": "T", "accept-language": "en" });
 		await wrapped("https://example.com", { headers });
@@ -193,8 +195,8 @@ describe("withAiaChasing", () => {
 			const cause = Object.assign(new Error("x"), { code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" });
 			throw Object.assign(new TypeError("fetch failed"), { cause });
 		};
-		const fetchAia = jest.fn(async () => new Response("ok"));
-		const wrapped = withAiaChasing(baseFetch, fetchAia as unknown as ReturnType<typeof initFetchAia>);
+		const fetchAia = jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>(async () => new Response("ok"));
+		const wrapped = withAiaChasing(baseFetch, fetchAia);
 
 		await wrapped("https://example.com");
 


### PR DESCRIPTION
## What

Removes the seven `fetchAia as unknown as ReturnType<typeof initFetchAia>` double-casts in `src/packages/crawl-article/src/aia-fetch.test.ts` by typing the jest mocks to the expected function shape.

## Why

- **Rule:** Avoid TypeScript Type Assertions (`as`)
- **Source:** CLAUDE.md
- **File:** `src/packages/crawl-article/src/aia-fetch.test.ts`

The `as unknown as T` double-cast is the strongest form of bypassing the compiler and is not a documented allowed exception. `withAiaChasing`'s second parameter is typed `(url: string, init?: AiaFetchInit) => Promise<Response>`, i.e. exactly `ReturnType<typeof initFetchAia>`.

## Change

- Add a local `type FetchAia = ReturnType<typeof initFetchAia>` alias inside the `withAiaChasing` describe block.
- Type each mock as `jest.fn<ReturnType<FetchAia>, Parameters<FetchAia>>(...)`, mirroring the existing `jest.fn<ReturnType<typeof fetchH2>, Parameters<typeof fetchH2>>()` precedent in `h2-fetch.test.ts`.
- Pass `fetchAia` directly to `withAiaChasing(baseFetch, fetchAia)` with no cast.

Contained to the test file; no production code, assertions, or coverage change.

🤖 Part of the guidelines & skills audit.