### PR TITLE
refactor(crawl-article): make PdfExtractProgress stage required

### DIFF
--- a/src/packages/crawl-article/src/pdf-extract.types.ts
+++ b/src/packages/crawl-article/src/pdf-extract.types.ts
@@ -27,17 +27,18 @@ export type PdfExtractStage = "comprehensive-extracting" | "comprehensive-cleani
  * the extractor does not await it and never surfaces errors from it. Indices
  * are 1-based.
  *
- * `stage` is set when the extractor transitions between coarse-grained phases
- * (`comprehensive-extracting` → `comprehensive-cleaning`). The orchestrator
- * handler latches `markCrawlStage` to that value so the reader-facing
- * progress bar advances past the OCR mark when LLM cleanup begins. The field
- * is optional for backward compatibility: when omitted, the orchestrator
- * keeps the prior "latch on first onProgress" behaviour.
+ * `stage` is the coarse-grained phase the part belongs to
+ * (`comprehensive-extracting` while Tesseract runs, `comprehensive-cleaning`
+ * once LLM cleanup begins). The orchestrator handler latches `markCrawlStage`
+ * to this value on a phase change so the reader-facing progress bar advances
+ * past the OCR mark when cleanup starts. Every part reports its phase, so the
+ * field is required: the compiler forces every producer to name the phase
+ * rather than defer a missing value to runtime.
  */
 export type PdfExtractProgress = (params: {
 	partIndex: number;
 	partCount: number;
-	stage?: PdfExtractStage;
+	stage: PdfExtractStage;
 }) => void;
 
 export type ExtractPdf = (params: {


### PR DESCRIPTION
## What

Make the `stage` field of `PdfExtractProgress` required and remove the
"optional for backward compatibility" justification from its doc comment.

## Why

`PdfExtractProgress` is an internal provider type — it is defined in
`src/packages/crawl-article` and consumed only inside this monorepo (the
sole producer is `projects/save-link/src/runtime/domain/article-parser/ocr-pdf.ts`).
Per the **Internal Contracts Are Not Versioned — Prefer Required Fields**
rule (`.claude/skills/test-driven-design/SKILL.md`), such types carry no
backward-compatibility obligation. Weakening one "for backward
compatibility" lets a producer silently omit the value and defers the
failure to runtime; required fields make the compiler force every in-repo
producer to supply the value.

## Change

- `src/packages/crawl-article/src/pdf-extract.types.ts`: `stage?` → `stage`, and the comment now explains the genuine why (every part reports its current coarse phase so the orchestrator latches `markCrawlStage` on a phase change) instead of the backward-compatibility note.

## Ripple

None. The only producer (`ocr-pdf.ts`) already supplies `stage` on every
`onProgress` call, and the only `PdfExtractProgress`-typed test callback
(`crawl-article.test.ts:684`) already passes it. The comprehensive-crawl
handler uses the separate `ComprehensiveCrawlProgress` type (whose optional
`stage` correctly models a forwarded-through callback) and is untouched.

🤖 Part of the guidelines & skills audit.