### PR TITLE
test(queue): assert title link target instead of existence in url-absence test

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -203,7 +203,9 @@ describe("Queue routes", () => {
 			const doc = new JSDOM(response.text).window.document;
 			const card = doc.querySelector("[data-test-article-list] .queue-article");
 			assert(card, "the saved article card must be rendered");
-			expect(card.querySelector("[data-test-article-title]")).not.toBeNull();
+			const titleLink = card.querySelector("[data-test-article-title]");
+			assert(titleLink, "the title link element must always be rendered");
+			expect(titleLink.getAttribute("href")).toContain("/view");
 			const urlLink = card.querySelector("[data-test-article-url]");
 			assert(urlLink, "the url link element must always be rendered");
 			expect(urlLink.classList.contains("queue-article__url--empty")).toBe(true);


### PR DESCRIPTION
## What

In `queue.listing.route.test.ts` ("should hide the URL link when siteName is empty"), replace the existence-only check `expect(card.querySelector("[data-test-article-title]")).not.toBeNull()` with a behaviour assertion: the title link renders and its `href` targets the article view route (`/view`).

## Why

The test-driven-design skill discourages existence-only `.not.toBeNull()` assertions in favour of asserting actual behaviour.

The original task suggested asserting the title *text* is non-empty (`textContent.trim().length > 0`). That can't pass in this fixture: the test stubs `refreshArticleIfStale` to return `{ action: "skip" }`, and `save-article-from-url.ts` stub-saves the skip/refreshed branch with `metadata: { title: "", siteName: "", … }` — only the `"new"` branch fills in a hostname-derived title. So the title text is intentionally empty here.

The title element's meaningful behaviour in this scenario is that it still renders as a clickable link to the article, so the assertion now checks the link target instead of its (empty) text. The test's primary focus — that an empty `siteName` hides the URL link via `queue-article__url--empty` — is unchanged.

## Verification

`pnpm nx run hutch:check` passes (lint, type-check, tests, coverage, knip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnifbaZoGApVXkxHPZhjEs)_