### PR TITLE
refactor(web-shell): type sendComponent fakes without `as` casts

### DIFF
--- a/src/packages/web-shell/src/content-negotiation.ts
+++ b/src/packages/web-shell/src/content-negotiation.ts
@@ -1,8 +1,11 @@
-import type { Request } from "express";
-
 export const MARKDOWN_MEDIA_TYPE = "text/markdown";
 
-export function wantsMarkdown(req: Request): boolean {
+export type AcceptNegotiable = {
+	get(name: string): string | undefined;
+	accepts(type: string): string | false;
+};
+
+export function wantsMarkdown(req: AcceptNegotiable): boolean {
 	const acceptHeader = req.get("Accept") || "";
 	if (!acceptHeader.includes(MARKDOWN_MEDIA_TYPE)) return false;
 	return req.accepts(MARKDOWN_MEDIA_TYPE) === MARKDOWN_MEDIA_TYPE;

--- a/src/packages/web-shell/src/send-component.test.ts
+++ b/src/packages/web-shell/src/send-component.test.ts
@@ -1,17 +1,17 @@
-import type { Request, Response } from "express";
 import type { Component } from "./component.types";
+import type { AcceptNegotiable } from "./content-negotiation";
 import { HtmlPage } from "./html-page";
 import { MarkdownPage } from "./markdown-page";
-import { sendComponent } from "./send-component";
+import { type SendableResponse, sendComponent } from "./send-component";
 
 interface FakeResponse {
 	calls: { status: number[]; set: Record<string, string>[]; send: unknown[] };
-	res: Response;
+	res: SendableResponse;
 }
 
 function createFakeResponse(): FakeResponse {
 	const calls: FakeResponse["calls"] = { status: [], set: [], send: [] };
-	const res = {
+	const res: SendableResponse = {
 		status(code: number) {
 			calls.status.push(code);
 			return res;
@@ -20,15 +20,15 @@ function createFakeResponse(): FakeResponse {
 			calls.set.push(headers);
 			return res;
 		},
-		send(body: unknown) {
+		send(body: string) {
 			calls.send.push(body);
 			return res;
 		},
-	} as unknown as Response;
+	};
 	return { calls, res };
 }
 
-function requestWithAccept(accept?: string): Request {
+function requestWithAccept(accept?: string): AcceptNegotiable {
 	const types = (accept || "").split(",").map(entry => {
 		const [type, ...params] = entry.trim().split(";");
 		const qParam = params.find(p => p.trim().startsWith("q="));
@@ -44,7 +44,7 @@ function requestWithAccept(accept?: string): Request {
 			}
 			return false;
 		},
-	} as unknown as Request;
+	};
 }
 
 describe("sendComponent", () => {

--- a/src/packages/web-shell/src/send-component.ts
+++ b/src/packages/web-shell/src/send-component.ts
@@ -1,8 +1,13 @@
-import type { Request, Response } from "express";
 import type { Component } from "./component.types";
-import { wantsMarkdown } from "./content-negotiation";
+import { type AcceptNegotiable, wantsMarkdown } from "./content-negotiation";
 
-export function sendComponent(req: Request, res: Response, component: Component): void {
+export type SendableResponse = {
+	status(code: number): SendableResponse;
+	set(headers: Record<string, string>): SendableResponse;
+	send(body: string): SendableResponse;
+};
+
+export function sendComponent(req: AcceptNegotiable, res: SendableResponse, component: Component): void {
 	if (wantsMarkdown(req)) {
 		const md = component.to("text/markdown");
 		if (md.statusCode !== 406) {


### PR DESCRIPTION
## What

`src/packages/web-shell/src/send-component.test.ts` faked Express objects with
`as unknown as Response` (line 27) and `as unknown as Request` (line 47).

## Why

CLAUDE.md ("Avoid TypeScript Type Assertions") forbids faking a partial object
with `as` — its documented GOOD example builds a typed fake instead. A
`… as unknown as Response` double-cast bypasses the compiler entirely, so a
future Express `Response`/`Request` API change is silently hidden from these
tests.

`Partial<Response>` on its own is insufficient here: `sendComponent` and
`wantsMarkdown` demanded the full `Request`/`Response`, whose overloaded
`get`/`accepts`/`set` signatures a simple fake cannot satisfy without
re-introducing a cast. The package already established the right pattern — the
compiled `dist/content-negotiation.d.ts` and source map show a hand-written
`AcceptNegotiable` type and a cast-free fake; the live `.ts` had regressed to a
full `Request`.

## Change

- `content-negotiation.ts`: export `AcceptNegotiable` (the `get`/`accepts`
  surface) and narrow `wantsMarkdown` to it; drop the now-unused `express`
  import.
- `send-component.ts`: add `SendableResponse` (the `status`/`set`/`send`
  surface) and narrow `sendComponent` to `AcceptNegotiable` + `SendableResponse`;
  drop the now-unused `express` import.
- `send-component.test.ts`: type both fakes with the narrow interfaces and
  remove both `as unknown as …` casts.

A full Express `Request`/`Response` is assignable to the narrow interfaces, so
all production callers (view.page.ts, server.ts, auth/oauth/queue/import pages,
etc.) continue to type-check unchanged. All test assertions are untouched.

- Rule: Avoid TypeScript Type Assertions — faking a partial object with `as`
- Source: CLAUDE.md
- File: src/packages/web-shell/src/send-component.test.ts

🤖 Part of the guidelines & skills audit.