### PR TITLE
refactor(domain): brand Minutes via zod .brand() instead of `as` cast

### DIFF
--- a/src/packages/domain/src/article/article.schema.ts
+++ b/src/packages/domain/src/article/article.schema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { Minutes } from "./article.types";
 
 export const SaveArticleInputSchema = z.object({
 	url: z.url({ message: "Please enter a valid URL" }),
@@ -21,6 +20,6 @@ export const SaveHtmlInputSchema = z.object({
 
 export const RAW_HTML_FIELD = "rawHtml" satisfies keyof z.infer<typeof SaveHtmlInputSchema>;
 
-export const MinutesSchema = z.number().transform((n): Minutes => n as Minutes);
+export const MinutesSchema = z.number().brand<"Minutes">();
 
 export const ArticleStatusSchema = z.enum(["unread", "read"]);

--- a/src/packages/domain/src/article/article.types.ts
+++ b/src/packages/domain/src/article/article.types.ts
@@ -1,7 +1,9 @@
+import type { z } from "zod";
 import type { UserId } from "../user/user.types";
+import type { MinutesSchema } from "./article.schema";
 import type { ReaderArticleHashId } from "./reader-article-hash-id";
 
-export type Minutes = number & { readonly __brand: "Minutes" };
+export type Minutes = z.infer<typeof MinutesSchema>;
 
 export type ArticleStatus = "unread" | "read";
 


### PR DESCRIPTION
## What

`src/packages/domain/src/article/article.schema.ts` built the `Minutes` branded number with a type assertion inside a `.transform()`:

```ts
export const MinutesSchema = z.number().transform((n): Minutes => n as Minutes);
```

This violates the **Avoid TypeScript Type Assertions (`as`)** rule in `CLAUDE.md`, which explicitly covers branded types and prescribes `.brand<>()` + `z.infer<>` as the correct mechanism.

## Change

- `article.schema.ts`: `MinutesSchema = z.number().brand<"Minutes">()` and remove the now-unused `import type { Minutes }`.
- `article.types.ts`: derive `Minutes` from the schema (`type Minutes = z.infer<typeof MinutesSchema>`), replacing the hand-written `number & { readonly __brand: "Minutes" }` so there is a single source of truth.

This mirrors the existing branded-value convention already used in the same package (`SaveableUrl` in `saveable-url.ts`, `ImportSessionId` in `import-session.schema.ts`).

## Why it's safe

- `.brand()` is a runtime no-op: `MinutesSchema.parse(7)` still returns `7`, so the existing test and every `MinutesSchema.parse(n)` call site (DynamoDB article store + route tests) stay green.
- No import cycle: `article.schema.ts` no longer imports `article.types.ts`; `article.types.ts` imports only the `MinutesSchema` value from `article.schema.ts`.

## Source

- Rule: Avoid TypeScript Type Assertions (`as`) — `CLAUDE.md`
- File: `src/packages/domain/src/article/article.schema.ts` (line 24)

🤖 Part of the guidelines & skills audit.