### PR TITLE
test: use UserIdSchema.parse for USER fixture in email verification test

### DIFF
--- a/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
+++ b/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
@@ -1,9 +1,9 @@
 import { ConditionalCheckFailedException, type DynamoDBDocumentClient } from "@packages/hutch-storage-client";
-import type { UserId } from "@packages/domain/user";
+import { UserIdSchema } from "@packages/domain/user";
 import { VerificationTokenSchema } from "@packages/test-fixtures/providers/email-verification";
 import { initDynamoDbEmailVerification } from "./dynamodb-email-verification";
 
-const USER = "abc123" as UserId;
+const USER = UserIdSchema.parse("abc123");
 const TOKEN = VerificationTokenSchema.parse("a".repeat(64));
 
 interface CapturedCommand {


### PR DESCRIPTION
Replaces the `as UserId` type assertion with the validated factory `UserIdSchema.parse("abc123")` in `dynamodb-email-verification.test.ts`, mirroring how `TOKEN` uses `VerificationTokenSchema.parse` on the line below. The unused `import type { UserId }` is swapped for the `UserIdSchema` value import.

This removes a TypeScript type assertion in line with the "Avoid TypeScript Type Assertions (`as`)" guideline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mm2drV3Ldev9WKSsRcy8bk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm2drV3Ldev9WKSsRcy8bk)_