### PR TITLE
refactor(provider-contracts): make GoogleIdSchema single source of truth for GoogleId

### DIFF
--- a/src/packages/provider-contracts/src/google-auth.ts
+++ b/src/packages/provider-contracts/src/google-auth.ts
@@ -1,9 +1,8 @@
 import { z } from "zod";
-import type { $brand } from "zod";
-
-export type GoogleId = string & $brand<"GoogleId">;
 
 export const GoogleIdSchema = z.string().brand<"GoogleId">();
+
+export type GoogleId = z.infer<typeof GoogleIdSchema>;
 
 export interface GoogleTokenResult {
 	googleId: GoogleId;


### PR DESCRIPTION
Make `GoogleIdSchema` the single source of truth for the `GoogleId` type in `src/packages/provider-contracts/src/google-auth.ts`.

- Derive `GoogleId` from the schema via `z.infer<typeof GoogleIdSchema>` (placed after the const) instead of the hand-written `string & $brand<"GoogleId">`.
- Remove the now-unused `import type { $brand } from "zod"`.

The branded type is semantically identical, but now there's no risk of the type and schema drifting apart.

Verified with `pnpm nx run provider-contracts:check` (tsc, biome, knip all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rjfy643rZwgyFNvUKi8uMw)_