### PR TITLE
docs(blog): add post on connecting an AI assistant with no API key

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/connect-ai-assistant-without-an-api-key.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/connect-ai-assistant-without-an-api-key.md
@@ -1,0 +1,51 @@
+---
+title: "Connect Your AI Assistant to Readplace With No API Key to Copy"
+description: "Connecting your AI assistant to Readplace needs no API key. The MCP client registers itself, you approve one OAuth sign-in, and you can revoke that access anytime. Then your assistant can save pages to your queue and list them back."
+slug: "connect-ai-assistant-without-an-api-key"
+date: "2026-06-21"
+author: "Fayner Brack"
+keywords: "MCP OAuth, connect AI assistant no API key, dynamic client registration, RFC 7591, Claude MCP, ChatGPT MCP, Perplexity MCP, read it later MCP, MCP server OAuth, save articles AI assistant, revoke AI access"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Connecting a tool to your AI assistant usually starts with an API key, a secret you generate once and keep somewhere safe. Readplace's MCP server skips it. You point Claude, ChatGPT, Perplexity, or a developer client at `readplace.com/mcp`, the assistant registers itself, and Readplace sends you to a sign-in to approve the connection. You don't create a credential or hand one over, and you can revoke the assistant's access whenever you want. Once connected, the assistant can save a page to your reading queue and read your list back.
+
+</div>
+</details>
+
+Point your assistant at `readplace.com/mcp` and it introduces itself to the server. No secret changes hands.
+
+Connecting a tool to an AI assistant usually runs the other way. You open a developer console, generate a long API key, and paste it into a settings box before anything talks to anything. Readplace has no box to paste into, because there is no key to make.
+
+## What stands in for the key
+
+Readplace runs an MCP server. MCP is the shared protocol that lets an AI assistant call outside tools, and Claude, ChatGPT, Perplexity, and developer clients like Claude Code and Cursor all speak it. To call a tool, the assistant first needs an identity the server recognises.
+
+The manual way to get that identity puts a person in the loop. You register the application in a console, copy the client ID and secret it returns, and paste both into the assistant.
+
+Readplace supports a step that drops the person from that loop. The assistant sends its own details to Readplace and gets its own identity back, on the spot. The standard for this is RFC 7591, dynamic client registration, and it runs as a couple of seconds of machine-to-machine talk you don't see.
+
+That identity is not a password, and it is not enough on its own. The assistant sends you to a Readplace sign-in. You approve once. Readplace hands back a token tied to your account, the assistant acts with that token, and you can revoke it whenever you like.
+
+> **There is no key to copy, because the assistant makes its own identity and you approve it once.**
+
+## A missing secret is one that can't leak
+
+An API key is a small liability you carry around. It sits in the assistant's settings, in a config file, sometimes in a screenshot from when you set things up. Anyone who reads it can act as you until you notice and rotate it.
+
+A credential that doesn't exist can't sit in any of those places.
+
+The token Readplace gives you after you sign in is scoped to your account and revocable from your settings. It is not a shared string you typed into a box. So the exposure is smaller. There is no long-lived secret in plain sight, and the access you granted ends the moment you withdraw it.
+
+## What the connection is for
+
+Setup is the part you do once. What matters is what comes after.
+
+Once connected, your assistant gets two tools. `save_link` adds a page to your reading queue, and the title, excerpt, and clean reader view fill in moments later, so the card shows up right away and finishes on its own. `list_queue` reads back what you have saved, filtered to unread or already read.
+
+People pay for Claude, ChatGPT, and Perplexity to find articles and summarise them. The save step used to mean leaving the chat and doing it by hand. Now you ask in plain language, and the page lands in your queue inside the conversation. Every page the assistant saves gets the same reader view and summary as one you save yourself.
+
+The per-client steps live at [readplace.com/mcp](https://readplace.com/mcp), the same address you hand your assistant. Open it from the browser you read in and connect from there. For more on the server and the two tools, the [earlier writeup on saving from your assistant](/blog/save-articles-with-your-ai-assistant) goes deeper.


### PR DESCRIPTION
## What

New blog post: **"Connect Your AI Assistant to Readplace With No API Key to Copy"** (`connect-ai-assistant-without-an-api-key.md`, dated 2026-06-21).

## Why this topic

I reviewed the commits that landed on `main` after the last published post (2026-06-19, the DNS agent-discovery post). The dominant user-facing theme since then is the **MCP connect experience**:

- `feat(oauth): self-service dynamic client registration (RFC 7591)` (#627)
- `feat(mcp): browser connection guide at /mcp, blog rewrite, homepage feature`
- `feat(hutch): add getting-started and example prompts to /mcp page`

Everything else in the window was internal (removing `as` casts, coverage cleanups, a Stripe fail-fast) and not suitable for external communication.

The 2026-06-16 post already covered "here's the MCP server and how to connect." To avoid keyword cannibalization, this post takes the one differentiator that post didn't make: **there is no API key to copy.** The client registers itself (RFC 7591 dynamic client registration) and you approve a single OAuth sign-in. That targets the paying audience that matters for conversion — Claude / ChatGPT / Perplexity / Cursor users — on a distinct keyword space (MCP OAuth, no API key, dynamic client registration).

## Editorial notes

- **Voice:** Principle (one claim, one mechanism).
- **Structural Variety:** ran the lookback against the last 8 posts. They open 5×"You", 2× declarative "A [noun]"; their TL;DRs lead on "Readplace"/"Save"/"You"; their final headers are "Why this matters/helps/now" and "Try it"; their CTAs repeat "[Install the browser extension]… or start at readplace.com". This draft breaks each axis: imperative opener, TL;DR opening on the reader's situation, argued sentence-case headers, and a rewritten CTA.
- **Not tagged `changelog`** on purpose — the existing 06-16 MCP post still drives the site-wide banner, and I didn't want to silently replace it. Easy to promote to a banner if you'd prefer this be the live hook.
- No time-bound pricing/founding-member copy.
- Couldn't run `fingerprint.py` (it lives in the Claude project context, not the repo), so I matched the register by hand: no semicolons/em-dashes, no banned absolutes, "however" unused.

## Verification

`pnpm nx run blog-site:check` passes — post is discovered and parsed, 66 tests green, 100% coverage. Full pre-commit `hutch:check` (31 projects) also passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7yxm9UKxdaMnVFVuvsoep

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7yxm9UKxdaMnVFVuvsoep)_