### PR TITLE
test(article-parser): replace negative LinkedIn run-on assertion with positive paragraph boundary

### DIFF
--- a/src/packages/article-parser/src/linkedin-pre-parser.test.ts
+++ b/src/packages/article-parser/src/linkedin-pre-parser.test.ts
@@ -155,7 +155,9 @@ describe("linkedinPreParser end-to-end through parseHtml", () => {
 		expect((content.match(/<p[\s>]/g) ?? []).length).toBeGreaterThanOrEqual(3);
 		expect(content).toContain("available dev positions");
 		expect(content).toContain("never the bottleneck");
-		expect(content).not.toContain("dev positions:\n\n1.");
+		expect(content).toContain(
+			'available dev positions:</p><p dir="ltr">1. The cycle of punched cards (70s)<br>',
+		);
 	});
 
 	it("leaves the same page mushed when the pre-parser is not registered", () => {


### PR DESCRIPTION
## What

In `src/packages/article-parser/src/linkedin-pre-parser.test.ts`, the end-to-end test "rebuilds the LinkedIn pre-wrap post into multiple paragraphs" asserted the absence of the un-rebuilt run-on text:

```ts
expect(content).not.toContain("dev positions:\n\n1.");
```

This is replaced with a positive assertion of the exact rebuilt paragraph boundary the parser produces:

```ts
expect(content).toContain(
	'available dev positions:</p><p dir="ltr">1. The cycle of punched cards (70s)<br>',
);
```

## Why

The [`Avoid Negative Test Assertions`](.claude/skills/test-driven-design/SKILL.md) rule forbids `.not.toContain()` — negative assertions become stale when the format changes and can pass for the wrong reason. The test's real intent is that the single `white-space: pre-wrap` host is split into separate paragraphs at each `\n\n`. The positive form asserts that exact boundary: the `:` sentence closes its `<p>` and a new `<p dir="ltr">` opens the list, with the list's single newlines rendered as `<br>`. A host left as one run-on paragraph could never produce the `</p><p` sequence, so this proves the same property the negation intended — and it is anchored to the parser's actual output, which I captured by compiling the package and running the suite.

The companion test (line 171), exercising the un-registered pre-parser, already uses `toContain("dev positions:\n\n1.")` as a legitimate positive assertion of the mushed state, so it is left unchanged.

## Source

- Rule: Avoid Negative Test Assertions
- Source: `.claude/skills/test-driven-design/SKILL.md`
- File: `src/packages/article-parser/src/linkedin-pre-parser.test.ts`

🤖 Part of the guidelines & skills audit.