### PR TITLE
test(queue): type save-content-limit fakes as Partial&lt;T&gt; instead of as unknown

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.test.ts
@@ -8,25 +8,28 @@ function fakeResponse(): {
 	calls: FakeJsonCalls;
 } {
 	const calls: FakeJsonCalls = {};
-	const res = {
+	const fake: Partial<Response> = {};
+	const res = fake as Response;
+	Object.assign(fake, {
 		status(s: number) { calls.status = s; return res; },
 		type(t: string) { calls.type = t; return res; },
 		json(body: unknown) { calls.body = body; return res; },
-	} as unknown as Response;
+	} satisfies Partial<Response>);
 	return { res, calls };
 }
 
 function fakeRequest(headers: Record<string, string>): Request {
-	return {
+	const fake = {
 		headers,
-		get(name: string) { return headers[name.toLowerCase()]; },
-		accepts(_type: string) {
+		get(name: string): string | undefined { return headers[name.toLowerCase()]; },
+		accepts(_type: string): string | false {
 			const accept = headers.accept ?? "";
 			return accept.includes("application/vnd.siren+json")
 				? "application/vnd.siren+json"
 				: false;
 		},
-	} as unknown as Request;
+	} as Partial<Request>;
+	return fake as Request;
 }
 
 describe("initSaveContentLimitHandler", () => {


### PR DESCRIPTION
## What

Replaces two `as unknown as` double-casts in
`projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.test.ts`
with explicit `Partial<T>` fakes.

- `fakeResponse` now declares the fake as `Partial<Response>` and returns the typed `res` from its chaining methods (`status`/`type`/`json`), so the handler's `.status(422).type(...).json(...)` chain still works.
- `fakeRequest` now asserts its literal `as Partial<Request>` (the explicit subset) before the single boundary narrow, and annotates `get`/`accepts` return types so they actually type-check against Express's overloaded signatures.

## Why

CLAUDE.md, section **"Avoid TypeScript Type Assertions (`as`)"**, forbids faking a partial object with `as` and requires `Partial<T>` to make the subset explicit. The previous `as unknown as Response` / `as unknown as Request` form erases the compiler's shape check completely, hiding any future mismatch if Express's types change. The new shape matches the pattern already sanctioned in this repo (`click-attribution.middleware.test.ts`, `require-admin.middleware.test.ts`).

- Rule: Avoid TypeScript Type Assertions (`as`) — fake partial objects via `Partial<T>`
- Source: CLAUDE.md
- File: `projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.test.ts`

## Verification

`pnpm nx run hutch:check` passes — tsc, biome, knip, unused-css, 100% coverage, and all tests green.

🤖 Part of the guidelines &amp; skills audit.