### PR TITLE
refactor(hutch-storage-client): remove `as` casts and what-only comment in batchGet

### DIFF
--- a/src/packages/hutch-storage-client/src/define-table.ts
+++ b/src/packages/hutch-storage-client/src/define-table.ts
@@ -17,9 +17,11 @@ import {
 	ScanCommand,
 	UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
-import type { z } from "zod";
+import { z } from "zod";
 
 type Key = Record<string, string | number>;
+
+const KeySchema = z.array(z.record(z.string(), z.union([z.string(), z.number()])));
 
 /** Every command input minus `TableName` — the gateway supplies the name. */
 type WithoutTable<T> = Omit<T, "TableName">;
@@ -38,7 +40,6 @@ export type DynamoTable<TSchema extends z.ZodObject> = {
 	/** Raw Put passthrough. Item is not parsed — writes bypass the read-side schema. */
 	put: (input: WithoutTable<PutCommandInput>) => Promise<void>;
 
-	/** Raw Update passthrough. */
 	update: (input: WithoutTable<UpdateCommandInput>) => Promise<void>;
 
 	/**
@@ -194,7 +195,7 @@ export async function batchGetFromTable<TSchema extends z.ZodObject>(config: {
 	const buildRequest = (batchKeys: readonly Key[]): BatchGetCommandInput => ({
 		RequestItems: {
 			[tableName]: {
-				Keys: batchKeys as Key[],
+				Keys: [...batchKeys],
 				...projectionOptions,
 			},
 		},
@@ -217,7 +218,7 @@ export async function batchGetFromTable<TSchema extends z.ZodObject>(config: {
 				await new Promise((resolve) =>
 					setTimeout(resolve, UNPROCESSED_KEYS_INITIAL_DELAY_MS * 2 ** attempt),
 				);
-				pending = unprocessed as Key[];
+				pending = KeySchema.parse(unprocessed);
 			}
 		}),
 	);


### PR DESCRIPTION
## What

Resolve three CLAUDE.md guideline findings in `src/packages/hutch-storage-client/src/define-table.ts`.

### 1. `Keys: batchKeys as Key[]` (line 197) — Avoid TypeScript Type Assertions
The cast existed only to strip `readonly` from `batchKeys` (`readonly Key[]`) to satisfy the SDK's mutable `Keys` field. Replaced with a mutable copy `[...batchKeys]`. `Key` (`Record<string, string | number>`) is structurally assignable to the SDK's `Record<string, NativeAttributeValue>`, so no assertion is required.

### 2. `pending = unprocessed as Key[]` (line 220) — Avoid TypeScript Type Assertions
`unprocessed` is DynamoDB SDK boundary data (`result.UnprocessedKeys?.[tableName]?.Keys`, typed `Record<string, NativeAttributeValue>[]`). Per the guideline, boundary data is validated with a Zod schema rather than cast. Added a module-level `KeySchema` and parse the response; promoted `import type { z }` to a value import (`zod` is already a declared dependency). The line is exercised by the existing `batch-get-from-table.test.ts` UnprocessedKeys retry tests, so coverage is unchanged.

### 3. `/** Raw Update passthrough. */` (line 41) — Comments Document Why, Not What
A pure what-comment restating the method name (unlike the sibling `put` doc, which explains writes bypass the read-side schema). Removed per the rule's "remove freely" stance; adding a why would require human approval.

## Why
- Rule: Avoid TypeScript Type Assertions (`as`) — source: CLAUDE.md
- Rule: Comments Document Why, Not What — source: CLAUDE.md

## Risk
Low. No public signature changes; `define-table.ts` consumers and `batch-get-from-table.test.ts` assert only on key/projection shape, which is preserved.

🤖 Part of the guidelines & skills audit.