### PR TITLE
feat(stripe): tag subscription metadata with userId

### DIFF
--- a/projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
 import { initStripeSubscriptions } from "./stripe-subscriptions";
+
+const USER_ID = UserIdSchema.parse("usr_test_abc123");
 
 function jsonResponse(status: number, body: object): Response {
 	return new Response(JSON.stringify(body), {
@@ -94,7 +97,7 @@ describe("initStripeSubscriptions", () => {
 	});
 
 	describe("createSubscriptionOnExistingCustomer", () => {
-		it("issues POST /v1/subscriptions with customer + items[0][price] and returns the new id", async () => {
+		it("issues POST /v1/subscriptions with customer + items[0][price] + userId metadata and returns the new id", async () => {
 			let receivedUrl: string | undefined;
 			let receivedInit: RequestInit | undefined;
 			const fakeFetch: typeof globalThis.fetch = async (input, init) => {
@@ -108,6 +111,7 @@ describe("initStripeSubscriptions", () => {
 			const result = await stripe.createSubscriptionOnExistingCustomer({
 				customerId: "cus_existing",
 				priceId: "price_abc",
+				userId: USER_ID,
 			});
 
 			assert.equal(result.subscriptionId, "sub_freshly_created");
@@ -119,6 +123,7 @@ describe("initStripeSubscriptions", () => {
 			const body = String(receivedInit?.body ?? "");
 			assert.ok(body.includes("customer=cus_existing"));
 			assert.ok(body.includes("items%5B0%5D%5Bprice%5D=price_abc"));
+			assert.ok(body.includes("metadata%5BuserId%5D=usr_test_abc123"));
 		});
 
 		it("throws with the Stripe error message when the API returns a non-2xx", async () => {
@@ -132,6 +137,7 @@ describe("initStripeSubscriptions", () => {
 					stripe.createSubscriptionOnExistingCustomer({
 						customerId: "cus_declined",
 						priceId: "price_abc",
+						userId: USER_ID,
 					}),
 				/Stripe createSubscriptionOnExistingCustomer failed \(402\): Your card was declined\./,
 			);
@@ -148,6 +154,7 @@ describe("initStripeSubscriptions", () => {
 					stripe.createSubscriptionOnExistingCustomer({
 						customerId: "cus_x",
 						priceId: "price_y",
+						userId: USER_ID,
 					}),
 				/Stripe createSubscriptionOnExistingCustomer failed \(500\): Stripe error/,
 			);
@@ -164,6 +171,7 @@ describe("initStripeSubscriptions", () => {
 					stripe.createSubscriptionOnExistingCustomer({
 						customerId: "cus_y",
 						priceId: "price_z",
+						userId: USER_ID,
 					}),
 				/Stripe createSubscriptionOnExistingCustomer failed \(400\): Stripe error/,
 			);

--- a/projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.ts
+++ b/projects/hutch/src/runtime/providers/stripe-subscriptions/stripe-subscriptions.ts
@@ -83,10 +83,13 @@ export function initStripeSubscriptions(deps: {
 	const createSubscriptionOnExistingCustomer: CreateSubscriptionOnExistingCustomer = async ({
 		customerId,
 		priceId,
+		userId,
 	}) => {
 		const body = new URLSearchParams();
 		body.set("customer", customerId);
 		body.set("items[0][price]", priceId);
+		// Traces the subscription back to its account when the customer paid under a different email.
+		body.set("metadata[userId]", userId);
 
 		const response = await deps.fetch(`${STRIPE_API}/subscriptions`, {
 			method: "POST",

--- a/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.test.ts
@@ -190,6 +190,7 @@ describe("subscription-start-request handler", () => {
 			{
 				customerId: "cus_with_card",
 				priceId: STRIPE_PRICE_ID,
+				userId: USER_ID,
 				subscriptionId: subject.succeededEvents[0].subscriptionId,
 			},
 		]);

--- a/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.ts
+++ b/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.ts
@@ -50,6 +50,7 @@ export function initSubscriptionStartRequestHandler(
 			const { subscriptionId } = await deps.createSubscriptionOnExistingCustomer({
 				customerId: row.customerId,
 				priceId: deps.stripePriceId,
+				userId,
 			});
 			await deps.publishSubscriptionChargeSucceeded({
 				userId,

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -200,6 +200,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 				const { subscriptionId } = await deps.createSubscriptionOnExistingCustomer({
 					customerId: row.customerId,
 					priceId: deps.stripePriceId,
+					userId,
 				});
 				await deps.upsertActiveSubscription({
 					userId,

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -391,6 +391,8 @@ describe("POST /account/subscribe", () => {
 		expect(created).toHaveLength(1);
 		expect(created[0].customerId).toBe("cus_was_paid");
 		expect(created[0].priceId).toBe("price_test_default");
+		// userId rides into Stripe metadata so the subscription is traceable to this account.
+		expect(created[0].userId).toBe(userId);
 
 		// Row is now active with the NEW subscriptionId, replacing sub_was_paid.
 		const row = await subscriptionProviders.findByUserId(userId);

--- a/src/packages/provider-contracts/src/stripe-subscriptions.ts
+++ b/src/packages/provider-contracts/src/stripe-subscriptions.ts
@@ -1,3 +1,5 @@
+import type { UserId } from "@packages/domain/user";
+
 export type CancelSubscriptionImmediately = (input: {
 	subscriptionId: string;
 }) => Promise<void>;
@@ -5,6 +7,7 @@ export type CancelSubscriptionImmediately = (input: {
 export type CreateSubscriptionOnExistingCustomer = (input: {
 	customerId: string;
 	priceId: string;
+	userId: UserId;
 }) => Promise<{ subscriptionId: string }>;
 
 export type ScheduleCancellationAtPeriodEnd = (input: {

--- a/src/packages/test-fixtures/src/providers/stripe-subscriptions/in-memory-stripe-subscriptions.test.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-subscriptions/in-memory-stripe-subscriptions.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { UserIdSchema } from "@packages/domain/user";
 import { initInMemoryStripeSubscriptions } from "./in-memory-stripe-subscriptions";
+
+const USER_ID = UserIdSchema.parse("usr_inmem_test");
 
 describe("initInMemoryStripeSubscriptions", () => {
 	it("records each cancelImmediately call for assertion", async () => {
@@ -34,16 +37,28 @@ describe("initInMemoryStripeSubscriptions", () => {
 		const first = await stripe.createSubscriptionOnExistingCustomer({
 			customerId: "cus_existing",
 			priceId: "price_abc",
+			userId: USER_ID,
 		});
 		const second = await stripe.createSubscriptionOnExistingCustomer({
 			customerId: "cus_existing",
 			priceId: "price_abc",
+			userId: USER_ID,
 		});
 
 		assert.notEqual(first.subscriptionId, second.subscriptionId);
 		assert.deepEqual(stripe.createdSubscriptions(), [
-			{ customerId: "cus_existing", priceId: "price_abc", subscriptionId: first.subscriptionId },
-			{ customerId: "cus_existing", priceId: "price_abc", subscriptionId: second.subscriptionId },
+			{
+				customerId: "cus_existing",
+				priceId: "price_abc",
+				userId: USER_ID,
+				subscriptionId: first.subscriptionId,
+			},
+			{
+				customerId: "cus_existing",
+				priceId: "price_abc",
+				userId: USER_ID,
+				subscriptionId: second.subscriptionId,
+			},
 		]);
 	});
 
@@ -51,7 +66,12 @@ describe("initInMemoryStripeSubscriptions", () => {
 		const stripe = initInMemoryStripeSubscriptions({ createSubscriptionFails: true });
 
 		await assert.rejects(
-			() => stripe.createSubscriptionOnExistingCustomer({ customerId: "cus_x", priceId: "price_y" }),
+			() =>
+				stripe.createSubscriptionOnExistingCustomer({
+					customerId: "cus_x",
+					priceId: "price_y",
+					userId: USER_ID,
+				}),
 			/In-memory Stripe createSubscription failure/,
 		);
 		assert.deepEqual(stripe.createdSubscriptions(), []);

--- a/src/packages/test-fixtures/src/providers/stripe-subscriptions/in-memory-stripe-subscriptions.ts
+++ b/src/packages/test-fixtures/src/providers/stripe-subscriptions/in-memory-stripe-subscriptions.ts
@@ -1,3 +1,4 @@
+import type { UserId } from "@packages/domain/user";
 import type {
 	CancelSubscriptionImmediately,
 	CreateSubscriptionOnExistingCustomer,
@@ -20,12 +21,18 @@ export function initInMemoryStripeSubscriptions(opts?: {
 	scheduleCancellationAtPeriodEnd: ScheduleCancellationAtPeriodEnd;
 	reverseScheduledCancellation: ReverseScheduledCancellation;
 	cancelledSubscriptionIds: () => readonly string[];
-	createdSubscriptions: () => readonly { customerId: string; priceId: string; subscriptionId: string }[];
+	createdSubscriptions: () => readonly {
+		customerId: string;
+		priceId: string;
+		userId: UserId;
+		subscriptionId: string;
+	}[];
 	scheduledCancellations: () => readonly { subscriptionId: string; cancellationEffectiveAt: string }[];
 	reversedCancellations: () => readonly string[];
 } {
 	const cancelled: string[] = [];
-	const created: { customerId: string; priceId: string; subscriptionId: string }[] = [];
+	const created: { customerId: string; priceId: string; userId: UserId; subscriptionId: string }[] =
+		[];
 	const scheduledCancellationCalls: { subscriptionId: string; cancellationEffectiveAt: string }[] = [];
 	const reversed: string[] = [];
 	let nextId = 1;
@@ -37,12 +44,13 @@ export function initInMemoryStripeSubscriptions(opts?: {
 	const createSubscriptionOnExistingCustomer: CreateSubscriptionOnExistingCustomer = async ({
 		customerId,
 		priceId,
+		userId,
 	}) => {
 		if (opts?.createSubscriptionFails) {
 			throw new Error("In-memory Stripe createSubscription failure");
 		}
 		const subscriptionId = `sub_inmem_${nextId++}`;
-		created.push({ customerId, priceId, subscriptionId });
+		created.push({ customerId, priceId, userId, subscriptionId });
 		return { subscriptionId };
 	};
 

--- a/src/packages/web-test-harness/src/bundle.types.ts
+++ b/src/packages/web-test-harness/src/bundle.types.ts
@@ -170,7 +170,12 @@ export interface StripeSubscriptionsBundle {
 	createSubscriptionOnExistingCustomer: CreateSubscriptionOnExistingCustomer;
 	scheduleCancellationAtPeriodEnd: ScheduleCancellationAtPeriodEnd;
 	reverseScheduledCancellation: ReverseScheduledCancellation;
-	createdSubscriptions: () => readonly { customerId: string; priceId: string; subscriptionId: string }[];
+	createdSubscriptions: () => readonly {
+		customerId: string;
+		priceId: string;
+		userId: UserId;
+		subscriptionId: string;
+	}[];
 	scheduledCancellations: () => readonly { subscriptionId: string; cancellationEffectiveAt: string }[];
 	reversedCancellations: () => readonly string[];
 }


### PR DESCRIPTION
## What

Attach the Readplace `userId` to the Stripe subscription's `metadata` when we create a subscription on an existing customer.

```
metadata[userId]=<userId>
```

## Why

So a subscription in Stripe can be traced back to its Readplace account even when the customer paid under a **different email** than the one on file. Today nothing on the Stripe object carries our internal id, so a mismatched email leaves the subscription un-identifiable from the Stripe side.

## Where

`createSubscriptionOnExistingCustomer` is the call that creates the subscription producing **the first charge** (Stripe invoices and charges the saved card immediately). It runs in two places, both of which already have the `userId` in hand:

- **Trial-end conversion** — `subscription-start-request-handler` (the first charge when a trial converts to paid)
- **One-click resubscribe** — the `cancelled` branch of `POST /account/subscribe`

`userId` is now a required field on the `CreateSubscriptionOnExistingCustomer` contract, so every subscription created this way is tagged.

## Notes / scope

- The Stripe **Checkout** path (`createCheckoutSession`, used for existing-user-subscribe and the test-only email/Google signup) is **not** covered here — that subscription is created inside Stripe's hosted flow and would need `subscription_data[metadata][userId]`. Happy to follow up if you want every checkout-created subscription tagged too; the trial conversion was the "first charge" target.
- Test fixtures (`in-memory-stripe-subscriptions`) now record `userId`, and the real provider test asserts `metadata%5BuserId%5D=…` is sent to Stripe.

## Verification

`pnpm check` passes (typecheck, lint, tests, coverage, knip) across all projects; the pre-commit hook ran the full `nx run-many --target=check --all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jJ86aaqxo7kPVHBE5pNd5

---
_Generated by [Claude Code](https://claude.ai/code/session_019jJ86aaqxo7kPVHBE5pNd5)_