### PR TITLE
chore(ios-poc): rename compile-test nx target to compile-dev

### DIFF
--- a/projects/ios-readplace-poc/README.md
+++ b/projects/ios-readplace-poc/README.md
@@ -135,7 +135,7 @@ app stores. The free-account signature lasts 7 days; re-run `make ipa` and
 re-install to renew.
 
 For a build that targets the deployed **staging** stack instead of production,
-run `make ipa-staging` (or `nx run ios-readplace-poc:compile-test`). It sets the
+run `make ipa-staging` (or `nx run ios-readplace-poc:compile-dev`). It sets the
 `STAGING` Swift compilation condition and writes a separate
 `build/Readplace-staging-unsigned.ipa`, so a tester signs in against staging
 without typing a URL. Same bundle id, so it replaces the prod app on a device.

--- a/projects/ios-readplace-poc/Shared/AppConfig.swift
+++ b/projects/ios-readplace-poc/Shared/AppConfig.swift
@@ -27,9 +27,9 @@ enum ServerEnvironment {
 /// callback listed in the server's
 /// `src/packages/domain/src/oauth/built-in-clients.ts`.
 enum AppConfig {
-	/// The server this build targets, fixed at compile time. The `compile-test`
-	/// build sets the `STAGING` Swift compilation condition to select staging;
-	/// every other build is production. There is no runtime override.
+	/// The server this build targets, fixed at compile time. Builds with the
+	/// `STAGING` Swift compilation condition select staging; every other build
+	/// is production. There is no runtime override.
 	#if STAGING
 	static let serverEnvironment: ServerEnvironment = .staging
 	#else

--- a/projects/ios-readplace-poc/project.json
+++ b/projects/ios-readplace-poc/project.json
@@ -21,7 +21,7 @@
       "cache": false,
       "dependsOn": ["generate"]
     },
-    "compile-test": {
+    "compile-dev": {
       "command": "READPLACE_ENV=staging bash scripts/build-unsigned-ipa.sh",
       "options": { "cwd": "{projectRoot}" },
       "outputs": ["{projectRoot}/build/Readplace-staging-unsigned.ipa"],


### PR DESCRIPTION
## What

Renames the staging-targeting nx target in `projects/ios-readplace-poc/project.json` from `compile-test` to `compile-dev` for naming consistency.

## Changes

- **`project.json`** — `compile-test` target renamed to `compile-dev` (still runs `READPLACE_ENV=staging bash scripts/build-unsigned-ipa.sh`).
- **`README.md`** — updated the reference to `nx run ios-readplace-poc:compile-dev`.
- **`Shared/AppConfig.swift`** — removed the stale `compile-test` command name from the doc comment, since hardcoding a target name in a code comment risks drifting from the actual target. The comment now describes the `STAGING` compilation condition (a code-level fact) instead.

## Notes

The new target name `compile-dev` is confirmed by the README reference called out in the task. No remaining `compile-test` references exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGQ9vD2r65wT56LUmTawkW)_