### PR TITLE
refactor(hutch): use an inline assert for extension-suggestion-banner invariants

### DIFF
--- a/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts
+++ b/projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts
@@ -1,3 +1,9 @@
+/** Inline assertion — esbuild bundles this module for the browser, where
+ * `node:assert` is not resolvable (same constraint as progress-bar.client.ts). */
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
 interface ExtensionSuggestionBannerStorage {
 	getItem(key: string): string | null;
 	setItem(key: string, value: string): void;
@@ -21,9 +27,10 @@ export function initExtensionSuggestionBanner(
 	deps: ExtensionSuggestionBannerDeps,
 ): ExtensionSuggestionBannerController {
 	function ensure<T>(value: T | null | undefined, description: string): T {
-		if (value === null || value === undefined) {
-			throw new Error(`extension-suggestion-banner: ${description}`);
-		}
+		assert(
+			value !== null && value !== undefined,
+			`extension-suggestion-banner: ${description}`,
+		);
 		return value;
 	}
 


### PR DESCRIPTION
## Audit finding (medium) — Use assert for runtime invariants

**Rule:** Use `assert` for Runtime Invariants (instead of `if`/`throw`)
**Source:** CLAUDE.md
**File:** `projects/hutch/src/runtime/web/shared/extension-suggestion-banner/extension-suggestion-banner.client.ts`

The `ensure` helper used a raw `if (value == null) throw`.

### Change
Added a tiny inline `assert(condition, message): asserts condition` and had `ensure` call it. This is a browser-bundled `*.client.ts`, so `node:assert` is **not** resolvable by esbuild (same constraint documented in `progress-bar.client.ts`) — the inline assertion satisfies the rule's intent in a browser-safe way. The thrown `Error` message is identical, so the existing tests asserting the descriptive errors remain green.

🤖 Part of the guidelines & skills audit.
