### PR TITLE
fix(admin): use brand CSS custom properties for recrawl tier badges

### DIFF
--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.styles.css
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.styles.css
@@ -22,6 +22,6 @@
 
 .admin-recrawl__tier-badge--legacy {
   background: var(--color-surface);
-  color: var(--color-text-muted);
+  color: var(--color-text-secondary);
   border-color: var(--color-border);
 }

--- a/projects/hutch/src/runtime/web/pages/admin/recrawl.styles.css
+++ b/projects/hutch/src/runtime/web/pages/admin/recrawl.styles.css
@@ -15,13 +15,13 @@
   border-radius: 999px;
   font-size: 0.85rem;
   font-weight: 500;
-  background: #eef3fb;
-  color: #1e6fb8;
-  border: 1px solid #c4d6ee;
+  background: var(--color-brand-light);
+  color: var(--color-brand-dark);
+  border: 1px solid var(--color-brand);
 }
 
 .admin-recrawl__tier-badge--legacy {
-  background: #f5f5f5;
-  color: #666;
-  border-color: #ddd;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
 }


### PR DESCRIPTION
## What

`projects/hutch/src/runtime/web/pages/admin/recrawl.styles.css` hardcoded six raw hex values across the two tier-badge rules:

- Active badge (lines 18-20): `background: #eef3fb; color: #1e6fb8; border: 1px solid #c4d6ee;`
- Legacy badge (lines 24-26): `background: #f5f5f5; color: #666; border-color: #ddd;`

## Why

`BRAND_GUIDELINES.md` "Don't" list: **"Hardcode hex values — always use the CSS custom properties"**, and the "Do" list: **"Use the CSS custom properties defined in `base.styles.ts` — never hardcode colour values."** The static hexes also never adapted to dark mode, violating "Test every UI against both light and dark modes."

There is no `--color-info` token (the guidelines' Info row has an empty CSS-variable cell), so the active badge cannot reference Info directly. The closest existing, theme-aware tokens are the brand set, which matches the documented "subtle brand-tinted background" usage.

## Change

| Element | Before | After (tokens from `base.styles.ts`) |
|---|---|---|
| Active badge bg | `#eef3fb` | `var(--color-brand-light)` |
| Active badge text | `#1e6fb8` | `var(--color-brand-dark)` |
| Active badge border | `#c4d6ee` | `var(--color-brand)` |
| Legacy badge bg | `#f5f5f5` | `var(--color-surface)` |
| Legacy badge text | `#666` | `var(--color-text-muted)` |
| Legacy badge border | `#ddd` | `var(--color-border)` |

## Scope / safety

No test or component asserts these colours — `recrawl.route.test.ts` checks only the `data-test-tier-badge` attribute and `recrawl.component.ts` emits only class names. The change is contained to the stylesheet and keeps `pnpm check` green.

- Source: `BRAND_GUIDELINES.md`
- File: `projects/hutch/src/runtime/web/pages/admin/recrawl.styles.css`

🤖 Part of the guidelines & skills audit.