### PR TITLE
test(home): replace existence-only and negative assertions with positive state checks

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -193,7 +193,11 @@ describe("GET /", () => {
 		const doc = new JSDOM(response.text).window.document;
 
 		const backstory = doc.querySelector('[data-test-section="backstory"]');
-		expect(backstory).not.toBeNull();
+		assert(backstory, "backstory section must be rendered");
+		expect(backstory.getAttribute("aria-label")).toBe("About the creator");
+		expect(backstory.querySelector(".home-backstory__title")?.textContent).toBe(
+			"I believe we can fix the web",
+		);
 	});
 
 	it("should render the founding pricing card and hide the fallback when under the limit", async () => {
@@ -295,11 +299,15 @@ describe("GET /", () => {
 		expect(section.querySelector(".home-cost__heading")?.textContent).toContain("$49");
 		const items = section.querySelectorAll("[data-test-cost-list] .home-cost__item");
 		expect(items.length).toBe(3);
+		const providerNames = Array.from(
+			section.querySelectorAll("[data-test-cost-list] .home-cost__item strong"),
+		).map((el) => el.textContent?.trim());
+		expect(providerNames).toEqual([
+			"Mozilla Readability",
+			"Real Tesseract OCR",
+			"DeepSeek V3.2",
+		]);
 		const text = section.textContent ?? "";
-		expect(text).toContain("Mozilla Readability");
-		expect(text).toContain("DeepSeek");
-		expect(text).toContain("Tesseract");
-		expect(text).not.toContain("Deep Infra");
 		expect(text).toContain("no data resale");
 	});
 
@@ -394,8 +402,16 @@ describe("GET /", () => {
 		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
-		const twitterSite = doc.querySelector('meta[name="twitter:site"]');
-		expect(twitterSite).toBeNull();
+		const twitterMetaNames = Array.from(
+			doc.querySelectorAll('meta[name^="twitter:"]'),
+		).map((meta) => meta.getAttribute("name"));
+		expect(twitterMetaNames).toEqual([
+			"twitter:card",
+			"twitter:title",
+			"twitter:description",
+			"twitter:image",
+			"twitter:creator",
+		]);
 	});
 
 	it("should include multiple structured data schemas", async () => {


### PR DESCRIPTION
## What

Fixes three assertion-quality violations in `projects/hutch/src/runtime/web/pages/home/home.route.test.ts` flagged by the guidelines audit.

## Why

Per the `test-driven-design` skill (`.claude/skills/test-driven-design/SKILL.md`):

1. **"Never Rely on `querySelector(...).toBeNull()` — Assert Existence First, Then Check State"** (line 196): `expect(backstory).not.toBeNull()` is existence-only; a selector typo makes it fail even when production is correct.
2. **Same rule** (line 398): `expect(twitterSite).toBeNull()` proves absence via a null query a selector typo satisfies spuriously.
3. **"Avoid Negative Test Assertions"** (line 302): `expect(text).not.toContain("Deep Infra")` goes stale on refactor and asserts nothing about the rendered provider list.

## Change

- **backstory**: `assert(backstory, ...)` then check the heading text (`I believe we can fix the web`) and `aria-label` (`About the creator`) — values confirmed in `home.template.html` lines 61, 65.
- **twitter:site**: enumerate all `meta[name^="twitter:"]` names and assert the exact set (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`, `twitter:creator`) — proving `twitter:site` is absent. Confirmed against the conditional render in `src/packages/web-shell/src/base.template.ts` lines 29-34 and the home seo config in `home.component.ts` (sets `twitterImage`, no `twitterSite`).
- **cost transparency**: assert the exact provider names in the cost list `<strong>` elements (`Mozilla Readability`, `Real Tesseract OCR`, `DeepSeek V3.2`) — confirmed in `home.template.html` lines 261-263.

Test-only change. No production signatures touched; no caller ripple; `assert` from `node:assert/strict` is already imported.

🤖 Part of the guidelines & skills audit.