### PR TITLE
refactor(infra): derive Lambda NODE_ENV from config, not stage name

### DIFF
--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -3,6 +3,7 @@ config:
   aws:allowedAccountIds:
     - '278728209435'
   hutch:stage: production
+  hutch:nodeEnv: production
   hutch:platformStack: organization/platform/prod
   hutch:domains:
     - hutch-app.com

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -3,6 +3,7 @@ config:
   aws:allowedAccountIds:
     - '572337278115'
   hutch:stage: staging
+  hutch:nodeEnv: development
   hutch:platformStack: organization/platform/staging
   hutch:deletionProtection: false
   hutch:staticDomains:

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -275,7 +275,7 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 	memorySize: 512,
 	timeout: 30,
 	environment: {
-		NODE_ENV: stage === "production" ? "production" : "development",
+		NODE_ENV: config.require("nodeEnv"),
 		PERSISTENCE: "prod",
 		APP_ORIGIN: appOrigin,
 		/** Same-origin fragment endpoint served by blog-site behind this same API


### PR DESCRIPTION
## What

The web Lambda's `NODE_ENV` was derived by branching on the environment
name:

```ts
NODE_ENV: stage === "production" ? "production" : "development",
```

This is replaced with a per-environment config value read via Pulumi's
config API:

```ts
NODE_ENV: config.require("nodeEnv"),
```

and the value is added to each environment's YAML:

- `Pulumi.prod.yaml` → `hutch:nodeEnv: production`
- `Pulumi.staging.yaml` → `hutch:nodeEnv: development`

These match exactly what the conditional produced for each stack, so the
deployed Lambda environment is unchanged.

## Why

`.claude/skills/infrastructure-design/SKILL.md` — **Data-Driven Over
Environment Conditionals**: infrastructure code must not branch on
environment names (`stage === "production"`). Environment differences
belong in each environment's YAML and must be read via the config API, so
adding a new environment means adding a YAML file rather than editing
code.

## Scope / safety

- `stage` is still used for the API Gateway description and gateway stage
  wiring, so the binding stays.
- No tests or callers reference `NODE_ENV` (no infra `*.test.ts`; the
  symbol appears only at its definition site).
- `src/infra/**` is excluded from coverage, so no coverage impact.

**File:** `projects/hutch/src/infra/index.ts`
**Source:** `.claude/skills/infrastructure-design/SKILL.md`

🤖 Part of the guidelines & skills audit.