### PR TITLE
refactor(browser-extension-core): remove `as` casts from core event emission

### DIFF
--- a/.claude/skills/test-driven-design/SKILL.md
+++ b/.claude/skills/test-driven-design/SKILL.md
@@ -49,6 +49,21 @@ Two refactors that almost always pay for themselves before adding a new case:
 
 If none of these shapes fit and the new case genuinely requires editing existing logic, that is a signal that MUST surface as a report to the user — not silently absorbing as line edits.
 
+### Uniform Interface Over Conditionals
+
+Prefer one path that treats every case alike over a conditional that branches to reconstruct per-case shapes. When the input already satisfies the output type, pass it through rather than re-discriminating it.
+
+```typescript
+// ❌ BAD - Branches on a discriminant to rebuild each arm by hand
+const failure: CoreError =
+	result.reason === "not-logged-in"
+		? { reason: "not-logged-in" }
+		: { reason: "error", error: result.error };
+
+// ✅ GOOD - Each input arm already satisfies CoreError; pass it through
+const failure: CoreError = result;
+```
+
 ### Dependency Injection Over Mocks
 
 Prefer dependency injection over `jest.mock()`. Mocks couple tests to implementation details.

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -75,7 +75,11 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 	function emitResult<T>(event: string, guardedResult: GuardedResult<Promise<T>>): void;
 	function emitResult<T>(event: string, guardedResult: GuardedResult<T | Promise<T>>): void {
 		if (!guardedResult.ok) {
-			eventBus.emit(event, "failure", { reason: guardedResult.reason } as CoreError);
+			const failure: CoreError =
+				guardedResult.reason === "not-logged-in"
+					? { reason: "not-logged-in" }
+					: { reason: "error", error: guardedResult.error };
+			eventBus.emit(event, "failure", failure);
 			return;
 		}
 		const value = guardedResult.value;
@@ -84,11 +88,11 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 				.then((resolved) => eventBus.emit(event, "success", resolved))
 				.catch((err: unknown) => {
 					if (err instanceof UnauthorizedError) {
-						eventBus.emit(event, "failure", { reason: "not-logged-in" } as CoreError);
+						eventBus.emit(event, "failure", { reason: "not-logged-in" } satisfies CoreError);
 						return;
 					}
 					const error = err instanceof Error ? err : new Error(String(err));
-					eventBus.emit(event, "failure", { reason: "error", error } as CoreError);
+					eventBus.emit(event, "failure", { reason: "error", error } satisfies CoreError);
 				});
 		} else {
 			eventBus.emit(event, "success", value);
@@ -140,7 +144,7 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 				})
 				.catch((err: unknown) => {
 					const error = err instanceof Error ? err : new Error(String(err));
-					eventBus.emit("logged-in", "failure", { reason: "error", error } as CoreError);
+					eventBus.emit("logged-in", "failure", { reason: "error", error } satisfies CoreError);
 				});
 		},
 
@@ -199,12 +203,11 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 			if (typeof handler === "function") {
 				eventBus.on(event, handler);
 			} else {
-				const resultHandler = handler as ResultCallbacks<unknown>;
 				eventBus.on(event, (type: unknown, value: unknown) => {
 					if (type === "success") {
-						resultHandler.success(value);
+						handler.success(value);
 					} else if (type === "failure") {
-						resultHandler.failure(value as CoreError);
+						handler.failure(value);
 					}
 				});
 			}
@@ -212,12 +215,11 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 
 		// biome-ignore lint/suspicious/noExplicitAny: implementation signature must accept all overloaded handler shapes
 		once(event: string, handler: any) {
-			const resultHandler = handler as ResultCallbacks<unknown>;
 			eventBus.once(event, (type: unknown, value: unknown) => {
 				if (type === "success") {
-					resultHandler.success(value);
+					handler.success(value);
 				} else if (type === "failure") {
-					resultHandler.failure(value as CoreError);
+					handler.failure(value);
 				}
 			});
 		},

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -75,8 +75,8 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 	function emitResult<T>(event: string, guardedResult: GuardedResult<Promise<T>>): void;
 	function emitResult<T>(event: string, guardedResult: GuardedResult<T | Promise<T>>): void {
 		if (!guardedResult.ok) {
-			const failure: CoreError = guardedResult;
-			eventBus.emit(event, "failure", failure);
+			const { ok: _ok, ...failure } = guardedResult;
+			eventBus.emit(event, "failure", failure satisfies CoreError);
 			return;
 		}
 		const value = guardedResult.value;

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -75,10 +75,7 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 	function emitResult<T>(event: string, guardedResult: GuardedResult<Promise<T>>): void;
 	function emitResult<T>(event: string, guardedResult: GuardedResult<T | Promise<T>>): void {
 		if (!guardedResult.ok) {
-			const failure: CoreError =
-				guardedResult.reason === "not-logged-in"
-					? { reason: "not-logged-in" }
-					: { reason: "error", error: guardedResult.error };
+			const failure: CoreError = guardedResult;
 			eventBus.emit(event, "failure", failure);
 			return;
 		}


### PR DESCRIPTION
## What

Removes all six `as` type assertions flagged in `projects/browser-extension-core/src/core.ts`.

## Why

CLAUDE.md's "Avoid TypeScript Type Assertions (`as`)" rule forbids using `as`
to coerce an object literal into a type or to cast a value coming from an
untyped source — both bypass the compiler and hide shape mismatches.

## How

- **`emitResult` failure branch:** `{ reason: guardedResult.reason } as CoreError`
  → a typed `const failure: CoreError` built by narrowing on
  `guardedResult.reason`. This also fixes a latent bug where the previous
  literal dropped the `error` field for the `"error"` case.
- **Catch handlers (`not-logged-in`, `error`, `login`):** `as CoreError` →
  `satisfies CoreError`, which validates the literal's shape at compile time.
- **`on` / `once`:** removed `handler as ResultCallbacks<unknown>` and
  `value as CoreError`. The implementation `handler` parameter is already typed
  `any` (allowed via the existing biome-ignore for overload dispatch), so
  `handler.success(value)` / `handler.failure(value)` type-check without casts.

## Verification

`pnpm nx run browser-extension-core:check` passes: tsc, biome, knip, all tests,
and 100% coverage (statements/branches/functions/lines).

🤖 Part of the guidelines & skills audit.