### PR TITLE
refactor(crawl-article): replace `as AddressInfo` cast with an assert guard in the SSRF test

### DIFF
--- a/src/packages/crawl-article/src/crawl-fetch-ssrf.test.ts
+++ b/src/packages/crawl-article/src/crawl-fetch-ssrf.test.ts
@@ -1,5 +1,5 @@
+import assert from "node:assert/strict";
 import http from "node:http";
-import type { AddressInfo } from "node:net";
 import { Agent } from "undici";
 import { initDefaultFetchAia } from "./aia-fetch";
 import {
@@ -70,7 +70,9 @@ async function startRedirectServer(location: string): Promise<{ origin: string; 
 		res.end();
 	});
 	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-	const { port } = server.address() as AddressInfo;
+	const address = server.address();
+	assert(address && typeof address === "object", "expected an AddressInfo from a listening TCP server");
+	const { port } = address;
 	return {
 		origin: `http://127.0.0.1:${port}`,
 		close: () => new Promise((resolve) => server.close(() => resolve())),


### PR DESCRIPTION
## What

`src/packages/crawl-article/src/crawl-fetch-ssrf.test.ts` cast the result of
`server.address()` directly to `AddressInfo` (line 73), violating CLAUDE.md's
**Avoid TypeScript Type Assertions (`as`)** rule. `server.address()` is typed
`string | AddressInfo | null`, so the cast silently hides a possible string/null
shape instead of guarding it.

## Change

- Replace `const { port } = server.address() as AddressInfo;` with:
  ```ts
  const address = server.address();
  assert(address && typeof address === "object", "expected an AddressInfo from a listening TCP server");
  const { port } = address;
  ```
  The `assert` from `node:assert/strict` narrows the union to `AddressInfo` via
  its assertion signature, so `port` is accessed with no cast. The assert's
  branch lives inside `assert`, not the caller, so no uncovered V8 branch is
  introduced.
- Add the `import assert from "node:assert/strict";` import (strict variant per
  CLAUDE.md test-code convention).
- Remove the now-unused `import type { AddressInfo } from "node:net";` to keep
  biome and knip green.

## Notes

The same `as AddressInfo` pattern exists at `h2-fetch.test.ts:18`; it is out of
scope for this finding (scoped to the target file) and left for a separate change
to avoid an unrelated ripple.

## Source

- Rule: Avoid TypeScript Type Assertions (`as`) — CLAUDE.md
- File: `src/packages/crawl-article/src/crawl-fetch-ssrf.test.ts`

🤖 Part of the guidelines & skills audit.