### PR TITLE
fix(changelog-banner): keep readers on the page when dismissing

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/blog.page.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.page.ts
@@ -96,7 +96,11 @@ export function initBlogRoutes(deps: { blogPosts: BlogPosts; base: RenderBase })
 	router.get("/", (req: Request, res: Response) => {
 		const posts = blogPosts.getAllPosts();
 		const changelogBanner = hideIfDismissed(blogPosts.getLatestChangelogBanner(), req);
-		sendComponent(req, res, base(BlogIndexPage({ posts }), { ...GUEST_STATE, changelogBanner }));
+		sendComponent(
+			req,
+			res,
+			base(BlogIndexPage({ posts }), { ...GUEST_STATE, changelogBanner, currentPath: req.originalUrl }),
+		);
 	});
 
 	router.get("/:slug", (req: Request<{ slug: string }>, res: Response) => {
@@ -108,10 +112,18 @@ export function initBlogRoutes(deps: { blogPosts: BlogPosts; base: RenderBase })
 		const post = blogPosts.findPostBySlug(req.params.slug);
 		const changelogBanner = hideIfDismissed(blogPosts.getLatestChangelogBanner(), req);
 		if (!post) {
-			sendComponent(req, res, base(NotFoundPage(), { ...GUEST_STATE, changelogBanner }));
+			sendComponent(
+				req,
+				res,
+				base(NotFoundPage(), { ...GUEST_STATE, changelogBanner, currentPath: req.originalUrl }),
+			);
 			return;
 		}
-		sendComponent(req, res, base(BlogPostPage({ post }), { ...GUEST_STATE, changelogBanner }));
+		sendComponent(
+			req,
+			res,
+			base(BlogPostPage({ post }), { ...GUEST_STATE, changelogBanner, currentPath: req.originalUrl }),
+		);
 	});
 
 	return router;

--- a/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
+++ b/projects/blog-site/src/runtime/web/pages/blog/blog.route.test.ts
@@ -335,7 +335,7 @@ describe("changelog banner on /blog pages", () => {
 		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
 	});
 
