### PR TITLE
refactor(hutch): unify fake-client helpers in generated-summary test

### DIFF
--- a/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.test.ts
+++ b/projects/hutch/src/runtime/providers/article-summary/dynamodb-generated-summary.test.ts
@@ -6,13 +6,6 @@ import { initDynamoDbGeneratedSummary } from "./dynamodb-generated-summary";
 
 type SendFn = DynamoDBDocumentClient["send"];
 
-function createFakeClient(item: Record<string, unknown> | undefined): DynamoDBDocumentClient {
-	const fake: Partial<DynamoDBDocumentClient> = {
-		send: async () => ({ Item: item }),
-	};
-	return fake as Partial<DynamoDBDocumentClient> as DynamoDBDocumentClient;
-}
-
 function createSendingClient(
 	impl: (input: unknown) => unknown,
 ): DynamoDBDocumentClient {
@@ -20,6 +13,10 @@ function createSendingClient(
 		send: (async (input: unknown) => impl(input)) as unknown as SendFn,
 	} as Partial<DynamoDBDocumentClient> as DynamoDBDocumentClient;
 }
+
+const createFakeClient = (
+	item: Record<string, unknown> | undefined,
+): DynamoDBDocumentClient => createSendingClient(() => ({ Item: item }));
 
 describe("initDynamoDbGeneratedSummary", () => {
 	it("returns undefined when no row exists", async () => {


### PR DESCRIPTION
## Summary

Unifies the two fake-client helpers in `dynamodb-generated-summary.test.ts` so there is a single place that constructs a faked `DynamoDBDocumentClient`.

- `createSendingClient(impl)` is kept as the one helper that performs the `as Partial<DynamoDBDocumentClient> as DynamoDBDocumentClient` cast.
- `createFakeClient(item)` is redefined to delegate to it: `const createFakeClient = (item) => createSendingClient(() => ({ Item: item }))`.

This removes the duplicated cast that previously lived in both helpers and mirrors the `clientReturning` / `createFakeClient` split already used in the sibling `dynamodb-article-crawl.test.ts`.

## Testing

- `jest` over the compiled `dynamodb-generated-summary.test.js`: 15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bx2jvvsEfCe5VvVaZh4zYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx2jvvsEfCe5VvVaZh4zYV)_