### PR TITLE
fix(oauth): use brand tokens for approve button colour and radius

### DIFF
--- a/projects/hutch/src/runtime/web/oauth/oauth.component.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.component.ts
@@ -45,13 +45,13 @@ const OAUTH_AUTHORIZE_STYLES = `
 .oauth-authorize__btn {
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
 .oauth-authorize__btn--approve {
   background: var(--primary);
-  color: white;
+  color: var(--primary-foreground);
   border: none;
 }
 


### PR DESCRIPTION
## What

Replace two hardcoded values in `oauth.component.ts` with brand CSS custom properties:

- `.oauth-authorize__btn` `border-radius: 4px` → `var(--radius-sm)` (6px)
- `.oauth-authorize__btn--approve` `color: white` → `var(--primary-foreground)`

## Why

- **Source:** `BRAND_GUIDELINES.md`
- **File:** `projects/hutch/src/runtime/web/oauth/oauth.component.ts`

The "Do's and Don'ts" section forbids hardcoding hex/colour values and mandates the CSS custom properties from `base.styles.ts`. The Buttons table specifies primary-button text as `--primary-foreground`. The Border Radius scale defines only `6px` (`--radius-sm`), `8px` (`--radius`), and `12px` (`--radius-lg`); buttons map to `--radius-sm`. The previous `4px` is off-scale and `white` is a hardcoded colour.

## Change

Pure inline-CSS string edits within the OAuth authorize style template. No exported signature, rendered HTML attribute, or coverage branch changes, so no test or caller updates are required.

🤖 Part of the guidelines & skills audit.