### PR TITLE
refactor(web-shell): narrow UserId test fixture without `as`

### DIFF
--- a/src/packages/web-shell/src/banner-state.test.ts
+++ b/src/packages/web-shell/src/banner-state.test.ts
@@ -8,8 +8,18 @@ import {
 
 /** The shell carries no @packages/domain dependency, so there is no UserId
  * schema to parse here. The truthiness of `userId` is all bannerStateFromRequest
- * reads, so a plain branded fixture is sufficient. */
-const USER_ID = "user-1" as unknown as NonNullable<BannerStateSource["userId"]>;
+ * reads, so a non-empty string narrowed through this predicate is a sufficient
+ * branded fixture — mirroring the isChangelogVersion + assert narrowing used in
+ * changelog-banner.test.ts, and avoiding an `as` cast to brand the value. */
+function isUserId(value: string): value is NonNullable<BannerStateSource["userId"]> {
+	return value.length > 0;
+}
+
+assert(isUserId("user-1"));
+assert(!isUserId(""));
+
+const USER_ID = "user-1";
+assert(isUserId(USER_ID));
 
 describe("bannerStateFromRequest", () => {
 	it("maps a present userId to isAuthenticated=true", () => {


### PR DESCRIPTION
## What

`src/packages/web-shell/src/banner-state.test.ts` built its branded
`UserId` fixture with a double assertion:

```ts
const USER_ID = "user-1" as unknown as NonNullable<BannerStateSource["userId"]>;
```

This is replaced with a test-local narrowing predicate + `assert`:

```ts
function isUserId(value: string): value is NonNullable<BannerStateSource["userId"]> {
	return value.length > 0;
}

assert(isUserId("user-1"));
assert(!isUserId(""));

const USER_ID = "user-1";
assert(isUserId(USER_ID));
```

## Why

- **Rule:** Avoid TypeScript type assertions (`as`) — branding domain IDs
  with `as` is explicitly forbidden and is not an allowed exception
  (`as const` / isolated Node wrapper).
- **Source:** CLAUDE.md.
- **File:** `src/packages/web-shell/src/banner-state.test.ts` (line 12).

The package intentionally carries no `@packages/domain`/zod dependency
(see the comment in `banner-state.ts`), so a zod branded factory is not
available here. Instead this reuses the runtime-guard + `assert`
narrowing pattern already established in the same package
(`changelog-banner.test.ts` uses `assert(isChangelogVersion(VERSION))`),
which the compiler accepts for narrowing a `string` to the brand.

## Coverage

The predicate's single condition is exercised in both directions at
module load (`isUserId("user-1")` → true, `isUserId("")` → false), so the
change keeps 100% coverage with no new uncovered branch.

🤖 Part of the guidelines & skills audit.