### PR TITLE
refactor(checkout-recovery): use HutchLogger for CLI fatal error and remove unapproved c8 ignore

### DIFF
--- a/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
+++ b/projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start -- composition root, no logic to test */
 import { createDynamoDocumentClient } from "@packages/hutch-storage-client";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initDynamoDbPendingSignup } from "../providers/pending-signup/dynamodb-pending-signup";
@@ -9,6 +8,8 @@ import { buildSignupResumeUrl } from "../web/auth/signup-resume-url";
 import { requireEnv } from "../domain/require-env";
 import { selectRecipients } from "../domain/checkout-recovery/select-recipients";
 
+const logger = HutchLogger.from(consoleLogger);
+
 async function main(): Promise<void> {
 	const tableName = requireEnv("DYNAMODB_PENDING_SIGNUPS_TABLE");
 	const stripeApiKey = requireEnv("STRIPE_SECRET_KEY");
@@ -18,8 +19,6 @@ async function main(): Promise<void> {
 	const from = requireEnv("RECOVERY_EMAIL_FROM");
 	const replyTo = requireEnv("RECOVERY_EMAIL_REPLY_TO");
 	const bcc = requireEnv("RECOVERY_EMAIL_BCC");
-
-	const logger = HutchLogger.from(consoleLogger);
 
 	const dynamoClient = createDynamoDocumentClient();
 	const pendingSignup = initDynamoDbPendingSignup({ client: dynamoClient, tableName });
@@ -90,7 +89,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-	console.error("[recovery] Fatal:", err);
+	logger.error("[recovery] Fatal:", err);
 	process.exit(1);
 });
-/* c8 ignore stop */


### PR DESCRIPTION
## What

Two guideline fixes in `projects/hutch/src/runtime/checkout-recovery/send-checkout-recovery-emails.cli.main.ts`.

### 1. Raw `console.error` → `HutchLogger`
- **Rule:** Logging — "Never use raw `console.log`/`console.error` in application code. In composition roots, create the logger with `HutchLogger.from(consoleLogger)`." (source: `CLAUDE.md`)
- **Change:** The `main().catch((err) => { console.error("[recovery] Fatal:", err); ... })` handler now logs via a module-scope `HutchLogger.from(consoleLogger)`. The logger that was created inside `main()` is hoisted to module scope and reused, so there is a single logger for the whole entry point. `HutchLogger.error` is a variadic `LogMethod`, so the existing two-argument call shape is preserved.

### 2. Unapproved whole-file `c8 ignore`
- **Rule:** "No Coverage Ignore Comments" / "Allowed `c8 ignore` Cases" — `c8 ignore` is forbidden unless explicitly approved; the only approved categories are thin AWS SDK wrappers, CI-only retry callbacks, V8 async artifacts, and V8 block-coverage phantoms. "composition root, no logic to test" is none of these. (source: `CLAUDE.md`)
- **Change:** Remove `/* c8 ignore start ... */` and `/* c8 ignore stop */`. This is safe for the 100% coverage gate because `enforce-coverage.config.base.js` already excludes `**/*.main.ts` from coverage (`BASE_EXCLUDE_PATTERNS`, "Entry points — side-effectful bootstrap code with no logic to unit test").

## Why it stays green
- No test references this file (no `*.test.ts` / `*.integration.ts` import it).
- No exported signatures change; imports remain used (tsc/biome/knip unaffected).
- Coverage is unchanged: the file is glob-excluded as a `*.main.ts` entry point.

🤖 Part of the guidelines & skills audit.