### PR TITLE
refactor(check-failed-articles): use const+arrow form for requireEnv

### DIFF
--- a/src/packages/check-failed-articles/scripts/require-env.ts
+++ b/src/packages/check-failed-articles/scripts/require-env.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
 
-export function requireEnv<T extends string = string>(name: string): T {
+export const requireEnv = <T extends string = string>(name: string): T => {
 	const value = process.env[name];
 	assert.ok(value !== undefined, `Environment variable ${name} is required but not set`);
 	return value as T;
-}
+};
 
 export function getEnv(name: string): string | undefined {
 	const value = process.env[name];


### PR DESCRIPTION
## Summary

Converts `requireEnv` in `src/packages/check-failed-articles/scripts/require-env.ts` from a function declaration to the canonical `const` + arrow form, so it matches the sibling `require-env.ts` copies in `projects/hutch` and `projects/blog-site`.

This is optional polish. The package does not enforce coverage, so the V8 arrow-const coverage motivation does not apply here — the change is purely for consistency with the sibling copies, and no explanatory comment is added.

`getEnv` is left unchanged. The export name is unchanged, so named imports are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7XsiKWa44yFyfHTp1RtJX)_