### PR TITLE
fix(oauth): build deny-path error redirect with URL API

### DIFF
--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -188,6 +188,46 @@ describe("OAuth routes", () => {
 			expect(response.headers.location).toContain("state=test-state-123");
 		});
 
+		it("appends error to a registered redirect_uri that already has a query string", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({
+				email: "test@example.com",
+				password: "password123",
+			});
+
+			const registration = await request(harness.server)
+				.post("/oauth/register")
+				.send({ redirect_uris: ["https://app.example.com/cb?tenant=acme"] });
+			expect(registration.status).toBe(201);
+			const dynamicClientId = registration.body.client_id;
+
+			const agent = request.agent(harness.server);
+			await agent.post("/login").type("form").send({
+				email: "test@example.com",
+				password: "password123",
+			});
+
+			const response = await agent
+				.post("/oauth/authorize")
+				.type("form")
+				.send({
+					client_id: dynamicClientId,
+					redirect_uri: "https://app.example.com/cb?tenant=acme",
+					response_type: "code",
+					code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+					code_challenge_method: "S256",
+					state: "test-state-123",
+					action: "deny",
+				});
+
+			expect(response.status).toBe(302);
+			const location = new URL(response.headers.location);
+			expect(location.searchParams.get("tenant")).toBe("acme");
+			expect(location.searchParams.get("error")).toBe("access_denied");
+			expect(location.searchParams.get("state")).toBe("test-state-123");
+			expect(response.headers.location).not.toContain("?tenant=acme?");
+		});
+
 		it("approves authorization and redirects with code", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const pkce = generatePKCE();

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -235,8 +235,12 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 					return;
 				}
 
-				const errorUrl = `${redirect_uri}?error=access_denied${state ? `&state=${encodeURIComponent(state)}` : ""}`;
-				res.redirect(302, errorUrl);
+				const errorUrl = new URL(redirect_uri);
+				errorUrl.searchParams.set("error", "access_denied");
+				if (state) {
+					errorUrl.searchParams.set("state", state);
+				}
+				res.redirect(302, errorUrl.toString());
 				return;
 			}
 


### PR DESCRIPTION
## Problem

The deny-path error redirect in `oauth.routes.ts` was built by string concatenation with an unconditional `?`:

```ts
const errorUrl = `${redirect_uri}?error=access_denied${state ? `&state=${encodeURIComponent(state)}` : ""}`;
```

Dynamic client registration (DCR) now lets an agent register an `https` `redirect_uri` that already contains a query string — the registration validator (`isAllowedDynamicRedirectUri`) only checks scheme/host, not the absence of a query. For such a client, the deny redirect produced a malformed URL with two `?` separators:

```
https://app.example.com/cb?tenant=acme?error=access_denied&state=...
```

The second `?` makes `error`/`state` part of the previous parameter's value, so the client cannot parse the OAuth error response.

## Fix

Build the redirect with the `URL`/`URLSearchParams` API so existing query parameters are preserved and the error/state params are appended with the correct separator:

```ts
const errorUrl = new URL(redirect_uri);
errorUrl.searchParams.set("error", "access_denied");
if (state) {
	errorUrl.searchParams.set("state", state);
}
res.redirect(302, errorUrl.toString());
```

## Test

Added a deny-path test that registers a dynamic client whose `redirect_uri` already contains `?tenant=acme`, denies authorization, and asserts the location parses cleanly — `tenant`, `error`, and `state` are all present and there is no `?tenant=acme?` double-separator.

`pnpm nx run hutch:check` passes (100% coverage maintained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6CJ2AzqgU5taoMtjho3Yo)_