### PR TITLE
docs(queue-card): clarify thumbnail onload reveals all thumbnails

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
@@ -1,5 +1,5 @@
 <div class="queue-article{{unreadClass}}" data-test-article="{{id}}"{{#if isFirst}} id="latest-saved"{{/if}}{{#if cardPollUrl}} hx-get="{{cardPollUrl}}" hx-trigger="every 3s" hx-target="this" hx-swap="outerHTML"{{/if}} data-card-status="{{cardStatus}}">
-	{{!-- onerror/onload defend against legacy DynamoDB rows whose imageUrl points at an external host that can 404 over time; a broken image removes its container instead of showing a placeholder. New saves use the S3-only thumbnail path in @packages/crawl-article. --}}
+	{{!-- The thumbnail link is display:none until onload adds --loaded (queue.styles.css), so onload is the reveal-on-load for every thumbnail, including S3 saves — removing it hides all thumbnails. onerror is the 404 safety net for legacy DynamoDB rows whose imageUrl points at an external host that can rot over time: a broken image removes its container instead of showing a placeholder. New saves use the S3-only thumbnail path in @packages/crawl-article. --}}
 	{{#if imageUrl}}<a href="{{linkUrl}}" class="queue-article__thumbnail-link" tabindex="-1" aria-hidden="true"><img class="queue-article__thumbnail" src="{{imageUrl}}" alt="" onload="this.parentElement.classList.add('queue-article__thumbnail-link--loaded')" onerror="this.parentElement.remove()"></a>{{/if}}
 	<div class="queue-article__content">
 		<div class="queue-article__title-row">


### PR DESCRIPTION
## Summary

Rewords the misleading Handlebars comment on the thumbnail `<img>` in `queue-card.template.html`.

The old comment framed both `onerror` and `onload` as a defense against legacy DynamoDB rows. But `.queue-article__thumbnail-link` is `display:none` by default (`queue.styles.css`), and `onload` adds the `--loaded` class that flips it to `display:block`. So `onload` is the **reveal-on-load mechanism for every thumbnail — including the S3 path**, not a legacy-row defense. A future maintainer reading the old comment might delete `onload` and unintentionally hide every thumbnail.

## Change

The reworded comment now distinguishes the two handlers:
- **`onload`** — reveals the otherwise-hidden thumbnail link for all saves (including S3); removing it hides every thumbnail.
- **`onerror`** — the 404 safety net for legacy external `imageUrl`s that can rot over time.

No behaviour change; comment only. Kept free of plan-bound/time-bound language per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kasNjV3EaDfn8ZZRp5Wq7

---
_Generated by [Claude Code](https://claude.ai/code/session_016kasNjV3EaDfn8ZZRp5Wq7)_