### PR TITLE
test(conversions): assert exact event shape instead of negative .not.toContain

### DIFF
--- a/projects/hutch/src/runtime/conversions.test.ts
+++ b/projects/hutch/src/runtime/conversions.test.ts
@@ -47,7 +47,6 @@ describe("emitUserCreated", () => {
 			method: "email",
 			tier: "free",
 		});
-		expect(JSON.stringify(captured[0])).not.toContain("stripe_checkout_session_id");
 	});
 
 	it("emits a trial signup event without a stripe checkout session id", () => {
@@ -64,11 +63,15 @@ describe("emitUserCreated", () => {
 			},
 		);
 
-		expect(captured[0]).toMatchObject({
-			tier: "trial",
+		expect(captured[0]).toEqual({
+			stream: "conversions",
+			event: "user_created",
+			timestamp: "2026-05-13T10:00:00.000Z",
+			user_id: TEST_USER_ID,
+			email_hash: "63f6f5c42a8bfcdb",
 			method: "email",
+			tier: "trial",
 		});
-		expect(JSON.stringify(captured[0])).not.toContain("stripe_checkout_session_id");
 	});
 
 	it("includes stripe_checkout_session_id for paid signups so the event can be joined to Stripe payment data downstream", () => {
@@ -186,16 +189,15 @@ describe("emitUserCreated", () => {
 			},
 		);
 
-		const serialized = JSON.stringify(captured[0]);
-		expect(serialized).not.toContain("utm_source");
-		expect(serialized).not.toContain("utm_medium");
-		expect(serialized).not.toContain("utm_campaign");
-		expect(serialized).not.toContain("utm_content");
-		expect(serialized).not.toContain("referrer_host");
-		expect(serialized).not.toContain("first_seen_at");
-		expect(serialized).not.toContain("landing_path");
-		expect(serialized).not.toContain("visitor_id");
-		expect(serialized).not.toContain("pending_save_id");
+		expect(captured[0]).toEqual({
+			stream: "conversions",
+			event: "user_created",
+			timestamp: "2026-05-13T10:00:00.000Z",
+			user_id: TEST_USER_ID,
+			email_hash: "5fe5806a804c99a3",
+			method: "email",
+			tier: "free",
+		});
 	});
 
 	it("includes pending_save_id so a signup-blocked save can be traced to the account it created", () => {
@@ -232,6 +234,14 @@ describe("emitUserCreated", () => {
 			},
 		);
 
-		expect(JSON.stringify(captured[0])).not.toContain("pending_save_id");
+		expect(captured[0]).toEqual({
+			stream: "conversions",
+			event: "user_created",
+			timestamp: "2026-05-13T10:00:00.000Z",
+			user_id: TEST_USER_ID,
+			email_hash: "908cf3c1dc654595",
+			method: "email",
+			tier: "free",
+		});
 	});
 });


### PR DESCRIPTION
## What

Removes the `.not.toContain(...)` negative assertions in `projects/hutch/src/runtime/conversions.test.ts` and replaces them with positive `toEqual` assertions of the exact emitted `ConversionEvent`.

## Why

The test-driven-design skill, section **Avoid Negative Test Assertions**, states that `.not.toContain()` assertions "become stale when code is refactored" and that tests should "Test the actual expected value" instead. Four sites (lines 50, 71, 190-199, 235) asserted against `JSON.stringify(captured[0])` to prove that `stripe_checkout_session_id`, `utm_*`, `referrer_host`, `first_seen_at`, `landing_path`, `visitor_id`, and `pending_save_id` were omitted.

## Change

- `emitUserCreated` (in `projects/hutch/src/runtime/conversions.ts`) builds a deterministic event using conditional spreads, so each test's full object is known.
- Free-signup case already had a complete `toEqual`; the trailing redundant `.not.toContain` is deleted.
- Trial, attribution-less, and organic (no-pending-save) cases now use a single exhaustive `toEqual` of the whole event, which positively proves the optional keys are absent — an unexpected extra key fails `toEqual`.
- Email-hash prefixes are the verified sha256 values of the lowercased test emails.

No production code, exported signatures, or other callers change; only this test file is edited.

- Rule: Avoid Negative Test Assertions
- Source: `.claude/skills/test-driven-design/SKILL.md`
- File: `projects/hutch/src/runtime/conversions.test.ts`

🤖 Part of the guidelines & skills audit.