### PR TITLE
feat(mcp): add article read tools, keep status/delete app-only

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -131,6 +131,7 @@ import { initExportRoutes } from "./web/pages/export/export.page";
 import { initAccountRoutes } from "./web/pages/account/account.page";
 import { initAgentSkills } from "./web/agent-skills/agent-skills";
 import { initMcpServer } from "./web/mcp/mcp-server";
+import { initMcpArticleOperations } from "./web/mcp/article-operations";
 import { initMcpRoutes } from "./web/mcp/mcp.routes";
 import { buildMcpServerCard } from "./web/mcp/server-card";
 import { initResolveSaveAccess } from "./web/mcp/save-access";
@@ -341,21 +342,12 @@ export function createApp(dependencies: AppDependencies): Express {
 				return { ok: false, message: "Could not save the link right now." };
 			}
 		},
-		listQueue: async ({ userId, status }) => {
-			const result = await deps.findArticlesByUser({
-				userId,
-				status,
-				excludeContent: true,
-			});
-			return {
-				total: result.total,
-				articles: result.articles.map((article) => ({
-					url: article.url,
-					title: article.metadata.title,
-					status: article.status,
-				})),
-			};
-		},
+		...initMcpArticleOperations({
+			findArticleById: deps.findArticleById,
+			findArticlesByUser: deps.findArticlesByUser,
+			readArticleContent: deps.readArticleContent,
+			findGeneratedSummary: deps.findGeneratedSummary,
+		}),
 	});
 
 	const secureCookies = isHttpsOrigin(appOrigin);

