### PR TITLE
refactor(check-stuck-articles): centralize env access through a getEnv boundary

### DIFF
--- a/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
+++ b/src/packages/check-stuck-articles/scripts/check-stuck-articles.ts
@@ -30,9 +30,13 @@ import {
 } from "./collect-stuck-rows";
 
 function requireEnv(name: string): string {
-	const value = process.env[name];
+	const value = getEnv(name);
 	assert(value, `${name} env var is required`);
 	return value;
+}
+
+function getEnv(name: string): string | undefined {
+	return process.env[name];
 }
 
 /**
@@ -57,7 +61,7 @@ const REACHABILITY_CONCURRENCY = 8;
  * unset and skip the write.
  */
 async function writeReportIfRequested(stuck: StuckRow[]): Promise<void> {
-	const reportPath = process.env.STUCK_ARTICLES_REPORT_PATH;
+	const reportPath = getEnv("STUCK_ARTICLES_REPORT_PATH");
 	if (reportPath === undefined) return;
 	await writeFile(reportPath, `${JSON.stringify({ stuck }, null, 2)}\n`, "utf8");
 }


### PR DESCRIPTION
## Audit findings (high priority) — Direct process.env access

**Rule:** Environment Variable Access — never read `process.env` directly
**Source:** CLAUDE.md
**File:** `src/packages/check-stuck-articles/scripts/check-stuck-articles.ts`

The script read `process.env` in its local `requireEnv` helper and again directly for `STUCK_ARTICLES_REPORT_PATH`.

### Change
As a standalone package it cannot import hutch's `require-env` (a forbidden cross-project relative import), so it keeps a local boundary — the same pattern as the sibling `check-failed-articles` script. Added a local `getEnv(name)` and routed **both** `requireEnv` and the report-path read through it, so `process.env` is now touched in exactly one place.

🤖 Part of the guidelines & skills audit.
