### PR TITLE
test(email-verification): assert TTL is a future unix timestamp

### DIFF
--- a/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
+++ b/projects/hutch/src/runtime/providers/email-verification/dynamodb-email-verification.test.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { ConditionalCheckFailedException, type DynamoDBDocumentClient } from "@packages/hutch-storage-client";
 import type { UserId } from "@packages/domain/user";
 import { VerificationTokenSchema } from "@packages/test-fixtures/providers/email-verification";
@@ -62,7 +63,8 @@ describe("initDynamoDbEmailVerification", () => {
 			expect(token).toMatch(/^[0-9a-f]{64}$/);
 			const put = commands.find((c) => c.name === "PutCommand");
 			expect(put?.input.Item).toMatchObject({ token, userId: USER, email: "user@example.com" });
-			expect(put?.input.Item).toHaveProperty("expiresAt");
+			const { expiresAt } = z.object({ expiresAt: z.number() }).parse(put?.input.Item);
+			expect(expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
 		});
 	});
 


### PR DESCRIPTION
## What

Strengthen the `createVerificationToken` test in `dynamodb-email-verification.test.ts` from an existence-only check on `expiresAt` to a value assertion that the TTL is a **future** unix timestamp.

## Why

`expect(put?.input.Item).toHaveProperty("expiresAt")` only confirmed the field is present — it would still pass if the provider wrote a past or zero TTL, which would silently expire every verification link immediately. Asserting `expiresAt > now` actually exercises the TTL contract.

## Notes

The captured command `input` is typed `Record<string, unknown>`, so the suggested `put?.input.Item?.expiresAt` doesn't type-check. The boundary value is validated through a small `z.object({ expiresAt: z.number() })` parse to obtain a typed number, matching the repo's "no `as`" / zod-at-boundaries conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAED8yfCx5zuFXFxPe635t)_