### PR TITLE
refactor(auth-test): parse UserId via schema instead of as-cast

### DIFF
--- a/projects/hutch/src/runtime/providers/auth/dynamodb-auth.test.ts
+++ b/projects/hutch/src/runtime/providers/auth/dynamodb-auth.test.ts
@@ -1,5 +1,5 @@
 import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
-import type { UserId } from "@packages/domain/user";
+import { UserIdSchema } from "@packages/domain/user";
 import { initDynamoDbAuth } from "./dynamodb-auth";
 
 /** Fake that honours the GetCommand projection so a row with fields missing from it round-trips as real DynamoDB would. */
@@ -48,7 +48,7 @@ function initAuth(client: DynamoDBDocumentClient) {
 	});
 }
 
-const USER = "abc123" as UserId;
+const USER = UserIdSchema.parse("abc123");
 
 describe("initDynamoDbAuth", () => {
 	describe("findUserByEmail", () => {


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/providers/auth/dynamodb-auth.test.ts` constructed a branded `UserId` test fixture with a type assertion:

```ts
const USER = "abc123" as UserId;
```

## Why

CLAUDE.md's **Avoid TypeScript Type Assertions (`as`)** section lists `const userId = rawValue as UserId` as the canonical anti-pattern and prescribes constructing branded ids through a validated factory: `UserIdSchema.parse(...)`. Casting to a branded type bypasses the compiler and is not one of the documented exceptions (`as const`, isolated Node wrappers).

- **Rule:** Avoid TypeScript Type Assertions (`as`)
- **Source:** CLAUDE.md
- **File:** `projects/hutch/src/runtime/providers/auth/dynamodb-auth.test.ts`

## Change

- Swap the type-only import `import type { UserId } from "@packages/domain/user";` for a value import `import { UserIdSchema } from "@packages/domain/user";`.
- Build the fixture with `const USER = UserIdSchema.parse("abc123");`.

`UserIdSchema` is already exported from `@packages/domain/user` and used this exact way in `projects/hutch/src/runtime/conversions.test.ts`. Its transform passes any string through, so the runtime value is unchanged and existing assertions remain green.

🤖 Part of the guidelines & skills audit.