### PR TITLE
refactor(hutch-storage-client): drop `as` casts from batchGetFromTable fake client

### DIFF
--- a/projects/hutch/src/runtime/providers/article-store/batch-get-from-table.test.ts
+++ b/projects/hutch/src/runtime/providers/article-store/batch-get-from-table.test.ts
@@ -34,33 +34,31 @@ function createFakeClient(
 		responses?: Array<{ url: string; payload: string }>;
 		unprocessedKeys?: Array<{ url: string }>;
 	},
-): { client: DynamoDBDocumentClient; calls: CapturedRequest[] } {
+): { client: Pick<DynamoDBDocumentClient, "send">; calls: CapturedRequest[] } {
 	const calls: CapturedRequest[] = [];
-	const fake: Partial<DynamoDBDocumentClient> = {
-		send: (async (input: BatchGetCommandLike) => {
-			const requestItems = input.input.RequestItems ?? {};
-			const tableName = Object.keys(requestItems)[0] ?? "";
-			const tableEntry = requestItems[tableName];
-			const rawKeys = tableEntry?.Keys ?? [];
-			const keys = rawKeys.map((k) => ({ url: String(k.url) }));
-			const callIndex = calls.length;
-			calls.push({
-				tableName,
-				keys,
-				projection: tableEntry?.ProjectionExpression,
-				expressionAttributeNames: tableEntry?.ExpressionAttributeNames,
-			});
-			const { responses = [], unprocessedKeys = [] } = respond(keys, callIndex);
-			return {
-				Responses: { [tableName]: responses },
-				UnprocessedKeys:
-					unprocessedKeys.length > 0
-						? { [tableName]: { Keys: unprocessedKeys } }
-						: undefined,
-			};
-		}) as unknown as SendFn,
-	};
-	return { client: fake as DynamoDBDocumentClient, calls };
+	const send: SendFn = (async (input: BatchGetCommandLike) => {
+		const requestItems = input.input.RequestItems ?? {};
+		const tableName = Object.keys(requestItems)[0] ?? "";
+		const tableEntry = requestItems[tableName];
+		const rawKeys = tableEntry?.Keys ?? [];
+		const keys = rawKeys.map((k) => ({ url: String(k.url) }));
+		const callIndex = calls.length;
+		calls.push({
+			tableName,
+			keys,
+			projection: tableEntry?.ProjectionExpression,
+			expressionAttributeNames: tableEntry?.ExpressionAttributeNames,
+		});
+		const { responses = [], unprocessedKeys = [] } = respond(keys, callIndex);
+		return {
+			Responses: { [tableName]: responses },
+			UnprocessedKeys:
+				unprocessedKeys.length > 0
+					? { [tableName]: { Keys: unprocessedKeys } }
+					: undefined,
+		};
+	}) as SendFn;
+	return { client: { send }, calls };
 }
 
 const TABLE = "test-articles";

--- a/src/packages/hutch-storage-client/src/define-table.ts
+++ b/src/packages/hutch-storage-client/src/define-table.ts
@@ -166,7 +166,7 @@ const UNPROCESSED_KEYS_INITIAL_DELAY_MS = 50;
  * by the 16 MB response cap or throttling) with exponential backoff.
  */
 export async function batchGetFromTable<TSchema extends z.ZodObject>(config: {
-	client: DynamoDBDocumentClient;
+	client: Pick<DynamoDBDocumentClient, "send">;
 	tableName: string;
 	schema: TSchema;
 	keys: readonly Key[];


### PR DESCRIPTION
## What

`batchGetFromTable`'s unit test built a `fake: Partial<DynamoDBDocumentClient>` and then threw away that safety with two type assertions:

```ts
send: (async (input) => { ... }) as unknown as SendFn,
// ...
return { client: fake as DynamoDBDocumentClient, calls };
```

Both are forbidden by the **Avoid TypeScript Type Assertions (`as`)** rule in `CLAUDE.md`, which specifically calls out "faking a partial object with `as` instead of `Partial<T>`". The `as unknown as SendFn` double-cast is the worst form: it erases all type checking on the fake's `send` implementation.

## Why it happened

`DynamoDBDocumentClient` is an AWS SDK class with a `protected` constructor and protected/private members, so it cannot be satisfied structurally — the test was forced to lie to the full type.

## Fix

`batchGetFromTable` only ever calls `client.send(...)`. Widen its `client` parameter from `DynamoDBDocumentClient` to `Pick<DynamoDBDocumentClient, "send">` (the capability actually used). The test can then inject a plain `{ send }` object — no cast on the client at all. The `send` value is typed `const send: SendFn = (...) => {...}` and collapsed from a double-cast to a single `as SendFn` at the AWS SDK's overloaded `send()` boundary, which is the documented isolated-third-party-wrapper exception.

The sole production caller, `dynamodb-article-store.ts`, passes a full `DynamoDBDocumentClient`, which satisfies `Pick<…, "send">`, so this is non-breaking.

## Verification

- `pnpm nx run hutch-storage-client:check` (tsc compile + tsc lint + biome + knip) passes with the widened signature.
- The rewritten test type-checks and all `batchGetFromTable` test cases pass.

## Rule / source

- Rule: Avoid TypeScript Type Assertions (`as`) — faking a partial object with `as` instead of `Partial<T>`
- Source: `CLAUDE.md`
- Files: `projects/hutch/src/runtime/providers/article-store/batch-get-from-table.test.ts` (lines 61, 63), `src/packages/hutch-storage-client/src/define-table.ts`

🤖 Part of the guidelines & skills audit.