### PR TITLE
refactor(password-reset): assert prior item on conditional delete

### DIFF
--- a/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.test.ts
+++ b/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.test.ts
@@ -92,18 +92,6 @@ describe("initDynamoDbPasswordReset", () => {
 			});
 		});
 
-		it("rejects when the delete returns no prior attributes", async () => {
-			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
-				email: "user@example.com",
-			});
-			const { client } = createFakeClient({});
-
-			expect(await initStore(client).verifyPasswordResetToken(token)).toEqual({
-				ok: false,
-				reason: "invalid-token",
-			});
-		});
-
 		it("rejects when the attribute_exists condition fails (token already consumed or absent)", async () => {
 			const token = await initStore(createFakeClient({}).client).createPasswordResetToken({
 				email: "user@example.com",

--- a/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.ts
+++ b/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { randomBytes } from "node:crypto";
 import {
 	ConditionalCheckFailedException,
@@ -50,9 +51,7 @@ export function initDynamoDbPasswordReset(deps: {
 				ReturnValues: "ALL_OLD",
 			});
 
-			if (!Attributes) {
-				return { ok: false, reason: "invalid-token" };
-			}
+			assert(Attributes, "a conditional delete with ReturnValues ALL_OLD always returns the prior item");
 
 			if (Attributes.expiresAt < Math.floor(Date.now() / 1000)) {
 				return { ok: false, reason: "invalid-token" };


### PR DESCRIPTION
## Summary

In `verifyPasswordResetToken`, the delete uses `ConditionExpression: attribute_exists(#tk)` with `ReturnValues: "ALL_OLD"`. When the token is missing, DynamoDB throws `ConditionalCheckFailedException` (already handled in the catch block). When the condition passes, a delete with `ALL_OLD` always returns the prior item — so the `if (!Attributes)` branch was unreachable.

- Replace the unreachable `if (!Attributes)` branch with `assert(Attributes, "a conditional delete with ReturnValues ALL_OLD always returns the prior item")`.
- Remove the now-dead "rejects when the delete returns no prior attributes" test.

## Verification

`pnpm nx run hutch:check` passes with all coverage thresholds met (100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LefvWdGfpcZKsZGPSgwNPF)_