### PR TITLE
refactor(import-session): extract mapping logic out of c8-ignored wrapper and adopt named params

### DIFF
--- a/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
+++ b/projects/hutch/src/runtime/providers/import-session/dynamodb-import-session.ts
@@ -9,12 +9,10 @@ import { z } from "zod";
 import { UserIdSchema } from "@packages/domain/user";
 import {
 	IMPORT_SESSION_TTL_SECONDS,
+	type ImportSessionStore,
 	ImportSessionIdSchema,
 } from "@packages/domain/import-session";
-import type {
-	ImportSession,
-	ImportSessionStore,
-} from "@packages/domain/import-session";
+import { computeDeselected, toImportSession } from "./import-session-mapping";
 
 const SessionRow = z.object({
 	sessionId: ImportSessionIdSchema,
@@ -29,22 +27,6 @@ const SessionRow = z.object({
 	allSelected: dynamoField(z.boolean()),
 });
 
-function toSession(row: z.infer<typeof SessionRow>): ImportSession {
-	const allSelected = row.allSelected ?? true;
-	return {
-		id: row.sessionId,
-		userId: row.userId,
-		createdAt: row.createdAt,
-		expiresAt: row.expiresAt,
-		totalUrls: row.totalUrls,
-		totalFound: row.totalFoundInFile,
-		truncated: row.truncated,
-		deselected: allSelected
-			? new Set(row.deselected ?? [])
-			: new Set(Array.from({ length: row.totalUrls }, (_v, i) => i)),
-	};
-}
-
 export function initDynamoDbImportSession(deps: {
 	client: DynamoDBDocumentClient;
 	tableName: string;
@@ -56,10 +38,10 @@ export function initDynamoDbImportSession(deps: {
 		schema: SessionRow,
 	});
 
-	async function loadOwned(id: string, userId: string) {
-		const row = await table.get({ sessionId: id });
+	async function loadOwned(owner: { id: string; userId: string }) {
+		const row = await table.get({ sessionId: owner.id });
 		if (!row) return undefined;
-		if (row.userId !== userId) return undefined;
+		if (row.userId !== owner.userId) return undefined;
 		if (row.expiresAt < Math.floor(deps.now().getTime() / 1000)) return undefined;
 		return row;
 	}
@@ -95,28 +77,30 @@ export function initDynamoDbImportSession(deps: {
 			};
 		},
 		findImportSession: async ({ id, userId }) => {
-			const row = await loadOwned(id, userId);
-			return row ? toSession(row) : undefined;
+			const row = await loadOwned({ id, userId });
+			return row ? toImportSession(row) : undefined;
 		},
 		loadImportSessionPage: async ({ id, userId, page, pageSize }) => {
-			const row = await loadOwned(id, userId);
+			const row = await loadOwned({ id, userId });
 			if (!row) return undefined;
 			const start = (page - 1) * pageSize;
 			const pageUrls = row.urls.slice(start, start + pageSize);
-			return { session: toSession(row), pageUrls, page, pageSize };
+			return { session: toImportSession(row), pageUrls, page, pageSize };
 		},
 		loadAllImportSessionUrls: async ({ id, userId }) => {
-			const row = await loadOwned(id, userId);
+			const row = await loadOwned({ id, userId });
 			return row?.urls;
 		},
 		toggleImportSelection: async ({ id, userId, index, checked }) => {
-			const row = await loadOwned(id, userId);
+			const row = await loadOwned({ id, userId });
 			if (!row) return;
 			const allSelected = row.allSelected ?? true;
 			if (!allSelected && !checked) return;
-			const current = allSelected
-				? new Set<number>(row.deselected ?? [])
-				: new Set(Array.from({ length: row.totalUrls }, (_v, i) => i));
+			const current = computeDeselected({
+				allSelected: row.allSelected,
+				deselected: row.deselected,
+				totalUrls: row.totalUrls,
+			});
 			if (checked) current.delete(index);
 			else current.add(index);
 			await table.update({
@@ -131,7 +115,7 @@ export function initDynamoDbImportSession(deps: {
 			});
 		},
 		toggleAllImportSelection: async ({ id, userId, checked }) => {
-			const row = await loadOwned(id, userId);
+			const row = await loadOwned({ id, userId });
 			if (!row) return;
 			await table.update({
 				Key: { sessionId: id },

--- a/projects/hutch/src/runtime/providers/import-session/import-session-mapping.test.ts
+++ b/projects/hutch/src/runtime/providers/import-session/import-session-mapping.test.ts
@@ -1,0 +1,67 @@
+import { UserIdSchema } from "@packages/domain/user";
+import { ImportSessionIdSchema } from "@packages/domain/import-session";
+import {
+	computeDeselected,
+	type ImportSessionRow,
+	toImportSession,
+} from "./import-session-mapping";
+
+const SESSION_ID = ImportSessionIdSchema.parse("a".repeat(32));
+const USER = UserIdSchema.parse("user-1");
+
+function row(overrides: Partial<ImportSessionRow> = {}): ImportSessionRow {
+	return {
+		sessionId: SESSION_ID,
+		userId: USER,
+		createdAt: "2026-06-20T00:00:00.000Z",
+		expiresAt: 1_700_000_000,
+		totalUrls: 3,
+		totalFoundInFile: 5,
+		truncated: true,
+		urls: ["https://a.example", "https://b.example", "https://c.example"],
+		...overrides,
+	};
+}
+
+describe("computeDeselected", () => {
+	it("returns the stored deselected indices when allSelected is true", () => {
+		const result = computeDeselected({ allSelected: true, deselected: [1], totalUrls: 3 });
+		expect([...result]).toEqual([1]);
+	});
+
+	it("treats a missing allSelected flag as everything selected", () => {
+		const result = computeDeselected({ deselected: [2], totalUrls: 3 });
+		expect([...result]).toEqual([2]);
+	});
+
+	it("defaults a missing deselected list to an empty set when allSelected is true", () => {
+		const result = computeDeselected({ allSelected: true, totalUrls: 3 });
+		expect([...result]).toEqual([]);
+	});
+
+	it("deselects every index when allSelected is false", () => {
+		const result = computeDeselected({ allSelected: false, deselected: [], totalUrls: 3 });
+		expect([...result].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+	});
+});
+
+describe("toImportSession", () => {
+	it("maps a stored row to the domain session with computed deselection", () => {
+		const session = toImportSession(row({ allSelected: true, deselected: [0, 2] }));
+		expect(session).toEqual({
+			id: SESSION_ID,
+			userId: USER,
+			createdAt: "2026-06-20T00:00:00.000Z",
+			expiresAt: 1_700_000_000,
+			totalUrls: 3,
+			totalFound: 5,
+			truncated: true,
+			deselected: new Set([0, 2]),
+		});
+	});
+
+	it("marks every index deselected when the stored row has allSelected false", () => {
+		const session = toImportSession(row({ allSelected: false, deselected: [] }));
+		expect(session.deselected).toEqual(new Set([0, 1, 2]));
+	});
+});

--- a/projects/hutch/src/runtime/providers/import-session/import-session-mapping.ts
+++ b/projects/hutch/src/runtime/providers/import-session/import-session-mapping.ts
@@ -1,0 +1,42 @@
+import type { ImportSession } from "@packages/domain/import-session";
+
+export interface ImportSessionRow {
+	sessionId: ImportSession["id"];
+	userId: ImportSession["userId"];
+	createdAt: string;
+	expiresAt: number;
+	totalUrls: number;
+	totalFoundInFile: number;
+	truncated: boolean;
+	urls: string[];
+	deselected?: number[];
+	allSelected?: boolean;
+}
+
+export function computeDeselected(params: {
+	allSelected?: boolean;
+	deselected?: number[];
+	totalUrls: number;
+}): Set<number> {
+	const allSelected = params.allSelected ?? true;
+	return allSelected
+		? new Set(params.deselected ?? [])
+		: new Set(Array.from({ length: params.totalUrls }, (_v, i) => i));
+}
+
+export function toImportSession(row: ImportSessionRow): ImportSession {
+	return {
+		id: row.sessionId,
+		userId: row.userId,
+		createdAt: row.createdAt,
+		expiresAt: row.expiresAt,
+		totalUrls: row.totalUrls,
+		totalFound: row.totalFoundInFile,
+		truncated: row.truncated,
+		deselected: computeDeselected({
+			allSelected: row.allSelected,
+			deselected: row.deselected,
+			totalUrls: row.totalUrls,
+		}),
+	};
+}


### PR DESCRIPTION
## What

- Extract the branching selection/mapping logic from `dynamodb-import-session.ts` into a new, non-c8-ignored `import-session-mapping.ts`:
  - `computeDeselected({ allSelected, deselected, totalUrls })` — the allSelected fallback, `Set` construction, and full-deselect index math.
  - `toImportSession(row)` — the stored-row to domain-`ImportSession` mapping.
- Add `import-session-mapping.test.ts` covering every branch (allSelected true/false, deselected present/absent), so the extracted logic meets the project coverage thresholds directly instead of hiding behind a blanket ignore.
- Change `loadOwned(id: string, userId: string)` to `loadOwned(owner: { id: string; userId: string })` and update all five call sites.

## Why

- **Named Parameters Over Positional When Types Repeat** (CLAUDE.md): the two consecutive `string` params (`id`, `userId`) are transposable and easy to swap by accident.
- **Allowed c8 ignore Cases — thin AWS SDK wrapper only** (CLAUDE.md / test-driven-design SKILL.md): the whole-file ignore is justified only for a truly trivial wrapper. SKILL.md directs extracting mapping/parsing logic into a helper and unit-testing it rather than ignore-wrapping branching code. After this change the wrapper is just guards plus single SDK calls, consistent with `dynamodb-article-store.ts`, `dynamodb-auth.ts`, and `dynamodb-pending-signup.ts`.

The factory's public signature and return type are unchanged, so the `app.ts` composition root is unaffected.

🤖 Part of the guidelines & skills audit.