### PR TITLE
fix(stripe-checkout): fail fast on missing email and cover the wrapper

### DIFF
--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.test.ts
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
+import { initStripeCheckout } from "./stripe-checkout";
+
+function jsonResponse(status: number, body: object): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("initStripeCheckout", () => {
+	describe("createCheckoutSession", () => {
+		it("issues POST /v1/checkout/sessions in subscription mode and returns the session id and url", async () => {
+			let receivedUrl: string | undefined;
+			let receivedInit: RequestInit | undefined;
+			const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+				receivedUrl = typeof input === "string" ? input : input.toString();
+				receivedInit = init;
+				return jsonResponse(200, {
+					id: "cs_test_created",
+					url: "https://checkout.stripe.com/c/pay/cs_test_created",
+				});
+			};
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			const result = await stripe.createCheckoutSession({
+				customerEmail: "buyer@example.com",
+				successUrl: "https://readplace.com/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+				cancelUrl: "https://readplace.com/signup",
+			});
+
+			assert.equal(result.id, "cs_test_created");
+			assert.equal(result.url, "https://checkout.stripe.com/c/pay/cs_test_created");
+			assert.equal(receivedUrl, "https://api.stripe.com/v1/checkout/sessions");
+			assert.equal(receivedInit?.method, "POST");
+			const headers = receivedInit?.headers as Record<string, string>;
+			assert.equal(headers?.Authorization, "Bearer sk_test_abc");
+			assert.equal(headers?.["Stripe-Version"], "2026-04-22.dahlia");
+			assert.equal(headers?.["Content-Type"], "application/x-www-form-urlencoded");
+			const body = String(receivedInit?.body ?? "");
+			assert.ok(body.includes("mode=subscription"));
+			assert.ok(body.includes("line_items%5B0%5D%5Bprice%5D=price_pro"));
+			assert.ok(body.includes("customer_email=buyer%40example.com"));
+			assert.ok(body.includes("allow_promotion_codes=true"));
+		});
+
+		it("throws with the Stripe error message when the API returns a non-2xx", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(400, { error: { code: "parameter_invalid", message: "No such price" } });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_missing",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() =>
+					stripe.createCheckoutSession({
+						customerEmail: "buyer@example.com",
+						successUrl: "https://readplace.com/ok",
+						cancelUrl: "https://readplace.com/cancel",
+					}),
+				/Stripe createCheckoutSession failed \(400\): No such price/,
+			);
+		});
+
+		it("uses 'Stripe error' when the Stripe error envelope omits a message", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(402, { error: { code: "missing_message" } });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() =>
+					stripe.createCheckoutSession({
+						customerEmail: "buyer@example.com",
+						successUrl: "https://readplace.com/ok",
+						cancelUrl: "https://readplace.com/cancel",
+					}),
+				/Stripe createCheckoutSession failed \(402\): Stripe error/,
+			);
+		});
+
+		it("falls back to a generic error message when the Stripe error shape is unrecognised", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(500, { unexpected: "shape" });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() =>
+					stripe.createCheckoutSession({
+						customerEmail: "buyer@example.com",
+						successUrl: "https://readplace.com/ok",
+						cancelUrl: "https://readplace.com/cancel",
+					}),
+				/Stripe createCheckoutSession failed \(500\): Stripe error/,
+			);
+		});
+	});
+
+	describe("retrieveCheckoutSession", () => {
+		it("issues GET /v1/checkout/sessions/<id> and maps a paid session, reading the email from customer_details", async () => {
+			let receivedUrl: string | undefined;
+			let receivedInit: RequestInit | undefined;
+			const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+				receivedUrl = typeof input === "string" ? input : input.toString();
+				receivedInit = init;
+				return jsonResponse(200, {
+					customer_details: { email: "paid@example.com" },
+					customer_email: null,
+					payment_status: "paid",
+					status: "complete",
+					created: 1735000000,
+					subscription: "sub_test_123",
+					customer: "cus_test_123",
+				});
+			};
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			const result = await stripe.retrieveCheckoutSession(
+				CheckoutSessionIdSchema.parse("cs_test_paid"),
+			);
+
+			assert.deepEqual(result, {
+				ok: true,
+				paid: true,
+				customerEmail: "paid@example.com",
+				status: "complete",
+				created: 1735000000,
+				subscriptionId: "sub_test_123",
+				customerId: "cus_test_123",
+			});
+			assert.equal(receivedUrl, "https://api.stripe.com/v1/checkout/sessions/cs_test_paid");
+			assert.equal(receivedInit?.method, "GET");
+			const headers = receivedInit?.headers as Record<string, string>;
+			assert.equal(headers?.Authorization, "Bearer sk_test_abc");
+			assert.equal(headers?.["Stripe-Version"], "2026-04-22.dahlia");
+		});
+
+		it("URL-encodes the session id so unusual characters reach Stripe intact", async () => {
+			let receivedUrl: string | undefined;
+			const fakeFetch: typeof globalThis.fetch = async (input) => {
+				receivedUrl = typeof input === "string" ? input : input.toString();
+				return jsonResponse(200, {
+					customer_details: { email: "x@example.com" },
+					payment_status: "paid",
+					status: "complete",
+					created: 1735000000,
+				});
+			};
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await stripe.retrieveCheckoutSession(CheckoutSessionIdSchema.parse("cs with/slash"));
+
+			assert.equal(
+				receivedUrl,
+				"https://api.stripe.com/v1/checkout/sessions/cs%20with%2Fslash",
+			);
+		});
+
+		it("falls back to customer_email when customer_details is absent, and omits subscription/customer ids when Stripe leaves them null", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(200, {
+					customer_email: "fallback@example.com",
+					payment_status: "no_payment_required",
+					status: "complete",
+					created: 1735000001,
+					subscription: null,
+					customer: null,
+				});
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			const result = await stripe.retrieveCheckoutSession(
+				CheckoutSessionIdSchema.parse("cs_test_fallback"),
+			);
+
+			assert.deepEqual(result, {
+				ok: true,
+				paid: true,
+				customerEmail: "fallback@example.com",
+				status: "complete",
+				created: 1735000001,
+			});
+		});
+
+		it("reports an unpaid open session as not paid", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(200, {
+					customer_details: { email: "open@example.com" },
+					payment_status: "unpaid",
+					status: "open",
+					created: 1735000002,
+				});
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			const result = await stripe.retrieveCheckoutSession(
+				CheckoutSessionIdSchema.parse("cs_test_open"),
+			);
+
+			assert.deepEqual(result, {
+				ok: true,
+				paid: false,
+				customerEmail: "open@example.com",
+				status: "open",
+				created: 1735000002,
+			});
+		});
+
+		it("throws when the session response carries no email at all — a complete session must always have one", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(200, {
+					customer_details: { email: null },
+					customer_email: null,
+					payment_status: "paid",
+					status: "complete",
+					created: 1735000003,
+				});
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() => stripe.retrieveCheckoutSession(CheckoutSessionIdSchema.parse("cs_test_noemail")),
+				/Stripe checkout session cs_test_noemail has no customer email/,
+			);
+		});
+
+		it("returns not-found when Stripe answers 404", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(404, { error: { code: "resource_missing", message: "No such session" } });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			const result = await stripe.retrieveCheckoutSession(
+				CheckoutSessionIdSchema.parse("cs_test_unknown"),
+			);
+
+			assert.deepEqual(result, { ok: false, reason: "not-found" });
+		});
+
+		it("returns not-found when a non-404 response carries the resource_missing code", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(400, { error: { code: "resource_missing", message: "No such session" } });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			const result = await stripe.retrieveCheckoutSession(
+				CheckoutSessionIdSchema.parse("cs_test_gone"),
+			);
+
+			assert.deepEqual(result, { ok: false, reason: "not-found" });
+		});
+
+		it("throws with the Stripe error message on a non-2xx that is neither 404 nor resource_missing", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(500, { error: { code: "api_error", message: "Stripe is down" } });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() => stripe.retrieveCheckoutSession(CheckoutSessionIdSchema.parse("cs_test_boom")),
+				/Stripe retrieveCheckoutSession failed \(500\): Stripe is down/,
+			);
+		});
+
+		it("falls back to a generic error message when the error shape is unrecognised on a non-2xx", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(503, { unexpected: "shape" });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() => stripe.retrieveCheckoutSession(CheckoutSessionIdSchema.parse("cs_test_x")),
+				/Stripe retrieveCheckoutSession failed \(503\): Stripe error/,
+			);
+		});
+
+		it("uses 'Stripe error' when a non-2xx error envelope omits a message", async () => {
+			const fakeFetch: typeof globalThis.fetch = async () =>
+				jsonResponse(502, { error: { code: "api_error" } });
+
+			const stripe = initStripeCheckout({
+				apiKey: "sk_test_abc",
+				priceId: "price_pro",
+				fetch: fakeFetch,
+			});
+
+			await assert.rejects(
+				() => stripe.retrieveCheckoutSession(CheckoutSessionIdSchema.parse("cs_test_y")),
+				/Stripe retrieveCheckoutSession failed \(502\): Stripe error/,
+			);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -1,4 +1,4 @@
-/* c8 ignore start -- thin Stripe API wrapper, tested via integration */
+import assert from "node:assert";
 import { z } from "zod";
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import type {
@@ -106,8 +106,8 @@ export function initStripeCheckout(deps: {
 		}
 
 		const parsed = RetrieveSessionResponse.parse(json);
-		const customerEmail =
-			parsed.customer_details?.email ?? parsed.customer_email ?? "";
+		const customerEmail = parsed.customer_details?.email ?? parsed.customer_email;
+		assert(customerEmail, `Stripe checkout session ${id} has no customer email`);
 		return {
 			ok: true,
 			paid: parsed.payment_status === "paid" || parsed.payment_status === "no_payment_required",
@@ -121,4 +121,3 @@ export function initStripeCheckout(deps: {
 
 	return { createCheckoutSession, retrieveCheckoutSession };
 }
-/* c8 ignore stop */


### PR DESCRIPTION
## What

Two related guideline fixes in `projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts`.

### 1. Remove the silent empty-string fallback (lines 109-110)

```ts
const customerEmail =
    parsed.customer_details?.email ?? parsed.customer_email ?? "";
```

The trailing `?? ""` lets a `complete`/`paid` checkout session through with no real email, even though the contract declares `customerEmail: string` and downstream checkout-recovery uses that field as an address. Replaced with a fast-failing invariant:

```ts
const customerEmail = parsed.customer_details?.email ?? parsed.customer_email;
assert(customerEmail, `Stripe checkout session ${id} has no customer email`);
```

`assert` (from `node:assert`) narrows `customerEmail` to `string`, so the contract is satisfied without the default.

- Rule: **No Silent Fallbacks for Missing Values** / **No Defensive Checks Without Valid Tests**
- Source: `.claude/skills/test-driven-design/SKILL.md`

### 2. Remove the blanket `c8 ignore` and cover the wrapper (lines 1, 124)

The file was wrapped in `/* c8 ignore start -- thin Stripe API wrapper, tested via integration */ … /* c8 ignore stop */`. CLAUDE.md sanctions a whole-file `c8 ignore` only for **thin AWS SDK wrappers** that are "3-5 lines, no branching". This is a non-AWS Stripe wrapper with real branching (error `safeParse`, `response.ok`, `404` + `resource_missing` mapping, `payment_status`/`status` mapping, conditional subscription/customer spreads, and the new email assert).

The sibling `stripe-subscriptions.ts` is an identical-shape Stripe fetch wrapper carrying **no** `c8 ignore`, fully covered by `stripe-subscriptions.test.ts` with a fake `fetch`. This change mirrors that pattern: both ignore markers are removed and a new co-located `stripe-checkout.test.ts` exercises create success + 3 error shapes and retrieve across paid/unpaid, both email sources, null id omission, missing-email assert, 404, `resource_missing`, non-2xx throw, unrecognised shape, and missing message — so the assert's false branch is covered and no new uncovered branch is introduced.

- Rule: **No Coverage Ignore Comments / Allowed c8 ignore Cases (thin AWS SDK wrappers only)**
- Source: `CLAUDE.md`

## Why it is safe

`auth.page.ts` consumes `pending.email`, not `session.customerEmail`, and the `RetrieveCheckoutSession` contract type is unchanged. The change is contained to the target file plus its new test.

🤖 Part of the guidelines & skills audit.