### PR TITLE
refactor(web-embed): serve the embed-builder script same-origin, not inline

### DIFF
--- a/projects/web-embed/src/runtime/embed/embed-client-script.ts
+++ b/projects/web-embed/src/runtime/embed/embed-client-script.ts
@@ -1,0 +1,46 @@
+/** Copy-to-clipboard + live PAGE_URL substitution for the embed builder page.
+ * Served same-origin at `/embed/embed.client.js` (see embed.page.ts) and
+ * referenced with `<script src>` rather than inlined, per the web skill's
+ * "Browser JS Is Bundled and Served Same-Origin" rule (inline scripts are a
+ * CSP liability). Kept as a self-executing IIFE string because web-embed has
+ * no client-TS bundler. */
+export const EMBED_CLIENT_JS = `(function() {
+  var buttons = document.querySelectorAll('[data-copy]');
+  for (var i = 0; i < buttons.length; i++) {
+    (function(btn) {
+      btn.addEventListener('click', function() {
+        var target = document.getElementById(btn.getAttribute('data-copy'));
+        if (!target) return;
+        navigator.clipboard.writeText(target.textContent || '').then(function() {
+          var original = btn.textContent;
+          btn.textContent = 'Copied';
+          setTimeout(function() { btn.textContent = original; }, 1500);
+        });
+      });
+    })(buttons[i]);
+  }
+
+  var snippetIds = ['snippet-a-code', 'snippet-b-code', 'snippet-c-code'];
+  var originals = {};
+  for (var i = 0; i < snippetIds.length; i++) {
+    var el = document.getElementById(snippetIds[i]);
+    if (el) originals[snippetIds[i]] = el.textContent;
+  }
+
+  var urlInput = document.querySelector('.embed-url-input__field');
+  if (urlInput) {
+    urlInput.addEventListener('input', function() {
+      var url = urlInput.value.trim();
+      for (var id in originals) {
+        var el = document.getElementById(id);
+        if (!el) continue;
+        if (url) {
+          el.textContent = originals[id].replace('PAGE_URL', encodeURIComponent(url));
+        } else {
+          el.textContent = originals[id];
+        }
+      }
+    });
+  }
+})();
+`;

--- a/projects/web-embed/src/runtime/embed/embed.component.ts
+++ b/projects/web-embed/src/runtime/embed/embed.component.ts
@@ -9,48 +9,6 @@ import { byteLength, renderCanonicalSnippet, renderSnippet } from "./snippet.com
 
 const EMBED_TEMPLATE = readFileSync(join(__dirname, "embed.template.html"), "utf-8");
 
-const COPY_SCRIPT = `<script>
-(function() {
-  var buttons = document.querySelectorAll('[data-copy]');
-  for (var i = 0; i < buttons.length; i++) {
-    (function(btn) {
-      btn.addEventListener('click', function() {
-        var target = document.getElementById(btn.getAttribute('data-copy'));
-        if (!target) return;
-        navigator.clipboard.writeText(target.textContent || '').then(function() {
-          var original = btn.textContent;
-          btn.textContent = 'Copied';
-          setTimeout(function() { btn.textContent = original; }, 1500);
-        });
-      });
-    })(buttons[i]);
-  }
-
-  var snippetIds = ['snippet-a-code', 'snippet-b-code', 'snippet-c-code'];
-  var originals = {};
-  for (var i = 0; i < snippetIds.length; i++) {
-    var el = document.getElementById(snippetIds[i]);
-    if (el) originals[snippetIds[i]] = el.textContent;
-  }
-
-  var urlInput = document.querySelector('.embed-url-input__field');
-  if (urlInput) {
-    urlInput.addEventListener('input', function() {
-      var url = urlInput.value.trim();
-      for (var id in originals) {
-        var el = document.getElementById(id);
-        if (!el) continue;
-        if (url) {
-          el.textContent = originals[id].replace('PAGE_URL', encodeURIComponent(url));
-        } else {
-          el.textContent = originals[id];
-        }
-      }
-    });
-  }
-})();
-</script>`;
-
 const CANONICAL_EMBED_ORIGIN = "https://readplace.com/embed";
 
 export interface EmbedPageInput {
@@ -91,7 +49,7 @@ export function EmbedPage(input: EmbedPageInput): Component {
 		pageStyles: EMBED_PAGE_STYLES,
 		bodyClass: "page-embed",
 		content,
-		scripts: COPY_SCRIPT,
+		scripts: `<script src="${input.embedOrigin}/embed.client.js" defer></script>`,
 		appOrigin: input.appOrigin,
 	});
 }

--- a/projects/web-embed/src/runtime/embed/embed.page.ts
+++ b/projects/web-embed/src/runtime/embed/embed.page.ts
@@ -4,6 +4,7 @@ import { sendComponent } from "@packages/web-shell";
 import { EmbedPage } from "./embed.component";
 import { PreviewPage } from "./preview.component";
 import { EMBED_ICON_SVG } from "./icon";
