### PR TITLE
refactor(test-fixtures): brand VerificationToken via zod instead of an as cast

### DIFF
--- a/src/packages/provider-contracts/src/email-verification.ts
+++ b/src/packages/provider-contracts/src/email-verification.ts
@@ -1,6 +1,7 @@
+import type { $brand } from "zod";
 import type { UserId } from "@packages/domain/user";
 
-export type VerificationToken = string & { readonly __brand: "VerificationToken" };
+export type VerificationToken = string & $brand<"VerificationToken">;
 
 export type CreateVerificationToken = (args: { userId: UserId; email: string }) => Promise<VerificationToken>;
 

--- a/src/packages/test-fixtures/src/providers/email-verification/email-verification.schema.ts
+++ b/src/packages/test-fixtures/src/providers/email-verification/email-verification.schema.ts
@@ -1,4 +1,3 @@
 import { z } from "zod";
-import type { VerificationToken } from "@packages/provider-contracts/email-verification";
 
-export const VerificationTokenSchema = z.string().transform((s): VerificationToken => s as VerificationToken);
+export const VerificationTokenSchema = z.string().brand<"VerificationToken">();


### PR DESCRIPTION
## What

`VerificationTokenSchema` branded its parsed value with an `as` cast inside a zod transform:

```ts
export const VerificationTokenSchema = z.string().transform((s): VerificationToken => s as VerificationToken);
```

This is a type assertion at a system boundary, which CLAUDE.md's "Avoid TypeScript Type Assertions" section explicitly forbids (its GOOD boundary example is `z.string().brand<...>()`, and `rawValue as UserId` is listed as BAD). The sibling `google-auth.schema.ts` already uses the compliant `z.string().brand<"GoogleId">()`.

## How

- `email-verification.schema.ts`: use `z.string().brand<"VerificationToken">()`; drop the now-unused `VerificationToken` import and the `as` cast.
- `provider-contracts/src/email-verification.ts`: define `VerificationToken` as `string & $brand<"VerificationToken">` (zod's brand), mirroring how `GoogleId` is defined. This makes the schema's parse output exactly assignable to the contract type.

## Why the previous attempt failed

It changed only the schema to `.brand<"VerificationToken">()` while leaving the contract's hand-rolled `{ readonly __brand: "VerificationToken" }`. zod's `.brand()` produces `string & z.$brand<...>`, structurally incompatible with the hand-rolled brand, so `VerificationTokenSchema.parse(...)` (the sole token construction site, used by both the in-memory and dynamodb providers) no longer typechecked — failing `@packages/test-fixtures:compile`. Aligning the contract to zod's `$brand` resolves this.

## Verification

- `@packages/provider-contracts:check` passes.
- `@packages/test-fixtures:check` passes (100% coverage maintained).
- hutch full `tsc --noEmit` exits 0; no verification-related type errors. Consumers treat the token opaquely, so no ripple.

Note: an unrelated, pre-existing `browser-extension-core:compile` error (missing `parsePopupMessage` export) exists in the working tree independently of this change (confirmed by stashing) and is out of scope here.

🤖 Part of the guidelines & skills audit.