### PR TITLE
feat(mcp): render date-only in formatArticle text block

### DIFF
--- a/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.test.ts
@@ -440,6 +440,29 @@ describe("initMcpServer", () => {
 			}
 		});
 
+		it("shows date-only in the text block but keeps the ISO timestamps in structuredContent", async () => {
+			const article = mcpArticle({
+				savedAt: "2026-01-01T12:34:56.000Z",
+				status: "read",
+				readAt: "2026-03-03T08:09:10.000Z",
+			});
+			const server = initMcpServer(fakeDeps({ getArticle: async () => article }));
+			const response = await call(server, 35, "get_article", { id: article.id });
+			expect(response).toMatchObject({
+				result: {
+					content: [
+						{ text: expect.stringContaining("Saved 2026-01-01; read 2026-03-03") },
+					],
+					structuredContent: {
+						article: {
+							savedAt: "2026-01-01T12:34:56.000Z",
+							readAt: "2026-03-03T08:09:10.000Z",
+						},
+					},
+				},
+			});
+		});
+
 		it("reports not found for an id that does not resolve", async () => {
 			const server = initMcpServer(fakeDeps({ getArticle: async () => null }));
 			const response = await call(server, 31, "get_article", { id: "x".repeat(32) });

--- a/projects/hutch/src/runtime/web/mcp/mcp-server.ts
+++ b/projects/hutch/src/runtime/web/mcp/mcp-server.ts
@@ -197,10 +197,17 @@ function notFoundResult(id: string): ToolResult {
 	});
 }
 
+/** The text block shows a friendlier date-only value; structuredContent keeps
+ * the full ISO timestamp. McpArticle dates are ISO 8601 in UTC, so the first
+ * ten characters are the calendar date. */
+function formatDate(iso: string): string {
+	return iso.slice(0, 10);
+}
+
 function formatArticle(article: McpArticle): string {
 	const dates = article.readAt
-		? `Saved ${article.savedAt}; read ${article.readAt}`
-		: `Saved ${article.savedAt}`;
+		? `Saved ${formatDate(article.savedAt)}; read ${formatDate(article.readAt)}`
+		: `Saved ${formatDate(article.savedAt)}`;
 	const excerpt = article.excerpt ? `\n${article.excerpt}` : "";
 	return `"${article.title || article.url}" [${article.status}] — ${article.url}\n${article.siteName} · ~${article.estimatedReadTime} min read · ${article.wordCount} words\n${dates}${excerpt}`;
 }


### PR DESCRIPTION
## What

`formatArticle` in `projects/hutch/src/runtime/web/mcp/mcp-server.ts` rendered raw ISO timestamps in the human-readable text block returned by `get_article` — e.g. `Saved 2026-01-01T12:34:56.000Z; read 2026-03-03T08:09:10.000Z`. This change renders a friendlier **date-only** value in that text block (`Saved 2026-01-01; read 2026-03-03`).

The full ISO timestamps are untouched in `structuredContent` (`article.savedAt` / `article.readAt`), so machine consumers still get the precise, JSON-friendly value.

## How

- Added a small `formatDate` helper that takes the date portion of the ISO 8601 (UTC) string. The `McpArticle` interface already documents these fields as ISO strings, so the first ten characters are the calendar date.
- Added a test asserting the text block shows date-only while `structuredContent` retains the full ISO timestamps.

## Verification

- `pnpm nx run hutch:check` (full pre-commit hook) passed.
- `mcp-server.test.ts`: 49/49 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGXNKvJYa9SuHSR3T2YHYm)_