### PR TITLE
chore(firefox-extension): remove leftover CI-probe comment from background

### DIFF
--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -1,5 +1,4 @@
 /* c8 ignore start -- composition root, all browser API glue, tested via Selenium E2E */
-// (test 4/4 probe: firefox-only edit must publish firefox but skip chrome)
 import {
 	BrowserExtensionCore,
 	initOAuthAuth,


### PR DESCRIPTION
## Audit finding (high priority) — leftover CI-probe comment

**Rule:** Comments Document Why, Not What — no time/plan/task-bound comments
**Source:** CLAUDE.md
**File:** `projects/extensions/firefox-extension/src/runtime/background/background.browser.ts`

Line 2 was a stray release-pipeline probe marker (`(test 4/4 probe: firefox-only edit must publish firefox but skip chrome)`) — the firefox sibling of the markers already removed from `browser-extension-core/zod-config.ts` and `founding-progress.styles.css`. Removed it.

### Scope note
This file's three `as`-cast findings (at `browser.storage.local` / `runtime.onMessage` / content-script boundaries) are intentionally **not** in this PR: validating them properly needs a project decision (add `zod` as an extension dependency vs hand-written type guards) plus internal-IPC judgement, so they warrant a dedicated reviewed PR.

🤖 Part of the guidelines & skills audit.
