### PR TITLE
refactor(chrome-extension): remove `as` casts from popup boundary and navigator probe

### DIFF
--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -3,6 +3,7 @@ import browser from "webextension-polyfill";
 import type {
 	ReadingListItem,
 	PopupMessage,
+	SavePhase,
 	GuardedResult,
 	SaveUrlResult,
 	RemoveUrlResult,
@@ -12,6 +13,12 @@ import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, instal
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 
 declare const __APP_DOMAINS__: string[];
+
+declare global {
+	interface Navigator {
+		userAgentData?: { platform: string };
+	}
+}
 
 const logger = HutchLogger.from(consoleLogger);
 
@@ -45,10 +52,21 @@ const sequencer = initSaveProgressSequencer({
 	},
 });
 
+function isSavePhase(value: unknown): value is SavePhase {
+	return value === "capturing" || value === "uploading";
+}
+
+function isSaveProgressMessage(
+	value: unknown,
+): value is { type: "save-progress"; phase: SavePhase } {
+	if (typeof value !== "object" || value === null) return false;
+	if (!("type" in value) || value.type !== "save-progress") return false;
+	return "phase" in value && isSavePhase(value.phase);
+}
+
 browser.runtime.onMessage.addListener((raw) => {
-	const message = raw as PopupMessage;
-	if (message.type !== "save-progress") return undefined;
-	sequencer.enqueue(message.phase);
+	if (!isSaveProgressMessage(raw)) return undefined;
+	sequencer.enqueue(raw.phase);
 	return undefined;
 });
 
@@ -444,11 +462,8 @@ document.getElementById("filter-input")?.addEventListener("input", () => {
 
 const shortcutHint = document.querySelector(".shortcut-hint");
 if (shortcutHint) {
-	// navigator.userAgentData is the modern replacement for navigator.platform
-	// but TypeScript DOM types don't include it yet, so use a type assertion
-	const nav = navigator as Navigator & { userAgentData?: { platform: string } };
-	const isMac = nav.userAgentData
-		? nav.userAgentData.platform === "macOS"
+	const isMac = navigator.userAgentData
+		? navigator.userAgentData.platform === "macOS"
 		: navigator.platform.startsWith("Mac");
 	if (isMac) {
 		shortcutHint.textContent = "";


### PR DESCRIPTION
## What

Removes the three guideline violations in
`projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts`:

1. **Message-boundary `as` cast** (`raw as PopupMessage`). The
   `browser.runtime.onMessage` listener receives `raw: unknown` from the
   runtime messaging boundary and only cares about the `save-progress` message.
   Replaced the cast with two type guards, `isSavePhase` and
   `isSaveProgressMessage`, that narrow `unknown` to
   `{ type: "save-progress"; phase: SavePhase }` with no assertion. The
   extension does not depend on zod (and CI runs no install), so a hand-rolled
   guard is the correct browser-safe validator — the same pattern already used
   by `isPopupMessage` in the firefox background script.

2. **`navigator as Navigator & { userAgentData?: ... }` cast** plus the
   discretionary comment that justified it (and made a time-bound "DOM types
   don't include it yet" claim). Replaced with a top-level
   `declare global { interface Navigator { userAgentData?: { platform: string } } }`
   augmentation so the field is typed directly, then read `navigator.userAgentData`
   with no cast and no comment.

## Why

CLAUDE.md "Avoid TypeScript Type Assertions (`as`)" bans casts outside the
allowed exceptions, prescribes a validator at system boundaries, and
"Comments Document Why, Not What" forbids comments that narrate a workaround
instead of encoding the why in code.

## Verification

`pnpm nx run chrome-extension:check` passes — tsc, biome, knip, and 100%
coverage (the file is a `*.browser.ts`, excluded from coverage, so no new
tests are required).

🤖 Part of the guidelines & skills audit.