+import { EMBED_CLIENT_JS } from "./embed-client-script";
 
 export function initEmbedRoutes(deps: { appOrigin: string }): Router {
 	const embedOrigin = `${deps.appOrigin}/embed`;
@@ -30,6 +31,13 @@ export function initEmbedRoutes(deps: { appOrigin: string }): Router {
 			.type("image/svg+xml")
 			.set("Cache-Control", "public, max-age=31536000, immutable")
 			.send(EMBED_ICON_SVG);
+	});
+
+	router.get("/embed.client.js", (_req, res) => {
+		res
+			.type("text/javascript")
+			.set("Cache-Control", "public, max-age=31536000, immutable")
+			.send(EMBED_CLIENT_JS);
 	});
 
 	return router;

--- a/projects/web-embed/src/runtime/embed/embed.page.ts
+++ b/projects/web-embed/src/runtime/embed/embed.page.ts
@@ -34,9 +34,14 @@ export function initEmbedRoutes(deps: { appOrigin: string }): Router {
 	});
 
 	router.get("/embed.client.js", (_req, res) => {
+		/** Revalidate, don't cache immutably: the page HTML is rendered fresh per
+		 * request and the script depends on its IDs/classes, so a stale-but-valid
+		 * copy would desync from the markup. The weak ETag res.send() emits keeps
+		 * returning visitors on cheap 304s. icon.svg stays immutable because it is
+		 * a canonical, content-stable URL embedded across the web. */
 		res
 			.type("text/javascript")
-			.set("Cache-Control", "public, max-age=31536000, immutable")
+			.set("Cache-Control", "public, max-age=0, must-revalidate")
 			.send(EMBED_CLIENT_JS);
 	});
 

--- a/projects/web-embed/src/runtime/embed/embed.route.test.ts
+++ b/projects/web-embed/src/runtime/embed/embed.route.test.ts
@@ -127,6 +127,11 @@ describe("GET /embed", () => {
 		expect(response.text).toContain("navigator.clipboard");
 	});
 
+	it("should serve the copy-to-clipboard script with a revalidating cache so it can never go stale against the per-request HTML", async () => {
+		const response = await request(makeServer()).get("/embed/embed.client.js");
+		expect(response.headers["cache-control"]).toBe("public, max-age=0, must-revalidate");
+	});
+
 	it("should register / with the default indexable robots directive", async () => {
 		const response = await request(makeServer()).get("/embed");
 		const doc = new JSDOM(response.text).window.document;

--- a/projects/web-embed/src/runtime/embed/embed.route.test.ts
+++ b/projects/web-embed/src/runtime/embed/embed.route.test.ts
@@ -112,8 +112,18 @@ describe("GET /embed", () => {
 		expect(doc.querySelectorAll("button[data-copy]")).toHaveLength(4);
 	});
 
-	it("should include the copy-to-clipboard inline script", async () => {
+	it("should reference the copy-to-clipboard script same-origin, not inline", async () => {
 		const response = await request(makeServer()).get("/embed");
+		const doc = new JSDOM(response.text).window.document;
+		const script = doc.querySelector('script[src$="/embed/embed.client.js"]');
+		expect(script).not.toBeNull();
+		expect(response.text).not.toContain("navigator.clipboard");
+	});
+
+	it("should serve the copy-to-clipboard script same-origin as JavaScript", async () => {
+		const response = await request(makeServer()).get("/embed/embed.client.js");
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toContain("text/javascript");
 		expect(response.text).toContain("navigator.clipboard");
 	});
 


### PR DESCRIPTION
## Audit finding (high) — Browser JS must be served same-origin, not inlined

**Rule:** Browser JS Is Bundled and Served Same-Origin
**Source:** web/SKILL.md
**File:** `projects/web-embed/src/runtime/embed/embed.component.ts`

The embed-builder page injected its copy-to-clipboard + live `PAGE_URL` substitution behaviour as an **inline `<script>`** — a CSP liability the skill forbids.

### Change
- Moved the IIFE into `embed-client-script.ts` (`EMBED_CLIENT_JS`).
- Serve it at **`/embed/embed.client.js`** — the same `router.get(...).type(...).send(...)` pattern web-embed already uses for `/embed/icon.svg`.
- The page now references it with `<script src="…/embed/embed.client.js" defer>` instead of inlining.

web-embed has no client-TS bundler, so the script stays a self-executing string served as a static **same-origin** asset (the rule's core concern — no inline script).

### Tests
Replaced the "inline script" assertion with one that confirms the page references the same-origin script and contains **no** inline `navigator.clipboard`; added a test that `GET /embed/embed.client.js` returns the JS as `text/javascript`.

🤖 Part of the guidelines & skills audit.
