### PR TITLE
refactor(check-failed-articles): isolate process.env access and drop silent default

### DIFF
--- a/src/packages/check-failed-articles/knip.config.ts
+++ b/src/packages/check-failed-articles/knip.config.ts
@@ -5,6 +5,7 @@ export default {
 		"scripts/check-failed-articles.ts",
 		"scripts/collect-failed-rows.ts",
 		"scripts/exclude-patterns.ts",
+		"scripts/require-env.ts",
 	],
 	ignoreBinaries: ["knip", "biome"],
 } satisfies KnipConfig;

--- a/src/packages/check-failed-articles/knip.config.ts
+++ b/src/packages/check-failed-articles/knip.config.ts
@@ -5,7 +5,6 @@ export default {
 		"scripts/check-failed-articles.ts",
 		"scripts/collect-failed-rows.ts",
 		"scripts/exclude-patterns.ts",
-		"scripts/require-env.ts",
 	],
 	ignoreBinaries: ["knip", "biome"],
 } satisfies KnipConfig;

--- a/src/packages/check-failed-articles/scripts/check-failed-articles.ts
+++ b/src/packages/check-failed-articles/scripts/check-failed-articles.ts
@@ -35,15 +35,11 @@ import { test } from "node:test";
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { type FailedRow, collectFailedRows } from "./collect-failed-rows";
 import { EXCLUDE_PATTERNS } from "./exclude-patterns";
-
-function requireEnv(name: string): string {
-	const value = process.env[name];
-	assert(value, `${name} env var is required`);
-	return value;
-}
+import { getEnv, requireEnv } from "./require-env";
 
 function parseLookbackDays(): number {
-	const raw = process.env.FAILED_ARTICLES_LOOKBACK_DAYS ?? "0";
+	const raw = getEnv("FAILED_ARTICLES_LOOKBACK_DAYS");
+	if (raw === undefined) return 0;
 	const parsed = Number(raw);
 	assert(
 		Number.isInteger(parsed) && parsed >= 0,
@@ -53,7 +49,7 @@ function parseLookbackDays(): number {
 }
 
 async function writeReportIfRequested(failed: FailedRow[]): Promise<void> {
-	const reportPath = process.env.FAILED_ARTICLES_REPORT_PATH;
+	const reportPath = getEnv("FAILED_ARTICLES_REPORT_PATH");
 	if (reportPath === undefined) return;
 	await writeFile(reportPath, `${JSON.stringify({ failed }, null, 2)}\n`, "utf8");
 }

--- a/src/packages/check-failed-articles/scripts/require-env.ts
+++ b/src/packages/check-failed-articles/scripts/require-env.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+
+export function requireEnv(name: string): string {
+	const value = process.env[name];
+	assert(value, `${name} env var is required`);
+	return value;
+}
+
+export function getEnv(name: string): string | undefined {
+	const value = process.env[name];
+	return value === undefined || value === "" ? undefined : value;
+}

--- a/src/packages/check-failed-articles/scripts/require-env.ts
+++ b/src/packages/check-failed-articles/scripts/require-env.ts
@@ -1,9 +1,9 @@
-import assert from "node:assert/strict";
+import assert from "node:assert";
 
-export function requireEnv(name: string): string {
+export function requireEnv<T extends string = string>(name: string): T {
 	const value = process.env[name];
-	assert(value, `${name} env var is required`);
-	return value;
+	assert.ok(value !== undefined, `Environment variable ${name} is required but not set`);
+	return value as T;
 }
 
 export function getEnv(name: string): string | undefined {


### PR DESCRIPTION
## What

Resolves three CLAUDE.md "Environment Variable Access" findings in `src/packages/check-failed-articles/scripts/check-failed-articles.ts`:

| Lines | Violation |
|-------|-----------|
| 39-43 | Local `requireEnv` re-implementation reading `process.env[name]` directly |
| 46 | `process.env.FAILED_ARTICLES_LOOKBACK_DAYS ?? "0"` — direct read **and** silent default for a missing env var |
| 56 | `process.env.FAILED_ARTICLES_REPORT_PATH` — direct read of an optional var |

## Why this shape

The rule's literal remedy ("use `requireEnv`/`getEnv` from the shared helper") can't be applied directly: the shared helper lives at `projects/hutch/src/runtime/domain/require-env.ts` inside the **hutch** project, and `@packages/check-failed-articles` declares no dependency on hutch. Importing it would require a cross-project relative path, which the **No Cross-Project Relative Imports** rule forbids, and no workspace package currently re-exports it. Extracting a shared package is a larger refactor that would also ripple into the identical sibling canary `check-stuck-articles`.

So the contained fix confines every `process.env` access to one isolated wrapper module (`scripts/require-env.ts`) exporting `requireEnv` + `getEnv`, following the **established per-project `require-env.ts` pattern** already shipped by `projects/hutch`, `projects/save-link`, `projects/web-embed`, and `projects/blog-site` — this canary adds the 5th local copy and is now the package's only `process.env` reader. It also removes the forbidden `?? "0"` default by reading through `getEnv` and branching to `0` explicitly. The wrapper now mirrors the canonical helper's API and semantics — `node:assert` with `assert.ok(value !== undefined)` (so empty-string vars are accepted like the shared copies), the `<T extends string = string>` generic (whose `return value as T` is the documented **isolated Node.js API wrappers** `as` exception), and a semantically-identical `getEnv` — so a future workspace-package extraction is trivial.

## Behaviour

Unchanged: unset `FAILED_ARTICLES_LOOKBACK_DAYS` still yields `0` (time gate disabled); unset `FAILED_ARTICLES_REPORT_PATH` still skips writing the report.

## Source

CLAUDE.md → "Coding Style › Environment Variable Access".

🤖 Part of the guidelines & skills audit.
