### PR TITLE
refactor(test-fixtures): brand CheckoutSessionId via zod instead of `as` cast

### DIFF
--- a/src/packages/provider-contracts/src/stripe-checkout.ts
+++ b/src/packages/provider-contracts/src/stripe-checkout.ts
@@ -1,4 +1,6 @@
-export type CheckoutSessionId = string & { readonly __brand: "CheckoutSessionId" };
+import type { $brand } from "zod";
+
+export type CheckoutSessionId = string & $brand<"CheckoutSessionId">;
 
 export interface CheckoutSession {
 	id: CheckoutSessionId;

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.schema.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.schema.ts
@@ -1,7 +1,3 @@
 import { z } from "zod";
-import type { CheckoutSessionId } from "@packages/provider-contracts/stripe-checkout";
 
-export const CheckoutSessionIdSchema = z
-	.string()
-	.min(1)
-	.transform((s): CheckoutSessionId => s as CheckoutSessionId);
+export const CheckoutSessionIdSchema = z.string().min(1).brand<"CheckoutSessionId">();


### PR DESCRIPTION
## What

`CheckoutSessionIdSchema` branded its validated string with a cast:

```ts
.transform((s): CheckoutSessionId => s as CheckoutSessionId);
```

An `as Brand` at a system boundary is exactly what CLAUDE.md's **Avoid TypeScript Type Assertions** section classifies as BAD, directing instead to zod's `.brand<>()` factory. This cast falls outside the documented exceptions (`as const`, isolated Node wrappers).

## Change

Apply the codebase's own established pattern for the sibling `GoogleId` type (`google-auth.schema.ts` + `provider-contracts/src/google-auth.ts`):

- `src/packages/provider-contracts/src/stripe-checkout.ts`: redeclare the brand as `string & $brand<"CheckoutSessionId">` (the shape zod's `.brand()` produces at runtime).
- `src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.schema.ts`: replace the `.transform(...as...)` with `.brand<"CheckoutSessionId">()` and remove the now-unused `CheckoutSessionId` type import.

The schema's inferred output type then equals the contract type exactly. Every consumer obtains values via `CheckoutSessionIdSchema.parse(...)` and passes them to `CheckoutSessionId`-typed functions, so nothing ripples — verified that no module imports the `CheckoutSessionId` *type* from the test-fixtures path (all import it from `@packages/provider-contracts/stripe-checkout`).

## Verification

- `pnpm check` (tsc + biome + knip + coverage + tests). These are declaration-only files with no branches, so coverage is unaffected — the identical GoogleId pair already proves the pattern passes.

## Rule

- Source: CLAUDE.md — "Avoid TypeScript Type Assertions (`as`)"
- File: `src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.schema.ts:7`

🤖 Part of the guidelines & skills audit.