### PR TITLE
refactor(crawl-article): inject PDF byte cap instead of mocking pdf-page-limits

### DIFF
--- a/projects/save-link/src/runtime/domain/save-link-raw-pdf/save-link-raw-pdf-command-handler.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-pdf/save-link-raw-pdf-command-handler.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import type { Handler, SQSBatchItemFailure, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { ExtractPdf } from "@packages/crawl-article";
-import { parsePdfFromBuffer } from "@packages/crawl-article";
+import { MAX_PDF_BYTES, parsePdfFromBuffer } from "@packages/crawl-article";
 import type { PublishEvent } from "@packages/hutch-infra-components/runtime";
 import {
 	markCrawlFailed,
@@ -76,6 +76,7 @@ export function initSaveLinkRawPdfCommandHandler(deps: {
 					 * those fields from the result accordingly. */
 					response: undefined,
 					url: detail.url,
+					maxPdfBytes: MAX_PDF_BYTES.bytes,
 					extractPdf,
 					logError: (msg, err) => logger.error(msg, { error: err }),
 				});

--- a/src/packages/crawl-article/src/crawl-article.test.ts
+++ b/src/packages/crawl-article/src/crawl-article.test.ts
@@ -13,10 +13,7 @@ import type { CurlFetch } from "./curl-fetch";
 import type { fetchH2 } from "./h2-fetch";
 import type { ExtractPdf } from "./pdf-extract.types";
 
-jest.mock("./pdf-page-limits", () => ({
-	MAX_PDF_BYTES: { bytes: 25 * 1024 * 1024, label: "25 MB" },
-	MAX_PDF_PAGES: 300,
-}));
+const PDF_BYTES_CAP = 25 * 1024 * 1024;
 
 const PDF_EXTRACT_FAILURE_REASON = "synthetic extractor failure";
 const PDF_MAGIC_BUFFER = Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.alloc(64, 0x20)]);
@@ -665,6 +662,7 @@ describe("parsePdfFromBuffer", () => {
 			bodyHash,
 			response: htmlResponse({ etag: '"pdf-1"', "last-modified": "Wed, 21 Oct 2025 07:28:00 GMT" }),
 			url: "https://example.com/doc.pdf",
+			maxPdfBytes: PDF_BYTES_CAP,
 			extractPdf,
 			logError: noopLogError,
 		});
@@ -689,6 +687,7 @@ describe("parsePdfFromBuffer", () => {
 			bodyHash: createHash("sha256").update(PDF_MAGIC_BUFFER).digest("hex"),
 			response: htmlResponse(),
 			url: "https://example.com/doc.pdf",
+			maxPdfBytes: PDF_BYTES_CAP,
 			extractPdf,
 			onProgress,
 			logError: noopLogError,
@@ -705,6 +704,7 @@ describe("parsePdfFromBuffer", () => {
 			bodyHash: createHash("sha256").update(PDF_MAGIC_BUFFER).digest("hex"),
 			response: htmlResponse(),
 			url: "https://example.com/scan.pdf",
+			maxPdfBytes: PDF_BYTES_CAP,
 			extractPdf,
 			logError,
 		});
@@ -727,6 +727,7 @@ describe("parsePdfFromBuffer", () => {
 			bodyHash,
 			response: undefined,
 			url: "https://example.com/doc.pdf",
+			maxPdfBytes: PDF_BYTES_CAP,
 			extractPdf,
 			logError: noopLogError,
 		});
@@ -741,7 +742,7 @@ describe("parsePdfFromBuffer", () => {
 	});
 
 	it("returns unsupported with the byte count when the body exceeds the cap, without invoking the extractor", async () => {
-		const oversize = Buffer.concat([Buffer.from("%PDF-1.4"), Buffer.alloc(25 * 1024 * 1024 + 1, 0x20)]);
+		const oversize = Buffer.concat([Buffer.from("%PDF-1.4"), Buffer.alloc(PDF_BYTES_CAP + 1, 0x20)]);
 		const extractPdf = jest.fn<ReturnType<ExtractPdf>, Parameters<ExtractPdf>>();
 		const logError = jest.fn();
 		const result = await parsePdfFromBuffer({
@@ -749,6 +750,7 @@ describe("parsePdfFromBuffer", () => {
 			bodyHash: createHash("sha256").update(oversize).digest("hex"),
 			response: htmlResponse(),
 			url: "https://example.com/huge.pdf",
+			maxPdfBytes: PDF_BYTES_CAP,
 			extractPdf,
 			logError,
 		});

--- a/src/packages/crawl-article/src/crawl-article.ts
+++ b/src/packages/crawl-article/src/crawl-article.ts
@@ -177,11 +177,12 @@ export async function parsePdfFromBuffer(input: {
 	bodyHash: string;
 	response: Response | undefined;
 	url: string;
+	maxPdfBytes: number;
 	extractPdf: ExtractPdf;
 	onProgress?: ComprehensiveCrawlProgress;
 	logError: (message: string, error?: Error) => void;
 }): Promise<CrawlArticleResult> {
-	if (input.buffer.length > MAX_PDF_BYTES.bytes) {
+	if (input.buffer.length > input.maxPdfBytes) {
 		input.logError(`[CrawlArticle] PDF body too large (${input.buffer.length} bytes) for ${input.url}`);
 		return { status: "unsupported", reason: `pdf body too large: ${input.buffer.length} bytes` };
 	}
@@ -278,6 +279,7 @@ export function initCrawlArticle(deps: {
 					bodyHash,
 					response,
 					url: params.url,
+					maxPdfBytes: MAX_PDF_BYTES.bytes,
 					extractPdf,
 					onProgress: params.onProgress,
 					logError,


### PR DESCRIPTION
## What

`parsePdfFromBuffer` read `MAX_PDF_BYTES.bytes` directly from the `./pdf-page-limits` module. To exercise the oversize-body branch without allocating a 500 MB buffer, `crawl-article.test.ts` used `jest.mock("./pdf-page-limits", …)` to shrink the cap to 25 MB.

## Why

The `test-driven-design` skill's **Dependency Injection Over Mocks** rule states: "Prefer dependency injection over `jest.mock()`. Mocks couple tests to implementation details." The byte cap is a dependency that should be injected, not module-mocked.

- Rule: Dependency Injection Over Mocks
- Source: `.claude/skills/test-driven-design/SKILL.md`
- File: `src/packages/crawl-article/src/crawl-article.test.ts` (lines 16-19)

## Change

- `parsePdfFromBuffer` now takes a required `maxPdfBytes: number` input field instead of reading the module constant. Kept required (not defaulted) per the "No Silent Fallbacks" / "No Defensive Checks Without Valid Tests" rules, avoiding an uncovered default branch.
- The `initCrawlArticle` orchestrator and the `save-link-raw-pdf` command handler pass the real `MAX_PDF_BYTES.bytes`.
- The test removes the `jest.mock` and injects a 25 MB cap directly into `parsePdfFromBuffer` calls.

🤖 Part of the guidelines & skills audit.