--- a/projects/hutch/src/runtime/web/mcp/article-operations.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/article-operations.test.ts
@@ -1,0 +1,245 @@
+import { MinutesSchema, ReaderArticleHashId } from "@packages/domain/article";
+import type { SavedArticle } from "@packages/domain/article";
+import { UserIdSchema } from "@packages/domain/user";
+import type {
+	FindArticleById,
+	FindArticlesByUser,
+	ReadArticleContent,
+} from "@packages/provider-contracts/article-store";
+import type { FindGeneratedSummary } from "@packages/provider-contracts/article-summary";
+import {
+	initMcpArticleOperations,
+	toMcpArticle,
+	toSummaryResult,
+} from "./article-operations";
+
+const userId = UserIdSchema.parse("00000000000000000000000000000001");
+
+function buildArticle(overrides: Partial<SavedArticle> = {}): SavedArticle {
+	const url = overrides.url ?? "https://example.com/a";
+	return {
+		id: ReaderArticleHashId.from(url),
+		userId,
+		url,
+		metadata: {
+			title: "Title",
+			siteName: "Example",
+			excerpt: "An excerpt",
+			wordCount: 400,
+			imageUrl: "https://example.com/i.png",
+		},
+		content: "<p>body</p>",
+		estimatedReadTime: MinutesSchema.parse(2),
+		status: "unread",
+		savedAt: new Date("2026-01-01T00:00:00.000Z"),
+		...overrides,
+	};
+}
+
+interface DepOverrides {
+	findArticleById?: FindArticleById;
+	findArticlesByUser?: FindArticlesByUser;
+	readArticleContent?: ReadArticleContent;
+	findGeneratedSummary?: FindGeneratedSummary;
+}
+
+function buildOps(overrides: DepOverrides = {}) {
+	return initMcpArticleOperations({
+		findArticleById: overrides.findArticleById ?? (async () => null),
+		findArticlesByUser:
+			overrides.findArticlesByUser ??
+			(async () => ({ articles: [], total: 0, page: 1, pageSize: 20 })),
+		readArticleContent: overrides.readArticleContent ?? (async () => undefined),
+		findGeneratedSummary:
+			overrides.findGeneratedSummary ?? (async () => undefined),
+	});
+}
+
+describe("toMcpArticle", () => {
+	it("maps every field, including optional imageUrl and readAt when present", () => {
+		const article = buildArticle({
+			status: "read",
+			readAt: new Date("2026-02-02T00:00:00.000Z"),
+		});
+		expect(toMcpArticle(article)).toEqual({
+			id: article.id.value,
+			url: "https://example.com/a",
+			title: "Title",
+			siteName: "Example",
+			excerpt: "An excerpt",
+			wordCount: 400,
+			imageUrl: "https://example.com/i.png",
+			estimatedReadTime: 2,
+			status: "read",
+			savedAt: "2026-01-01T00:00:00.000Z",
+			readAt: "2026-02-02T00:00:00.000Z",
+		});
+	});
+
+	it("omits imageUrl and readAt when they are absent", () => {
+		const article = buildArticle({
+			metadata: {
+				title: "T",
+				siteName: "S",
+				excerpt: "E",
+				wordCount: 1,
+			},
+		});
+		const mapped = toMcpArticle(article);
+		expect(mapped).not.toHaveProperty("imageUrl");
+		expect(mapped).not.toHaveProperty("readAt");
+	});
+});
+
+describe("toSummaryResult", () => {
+	it("treats a missing summary row as pending", () => {
+		expect(toSummaryResult(undefined)).toEqual({ status: "pending" });
+	});
+
+	it("passes a pending summary through", () => {
+		expect(toSummaryResult({ status: "pending" })).toEqual({ status: "pending" });
+	});
+
+	it("returns the summary and excerpt when ready", () => {
+		expect(
+			toSummaryResult({ status: "ready", summary: "TL;DR", excerpt: "ex" }),
+		).toEqual({ status: "ready", summary: "TL;DR", excerpt: "ex" });
+	});
+
+	it("omits the excerpt when a ready summary has none", () => {
+		expect(toSummaryResult({ status: "ready", summary: "TL;DR" })).toEqual({
+			status: "ready",
+			summary: "TL;DR",
+		});
+	});
+
+	it("carries the reason for a failed summary", () => {
+		expect(toSummaryResult({ status: "failed", reason: "too long" })).toEqual({
+			status: "failed",
+			reason: "too long",
+		});
+	});
+
+	it("carries the reason for a skipped summary, and omits it when absent", () => {
+		expect(toSummaryResult({ status: "skipped", reason: "too short" })).toEqual({
+			status: "skipped",
+			reason: "too short",
+		});
+		expect(toSummaryResult({ status: "skipped" })).toEqual({ status: "skipped" });
+	});
+});
+
+describe("initMcpArticleOperations", () => {
+	describe("listQueue", () => {
+		it("forwards the query (excluding content) and maps rows to MCP articles", async () => {
+			const article = buildArticle();
+			const findArticlesByUser = jest.fn(async () => ({
+				articles: [article],
+				total: 1,
+				page: 2,
+				pageSize: 5,
+			}));
+			const ops = buildOps({ findArticlesByUser });
+
+			const result = await ops.listQueue({
+				userId,
+				status: "read",
+				sort: "readAt",
+				order: "asc",
+				page: 2,
+				pageSize: 5,
+			});
+
+			expect(findArticlesByUser).toHaveBeenCalledWith({
+				userId,
+				status: "read",
+				sort: "readAt",
+				order: "asc",
+				page: 2,
+				pageSize: 5,
+				excludeContent: true,
+			});
+			expect(result).toEqual({
+				total: 1,
+				page: 2,
+				pageSize: 5,
+				articles: [toMcpArticle(article)],
+			});
+		});
+	});
+
+	describe("getArticle", () => {
+		it("returns the mapped article when the owner's id resolves", async () => {
+			const article = buildArticle();
+			const ops = buildOps({ findArticleById: async () => article });
+			expect(await ops.getArticle({ userId, id: article.id.value })).toEqual(
+				toMcpArticle(article),
+			);
+		});
+
+		it("returns null when the id does not resolve to an owned article", async () => {
+			const ops = buildOps({ findArticleById: async () => null });
+			expect(
+				await ops.getArticle({ userId, id: "0".repeat(32) }),
+			).toBeNull();
+		});
+
+		it("returns null without hitting the store for a malformed id", async () => {
+			const findArticleById = jest.fn(async () => null);
+			const ops = buildOps({ findArticleById });
+			expect(await ops.getArticle({ userId, id: "not-a-hash" })).toBeNull();
+			expect(findArticleById).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("getArticleContent", () => {
+		it("reports not_found when the id does not resolve", async () => {
+			const ops = buildOps({ findArticleById: async () => null });
+			expect(await ops.getArticleContent({ userId, id: "0".repeat(32) })).toEqual({
+				status: "not_found",
+			});
+		});
+
+		it("reports pending while the reader view is still being fetched", async () => {
+			const article = buildArticle();
+			const ops = buildOps({
+				findArticleById: async () => article,
+				readArticleContent: async () => undefined,
+			});
+			expect(
+				await ops.getArticleContent({ userId, id: article.id.value }),
+			).toEqual({ status: "pending" });
+		});
+
+		it("returns the cleaned HTML when ready", async () => {
+			const article = buildArticle();
+			const ops = buildOps({
+				findArticleById: async () => article,
+				readArticleContent: async () => "<article>hi</article>",
+			});
+			expect(
+				await ops.getArticleContent({ userId, id: article.id.value }),
+			).toEqual({ status: "ready", content: "<article>hi</article>" });
+		});
+	});
+
+	describe("getArticleSummary", () => {
+		it("reports not_found when the id does not resolve", async () => {
+			const ops = buildOps({ findArticleById: async () => null });
+			expect(await ops.getArticleSummary({ userId, id: "0".repeat(32) })).toEqual({
+				status: "not_found",
+			});
+		});
+
+		it("maps the stored summary for an owned article", async () => {
+			const article = buildArticle();
+			const ops = buildOps({
+				findArticleById: async () => article,
+				findGeneratedSummary: async () => ({ status: "ready", summary: "TL;DR" }),
+			});
+			expect(
+				await ops.getArticleSummary({ userId, id: article.id.value }),
+			).toEqual({ status: "ready", summary: "TL;DR" });
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/article-operations.ts
+++ b/projects/hutch/src/runtime/web/mcp/article-operations.ts
@@ -1,0 +1,132 @@
+import { ReaderArticleHashIdSchema } from "@packages/domain/article";
+import type { SavedArticle } from "@packages/domain/article";
+import type { UserId } from "@packages/domain/user";
+import type {
+	FindArticleById,
+	FindArticlesByUser,
+	ReadArticleContent,
+} from "@packages/provider-contracts/article-store";
+import type {
+	FindGeneratedSummary,
+	GeneratedSummary,
+} from "@packages/provider-contracts/article-summary";
+import type {
+	ArticleSummaryResult,
+	McpArticle,
+	McpServerDeps,
+} from "./mcp-server";
+
+interface McpArticleOperationDeps {
+	findArticleById: FindArticleById;
+	findArticlesByUser: FindArticlesByUser;
+	readArticleContent: ReadArticleContent;
+	findGeneratedSummary: FindGeneratedSummary;
+}
+
+export function toMcpArticle(article: SavedArticle): McpArticle {
+	return {
+		id: article.id.value,
+		url: article.url,
+		title: article.metadata.title,
+		siteName: article.metadata.siteName,
+		excerpt: article.metadata.excerpt,
+		wordCount: article.metadata.wordCount,
+		...(article.metadata.imageUrl !== undefined
+			? { imageUrl: article.metadata.imageUrl }
+			: {}),
+		estimatedReadTime: article.estimatedReadTime,
+		status: article.status,
+		savedAt: article.savedAt.toISOString(),
+		...(article.readAt !== undefined
+			? { readAt: article.readAt.toISOString() }
+			: {}),
+	};
+}
+
+export function toSummaryResult(
+	summary: GeneratedSummary | undefined,
+): ArticleSummaryResult {
+	if (!summary) return { status: "pending" };
+	switch (summary.status) {
+		case "pending":
+			return { status: "pending" };
+		case "ready":
+			return {
+				status: "ready",
+				summary: summary.summary,
+				...(summary.excerpt !== undefined ? { excerpt: summary.excerpt } : {}),
+			};
+		case "failed":
+			return { status: "failed", reason: summary.reason };
+		case "skipped":
+			return {
+				status: "skipped",
+				...(summary.reason !== undefined ? { reason: summary.reason } : {}),
+			};
+	}
+}
+
+/**
+ * Builds the article-facing MCP operations from the same store seams the
+ * hypermedia `/queue` API uses. Lives here rather than in the composition root
+ * so the id→owner resolution and the metadata/summary mapping are unit-testable
+ * without standing up the whole app. Every lookup is owner-scoped
+ * (`findArticleById` is keyed by userId), so a cross-user or malformed id
+ * resolves to "not found" rather than another user's article.
+ */
+export function initMcpArticleOperations(
+	deps: McpArticleOperationDeps,
+): Pick<
+	McpServerDeps,
+	"listQueue" | "getArticle" | "getArticleContent" | "getArticleSummary"
+> {
+	async function resolveOwned(
+		userId: UserId,
+		id: string,
+	): Promise<SavedArticle | null> {
+		const parsed = ReaderArticleHashIdSchema.safeParse(id);
+		if (!parsed.success) return null;
+		return deps.findArticleById(parsed.data, userId);
+	}
+
+	return {
+		listQueue: async ({ userId, status, sort, order, page, pageSize }) => {
+			const result = await deps.findArticlesByUser({
+				userId,
+				status,
+				sort,
+				order,
+				page,
+				pageSize,
+				excludeContent: true,
+			});
+			return {
+				total: result.total,
+				page: result.page,
+				pageSize: result.pageSize,
+				articles: result.articles.map(toMcpArticle),
+			};
+		},
+
+		getArticle: async ({ userId, id }) => {
+			const article = await resolveOwned(userId, id);
+			return article ? toMcpArticle(article) : null;
+		},
+
+		getArticleContent: async ({ userId, id }) => {
+			const article = await resolveOwned(userId, id);
+			if (!article) return { status: "not_found" };
+			const content = await deps.readArticleContent(article.url);
+			return content === undefined
+				? { status: "pending" }
+				: { status: "ready", content };
+		},
+
+		getArticleSummary: async ({ userId, id }) => {
+			const article = await resolveOwned(userId, id);
+			if (!article) return { status: "not_found" };
+			const summary = await deps.findGeneratedSummary(article.url);
+			return toSummaryResult(summary);
+		},
+	};
+}

--- a/projects/hutch/src/runtime/web/mcp/cursor.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/cursor.test.ts
@@ -1,0 +1,38 @@
+import { decodeQueueCursor, encodeQueueCursor } from "./cursor";
+
+describe("queue cursor codec", () => {
+	it("round-trips a full cursor", () => {
+		const cursor = {
+			page: 3,
+			pageSize: 10,
+			status: "read" as const,
+			sort: "readAt" as const,
+			order: "asc" as const,
+		};
+		expect(decodeQueueCursor(encodeQueueCursor(cursor))).toEqual(cursor);
+	});
+
+	it("round-trips a minimal cursor with no filters", () => {
+		const cursor = { page: 2, pageSize: 20 };
+		expect(decodeQueueCursor(encodeQueueCursor(cursor))).toEqual(cursor);
+	});
+
+	it("returns null for a token that is not base64url-encoded JSON", () => {
+		expect(decodeQueueCursor("!!!not base64!!!")).toBeNull();
+	});
+
+	it("returns null for valid JSON of the wrong shape", () => {
+		const token = Buffer.from(JSON.stringify({ page: 0, pageSize: 5 }), "utf8").toString(
+			"base64url",
+		);
+		expect(decodeQueueCursor(token)).toBeNull();
+	});
+
+	it("returns null for a pageSize beyond the allowed maximum", () => {
+		const token = Buffer.from(
+			JSON.stringify({ page: 1, pageSize: 9999 }),
+			"utf8",
+		).toString("base64url");
+		expect(decodeQueueCursor(token)).toBeNull();
+	});
+});

--- a/projects/hutch/src/runtime/web/mcp/cursor.ts
+++ b/projects/hutch/src/runtime/web/mcp/cursor.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { ArticleStatus } from "@packages/domain/article";
+import type {
+	SortField,
+	SortOrder,
+} from "@packages/provider-contracts/article-store";
+
+/**
+ * The state carried across `list_queue` pages. The MCP layer exposes only an
+ * opaque `nextCursor` token; this is what that token wraps so a follow-up call
+ * resumes the same filter/sort at the next page over the store's offset
+ * pagination. `sort` is the store-level field name, so a decoded cursor passes
+ * straight to `findArticlesByUser` without re-mapping.
+ */
+export interface QueueCursor {
+	readonly page: number;
+	readonly pageSize: number;
+	readonly status?: ArticleStatus;
+	readonly sort?: SortField;
+	readonly order?: SortOrder;
+}
+
+const QueueCursorSchema = z.object({
+	page: z.number().int().min(1),
+	pageSize: z.number().int().min(1).max(100),
+	status: z.enum(["unread", "read"]).optional(),
+	sort: z.enum(["savedAt", "readAt"]).optional(),
+	order: z.enum(["asc", "desc"]).optional(),
+});
+
+export function encodeQueueCursor(cursor: QueueCursor): string {
+	return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+/** Decode a token produced by {@link encodeQueueCursor}. Returns `null` for any
+ * token that doesn't base64url-decode to JSON of the expected shape — a forged,
+ * truncated, or stale cursor — so the caller can ask the agent to restart from
+ * the first page instead of trusting attacker-controlled pagination. */
+export function decodeQueueCursor(token: string): QueueCursor | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(Buffer.from(token, "base64url").toString("utf8"));
+	} catch {
+		return null;
+	}
+	const result = QueueCursorSchema.safeParse(parsed);
+	return result.success ? result.data : null;
+}

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
@@ -1,6 +1,11 @@
 import { UserIdSchema } from "@packages/domain/user";
 import { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from "./protocol";
-import { initMcpServer, type McpServerDeps } from "./mcp-server";
+import { encodeQueueCursor } from "./cursor";
+import {
+	initMcpServer,
+	type McpArticle,
+	type McpServerDeps,
+} from "./mcp-server";
 
 const userId = UserIdSchema.parse("00000000000000000000000000000001");
 const context = { userId };
@@ -8,9 +13,44 @@ const context = { userId };
 function fakeDeps(overrides?: Partial<McpServerDeps>): McpServerDeps {
 	return {
 		saveLink: async () => ({ ok: true, title: "Example", url: "https://example.com/" }),
-		listQueue: async () => ({ total: 0, articles: [] }),
+		listQueue: async () => ({ total: 0, page: 1, pageSize: 20, articles: [] }),
+		getArticle: async () => null,
+		getArticleContent: async () => ({ status: "not_found" }),
+		getArticleSummary: async () => ({ status: "not_found" }),
 		...overrides,
 	};
+}
+
+function mcpArticle(overrides: Partial<McpArticle> = {}): McpArticle {
+	return {
+		id: "0".repeat(32),
+		url: "https://a.test/",
+		title: "A",
+		siteName: "Example",
+		excerpt: "",
+		wordCount: 10,
+		estimatedReadTime: 1,
+		status: "unread",
+		savedAt: "2026-01-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+function call(
+	server: ReturnType<typeof initMcpServer>,
+	id: number,
+	name: string,
+	args?: unknown,
+) {
+	return server.handle(
+		{
+			jsonrpc: "2.0",
+			id,
+			method: "tools/call",
+			params: { name, ...(args !== undefined ? { arguments: args } : {}) },
+		},
+		context,
+	);
 }
 
 describe("initMcpServer", () => {
@@ -31,6 +71,17 @@ describe("initMcpServer", () => {
 		});
 	});
 
+	it("instructs that marking read and deleting are app-only", async () => {
+		const server = initMcpServer(fakeDeps());
+		const response = await server.handle(
+			{ jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+			context,
+		);
+		expect(response).toMatchObject({
+			result: { instructions: expect.stringContaining("Readplace app") },
+		});
+	});
+
 	it("answers ping with an empty result", async () => {
 		const server = initMcpServer(fakeDeps());
 		const response = await server.handle(
@@ -40,7 +91,7 @@ describe("initMcpServer", () => {
 		expect(response).toEqual({ jsonrpc: "2.0", id: "p", result: {} });
 	});
 
-	it("lists both tools, in order, with their JSON Schemas", async () => {
+	it("lists every tool, in order, with schemas and annotations", async () => {
 		const server = initMcpServer(fakeDeps());
 		const response = await server.handle(
 			{ jsonrpc: "2.0", id: 2, method: "tools/list" },
@@ -50,8 +101,13 @@ describe("initMcpServer", () => {
 			id: 2,
 			result: {
 				tools: [
-					{ name: "save_link", inputSchema: { required: ["url"] } },
-					{ name: "list_queue", inputSchema: { type: "object" } },
+					{ name: "save_link", annotations: { openWorldHint: true } },
+					{ name: "list_queue", annotations: { readOnlyHint: true } },
+					{ name: "get_article", annotations: { readOnlyHint: true } },
+					{ name: "get_article_content" },
+					{ name: "get_article_summary" },
+					{ name: "set_article_status", annotations: { readOnlyHint: true } },
+					{ name: "delete_article", annotations: { readOnlyHint: true } },
 				],
 			},
 		});
@@ -133,15 +189,9 @@ describe("initMcpServer", () => {
 				url: "https://example.com/a",
 			}));
 			const server = initMcpServer(fakeDeps({ saveLink }));
-			const response = await server.handle(
-				{
-					jsonrpc: "2.0",
-					id: 4,
-					method: "tools/call",
-					params: { name: "save_link", arguments: { url: "https://example.com/a" } },
-				},
-				context,
-			);
+			const response = await call(server, 4, "save_link", {
+				url: "https://example.com/a",
+			});
 			expect(saveLink).toHaveBeenCalledWith({ userId, url: "https://example.com/a" });
 			expect(response).toMatchObject({
 				id: 4,
@@ -153,15 +203,7 @@ describe("initMcpServer", () => {
 		it("surfaces a save rejection as an error result", async () => {
 			const saveLink = jest.fn(async () => ({ ok: false as const, message: "Not a saveable URL" }));
 			const server = initMcpServer(fakeDeps({ saveLink }));
-			const response = await server.handle(
-				{
-					jsonrpc: "2.0",
-					id: 5,
-					method: "tools/call",
-					params: { name: "save_link", arguments: { url: "chrome://x" } },
-				},
-				context,
-			);
+			const response = await call(server, 5, "save_link", { url: "chrome://x" });
 			expect(response).toMatchObject({
 				id: 5,
 				result: { content: [{ type: "text", text: "Not a saveable URL" }], isError: true },
@@ -170,10 +212,7 @@ describe("initMcpServer", () => {
 
 		it("returns an error result when the url argument is missing", async () => {
 			const server = initMcpServer(fakeDeps());
-			const response = await server.handle(
-				{ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "save_link" } },
-				context,
-			);
+			const response = await call(server, 6, "save_link");
 			expect(response).toMatchObject({
 				id: 6,
 				result: { isError: true, content: [{ text: expect.stringContaining("url") }] },
@@ -185,15 +224,7 @@ describe("initMcpServer", () => {
 				throw new Error("boom");
 			});
 			const server = initMcpServer(fakeDeps({ saveLink }));
-			const response = await server.handle(
-				{
-					jsonrpc: "2.0",
-					id: 7,
-					method: "tools/call",
-					params: { name: "save_link", arguments: { url: "https://example.com/a" } },
-				},
-				context,
-			);
+			const response = await call(server, 7, "save_link", { url: "https://example.com/a" });
 			expect(response).toMatchObject({
 				id: 7,
 				result: { isError: true, content: [{ text: expect.stringContaining("boom") }] },
@@ -202,42 +233,44 @@ describe("initMcpServer", () => {
 	});
 
 	describe("tools/call list_queue", () => {
-		it("reports an empty queue", async () => {
+		it("reports an empty queue with the exact legacy text", async () => {
 			const server = initMcpServer(fakeDeps());
-			const response = await server.handle(
-				{ jsonrpc: "2.0", id: 8, method: "tools/call", params: { name: "list_queue" } },
-				context,
-			);
+			const response = await call(server, 8, "list_queue");
 			expect(response).toMatchObject({
 				id: 8,
 				result: { content: [{ type: "text", text: "Your Readplace queue is empty." }] },
 			});
 		});
 
-		it("formats saved articles and forwards the status filter", async () => {
+		it("formats saved articles, exposes ids in structuredContent, and forwards the status filter", async () => {
 			const listQueue = jest.fn(async () => ({
 				total: 2,
+				page: 1,
+				pageSize: 20,
 				articles: [
-					{ url: "https://a.test/", title: "A", status: "unread" as const },
-					{ url: "https://b.test/", title: "", status: "read" as const },
+					mcpArticle({ id: "a".repeat(32), url: "https://a.test/", title: "A", status: "unread" }),
+					mcpArticle({ id: "b".repeat(32), url: "https://b.test/", title: "", status: "read" }),
 				],
 			}));
 			const server = initMcpServer(fakeDeps({ listQueue }));
-			const response = await server.handle(
-				{
-					jsonrpc: "2.0",
-					id: 9,
-					method: "tools/call",
-					params: { name: "list_queue", arguments: { status: "unread" } },
-				},
-				context,
-			);
-			expect(listQueue).toHaveBeenCalledWith({ userId, status: "unread" });
-			expect(response).toMatchObject({
-				result: { content: [{ text: expect.stringContaining("You have 2 saved article(s)") }] },
+			const response = await call(server, 9, "list_queue", { status: "unread" });
+			expect(listQueue).toHaveBeenCalledWith({
+				userId,
+				status: "unread",
+				page: 1,
+				sort: undefined,
+				order: undefined,
+				pageSize: undefined,
 			});
 			expect(response).toMatchObject({
-				result: { content: [{ text: expect.stringContaining("https://a.test/") }] },
+				result: {
+					content: [{ text: expect.stringContaining("You have 2 saved article(s)") }],
+					structuredContent: {
+						total: 2,
+						count: 2,
+						articles: [{ id: "a".repeat(32) }, { id: "b".repeat(32) }],
+					},
+				},
 			});
 			// Falls back to the url when the title is still empty (content loading).
 			expect(response).toMatchObject({
@@ -248,16 +281,12 @@ describe("initMcpServer", () => {
 		it("flags that only the first page is shown when the total exceeds the listed articles", async () => {
 			const listQueue = jest.fn(async () => ({
 				total: 5,
-				articles: [
-					{ url: "https://a.test/", title: "A", status: "unread" as const },
-					{ url: "https://b.test/", title: "B", status: "unread" as const },
-				],
+				page: 1,
+				pageSize: 20,
+				articles: [mcpArticle({ title: "A" }), mcpArticle({ title: "B" })],
 			}));
 			const server = initMcpServer(fakeDeps({ listQueue }));
-			const response = await server.handle(
-				{ jsonrpc: "2.0", id: 14, method: "tools/call", params: { name: "list_queue" } },
-				context,
-			);
+			const response = await call(server, 14, "list_queue");
 			expect(response).toMatchObject({
 				result: {
 					content: [
@@ -267,17 +296,104 @@ describe("initMcpServer", () => {
 			});
 		});
 
+		it("emits a nextCursor when more pages remain", async () => {
+			const listQueue = jest.fn(async () => ({
+				total: 5,
+				page: 1,
+				pageSize: 2,
+				articles: [mcpArticle({ title: "A" }), mcpArticle({ title: "B" })],
+			}));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await call(server, 20, "list_queue", { limit: 2 });
+			expect(response).toMatchObject({
+				result: { structuredContent: { nextCursor: expect.any(String) } },
+			});
+		});
+
+		it("continues from a cursor at the next page", async () => {
+			const cursor = encodeQueueCursor({ page: 2, pageSize: 2 });
+			const listQueue = jest.fn(async () => ({
+				total: 5,
+				page: 2,
+				pageSize: 2,
+				articles: [mcpArticle({ title: "C" }), mcpArticle({ title: "D" })],
+			}));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await call(server, 21, "list_queue", { cursor });
+			expect(listQueue).toHaveBeenCalledWith({
+				userId,
+				page: 2,
+				pageSize: 2,
+				status: undefined,
+				sort: undefined,
+				order: undefined,
+			});
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("Showing 2 more of your 5 saved article(s):") }] },
+			});
+		});
+
+		it("reports no-more-articles for a page past the end", async () => {
+			const cursor = encodeQueueCursor({ page: 9, pageSize: 2 });
+			const listQueue = jest.fn(async () => ({
+				total: 5,
+				page: 9,
+				pageSize: 2,
+				articles: [],
+			}));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await call(server, 22, "list_queue", { cursor });
+			expect(response).toMatchObject({
+				result: { content: [{ text: "No more saved articles." }] },
+			});
+		});
+
+		it("rejects an invalid cursor with a restart instruction", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await call(server, 23, "list_queue", { cursor: "garbage" });
+			expect(response).toMatchObject({
+				id: 23,
+				result: { isError: true, content: [{ text: expect.stringContaining("without a cursor") }] },
+			});
+		});
+
+		it("maps sort:read to the readAt index when status is read", async () => {
+			const listQueue = jest.fn(async () => ({ total: 0, page: 1, pageSize: 20, articles: [] }));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			await call(server, 24, "list_queue", { status: "read", sort: "read", order: "asc" });
+			expect(listQueue).toHaveBeenCalledWith({
+				userId,
+				status: "read",
+				sort: "readAt",
+				order: "asc",
+				page: 1,
+				pageSize: undefined,
+			});
+		});
+
+		it("maps sort:saved to the savedAt index", async () => {
+			const listQueue = jest.fn(async () => ({ total: 0, page: 1, pageSize: 20, articles: [] }));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			await call(server, 25, "list_queue", { sort: "saved" });
+			expect(listQueue).toHaveBeenCalledWith(
+				expect.objectContaining({ sort: "savedAt" }),
+			);
+		});
+
+		it("refuses sort:read without status:read", async () => {
+			const listQueue = jest.fn(async () => ({ total: 0, page: 1, pageSize: 20, articles: [] }));
+			const server = initMcpServer(fakeDeps({ listQueue }));
+			const response = await call(server, 26, "list_queue", { sort: "read" });
+			expect(response).toMatchObject({
+				id: 26,
+				result: { isError: true, content: [{ text: expect.stringContaining('status:"read"') }] },
+			});
+			expect(listQueue).not.toHaveBeenCalled();
+		});
+
 		it("returns an error result for an invalid status", async () => {
 			const server = initMcpServer(fakeDeps());
-			const response = await server.handle(
-				{
-					jsonrpc: "2.0",
-					id: 10,
-					method: "tools/call",
-					params: { name: "list_queue", arguments: { status: "archived" } },
-				},
-				context,
-			);
+			const response = await call(server, 10, "list_queue", { status: "archived" });
 			expect(response).toMatchObject({ id: 10, result: { isError: true } });
 		});
 
@@ -286,14 +402,246 @@ describe("initMcpServer", () => {
 				throw new Error("db down");
 			});
 			const server = initMcpServer(fakeDeps({ listQueue }));
-			const response = await server.handle(
-				{ jsonrpc: "2.0", id: 11, method: "tools/call", params: { name: "list_queue" } },
-				context,
-			);
+			const response = await call(server, 11, "list_queue");
 			expect(response).toMatchObject({
 				id: 11,
 				result: { isError: true, content: [{ text: expect.stringContaining("db down") }] },
 			});
+		});
+	});
+
+	describe("tools/call get_article", () => {
+		it("returns the article's metadata and structured payload", async () => {
+			const article = mcpArticle({ title: "Deep Work", url: "https://a.test/dw" });
+			const server = initMcpServer(fakeDeps({ getArticle: async () => article }));
+			const response = await call(server, 30, "get_article", { id: article.id });
+			expect(response).toMatchObject({
+				result: {
+					content: [{ text: expect.stringContaining("Deep Work") }],
+					structuredContent: { found: true, article: { id: article.id } },
+				},
+			});
+		});
+
+		it("falls back to the url and shows read date and excerpt when present", async () => {
+			const article = mcpArticle({
+				title: "",
+				url: "https://a.test/x",
+				excerpt: "A short take",
+				status: "read",
+				readAt: "2026-03-03T00:00:00.000Z",
+			});
+			const server = initMcpServer(fakeDeps({ getArticle: async () => article }));
+			const response = await call(server, 34, "get_article", { id: article.id });
+			for (const fragment of ["https://a.test/x", "A short take", "read 2026-03-03"]) {
+				expect(response).toMatchObject({
+					result: { content: [{ text: expect.stringContaining(fragment) }] },
+				});
+			}
+		});
+
+		it("reports not found for an id that does not resolve", async () => {
+			const server = initMcpServer(fakeDeps({ getArticle: async () => null }));
+			const response = await call(server, 31, "get_article", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: {
+					content: [{ text: expect.stringContaining("No saved article") }],
+					structuredContent: { found: false },
+				},
+			});
+		});
+
+		it("rejects a missing id", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await call(server, 32, "get_article", {});
+			expect(response).toMatchObject({
+				id: 32,
+				result: { isError: true, content: [{ text: expect.stringContaining("id") }] },
+			});
+		});
+
+		it("returns an error result when the lookup throws", async () => {
+			const server = initMcpServer(
+				fakeDeps({
+					getArticle: async () => {
+						throw new Error("kaboom");
+					},
+				}),
+			);
+			const response = await call(server, 33, "get_article", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { isError: true, content: [{ text: expect.stringContaining("kaboom") }] },
+			});
+		});
+	});
+
+	describe("tools/call get_article_content", () => {
+		it("returns the cleaned HTML when ready", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleContent: async () => ({ status: "ready", content: "<p>hi</p>" }) }),
+			);
+			const response = await call(server, 40, "get_article_content", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: {
+					content: [{ text: "<p>hi</p>" }],
+					structuredContent: { status: "ready", content: "<p>hi</p>" },
+				},
+			});
+		});
+
+		it("reports that the reader view is still loading", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleContent: async () => ({ status: "pending" }) }),
+			);
+			const response = await call(server, 41, "get_article_content", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: {
+					content: [{ text: expect.stringContaining("isn't ready yet") }],
+					structuredContent: { status: "pending" },
+				},
+			});
+		});
+
+		it("reports not found", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleContent: async () => ({ status: "not_found" }) }),
+			);
+			const response = await call(server, 42, "get_article_content", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("No saved article") }] },
+			});
+		});
+
+		it("rejects a missing id", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await call(server, 43, "get_article_content", {});
+			expect(response).toMatchObject({ result: { isError: true } });
+		});
+
+		it("returns an error result when the lookup throws", async () => {
+			const server = initMcpServer(
+				fakeDeps({
+					getArticleContent: async () => {
+						throw new Error("read fail");
+					},
+				}),
+			);
+			const response = await call(server, 44, "get_article_content", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { isError: true, content: [{ text: expect.stringContaining("read fail") }] },
+			});
+		});
+	});
+
+	describe("tools/call get_article_summary", () => {
+		it("returns the summary when ready", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleSummary: async () => ({ status: "ready", summary: "The gist." }) }),
+			);
+			const response = await call(server, 50, "get_article_summary", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: {
+					content: [{ text: "The gist." }],
+					structuredContent: { status: "ready", summary: "The gist." },
+				},
+			});
+		});
+
+		it("reports a pending summary", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleSummary: async () => ({ status: "pending" }) }),
+			);
+			const response = await call(server, 51, "get_article_summary", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("still being generated") }] },
+			});
+		});
+
+		it("reports a failed summary with its reason", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleSummary: async () => ({ status: "failed", reason: "model error" }) }),
+			);
+			const response = await call(server, 52, "get_article_summary", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("model error") }] },
+			});
+		});
+
+		it("reports a skipped summary", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleSummary: async () => ({ status: "skipped" }) }),
+			);
+			const response = await call(server, 53, "get_article_summary", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("No summary was generated") }] },
+			});
+		});
+
+		it("reports not found", async () => {
+			const server = initMcpServer(
+				fakeDeps({ getArticleSummary: async () => ({ status: "not_found" }) }),
+			);
+			const response = await call(server, 54, "get_article_summary", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { content: [{ text: expect.stringContaining("No saved article") }] },
+			});
+		});
+
+		it("rejects a missing id", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await call(server, 55, "get_article_summary", {});
+			expect(response).toMatchObject({ result: { isError: true } });
+		});
+
+		it("returns an error result when the lookup throws", async () => {
+			const server = initMcpServer(
+				fakeDeps({
+					getArticleSummary: async () => {
+						throw new Error("summary fail");
+					},
+				}),
+			);
+			const response = await call(server, 56, "get_article_summary", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				result: { isError: true, content: [{ text: expect.stringContaining("summary fail") }] },
+			});
+		});
+	});
+
+	describe("tools/call app-only write tools", () => {
+		it("redirects set_article_status to the app without mutating", async () => {
+			const updateSpy = jest.fn();
+			const server = initMcpServer(fakeDeps());
+			const response = await call(server, 60, "set_article_status", {
+				id: "x".repeat(32),
+				status: "read",
+			});
+			expect(updateSpy).not.toHaveBeenCalled();
+			expect(response).toMatchObject({
+				id: 60,
+				result: {
+					content: [{ text: expect.stringContaining("Readplace app") }],
+					structuredContent: {
+						action: "set_article_status",
+						performed: false,
+						completeInApp: "https://readplace.com/queue",
+					},
+				},
+			});
+			expect(response).not.toMatchObject({ result: { isError: true } });
+		});
+
+		it("redirects delete_article to the app without deleting", async () => {
+			const server = initMcpServer(fakeDeps());
+			const response = await call(server, 61, "delete_article", { id: "x".repeat(32) });
+			expect(response).toMatchObject({
+				id: 61,
+				result: {
+					content: [{ text: expect.stringContaining("Readplace app") }],
+					structuredContent: { action: "delete_article", performed: false },
+				},
+			});
+			expect(response).not.toMatchObject({ result: { isError: true } });
 		});
 	});
 
