### PR TITLE
test(web-embed): replace stale negative assertion with exact canonical snippet check

### DIFF
--- a/projects/web-embed/src/runtime/embed/embed.route.test.ts
+++ b/projects/web-embed/src/runtime/embed/embed.route.test.ts
@@ -4,6 +4,7 @@ import { JSDOM } from "jsdom";
 import request from "supertest";
 import express from "express";
 import { initEmbedRoutes } from "./embed.page";
+import { renderCanonicalSnippet } from "./snippet.component";
 
 const servers: Server[] = [];
 afterEach(async () => {
@@ -146,9 +147,7 @@ describe("GET /embed", () => {
 		const doc = new JSDOM(response.text).window.document;
 		const source = doc.querySelector('[data-test="source-b"]');
 		assert(source, "source-b must be rendered");
-		expect(source.textContent).toContain("https://readplace.com/save?url=PAGE_URL");
-		expect(source.textContent).toContain("https://readplace.com/embed/icon.svg");
-		expect(source.textContent).not.toContain("http://127.0.0.1:9999");
+		expect(source.textContent).toBe(renderCanonicalSnippet("b"));
 	});
 
 	it("should link the footer back to the Readplace app origin", async () => {


### PR DESCRIPTION
## What

In `projects/web-embed/src/runtime/embed/embed.route.test.ts`, the test "should keep the canonical readplace.com URLs and PAGE_URL placeholder inside the copy-paste source blocks regardless of config" ended with a negative assertion:

```ts
expect(source.textContent).not.toContain("http://127.0.0.1:9999");
```

## Why

The [test-driven-design skill](.claude/skills/test-driven-design/SKILL.md) — section **"Avoid Negative Test Assertions"** — explicitly calls out `.not.toContain()` as becoming stale when code is refactored, and prescribes asserting the actual expected value instead.

The source-b block is rendered as `<pre data-test="source-b">{{snippetB}}</pre>` where `snippetB` is `renderCanonicalSnippet("b")` (`embed.component.ts`). Because Handlebars double-stache escapes the snippet, JSDOM's `textContent` decodes back to exactly the canonical snippet string. Asserting that exact value positively proves both that the canonical `readplace.com` URLs / `PAGE_URL` placeholder are present and that the overridden `appOrigin` (`http://127.0.0.1:9999`) cannot leak — without any fragile negative assertion.

## Change

- Import the already-exported, production-used `renderCanonicalSnippet`.
- Replace the two `toContain` checks and the trailing `.not.toContain(...)` with a single exact-value assertion: `expect(source.textContent).toBe(renderCanonicalSnippet("b"))`.

## Verification

- `pnpm check` (tsc + biome + knip + 100% coverage + tests).

🤖 Part of the guidelines & skills audit.