### PR TITLE
refactor(hutch): partial-apply saveArticleFromUrl as initSaveArticleFromUrl

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -128,7 +128,7 @@ import { initMcpServer } from "./web/mcp/mcp-server";
 import { initMcpRoutes } from "./web/mcp/mcp.routes";
 import { buildMcpServerCard } from "./web/mcp/server-card";
 import { initResolveSaveAccess } from "./web/mcp/save-access";
-import { saveArticleFromUrl } from "./web/shared/save-article/save-article-from-url";
+import { initSaveArticleFromUrl } from "./web/shared/save-article/save-article-from-url";
 import type { FoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import { initDualAuth } from "./web/dual-auth.middleware";
 import { initMarkExtensionInstalled } from "./web/mark-extension-installed.middleware";
@@ -317,7 +317,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			}
 			try {
 				const freshness = await deps.refreshArticleIfStale({ url: validation.url });
-				const { saved } = await saveArticleFromUrl(deps, {
+				const { saved } = await initSaveArticleFromUrl(deps)({
 					userId,
 					url: validation.url,
 					freshness,

--- a/projects/hutch/src/runtime/web/pages/import/import.page.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.page.ts
@@ -17,7 +17,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import { Base } from "../../base.component";
 import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "@packages/web-shell";
-import { saveArticleFromUrl, type SaveArticleFromUrlDependencies } from "../../shared/save-article/save-article-from-url";
+import { initSaveArticleFromUrl, type SaveArticleFromUrlDependencies } from "../../shared/save-article/save-article-from-url";
 import type { AnalyticsEvent } from "../../middleware/analytics";
 import { hashIp } from "../../middleware/analytics";
 import { ANALYTICS_EVENTS, STREAMS } from "../../../observability/events";
@@ -278,7 +278,7 @@ export function initImportSessionRoutes(deps: ImportRouteDependencies): Router {
 				batch.map((url) =>
 					deps
 						.refreshArticleIfStale({ url })
-						.then((freshness) => saveArticleFromUrl(deps, { userId, url, freshness }))
+						.then((freshness) => initSaveArticleFromUrl(deps)({ userId, url, freshness }))
 						.catch((error: unknown) => {
 							deps.logError(
 								`Failed to import url=${url}`,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -53,7 +53,7 @@ import type { PollUrlBuilder } from "../../shared/article-reader/article-reader.
 import type { PublishLinkSaved } from "@packages/provider-contracts/events";
 import type { PublishSaveLinkRawHtmlCommand } from "@packages/provider-contracts/events";
 import type { PutPendingHtml } from "@packages/provider-contracts/pending-html";
-import { saveArticleFromUrl } from "../../shared/save-article/save-article-from-url";
+import { initSaveArticleFromUrl } from "../../shared/save-article/save-article-from-url";
 import { Base } from "../../base.component";
 import type { BuildBannerState } from "../../banner-state";
 import { sendComponent } from "@packages/web-shell";
@@ -225,6 +225,7 @@ const SAVE_INTENT_PATH = {
 
 export function initQueueRoutes(deps: QueueDependencies): Router {
 	const router = express.Router();
+	const saveArticleFromUrl = initSaveArticleFromUrl(deps);
 
 	/** Records a save-intent for an authenticated save surface. The save has
 	 * already happened (or failed) by the time this is called, so `outcome` is
@@ -482,7 +483,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 		try {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
-			const result = await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
+			const result = await saveArticleFromUrl({ userId, url: validation.url, freshness });
 			markExtensionSavedArticle(res);
 			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.saveArticle, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
@@ -567,7 +568,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 						`[SaveHtmlOversize] falling back to URL-only url=${urlOnlyValidation.url} userId=${userId} sizeBytes=${sizeBytes}`,
 					);
 					const freshness = await deps.refreshArticleIfStale({ url: urlOnlyValidation.url });
-					const result = await saveArticleFromUrl(deps, { userId, url: urlOnlyValidation.url, freshness });
+					const result = await saveArticleFromUrl({ userId, url: urlOnlyValidation.url, freshness });
 					markExtensionSavedArticle(res);
 					emitSaveIntent({ req, url: urlOnlyValidation.url, path: SAVE_INTENT_PATH.saveHtml, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 					res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
@@ -598,7 +599,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				title: parsed.data.title,
 			});
 
-			const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
+			const result = await saveArticleFromUrl({ userId, url: articleUrl, freshness });
 			markExtensionSavedArticle(res);
 			emitSaveIntent({ req, url: articleUrl, path: SAVE_INTENT_PATH.saveHtml, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 			res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
@@ -746,7 +747,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					return;
 				}
 
-				const result = await saveArticleFromUrl(deps, { userId, url: articleUrl, freshness });
+				const result = await saveArticleFromUrl({ userId, url: articleUrl, freshness });
 				markExtensionSavedArticle(res);
 				emitSaveIntent({ req, url: articleUrl, path: SAVE_INTENT_PATH.saveContent, surface: SAVE_SURFACES.extension, outcome: SAVE_OUTCOMES.saved });
 				res.status(201).type(SIREN_MEDIA_TYPE).json(toArticleEntity(result.saved));
@@ -787,7 +788,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 		try {
 			const freshness = await deps.refreshArticleIfStale({ url: validation.url });
-			await saveArticleFromUrl(deps, { userId, url: validation.url, freshness });
+			await saveArticleFromUrl({ userId, url: validation.url, freshness });
 			emitSaveIntent({ req, url: validation.url, path: SAVE_INTENT_PATH.save, surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.saved });
 			res.redirect(303, `${QUEUE_PATH}#latest-saved`);
 		} catch (error) {

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.test.ts
@@ -3,7 +3,7 @@ import { MinutesSchema } from "@packages/domain/article";
 import type { SavedArticle } from "@packages/domain/article";
 import { UserIdSchema } from "@packages/domain/user";
 import {
-	saveArticleFromUrl,
+	initSaveArticleFromUrl,
 	type SaveArticleFromUrlDependencies,
 } from "./save-article-from-url";
 
@@ -72,7 +72,7 @@ describe("saveArticleFromUrl", () => {
 	it("primes the crawl + summary pipeline on a 'new' freshness verdict", async () => {
 		const tracker = makeTracker();
 
-		await saveArticleFromUrl(tracker.deps, {
+		await initSaveArticleFromUrl(tracker.deps)({
 			userId,
 			url: exampleUrl,
 			freshness: { action: "new" },
@@ -90,7 +90,7 @@ describe("saveArticleFromUrl", () => {
 	it("publishes a link saved event when 'refreshed' has fresh content", async () => {
 		const tracker = makeTracker();
 
-		await saveArticleFromUrl(tracker.deps, {
+		await initSaveArticleFromUrl(tracker.deps)({
 			userId,
 			url: exampleUrl,
 			freshness: {
@@ -116,7 +116,7 @@ describe("saveArticleFromUrl", () => {
 	it("does not publish on 'refreshed' verdicts whose article has no content", async () => {
 		const tracker = makeTracker();
 
-		await saveArticleFromUrl(tracker.deps, {
+		await initSaveArticleFromUrl(tracker.deps)({
 			userId,
 			url: exampleUrl,
 			freshness: {
@@ -141,7 +141,7 @@ describe("saveArticleFromUrl", () => {
 	it("does not publish or re-prime on 'skip' or 'unchanged' verdicts", async () => {
 		const tracker = makeTracker();
 
-		await saveArticleFromUrl(tracker.deps, {
+		await initSaveArticleFromUrl(tracker.deps)({
 			userId,
 			url: exampleUrl,
 			freshness: { action: "skip" },
@@ -155,7 +155,7 @@ describe("saveArticleFromUrl", () => {
 		const previouslyRead = makeSaved({ status: "read", readAt: new Date() });
 		const tracker = makeTracker(previouslyRead);
 
-		const result = await saveArticleFromUrl(tracker.deps, {
+		const result = await initSaveArticleFromUrl(tracker.deps)({
 			userId,
 			url: exampleUrl,
 			freshness: { action: "new" },

--- a/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
+++ b/projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts
@@ -73,9 +73,12 @@ async function saveByFreshness(
 	return { saved: await markUnreadIfRead(deps.updateArticleStatus, saved) };
 }
 
-export function saveArticleFromUrl(
+export function initSaveArticleFromUrl(
 	deps: SaveArticleFromUrlDependencies,
-	params: { userId: UserId; url: SaveableUrl; freshness: ContentFreshnessResult },
-): Promise<{ saved: SavedArticle }> {
-	return saveByFreshness(deps, params);
+): (params: {
+	userId: UserId;
+	url: SaveableUrl;
+	freshness: ContentFreshnessResult;
+}) => Promise<{ saved: SavedArticle }> {
+	return (params) => saveByFreshness(deps, params);
 }


### PR DESCRIPTION
## Audit finding (medium) — Partial Application for Domain Functions

**Rule:** Domain functions with dependencies must use partial application (`init*` prefix)
**Source:** test-driven-design/SKILL.md
**File:** `projects/hutch/src/runtime/web/shared/save-article/save-article-from-url.ts`

`saveArticleFromUrl(deps, params)` mixed injected dependencies and per-call params in one positional signature, re-passing `deps` at every call site.

### Change
`initSaveArticleFromUrl(deps)` now returns `(params) => Promise<{ saved }>`.
- `initQueueRoutes` binds it once (`const saveArticleFromUrl = initSaveArticleFromUrl(deps)`); its 5 save paths call the bound function with just `params`.
- `server.ts` and `import.page.ts` call `initSaveArticleFromUrl(deps)({…})` at their single sites.
- The unit test binds `tracker.deps` the same way.

🤖 Part of the guidelines & skills audit.
