### PR TITLE
test(article-parser): replace negative assertions in the-information pre-parser test

### DIFF
--- a/src/packages/article-parser/src/the-information-pre-parser.test.ts
+++ b/src/packages/article-parser/src/the-information-pre-parser.test.ts
@@ -70,7 +70,7 @@ describe("theInformationPreParser.extract", () => {
 
 		const result = theInformationPreParser.extract({ html });
 
-		expect(result?.bodyHtml).not.toContain("Photo by");
+		expect(result?.bodyHtml?.startsWith("<p>Lead.</p>")).toBe(true);
 		expect(result?.bodyHtml).toContain("Lead.");
 	});
 
@@ -86,9 +86,7 @@ describe("theInformationPreParser.extract", () => {
 
 		const result = theInformationPreParser.extract({ html });
 
-		expect(result?.bodyHtml).not.toContain("<tag>");
-		expect(result?.bodyHtml).toContain("&lt;tag&gt;");
-		expect(result?.bodyHtml).toContain("&amp; ampersand");
+		expect(result?.bodyHtml).toContain("<p>Caption with &lt;tag&gt; and &amp; ampersand inside.</p>");
 	});
 
 	it("returns undefined when the Article script tag is absent", () => {


### PR DESCRIPTION
## What

Rewrites two negative assertions in `src/packages/article-parser/src/the-information-pre-parser.test.ts` to positive assertions of the actual expected output.

## Why

The [test-driven-design skill](.claude/skills/test-driven-design/SKILL.md) "Avoid Negative Test Assertions" rule forbids `.not.toContain()` — such assertions become stale when the output format changes and can pass for the wrong reason (e.g. a renamed token).

- Line 73: `.not.toContain("Photo by")` proved "no caption" only by the absence of a token; it would still pass if the caption copy changed. Replaced with a positive assertion that the bodyHtml starts with the blurb paragraph `<p>Lead.</p>`, which directly encodes "no caption paragraph precedes the blurb".
- Line 89: `.not.toContain("<tag>")` is replaced with a positive assertion of the full escaped caption paragraph `<p>Caption with &lt;tag&gt; and &amp; ampersand inside.</p>`. This is strictly stronger than the two granular positives on lines 90-91, so those are folded in.

## How verified

The exact serialized `bodyHtml` for both inputs was captured by running the compiled parser (`dist/the-information-pre-parser.js`) against the same JSON the tests use, confirming the positive strings match byte-for-byte. Production code is untouched, so coverage, tsc, biome and knip are unaffected.

🤖 Part of the guidelines & skills audit.