@@ -308,10 +656,7 @@ describe("initMcpServer", () => {
 
 	it("rejects tools/call for an unknown tool", async () => {
 		const server = initMcpServer(fakeDeps());
-		const response = await server.handle(
-			{ jsonrpc: "2.0", id: 13, method: "tools/call", params: { name: "delete_everything" } },
-			context,
-		);
+		const response = await call(server, 13, "delete_everything");
 		expect(response).toMatchObject({
 			id: 13,
 			error: { code: -32602, message: "Unknown tool: delete_everything" },

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
@@ -610,13 +610,11 @@ describe("initMcpServer", () => {
 
 	describe("tools/call app-only write tools", () => {
 		it("redirects set_article_status to the app without mutating", async () => {
-			const updateSpy = jest.fn();
 			const server = initMcpServer(fakeDeps());
 			const response = await call(server, 60, "set_article_status", {
 				id: "x".repeat(32),
 				status: "read",
 			});
-			expect(updateSpy).not.toHaveBeenCalled();
 			expect(response).toMatchObject({
 				id: 60,
 				result: {

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.ts
@@ -1,33 +1,74 @@
 import { z } from "zod";
 import type { UserId } from "@packages/domain/user";
 import type { ArticleStatus } from "@packages/domain/article";
+import type {
+	SortField,
+	SortOrder,
+} from "@packages/provider-contracts/article-store";
 import { MCP_PROTOCOL_VERSION, MCP_SERVER_INFO } from "./protocol";
+import { decodeQueueCursor, encodeQueueCursor } from "./cursor";
 import {
+	ArticleIdArgs,
+	DELETE_ARTICLE_TOOL,
+	GET_ARTICLE_CONTENT_TOOL,
+	GET_ARTICLE_SUMMARY_TOOL,
+	GET_ARTICLE_TOOL,
 	LIST_QUEUE_TOOL,
 	ListQueueArgs,
 	SAVE_LINK_TOOL,
+	SET_ARTICLE_STATUS_TOOL,
 	SaveLinkArgs,
 	TOOL_DEFINITIONS,
 } from "./tool-definitions";
+
+/** The user's queue in the Readplace app. Status changes and deletions happen
+ * here, not over MCP — the redirect tools point the user at this URL. */
+const APP_QUEUE_URL = "https://readplace.com/queue";
 
 type SaveLinkResult =
 	| { readonly ok: true; readonly title: string; readonly url: string }
 	| { readonly ok: false; readonly message: string };
 
-interface QueueArticle {
+/** One saved article as the read tools expose it: metadata only (the reader
+ * HTML is fetched separately by `get_article_content`). Dates are ISO strings
+ * so the structured payload is plain JSON. */
+export interface McpArticle {
+	readonly id: string;
 	readonly url: string;
 	readonly title: string;
+	readonly siteName: string;
+	readonly excerpt: string;
+	readonly wordCount: number;
+	readonly imageUrl?: string;
+	readonly estimatedReadTime: number;
 	readonly status: ArticleStatus;
+	readonly savedAt: string;
+	readonly readAt?: string;
 }
 
-interface ListQueueResult {
+export type ArticleContentResult =
+	| { readonly status: "ready"; readonly content: string }
+	| { readonly status: "pending" }
+	| { readonly status: "not_found" };
+
+export type ArticleSummaryResult =
+	| { readonly status: "not_found" }
+	| { readonly status: "pending" }
+	| { readonly status: "ready"; readonly summary: string; readonly excerpt?: string }
+	| { readonly status: "failed"; readonly reason: string }
+	| { readonly status: "skipped"; readonly reason?: string };
+
+export interface ListQueueResult {
 	readonly total: number;
-	readonly articles: readonly QueueArticle[];
+	readonly page: number;
+	readonly pageSize: number;
+	readonly articles: readonly McpArticle[];
 }
 
 /** The domain operations the tools delegate to. The composition root wires
- * these to the same save/list pipeline the hypermedia `/queue` API uses, so an
- * MCP `save_link` and an extension save are the identical write. */
+ * these to the same save/list/read pipeline the hypermedia `/queue` API uses,
+ * so an MCP `save_link` and an extension save are the identical write, and the
+ * read tools see exactly what the user's own queue shows. */
 export interface McpServerDeps {
 	saveLink: (params: {
 		userId: UserId;
@@ -36,7 +77,23 @@ export interface McpServerDeps {
 	listQueue: (params: {
 		userId: UserId;
 		status?: ArticleStatus;
+		sort?: SortField;
+		order?: SortOrder;
+		page?: number;
+		pageSize?: number;
 	}) => Promise<ListQueueResult>;
+	getArticle: (params: {
+		userId: UserId;
+		id: string;
+	}) => Promise<McpArticle | null>;
+	getArticleContent: (params: {
+		userId: UserId;
+		id: string;
+	}) => Promise<ArticleContentResult>;
+	getArticleSummary: (params: {
+		userId: UserId;
+		id: string;
+	}) => Promise<ArticleSummaryResult>;
 }
 
 /** The authenticated caller a request runs as. Resolved from the OAuth bearer
@@ -68,6 +125,7 @@ interface TextContent {
 
 interface ToolResult {
 	readonly content: readonly TextContent[];
+	readonly structuredContent?: unknown;
 	readonly isError?: boolean;
 }
 
@@ -118,12 +176,33 @@ function text(value: string): ToolResult {
 	return { content: [{ type: "text", text: value }] };
 }
 
+/** A successful tool result that carries both a human-readable text block (for
+ * clients that only render text) and the machine-readable `structuredContent`
+ * (for clients that consume structured output). */
+function data(textValue: string, structuredContent: unknown): ToolResult {
+	return { content: [{ type: "text", text: textValue }], structuredContent };
+}
+
 function toolError(value: string): ToolResult {
 	return { content: [{ type: "text", text: value }], isError: true };
 }
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function notFoundResult(id: string): ToolResult {
+	return data(`No saved article with id ${id} is in your queue.`, {
+		found: false,
+	});
+}
+
+function formatArticle(article: McpArticle): string {
+	const dates = article.readAt
+		? `Saved ${article.savedAt}; read ${article.readAt}`
+		: `Saved ${article.savedAt}`;
+	const excerpt = article.excerpt ? `\n${article.excerpt}` : "";
+	return `"${article.title || article.url}" [${article.status}] — ${article.url}\n${article.siteName} · ~${article.estimatedReadTime} min read · ${article.wordCount} words\n${dates}${excerpt}`;
 }
 
 export function initMcpServer(deps: McpServerDeps): McpServer {
@@ -133,7 +212,7 @@ export function initMcpServer(deps: McpServerDeps): McpServer {
 			capabilities: { tools: { listChanged: false } },
 			serverInfo: MCP_SERVER_INFO,
 			instructions:
-				"Use save_link to add a URL to the user's Readplace reading queue, and list_queue to see what they have saved.",
+				"save_link adds a URL to the user's Readplace reading queue; list_queue lists saved articles, each with an id you pass to get_article (metadata), get_article_content (reader HTML), and get_article_summary (AI TL;DR). Marking an article read/unread or deleting it is intentionally NOT available to the assistant — the set_article_status and delete_article tools only return instructions for the user to do it in the Readplace app.",
 		};
 	}
 
@@ -144,6 +223,7 @@ export function initMcpServer(deps: McpServerDeps): McpServer {
 				title: tool.title,
 				description: tool.description,
 				inputSchema: tool.inputSchema,
+				annotations: tool.annotations,
 			})),
 		};
 	}
@@ -176,29 +256,206 @@ export function initMcpServer(deps: McpServerDeps): McpServer {
 	): Promise<ToolResult> {
 		const args = ListQueueArgs.safeParse(rawArgs);
 		if (!args.success) {
-			return toolError('list_queue `status` must be "unread" or "read".');
+			return toolError(
+				'list_queue arguments are invalid: `status` must be "unread" or "read", `sort` "saved" or "read", `order` "asc" or "desc".',
+			);
 		}
+		const a = args.data;
+
+		let page: number;
+		let pageSize: number | undefined;
+		let status: ArticleStatus | undefined;
+		let sort: SortField | undefined;
+		let order: SortOrder | undefined;
+		if (a.cursor !== undefined) {
+			const decoded = decodeQueueCursor(a.cursor);
+			if (!decoded) {
+				return toolError(
+					"That pagination cursor is invalid or expired. Call list_queue again without a cursor to start from the first page.",
+				);
+			}
+			({ page, pageSize, status, sort, order } = decoded);
+		} else {
+			sort =
+				a.sort === "read" ? "readAt" : a.sort === "saved" ? "savedAt" : undefined;
+			if (sort === "readAt" && a.status !== "read") {
+				return toolError(
+					'Sorting by read date (`sort:"read"`) only applies to read articles — pass `status:"read"` as well.',
+				);
+			}
+			page = 1;
+			pageSize = a.limit;
+			status = a.status;
+			order = a.order;
+		}
+
 		try {
 			const outcome = await deps.listQueue({
 				userId: context.userId,
-				status: args.data.status,
+				status,
+				sort,
+				order,
+				page,
+				pageSize,
 			});
-			if (outcome.total === 0) {
-				return text("Your Readplace queue is empty.");
+			const hasMore = outcome.page * outcome.pageSize < outcome.total;
+			const nextCursor = hasMore
+				? encodeQueueCursor({
+						page: outcome.page + 1,
+						pageSize: outcome.pageSize,
+						status,
+						sort,
+						order,
+					})
+				: undefined;
+			const structuredContent = {
+				articles: outcome.articles,
+				total: outcome.total,
+				count: outcome.articles.length,
+				...(nextCursor ? { nextCursor } : {}),
+			};
+
+			if (outcome.articles.length === 0) {
+				return data(
+					outcome.total === 0
+						? "Your Readplace queue is empty."
+						: "No more saved articles.",
+					structuredContent,
+				);
 			}
+
 			const lines = outcome.articles.map(
 				(article) =>
 					`- ${article.title || article.url} [${article.status}] ${article.url}`,
 			);
 			const shown = outcome.articles.length;
-			const header =
-				shown < outcome.total
-					? `You have ${outcome.total} saved article(s); showing the first ${shown}:`
-					: `You have ${outcome.total} saved article(s):`;
-			return text(`${header}\n${lines.join("\n")}`);
+			let header: string;
+			if (outcome.page > 1) {
+				header = `Showing ${shown} more of your ${outcome.total} saved article(s):`;
+			} else if (shown < outcome.total) {
+				header = `You have ${outcome.total} saved article(s); showing the first ${shown}:`;
+			} else {
+				header = `You have ${outcome.total} saved article(s):`;
+			}
+			return data(`${header}\n${lines.join("\n")}`, structuredContent);
 		} catch (error) {
 			return toolError(`Could not list your queue. ${errorMessage(error)}`);
 		}
+	}
+
+	async function runGetArticle(
+		rawArgs: unknown,
+		context: McpRequestContext,
+	): Promise<ToolResult> {
+		const args = ArticleIdArgs.safeParse(rawArgs);
+		if (!args.success) return toolError("get_article requires an `id` string.");
+		try {
+			const article = await deps.getArticle({
+				userId: context.userId,
+				id: args.data.id,
+			});
+			if (!article) return notFoundResult(args.data.id);
+			return data(formatArticle(article), { found: true, article });
+		} catch (error) {
+			return toolError(`Could not load the article. ${errorMessage(error)}`);
+		}
+	}
+
+	async function runGetArticleContent(
+		rawArgs: unknown,
+		context: McpRequestContext,
+	): Promise<ToolResult> {
+		const args = ArticleIdArgs.safeParse(rawArgs);
+		if (!args.success) {
+			return toolError("get_article_content requires an `id` string.");
+		}
+		try {
+			const result = await deps.getArticleContent({
+				userId: context.userId,
+				id: args.data.id,
+			});
+			switch (result.status) {
+				case "not_found":
+					return notFoundResult(args.data.id);
+				case "pending":
+					return data(
+						"That article is still being fetched; its reader view isn't ready yet. Try again shortly.",
+						result,
+					);
+				case "ready":
+					return data(result.content, result);
+			}
+		} catch (error) {
+			return toolError(
+				`Could not load the article content. ${errorMessage(error)}`,
+			);
+		}
+	}
+
+	async function runGetArticleSummary(
+		rawArgs: unknown,
+		context: McpRequestContext,
+	): Promise<ToolResult> {
+		const args = ArticleIdArgs.safeParse(rawArgs);
+		if (!args.success) {
+			return toolError("get_article_summary requires an `id` string.");
+		}
+		try {
+			const result = await deps.getArticleSummary({
+				userId: context.userId,
+				id: args.data.id,
+			});
+			switch (result.status) {
+				case "not_found":
+					return notFoundResult(args.data.id);
+				case "pending":
+					return data(
+						"The AI summary for that article is still being generated. Try again shortly.",
+						result,
+					);
+				case "ready":
+					return data(result.summary, result);
+				case "failed":
+					return data(
+						`The summary for that article could not be generated: ${result.reason}`,
+						result,
+					);
+				case "skipped":
+					return data(
+						"No summary was generated for that article (it may be too short or an unsupported type).",
+						result,
+					);
+			}
+		} catch (error) {
+			return toolError(
+				`Could not load the article summary. ${errorMessage(error)}`,
+			);
+		}
+	}
+
+	/** Both write actions are app-only. The handler never touches the store; it
+	 * returns the same wording the user would see if they asked the assistant to
+	 * do it, so the assistant relays "do it in the app" instead of inventing a
+	 * capability it doesn't have. */
+	function appOnlyResult(
+		action: "set_article_status" | "delete_article",
+		message: string,
+	): ToolResult {
+		return data(message, { action, performed: false, completeInApp: APP_QUEUE_URL });
+	}
+
+	function runSetArticleStatus(): ToolResult {
+		return appOnlyResult(
+			"set_article_status",
+			`Marking an article read or unread is done in the Readplace app, not by your assistant, so changes to your queue stay under your control. Open your queue at ${APP_QUEUE_URL} to change an article's status.`,
+		);
+	}
+
+	function runDeleteArticle(): ToolResult {
+		return appOnlyResult(
+			"delete_article",
+			`Deleting a saved article is done in the Readplace app, not by your assistant, so nothing is removed by mistake. Open your queue at ${APP_QUEUE_URL} to delete an article.`,
+		);
 	}
 
 	async function handleToolsCall(
@@ -216,6 +473,16 @@ export function initMcpServer(deps: McpServerDeps): McpServer {
 				return success(id, await runSaveLink(rawArgs, context));
 			case LIST_QUEUE_TOOL.name:
 				return success(id, await runListQueue(rawArgs, context));
+			case GET_ARTICLE_TOOL.name:
+				return success(id, await runGetArticle(rawArgs, context));
+			case GET_ARTICLE_CONTENT_TOOL.name:
+				return success(id, await runGetArticleContent(rawArgs, context));
+			case GET_ARTICLE_SUMMARY_TOOL.name:
+				return success(id, await runGetArticleSummary(rawArgs, context));
+			case SET_ARTICLE_STATUS_TOOL.name:
+				return success(id, runSetArticleStatus());
+			case DELETE_ARTICLE_TOOL.name:
+				return success(id, runDeleteArticle());
 			default:
 				return failure(id, -32602, `Unknown tool: ${parsed.data.name}`);
 		}

--- a/projects/hutch/src/runtime/web/mcp/mcp.integration.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp.integration.ts
@@ -19,13 +19,16 @@ function generatePkce() {
 	return { codeVerifier, codeChallenge };
 }
 
-async function obtainAccessToken(harness: TestAppHarness): Promise<string> {
-	await harness.auth.createUser({ email: "mcp@example.com", password: "password123" });
+async function obtainAccessToken(
+	harness: TestAppHarness,
+	email = "mcp@example.com",
+): Promise<string> {
+	await harness.auth.createUser({ email, password: "password123" });
 	const agent = request.agent(harness.server);
 	await agent
 		.post("/login")
 		.type("form")
-		.send({ email: "mcp@example.com", password: "password123" });
+		.send({ email, password: "password123" });
 
 	const { codeVerifier, codeChallenge } = generatePkce();
 	const authorizeResponse = await agent
@@ -67,6 +70,27 @@ function callTool(harness: TestAppHarness, accessToken: string, body: unknown) {
 		.set("Authorization", `Bearer ${accessToken}`)
 		.set("Content-Type", "application/json")
 		.send(JSON.stringify(body));
+}
+
+let nextId = 100;
+function tool(name: string, args?: unknown) {
+	return {
+		jsonrpc: "2.0",
+		id: nextId++,
+		method: "tools/call",
+		params: { name, ...(args !== undefined ? { arguments: args } : {}) },
+	};
+}
+
+async function saveAndGetFirstId(
+	harness: TestAppHarness,
+	accessToken: string,
+): Promise<string> {
+	await callTool(harness, accessToken, tool("save_link", { url: "https://example.com/article" }));
+	const list = await callTool(harness, accessToken, tool("list_queue"));
+	const id = list.body.result.structuredContent.articles[0]?.id;
+	assert(typeof id === "string", "list_queue must expose an article id");
+	return id;
 }
 
 const useApp = useTestServer();
@@ -141,5 +165,75 @@ describe("MCP server over the real app", () => {
 		expect(response.status).toBe(200);
 		expect(response.body.result.isError).toBe(true);
 		expect(response.body.result.content[0].text).toContain("subscription");
+	});
+
+	it("advertises the read tools and the app-only write tools", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
+		const response = await callTool(harness, accessToken, {
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/list",
+		});
+		expect(response.body.result.tools.map((t: { name: string }) => t.name)).toEqual([
+			"save_link",
+			"list_queue",
+			"get_article",
+			"get_article_content",
+			"get_article_summary",
+			"set_article_status",
+			"delete_article",
+		]);
+	});
+
+	it("fetches a saved article's metadata, content, and summary by id", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
+		const id = await saveAndGetFirstId(harness, accessToken);
+
+		const article = await callTool(harness, accessToken, tool("get_article", { id }));
+		expect(article.body.result.isError).toBeUndefined();
+		expect(article.body.result.structuredContent).toMatchObject({
+			found: true,
+			article: { id },
+		});
+
+		const content = await callTool(harness, accessToken, tool("get_article_content", { id }));
+		expect(content.body.result.isError).toBeUndefined();
+		expect(typeof content.body.result.structuredContent.status).toBe("string");
+
+		const summary = await callTool(harness, accessToken, tool("get_article_summary", { id }));
+		expect(summary.body.result.isError).toBeUndefined();
+		expect(typeof summary.body.result.structuredContent.status).toBe("string");
+	});
+
+	it("reports not found for an id the caller does not own", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const ownerToken = await obtainAccessToken(harness);
+		const id = await saveAndGetFirstId(harness, ownerToken);
+
+		const otherToken = await obtainAccessToken(harness, "other@example.com");
+		const article = await callTool(harness, otherToken, tool("get_article", { id }));
+		expect(article.body.result.structuredContent).toEqual({ found: false });
+
+		const list = await callTool(harness, otherToken, tool("list_queue"));
+		expect(list.body.result.structuredContent.total).toBe(0);
+	});
+
+	it("never changes status or deletes through the write tools", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await obtainAccessToken(harness);
+		const id = await saveAndGetFirstId(harness, accessToken);
+
+		const del = await callTool(harness, accessToken, tool("delete_article", { id }));
+		expect(del.body.result.structuredContent.performed).toBe(false);
+		const status = await callTool(harness, accessToken, tool("set_article_status", { id, status: "read" }));
+		expect(status.body.result.structuredContent.performed).toBe(false);
+
+		// The article is still present and still unread — the writes did nothing.
+		const article = await callTool(harness, accessToken, tool("get_article", { id }));
+		expect(article.body.result.structuredContent.article.status).toBe("unread");
+		const list = await callTool(harness, accessToken, tool("list_queue"));
+		expect(list.body.result.structuredContent.total).toBe(1);
 	});
 });

--- a/projects/hutch/src/runtime/web/mcp/mcp.routes.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp.routes.test.ts
@@ -13,7 +13,10 @@ const validateAccessToken: ValidateAccessToken = async (token) =>
 function buildApp(): Express {
 	const mcpServer = initMcpServer({
 		saveLink: async ({ url }) => ({ ok: true, title: "Saved", url }),
-		listQueue: async () => ({ total: 0, articles: [] }),
+		listQueue: async () => ({ total: 0, page: 1, pageSize: 20, articles: [] }),
+		getArticle: async () => null,
+		getArticleContent: async () => ({ status: "not_found" }),
+		getArticleSummary: async () => ({ status: "not_found" }),
 	});
 	const app = express();
 	app.use(

--- a/projects/hutch/src/runtime/web/mcp/server-card.ts
+++ b/projects/hutch/src/runtime/web/mcp/server-card.ts
@@ -16,7 +16,7 @@ export function buildMcpServerCard(baseUrl: string): object {
 		protocolVersion: MCP_PROTOCOL_VERSION,
 		serverInfo: MCP_SERVER_INFO,
 		description:
-			"Save links to your Readplace reading queue and list what you have saved.",
+			"Save links to your Readplace reading queue, list what you have saved, and fetch a saved article's metadata, reader view, and AI summary. Marking articles read and deleting them are done in the Readplace app.",
 		documentationUrl: `${baseUrl}/auth.md`,
 		transport: {
 			type: "streamable-http",

--- a/projects/hutch/src/runtime/web/mcp/tool-definitions.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/tool-definitions.test.ts
@@ -1,17 +1,46 @@
 import {
+	ArticleIdArgs,
+	DELETE_ARTICLE_TOOL,
+	GET_ARTICLE_CONTENT_TOOL,
+	GET_ARTICLE_SUMMARY_TOOL,
+	GET_ARTICLE_TOOL,
 	LIST_QUEUE_TOOL,
 	ListQueueArgs,
 	SAVE_LINK_TOOL,
+	SET_ARTICLE_STATUS_TOOL,
 	SaveLinkArgs,
 	TOOL_DEFINITIONS,
 } from "./tool-definitions";
 
 describe("MCP tool definitions", () => {
-	it("exposes save_link and list_queue", () => {
+	it("exposes the save, list, and by-id read tools plus the app-only write tools", () => {
 		expect(TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([
 			"save_link",
 			"list_queue",
+			"get_article",
+			"get_article_content",
+			"get_article_summary",
+			"set_article_status",
+			"delete_article",
 		]);
+	});
+
+	it("annotates every tool with its read/write and reach hints", () => {
+		expect(SAVE_LINK_TOOL.annotations).toMatchObject({
+			readOnlyHint: false,
+			openWorldHint: true,
+		});
+		for (const tool of [
+			LIST_QUEUE_TOOL,
+			GET_ARTICLE_TOOL,
+			GET_ARTICLE_CONTENT_TOOL,
+			GET_ARTICLE_SUMMARY_TOOL,
+		]) {
+			expect(tool.annotations).toMatchObject({
+				readOnlyHint: true,
+				openWorldHint: false,
+			});
+		}
 	});
 
 	describe("save_link", () => {
@@ -35,6 +64,66 @@ describe("MCP tool definitions", () => {
 			expect(ListQueueArgs.safeParse({ status: "unread" }).success).toBe(true);
 			expect(ListQueueArgs.safeParse({ status: "read" }).success).toBe(true);
 			expect(ListQueueArgs.safeParse({ status: "archived" }).success).toBe(false);
+		});
+
+		it("accepts the pagination and sort controls", () => {
+			expect(LIST_QUEUE_TOOL.inputSchema).toMatchObject({
+				properties: {
+					sort: { enum: ["saved", "read"] },
+					order: { enum: ["asc", "desc"] },
+					limit: { type: "integer", minimum: 1, maximum: 100 },
+					cursor: { type: "string" },
+				},
+			});
+			expect(
+				ListQueueArgs.safeParse({ sort: "read", order: "asc", limit: 5 }).success,
+			).toBe(true);
+			expect(ListQueueArgs.safeParse({ cursor: "abc" }).success).toBe(true);
+			expect(ListQueueArgs.safeParse({ sort: "newest" }).success).toBe(false);
+			expect(ListQueueArgs.safeParse({ limit: 0 }).success).toBe(false);
+			expect(ListQueueArgs.safeParse({ limit: 101 }).success).toBe(false);
+		});
+	});
+
+	describe("by-id read tools", () => {
+		it.each([
+			["get_article", GET_ARTICLE_TOOL],
+			["get_article_content", GET_ARTICLE_CONTENT_TOOL],
+			["get_article_summary", GET_ARTICLE_SUMMARY_TOOL],
+		])("requires an id in %s's JSON Schema", (_name, tool) => {
+			expect(tool.inputSchema).toMatchObject({
+				required: ["id"],
+				properties: { id: { type: "string" } },
+			});
+		});
+
+		it("validates the shared id argument", () => {
+			expect(ArticleIdArgs.safeParse({ id: "abc" }).success).toBe(true);
+			expect(ArticleIdArgs.safeParse({}).success).toBe(false);
+			expect(ArticleIdArgs.safeParse({ id: "" }).success).toBe(false);
+		});
+	});
+
+	describe("app-only write tools", () => {
+		it("advertises set_article_status as a read-only, non-destructive redirect", () => {
+			expect(SET_ARTICLE_STATUS_TOOL.inputSchema).toMatchObject({
+				required: ["id", "status"],
+				properties: { status: { enum: ["read", "unread"] } },
+			});
+			expect(SET_ARTICLE_STATUS_TOOL.annotations).toMatchObject({
+				readOnlyHint: true,
+				destructiveHint: false,
+			});
+		});
+
+		it("advertises delete_article as a read-only, non-destructive redirect", () => {
+			expect(DELETE_ARTICLE_TOOL.inputSchema).toMatchObject({
+				required: ["id"],
+			});
+			expect(DELETE_ARTICLE_TOOL.annotations).toMatchObject({
+				readOnlyHint: true,
+				destructiveHint: false,
+			});
 		});
 	});
 });

--- a/projects/hutch/src/runtime/web/mcp/tool-definitions.ts
+++ b/projects/hutch/src/runtime/web/mcp/tool-definitions.ts
@@ -1,5 +1,16 @@
 import { z } from "zod";
 
+/** MCP tool annotations: advisory hints a client uses to decide how much to
+ * trust or how loudly to confirm a tool call. `readOnlyHint` marks a tool that
+ * never changes anything; `openWorldHint` marks one that reaches the public
+ * internet (only `save_link` does). See the MCP tool annotations spec. */
+interface McpToolAnnotations {
+	readonly readOnlyHint?: boolean;
+	readonly destructiveHint?: boolean;
+	readonly idempotentHint?: boolean;
+	readonly openWorldHint?: boolean;
+}
+
 /**
  * Public metadata for a Readplace MCP tool: the JSON Schema advertised in
  * `tools/list` and summarised on the server card. The matching Zod validator
@@ -12,6 +23,7 @@ interface McpToolDefinition {
 	readonly title: string;
 	readonly description: string;
 	readonly inputSchema: Record<string, unknown>;
+	readonly annotations: McpToolAnnotations;
 }
 
 export const SaveLinkArgs = z.object({
@@ -20,7 +32,26 @@ export const SaveLinkArgs = z.object({
 
 export const ListQueueArgs = z.object({
 	status: z.enum(["unread", "read"]).optional(),
+	sort: z.enum(["saved", "read"]).optional(),
+	order: z.enum(["asc", "desc"]).optional(),
+	limit: z.number().int().min(1).max(100).optional(),
+	cursor: z.string().min(1).optional(),
 });
+
+/** Shared by every by-id read tool (`get_article`, `get_article_content`,
+ * `get_article_summary`). The id is the 32-hex hash an agent reads off a
+ * `list_queue` result; the server resolves it to an owned article. */
+export const ArticleIdArgs = z.object({
+	id: z.string().min(1),
+});
+
+const ID_PROPERTY = {
+	id: {
+		type: "string",
+		description:
+			"The article's id from a list_queue result (a 32-character hex string).",
+	},
+} as const;
 
 export const SAVE_LINK_TOOL: McpToolDefinition = {
 	name: "save_link",
@@ -38,13 +69,19 @@ export const SAVE_LINK_TOOL: McpToolDefinition = {
 		required: ["url"],
 		additionalProperties: false,
 	},
+	annotations: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	},
 };
 
 export const LIST_QUEUE_TOOL: McpToolDefinition = {
 	name: "list_queue",
 	title: "List saved articles",
 	description:
-		"List the pages the user has saved to their Readplace reading queue, optionally filtered to unread or already-read items.",
+		"List the pages the user has saved to their Readplace reading queue, optionally filtered to unread or already-read items. Each item includes an `id` you can pass to get_article, get_article_content, or get_article_summary. Use `limit` and the `nextCursor` from a previous result to page through a long queue.",
 	inputSchema: {
 		type: "object",
 		properties: {
@@ -54,12 +91,132 @@ export const LIST_QUEUE_TOOL: McpToolDefinition = {
 				description:
 					"Filter to only unread or only read items. Omit to list everything.",
 			},
+			sort: {
+				type: "string",
+				enum: ["saved", "read"],
+				description:
+					'Sort by date saved (default) or date read. "read" requires status "read".',
+			},
+			order: {
+				type: "string",
+				enum: ["asc", "desc"],
+				description: "Sort direction. Defaults to newest first (desc).",
+			},
+			limit: {
+				type: "integer",
+				minimum: 1,
+				maximum: 100,
+				description: "Maximum items to return per page (default 20).",
+			},
+			cursor: {
+				type: "string",
+				description:
+					"An opaque nextCursor from a previous list_queue result, to fetch the following page.",
+			},
 		},
 		additionalProperties: false,
+	},
+	annotations: { readOnlyHint: true, openWorldHint: false },
+};
+
+export const GET_ARTICLE_TOOL: McpToolDefinition = {
+	name: "get_article",
+	title: "Get a saved article",
+	description:
+		"Return the full metadata (title, site, excerpt, word count, estimated read time, status, and saved/read dates) for one saved article, looked up by the id from a list_queue result.",
+	inputSchema: {
+		type: "object",
+		properties: { ...ID_PROPERTY },
+		required: ["id"],
+		additionalProperties: false,
+	},
+	annotations: { readOnlyHint: true, openWorldHint: false },
+};
+
+export const GET_ARTICLE_CONTENT_TOOL: McpToolDefinition = {
+	name: "get_article_content",
+	title: "Get a saved article's reader view",
+	description:
+		"Return the cleaned, readable HTML of one saved article, looked up by id. If the reader view is still being fetched, reports that it is not ready yet rather than failing.",
+	inputSchema: {
+		type: "object",
+		properties: { ...ID_PROPERTY },
+		required: ["id"],
+		additionalProperties: false,
+	},
+	annotations: { readOnlyHint: true, openWorldHint: false },
+};
+
+export const GET_ARTICLE_SUMMARY_TOOL: McpToolDefinition = {
+	name: "get_article_summary",
+	title: "Get a saved article's summary",
+	description:
+		"Return the AI-generated TL;DR for one saved article, looked up by id, or its current status (pending, failed, or skipped) when a summary is not yet available.",
+	inputSchema: {
+		type: "object",
+		properties: { ...ID_PROPERTY },
+		required: ["id"],
+		additionalProperties: false,
+	},
+	annotations: { readOnlyHint: true, openWorldHint: false },
+};
+
+/** `set_article_status` and `delete_article` are deliberately app-only: an
+ * assistant must not flip an article's read state or delete it on the user's
+ * behalf. They are advertised (so the assistant maps the user's intent to a
+ * clear answer instead of an empty "I can't") but their handlers never mutate —
+ * they return instructions to do it in the app. Hence `readOnlyHint: true`. */
+export const SET_ARTICLE_STATUS_TOOL: McpToolDefinition = {
+	name: "set_article_status",
+	title: "Mark an article read or unread (in the app)",
+	description:
+		"Marking a saved article read or unread is done by the user in the Readplace app, not by the assistant. Calling this does NOT change anything — it returns instructions to open the app.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			...ID_PROPERTY,
+			status: {
+				type: "string",
+				enum: ["read", "unread"],
+				description: "The status the user wants to set.",
+			},
+		},
+		required: ["id", "status"],
+		additionalProperties: false,
+	},
+	annotations: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
+};
+
+export const DELETE_ARTICLE_TOOL: McpToolDefinition = {
+	name: "delete_article",
+	title: "Delete a saved article (in the app)",
+	description:
+		"Deleting a saved article is done by the user in the Readplace app, not by the assistant. Calling this does NOT delete anything — it returns instructions to open the app.",
+	inputSchema: {
+		type: "object",
+		properties: { ...ID_PROPERTY },
+		required: ["id"],
+		additionalProperties: false,
+	},
+	annotations: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
 	},
 };
 
 export const TOOL_DEFINITIONS: readonly McpToolDefinition[] = [
 	SAVE_LINK_TOOL,
 	LIST_QUEUE_TOOL,
+	GET_ARTICLE_TOOL,
+	GET_ARTICLE_CONTENT_TOOL,
+	GET_ARTICLE_SUMMARY_TOOL,
+	SET_ARTICLE_STATUS_TOOL,
+	DELETE_ARTICLE_TOOL,
 ];

--- a/projects/hutch/src/runtime/web/pages/mcp/mcp-connect.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/mcp/mcp-connect.route.test.ts
@@ -20,6 +20,8 @@ describe("GET /mcp (browser connection guide)", () => {
 		expect(response.text).toContain("Claude");
 		expect(response.text).toContain("ChatGPT");
 		expect(response.text).toContain("Perplexity");
+		expect(response.text).toContain("get_article");
+		expect(response.text).toContain("marking articles read and deleting them stay in the Readplace app");
 	});
 
 	it.each([

--- a/projects/hutch/src/runtime/web/pages/mcp/mcp-connect.template.html
+++ b/projects/hutch/src/runtime/web/pages/mcp/mcp-connect.template.html
@@ -23,7 +23,8 @@
 
       <section class="mcp-connect__tool">
         <h2 class="mcp-connect__tool-name">What your assistant can do</h2>
-        <p class="mcp-connect__tool-req">Once connected, your assistant gets two tools: <strong>save_link</strong> adds a page to your queue (the title, excerpt, and clean reader view fill in moments later), and <strong>list_queue</strong> reads back what you have saved, filtered to unread or already-read. Every page it saves gets the same reader view and summary as one you save yourself.</p>
+        <p class="mcp-connect__tool-req"><strong>save_link</strong> adds a page to your queue (the title, excerpt, and clean reader view fill in moments later). <strong>list_queue</strong> reads back what you have saved, filtered to unread or already-read. From a listed item, <strong>get_article</strong> returns its details, <strong>get_article_content</strong> returns the clean reader view, and <strong>get_article_summary</strong> returns the AI TL;DR. Every page it saves gets the same reader view and summary as one you save yourself.</p>
+        <p class="mcp-connect__tool-req">For your safety, <strong>marking articles read and deleting them stay in the Readplace app</strong> &mdash; your assistant can&rsquo;t change or remove items in your queue, only point you to the app to do it yourself.</p>
       </section>
     </div>
   </main>


### PR DESCRIPTION
## What

Expands the Readplace MCP server to expose existing read functionality, while deliberately keeping the two destructive actions — marking read/unread and deleting — **out of the assistant** for safety.

### New read tools (delegate to the same store seams `/queue` uses)
- **`get_article`** — full metadata for one saved article by id.
- **`get_article_content`** — cleaned reader HTML on demand, with a "still being fetched" status instead of an error while the crawl runs.
- **`get_article_summary`** — the existing AI TL;DR, with `pending` / `ready` / `failed` / `skipped` status.
- **`list_queue` (enhanced)** — opaque-cursor pagination (`limit` + `nextCursor`), `sort` (saved/read date) + `order`, and a structured result that now carries each article's **`id`** so the by-id tools can target it. No-args calls stay **byte-for-byte backward compatible**.

Every lookup is owner-scoped (`findArticleById` is keyed by `userId`), so a cross-user or malformed id resolves to "not found" rather than another user's article — verified by an integration test.

### Status change & deletion stay app-only (the safety ask)
`set_article_status` and `delete_article` are **advertised but never mutate**. Calling either returns a clear message pointing the user to the Readplace app (`/queue`), plus `structuredContent.performed: false`. They're annotated `readOnlyHint: true` since nothing is written. This way, when a user asks the assistant to mark-read or delete, it gives a clear "do it in the app" answer instead of an empty "I can't" — without ever letting a hallucination commit a destructive write. An end-to-end test calls both and then proves the queue is unchanged.

### Cross-cutting polish
- Accurate tool **annotations** on every tool (incl. `save_link`/`list_queue`).
- **`structuredContent`** + serialized-text fallback on the data tools.
- Updated `/mcp` connect page, server card, and `initialize` instructions to describe the toolset and the app-only policy.

## Design notes
- `save_link` is unchanged (still gated by the save-access seam); the new write tools mirror the app, which does **not** gate `/:id/status` or `/:id/delete` — but here they don't write at all.
- The read logic lives in a unit-tested `article-operations.ts` module, keeping the composition root thin.
- Cursor pagination is satisfied at the MCP layer by wrapping the store's existing offset pagination in an opaque token — no schema/table change.

## Testing
`pnpm nx run hutch:check` passes (lint, types, knip, unused-CSS, 100% function / threshold coverage). MCP suites: **107 tests across 8 suites**, including per-user isolation, pagination boundaries, invalid-cursor restart, content/summary pending states, and the no-mutation guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJAiwanY8fjG3S1Nyb6LmC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJAiwanY8fjG3S1Nyb6LmC)_