### PR TITLE
refactor(hutch-storage-client): brand dynamoField without an `as` cast

### DIFF
--- a/src/packages/hutch-storage-client/src/dynamo-field.ts
+++ b/src/packages/hutch-storage-client/src/dynamo-field.ts
@@ -11,7 +11,7 @@ import type { z } from "zod";
  */
 export function dynamoField<T extends z.ZodTypeAny>(schema: T) {
 	const wrapped = schema.nullish().transform((v) => v ?? undefined);
-	return wrapped as typeof wrapped & { readonly __dynamoField: true };
+	return Object.assign(wrapped, { __dynamoField: true as const });
 }
 
 export type DynamoFieldSchema = z.ZodTypeAny & { readonly __dynamoField: true };


### PR DESCRIPTION
## What

`dynamoField` in `src/packages/hutch-storage-client/src/dynamo-field.ts` produced its `__dynamoField` brand with a type assertion:

```ts
return wrapped as typeof wrapped & { readonly __dynamoField: true };
```

This `as` fabricates a brand the runtime value does not actually carry. The branded `DynamoFieldSchema` type is meant to be produced by a real, validated construction, not asserted into existence.

## Why

Per **CLAUDE.md → "Avoid TypeScript Type Assertions (`as`)"**, `as` is forbidden except for `as const` and isolated Node.js API wrappers. A branded type asserted via `as` silently hides upstream type drift instead of producing a compile error.

## Change

Replace the assertion with `Object.assign`, which both attaches the brand at runtime and lets TypeScript infer the intersection precisely:

```ts
return Object.assign(wrapped, { __dynamoField: true as const });
```

`true as const` is the allowed `as const` narrowing, not a type assertion. I verified with an isolated `tsc --strict` compile that the inferred return type remains assignable to the exported `DynamoFieldSchema` (`z.ZodTypeAny & { readonly __dynamoField: true }`), so the public type contract and all existing call sites are unchanged. No tests reference the internals (the package has no test files), and no new branches are introduced, so coverage is unaffected.

- Rule: Avoid TypeScript Type Assertions (`as`)
- Source: CLAUDE.md
- File: `src/packages/hutch-storage-client/src/dynamo-field.ts`

🤖 Part of the guidelines & skills audit.