### PR TITLE
test(queue): assert thumbnail card state positively instead of toBeNull

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.card.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.card.route.test.ts
@@ -125,7 +125,9 @@ describe("Queue routes", () => {
 
 			const response = await agent.get("/queue");
 			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector(".queue-article__thumbnail")).toBeNull();
+			const card = doc.querySelector(".queue-article");
+			assert(card, "card must be rendered");
+			expect(card.querySelectorAll(".queue-article__thumbnail-link").length).toBe(0);
 		});
 
 		it("should hide thumbnail wrapper until image loads successfully", async () => {
@@ -279,11 +281,15 @@ describe("Queue routes", () => {
 				},
 			});
 			const thumbnail = dom.window.document.querySelector<HTMLImageElement>(".queue-article__thumbnail");
-			expect(thumbnail?.closest("a")).not.toBeNull();
+			const link = thumbnail?.closest("a");
+			assert(link, "thumbnail link must be rendered before the error event");
+			expect(link.classList.contains("queue-article__thumbnail-link")).toBe(true);
 
 			thumbnail?.dispatchEvent(new dom.window.Event("error"));
 
-			expect(dom.window.document.querySelector(".queue-article__thumbnail-link")).toBeNull();
+			const card = dom.window.document.querySelector(".queue-article");
+			assert(card, "card must remain rendered after the thumbnail error event");
+			expect(card.querySelectorAll(".queue-article__thumbnail-link").length).toBe(0);
 
 			dom.window.close();
 		});


### PR DESCRIPTION
## What

Replaces three fragile existence/absence assertions in `projects/hutch/src/runtime/web/pages/queue/queue.card.route.test.ts` with positive, anchored assertions.

## Why

The **test-driven-design** skill (`.claude/skills/test-driven-design/SKILL.md`, "Never Rely on `querySelector(...).toBeNull()` — Assert Existence First, Then Check State" and "Avoid Negative Test Assertions") forbids `querySelector(...).toBeNull()` and `.not.toBeNull()`: a selector typo returns `null`, so the assertion passes (or, for `.not.toBeNull()`, fails) for the wrong reason.

Findings addressed:
- Line 128: `expect(doc.querySelector(".queue-article__thumbnail")).toBeNull();`
- Line 282: `expect(thumbnail?.closest("a")).not.toBeNull();`
- Line 286: `expect(dom.window.document.querySelector(".queue-article__thumbnail-link")).toBeNull();`

## Change

Each assertion now anchors on the `.queue-article` card, asserts it exists (so a selector typo fails loudly at `assert(card)`), and then checks a positive fact:
- No-image and post-`error` cases assert the count of `.queue-article__thumbnail-link` elements is `0`.
- The pre-`error` case asserts the thumbnail link exists and carries the `queue-article__thumbnail-link` class.

The production template (`queue-card/queue-card.template.html`) legitimately omits the wrapper when there is no `imageUrl` and removes it on image error (documented vestigial `onerror` safety net), so production behaviour is intentionally left unchanged. `node:assert/strict` is already imported; no new imports, no coverage impact, only the test file changes. All asserted values match real rendered output.

🤖 Part of the guidelines & skills audit.