### PR TITLE
test(ban): replace as-unknown-as casts with Partial Express fakes

### DIFF
--- a/projects/hutch/src/runtime/web/middleware/ban.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/ban.test.ts
@@ -6,17 +6,17 @@ const KNOWN_BANNED_HASH = "836d77f3df16e15f";
 
 function run(hashIp: HashIp): { status?: number; nextCalled: boolean } {
 	let status: number | undefined;
-	const res = {
+	const res: Partial<Response> = {
 		status: (code: number) => {
 			status = code;
-			return res;
+			return res as Response;
 		},
 		end: jest.fn(),
-	} as unknown as Response;
-	const req = { ip: "1.2.3.4" } as unknown as Request;
-	const next = jest.fn() as unknown as NextFunction;
-	createBanMiddleware({ salt: "salt", hashIp })(req, res, next);
-	return { status, nextCalled: (next as jest.Mock).mock.calls.length > 0 };
+	};
+	const req: Partial<Request> = { ip: "1.2.3.4" };
+	const next = jest.fn();
+	createBanMiddleware({ salt: "salt", hashIp })(req as Request, res as Response, next as NextFunction);
+	return { status, nextCalled: next.mock.calls.length > 0 };
 }
 
 describe("createBanMiddleware", () => {


### PR DESCRIPTION
## What

Removes the three `as unknown as` double-casts in `ban.test.ts` that
faked Express `Response`, `Request`, and `NextFunction`.

## Why

CLAUDE.md's "Avoid TypeScript Type Assertions" section forbids faking a
partial object with `as` and documents `Partial<T>` as the correct
alternative (the `createFakeResponse(): Partial<Response>` example). The
sibling `rate-limit.test.ts` already follows this with `Partial<Request>`
and a single `as Request` cast at the call site, so the double-cast here
was avoidable.

## How

- `res` is now `Partial<Response>`; its `status()` returns `res as Response`
  to satisfy the chainable signature.
- `req` is now `Partial<Request>`.
- `next` is a plain `jest.fn()` (typed `jest.Mock`), so `next.mock.calls`
  is read directly without the previous `(next as jest.Mock)` cast.
- The handler is invoked with single contained casts at the boundary
  (`req as Request, res as Response, next as NextFunction`), mirroring the
  sibling test.

## Verification

- hutch tsconfig type-checks with 0 errors
- All 3 `createBanMiddleware` tests pass
- biome lint clean on the middleware directory

🤖 Part of the guidelines & skills audit.