### PR TITLE
test(web-shell): assert hidden changelog banner state positively

### DIFF
--- a/src/packages/web-shell/src/changelog-banner.test.ts
+++ b/src/packages/web-shell/src/changelog-banner.test.ts
@@ -152,7 +152,7 @@ describe("renderChangelogBannerShell", () => {
 		assert(banner, "the banner element must always render so layout stays stable");
 		expect(banner.classList.contains("changelog-banner--hidden")).toBe(true);
 		expect(banner.classList.contains("changelog-banner--visible")).toBe(false);
-		expect(banner.querySelector(".changelog-banner__hook")).toBeNull();
+		expect(banner.children.length).toBe(0);
 	});
 
 	it("uses role=status with a polite live region for assistive tech", () => {


### PR DESCRIPTION
## What

In `src/packages/web-shell/src/changelog-banner.test.ts`, the "renders the hidden, empty banner when no banner is present" test asserted emptiness with:

```ts
expect(banner.querySelector(".changelog-banner__hook")).toBeNull();
```

## Why

The [test-driven-design skill](.claude/skills/test-driven-design/SKILL.md) rule **"Never Rely on `querySelector(...).toBeNull()` — Assert Existence First, Then Check State"** forbids this pattern: a typo in the selector also returns `null`, so the assertion passes for the wrong reason. The changelog banner is a binary shown/hidden element rendered unconditionally with a `--hidden`/`--visible` state class; the test should assert on the rendered state rather than on a hook selector resolving to null.

The test already does the right thing for visibility — it asserts the element exists (`assert(banner, …)`) and checks the `--hidden`/`--visible` classes positively. Only the trailing null probe violated the rule.

## Change

Per `CHANGELOG_SHELL_TEMPLATE` in `changelog-banner.ts`, when `visible` is false the entire `{{#if visible}}…{{/if}}` inner block is omitted, so the hidden `.changelog-banner` element has zero child elements. The null probe is replaced with a positive assertion of that rendered state:

```ts
expect(banner.children.length).toBe(0);
```

A selector typo can no longer make the check pass, and the assertion describes the actual hidden-state output.

- Rule: Never Rely on `querySelector(...).toBeNull()` — assert existence then check state
- Source: `.claude/skills/test-driven-design/SKILL.md`
- File: `src/packages/web-shell/src/changelog-banner.test.ts`

🤖 Part of the guidelines & skills audit.