### PR TITLE
test(hutch): drop `as` casts in api.routes.test in favor of validated UserId factory

### DIFF
--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import request from "supertest";
-import type { Token, Client } from "@node-oauth/oauth2-server";
+import type { Token } from "@node-oauth/oauth2-server";
 import { useTestServer } from "../../test-app";
 import type { TestAppHarness } from "../../test-app";
 import {
@@ -14,10 +14,10 @@ import {
 } from "@packages/test-fixtures";
 import { initReadabilityParser } from "@packages/article-parser";
 
-import type { UserId } from "@packages/domain/user";
+import { UserIdSchema } from "@packages/domain/user";
 import { SIREN_MEDIA_TYPE } from "./siren";
 
-const TEST_USER_ID = "test-user-123" as UserId;
+const TEST_USER_ID = UserIdSchema.parse("test-user-123");
 
 function createTestToken(): Token {
 	return {
@@ -29,7 +29,7 @@ function createTestToken(): Token {
 			id: "hutch-firefox-extension",
 			grants: ["authorization_code", "refresh_token"],
 			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
-		} as Client,
+		},
 		user: { id: TEST_USER_ID },
 	};
 }


### PR DESCRIPTION
## What

Removes two TypeScript type assertions from `projects/hutch/src/runtime/web/api/api.routes.test.ts` that violate the **Avoid TypeScript Type Assertions (`as`)** rule in `CLAUDE.md`.

## Why

- **`"test-user-123" as UserId`** casts a raw string into a branded domain ID, bypassing the brand's intended guard. Per CLAUDE.md ("Branded Types for Domain IDs" / "Avoid TypeScript Type Assertions"), branded IDs must come from a validated factory. The codebase already exports `UserIdSchema` from `@packages/domain/user` and uses `UserIdSchema.parse(...)` for this exact purpose in many sibling test files.
- **`{ ... } as Client`** asserts a full `Client` from a partial literal, hiding any future required field added upstream. The `Client` interface only requires `id` and `grants` (both present in the literal), so the assertion is unnecessary — letting the `createTestToken(): Token` return annotation structurally check the literal restores the compile-time guard.

## Change

- `TEST_USER_ID` now built with `UserIdSchema.parse("test-user-123")` (same string value, brand applied via the validated factory).
- `as Client` removed from the fake token's `client` literal.
- Imports adjusted so no import goes unused under biome/knip: `import type { Token }` and value import `import { UserIdSchema }`.

No runtime values or test assertions change; the suite stays green.

**Source:** CLAUDE.md
**File:** `projects/hutch/src/runtime/web/api/api.routes.test.ts`

🤖 Part of the guidelines & skills audit.