### PR TITLE
refactor(crawl-article): validate oembed response with Zod instead of `as`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,9 @@ importers:
       undici:
         specifier: 6.21.0
         version: 6.21.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/escape-html':
         specifier: 1.0.4

--- a/src/packages/crawl-article/package.json
+++ b/src/packages/crawl-article/package.json
@@ -17,7 +17,8 @@
     "@packages/article-state-types": "workspace:*",
     "escape-html": "1.0.3",
     "linkedom": "0.18.12",
-    "undici": "6.21.0"
+    "undici": "6.21.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/escape-html": "1.0.4",

--- a/src/packages/crawl-article/src/x-twitter-preprocessor.ts
+++ b/src/packages/crawl-article/src/x-twitter-preprocessor.ts
@@ -1,8 +1,16 @@
 import { createHash } from "node:crypto";
+import { z } from "zod";
 import type { CrawlArticleResult } from "./crawl-article.types";
 import type { CrawlFetch } from "./crawl-fetch";
 
 const FETCH_TIMEOUT_MS = 10000;
+
+const OembedResponse = z
+	.object({
+		author_name: z.string().catch(""),
+		html: z.string().catch(""),
+	})
+	.catch({ author_name: "", html: "" });
 const X_TWITTER_PATTERN = /^https?:\/\/(x\.com|twitter\.com)\//;
 const TWEET_STATUS_PATH = /^(\/[^/]+\/status\/\d+)/;
 
@@ -42,9 +50,7 @@ export function initFetchTweetViaOembed(deps: {
 			}
 			const text = await response.text();
 			const bodyHash = createHash("sha256").update(text).digest("hex");
-			const data = JSON.parse(text) as Record<string, unknown>;
-			const authorName = typeof data.author_name === "string" ? data.author_name : "";
-			const embed = typeof data.html === "string" ? data.html : "";
+			const { author_name: authorName, html: embed } = OembedResponse.parse(JSON.parse(text));
 			const html = `<html><head><title>${authorName}</title></head><body>${embed}</body></html>`;
 			return { status: "fetched", html, bodyHash };
 		} catch (error) {


### PR DESCRIPTION
## What

Removes the `as Record<string, unknown>` assertion on the Twitter/X
oembed HTTP response body in `x-twitter-preprocessor.ts` and validates
the payload with a Zod schema at the system boundary.

## Why

The oembed body is an external API response decoded at a system
boundary. CLAUDE.md ("Avoid TypeScript Type Assertions (as)" and
"Runtime Validation with Zod") requires `.safeParse`/`.parse` with a Zod
schema there, not a type assertion. This is not an allowed exception
(not `as const`, not an isolated Node API wrapper).

## How

- Add `OembedResponse`: `z.object({ author_name: z.string().catch(""),
  html: z.string().catch("") }).catch({ author_name: "", html: "" })`.
  The per-field and top-level `.catch` make `parse` total — it never
  throws for any JSON value and always returns the same `""` defaults
  the previous `typeof === "string" ? … : ""` guards produced. No new
  branch is introduced and the file stays at 100% coverage.
- Replace `JSON.parse(text) as Record<string, unknown>` plus the two
  inline guards with `OembedResponse.parse(JSON.parse(text))`.
- Declare `zod@4.4.3` (the version already used across the workspace) in
  `package.json` and add the matching crawl-article entry to
  `pnpm-lock.yaml` so the package compiles and `pnpm install
  --frozen-lockfile` passes. The prior automated attempt failed at
  `@packages/crawl-article:compile` precisely because it used zod
  without declaring it.

## Verification

- `pnpm install --frozen-lockfile` — passes.
- `pnpm nx run @packages/crawl-article:check` — compile + biome + knip
  green.
- `x-twitter-preprocessor.ts` coverage: 100% statements / branches /
  functions / lines. Existing tests unchanged and passing.

🤖 Part of the guidelines & skills audit.