### PR TITLE
test(web-shell): assert installed variant state instead of CTA absence

### DIFF
--- a/src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts
+++ b/src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts
@@ -130,24 +130,32 @@ describe("renderExtensionSuggestionBanner", () => {
 			);
 		});
 
-		it("hides the install CTA button (the user already has it)", () => {
+		it("renders the installed variant, which has no install CTA button (the user already has it)", () => {
 			const doc = parse(
 				renderExtensionSuggestionBanner({ show: true, extensionInstalled: true }),
 			);
 
+			const message = doc.querySelector(
+				"[data-test-extension-suggestion-variant]",
+			);
+			assert(message, "message variant marker must be rendered");
 			expect(
-				doc.querySelector("[data-test-extension-suggestion-cta]"),
-			).toBeNull();
+				message.getAttribute("data-test-extension-suggestion-variant"),
+			).toBe("installed");
 		});
 
-		it("hides the inline install link (the user already has it)", () => {
+		it("renders the installed variant, which has no inline install link (the user already has it)", () => {
 			const doc = parse(
 				renderExtensionSuggestionBanner({ show: true, extensionInstalled: true }),
 			);
 
+			const message = doc.querySelector(
+				"[data-test-extension-suggestion-variant]",
+			);
+			assert(message, "message variant marker must be rendered");
 			expect(
-				doc.querySelector("[data-test-extension-suggestion-inline]"),
-			).toBeNull();
+				message.getAttribute("data-test-extension-suggestion-variant"),
+			).toBe("installed");
 		});
 
 		it("tells the reader to save again using the extension", () => {

--- a/src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts
+++ b/src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts
@@ -135,13 +135,20 @@ describe("renderExtensionSuggestionBanner", () => {
 				renderExtensionSuggestionBanner({ show: true, extensionInstalled: true }),
 			);
 
-			const message = doc.querySelector(
+			const banner = doc.querySelector(
+				"[data-test-extension-suggestion-banner]",
+			);
+			assert(banner, "banner must be rendered");
+			const message = banner.querySelector(
 				"[data-test-extension-suggestion-variant]",
 			);
 			assert(message, "message variant marker must be rendered");
 			expect(
 				message.getAttribute("data-test-extension-suggestion-variant"),
 			).toBe("installed");
+			expect(
+				banner.querySelector("[data-test-extension-suggestion-cta]"),
+			).toBeNull();
 		});
 
 		it("renders the installed variant, which has no inline install link (the user already has it)", () => {
@@ -149,13 +156,20 @@ describe("renderExtensionSuggestionBanner", () => {
 				renderExtensionSuggestionBanner({ show: true, extensionInstalled: true }),
 			);
 
-			const message = doc.querySelector(
+			const banner = doc.querySelector(
+				"[data-test-extension-suggestion-banner]",
+			);
+			assert(banner, "banner must be rendered");
+			const message = banner.querySelector(
 				"[data-test-extension-suggestion-variant]",
 			);
 			assert(message, "message variant marker must be rendered");
 			expect(
 				message.getAttribute("data-test-extension-suggestion-variant"),
 			).toBe("installed");
+			expect(
+				banner.querySelector("[data-test-extension-suggestion-inline]"),
+			).toBeNull();
 		});
 
 		it("tells the reader to save again using the extension", () => {


### PR DESCRIPTION
## What

Replace two `querySelector(...).toBeNull()` assertions in the extension-suggestion-banner component test with positive assertions on the rendered variant's state metadata.

## Why

Per the [`test-driven-design` skill](.claude/skills/test-driven-design/SKILL.md) rule **"Never Rely on `querySelector(...).toBeNull()` — Assert Existence First, Then Check State"**, asserting that the install CTA / inline link is `null` proves "this is hidden" only fragilely: a typo in the selector also returns `null`, so the assertion passes for the wrong reason.

The template (`extension-suggestion-banner.template.ts`) already renders the message element unconditionally and encodes the variant as `data-test-extension-suggestion-variant` (`"installed"` vs `"not-installed"`). The install CTA (`data-test-extension-suggestion-cta`) and inline link (`data-test-extension-suggestion-inline`) exist only in the `not-installed` branch. Asserting the variant element exists and that its state equals `"installed"` positively proves the install affordances were not rendered.

## Change

- File: `src/packages/web-shell/src/shared/extension-suggestion-banner/extension-suggestion-banner.component.test.ts`
- The "hides the install CTA button" and "hides the inline install link" tests now look up `[data-test-extension-suggestion-variant]`, assert it is rendered, and assert its state metadata is `"installed"`.

Source rule: `.claude/skills/test-driven-design/SKILL.md`.

🤖 Part of the guidelines & skills audit.