### PR TITLE
test(google-auth): remove `as` casts in google-token test

### DIFF
--- a/projects/hutch/src/runtime/providers/google-auth/google-token.test.ts
+++ b/projects/hutch/src/runtime/providers/google-auth/google-token.test.ts
@@ -37,14 +37,16 @@ describe("initExchangeGoogleCode", () => {
 
 		assert.equal(receivedUrl, "https://oauth2.googleapis.com/token");
 		assert.equal(receivedInit?.method, "POST");
-		const headers = receivedInit?.headers as Record<string, string>;
-		assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
-		const body = new URLSearchParams(receivedInit?.body as string);
-		assert.equal(body.get("code"), "auth-code-789");
-		assert.equal(body.get("client_id"), "client-id-123");
-		assert.equal(body.get("client_secret"), "client-secret-456");
-		assert.equal(body.get("redirect_uri"), "https://app.test/auth/google/callback");
-		assert.equal(body.get("grant_type"), "authorization_code");
+		const headers = new Headers(receivedInit?.headers);
+		assert.equal(headers.get("Content-Type"), "application/x-www-form-urlencoded");
+		const body = receivedInit?.body;
+		assert(typeof body === "string");
+		const params = new URLSearchParams(body);
+		assert.equal(params.get("code"), "auth-code-789");
+		assert.equal(params.get("client_id"), "client-id-123");
+		assert.equal(params.get("client_secret"), "client-secret-456");
+		assert.equal(params.get("redirect_uri"), "https://app.test/auth/google/callback");
+		assert.equal(params.get("grant_type"), "authorization_code");
 	});
 
 	it("decodes the id_token payload into the branded google identity", async () => {


### PR DESCRIPTION
## What

Removes the two `as` type assertions in `google-token.test.ts`:

- Headers are now read via `new Headers(receivedInit?.headers).get(...)` instead of casting to `Record<string, string>`.
- The request body is narrowed to a string with `const body = receivedInit?.body; assert(typeof body === "string");` before constructing `new URLSearchParams(body)`, instead of casting with `as string`.

The `URLSearchParams` instance was renamed to `params` (since `body` now holds the raw string) and the assertions updated accordingly.

## Why

Aligns with the coding-style guideline to avoid TypeScript type assertions (`as`), which bypass the compiler and hide upstream type mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U68totrNr7E3436peEpavP

---
_Generated by [Claude Code](https://claude.ai/code/session_01U68totrNr7E3436peEpavP)_