### PR TITLE
refactor(hutch): remove defaultValue escape hatch from requireEnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -44,6 +44,16 @@ export TRIAL_SCHEDULER_ROLE_ARN='arn:aws:iam::000000000000:role/hutch-trial-sche
 export ANALYTICS_SALT='local-dev-salt'
 export EXPIRY_COUNTDOWN='enabled'
 export FOUNDING_MEMBER_LIMIT='50'
+# Local-dev server port + app origin. In production these are required and set
+# by the Lambda environment / deploy; requireEnv no longer defaults them.
+export PORT='3000'
+export APP_ORIGIN='http://localhost:3000'
+# Rate-limit rules (requests/seconds). Production sets these on the Lambda; the
+# dev values match the historical requireEnv defaults.
+export RATE_LIMIT_VIEW_CRAWL='1000/3600'
+export RATE_LIMIT_LOGIN='1000/900'
+export RATE_LIMIT_SIGNUP='1000/3600'
+export RATE_LIMIT_FORGOT_PASSWORD='1000/3600'
 # Where hutch fetches the site-wide changelog banner fragment. Points at the
 # local blog-site dev server (`pnpm --filter blog-site dev`, port 3200). hutch
 # fails open if it's unreachable, so the app still runs without blog-site up.

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -277,6 +277,10 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 	environment: {
 		NODE_ENV: stage === "production" ? "production" : "development",
 		PERSISTENCE: "prod",
+		/** server.ts reads PORT at module load (it is imported transitively by the
+		 * Lambda handler via createHutchApp). requireEnv no longer defaults it, so
+		 * it must be present even though serverless-http does not bind a port. */
+		PORT: "3000",
 		APP_ORIGIN: appOrigin,
 		/** Same-origin fragment endpoint served by blog-site behind this same API
 		 * Gateway (/blog/{proxy+} routes there). The banner source is cached and

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -414,10 +414,10 @@ function initProviders() {
 	// so prod-strength per-IP limits would throttle a full e2e run.
 	const { consumeRateLimit } = initInMemoryRateLimit({ now: () => new Date() });
 	const rateLimitRules: RateLimitRules = {
-		viewCrawl: parseRateLimitRule(requireEnv("RATE_LIMIT_VIEW_CRAWL", { defaultValue: "1000/3600" })),
-		login: parseRateLimitRule(requireEnv("RATE_LIMIT_LOGIN", { defaultValue: "1000/900" })),
-		signup: parseRateLimitRule(requireEnv("RATE_LIMIT_SIGNUP", { defaultValue: "1000/3600" })),
-		forgotPassword: parseRateLimitRule(requireEnv("RATE_LIMIT_FORGOT_PASSWORD", { defaultValue: "1000/3600" })),
+		viewCrawl: parseRateLimitRule(requireEnv("RATE_LIMIT_VIEW_CRAWL")),
+		login: parseRateLimitRule(requireEnv("RATE_LIMIT_LOGIN")),
+		signup: parseRateLimitRule(requireEnv("RATE_LIMIT_SIGNUP")),
+		forgotPassword: parseRateLimitRule(requireEnv("RATE_LIMIT_FORGOT_PASSWORD")),
 	};
 
 	return {
@@ -480,7 +480,7 @@ export function createHutchApp(deps?: {
 }) {
 	const { auth, articleStore, oauthModel, validateAccessToken, importSessionStore, ...providers } = initProviders();
 
-	const appOrigin = deps?.appOrigin ?? requireEnv("APP_ORIGIN", { defaultValue: `http://localhost:${getEnv("PORT") || "3000"}` });
+	const appOrigin = deps?.appOrigin ?? requireEnv("APP_ORIGIN");
 	const staticBaseUrl = requireEnv("STATIC_BASE_URL");
 	const expiryCountdown = requireEnv<"enabled" | "disabled">("EXPIRY_COUNTDOWN");
 	const foundingMemberLimit = Number.parseInt(requireEnv("FOUNDING_MEMBER_LIMIT"), 10);

--- a/projects/hutch/src/runtime/domain/require-env.test.ts
+++ b/projects/hutch/src/runtime/domain/require-env.test.ts
@@ -16,11 +16,6 @@ describe("requireEnv", () => {
 		expect(requireEnv("TEST_VAR")).toBe("hello");
 	});
 
-	it("should return the default value when the environment variable is not set", () => {
-		delete process.env.MISSING_VAR;
-		expect(requireEnv("MISSING_VAR", { defaultValue: "fallback" })).toBe("fallback");
-	});
-
 	it("should throw when the environment variable is not set and no default provided", () => {
 		delete process.env.MISSING_VAR;
 		expect(() => requireEnv("MISSING_VAR")).toThrow(
@@ -31,11 +26,6 @@ describe("requireEnv", () => {
 	it("should return empty string when the environment variable is set to empty string", () => {
 		process.env.EMPTY_VAR = "";
 		expect(requireEnv("EMPTY_VAR")).toBe("");
-	});
-
-	it("should return empty string over default when the environment variable is set to empty string", () => {
-		process.env.EMPTY_VAR = "";
-		expect(requireEnv("EMPTY_VAR", { defaultValue: "fallback" })).toBe("");
 	});
 
 });

--- a/projects/hutch/src/runtime/domain/require-env.ts
+++ b/projects/hutch/src/runtime/domain/require-env.ts
@@ -1,11 +1,8 @@
 import assert from 'node:assert';
 
 // V8 coverage: Use const + arrow function to avoid function declaration coverage quirks - see https://github.com/jestjs/jest/issues/11188
-export const requireEnv = <T extends string = string>(name: string, options?: { defaultValue: T }): T => {
-  const defaultValue = options?.defaultValue;
+export const requireEnv = <T extends string = string>(name: string): T => {
   const value = process.env[name];
-  // Single-line conditional for accurate V8 coverage - see https://github.com/jestjs/jest/issues/11188
-  if (value === undefined && defaultValue !== undefined) return defaultValue;
   assert.ok(value !== undefined, `Environment variable ${name} is required but not set`);
   return value as T;
 };

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -157,7 +157,7 @@ import { requireNotLocked } from "./web/middleware/require-not-locked.middleware
 import { requireEnv, getEnv } from "./domain/require-env";
 import "./web/session.types";
 
-export const PORT = requireEnv("PORT", { defaultValue: "3000" });
+export const PORT = requireEnv("PORT");
 
 const noop = () => {};
 


### PR DESCRIPTION
## Audit finding (high) — Never default missing environment variables

**Rule:** Never default missing environment variables (no `requireEnv` defaultValue)
**Source:** CLAUDE.md
**File:** `projects/hutch/src/runtime/domain/require-env.ts`

`requireEnv(name, { defaultValue })` let a missing variable silently fall back to a default — the exact pattern the rule forbids ("let the process fail if a variable is not set").

### Change
- Removed the `defaultValue` option; `requireEnv(name)` now always asserts the variable is set.
- **Callers** that relied on a default now require the value:
  - `app.ts`: `RATE_LIMIT_*` (×4) and `APP_ORIGIN` — already provided by the Lambda `environment` block in `infra/index.ts` for production.
  - `server.ts`: `PORT`. Because `server.ts` reads `PORT` at module load and is imported by the web Lambda (via `createHutchApp`), **`PORT` is now also added to the Lambda `environment`** so the cold-start read succeeds (serverless-http binds no port, but the read must not throw).
- `.envrc` provides all six for local dev and the test run (the pre-commit hook sources `.envrc`), so route/unit tests that construct the app keep passing.
- `require-env.test.ts` drops the two tests that exercised the removed option.

### Production safety
Only the web Lambda (`lambda.main.ts → app.ts → server.ts`) loads these reads; the other handlers don't. `RATE_LIMIT_*`/`APP_ORIGIN` were already on its env; `PORT` is added here.

🤖 Part of the guidelines & skills audit.
