### PR TITLE
refactor(firefox-extension): replace boundary `as` casts with type guards

### DIFF
--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -26,12 +26,23 @@ declare const __SERVER_URL__: string;
 const SERVER_URL = __SERVER_URL__;
 const CLIENT_ID = "hutch-firefox-extension";
 
+function isOAuthTokens(value: unknown): value is OAuthTokens {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"accessToken" in value &&
+		typeof value.accessToken === "string" &&
+		"refreshToken" in value &&
+		typeof value.refreshToken === "string"
+	);
+}
+
 const tokenStorage: TokenStorage = {
 	async getTokens(): Promise<OAuthTokens | null> {
 		const result = await browser.storage.local.get(STORAGE_KEY);
 		const raw = result[STORAGE_KEY];
-		if (!raw) return null;
-		return raw as OAuthTokens;
+		if (!isOAuthTokens(raw)) return null;
+		return raw;
 	},
 	async setTokens(tokens: OAuthTokens): Promise<void> {
 		await browser.storage.local.set({ [STORAGE_KEY]: tokens });
@@ -190,7 +201,7 @@ async function captureActiveTabHtml(message: {
 		),
 	]).catch(() => undefined);
 	if (captured && typeof captured === "object" && "rawHtml" in captured) {
-		const rawHtml = (captured as { rawHtml: unknown }).rawHtml;
+		const rawHtml = captured.rawHtml;
 		if (typeof rawHtml === "string" && rawHtml.length > 0) return rawHtml;
 	}
 	return undefined;
@@ -201,13 +212,37 @@ function broadcastSaveProgress(phase: SavePhase): void {
 	browser.runtime.sendMessage({ type: "save-progress", phase }).catch(() => {});
 }
 
+const POPUP_MESSAGE_TYPES = new Set([
+	"save-current-tab",
+	"save-progress",
+	"remove-item",
+	"check-url",
+	"get-all-items",
+	"login",
+	"logout",
+]);
+
+function hasStringType(value: unknown): value is { type: string } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function isPopupMessage(value: unknown): value is PopupMessage {
+	return hasStringType(value) && POPUP_MESSAGE_TYPES.has(value.type);
+}
+
 browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
-	if ((raw as { type: string }).type === "shortcut-pressed") {
+	if (hasStringType(raw) && raw.type === "shortcut-pressed") {
 		browser.browserAction.openPopup().catch((err) => logger.error(err));
 		return;
 	}
 
-	const message = raw as PopupMessage;
+	if (!isPopupMessage(raw)) return;
+	const message = raw;
 
 	corePromise
 		.then((core) => {


### PR DESCRIPTION
## What

Removes the three `as` type assertions in the Firefox extension
background worker (`background.browser.ts`) and replaces them with runtime
type guards that validate external data at the boundary.

## Why

`browser.storage.local.get`, `runtime.onMessage`, and the content-script
`sendMessage` response all return untyped/`unknown` data. Casting that
data to `OAuthTokens`, `PopupMessage`, and `{ rawHtml: unknown }` with
`as` bypasses the compiler and silently accepts malformed shapes, which
the CLAUDE.md "Avoid TypeScript Type Assertions" rule forbids. The rule
normally directs Zod validation at boundaries, but browser extensions do
not depend on Zod (and no install runs in CI), so the browser-safe
equivalent is a hand-rolled `function isX(v: unknown): v is X` guard.

## Changes

- Add `isOAuthTokens`; `getTokens` returns `null` on a malformed stored
  blob instead of casting.
- Add `hasStringType` and `isPopupMessage`; the `onMessage` listener
  validates the discriminant before narrowing and ignores unknown
  messages.
- Drop the redundant `as { rawHtml: unknown }` cast, relying on the
  existing `in` narrowing.

## Verification

`pnpm nx run firefox-extension:check` passes (tsc, biome, knip, 100%
coverage). `background.browser.ts` is excluded from coverage, so no test
changes are required.

🤖 Part of the guidelines & skills audit.