### PR TITLE
test(web): use Partial<T> fakes instead of `as unknown as` in error-handler test

### DIFF
--- a/projects/hutch/src/runtime/web/middleware/error-handler.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/error-handler.test.ts
@@ -5,10 +5,13 @@ import { logAndRespondOnError } from "./error-handler";
 describe("logAndRespondOnError", () => {
 	it("logs the error and responds with 500 JSON", () => {
 		const errorCalls: string[] = [];
-		const logger: Partial<HutchLogger> = {
-			error: (...args: unknown[]) => {
+		const logger: HutchLogger = {
+			info: () => {},
+			error: (...args) => {
 				errorCalls.push(String(args[0]));
 			},
+			warn: () => {},
+			debug: () => {},
 		};
 		const statusMock = jest.fn().mockReturnThis();
 		const jsonMock = jest.fn();
@@ -16,7 +19,7 @@ describe("logAndRespondOnError", () => {
 		const req: Partial<Request> = {};
 		const next: NextFunction = jest.fn();
 
-		logAndRespondOnError(logger as HutchLogger)(
+		logAndRespondOnError(logger)(
 			new Error("boom"),
 			req as Request,
 			res as Response,

--- a/projects/hutch/src/runtime/web/middleware/error-handler.test.ts
+++ b/projects/hutch/src/runtime/web/middleware/error-handler.test.ts
@@ -5,13 +5,23 @@ import { logAndRespondOnError } from "./error-handler";
 describe("logAndRespondOnError", () => {
 	it("logs the error and responds with 500 JSON", () => {
 		const errorCalls: string[] = [];
-		const logger = { error: (msg: string) => errorCalls.push(msg) } as unknown as HutchLogger;
+		const logger: Partial<HutchLogger> = {
+			error: (...args: unknown[]) => {
+				errorCalls.push(String(args[0]));
+			},
+		};
 		const statusMock = jest.fn().mockReturnThis();
 		const jsonMock = jest.fn();
-		const res = { status: statusMock, json: jsonMock } as unknown as Response;
-		const next = jest.fn() as unknown as NextFunction;
+		const res: Partial<Response> = { status: statusMock, json: jsonMock };
+		const req: Partial<Request> = {};
+		const next: NextFunction = jest.fn();
 
-		logAndRespondOnError(logger)(new Error("boom"), {} as Request, res, next);
+		logAndRespondOnError(logger as HutchLogger)(
+			new Error("boom"),
+			req as Request,
+			res as Response,
+			next,
+		);
 
 		expect(errorCalls).toHaveLength(1);
 		const parsed = JSON.parse(errorCalls[0]);


### PR DESCRIPTION
## What

Replaces forbidden `as unknown as` double-casts (and `{} as Request`) in
`error-handler.test.ts` with explicit `Partial<T>` fakes, per CLAUDE.md's
"Avoid TypeScript Type Assertions — fake partial objects with `Partial<T>`".

## Why

The test faked `HutchLogger`, `Response`, and `Request` with `as unknown as`,
which bypasses the compiler entirely. `Partial<X>` declarations make the subset
of provided members explicit and compiler-checked, catching key typos that the
double-cast silently swallowed.

## How

- `logger` is now `Partial<HutchLogger>` with `error: (...args: unknown[]) => void`
  matching the real signature, pushing `String(args[0])`.
- `res` is `Partial<Response>`, `req` is `Partial<Request>`, `next` is typed
  `NextFunction` directly.
- Each is passed with a single `as X` at the call boundary — the same pattern
  already used by `rate-limit.test.ts` (`req as Request`) and
  `require-admin.middleware.test.ts` (`stub as Response`).

## Verification

- `tsc --noEmit` on the hutch project passes clean (no errors).
- `error-handler.test.ts` passes (1/1).

🤖 Part of the guidelines & skills audit.