### PR TITLE
refactor(web-shell): remove Request type assertions from content-negotiation test

### DIFF
--- a/src/packages/web-shell/src/content-negotiation.test.ts
+++ b/src/packages/web-shell/src/content-negotiation.test.ts
@@ -1,7 +1,6 @@
-import type { Request } from "express";
-import { wantsMarkdown } from "./content-negotiation";
+import { type AcceptNegotiable, wantsMarkdown } from "./content-negotiation";
 
-function requestWithAccept(accept: string): Request {
+function requestWithAccept(accept: string): AcceptNegotiable {
 	const types = accept.split(",").map(entry => {
 		const [type, ...params] = entry.trim().split(";");
 		const qParam = params.find(p => p.trim().startsWith("q="));
@@ -17,7 +16,7 @@ function requestWithAccept(accept: string): Request {
 			}
 			return false;
 		},
-	} as unknown as Request;
+	};
 }
 
 describe("wantsMarkdown", () => {
@@ -46,7 +45,7 @@ describe("wantsMarkdown", () => {
 	});
 
 	it("returns false when no Accept header is present", () => {
-		const req = { get: () => undefined, accepts: () => false } as unknown as Request;
+		const req: AcceptNegotiable = { get: () => undefined, accepts: () => false };
 
 		expect(wantsMarkdown(req)).toBe(false);
 	});

--- a/src/packages/web-shell/src/content-negotiation.ts
+++ b/src/packages/web-shell/src/content-negotiation.ts
@@ -1,8 +1,11 @@
-import type { Request } from "express";
-
 export const MARKDOWN_MEDIA_TYPE = "text/markdown";
 
-export function wantsMarkdown(req: Request): boolean {
+export type AcceptNegotiable = {
+	get(name: string): string | undefined;
+	accepts(type: string): string | false;
+};
+
+export function wantsMarkdown(req: AcceptNegotiable): boolean {
 	const acceptHeader = req.get("Accept") || "";
 	if (!acceptHeader.includes(MARKDOWN_MEDIA_TYPE)) return false;
 	return req.accepts(MARKDOWN_MEDIA_TYPE) === MARKDOWN_MEDIA_TYPE;


### PR DESCRIPTION
## What

Removes two `as unknown as Request` casts from `content-negotiation.test.ts` by narrowing `wantsMarkdown`'s parameter to a minimal structural type.

## Why

`CLAUDE.md` → **Avoid TypeScript Type Assertions (`as`)** forbids using `as` to fake partial objects; the rule explicitly applies in test code. The two fakes used `} as unknown as Request;` (line 20) and `... } as unknown as Request;` (line 49), neither of which is an allowed exception (`as const` / isolated Node wrapper).

- **Rule:** Avoid TypeScript Type Assertions (`as`) — fake partials without bypassing the compiler
- **Source:** CLAUDE.md
- **File:** `src/packages/web-shell/src/content-negotiation.test.ts` (+ `src/packages/web-shell/src/content-negotiation.ts`)

## Change

- Add `export type AcceptNegotiable = { get(name: string): string | undefined; accepts(type: string): string | false }` in `content-negotiation.ts` and accept it in `wantsMarkdown` (the only members the function uses).
- Type the test fakes as `AcceptNegotiable`; the factory now returns `AcceptNegotiable`. No `as` anywhere.
- Remove the now-unused `import type { Request }` from both files.

`Pick<Request, "get" | "accepts">` was intentionally avoided because it keeps express's `get(name: "set-cookie"): string[] | undefined` overload, which the string-returning fakes cannot satisfy — that overload is the reason the original cast existed. A full express `Request` remains structurally assignable to `AcceptNegotiable`, so production callers (`send-component.ts`, `server.ts`, `view.page.ts`) are unchanged.

## Verification

- `pnpm nx run web-shell:check` — passes (tsc, biome, knip, tests, 100% coverage).
- `pnpm nx run hutch:compile` — passes (downstream callers compile unchanged).

🤖 Part of the guidelines & skills audit.