### PR TITLE
test(auth): drop redundant `as Client` assertion in verification-lockout test

### DIFF
--- a/projects/hutch/src/runtime/web/auth/verification-lockout.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/verification-lockout.route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import type { Token, Client } from "@node-oauth/oauth2-server";
+import type { Token } from "@node-oauth/oauth2-server";
 import type { UserId } from "@packages/domain/user";
 import { MinutesSchema } from "@packages/domain/article";
 import { loginAgent, useTestServer } from "../../test-app";
@@ -51,7 +51,7 @@ async function mintAccessToken(
 			id: "hutch-firefox-extension",
 			grants: ["authorization_code", "refresh_token"],
 			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
-		} as Client,
+		},
 		user: { id: userId },
 	};
 	const saved = await harness.oauthModel.saveToken(token, client, {


### PR DESCRIPTION
## What

Removes the `as Client` type assertion in `mintAccessToken` inside
`projects/hutch/src/runtime/web/auth/verification-lockout.route.test.ts`, and
drops the now-unused `Client` type import.

## Why

- **Rule:** "Avoid TypeScript Type Assertions (`as`)" (source: `CLAUDE.md`).
  Faking an object with `as` is explicitly forbidden, and `as Client` is not
  an allowed exception (not `as const`, not an isolated Node API wrapper).
- The object literal already provides every **required** field of the
  `@node-oauth/oauth2-server` `Client` interface (`id: string` and
  `grants: string | string[]`); `redirectUris` and the remaining fields are
  optional. The literal is thus a complete, valid `Client`, so the assertion
  was redundant — removing it makes TypeScript structurally verify the value
  against `Token.client: Client`.
- `Partial<Client>` (the suggested remedy) would not type-check here because
  `Token.client` requires a full `Client`, so the correct fix is to delete the
  assertion outright.

## Change

- Remove `as Client` from the inline `client` object in the `Token` literal.
- Remove `Client` from the `@node-oauth/oauth2-server` type import (it was only
  referenced by the removed assertion); `Token` stays as it is still used.

No runtime behaviour changes; tests continue to pass and `pnpm check`
(tsc + biome + knip + coverage) stays green.

🤖 Part of the guidelines & skills audit.