### PR TITLE
refactor(reader-iframe): drop double cast in observer test fake

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.client.test.ts
@@ -2,8 +2,13 @@ import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { initReaderIframes, measureContentHeight } from "./reader-iframe.client";
 
+interface FakeObserverInstance {
+	observe(): void;
+	disconnect(): void;
+}
+
 interface FakeObserverCtor {
-	new (cb: () => void): { observe(): void; disconnect(): void };
+	new (cb: () => void): FakeObserverInstance;
 }
 
 interface FakeObserverFactory {
@@ -13,7 +18,7 @@ interface FakeObserverFactory {
 
 function makeObserverFactory(): FakeObserverFactory {
 	const callbacks: Array<() => void> = [];
-	class FakeObserver {
+	class FakeObserver implements FakeObserverInstance {
 		private readonly cb: () => void;
 		constructor(cb: () => void) {
 			this.cb = cb;
@@ -26,7 +31,7 @@ function makeObserverFactory(): FakeObserverFactory {
 		}
 	}
 	return {
-		Ctor: FakeObserver as unknown as FakeObserverCtor,
+		Ctor: FakeObserver,
 		trigger() {
 			for (const cb of callbacks.slice()) cb();
 		},


### PR DESCRIPTION
## What

Removes the `as unknown as FakeObserverCtor` double type assertion from the reader-iframe client test's `makeObserverFactory` helper.

## Why

CLAUDE.md's **"Avoid TypeScript Type Assertions (`as`)"** rule forbids `as` outside the documented exceptions (`as const`, isolated Node wrappers). The `FakeObserver as unknown as FakeObserverCtor` cast is the explicitly-discouraged pattern of forcing a fake to satisfy an interface instead of declaring the fake to satisfy it directly.

## Change

- Extract the observer instance shape into a named `FakeObserverInstance` interface.
- Declare `class FakeObserver implements FakeObserverInstance` so the compiler verifies the shape.
- Assign `Ctor: FakeObserver` with no cast.

The class is structurally compatible with `new (cb: () => void) => FakeObserverInstance`, so the cast was unnecessary. Verified with a standalone `tsc --strict --noEmit` reproduction that assigns the factory's `Ctor` to both the `ResizeObserver` and `MutationObserver` deps slots — it type-checks clean. No asserted values or signatures change, so the existing test cases remain green.

- Rule source: CLAUDE.md — "Avoid TypeScript Type Assertions (`as`)"
- File: `projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.client.test.ts`

🤖 Part of the guidelines & skills audit.