### PR TITLE
test(queue): assert dismissed onboarding via hidden state class instead of toBeNull

### DIFF
--- a/projects/hutch/src/runtime/web/onboarding/onboarding.component.test.ts
+++ b/projects/hutch/src/runtime/web/onboarding/onboarding.component.test.ts
@@ -209,4 +209,13 @@ describe("OnboardingChecklist", () => {
 		const steps = doc.querySelector("[data-test-onboarding-steps]");
 		assert.equal(steps, null);
 	});
+
+	it("renders the container hidden when dismissed", () => {
+		const doc = parse(OnboardingChecklist(contextWith(), { dismissed: true }));
+
+		const container = doc.querySelector("[data-test-onboarding]");
+		assert(container, "onboarding container must still be rendered when dismissed");
+		assert(container.classList.contains("onboarding--hidden"));
+		assert(!container.classList.contains("onboarding--visible"));
+	});
 });

--- a/projects/hutch/src/runtime/web/onboarding/onboarding.component.ts
+++ b/projects/hutch/src/runtime/web/onboarding/onboarding.component.ts
@@ -50,12 +50,16 @@ function allStepsComplete(ctx: OnboardingContext): boolean {
 	return ONBOARDING_STEPS.every((step) => step.isComplete(ctx));
 }
 
-export function OnboardingChecklist(ctx: OnboardingContext): string {
+export function OnboardingChecklist(
+	ctx: OnboardingContext,
+	options: { dismissed?: boolean } = {},
+): string {
 	const steps = ONBOARDING_STEPS.map((step) => toStepDisplayModel(step, ctx));
 	const allComplete = allStepsComplete(ctx);
-	const stateClass = allComplete
+	const activeStateClass = allComplete
 		? "onboarding--complete"
 		: "onboarding--visible";
+	const stateClass = options.dismissed ? "onboarding--hidden" : activeStateClass;
 	return render(ONBOARDING_TEMPLATE, {
 		steps,
 		stateClass,

--- a/projects/hutch/src/runtime/web/onboarding/onboarding.styles.css
+++ b/projects/hutch/src/runtime/web/onboarding/onboarding.styles.css
@@ -15,6 +15,10 @@
   display: block;
 }
 
+.onboarding--hidden {
+  display: none;
+}
+
 .onboarding__intro {
   display: flex;
   align-items: flex-start;

--- a/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
@@ -205,7 +205,8 @@ describe("Queue onboarding", () => {
 
 		const doc = new JSDOM(response.text).window.document;
 		const onboarding = doc.querySelector("[data-test-onboarding]");
-		expect(onboarding).toBeNull();
+		assert(onboarding, "onboarding container must still be rendered so visibility is encoded as a state class");
+		expect(onboarding.classList.contains("onboarding--hidden")).toBe(true);
 	});
 
 	it("re-renders onboarding when dismiss cookie is present but alive cookie is missing", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts
@@ -194,7 +194,7 @@ describe("Queue onboarding", () => {
 	 *   2. Dismiss cookie alone → onboarding re-renders with install-extension
 	 *      marked incomplete, so the user is prompted to install in this browser.
 	 */
-	it("does not render onboarding when dismiss cookie matches current version and extension is alive", async () => {
+	it("renders onboarding hidden when dismiss cookie matches current version and extension is alive", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { auth } = harness;
 		const agent = await loginAgent(harness.server, auth);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -83,13 +83,14 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { extensionInstalled: 
 		content: "sort",
 	});
 
-	const onboardingHtml = options.onboardingDismissed
-		? ""
-		: OnboardingChecklist({
+	const onboardingHtml = OnboardingChecklist(
+		{
 			extensionInstalled: options.extensionInstalled,
 			extensionSavedArticle: options.extensionSavedArticle,
 			browser: options.browser,
-		});
+		},
+		{ dismissed: options.onboardingDismissed },
+	);
 
 	const banner: SubscriptionBannerState = vm.subscriptionBanner;
 	return {


### PR DESCRIPTION
## What

The dismissed-onboarding route test proved the element was gone with:

```ts
const onboarding = doc.querySelector("[data-test-onboarding]");
expect(onboarding).toBeNull();
```

The **test-driven-design skill** (`.claude/skills/test-driven-design/SKILL.md`, "Never Rely on `querySelector(...).toBeNull()`") flags this exact pattern — and uses this very `[data-test-onboarding]` selector as its example. A typo in the selector also returns `null`, so the assertion passes for the wrong reason. The skill prescribes rendering the element unconditionally and encoding visibility as a state class, then asserting the class positively.

## Why a production change is required

In production the dismissed branch emitted an empty string (`queue.component.ts`), so there was no element to assert state on. A test-only rewrite could not satisfy the rule.

## Change

- `onboarding.component.ts` — `OnboardingChecklist` accepts an optional `{ dismissed }` option and sets `stateClass` to `onboarding--hidden` when dismissed (two flat ternaries, avoiding biome `noNestedTernary`).
- `onboarding.styles.css` — adds `.onboarding--hidden { display: none; }` (explicit hidden state, paired with the existing `--visible`/`--complete`).
- `queue.component.ts` — always renders the checklist and passes `dismissed` instead of returning `""`.
- `queue-onboarding.route.test.ts` — the dismissed test asserts the element exists, then checks `onboarding--hidden`.
- `onboarding.component.test.ts` — adds a unit test covering the dismissed branch so coverage stays at 100%.

The optional second argument keeps all existing one-arg `OnboardingChecklist(...)` callers valid. The `onboarding--hidden` class is emitted in the dismissed renders, satisfying the unused-css gate.

**Rule:** Never Rely on `querySelector(...).toBeNull()` — assert existence first, then check state
**Source:** `.claude/skills/test-driven-design/SKILL.md`
**File:** `projects/hutch/src/runtime/web/pages/queue/queue-onboarding.route.test.ts`

🤖 Part of the guidelines & skills audit.