### PR TITLE
test(e2e): document CI-only reason for href catch c8 ignore

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/queue-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/queue-actions.ts
@@ -145,6 +145,7 @@ export function createQueueActions(
             .locator('#latest-saved .queue-article__url')
             .first()
             .getAttribute('href')
+            // c8 ignore: catch only fires on CI when the latest-saved card is detached mid page-reload
             .catch(/* c8 ignore next */ () => null)
           return latestHref?.includes(slug) === true
         },


### PR DESCRIPTION
## What

Add an approved inline reason to the `/* c8 ignore next */` on the `.catch(() => null)` that guards `getAttribute('href')` inside the pagination-save retriable in `projects/hutch/src/e2e/queue-flow/queue-actions.ts`.

## Why

- **Rule:** CLAUDE.md — "No Coverage Ignore Comments" / "Allowed `c8 ignore` Cases": ignore comments are forbidden unless explicitly approved, and when necessary must carry an inline reason mapping to an approved category.
- **Source:** CLAUDE.md
- The original ignore had no reason. The catch only executes when the Playwright locator rejects because the `#latest-saved` card is detached during a page reload — a CI-only flakiness path that never runs on a clean local pass. This is the same approved CI-only-callback category already documented for the `beforeRetry` ignore at lines 336-337 of the same file.

## Change

Add a `// c8 ignore:` reason line above the `.catch`, mirroring the existing `beforeRetry` precedent's wording and placement. No signature, output, or behavior changes; no test or caller updates required.

🤖 Part of the guidelines & skills audit.