### PR TITLE
test(password-reset): assert ConditionExpression with toContain

### DIFF
--- a/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.test.ts
+++ b/projects/hutch/src/runtime/providers/password-reset/dynamodb-password-reset.test.ts
@@ -73,7 +73,7 @@ describe("initDynamoDbPasswordReset", () => {
 			expect(result).toEqual({ ok: true, email: "user@example.com" });
 			const del = commands.find((c) => c.name === "DeleteCommand");
 			expect(del?.input.Key).toEqual({ token });
-			expect(del?.input.ConditionExpression).toBe("attribute_exists(#tk)");
+			expect(del?.input.ConditionExpression).toContain("attribute_exists(#tk)");
 			expect(del?.input.ReturnValues).toBe("ALL_OLD");
 		});
 


### PR DESCRIPTION
## Summary

Changes the `ConditionExpression` assertion in `dynamodb-password-reset.test.ts:76` from `toBe` to `toContain`, per the test-driven-design skill.

Matching the substring `"attribute_exists(#tk)"` rather than asserting exact string equality keeps the test robust if additional condition clauses are appended to the expression, while still verifying the key invariant (the delete is guarded by the token's existence).

## Verification

- `pnpm nx run hutch:check` passes (lint, type-check, tests, coverage thresholds met).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123yxjNrC5J8DNe6jJctBRe)_