### PR TITLE
test(mcp): remove redundant negative isError assertions

### DIFF
--- a/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
@@ -197,7 +197,6 @@ describe("initMcpServer", () => {
 				id: 4,
 				result: { content: [{ type: "text", text: expect.stringContaining("My Article") }] },
 			});
-			expect(response).not.toMatchObject({ result: { isError: true } });
 		});
 
 		it("surfaces a save rejection as an error result", async () => {
@@ -626,7 +625,6 @@ describe("initMcpServer", () => {
 					},
 				},
 			});
-			expect(response).not.toMatchObject({ result: { isError: true } });
 		});
 
 		it("redirects delete_article to the app without deleting", async () => {
@@ -639,7 +637,6 @@ describe("initMcpServer", () => {
 					structuredContent: { action: "delete_article", performed: false },
 				},
 			});
-			expect(response).not.toMatchObject({ result: { isError: true } });
 		});
 	});
 


### PR DESCRIPTION
## Summary

Removes three redundant `expect(response).not.toMatchObject({ result: { isError: true } })` assertions from `mcp-server.test.ts`. Each one sat directly after a positive assertion that already checks the success-shaped `content` / `structuredContent` payload, so the negative check proved nothing the positive assertion didn't already establish.

Affected tests:
- `save_link` reports the title (was line 200)
- `set_article_status` redirects to the app (was line 629)
- `delete_article` redirects to the app (was line 642)

## Verification

`pnpm check` passes; the `mcp-server` suite still runs all 48 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzkGvxjMGdc8tifCt4WWfs)_