### PR TITLE
refactor(hutch): brand userId on UploadUserDataExportParams

### DIFF
--- a/projects/hutch/src/runtime/export-user-data/export-user-data-handler.ts
+++ b/projects/hutch/src/runtime/export-user-data/export-user-data-handler.ts
@@ -97,7 +97,7 @@ async function processCommand(
 	const body = JSON.stringify(envelope, null, 2);
 
 	const { s3Key, downloadUrl } = await deps.uploadUserDataExport({
-		userId: detail.userId,
+		userId,
 		body,
 	});
 	deps.logger.info("[ExportUserData] uploaded export to S3", {

--- a/projects/hutch/src/runtime/providers/user-data-export/user-data-export.types.ts
+++ b/projects/hutch/src/runtime/providers/user-data-export/user-data-export.types.ts
@@ -1,5 +1,7 @@
+import type { UserId } from "@packages/domain/user";
+
 export interface UploadUserDataExportParams {
-	userId: string;
+	userId: UserId;
 	body: string;
 }
 


### PR DESCRIPTION
## What

`UploadUserDataExportParams.userId` was declared as a raw `string`, defeating the branded `UserId` type the caller already produces. This narrows it to the established `UserId` branded type and threads the branded value through the handler.

## Why

`projects/hutch/src/runtime/export-user-data/export-user-data-handler.ts` parses the command's user id into a branded `UserId` via `UserIdSchema.parse(detail.userId)`, but the provider param widened it back to a plain `string`, removing the mix-up protection the brand exists for. CLAUDE.md "Branded Types for Domain IDs" mandates branded types for domain IDs, and sibling providers (`session.types.ts`, `banner-state.ts`, `analytics.ts`) already follow this.

## Changes

- `user-data-export.types.ts`: `userId: string` → `userId: UserId` (import added from `@packages/domain/user`).
- `export-user-data-handler.ts`: pass the already-branded `userId` into `uploadUserDataExport` instead of the raw `detail.userId`.

No test changes required: the test harness types `uploadCalls.userId` as `string` and feeds `UserId` values, and `s3-user-data-export.ts` uses `userId` only in template strings — both remain valid since `UserId` is a `string` subtype. `tsc` on the hutch project passes with zero errors.

🤖 Part of the guidelines & skills audit.