### PR TITLE
refactor(domain): brand UserId via zod instead of `as` cast

### DIFF
--- a/projects/hutch/src/runtime/web/banner-state.ts
+++ b/projects/hutch/src/runtime/web/banner-state.ts
@@ -1,4 +1,4 @@
-import type { UserId } from "@packages/domain/user";
+import { UserIdSchema } from "@packages/domain/user";
 import { bannerStateFromRequest } from "@packages/web-shell";
 import type { BannerState, BannerStateSource } from "@packages/web-shell";
 import type {
@@ -27,8 +27,8 @@ export function initBuildBannerState(deps: {
 		const changelogBanner =
 			banner && banner.version !== source.dismissedChangelogVersion ? banner : undefined;
 		const withBanner: BannerState = changelogBanner ? { ...base, changelogBanner } : base;
-		const userId: UserId | undefined = source.userId;
-		if (!userId) return withBanner;
+		if (!source.userId) return withBanner;
+		const userId = UserIdSchema.parse(source.userId);
 		const access =
 			options?.preFetchedAccess ?? (await deps.getEffectiveAccess(userId));
 		const trial = toTrialDisplay(access, deps.now());

--- a/src/packages/domain/src/user/user.schema.ts
+++ b/src/packages/domain/src/user/user.schema.ts
@@ -1,4 +1,4 @@
 import { z } from "zod";
-import type { UserId } from "./user.types";
 
-export const UserIdSchema = z.string().transform((s: string): UserId => s as UserId);
+export const UserIdSchema = z.string().brand<"UserId">();
+export type UserId = z.infer<typeof UserIdSchema>;

--- a/src/packages/domain/src/user/user.types.ts
+++ b/src/packages/domain/src/user/user.types.ts
@@ -1,2 +1,2 @@
-export type UserId = string & { readonly __brand: "UserId" };
+export type { UserId } from "./user.schema";
 

--- a/src/packages/web-shell/src/banner-state.test.ts
+++ b/src/packages/web-shell/src/banner-state.test.ts
@@ -1,15 +1,13 @@
 import assert from "node:assert/strict";
 import {
-	type BannerStateSource,
 	bannerStateFromRequest,
 	buildGuestNavItems,
 	buildNavGroups,
 } from "./banner-state";
 
-/** The shell carries no @packages/domain dependency, so there is no UserId
- * schema to parse here. The truthiness of `userId` is all bannerStateFromRequest
- * reads, so a plain branded fixture is sufficient. */
-const USER_ID = "user-1" as unknown as NonNullable<BannerStateSource["userId"]>;
+/** The shell carries no @packages/domain dependency and reads `userId` only for
+ * truthiness, so a plain string id is sufficient — there is no brand to parse. */
+const USER_ID = "user-1";
 
 describe("bannerStateFromRequest", () => {
 	it("maps a present userId to isAuthenticated=true", () => {

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -2,13 +2,6 @@ import type { ChangelogBanner } from "./changelog-banner";
 import { withInternalTracking } from "./internal-link-tracking";
 import type { TrialDisplay } from "./trial-countdown.format";
 
-/** Local brand for the authenticated user's identifier. Inlined (rather than
- * imported from @packages/domain) so the shell carries no dependency on the
- * domain package — a domain change must not invalidate the content sites that
- * consume this shell. The brand is structural: any UserId from elsewhere
- * assigns to it without a cast. */
-type UserId = string & { readonly __brand: "UserId" };
-
 /** Presentational standing of an *unverified* account, mirroring TrialDisplay:
  * the consuming site computes it from its own domain and hands it to the shell,
  * which only renders copy. Inlined (rather than imported from the domain) so the
@@ -23,7 +16,11 @@ type VerificationStatus =
 	| { state: "locked" };
 
 export interface BannerStateSource {
-	userId?: UserId;
+	/** The authenticated user's id as a plain string. The shell reads it only for
+	 * truthiness (isAuthenticated) and carries no @packages/domain dependency, so
+	 * it deliberately does not reconstruct the domain's branded UserId here — a
+	 * domain change must not invalidate the content sites that consume this shell. */
+	userId?: string;
 	emailVerified?: boolean;
 	verificationStatus?: VerificationStatus;
 	/** The changelog version the reader has dismissed, lifted from the dismissal


### PR DESCRIPTION
## Why

`src/packages/domain/src/user/user.schema.ts` branded its value with
`s as UserId` inside a `transform` — the exact BAD pattern CLAUDE.md's
"Avoid TypeScript Type Assertions (`as`)" section contrasts against its
canonical GOOD example, `z.string().brand<'UserId'>()`.

## What changed

- **`user.schema.ts`**: `UserIdSchema = z.string().brand<"UserId">()` and
  `type UserId = z.infer<typeof UserIdSchema>`. The schema now owns the brand;
  no `as`.
- **`user.types.ts`**: re-exports `UserId` from the schema (schema owns the
  type, types file re-exports — avoids a circular import).
- **`@packages/web-shell/banner-state.ts`**: zod 4's brand is structurally
  `{ [$brand]: ... }`, not the previous `{ readonly __brand: "UserId" }`, which
  broke the shell's deliberately-decoupled structural bridge. `BannerStateSource.userId`
  is loosened to plain `string` — the shell only reads it for truthiness and
  must carry no domain/zod dependency. Its test fixture drops the now-needless cast.
- **`projects/hutch/.../web/banner-state.ts`**: narrows `source.userId` back to a
  domain `UserId` via `UserIdSchema.parse`, validating the branded id at the
  boundary.

## Verification

- `nx run domain:check` — pass, 100% coverage
- `nx run @packages/web-shell:check` — pass, 100% coverage
- hutch `tsc` — no errors related to `UserId` / `banner-state` / `BannerStateSource`
  (all ~20 `buildBannerState(req)` call sites still compile)
- hutch `banner-state` tests — 11 passed

Existing `"literal" as UserId` casts across test files remain valid (a string is
assignable through `as` to the zod brand).

🤖 Part of the guidelines & skills audit.