### PR TITLE
refactor(provider-contracts): brand userId in link and export event contracts

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -10,6 +10,7 @@ import express from "express";
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ValidateSaveableUrl } from "@packages/domain/article";
+import type { UserId } from "@packages/domain/user";
 import { SaveArticleInputSchema, SaveHtmlInputSchema, ArticleStatusSchema, MAX_RAW_HTML_REQUEST_BYTES, RAW_HTML_FIELD, saveableUrlErrorMessage } from "@packages/domain/article";
 import { buildSaveIntentEvent, hashIp, type AnalyticsEvent } from "../../middleware/analytics";
 import { ANALYTICS_EVENTS, SAVE_OUTCOMES, SAVE_SURFACES, STREAMS, type SaveOutcome, type SaveSurface } from "../../../observability/events";
@@ -125,7 +126,7 @@ type SaveContentMediaHandler = (input: {
 	url: string;
 	bytes: Buffer;
 	title?: string;
-	userId: string;
+	userId: UserId;
 }) => Promise<SaveContentResult>;
 
 function normalizeMediaType(mediaType: string): string {

--- a/src/packages/provider-contracts/src/events.ts
+++ b/src/packages/provider-contracts/src/events.ts
@@ -5,14 +5,14 @@ export type PublishCancelSubscriptionCommand = (params: {
 }) => Promise<void>;
 
 export type PublishExportUserDataCommand = (params: {
-	userId: string;
+	userId: UserId;
 	email: string;
 	requestedAt: string;
 }) => Promise<void>;
 
 export type PublishLinkSaved = (params: {
 	url: string;
-	userId: string;
+	userId: UserId;
 }) => Promise<void>;
 
 export type PublishRecrawlLinkInitiated = (params: {
@@ -42,13 +42,13 @@ export type PublishSaveAnonymousLink = (params: {
 
 export type PublishSaveLinkRawHtmlCommand = (params: {
 	url: string;
-	userId: string;
+	userId: UserId;
 	title?: string;
 }) => Promise<void>;
 
 export type PublishSaveLinkRawPdfCommand = (params: {
 	url: string;
-	userId: string;
+	userId: UserId;
 }) => Promise<void>;
 
 export type PublishStaleCheckRequested = (params: {

--- a/src/packages/test-fixtures/src/fixture.test.ts
+++ b/src/packages/test-fixtures/src/fixture.test.ts
@@ -1,4 +1,5 @@
 import { calculateReadTime } from "@packages/domain/article";
+import { UserIdSchema } from "@packages/domain/user";
 import {
 	createFakeSummaryProvider,
 	createDefaultTestAppFixture,
@@ -289,7 +290,7 @@ describe("createFakePublishLinkSaved", () => {
 		};
 		const publish = createFakePublishLinkSaved(apply);
 
-		await publish({ url: "https://example.com/x", userId: "user-1" });
+		await publish({ url: "https://example.com/x", userId: UserIdSchema.parse("user-1") });
 
 		expect(calls).toEqual(["https://example.com/x"]);
 	});


### PR DESCRIPTION
## What

Type `userId` as the `UserId` brand (instead of raw `string`) on the four event publisher contracts in `src/packages/provider-contracts/src/events.ts` that were still using a plain string:

- `PublishExportUserDataCommand`
- `PublishLinkSaved`
- `PublishSaveLinkRawHtmlCommand`
- `PublishSaveLinkRawPdfCommand`

## Why

- **Rule:** Branded Types for Domain IDs
- **Source:** CLAUDE.md

The `UserId` brand is already imported at the top of `events.ts` and applied to every subscription-related publisher (e.g. `PublishCancelSubscriptionCommand`, `PublishSubscriptionCancelled`). These four link/export publishers were inconsistent, typing the same concept as a raw `string`, which loses the protection against passing an unrelated string (such as `url`) where a `userId` is expected.

## Ripples handled (keeps `pnpm check` green)

- `projects/hutch/src/runtime/web/pages/queue/queue.page.ts`: `SaveContentMediaHandler` forwarded a `string` `userId` to the now-branded PDF/HTML publishers. Retyped that field to `UserId` and added the import; its only call site passes `req.userId` (already `UserId`).
- `src/packages/test-fixtures/src/fixture.test.ts`: a test built params with the raw literal `userId: "user-1"`. Switched to `UserIdSchema.parse("user-1")` (the repo's brand constructor) rather than an `as` cast, and imported `UserIdSchema`.

Production call sites (`export.page.ts`, `save-article-from-url.ts`) already source `userId` from `req.userId`, declared as `UserId` in `session.types.ts`, so they require no changes. The eventbridge and in-memory implementations consume `params` transparently.

🤖 Part of the guidelines & skills audit.