### PR TITLE
perf(onboarding): lazy-load founder avatar so hidden onboarding skips the request

### DIFF
--- a/projects/hutch/src/runtime/web/onboarding/onboarding.template.html
+++ b/projects/hutch/src/runtime/web/onboarding/onboarding.template.html
@@ -4,13 +4,13 @@
     <form method="POST" action="/queue/dismiss-onboarding" class="onboarding__dismiss-form">
       <button type="submit" class="onboarding__dismiss" aria-label="Dismiss" data-test-onboarding-dismiss>&times;</button>
     </form>
-    <img class="onboarding__avatar" src="{{founderAvatarUrl}}" alt="Fayner Brack" width="72" height="72">
+    <img class="onboarding__avatar" src="{{founderAvatarUrl}}" alt="Fayner Brack" width="72" height="72" loading="lazy">
     <h2 class="onboarding__success-title">You did it! ✅</h2>
     <p class="onboarding__success-message">You're officially one of us. Welcome to Readplace.</p>
   </div>
   {{else}}
   <header class="onboarding__intro">
-    <img class="onboarding__avatar" src="{{founderAvatarUrl}}" alt="Fayner Brack" width="72" height="72">
+    <img class="onboarding__avatar" src="{{founderAvatarUrl}}" alt="Fayner Brack" width="72" height="72" loading="lazy">
     <div class="onboarding__intro-text">
       <h2 class="onboarding__title">Hi, I'm Fayner Brack!</h2>
       <p class="onboarding__lede">I built Readplace from my reading system so you could also save articles and actually read them later. Here are a few small things to set you up.</p>


### PR DESCRIPTION
## What

Add `loading="lazy"` to both `onboarding__avatar` `<img>` tags in `onboarding.template.html`.

## Why

For dismissed users the onboarding container is rendered with `display:none`. Eager image loading still fetched the founder avatar even though it is never visible. With `loading="lazy"`, the browser defers (and skips) the request while the container is hidden.

Both avatar instances are covered:
- the `onboarding__success` variant (`{{#if allComplete}}`)
- the `onboarding__intro` variant (`{{else}}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHNwW1S8CDoYdxpQc19Mtf)_