### PR TITLE
refactor(hutch): require emailVerified in the OAuth DynamoDB row schemas

### DIFF
--- a/projects/hutch/src/runtime/providers/oauth/dynamodb-oauth-model.ts
+++ b/projects/hutch/src/runtime/providers/oauth/dynamodb-oauth-model.ts
@@ -45,7 +45,7 @@ const TokenRow = z.object({
 	clientId: z.string(),
 	userId: z.string(),
 	scope: z.array(z.string()).optional(),
-	emailVerified: z.boolean(),
+	emailVerified: z.boolean().optional(),
 });
 
 const RefreshIndexRow = z.object({

--- a/projects/hutch/src/runtime/providers/oauth/dynamodb-oauth-model.ts
+++ b/projects/hutch/src/runtime/providers/oauth/dynamodb-oauth-model.ts
@@ -33,7 +33,7 @@ const AuthCodeRow = z.object({
 	codeChallenge: z.string(),
 	codeChallengeMethod: z.enum(["S256", "plain"]),
 	scope: z.array(z.string()).optional(),
-	emailVerified: z.boolean().optional(),
+	emailVerified: z.boolean(),
 });
 
 const TokenRow = z.object({
@@ -45,7 +45,7 @@ const TokenRow = z.object({
 	clientId: z.string(),
 	userId: z.string(),
 	scope: z.array(z.string()).optional(),
-	emailVerified: z.boolean().optional(),
+	emailVerified: z.boolean(),
 });
 
 const RefreshIndexRow = z.object({


### PR DESCRIPTION
## Audit finding (high) — Prefer Required Fields

**Rule:** Internal Contracts Are Not Versioned — Prefer Required Fields
**Source:** test-driven-design/SKILL.md, CLAUDE.md
**File:** `projects/hutch/src/runtime/providers/oauth/dynamodb-oauth-model.ts`

`AuthCodeRow.emailVerified` and `TokenRow.emailVerified` were `z.boolean().optional()`, but these are **internal** DynamoDB schemas: every producer writes a concrete boolean (`emailVerified: user.emailVerified === true`), and the rows are **TTL-expiring** (auth codes in minutes, tokens in hours/days), so no legacy row without the field survives.

### Change
Dropped `.optional()` from both — the schema now models the field as always present, matching reality and catching any future producer that forgets it.

### Scope note (separate, security-reviewed PR)
This file's other findings are **intentionally not** in this PR because they're security-sensitive and need new test coverage:
- the whole-file `/* c8 ignore */` over branching OAuth logic → remove it and write unit tests;
- production importing `getClient`/`generateToken` from `@packages/test-fixtures` → extract to a production module;
- the `refreshToken ?? ""` gate in `saveToken` → model the absent refresh token explicitly.

🤖 Part of the guidelines & skills audit.
