### PR TITLE
fix(browser-extension-core): inject HutchLogger and brand item id via zod

### DIFF
--- a/projects/browser-extension-core/src/domain/reading-list-item-id.ts
+++ b/projects/browser-extension-core/src/domain/reading-list-item-id.ts
@@ -1,0 +1,6 @@
+import "../zod-config";
+import { z } from "zod";
+
+export const ReadingListItemIdSchema = z.string().brand<"ReadingListItemId">();
+
+export type ReadingListItemId = z.infer<typeof ReadingListItemIdSchema>;

--- a/projects/browser-extension-core/src/domain/reading-list-item.types.ts
+++ b/projects/browser-extension-core/src/domain/reading-list-item.types.ts
@@ -1,6 +1,5 @@
-export type ReadingListItemId = string & {
-	readonly __brand: "ReadingListItemId";
-};
+export type { ReadingListItemId } from "./reading-list-item-id";
+import type { ReadingListItemId } from "./reading-list-item-id";
 
 export interface ReadingListItem {
 	id: ReadingListItemId;

--- a/projects/browser-extension-core/src/e2e/pdf-save-scenario.ts
+++ b/projects/browser-extension-core/src/e2e/pdf-save-scenario.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash, randomBytes } from "node:crypto";
 import { z } from "zod";
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 import { initSirenReadingList } from "../reading-list/siren-reading-list";
 
 /**
@@ -187,6 +188,7 @@ export async function runPdfSaveScenario(
 		onUnauthorized: async () => {
 			throw new Error("Unauthorized while running pdf-save scenario");
 		},
+		logger: HutchLogger.from(consoleLogger),
 	});
 
 	const saveResult = await saveUrl({

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { noopLogger } from "@packages/hutch-logger";
 import type { ReadingListItemId } from "../domain/reading-list-item.types";
 import { UnauthorizedError } from "../auth/unauthorized-error";
 import {
@@ -1018,7 +1019,7 @@ describe("save-html action", () => {
 	function createUnderstandingsWithSaveHtml() {
 		return groupOf(
 			initSaveArticleUnderstanding(),
-			initSaveHtmlUnderstanding(),
+			initSaveHtmlUnderstanding({ logger: noopLogger }),
 			initDeleteArticleUnderstanding(),
 			httpCacheable(initListArticlesUnderstanding()),
 		);
@@ -1439,7 +1440,7 @@ describe("save-content action", () => {
 	function createUnderstandingsWithSaveContent() {
 		return groupOf(
 			initSaveArticleUnderstanding(),
-			initSaveContentUnderstanding({ parsers: { "application/pdf": pdfContentBody, "text/html": htmlContentBody } }),
+			initSaveContentUnderstanding({ parsers: { "application/pdf": pdfContentBody, "text/html": htmlContentBody }, logger: noopLogger }),
 			initDeleteArticleUnderstanding(),
 			httpCacheable(initListArticlesUnderstanding()),
 		);
@@ -1786,6 +1787,7 @@ describe("initSirenReadingList capability negotiation", () => {
 			getAccessToken: async () => "test-token",
 			fetchFn,
 			onUnauthorized,
+			logger: noopLogger,
 		};
 	}
 
@@ -2191,6 +2193,7 @@ describe("initSirenReadingList", () => {
 			getAccessToken: async () => "test-token",
 			fetchFn,
 			onUnauthorized,
+			logger: noopLogger,
 		};
 	}
 
@@ -2994,6 +2997,7 @@ describe("initSirenReadingList", () => {
 				getAccessToken: async () => null,
 				fetchFn,
 				onUnauthorized: async () => {},
+				logger: noopLogger,
 			};
 			const list = initSirenReadingList(deps);
 			await expect(list.getAllItems()).rejects.toThrow(

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
@@ -1,9 +1,8 @@
 import "../zod-config";
 import { z } from "zod";
-import type {
-	ReadingListItem,
-	ReadingListItemId,
-} from "../domain/reading-list-item.types";
+import type { HutchLogger } from "@packages/hutch-logger";
+import type { ReadingListItem } from "../domain/reading-list-item.types";
+import { ReadingListItemIdSchema } from "../domain/reading-list-item-id";
 import { UnauthorizedError } from "../auth/unauthorized-error";
 import type {
 	FindByUrl,
@@ -38,7 +37,7 @@ class NotSaveableError extends Error {
 }
 
 const SirenPropertiesSchema = z.object({
-	id: z.string(),
+	id: ReadingListItemIdSchema,
 	url: z.string(),
 	title: z.string(),
 	savedAt: z.string(),
@@ -180,7 +179,7 @@ function toReadingListItem(
 	const props = SirenPropertiesSchema.parse(entity.properties);
 	const readHref = findLinkHref(entity, "read");
 	return {
-		id: props.id as ReadingListItemId,
+		id: props.id,
 		url: props.url,
 		title: props.title,
 		savedAt: new Date(props.savedAt),
@@ -233,7 +232,9 @@ export function initSaveArticleUnderstanding(): Map<string, ActionHandler> {
 	return handlers;
 }
 
-export function initSaveHtmlUnderstanding(): Map<string, ActionHandler> {
+export function initSaveHtmlUnderstanding(deps: {
+	logger: HutchLogger;
+}): Map<string, ActionHandler> {
 	const handlers = new Map<string, ActionHandler>();
 	handlers.set("save-html", (sirenAction, context) => {
 		return async (fields) => {
@@ -270,7 +271,7 @@ export function initSaveHtmlUnderstanding(): Map<string, ActionHandler> {
 					throw new Error(`Save failed: ${response.status}`);
 				}
 				const fallbackAction = errorActions[0];
-				console.warn(errorParsed.data.properties.message);
+				deps.logger.warn(errorParsed.data.properties.message);
 				const fallbackBody: Record<string, string> = { url: fields.url };
 				if (fields.title) fallbackBody.title = fields.title;
 				const fallbackContentType = fallbackAction.type === undefined
@@ -304,6 +305,7 @@ export function initSaveHtmlUnderstanding(): Map<string, ActionHandler> {
 
 export function initSaveContentUnderstanding(deps: {
 	parsers: Record<string, ContentBodyBuilder>;
+	logger: HutchLogger;
 }): Map<string, ActionHandler> {
 	const handlers = new Map<string, ActionHandler>();
 	handlers.set("save-content", (sirenAction, context) => {
@@ -340,7 +342,7 @@ export function initSaveContentUnderstanding(deps: {
 					throw new Error(`Save failed: ${response.status}`);
 				}
 				const fallbackAction = errorActions[0];
-				console.warn(errorParsed.data.properties.message);
+				deps.logger.warn(errorParsed.data.properties.message);
 				const fallbackBody: Record<string, string> = { url: input.url };
 				if (input.title) fallbackBody.title = input.title;
 				const fallbackContentType = fallbackAction.type === undefined
@@ -597,6 +599,7 @@ export interface SirenReadingListDeps {
 	getAccessToken: () => Promise<string | null>;
 	fetchFn: typeof fetch;
 	onUnauthorized: () => Promise<void>;
+	logger: HutchLogger;
 }
 
 export function initSirenReadingList(deps: SirenReadingListDeps): {
@@ -607,12 +610,13 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 } {
 	const understandings = groupOf(
 		initSaveArticleUnderstanding(),
-		initSaveHtmlUnderstanding(),
+		initSaveHtmlUnderstanding({ logger: deps.logger }),
 		initSaveContentUnderstanding({
 			parsers: {
 				"application/pdf": pdfContentBody,
 				"text/html": htmlContentBody,
 			},
+			logger: deps.logger,
 		}),
 		initDeleteArticleUnderstanding(),
 		httpCacheable(initListArticlesUnderstanding()),

--- a/projects/extensions/chrome-extension/src/e2e/tab-switch-flow/run.e2e-local.main.ts
+++ b/projects/extensions/chrome-extension/src/e2e/tab-switch-flow/run.e2e-local.main.ts
@@ -23,6 +23,7 @@ import {
 	createLoginActions,
 } from "browser-extension-core/e2e-actions";
 import { initSirenReadingList } from "browser-extension-core";
+import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
 
 const EXTENSION_DIR = path.resolve(__dirname, "../../../dist-extension-compiled");
 const CFT_PATH_FILE = path.resolve(__dirname, "../../../.cache/chrome/binary-path");
@@ -253,6 +254,7 @@ async function assertSavedContentIsPageA(): Promise<void> {
 		onUnauthorized: async () => {
 			throw new Error("Unauthorized while walking the saved queue");
 		},
+		logger: HutchLogger.from(consoleLogger),
 	});
 
 	const deadline = Date.now() + 60_000;

--- a/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
@@ -148,6 +148,7 @@ async function initCore() {
 		getAccessToken: auth.getAccessToken,
 		fetchFn: (...args) => fetch(...args),
 		onUnauthorized: auth.logout,
+		logger,
 	});
 
 	const core = BrowserExtensionCore(shell, { auth, logger, readingList });

--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -159,6 +159,7 @@ async function initCore() {
 		getAccessToken: auth.getAccessToken,
 		fetchFn: (...args) => fetch(...args),
 		onUnauthorized: auth.logout,
+		logger,
 	});
 
 	const core = BrowserExtensionCore(shell, { auth, logger, readingList });


### PR DESCRIPTION
## Audit findings — siren-reading-list (high)

**Source:** CLAUDE.md (Logging; No Default Noop Logger; Avoid `as`; Branded Types)
**File:** `projects/browser-extension-core/src/reading-list/siren-reading-list.ts`

1. **Raw `console.warn`** on the save-html and save-content fallback paths → replaced with an **injected, required** `HutchLogger` (no noop default in production). Threaded through `SirenReadingListDeps` and the two understanding factories; composition roots (chrome/firefox `background.browser.ts`) pass the logger already in scope, the two e2e drivers construct `HutchLogger.from(consoleLogger)`, and the unit tests pass `noopLogger`.
2. **`as ReadingListItemId`** → branded via Zod: a new `domain/reading-list-item-id.ts` owns `z.string().brand<"ReadingListItemId">()`; `SirenPropertiesSchema.id` parses into the branded type, so the cast is gone. `reading-list-item.types.ts` re-exports the inferred type (no circular import).

8 files (the module, the new id schema, the types re-export, the test, both extension composition roots, and two e2e drivers). `*.browser.ts`/`*.main.ts` are coverage-excluded; the library + tests keep 100% coverage.

🤖 Part of the guidelines & skills audit.
