### PR TITLE
refactor(firefox-extension): remove `as` casts at the popup message boundary

### DIFF
--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -45,9 +45,8 @@ const sequencer = initSaveProgressSequencer({
 });
 
 browser.runtime.onMessage.addListener((raw) => {
-	const message = raw as PopupMessage;
-	if (message.type !== "save-progress") return undefined;
-	sequencer.enqueue(message.phase);
+	if (!isSaveProgressMessage(raw)) return undefined;
+	sequencer.enqueue(raw.phase);
 	return undefined;
 });
 
@@ -67,8 +66,22 @@ async function finishSavingProgress(): Promise<void> {
 	});
 }
 
-function send(message: PopupMessage): Promise<unknown> {
-	return browser.runtime.sendMessage(message);
+/** Isolated boundary wrapper: the single contained assertion for the untyped
+ * webextension-polyfill response, so call sites stay free of `as`. */
+function send<T>(message: PopupMessage): Promise<T> {
+	return browser.runtime.sendMessage(message) as Promise<T>;
+}
+
+function isSaveProgressMessage(
+	raw: unknown,
+): raw is Extract<PopupMessage, { type: "save-progress" }> {
+	return (
+		typeof raw === "object" &&
+		raw !== null &&
+		"type" in raw &&
+		raw.type === "save-progress" &&
+		"phase" in raw
+	);
 }
 
 async function performLogout() {
@@ -218,10 +231,10 @@ function renderLinks(items: ReadingListItem[]) {
 			const overlay = document.getElementById("spinner-overlay");
 			if (overlay) overlay.hidden = false;
 			try {
-				const result = (await send({
+				const result = await send<GuardedResult<RemoveUrlResult>>({
 					type: "remove-item",
 					id: item.id,
-				})) as GuardedResult<RemoveUrlResult>;
+				});
 
 				if (isNotLoggedIn(result)) {
 					await performLogout();
@@ -252,9 +265,9 @@ function filterItems(): ReadingListItem[] {
 }
 
 async function loadAllItems() {
-	const result = (await send({
+	const result = await send<GuardedResult<ReadingListItem[]>>({
 		type: "get-all-items",
-	})) as GuardedResult<ReadingListItem[]>;
+	});
 
 	if (isNotLoggedIn(result)) {
 		await performLogout();
@@ -340,10 +353,10 @@ async function saveAndShowList() {
 		return;
 	}
 
-	const checkResult = (await send({
+	const checkResult = await send<GuardedResult<ReadingListItem | null>>({
 		type: "check-url",
 		url: activeTab.url,
-	})) as GuardedResult<ReadingListItem | null>;
+	});
 
 	if (isNotLoggedIn(checkResult)) {
 		await performLogout();
@@ -359,12 +372,12 @@ async function saveAndShowList() {
 		return;
 	}
 
-	const saveResult = (await send({
+	const saveResult = await send<GuardedResult<SaveUrlResult>>({
 		type: "save-current-tab",
 		url: activeTab.url,
 		title: activeTab.title,
 		tabId: activeTab.tabId,
-	})) as GuardedResult<SaveUrlResult>;
+	});
 
 	if (isNotLoggedIn(saveResult)) {
 		await performLogout();

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -415,11 +415,11 @@ document.getElementById("login-button")?.addEventListener("click", async () => {
 	if (loginError) loginError.hidden = true;
 
 	try {
-		const result = (await send({ type: "login" })) as {
+		const result = await send<{
 			ok: boolean;
 			reason?: string;
 			error?: { message?: string };
-		};
+		}>({ type: "login" });
 		if (!result.ok) {
 			if (loginError) {
 				loginError.textContent = `Login failed: ${result.reason ?? "unknown"} — ${result.error?.message ?? ""}`;


### PR DESCRIPTION
## Audit findings (medium) — `as` at the popup message boundary

**Rule:** Avoid TypeScript Type Assertions (`as`)
**Source:** CLAUDE.md
**File:** `projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts`

The popup cast `runtime.onMessage` payloads (`raw as PopupMessage`) and four `send(...)` responses (`as GuardedResult<…>`).

### Change
- **onMessage:** narrowed with an `isSaveProgressMessage(raw): raw is Extract<PopupMessage, {type:"save-progress"}>` type guard — no `as`.
- **send:** now generic `send<T>(message): Promise<T>`, so all four call sites are assertion-free. The single unavoidable assertion for webextension-polyfill's untyped response is contained in that one boundary wrapper (the documented isolated-wrapper exception), instead of being repeated at every call site.

The extensions don't depend on `zod`, so a hand-written guard + a typed boundary wrapper is the dependency-free fix. `*.browser.ts` is excluded from coverage, so this is a type/lint-only change.

🤖 Part of the guidelines & skills audit.
