### PR TITLE
test(reader-ready-fanout): replace `as UserId` casts with UserIdSchema.parse

### DIFF
--- a/projects/hutch/src/runtime/reader-ready-fanout/reader-ready-fanout-handler.test.ts
+++ b/projects/hutch/src/runtime/reader-ready-fanout/reader-ready-fanout-handler.test.ts
@@ -1,6 +1,6 @@
 import type { Context, SQSEvent } from "aws-lambda";
 import { noopLogger } from "@packages/hutch-logger";
-import type { UserId } from "@packages/domain/user";
+import { UserIdSchema } from "@packages/domain/user";
 import { initReaderReadyUsersNotificationFanoutHandler, type ReaderReadyUsersNotificationFanoutDeps } from "./reader-ready-fanout-handler";
 
 const URL = "https://example.com/article";
@@ -55,8 +55,8 @@ function createHandler(overrides: Partial<ReaderReadyUsersNotificationFanoutDeps
 
 describe("initReaderReadyUsersNotificationFanoutHandler", () => {
 	it("stamps succeededAt for every saver and dispatches a notify command only for savers who viewed while loading (hasSummary=true)", async () => {
-		const viewedSaver = { userId: "viewer" as UserId, viewedAt: new Date("2026-05-30T11:50:00.000Z") };
-		const neverViewedSaver = { userId: "never" as UserId, viewedAt: undefined };
+		const viewedSaver = { userId: UserIdSchema.parse("viewer"), viewedAt: new Date("2026-05-30T11:50:00.000Z") };
+		const neverViewedSaver = { userId: UserIdSchema.parse("never"), viewedAt: undefined };
 		const { handler, deps } = createHandler({
 			findUserArticlesByUrl: jest.fn().mockResolvedValue([viewedSaver, neverViewedSaver]),
 		});
@@ -76,7 +76,7 @@ describe("initReaderReadyUsersNotificationFanoutHandler", () => {
 	});
 
 	it("stamps succeededAt but dispatches nothing when the summary was skipped (hasSummary=false)", async () => {
-		const viewedSaver = { userId: "viewer" as UserId, viewedAt: new Date("2026-05-30T11:50:00.000Z") };
+		const viewedSaver = { userId: UserIdSchema.parse("viewer"), viewedAt: new Date("2026-05-30T11:50:00.000Z") };
 		const { handler, deps } = createHandler({
 			findUserArticlesByUrl: jest.fn().mockResolvedValue([viewedSaver]),
 		});


### PR DESCRIPTION
## What

The `reader-ready-fanout-handler.test.ts` test constructed savers with `userId: "viewer" as UserId` (and `"never"`), casting raw strings to the branded `UserId` type via `as`.

## Why

CLAUDE.md's **Avoid TypeScript Type Assertions (`as`)** rule forbids using `as` to cast a raw value to a branded domain ID and prescribes the validated-factory pattern (`UserIdSchema.parse(rawValue)`). The cast bypasses the compiler so a wrong-shaped value would be silently accepted, and the rule lists no test-file exception for branded-ID casts.

## How

- Switched the import from `import type { UserId }` to the runtime `import { UserIdSchema }` from `@packages/domain/user`.
- Replaced all three `"…" as UserId` occurrences with `UserIdSchema.parse("…")`, matching the established pattern used across the hutch suite (e.g. `conversions.test.ts`, `banner-state.test.ts`).

The `UserIdSchema` transform is an identity at runtime, so the existing positive assertions (`toHaveBeenCalledWith({ userId: "viewer", … })`) remain exactly correct. Verified by compiling and running the suite: 4/4 tests pass, no tsc errors for this file.

🤖 Part of the guidelines & skills audit.