### PR TITLE
refactor(share-balloon): assert for invariants, remove PR-bound comment

### DIFF
--- a/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
+++ b/projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts
@@ -43,10 +43,14 @@ export function initShareBalloon(
 	const OPEN_CLASS = "share-balloon__wrap--open";
 	const COPIED_VISIBLE_CLASS = "share-balloon__copied--visible";
 
+	function assert(cond: unknown, message: string): asserts cond {
+		/** esbuild bundles this module for the browser, where `node:assert`
+		 * is not resolvable, so the invariant check is inlined here. */
+		if (!cond) throw new Error(`share balloon: ${message}`);
+	}
+
 	function ensure<T>(value: T | null | undefined, description: string): T {
-		if (value === null || value === undefined) {
-			throw new Error(`share balloon: ${description}`);
-		}
+		assert(value !== null && value !== undefined, description);
 		return value;
 	}
 
@@ -103,8 +107,8 @@ export function initShareBalloon(
 			"[data-reader-status]",
 		);
 		/** No reader-slot in the DOM means the host page does not track article
-		 * crawl state (e.g. share-balloon-only test fixtures). Default to ready
-		 * so the balloon retains its pre-#389 behaviour in those contexts. */
+		 * crawl state (e.g. share-balloon-only test fixtures), so default to
+		 * ready and let the balloon open in those contexts. */
 		if (slot === null) return true;
 		return slot.getAttribute("data-reader-status") === "ready";
 	}


### PR DESCRIPTION
## What

Two guideline fixes in `projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts`.

### 1. Use `assert` for runtime invariants (lines 46-51)

The `ensure()` helper used a hand-rolled `if (value === null || value === undefined) { throw … }`. CLAUDE.md ("Use `assert` for Runtime Invariants") requires an assert over if/throw for invariant checks.

This module is bundled for the browser by esbuild, so the literal `node:assert` import is not resolvable in the target. The codebase already solved this in `progress-bar.client.ts` with a tiny inline `assert(cond, message): asserts cond` helper. This change reuses that exact pattern and has `ensure()` delegate to it; the `asserts cond` predicate narrows `T | null | undefined` to `T`, so `pickElement`/`pickAttribute` keep their return types and no callers change. The `"share balloon: …"` message format is preserved.

### 2. Remove PR-bound comment (lines 105-108)

CLAUDE.md ("Comments Document Why, Not What") forbids comments tied to a specific PR/issue moment. `pre-#389 behaviour` references PR #389 and will rot. The comment is reworded to keep the genuine why (no reader-slot means the host page does not track crawl state, so the balloon defaults to ready) without the PR reference.

## Why

- rule: Use `assert` for Runtime Invariants / Comments Document Why, Not What
- source: CLAUDE.md
- file: `projects/hutch/src/runtime/web/shared/share-balloon/share-balloon.client.ts`

## Tests

No behaviour change. Existing tests never exercise the throw path nor assert on its message, so they remain green. No exported signatures change.

🤖 Part of the guidelines & skills audit.