### PR TITLE
test(test-fixtures): cover in-memory refresh-article-content and drop unapproved c8 ignore

### DIFF
--- a/src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.test.ts
+++ b/src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import { HutchLogger } from "@packages/hutch-logger";
 import { initInMemoryRefreshArticleContent } from "./in-memory-refresh-article-content";
 
 describe("initInMemoryRefreshArticleContent", () => {
@@ -30,27 +30,5 @@ describe("initInMemoryRefreshArticleContent", () => {
 		});
 
 		assert.equal(logged.length, 1);
-	});
-
-	it("resolves with a noop logger", async () => {
-		const { publishRefreshArticleContent } = initInMemoryRefreshArticleContent({
-			logger: HutchLogger.from(noopLogger),
-		});
-
-		await assert.doesNotReject(
-			publishRefreshArticleContent({
-				url: "https://example.com/other",
-				html: "<p>x</p>",
-				metadata: {
-					title: "Other",
-					siteName: "Other Site",
-					excerpt: "x",
-					wordCount: 1,
-				},
-				estimatedReadTime: 1,
-				contentFetchedAt: "2026-06-21T00:00:00.000Z",
-				bodyHash: "hash2",
-			}),
-		);
 	});
 });

--- a/src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.test.ts
+++ b/src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import { initInMemoryRefreshArticleContent } from "./in-memory-refresh-article-content";
+
+describe("initInMemoryRefreshArticleContent", () => {
+	it("logs once and completes without throwing", async () => {
+		const logged: unknown[] = [];
+		const logger = HutchLogger.from({
+			info: (...args: unknown[]) => {
+				logged.push(args);
+			},
+			error: () => {},
+			warn: () => {},
+			debug: () => {},
+		});
+		const { publishRefreshArticleContent } = initInMemoryRefreshArticleContent({ logger });
+
+		await publishRefreshArticleContent({
+			url: "https://example.com/article",
+			html: "<p>hello</p>",
+			metadata: {
+				title: "Example",
+				siteName: "Example Site",
+				excerpt: "An excerpt",
+				wordCount: 2,
+			},
+			estimatedReadTime: 1,
+			contentFetchedAt: "2026-06-21T00:00:00.000Z",
+			bodyHash: "hash",
+		});
+
+		assert.equal(logged.length, 1);
+	});
+
+	it("resolves with a noop logger", async () => {
+		const { publishRefreshArticleContent } = initInMemoryRefreshArticleContent({
+			logger: HutchLogger.from(noopLogger),
+		});
+
+		await assert.doesNotReject(
+			publishRefreshArticleContent({
+				url: "https://example.com/other",
+				html: "<p>x</p>",
+				metadata: {
+					title: "Other",
+					siteName: "Other Site",
+					excerpt: "x",
+					wordCount: 1,
+				},
+				estimatedReadTime: 1,
+				contentFetchedAt: "2026-06-21T00:00:00.000Z",
+				bodyHash: "hash2",
+			}),
+		);
+	});
+});

--- a/src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.ts
+++ b/src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start -- only used in dev composition root (app.ts) */
 import type { HutchLogger } from "@packages/hutch-logger";
 import type { PublishRefreshArticleContent } from "@packages/provider-contracts/events";
 
@@ -15,4 +14,3 @@ export function initInMemoryRefreshArticleContent(deps: {
 
 	return { publishRefreshArticleContent };
 }
-/* c8 ignore stop */


### PR DESCRIPTION
## What

Removes the whole-file `c8 ignore` wrapper from
`src/packages/test-fixtures/src/providers/events/in-memory-refresh-article-content.ts`
and adds a unit test that exercises the provider so coverage stays at 100% without any ignore comment.

## Why

The file opened with `/* c8 ignore start -- only used in dev composition root (app.ts) */`
and closed with `/* c8 ignore stop */`. Per **CLAUDE.md** ("No Coverage Ignore Comments" and
"Allowed `c8 ignore` Cases"), `c8 ignore` is forbidden unless explicitly approved, and the
allowed list is limited to thin AWS SDK wrappers, CI-only retry callbacks, V8 async artifacts,
and V8 block-coverage phantoms. "only used in dev composition root" is none of these, and the
guidance is to restructure code so the path is exercised rather than ignored.

The sibling no-op publisher `in-memory-subscription-cancelled.ts` carries no ignore and is
covered by `in-memory-subscription-cancelled.test.ts`. This change brings the refresh-article-content
provider in line with that pattern.

## Change

- Drop the `c8 ignore start/stop` lines (rule source: CLAUDE.md).
- Add `in-memory-refresh-article-content.test.ts` mirroring the sibling test: it invokes
  `publishRefreshArticleContent` with a full payload and asserts exactly one log call, plus a
  positive `doesNotReject` assertion.

No exported signature changes; the two callers (`app.ts`, `e2e-server.main.ts`) are unaffected.

🤖 Part of the guidelines & skills audit.