### PR TITLE
refactor(pending-signup): unit-test dynamo wrapper, move checkout schema out of test-fixtures

### DIFF
--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.test.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.test.ts
@@ -1,0 +1,317 @@
+import { CheckoutSessionIdSchema } from "@packages/provider-contracts/stripe-checkout";
+import type { DynamoDBDocumentClient } from "@packages/hutch-storage-client";
+import { UserIdSchema } from "@packages/domain/user";
+import { initDynamoDbPendingSignup } from "./dynamodb-pending-signup";
+
+type SendFn = DynamoDBDocumentClient["send"];
+
+type CommandInput = {
+	Item?: Record<string, unknown>;
+	Key?: Record<string, unknown>;
+	ReturnValues?: string;
+	UpdateExpression?: string;
+	ProjectionExpression?: string;
+	ExclusiveStartKey?: Record<string, unknown>;
+	ExpressionAttributeValues?: Record<string, unknown>;
+};
+
+function createClient(impl: (input: CommandInput) => unknown): {
+	client: DynamoDBDocumentClient;
+	inputs: CommandInput[];
+} {
+	const inputs: CommandInput[] = [];
+	const client = {
+		send: (async (command: { input: CommandInput }) => {
+			inputs.push(command.input);
+			return impl(command.input);
+		}) as unknown as SendFn,
+	} as DynamoDBDocumentClient;
+	return { client, inputs };
+}
+
+const TABLE = "pending-signups";
+const SESSION_ID = CheckoutSessionIdSchema.parse("cs_test_123");
+const USER_ID = UserIdSchema.parse("user-abc");
+
+describe("initDynamoDbPendingSignup", () => {
+	describe("storePendingSignup", () => {
+		it("persists an email signup with passwordHash and returnUrl", async () => {
+			const { client, inputs } = createClient(() => ({}));
+			const { storePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			await storePendingSignup({
+				checkoutSessionId: SESSION_ID,
+				signup: {
+					method: "email",
+					email: "a@b.com",
+					passwordHash: "hash-1",
+					returnUrl: "/queue",
+				},
+				createdAt: 100,
+			});
+
+			expect(inputs[0]?.Item).toEqual({
+				checkoutSessionId: SESSION_ID,
+				method: "email",
+				email: "a@b.com",
+				createdAt: 100,
+				passwordHash: "hash-1",
+				returnUrl: "/queue",
+			});
+		});
+
+		it("persists a google signup with userId and omits returnUrl when absent", async () => {
+			const { client, inputs } = createClient(() => ({}));
+			const { storePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			await storePendingSignup({
+				checkoutSessionId: SESSION_ID,
+				signup: { method: "google", email: "g@b.com", userId: USER_ID },
+				createdAt: 200,
+			});
+
+			expect(inputs[0]?.Item).toEqual({
+				checkoutSessionId: SESSION_ID,
+				method: "google",
+				email: "g@b.com",
+				createdAt: 200,
+				userId: USER_ID,
+			});
+		});
+
+		it("persists an existing-user-subscribe signup with userId", async () => {
+			const { client, inputs } = createClient(() => ({}));
+			const { storePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			await storePendingSignup({
+				checkoutSessionId: SESSION_ID,
+				signup: {
+					method: "existing-user-subscribe",
+					email: "e@b.com",
+					userId: USER_ID,
+				},
+				createdAt: 300,
+			});
+
+			expect(inputs[0]?.Item).toEqual({
+				checkoutSessionId: SESSION_ID,
+				method: "existing-user-subscribe",
+				email: "e@b.com",
+				createdAt: 300,
+				userId: USER_ID,
+			});
+		});
+	});
+
+	describe("consumePendingSignup", () => {
+		it("returns null when no row was deleted", async () => {
+			const { client } = createClient(() => ({}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toBeNull();
+		});
+
+		it("reconstructs an email signup including returnUrl", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "email",
+					email: "a@b.com",
+					passwordHash: "hash-1",
+					returnUrl: "/queue",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toEqual({
+				method: "email",
+				email: "a@b.com",
+				passwordHash: "hash-1",
+				returnUrl: "/queue",
+			});
+		});
+
+		it("returns null for an email row missing its passwordHash", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "email",
+					email: "a@b.com",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toBeNull();
+		});
+
+		it("reconstructs an existing-user-subscribe signup", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "existing-user-subscribe",
+					email: "e@b.com",
+					userId: USER_ID,
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toEqual({
+				method: "existing-user-subscribe",
+				email: "e@b.com",
+				userId: USER_ID,
+			});
+		});
+
+		it("returns null for an existing-user-subscribe row missing its userId", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "existing-user-subscribe",
+					email: "e@b.com",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toBeNull();
+		});
+
+		it("reconstructs a google signup with returnUrl", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "google",
+					email: "g@b.com",
+					userId: USER_ID,
+					returnUrl: "/account",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toEqual({
+				method: "google",
+				email: "g@b.com",
+				userId: USER_ID,
+				returnUrl: "/account",
+			});
+		});
+
+		it("returns null for a google row missing its userId", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "google",
+					email: "g@b.com",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("listAllPendingSignups", () => {
+		it("paginates through every scan page and projects the summary fields", async () => {
+			const pages = [
+				{
+					Items: [
+						{
+							checkoutSessionId: SESSION_ID,
+							email: "a@b.com",
+							createdAt: 100,
+							checkoutRecoveryEmailSentAt: 150,
+						},
+					],
+					LastEvaluatedKey: { checkoutSessionId: SESSION_ID },
+				},
+				{
+					Items: [{ checkoutSessionId: SESSION_ID, email: "c@b.com" }],
+				},
+			];
+			let call = 0;
+			const { client, inputs } = createClient(() => pages[call++]);
+			const { listAllPendingSignups } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			const result = await listAllPendingSignups();
+
+			expect(result).toEqual([
+				{
+					checkoutSessionId: SESSION_ID,
+					email: "a@b.com",
+					createdAt: 100,
+					checkoutRecoveryEmailSentAt: 150,
+				},
+				{ checkoutSessionId: SESSION_ID, email: "c@b.com" },
+			]);
+			expect(inputs[1]?.ExclusiveStartKey).toEqual({
+				checkoutSessionId: SESSION_ID,
+			});
+		});
+	});
+
+	describe("markCheckoutRecoveryEmailSent", () => {
+		it("issues an update that sets checkoutRecoveryEmailSentAt", async () => {
+			const { client, inputs } = createClient(() => ({}));
+			const { markCheckoutRecoveryEmailSent } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+			});
+
+			await markCheckoutRecoveryEmailSent({
+				checkoutSessionId: SESSION_ID,
+				sentAt: 999,
+			});
+
+			expect(inputs[0]?.UpdateExpression).toBe(
+				"SET checkoutRecoveryEmailSentAt = :sentAt",
+			);
+			expect(inputs[0]?.ExpressionAttributeValues?.[":sentAt"]).toBe(999);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */
 import {
 	type DynamoDBDocumentClient,
 	defineDynamoTable,
@@ -6,7 +5,7 @@ import {
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import { UserIdSchema } from "@packages/domain/user";
-import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
+import { CheckoutSessionIdSchema } from "@packages/provider-contracts/stripe-checkout";
 import type {
 	ConsumePendingSignup,
 	ListAllPendingSignups,
@@ -154,4 +153,3 @@ export function initDynamoDbPendingSignup(deps: {
 		markCheckoutRecoveryEmailSent,
 	};
 }
-/* c8 ignore stop */

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -1,9 +1,9 @@
 /* c8 ignore start -- thin Stripe API wrapper, tested via integration */
 import { z } from "zod";
-import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
-import type {
-	CreateCheckoutSession,
-	RetrieveCheckoutSession,
+import {
+	CheckoutSessionIdSchema,
+	type CreateCheckoutSession,
+	type RetrieveCheckoutSession,
 } from "@packages/provider-contracts/stripe-checkout";
 
 const STRIPE_API = "https://api.stripe.com/v1";

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -30,8 +30,10 @@ import type {
 	CreateTrialEndSchedule,
 	DeleteTrialEndSchedule,
 } from "@packages/provider-contracts/trial-scheduler";
-import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
-import type { RetrieveCheckoutSession } from "@packages/provider-contracts/stripe-checkout";
+import {
+	CheckoutSessionIdSchema,
+	type RetrieveCheckoutSession,
+} from "@packages/provider-contracts/stripe-checkout";
 import type {
 	ConsumeRateLimit,
 	RateLimitRules,

--- a/src/packages/provider-contracts/src/index.ts
+++ b/src/packages/provider-contracts/src/index.ts
@@ -15,7 +15,7 @@ export type * from "./pending-signup";
 export type * from "./rate-limit";
 export type * from "./reader-ready-state";
 export type * from "./refresh-html";
-export type * from "./stripe-checkout";
+export * from "./stripe-checkout";
 export type * from "./stripe-subscriptions";
 export type * from "./subscription-providers";
 export type * from "./trial-scheduler";

--- a/src/packages/provider-contracts/src/stripe-checkout.ts
+++ b/src/packages/provider-contracts/src/stripe-checkout.ts
@@ -1,6 +1,8 @@
-import type { $brand } from "zod";
+import { z, type $brand } from "zod";
 
 export type CheckoutSessionId = string & $brand<"CheckoutSessionId">;
+
+export const CheckoutSessionIdSchema = z.string().min(1).brand<"CheckoutSessionId">();
 
 export interface CheckoutSession {
 	id: CheckoutSessionId;

--- a/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.schema.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-checkout/stripe-checkout.schema.ts
@@ -1,3 +1,1 @@
-import { z } from "zod";
-
-export const CheckoutSessionIdSchema = z.string().min(1).brand<"CheckoutSessionId">();
+export { CheckoutSessionIdSchema } from "@packages/provider-contracts/stripe-checkout";


### PR DESCRIPTION
## What

Two fixes to `projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts`.

### 1. Remove the whole-file `c8 ignore` and unit-test the branching logic

`dynamodb-pending-signup.ts` was wrapped top-to-bottom in `/* c8 ignore start -- thin AWS SDK wrapper, tested via integration */`. The test-driven-design skill ("Thin AWS SDK Wrappers Are Unit-Tested With Fake Clients") reserves the whole-file ignore for wrappers that are "truly trivial (3–5 lines, no branching)" and requires non-trivial mapping/branching logic to be extracted and unit-tested directly with the `Partial<DynamoDBDocumentClient>` fake-client pattern. `consumePendingSignup` discriminates three signup methods and has three null-handling branches; `storePendingSignup` and `listAllPendingSignups` also branch.

- Removed the file-wide ignore comments.
- Added co-located `dynamodb-pending-signup.test.ts` using the fake-client pattern (routing on the captured command input), covering all four functions and every branch to 100%.

### 2. Move `CheckoutSessionIdSchema` out of the test-only package

The production wrapper imported `CheckoutSessionIdSchema` from `@packages/test-fixtures/providers/stripe-checkout`, a package whose own `package.json` describes it as the home for "in-memory implementations and the default test-app fixture builder." Per the No Default In-Memory Implementations rule, fixtures are for tests only.

- Moved the schema into `@packages/provider-contracts/stripe-checkout` (beside the `CheckoutSessionId` branded type; provider-contracts already depends on zod).
- Flipped the provider-contracts index barrel from `export type *` to `export *` for stripe-checkout so the value is exported.
- Reduced the test-fixtures schema file to a re-export so its in-memory implementation and existing tests keep importing `./stripe-checkout.schema` unchanged.

## Rule / source

- test-driven-design/SKILL.md — Thin AWS SDK Wrappers Are Unit-Tested With Fake Clients
- test-driven-design/SKILL.md + CLAUDE.md — No Default In-Memory Implementations / fixtures are for tests only

## Verification

`pnpm check` (tsc + biome + knip + 100% coverage + tests) across the affected projects.

🤖 Part of the guidelines & skills audit.