### PR TITLE
test(hutch): unit-test email verification provider instead of c8-ignoring it

### DIFF
--- a/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
+++ b/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
@@ -1,0 +1,122 @@
+import { ConditionalCheckFailedException, type DynamoDBDocumentClient } from "@packages/hutch-storage-client";
+import type { UserId } from "@packages/domain/user";
+import { VerificationTokenSchema } from "@packages/test-fixtures/providers/email-verification";
+import { initDynamoDbEmailVerification } from "./dynamodb-email-verification";
+
+const USER = "abc123" as UserId;
+const TOKEN = VerificationTokenSchema.parse("a".repeat(64));
+
+interface CapturedCommand {
+	name: string;
+	input: Record<string, unknown>;
+}
+
+type CommandResponse = Record<string, unknown> | (() => Record<string, unknown>);
+
+/** Records every command sent and replays a canned response keyed by command
+ * type, so a test can assert the exact ConditionExpression / ReturnValues the
+ * provider builds. A function response is invoked so a test can throw to
+ * simulate a failed conditional delete. */
+function createFakeClient(
+	responses: Partial<Record<string, CommandResponse>> = {},
+): { client: DynamoDBDocumentClient; commands: CapturedCommand[] } {
+	const commands: CapturedCommand[] = [];
+	const client = {
+		send: (async (command: { constructor: { name: string }; input: Record<string, unknown> }) => {
+			const name = command.constructor.name;
+			commands.push({ name, input: command.input });
+			const response = responses[name];
+			if (!response) return {};
+			return typeof response === "function" ? response() : response;
+		}) as DynamoDBDocumentClient["send"],
+	};
+	return { client: client as typeof client & DynamoDBDocumentClient, commands };
+}
+
+function initVerification(client: DynamoDBDocumentClient) {
+	return initDynamoDbEmailVerification({ client, tableName: "verifications" });
+}
+
+function rowAttributes(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		Attributes: {
+			token: TOKEN,
+			userId: USER,
+			email: "user@example.com",
+			expiresAt: Math.floor(Date.now() / 1000) + 3600,
+			...overrides,
+		},
+	};
+}
+
+describe("initDynamoDbEmailVerification", () => {
+	describe("createVerificationToken", () => {
+		it("persists a 64-char hex token guarded against overwrite and returns it", async () => {
+			const { client, commands } = createFakeClient();
+
+			const token = await initVerification(client).createVerificationToken({
+				userId: USER,
+				email: "user@example.com",
+			});
+
+			expect(token).toMatch(/^[0-9a-f]{64}$/);
+			const put = commands.find((c) => c.name === "PutCommand");
+			expect(put?.input.Item).toMatchObject({ token, userId: USER, email: "user@example.com" });
+			expect(put?.input.Item).toHaveProperty("expiresAt");
+		});
+	});
+
+	describe("verifyEmailToken", () => {
+		it("returns the user and email when the deleted token is still valid", async () => {
+			const { client, commands } = createFakeClient({ DeleteCommand: rowAttributes() });
+
+			const result = await initVerification(client).verifyEmailToken(TOKEN);
+
+			expect(result).toEqual({ ok: true, userId: USER, email: "user@example.com" });
+			const del = commands.find((c) => c.name === "DeleteCommand");
+			expect(del?.input.ReturnValues).toBe("ALL_OLD");
+			expect(del?.input.ConditionExpression).toContain("attribute_exists");
+		});
+
+		it("rejects with invalid-token when no row was deleted", async () => {
+			const { client } = createFakeClient({ DeleteCommand: {} });
+
+			const result = await initVerification(client).verifyEmailToken(TOKEN);
+
+			expect(result).toEqual({ ok: false, reason: "invalid-token" });
+		});
+
+		it("rejects with invalid-token when the deleted token has expired", async () => {
+			const { client } = createFakeClient({
+				DeleteCommand: rowAttributes({ expiresAt: Math.floor(Date.now() / 1000) - 1 }),
+			});
+
+			const result = await initVerification(client).verifyEmailToken(TOKEN);
+
+			expect(result).toEqual({ ok: false, reason: "invalid-token" });
+		});
+
+		it("rejects with invalid-token when the conditional delete finds no token", async () => {
+			const { client } = createFakeClient({
+				DeleteCommand: () => {
+					throw new ConditionalCheckFailedException({ $metadata: {}, message: "missing" });
+				},
+			});
+
+			const result = await initVerification(client).verifyEmailToken(TOKEN);
+
+			expect(result).toEqual({ ok: false, reason: "invalid-token" });
+		});
+
+		it("propagates errors that are not a failed condition", async () => {
+			const failure = new Error("throttled");
+			const { client } = createFakeClient({
+				DeleteCommand: () => {
+					throw failure;
+				},
+			});
+
+			await expect(initVerification(client).verifyEmailToken(TOKEN)).rejects.toThrow(failure);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
+++ b/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
@@ -51,7 +51,7 @@ function rowAttributes(overrides: Record<string, unknown> = {}): Record<string, 
 
 describe("initDynamoDbEmailVerification", () => {
 	describe("createVerificationToken", () => {
-		it("persists a 64-char hex token guarded against overwrite and returns it", async () => {
+		it("persists a 64-char hex token and returns it", async () => {
 			const { client, commands } = createFakeClient();
 
 			const token = await initVerification(client).createVerificationToken({

--- a/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.ts
+++ b/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
 import { randomBytes } from "node:crypto";
 import {
 	ConditionalCheckFailedException,
@@ -79,4 +78,3 @@ export function initDynamoDbEmailVerification(deps: {
 
 	return { createVerificationToken, verifyEmailToken };
 }
-/* c8 ignore stop */


### PR DESCRIPTION
## What

Removes the whole-file `c8 ignore` from `dynamodb-email-verification.ts` and adds a unit test that exercises its branching logic with the fake-client pattern.

## Why

The file was blanket-ignored as a `thin AWS SDK wrapper, tested via integration`, but `verifyEmailToken` is not trivial — it contains real domain branching:

- the missing-`Attributes` check (returns `invalid-token`),
- the token-expiry comparison (returns `invalid-token`),
- the `ConditionalCheckFailedException` catch (maps to `invalid-token`),
- the re-throw of any other error.

The test-driven-design skill (Thin AWS SDK Wrappers Are Unit-Tested With Fake Clients) reserves whole-file `c8 ignore` for wrappers that are "truly trivial (3-5 lines, no branching)" and states "Do NOT add a `.integration.ts` to plug coverage gaps — extract the mapping/parsing logic ... and unit-test the helper directly." Blanket-ignoring this file hid untested branching.

## Change

- `dynamodb-email-verification.ts`: removed the `/* c8 ignore start -- ... */` and `/* c8 ignore stop */` pair.
- `dynamodb-email-verification.test.ts` (new): a command-capturing `Partial<DynamoDBDocumentClient>` fake covers `createVerificationToken` (the guarded `put`) and all five `verifyEmailToken` outcomes (valid, no-row, expired, conditional-check-failed, and non-conditional error propagation).

## Verification

Scoped jest coverage on the source file reports 100% statements / branches / functions / lines with the ignore removed; all 6 new tests pass. `tsc` reports no errors for the changed files.

## Source

- Rule: `.claude/skills/test-driven-design/SKILL.md` (Thin AWS SDK Wrappers Are Unit-Tested With Fake Clients)
- Rule: `CLAUDE.md` (Allowed `c8 ignore` Cases)
- File: `projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.ts`

🤖 Part of the guidelines & skills audit.