### PR TITLE
test(queue): replace empty-queue toBeNull with positive list assertion

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -27,8 +27,9 @@ describe("Queue routes", () => {
 
 			const queueResponse = await agent.get("/queue");
 			const doc = new JSDOM(queueResponse.text).window.document;
-			expect(doc.querySelectorAll(".queue-article").length).toBe(1);
-			expect(doc.querySelector("[data-test-empty-queue]")).toBeNull();
+			const list = doc.querySelector("[data-test-article-list]");
+			assert(list, "article list region must render after a save");
+			expect(list.querySelectorAll(".queue-article").length).toBe(1);
 		});
 
 		it("should show error for invalid URL", async () => {


### PR DESCRIPTION
## What

In `projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts`, the
"should save an article and redirect" test ended with:

```ts
expect(doc.querySelector("[data-test-empty-queue]")).toBeNull();
```

This is replaced with a positive assertion that the article-list region is
rendered and contains the single saved article.

## Why

The test-driven-design skill (`.claude/skills/test-driven-design/SKILL.md` →
"Never Rely on `querySelector(...).toBeNull()` — Assert Existence First, Then
Check State") flags `.toBeNull()` as fragile: a typo in the selector also
returns `null`, so the assertion passes for the wrong reason.

The skill's preferred remedy (render the element unconditionally and toggle a
state class) is intentionally **not** applied here. The queue template renders
`data-test-empty-queue` and `data-test-article-list` as two mutually-exclusive
`{{#if}}` regions, and that presence/absence contract is relied on by:
- the delete-flow integration test (asserts the empty region's text when the
  queue is empty), and
- the queue e2e flow (`save-permalink-actions.ts` asserts the empty region is
  visible).

Converting to always-render-plus-state-class would make those
`toBeVisible`/text assertions pass unconditionally, weakening them. The
contained fix that satisfies the skill's core principle ("assert existence
first, then check state"; "test the actual expected value") is to assert the
state that genuinely exists after a save.

## Change

```ts
// before
expect(doc.querySelectorAll(".queue-article").length).toBe(1);
expect(doc.querySelector("[data-test-empty-queue]")).toBeNull();

// after
const list = doc.querySelector("[data-test-article-list]");
assert(list, "article list region must render after a save");
expect(list.querySelectorAll(".queue-article").length).toBe(1);
```

No production code, exported signatures, or other tests change.

🤖 Part of the guidelines & skills audit.