-	it("renders the banner on a post page too (same shell, every page)", async () => {
+	it("renders the banner on a post page too and posts that post's path so dismissing stays on the post", async () => {
 		const slug = firstPost.slug;
 		const blogPostsStub: BlogPosts = {
 			getAllPosts: () => [firstPost],
@@ -350,10 +350,11 @@ describe("changelog banner on /blog pages", () => {
 		expressApp.use("/blog", initBlogRoutes({ blogPosts: blogPostsStub, base }));
 
 		const response = await request(expressApp).get(`/blog/${slug}`);
-		const banner = new JSDOM(response.text).window.document.querySelector(
-			"[data-test-changelog-banner]",
-		);
+		const doc = new JSDOM(response.text).window.document;
+		const banner = doc.querySelector("[data-test-changelog-banner]");
 		expect(banner?.classList.contains("changelog-banner--visible")).toBe(true);
+		const returnTo = doc.querySelector('.changelog-banner__dismiss input[name="returnTo"]');
+		expect(returnTo?.getAttribute("value")).toBe(`/blog/${slug}`);
 	});
 });
 

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -694,7 +694,7 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	/** Same-origin dismissal endpoint for the site-wide changelog banner; served
 	 * here on $default even when the close button is clicked on a /blog page. */
-	app.use(initChangelogDismissRoute({ appOrigin, secureCookies }));
+	app.use(initChangelogDismissRoute({ secureCookies }));
 
 	const authRouter = initAuthRoutes({
 		hashPassword: deps.hashPassword,

--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -239,4 +239,16 @@ describe("initBuildBannerState", () => {
 			expect(result.changelogBanner).toBeUndefined();
 		});
 	});
+
+	it("threads the request's originalUrl onto currentPath so the changelog dismiss form returns the reader to where they were", async () => {
+		const build = initBuildBannerState({
+			getEffectiveAccess: jest.fn(),
+			getChangelogBanner: noChangelogBanner,
+			now: () => FIXED_NOW,
+		});
+
+		const result = await build({ originalUrl: "/queue?filter=unread" });
+
+		expect(result.currentPath).toBe("/queue?filter=unread");
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
 import { useTestServer } from "../../../test-app";
-import { safeBackPath } from "./changelog-dismiss.route";
+import { safeReturnPath } from "./changelog-dismiss.route";
 
 const useApp = useTestServer();
 const COOKIE = "rp_changelog_dismissed";
@@ -11,44 +11,47 @@ function setCookies(headers: { [key: string]: string | string[] | undefined }): 
 	return Array.isArray(raw) ? raw : raw ? [raw] : [];
 }
 
-describe("safeBackPath", () => {
-	const ORIGIN = "https://readplace.com";
-
-	it("returns / when there is no referer", () => {
-		expect(safeBackPath(undefined, ORIGIN)).toBe("/");
+describe("safeReturnPath", () => {
+	it("returns / when there is no return path", () => {
+		expect(safeReturnPath(undefined)).toBe("/");
 	});
 
-	it("returns the path and query for a same-origin referer", () => {
-		expect(safeBackPath("https://readplace.com/queue?filter=unread", ORIGIN)).toBe(
-			"/queue?filter=unread",
-		);
+	it("returns / when the return path is not a string (e.g. a duplicated form field)", () => {
+		expect(safeReturnPath(["/queue", "/account"])).toBe("/");
 	});
 
-	it("returns / for a cross-origin referer", () => {
-		expect(safeBackPath("https://evil.example/queue", ORIGIN)).toBe("/");
+	it("returns the path and query for a root-relative return path", () => {
+		expect(safeReturnPath("/queue?filter=unread")).toBe("/queue?filter=unread");
 	});
 
-	it("returns / for a protocol-relative path on a same-origin referer", () => {
-		expect(safeBackPath("https://readplace.com//evil.com", ORIGIN)).toBe("/");
+	it("returns / for an absolute, cross-origin URL", () => {
+		expect(safeReturnPath("https://evil.example/queue")).toBe("/");
 	});
 
-	it("returns / for a malformed referer", () => {
-		expect(safeBackPath("not a url", ORIGIN)).toBe("/");
+	it("returns / for a protocol-relative authority a browser would resolve off-site", () => {
+		expect(safeReturnPath("//evil.example/queue")).toBe("/");
+	});
+
+	it("returns / for a path that normalises to a // authority", () => {
+		expect(safeReturnPath("/..//evil.example")).toBe("/");
+	});
+
+	it("returns / for an unparseable return path", () => {
+		expect(safeReturnPath("http://[")).toBe("/");
 	});
 });
 
 describe("POST /banner/changelog/dismiss", () => {
-	it("sets the dismissal cookie for a valid version and redirects back to the same-origin referer", async () => {
+	it("sets the dismissal cookie for a valid version and redirects to the posted return path", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const response = await request(harness.server)
 			.post("/banner/changelog/dismiss")
 			.type("form")
-			.set("Referer", `${TEST_APP_ORIGIN}/queue`)
-			.send({ version: "a1b2c3d4" });
+			.send({ version: "a1b2c3d4", returnTo: "/queue?filter=unread" });
 
 		expect(response.status).toBe(303);
-		expect(response.headers.location).toBe("/queue");
+		expect(response.headers.location).toBe("/queue?filter=unread");
 
 		const setCookie = setCookies(response.headers);
 		const cookie = setCookie.find((c) => c.startsWith(`${COOKIE}=`));
@@ -59,21 +62,20 @@ describe("POST /banner/changelog/dismiss", () => {
 		expect(cookie).toContain("Path=/");
 	});
 
-	it("redirects to / (never a protocol-relative Location) for a same-origin referer with a // path", async () => {
+	it("redirects to / (never a protocol-relative Location) for a // return path", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const response = await request(harness.server)
 			.post("/banner/changelog/dismiss")
 			.type("form")
-			.set("Referer", `${TEST_APP_ORIGIN}//evil.com`)
-			.send({ version: "a1b2c3d4" });
+			.send({ version: "a1b2c3d4", returnTo: "//evil.com" });
 
 		expect(response.status).toBe(303);
 		expect(response.headers.location).toBe("/");
 		expect(response.headers.location.startsWith("//")).toBe(false);
 	});
 
-	it("redirects to / when no referer is present", async () => {
+	it("redirects to / when no return path is posted", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const response = await request(harness.server)
@@ -85,28 +87,30 @@ describe("POST /banner/changelog/dismiss", () => {
 		expect(response.headers.location).toBe("/");
 	});
 
-	it("ignores an invalid version (sets no cookie) but still redirects", async () => {
+	it("ignores an invalid version (sets no cookie) but still redirects back", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const response = await request(harness.server)
 			.post("/banner/changelog/dismiss")
 			.type("form")
-			.send({ version: "not-hex-value" });
+			.send({ version: "not-hex-value", returnTo: "/queue" });
 
 		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
 		const setCookie = setCookies(response.headers);
 		expect(setCookie.some((c) => c.startsWith(`${COOKIE}=`))).toBe(false);
 	});
 
-	it("ignores a missing version (sets no cookie) but still redirects", async () => {
+	it("ignores a missing version (sets no cookie) but still redirects back", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 		const response = await request(harness.server)
 			.post("/banner/changelog/dismiss")
 			.type("form")
-			.send({});
+			.send({ returnTo: "/queue" });
 
 		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
 		const setCookie = setCookies(response.headers);
 		expect(setCookie.some((c) => c.startsWith(`${COOKIE}=`))).toBe(false);
 	});

--- a/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
+++ b/projects/hutch/src/runtime/web/pages/banner/changelog-dismiss.route.ts
@@ -4,17 +4,30 @@ import { baseCookieOptions } from "../../cookie-options";
 
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
-/** Where to send the reader after dismissing. The Referer is untrusted, so only
- * a same-origin URL is honoured (its path + query); anything absent,
- * cross-origin, protocol-relative (`//host`, which a same-origin Referer can
- * still yield as a pathname and a browser resolves off-site), or unparseable
- * falls back to "/". Pure and exported so the safety rules are covered without
- * an HTTP round-trip. */
-export function safeBackPath(referer: string | undefined, appOrigin: string): string {
-	if (!referer) return "/";
+/** A throwaway origin to resolve the posted `returnTo` against, so a same-origin
+ * relative path keeps this origin while anything off-site (an absolute URL,
+ * `javascript:`, a protocol-relative `//host`, a backslash `/\host` authority,
+ * or a control-character bypass) resolves to a different origin and is rejected.
+ * `.invalid` is reserved by RFC 2606 and can never be a real destination. */
+const RETURN_PATH_BASE = "https://return-path.invalid";
+
+/** Where to send the reader after dismissing. The banner renders `returnTo` from
+ * the page's own `originalUrl`, but the value still crosses the client boundary
+ * (a reader can craft any POST body), so it is validated like any untrusted
+ * redirect target: resolved against `RETURN_PATH_BASE` and honoured (as its path
+ * + query) only when it stays same-origin and does not yield a `//host` pathname
+ * a browser would resolve off-site. Anything off-origin, unparseable, missing, or
+ * non-string falls back to "/". Pure and exported so the safety rules are covered
+ * without an HTTP round-trip.
+ *
+ * A posted `returnTo` carries the origin page rather than the `Referer` header,
+ * which helmet's default `Referrer-Policy: no-referrer` strips from the no-JS
+ * form POST — without it every dismissal would dead-end on the homepage. */
+export function safeReturnPath(returnTo: unknown): string {
+	if (typeof returnTo !== "string") return "/";
 	try {
-		const target = new URL(referer);
-		if (target.origin !== new URL(appOrigin).origin) return "/";
+		const target = new URL(returnTo, RETURN_PATH_BASE);
+		if (target.origin !== RETURN_PATH_BASE) return "/";
 		const path = `${target.pathname}${target.search}`;
 		return path.startsWith("//") ? "/" : path;
 	} catch {
@@ -26,12 +39,11 @@ export function safeBackPath(referer: string | undefined, appOrigin: string): st
  * Served by hutch's $default even when the button is clicked on a /blog page,
  * since both share the readplace.com origin. Records the dismissed version in a
  * year-long, path:"/" cookie (so both deployables read it) and 303-redirects the
- * reader back to where they were. The posted version is the one actually
- * rendered to the reader, so the cookie matches what they saw regardless of
- * hutch's cache freshness. An invalid or missing version is ignored (no cookie),
- * still redirecting back so the button never dead-ends. */
+ * reader back to the page they dismissed on (the posted `returnTo`). The posted
+ * version is the one actually rendered to the reader, so the cookie matches what
+ * they saw regardless of hutch's cache freshness. An invalid or missing version
+ * is ignored (no cookie), still redirecting back so the button never dead-ends. */
 export function initChangelogDismissRoute(deps: {
-	appOrigin: string;
 	secureCookies: boolean;
 }): Router {
 	const router = express.Router();
@@ -44,7 +56,7 @@ export function initChangelogDismissRoute(deps: {
 				maxAge: ONE_YEAR_MS,
 			});
 		}
-		res.redirect(303, safeBackPath(req.get("referer"), deps.appOrigin));
+		res.redirect(303, safeReturnPath(req.body.returnTo));
 	});
 
 	return router;

--- a/src/packages/web-shell/src/banner-state.test.ts
+++ b/src/packages/web-shell/src/banner-state.test.ts
@@ -27,6 +27,16 @@ describe("bannerStateFromRequest", () => {
 		expect(bannerStateFromRequest({ emailVerified: false }).emailVerified).toBe(false);
 		expect(bannerStateFromRequest({}).emailVerified).toBeUndefined();
 	});
+
+	it("copies originalUrl to currentPath so the changelog dismiss form can post a return path", () => {
+		expect(
+			bannerStateFromRequest({ originalUrl: "/blog/x?utm_source=changelog-banner" }).currentPath,
+		).toBe("/blog/x?utm_source=changelog-banner");
+	});
+
+	it("leaves currentPath undefined when the source carries no originalUrl", () => {
+		expect(bannerStateFromRequest({}).currentPath).toBeUndefined();
+	});
 });
 
 describe("buildGuestNavItems", () => {

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -28,6 +28,13 @@ export interface BannerStateSource {
 	 * equals the live banner's version the banner is suppressed; a newer post
 	 * carries a different version and reappears. */
 	dismissedChangelogVersion?: string;
+	/** The request's `originalUrl` (path + query). Express populates it on every
+	 * request, so a consuming site that passes the request as the source supplies
+	 * it structurally; `bannerStateFromRequest` copies it to
+	 * `BannerState.currentPath` so the changelog banner's no-JS dismiss form can
+	 * post the page the reader is on (the dismiss route cannot rely on `Referer`,
+	 * which helmet's default `no-referrer` policy strips). */
+	originalUrl?: string;
 }
 
 export type NavItemKey =
@@ -142,6 +149,12 @@ export interface BannerState {
 	 * the reader has dismissed the current one; the shell then renders the
 	 * hidden, empty banner shell. */
 	changelogBanner?: ChangelogBanner;
+	/** Path (+ query) of the page this banner is rendered on, echoed into the
+	 * changelog dismiss form's hidden `returnTo` field so dismissing returns the
+	 * reader to where they were rather than the homepage. Undefined when the
+	 * rendering site supplies no request URL; the dismiss route then falls back
+	 * to "/". */
+	currentPath?: string;
 }
 
 const NAV_QUEUE = navItem({ key: "queue", label: "Queue", path: "/queue", method: "GET", icon: "fa-solid fa-inbox" });
@@ -187,5 +200,6 @@ export function bannerStateFromRequest(source: BannerStateSource): BannerState {
 		isAuthenticated: Boolean(source.userId),
 		emailVerified: source.emailVerified,
 		verification: source.verificationStatus,
+		currentPath: source.originalUrl,
 	};
 }

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -271,6 +271,24 @@ describe("Base component", () => {
 		);
 	});
 
+	it("threads currentPath into the changelog dismiss form so dismissing stays on the current page", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			...GUEST_STATE,
+			currentPath: "/blog/keyboard-shortcuts",
+			changelogBanner: {
+				hook: "I added keyboard shortcuts to the reader",
+				href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+				version: CHANGELOG_VERSION,
+			},
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const returnTo = doc.querySelector('.changelog-banner__dismiss input[name="returnTo"]');
+		assert(returnTo, "the dismiss form must carry the return path");
+		expect(returnTo.getAttribute("value")).toBe("/blog/keyboard-shortcuts");
+	});
+
 	it("should set meta description from seo", () => {
 		const page = createTestPageBody({ seo: { title: "T", description: "My desc", canonicalUrl: "https://readplace.com" } });
 		const result = Base(page, GUEST_STATE).to("text/html");

--- a/src/packages/web-shell/src/base.component.ts
+++ b/src/packages/web-shell/src/base.component.ts
@@ -258,7 +258,7 @@ export function initBase(config: BaseConfig): RenderBase {
 			verifyBannerStyles: VERIFY_BANNER_STYLES,
 			trialCountdownStyles: TRIAL_COUNTDOWN_STYLES,
 			extensionSuggestionBannerStyles: EXTENSION_SUGGESTION_BANNER_STYLES,
-			changelogBanner: renderChangelogBannerShell(state.changelogBanner),
+			changelogBanner: renderChangelogBannerShell(state.changelogBanner, state.currentPath),
 			verifyBanner: renderVerifyBanner(state),
 			extensionSuggestionBanner: renderExtensionSuggestionBanner({
 				show: state.showExtensionSuggestionBanner ?? false,

--- a/src/packages/web-shell/src/changelog-banner.test.ts
+++ b/src/packages/web-shell/src/changelog-banner.test.ts
@@ -202,6 +202,31 @@ describe("renderChangelogBannerShell", () => {
 		assert(close, "the close button must render");
 		expect(close.getAttribute("aria-label")).toBe("Dismiss changelog banner");
 	});
+
+	it("carries the return path as a hidden field so dismissing returns the reader to the page they were on", () => {
+		const doc = parse(
+			renderChangelogBannerShell(BANNER, "/blog/keyboard-shortcuts?utm_source=changelog-banner"),
+		);
+		const returnTo = doc.querySelector('.changelog-banner__dismiss input[name="returnTo"]');
+		assert(returnTo, "the dismiss form must post the return path");
+		expect(returnTo.getAttribute("value")).toBe(
+			"/blog/keyboard-shortcuts?utm_source=changelog-banner",
+		);
+	});
+
+	it("escapes the return path in the hidden field so a crafted path cannot break out of the attribute", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER, '/x?a="1"&b=<2>'));
+		const returnTo = doc.querySelector('.changelog-banner__dismiss input[name="returnTo"]');
+		assert(returnTo, "the dismiss form must post the return path");
+		expect(returnTo.getAttribute("value")).toBe('/x?a="1"&b=<2>');
+	});
+
+	it("renders an empty return path when none is supplied so the dismiss route falls back to /", () => {
+		const doc = parse(renderChangelogBannerShell(BANNER));
+		const returnTo = doc.querySelector('.changelog-banner__dismiss input[name="returnTo"]');
+		assert(returnTo, "the dismiss form must always carry the return-path input");
+		expect(returnTo.getAttribute("value")).toBe("");
+	});
 });
 
 describe("readCookie", () => {

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -90,16 +90,20 @@ export function parseChangelogBannerFragment(html: string): ChangelogBanner | un
  * shell. Always emits the `.changelog-banner` element — `--visible` with content
  * when a banner is present, `--hidden` and empty otherwise — so the markup is
  * stable for tests and SSR (no client JS decides visibility). The close control
- * is a no-JS POST form carrying the rendered version, so the dismissal records
- * exactly the announcement the reader saw. */
-const CHANGELOG_SHELL_TEMPLATE = `<div class="changelog-banner {{#if visible}}changelog-banner--visible{{else}}changelog-banner--hidden{{/if}}" role="status" aria-live="polite" data-test-changelog-banner>{{#if visible}}<div class="changelog-banner__inner"><span class="changelog-banner__chip" aria-hidden="true">NEW</span><span class="changelog-banner__hook">{{hook}}</span><a class="changelog-banner__link" href="{{href}}">Read more <span class="changelog-banner__arrow" aria-hidden="true">&rarr;</span></a><form class="changelog-banner__dismiss" method="POST" action="/banner/changelog/dismiss"><input type="hidden" name="version" value="{{version}}"><button type="submit" class="changelog-banner__close" aria-label="Dismiss changelog banner"><span aria-hidden="true">&times;</span></button></form></div>{{/if}}</div>`;
+ * is a no-JS POST form carrying the rendered version (so the dismissal records
+ * exactly the announcement the reader saw) and the page's own path as `returnTo`
+ * (so the dismiss route sends the reader back where they were rather than the
+ * homepage — it cannot read `Referer`, which helmet's default `no-referrer`
+ * policy strips from the POST). */
+const CHANGELOG_SHELL_TEMPLATE = `<div class="changelog-banner {{#if visible}}changelog-banner--visible{{else}}changelog-banner--hidden{{/if}}" role="status" aria-live="polite" data-test-changelog-banner>{{#if visible}}<div class="changelog-banner__inner"><span class="changelog-banner__chip" aria-hidden="true">NEW</span><span class="changelog-banner__hook">{{hook}}</span><a class="changelog-banner__link" href="{{href}}">Read more <span class="changelog-banner__arrow" aria-hidden="true">&rarr;</span></a><form class="changelog-banner__dismiss" method="POST" action="/banner/changelog/dismiss"><input type="hidden" name="version" value="{{version}}"><input type="hidden" name="returnTo" value="{{returnTo}}"><button type="submit" class="changelog-banner__close" aria-label="Dismiss changelog banner"><span aria-hidden="true">&times;</span></button></form></div>{{/if}}</div>`;
 
-export function renderChangelogBannerShell(banner?: ChangelogBanner): string {
+export function renderChangelogBannerShell(banner?: ChangelogBanner, returnTo?: string): string {
 	return render(CHANGELOG_SHELL_TEMPLATE, {
 		visible: Boolean(banner),
 		hook: banner?.hook,
 		href: banner?.href,
 		version: banner?.version,
+		returnTo,
 	});
 }
 


### PR DESCRIPTION
## Problem

Closing the site-wide changelog banner (the sticky "NEW …" widget at the top) sent the reader to the **homepage** instead of leaving them where they were — most visibly while reading the very blog post the banner announced.

## Root cause

The banner's close control is a no-JS POST form to `/banner/changelog/dismiss`. The handler redirected the reader back using the `Referer` header (`safeBackPath`). But both deployables run `helmet()`, whose **default `Referrer-Policy: no-referrer` strips `Referer`** from the request — so the handler always saw `undefined` and fell back to `/`.

The existing route tests passed only because supertest sets `Referer` manually, which masked the real-browser behaviour.

## Fix

Carry the origin page **explicitly** rather than depending on a header the app's own security policy removes (and which is unreliable in general):

- The changelog banner shell renders the current page path into a hidden `returnTo` field, threaded through a new `BannerState.currentPath` (sourced from each site's request `originalUrl`).
- The dismiss route now reads `returnTo` and validates it as a safe **same-origin relative path** before redirecting. `safeBackPath` is replaced by `safeReturnPath`, which resolves the value against a throwaway origin and rejects absolute URLs, `javascript:`, protocol-relative (`//host`), backslash (`/\host`), and control-character authorities a browser would resolve off-site.

This is self-contained to the banner feature — no global security-header or analytics changes. On the blog (no htmx) the field always carries the exact current page, so dismissing keeps the reader on the post.

## Tests

- `safeReturnPath` unit tests cover every branch (non-string, off-origin, `//`-normalised path, unparseable, happy path).
- Dismiss route POST tests now drive the `returnTo` form field instead of `Referer`.
- `bannerStateFromRequest` / `initBuildBannerState` tests assert `currentPath` is populated from `originalUrl`.
- `renderChangelogBannerShell` tests assert the hidden field renders and is HTML-escaped.
- The blog post-page test asserts the dismiss form posts `returnTo=/blog/<slug>` — the direct regression test for the reported bug.

`pnpm check` passes across the affected projects (`web-shell`, `hutch`, `blog-site`) with coverage thresholds met; the changed files are at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMYLcKPVtCqGt9o9d4CxNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMYLcKPVtCqGt9o9d4CxNt)_