### PR TITLE
test(web-shell): assert trial-countdown via state class, not null absence

### DIFF
--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -63,7 +63,10 @@ describe("GET /account (founding member, no subscription row)", () => {
 		expect(card.classList.contains("account-card--founding")).toBe(true);
 		expect(card.getAttribute("data-test-account-state")).toBe("founding");
 		expect(actionKeys(doc)).toEqual([]);
-		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown element must always be in the DOM");
+		expect(countdown.classList.contains("trial-countdown--hidden")).toBe(true);
+		expect(countdown.getAttribute("data-trial-state")).toBe("");
 	});
 });
 
@@ -91,7 +94,10 @@ describe("GET /account (active paid subscription)", () => {
 		expect(cancelForm.tagName.toLowerCase()).toBe("form");
 		expect(cancelForm.getAttribute("action")).toBe("/account/cancel?utm_source=account&utm_medium=internal&utm_content=cancel-form");
 		expect(cancelForm.getAttribute("method")?.toUpperCase()).toBe("POST");
-		expect(doc.querySelector("[data-test-trial-countdown]")).toBeNull();
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown element must always be in the DOM");
+		expect(countdown.classList.contains("trial-countdown--hidden")).toBe(true);
+		expect(countdown.getAttribute("data-trial-state")).toBe("");
 	});
 });
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.subscription-banner.route.test.ts
@@ -31,6 +31,10 @@ describe("Queue page banner state", () => {
 		const saveForm = doc.querySelector('[data-test-form="save-article"]');
 		assert(saveForm, "save form must be rendered with full access for a founding member");
 		expect(saveForm.classList.contains("queue__save-form--disabled")).toBe(false);
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown element must always be in the DOM");
+		expect(countdown.classList.contains("trial-countdown--hidden")).toBe(true);
+		expect(countdown.getAttribute("data-trial-state")).toBe("");
 	});
 
 	it("renders the header trial countdown and the queue aside trial-countdown banner for a trialing user", async () => {

--- a/projects/hutch/src/runtime/web/trial-countdown.client.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.client.ts
@@ -14,7 +14,7 @@ interface TrialCountdownController {
 	stop(): void;
 }
 
-const SELECTOR = "[data-test-trial-countdown]";
+const SELECTOR = ".trial-countdown";
 const TICK_INTERVAL_MS = 1000;
 const ESCALATIONS: readonly TrialEscalation[] = [
 	"soft",

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -25,6 +25,12 @@ function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
 
 const GUEST_STATE: BannerState = { isAuthenticated: false, emailVerified: undefined };
 
+function loadedClientScripts(doc: Document): string[] {
+	return Array.from(doc.querySelectorAll('script[src*="/client-dist/"]')).map(
+		(el) => el.getAttribute("src") ?? "",
+	);
+}
+
 describe("Base component", () => {
 	it("should render a complete HTML page with the provided title", () => {
 		const page = createTestPageBody({ seo: { title: "My Title", description: "Desc", canonicalUrl: "https://readplace.com" } });
@@ -621,22 +627,19 @@ describe("Base component", () => {
 		).toBe("https://readplace.com/view/example.com/original-post");
 	});
 
-	it("does not render the trial countdown when state.trial is undefined", () => {
+	it("renders the trial countdown hidden (state class) and omits the client script when state.trial is undefined", () => {
 		const page = createTestPageBody();
 		const result = Base(page, { isAuthenticated: true, emailVerified: true }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		const headerContent = doc.querySelector(".header__content");
-		assert(headerContent, "header content container must exist");
-		const brand = headerContent.querySelector(".header__brand");
-		assert(brand, "brand link must exist");
-		const next = brand.nextElementSibling;
-		assert(next, "an element must follow the brand inside .header__content");
-		expect(next.tagName).toBe("NAV");
-		expect(next.classList.contains("nav")).toBe(true);
-		expect(
-			doc.querySelector('script[src$="/client-dist/trial-countdown.client.js"]'),
-		).toBeNull();
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown element must always be in the DOM");
+		expect(countdown.classList.contains("trial-countdown--hidden")).toBe(true);
+		expect(countdown.getAttribute("data-trial-state")).toBe("");
+
+		const scripts = loadedClientScripts(doc);
+		expect(scripts).toContain("/client-dist/toast.client.js");
+		expect(scripts).not.toContain("/client-dist/trial-countdown.client.js");
 	});
 
 	it("renders the trial countdown with text/data-attrs and includes the client script when trial.state='active'", () => {
@@ -667,6 +670,7 @@ describe("Base component", () => {
 		expect(countdown.getAttribute("data-trial-ends-at-iso")).toBe("2026-01-15T00:00:00.000Z");
 		expect(countdown.getAttribute("data-server-now-iso")).toBe("2026-01-01T00:00:00.000Z");
 		expect(countdown.classList.contains("trial-countdown--moderate")).toBe(true);
+		expect(countdown.classList.contains("trial-countdown--visible")).toBe(true);
 		expect(countdown.getAttribute("role")).toBe("timer");
 		expect(countdown.getAttribute("aria-live")).toBe("off");
 
@@ -691,10 +695,11 @@ describe("Base component", () => {
 		expect(countdown.textContent).toBe("Subscription not active");
 		expect(countdown.getAttribute("data-trial-state")).toBe("expired");
 		expect(countdown.classList.contains("trial-countdown--expired")).toBe(true);
+		expect(countdown.classList.contains("trial-countdown--visible")).toBe(true);
 
-		expect(
-			doc.querySelector('script[src$="/client-dist/trial-countdown.client.js"]'),
-		).toBeNull();
+		const scripts = loadedClientScripts(doc);
+		expect(scripts).toContain("/client-dist/toast.client.js");
+		expect(scripts).not.toContain("/client-dist/trial-countdown.client.js");
 	});
 
 	it("renders the trial countdown as an anchor to /account so the user can fix the subscription state from any page", () => {

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -26,9 +26,11 @@ function createTestPageBody(overrides: Partial<PageBody> = {}): PageBody {
 const GUEST_STATE: BannerState = { isAuthenticated: false, emailVerified: undefined };
 
 function loadedClientScripts(doc: Document): string[] {
-	return Array.from(doc.querySelectorAll('script[src*="/client-dist/"]')).map(
-		(el) => el.getAttribute("src") ?? "",
-	);
+	return Array.from(doc.querySelectorAll('script[src*="/client-dist/"]')).map((el) => {
+		const src = el.getAttribute("src");
+		assert(src, "a script matched by [src*='/client-dist/'] must carry a src");
+		return src;
+	});
 }
 
 describe("Base component", () => {

--- a/src/packages/web-shell/src/base.styles.ts
+++ b/src/packages/web-shell/src/base.styles.ts
@@ -461,7 +461,15 @@ export const TRIAL_COUNTDOWN_STYLES = `
     text-underline-offset: 3px;
   }
 
-  /* purgecss-ignore-start: modifier suffix is interpolated from BannerState.trial.escalation in nav.template.ts */
+  /* purgecss-ignore-start: modifier suffix is interpolated from BannerState.trial.escalation and the visibility state in nav.template.ts */
+  .trial-countdown--visible {
+    display: inline-block;
+  }
+
+  .trial-countdown--hidden {
+    display: none;
+  }
+
   .trial-countdown--soft {
     font-weight: 500;
     opacity: 0.85;

--- a/src/packages/web-shell/src/nav.component.test.ts
+++ b/src/packages/web-shell/src/nav.component.test.ts
@@ -16,7 +16,7 @@ const ACTIVE_TRIAL: TrialDisplay = {
 };
 
 describe("Nav component", () => {
-	it("omits the trial countdown when trialCounter is undefined", () => {
+	it("renders the trial countdown hidden (via state class) when trialCounter is undefined", () => {
 		const doc = parse(
 			Nav({
 				variant: "default",
@@ -25,12 +25,11 @@ describe("Nav component", () => {
 			}),
 		);
 
-		const brand = doc.querySelector(".header__brand");
-		assert(brand, "header brand must render");
-		const afterBrand = brand.nextElementSibling;
-		assert(afterBrand, "an element must follow the brand inside .header__content");
-		expect(afterBrand.tagName).toBe("NAV");
-		expect(afterBrand.classList.contains("nav")).toBe(true);
+		const countdown = doc.querySelector("[data-test-trial-countdown]");
+		assert(countdown, "trial countdown element must always be in the DOM");
+		expect(countdown.classList.contains("trial-countdown--hidden")).toBe(true);
+		expect(countdown.getAttribute("data-trial-state")).toBe("");
+		expect(countdown.textContent).toBe("");
 	});
 
 	it("renders the trial countdown with active state, escalation class, and data attributes", () => {
@@ -47,6 +46,7 @@ describe("Nav component", () => {
 		assert(countdown, "trial countdown must be present for an active trial");
 		expect(countdown.textContent).toBe("13d 12h left in your free trial");
 		expect(countdown.classList.contains("trial-countdown--moderate")).toBe(true);
+		expect(countdown.classList.contains("trial-countdown--visible")).toBe(true);
 		expect(countdown.getAttribute("data-trial-state")).toBe("active");
 		expect(countdown.getAttribute("data-trial-ends-at-iso")).toBe("2026-01-15T00:00:00.000Z");
 		expect(countdown.getAttribute("data-server-now-iso")).toBe("2026-01-01T00:00:00.000Z");

--- a/src/packages/web-shell/src/nav.component.ts
+++ b/src/packages/web-shell/src/nav.component.ts
@@ -37,7 +37,7 @@ export function Nav(props: NavProps): string {
 	const trial = props.trialCounter;
 	return render(NAV_TEMPLATE, {
 		transparent: props.variant === "transparent",
-		trial: Boolean(trial),
+		trialVisibility: trial ? "visible" : "hidden",
 		trialDisplayText: trial ? formatTrialDisplay(trial) : "",
 		trialState: trial?.state ?? "",
 		trialEscalationClass: escalationClassFor(trial),

--- a/src/packages/web-shell/src/nav.template.ts
+++ b/src/packages/web-shell/src/nav.template.ts
@@ -1,8 +1,7 @@
 export const NAV_TEMPLATE = `  <header class="header{{#if transparent}} header--transparent{{/if}}">
     <div class="header__content">
       <a href="{{track '/' source='header' content='brand'}}" class="header__brand">Read<span class="header__brand-mark">place</span></a>
-      {{#if trial}}
-      <a class="trial-countdown trial-countdown--{{trialEscalationClass}}"
+      <a class="trial-countdown trial-countdown--{{trialEscalationClass}} trial-countdown--{{trialVisibility}}"
          href="{{track '/account' source='header' content='trial-countdown'}}"
          data-trial-ends-at-iso="{{trialEndsAtIso}}"
          data-server-now-iso="{{serverNowIso}}"
@@ -11,7 +10,6 @@ export const NAV_TEMPLATE = `  <header class="header{{#if transparent}} header--
          aria-live="off"
          aria-atomic="true"
          data-test-trial-countdown>{{trialDisplayText}}</a>
-      {{/if}}
       <nav class="nav">
         <button class="nav__toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-menu">
           <span class="nav__toggle-bar"></span>


### PR DESCRIPTION
## Why

`base.component.test.ts` proved the "no trial countdown" case with
`expect(querySelector("[data-test-trial-countdown]")).toBeNull()`. Per
`.claude/skills/test-driven-design/SKILL.md` ("Never Rely on
`querySelector(...).toBeNull()` — Assert Existence First, Then Check State"),
this is fragile: a selector typo also returns `null`, so the assertion passes
for the wrong reason. The trial countdown is a binary shown/hidden element, so
the doc requires rendering it unconditionally with a state class and asserting
on that class.

## What

- **nav.template.ts** — render the trial-countdown anchor unconditionally,
  carrying `trial-countdown--{{trialVisibility}}` (`visible` / `hidden`).
- **nav.component.ts** — replace the `trial: Boolean(trial)` flag with
  `trialVisibility`; the existing helpers already emit empty/`expired` metadata
  for the no-trial case.
- **base.styles.ts** — add explicit `.trial-countdown--visible` /
  `.trial-countdown--hidden` display rules (state explicit on both sides).
- **Tests** — convert every `.toBeNull()` trial assertion to
  assert-existence-then-check-`--hidden`, and add `--visible` checks to the
  active/expired cases. This spans the web-shell base/nav tests and the hutch
  `account` / `queue` route tests, which render the shared `Nav` via
  `@packages/web-shell`. The client script is genuinely conditional (a script
  cannot be "rendered hidden"), so its absence is asserted against the concrete
  loaded-script list, anchored by a known always-present bundle.

## Verification

- `@packages/web-shell:check` passes fully — 168 tests, 100% coverage,
  lint/knip/tsc clean.
- The two affected hutch route suites pass (44 tests).

The unrelated `hutch:check` / `browser-extension-core:compile` failure in the
shared working tree comes from other in-flight audit work (an untracked
`popup-message.types.test.ts` and an `extension-suggestion-banner.client.ts`
bundling `node:assert`); neither file is touched here.

🤖 Part of the guidelines & skills audit.