### PR TITLE
docs(queue-card): remove plan-bound clause from thumbnail comment

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
@@ -1,5 +1,5 @@
 <div class="queue-article{{unreadClass}}" data-test-article="{{id}}"{{#if isFirst}} id="latest-saved"{{/if}}{{#if cardPollUrl}} hx-get="{{cardPollUrl}}" hx-trigger="every 3s" hx-target="this" hx-swap="outerHTML"{{/if}} data-card-status="{{cardStatus}}">
-	{{!-- onerror is a vestigial safety net for legacy DynamoDB rows whose imageUrl still points at an external host that can 404 over time. New saves go through the S3-only thumbnail path in @packages/crawl-article, so once a backfill migration rewrites every legacy row to a CDN URL, this onerror (and the paired onload) can be deleted. --}}
+	{{!-- onerror/onload defend against legacy DynamoDB rows whose imageUrl points at an external host that can 404 over time; a broken image removes its container instead of showing a placeholder. New saves use the S3-only thumbnail path in @packages/crawl-article. --}}
 	{{#if imageUrl}}<a href="{{linkUrl}}" class="queue-article__thumbnail-link" tabindex="-1" aria-hidden="true"><img class="queue-article__thumbnail" src="{{imageUrl}}" alt="" onload="this.parentElement.classList.add('queue-article__thumbnail-link--loaded')" onerror="this.parentElement.remove()"></a>{{/if}}
 	<div class="queue-article__content">
 		<div class="queue-article__title-row">


### PR DESCRIPTION
## What

Removes the plan-bound clause from the Handlebars comment on the thumbnail `<img>` in `queue-card.template.html`.

Before:
> onerror is a vestigial safety net for legacy DynamoDB rows whose imageUrl still points at an external host that can 404 over time. New saves go through the S3-only thumbnail path in @packages/crawl-article, **so once a backfill migration rewrites every legacy row to a CDN URL, this onerror (and the paired onload) can be deleted.**

After (keeps the genuine why, drops the deletion-after-migration narrative):
> onerror/onload defend against legacy DynamoDB rows whose imageUrl points at an external host that can 404 over time; a broken image removes its container instead of showing a placeholder. New saves use the S3-only thumbnail path in @packages/crawl-article.

## Why

CLAUDE.md ("No time-bound or plan-bound comments") forbids comments that tie code lifetime to a future event ("remove when Y is concluded", "temporary until rollout completes"). The removed clause ties the `onerror`/`onload` handlers to a future backfill migration that no one will remember to revisit, so the comment rots. If the handlers should genuinely be removed after a migration, that belongs in a tracked issue, not a narrating comment.

## Source

- Rule: No time-bound or plan-bound comments
- Doc: CLAUDE.md
- File: `projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html` (line 2)

## Impact

Handlebars comment only — no runtime output, no test or caller changes, no effect on tsc/biome/knip/coverage.

🤖 Part of the guidelines & skills audit.