### PR TITLE
test(home): positive state-class assertions over querySelector toBeNull

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -118,6 +118,12 @@ export function HomePage(params: {
 	const fallbackStateClass = foundingAllocationAvailable
 		? "home-pricing__fallback--hidden"
 		: "home-pricing__fallback--visible";
+	const pricingTitleStateClass = foundingAllocationAvailable
+		? "home-pricing__title--visible"
+		: "home-pricing__title--hidden";
+	const progressStateClass = foundingAllocationAvailable
+		? "home-pricing__progress--visible"
+		: "home-pricing__progress--hidden";
 	return {
 		seo: {
 			title: "Readplace — Read the web, not the slop. | Read-It-Later App",
@@ -312,7 +318,8 @@ export function HomePage(params: {
 			founderAvatarUrl: `${staticBaseUrl}/fayner-brack.jpg`,
 			foundingProgressHtml,
 			foundingMemberLimit,
-			foundingAllocationAvailable,
+			pricingTitleStateClass,
+			progressStateClass,
 			pricingGridStateClass,
 			fallbackStateClass,
 			featuredFeatures: [

--- a/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
@@ -24,7 +24,9 @@ describe("GET / with exhausted founding allocation", () => {
 		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
-		expect(doc.querySelector("[data-test-founding-progress]")).toBeNull();
+		const progressSlot = doc.querySelector("[data-test-founding-progress-slot]");
+		assert(progressSlot, "founding progress slot must be rendered");
+		expect(progressSlot.classList.contains("home-pricing__progress--hidden")).toBe(true);
 	}, 30000);
 
 	it("should hide the founding pricing card and show the fallback benefits + CTA when over the limit", async () => {
@@ -51,7 +53,11 @@ describe("GET / with exhausted founding allocation", () => {
 		const benefits = fallback.querySelector("[data-test-fallback-benefits]");
 		assert(benefits, "fallback benefits list must be rendered");
 		expect(benefits.querySelectorAll(".pricing-card__feature").length).toBe(6);
-		expect(fallback.querySelector('[data-test-cta="become-member"]')).not.toBeNull();
+		const becomeMemberCta = fallback.querySelector('[data-test-cta="become-member"]');
+		assert(becomeMemberCta, "become-member CTA must be rendered");
+		expect(becomeMemberCta.getAttribute("href")).toBe(
+			"/signup?utm_source=homepage&utm_medium=internal&utm_content=signup-body",
+		);
 	}, 30000);
 
 	it("should hide the founding pricing title when over the limit", async () => {
@@ -65,8 +71,9 @@ describe("GET / with exhausted founding allocation", () => {
 		const response = await request(harness.server).get("/");
 		const doc = new JSDOM(response.text).window.document;
 
-		expect(doc.querySelector("[data-test-pricing-title]")).toBeNull();
-		expect(response.text).not.toContain(`Free for the first ${TEST_FOUNDING_MEMBER_LIMIT} members.`);
+		const pricingTitle = doc.querySelector("[data-test-pricing-title]");
+		assert(pricingTitle, "pricing title must be rendered");
+		expect(pricingTitle.classList.contains("home-pricing__title--hidden")).toBe(true);
 	}, 30000);
 });
 
@@ -220,7 +227,8 @@ describe("GET /sitemap.xml", () => {
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toMatch(/application\/xml/);
 
-		const urls = Array.from(response.text.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1]);
+		const sitemapDoc = new JSDOM(response.text, { contentType: "text/xml" }).window.document;
+		const urls = Array.from(sitemapDoc.querySelectorAll("loc")).map((loc) => loc.textContent);
 		// Blog URLs are served from blog-site's own /blog/sitemap.xml (a separate
 		// deployable), advertised via a second Sitemap line in robots.txt.
 		expect(urls).toEqual([

--- a/projects/hutch/src/runtime/web/pages/home/home.styles.css
+++ b/projects/hutch/src/runtime/web/pages/home/home.styles.css
@@ -1042,6 +1042,22 @@ hr::before {
   display: none;
 }
 
+.home-pricing__title--visible {
+  display: block;
+}
+
+.home-pricing__title--hidden {
+  display: none;
+}
+
+.home-pricing__progress--visible {
+  display: block;
+}
+
+.home-pricing__progress--hidden {
+  display: none;
+}
+
 .home-pricing__fallback {
   max-width: 480px;
   margin: 0 auto;

--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -270,12 +270,10 @@
 
     <section id="pricing" class="home-pricing" data-test-section="pricing" aria-label="Pricing">
       <div class="home-pricing__container">
-        {{#if foundingAllocationAvailable}}
-        <div class="section-header" data-test-pricing-title>
+        <div class="section-header home-pricing__title {{pricingTitleStateClass}}" data-test-pricing-title>
           <h2 class="section-header__title">Free for the first {{foundingMemberLimit}} members.</h2>
         </div>
-        {{/if}}
-        {{{foundingProgressHtml}}}
+        <div class="home-pricing__progress {{progressStateClass}}" data-test-founding-progress-slot>{{{foundingProgressHtml}}}</div>
         <div class="pricing-grid {{pricingGridStateClass}}">
           <div class="pricing-card pricing-card--featured" data-test-plan="founding">
             <span class="pricing-card__badge">First {{foundingMemberLimit}} Users</span>


### PR DESCRIPTION
## What

`home.static.route.test.ts` proved hidden/absent UI state with
`querySelector(...).toBeNull()` / `.not.toBeNull()` and a stale
`.not.toContain(...)`, and extracted sitemap `<loc>` values with a regex.

## Why

- **test-driven-design/SKILL.md — "Never Rely on `querySelector(...).toBeNull()`"**: a selector typo also returns `null`, so the assertion passes for the wrong reason. The element must be rendered unconditionally with a state class that the test looks up and asserts on.
- **test-driven-design/SKILL.md — "Avoid Negative Test Assertions"**: `.not.toContain(...)` goes stale when copy changes; assert the actual expected state instead.
- **web/SKILL.md — "Structured Parsing Over Regex"**: XML must be parsed with a DOM parser, not regex.

## Change

- `home.template.html`: the pricing title now always renders with `home-pricing__title {{pricingTitleStateClass}}` (no more `{{#if foundingAllocationAvailable}}`); the founding-progress slot is wrapped in `home-pricing__progress {{progressStateClass}}` carrying `data-test-founding-progress-slot`.
- `home.component.ts`: derives `pricingTitleStateClass` and `progressStateClass` (visible/hidden) and passes them to the template; drops the now-unused `foundingAllocationAvailable` template field.
- `home.styles.css`: adds the `home-pricing__title--visible/--hidden` and `home-pricing__progress--visible/--hidden` rules.
- `home.static.route.test.ts`: asserts the title and progress slot exist then checks their hidden state class; checks the become-member CTA's `href`; parses the sitemap `<loc>` values via JSDOM XML.

The under-the-limit positive tests in `home.route.test.ts` continue to resolve the inner elements and stay green; the shared `renderFoundingProgress` component (also used by the auth pages) is untouched.

🤖 Part of the guidelines & skills audit.