### PR TITLE
refactor(test-fixtures): extract shared buildLambdaContext fixture

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1119,6 +1119,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/aws-lambda':
+        specifier: 8.10.161
+        version: 8.10.161
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -2239,21 +2242,25 @@ packages:
     resolution: {integrity: sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.5':
     resolution: {integrity: sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.5':
     resolution: {integrity: sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.5':
     resolution: {integrity: sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.5':
     resolution: {integrity: sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==}

--- a/projects/hutch/src/runtime/cancel-subscription/cancel-subscription-handler.test.ts
+++ b/projects/hutch/src/runtime/cancel-subscription/cancel-subscription-handler.test.ts
@@ -9,7 +9,7 @@ import type {
 	PublishSubscriptionCancelled,
 } from "@packages/test-fixtures/providers/events";
 import { buildSqsEvent } from "@packages/test-fixtures/sqs";
-import type { Context } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { initCancelSubscriptionHandler } from "./cancel-subscription-handler";
 
 const USER_ID = UserIdSchema.parse("4".repeat(32));
@@ -17,23 +17,6 @@ const STRIPE_PERIOD_END = "2026-06-22T10:00:00.000Z";
 
 function buildEventBridgeBody(userId: string): string {
 	return JSON.stringify({ detail: { userId } });
-}
-
-function buildLambdaContext(): Context {
-	return {
-		callbackWaitsForEmptyEventLoop: false,
-		functionName: "cancel-subscription",
-		functionVersion: "$LATEST",
-		invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789012:function:cancel-subscription",
-		memoryLimitInMB: "128",
-		awsRequestId: "test-request-id",
-		logGroupName: "/aws/lambda/cancel-subscription",
-		logStreamName: "test-log-stream",
-		getRemainingTimeInMillis: () => 0,
-		done: () => {},
-		fail: () => {},
-		succeed: () => {},
-	};
 }
 
 interface Subject {

--- a/projects/hutch/src/runtime/export-user-data/export-user-data-handler.test.ts
+++ b/projects/hutch/src/runtime/export-user-data/export-user-data-handler.test.ts
@@ -1,5 +1,6 @@
 import { noopLogger, HutchLogger } from "@packages/hutch-logger";
-import type { Context, SQSBatchResponse, SQSEvent, SQSRecord, SQSRecordAttributes } from "aws-lambda";
+import type { SQSBatchResponse, SQSEvent, SQSRecord, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { z } from "zod";
 import { initInMemoryArticleStore } from "@packages/test-fixtures/providers/article-store";
 import { MinutesSchema } from "@packages/domain/article";
@@ -13,21 +14,6 @@ const stubAttributes: SQSRecordAttributes = {
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 const ExportBodySchema = z.object({
@@ -104,7 +90,7 @@ async function invokeHandler(
 	harness: HandlerHarness,
 	detail: { userId: string; email: string; requestedAt: string },
 ): Promise<SQSBatchResponse> {
-	const result = harness.handler(createSqsEvent(detail), stubContext, () => {});
+	const result = harness.handler(createSqsEvent(detail), buildLambdaContext(), () => {});
 	const awaited = result instanceof Promise ? await result : result;
 	if (!awaited) throw new Error("handler returned void; expected SQSBatchResponse");
 	return awaited;
@@ -222,7 +208,7 @@ describe("initExportUserDataHandler", () => {
 			}],
 		};
 
-		const result = harness.handler(invalidEvent, stubContext, () => {});
+		const result = harness.handler(invalidEvent, buildLambdaContext(), () => {});
 		const response = result instanceof Promise ? await result : result;
 
 		expect(response).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
@@ -281,7 +267,7 @@ describe("initExportUserDataHandler", () => {
 				email: "user@example.com",
 				requestedAt: "2026-04-30T11:59:00.000Z",
 			}),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 		if (result instanceof Promise) await result;

--- a/projects/hutch/src/runtime/handle-subscription-cancellation-scheduled/handle-subscription-cancellation-scheduled-handler.test.ts
+++ b/projects/hutch/src/runtime/handle-subscription-cancellation-scheduled/handle-subscription-cancellation-scheduled-handler.test.ts
@@ -1,25 +1,11 @@
 import assert from "node:assert/strict";
-import type { Context, SQSEvent } from "aws-lambda";
+import type { SQSEvent } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initHandleSubscriptionCancellationScheduledHandler } from "./handle-subscription-cancellation-scheduled-handler";
 
 const USER_ID = UserIdSchema.parse("user-cancel-scheduled");
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function buildSqsEvent(records: Array<{ messageId: string; body: string }>): SQSEvent {
 	return {
@@ -77,7 +63,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -107,7 +93,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -136,7 +122,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -162,7 +148,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -181,7 +167,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-schema", body: JSON.stringify({ detail: { userId: USER_ID } }) },
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -209,7 +195,7 @@ describe("handle-subscription-cancellation-scheduled-handler", () => {
 				{ messageId: "msg-1", body },
 				{ messageId: "msg-2-dup", body },
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/handle-subscription-cancelled/handle-subscription-cancelled-handler.test.ts
+++ b/projects/hutch/src/runtime/handle-subscription-cancelled/handle-subscription-cancelled-handler.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import type { Context, SQSEvent } from "aws-lambda";
+import type { SQSEvent } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initHandleSubscriptionCancelledHandler } from "./handle-subscription-cancelled-handler";
@@ -24,21 +25,6 @@ function makeNoopEmit(): EmitSubscriptionEvent {
 }
 
 const USER_ID = UserIdSchema.parse("user-cancel");
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function buildSqsEvent(records: Array<{ messageId: string; body: string }>): SQSEvent {
 	return {
@@ -92,7 +78,7 @@ describe("handle-subscription-cancelled-handler", () => {
 					body: buildEventBridgeBody({ userId: USER_ID, subscriptionId: "sub_x", reason: "stripe_webhook" }),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -124,7 +110,7 @@ describe("handle-subscription-cancelled-handler", () => {
 					body: buildEventBridgeBody({ userId: USER_ID, reason: "user_initiated_trial" }),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -142,7 +128,7 @@ describe("handle-subscription-cancelled-handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-fail", body: buildEventBridgeBody({ userId: USER_ID }) }]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -160,7 +146,7 @@ describe("handle-subscription-cancelled-handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "not-json" }]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -178,7 +164,7 @@ describe("handle-subscription-cancelled-handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-schema", body: JSON.stringify({ detail: { reason: "stripe_webhook" } }) }]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -205,7 +191,7 @@ describe("handle-subscription-cancelled-handler", () => {
 				{ messageId: "msg-boom", body: buildEventBridgeBody({ userId: "user-boom" }) },
 				{ messageId: "msg-ok-2", body: buildEventBridgeBody({ userId: "user-ok-2" }) },
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/reader-ready-fanout/reader-ready-fanout-handler.test.ts
+++ b/projects/hutch/src/runtime/reader-ready-fanout/reader-ready-fanout-handler.test.ts
@@ -1,25 +1,11 @@
-import type { Context, SQSEvent } from "aws-lambda";
+import type { SQSEvent } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { noopLogger } from "@packages/hutch-logger";
 import { UserIdSchema } from "@packages/domain/user";
 import { initReaderReadyUsersNotificationFanoutHandler, type ReaderReadyUsersNotificationFanoutDeps } from "./reader-ready-fanout-handler";
 
 const URL = "https://example.com/article";
 const SUCCEEDED_AT = "2026-05-30T12:00:00.000Z";
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function sqsEvent(detail: unknown, messageId = "msg-1"): SQSEvent {
 	return {
@@ -63,7 +49,7 @@ describe("initReaderReadyUsersNotificationFanoutHandler", () => {
 
 		const result = await handler(
 			sqsEvent({ url: URL, succeededAt: SUCCEEDED_AT, hasSummary: true }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -81,7 +67,7 @@ describe("initReaderReadyUsersNotificationFanoutHandler", () => {
 			findUserArticlesByUrl: jest.fn().mockResolvedValue([viewedSaver]),
 		});
 
-		await handler(sqsEvent({ url: URL, succeededAt: SUCCEEDED_AT, hasSummary: false }), stubContext, () => {});
+		await handler(sqsEvent({ url: URL, succeededAt: SUCCEEDED_AT, hasSummary: false }), buildLambdaContext(), () => {});
 
 		expect(deps.markReaderViewSucceeded).toHaveBeenCalledTimes(1);
 		expect(deps.dispatchNotifyReaderViewReady).not.toHaveBeenCalled();
@@ -94,7 +80,7 @@ describe("initReaderReadyUsersNotificationFanoutHandler", () => {
 
 		const result = await handler(
 			sqsEvent({ url: URL, succeededAt: SUCCEEDED_AT, hasSummary: true }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -104,7 +90,7 @@ describe("initReaderReadyUsersNotificationFanoutHandler", () => {
 	it("reports a batch item failure on an invalid event detail", async () => {
 		const { handler, deps } = createHandler();
 
-		const result = await handler(sqsEvent({ url: URL }), stubContext, () => {});
+		const result = await handler(sqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(deps.findUserArticlesByUrl).not.toHaveBeenCalled();

--- a/projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.test.ts
+++ b/projects/hutch/src/runtime/reader-ready-notify/reader-ready-notify-handler.test.ts
@@ -1,4 +1,5 @@
-import type { Context, SQSEvent } from "aws-lambda";
+import type { SQSEvent } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { noopLogger } from "@packages/hutch-logger";
 import { ReaderArticleHashId } from "@packages/domain/article";
 import { ReaderReadyEmailSentEvent } from "@packages/hutch-infra-components";
@@ -11,21 +12,6 @@ const VIEWED_AT = new Date("2026-05-30T12:01:00.000Z"); // viewed while loading
 const SUCCEEDED_AT = "2026-05-30T12:02:00.000Z"; // 2 min after save -> generation > 60s
 const NOW = new Date("2026-05-30T12:07:00.000Z");
 const COOLDOWN_MS = 6 * 60 * 60 * 1000;
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function sqsEvent(detail: unknown, messageId = "msg-1"): SQSEvent {
 	return {
@@ -92,7 +78,7 @@ describe("initReaderReadyNotifyHandler", () => {
 		it("claims the cooldown, sends the email, stamps emailSentAt, and publishes ReaderReadyEmailSent", async () => {
 			const { handler, deps } = createHandler();
 
-			const result = await handler(command(), stubContext, () => {});
+			const result = await handler(command(), buildLambdaContext(), () => {});
 
 			expect(result).toEqual({ batchItemFailures: [] });
 			expect(deps.claimReaderReadyEmailSlot).toHaveBeenCalledWith({ userId: USER_ID, now: NOW, cooldownMs: COOLDOWN_MS });
@@ -115,7 +101,7 @@ describe("initReaderReadyNotifyHandler", () => {
 
 	describe("gates (skip without sending)", () => {
 		async function expectSkipped(deps: ReturnType<typeof createHandler>["deps"], handler: ReturnType<typeof createHandler>["handler"]) {
-			const result = await handler(command(), stubContext, () => {});
+			const result = await handler(command(), buildLambdaContext(), () => {});
 			expect(result).toEqual({ batchItemFailures: [] });
 			expect(deps.sendEmail).not.toHaveBeenCalled();
 			expect(deps.markReaderReadyEmailSent).not.toHaveBeenCalled();
@@ -163,7 +149,7 @@ describe("initReaderReadyNotifyHandler", () => {
 			});
 			const result = await handler(
 				command({ succeededAt: "2026-05-30T12:00:30.000Z" }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 			expect(result).toEqual({ batchItemFailures: [] });
@@ -213,7 +199,7 @@ describe("initReaderReadyNotifyHandler", () => {
 			const { handler, deps } = createHandler({
 				claimReaderReadyEmailSlot: jest.fn().mockResolvedValue(false),
 			});
-			const result = await handler(command(), stubContext, () => {});
+			const result = await handler(command(), buildLambdaContext(), () => {});
 			expect(result).toEqual({ batchItemFailures: [] });
 			expect(deps.sendEmail).not.toHaveBeenCalled();
 			expect(deps.markReaderReadyEmailSent).not.toHaveBeenCalled();
@@ -226,7 +212,7 @@ describe("initReaderReadyNotifyHandler", () => {
 				sendEmail: jest.fn().mockRejectedValue(new Error("resend down")),
 			});
 
-			const result = await handler(command(), stubContext, () => {});
+			const result = await handler(command(), buildLambdaContext(), () => {});
 
 			expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 			expect(deps.releaseReaderReadyEmailSlot).toHaveBeenCalledWith({ userId: USER_ID, claimedAt: NOW });
@@ -236,7 +222,7 @@ describe("initReaderReadyNotifyHandler", () => {
 		it("reports a batch item failure on an invalid command detail", async () => {
 			const { handler, deps } = createHandler();
 
-			const result = await handler(sqsEvent({ url: URL }), stubContext, () => {});
+			const result = await handler(sqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 			expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 			expect(deps.findUserArticleNotificationState).not.toHaveBeenCalled();

--- a/projects/hutch/src/runtime/schedule-trial-feedback-email/schedule-trial-feedback-email-handler.test.ts
+++ b/projects/hutch/src/runtime/schedule-trial-feedback-email/schedule-trial-feedback-email-handler.test.ts
@@ -3,6 +3,7 @@ import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initInMemoryTrialScheduler } from "@packages/test-fixtures/providers/trial-scheduler";
 import { buildSqsEvent } from "@packages/test-fixtures/sqs";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import {
 	initScheduleTrialFeedbackEmailHandler,
 	TRIAL_FEEDBACK_EMAIL_DELAY_MS,
@@ -57,7 +58,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -82,7 +83,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -108,7 +109,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -133,7 +134,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 		await subject.handler(
@@ -146,7 +147,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -176,7 +177,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -199,7 +200,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -223,7 +224,7 @@ describe("schedule-trial-feedback-email handler", () => {
 					}),
 				},
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/send-trial-feedback-email/send-trial-feedback-email-handler.test.ts
+++ b/projects/hutch/src/runtime/send-trial-feedback-email/send-trial-feedback-email-handler.test.ts
@@ -1,32 +1,15 @@
 import assert from "node:assert/strict";
-import type { Context } from "aws-lambda";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initInMemoryEmail } from "@packages/test-fixtures/providers/email";
 import { initInMemorySubscriptionProviders } from "@packages/test-fixtures/providers/subscription-providers";
 import type { FindArticlesByUser } from "@packages/test-fixtures/providers/article-store";
 import { buildSqsEvent } from "@packages/test-fixtures/sqs";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import {
 	initSendTrialFeedbackEmailHandler,
 	type SendTrialFeedbackEmailDeps,
 } from "./send-trial-feedback-email-handler";
-
-/** The SQS handler ignores the Lambda Context; a single typed value satisfies
- * the Handler signature without an `as` assertion at every call site. */
-const lambdaContext = {
-	callbackWaitsForEmptyEventLoop: false,
-	functionName: "send-trial-feedback-email",
-	functionVersion: "$LATEST",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:000000000000:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "test-log-group",
-	logStreamName: "test-log-stream",
-	getRemainingTimeInMillis: () => 30_000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-} satisfies Context;
 
 const USER_ID = UserIdSchema.parse("6".repeat(32));
 const FOUNDER_AVATAR_URL = "https://static.readplace.com/fayner-brack.jpg";
@@ -87,7 +70,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-ok", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -116,7 +99,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		await subject.handler(
 			buildSqsEvent([{ messageId: "msg-zero", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -137,7 +120,7 @@ describe("send-trial-feedback-email handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-reactivated", body: buildEventBridgeBody(USER_ID) },
 			]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -159,7 +142,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		await subject.handler(
 			buildSqsEvent([{ messageId: "msg-active", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -178,7 +161,7 @@ describe("send-trial-feedback-email handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-dup", body: buildEventBridgeBody(USER_ID) },
 			]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -192,7 +175,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-missing", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -210,7 +193,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-no-email", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -228,7 +211,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		await subject.handler(
 			buildSqsEvent([{ messageId: "msg-one", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -263,7 +246,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-fail", body: buildEventBridgeBody(USER_ID) }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -280,7 +263,7 @@ describe("send-trial-feedback-email handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "not-json" }]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -296,7 +279,7 @@ describe("send-trial-feedback-email handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-schema", body: JSON.stringify({ detail: {} }) },
 			]),
-			lambdaContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/stripe-webhook-receiver/stripe-webhook-receiver-handler.test.ts
+++ b/projects/hutch/src/runtime/stripe-webhook-receiver/stripe-webhook-receiver-handler.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import type { APIGatewayProxyEventV2, Context } from "aws-lambda";
+import type { APIGatewayProxyEventV2 } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import type { StripeEventType } from "@packages/hutch-infra-components";
 import {
@@ -10,21 +11,6 @@ import { UnconfiguredStripeEventError } from "./unconfigured-stripe-event-error"
 import { signStripeWebhookHeader } from "./sign-stripe-webhook-header.test-helper";
 
 const TEST_SECRET = "whsec_test_handler_secret";
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:us-east-1:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function buildApiGatewayEvent(params: {
 	body: string;
@@ -91,7 +77,7 @@ describe("stripe-webhook-receiver-handler", () => {
 		});
 
 		const body = buildStripeEvent({ type: "customer.subscription.deleted", subscriptionId: "sub_1" });
-		const result = await handler(buildApiGatewayEvent({ body }), stubContext, () => {});
+		const result = await handler(buildApiGatewayEvent({ body }), buildLambdaContext(), () => {});
 
 		assert(result);
 		assert.equal(result.statusCode, 400);
@@ -112,7 +98,7 @@ describe("stripe-webhook-receiver-handler", () => {
 				body,
 				signatureHeader: buildSignature(rawBody, { secret: "whsec_wrong" }),
 			}),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -137,7 +123,7 @@ describe("stripe-webhook-receiver-handler", () => {
 		const rawBody = Buffer.from(body);
 		const result = await handler(
 			buildApiGatewayEvent({ body, signatureHeader: buildSignature(rawBody) }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -161,7 +147,7 @@ describe("stripe-webhook-receiver-handler", () => {
 			async () => {
 				await handler(
 					buildApiGatewayEvent({ body, signatureHeader: buildSignature(rawBody) }),
-					stubContext,
+					buildLambdaContext(),
 					() => {},
 				);
 			},
@@ -190,7 +176,7 @@ describe("stripe-webhook-receiver-handler", () => {
 			async () => {
 				await handler(
 					buildApiGatewayEvent({ body, signatureHeader: buildSignature(rawBody) }),
-					stubContext,
+					buildLambdaContext(),
 					() => {},
 				);
 			},
@@ -216,7 +202,7 @@ describe("stripe-webhook-receiver-handler", () => {
 		const b64Body = rawBody.toString("base64");
 		const result = await handler(
 			{ ...buildApiGatewayEvent({ body: b64Body, signatureHeader: buildSignature(rawBody) }), isBase64Encoded: true },
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { Context } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import type { PublishCancelSubscriptionCommand } from "@packages/test-fixtures/providers/events";
@@ -8,21 +8,6 @@ import { initSubscriptionChargeFailedHandler } from "./subscription-charge-faile
 import { initEmitSubscriptionEvent, type SubscriptionLogEvent } from "../observability/subscription-events";
 
 const USER_ID = UserIdSchema.parse("3".repeat(32));
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function makeEmit(): { emit: ReturnType<typeof initEmitSubscriptionEvent>; captured: SubscriptionLogEvent[] } {
 	const captured: SubscriptionLogEvent[] = [];
@@ -62,7 +47,7 @@ describe("subscription-charge-failed handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -99,7 +84,7 @@ describe("subscription-charge-failed handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -119,7 +104,7 @@ describe("subscription-charge-failed handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "garbage" }]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -143,7 +128,7 @@ describe("subscription-charge-failed handler", () => {
 					body: JSON.stringify({ detail: { userId: USER_ID, reason: "made_up" } }),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -170,7 +155,7 @@ describe("subscription-charge-failed handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/subscription-charge-succeeded/subscription-charge-succeeded-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-charge-succeeded/subscription-charge-succeeded-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { Context } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { UserIdSchema } from "@packages/domain/user";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initInMemorySubscriptionProviders } from "@packages/test-fixtures/providers/subscription-providers";
@@ -8,21 +8,6 @@ import { initSubscriptionChargeSucceededHandler } from "./subscription-charge-su
 import { initEmitSubscriptionEvent, type SubscriptionLogEvent } from "../observability/subscription-events";
 
 const USER_ID = UserIdSchema.parse("2".repeat(32));
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function buildBody(detail: {
 	userId: string;
@@ -68,7 +53,7 @@ describe("subscription-charge-succeeded handler", () => {
 					}),
 				},
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -93,7 +78,7 @@ describe("subscription-charge-succeeded handler", () => {
 
 		const result = await handler(
 			buildSqsEvent([{ messageId: "msg-bad", body: "{not-json" }]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -110,7 +95,7 @@ describe("subscription-charge-succeeded handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-schema", body: JSON.stringify({ detail: { userId: USER_ID, customerId: "cus_x" } }) },
 			]),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-start-request/subscription-start-request-handler.test.ts
@@ -8,6 +8,7 @@ import type {
 	PublishSubscriptionChargeSucceeded,
 } from "@packages/test-fixtures/providers/events";
 import { buildSqsEvent } from "@packages/test-fixtures/sqs";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { initSubscriptionStartRequestHandler } from "./subscription-start-request-handler";
 
 const USER_ID = UserIdSchema.parse("1".repeat(32));
@@ -59,7 +60,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-missing", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -80,7 +81,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-active", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -102,7 +103,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-cancelled", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -125,7 +126,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-pc", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -145,7 +146,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-no-card", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -175,7 +176,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-charge", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -210,7 +211,7 @@ describe("subscription-start-request handler", () => {
 
 		const result = await subject.handler(
 			buildSqsEvent([{ messageId: "msg-stripe-fail", body: buildEventBridgeBody(USER_ID) }]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -230,7 +231,7 @@ describe("subscription-start-request handler", () => {
 				{ messageId: "msg-bad", body: "not-json" },
 				{ messageId: "msg-good", body: buildEventBridgeBody(USER_ID) },
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -246,7 +247,7 @@ describe("subscription-start-request handler", () => {
 			buildSqsEvent([
 				{ messageId: "msg-schema", body: JSON.stringify({ detail: {} }) },
 			]),
-			{} as never,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initComprehensiveCrawlDlqHandler } from "./comprehensive-crawl-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string; userId?: string; recrawl?: boolean },
@@ -60,7 +46,7 @@ describe("initComprehensiveCrawlDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/scan.pdf", userId: "user-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initComprehensiveCrawlDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/comprehensive-crawl/comprehensive-crawl-handler.test.ts
@@ -9,28 +9,14 @@ import {
 import { initComprehensiveCrawlHandler } from "./comprehensive-crawl-handler";
 import type { FinalizeArticle, FinalizedArticle } from "@packages/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(
@@ -110,7 +96,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ putTierSource, publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(putTierSource).toHaveBeenCalledWith({
 			url: "https://example.com/doc.pdf",
@@ -142,7 +128,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ crawlArticle, finalizeArticle });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 
 		expect(finalizeArticle).toHaveBeenCalledWith({
 			url: "https://example.com/doc.pdf",
@@ -156,7 +142,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 
 		expect(publishEvent).toHaveBeenCalledWith(TierContentExtractedEvent, {
 			url: "https://example.com/doc.pdf",
@@ -170,7 +156,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", recrawl: true }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", recrawl: true }), buildLambdaContext(), () => {});
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
 		expect(publishEvent).toHaveBeenCalledWith(RecrawlContentExtractedEvent, {
@@ -197,7 +183,7 @@ describe("initComprehensiveCrawlHandler", () => {
 				refresh: true,
 				previousBodyHash: "h".repeat(64),
 			}),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -226,7 +212,7 @@ describe("initComprehensiveCrawlHandler", () => {
 				refresh: true,
 				previousBodyHash: "h".repeat(64),
 			}),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -248,7 +234,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ publishEvent, updateFetchTimestamp, crawlArticle });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", refresh: true }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf", refresh: true }), buildLambdaContext(), () => {});
 
 		expect(updateFetchTimestamp).not.toHaveBeenCalled();
 		expect(publishEvent).toHaveBeenCalledTimes(1);
@@ -279,7 +265,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/scan.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -310,7 +296,7 @@ describe("initComprehensiveCrawlHandler", () => {
 			readTierSnapshot,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/scan.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/scan.pdf" }), buildLambdaContext(), () => {});
 
 		expect(logCrawlOutcome).toHaveBeenCalledWith({
 			url: "https://example.com/scan.pdf",
@@ -334,7 +320,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/doc.pdf" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -351,7 +337,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad.pdf" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -378,7 +364,7 @@ describe("initComprehensiveCrawlHandler", () => {
 			markCrawlStage,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 		await new Promise((resolve) => setImmediate(resolve));
 
 		const extractingWrites = markCrawlStage.mock.calls.filter(
@@ -405,7 +391,7 @@ describe("initComprehensiveCrawlHandler", () => {
 			logger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 
 		expect(warn).toHaveBeenCalledWith(
 			"[ComprehensiveCrawlCommand] comprehensive-extracting stage write failed",
@@ -425,7 +411,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ crawlArticle, markCrawlProgress });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 
 		expect(markCrawlProgress).toHaveBeenCalledWith({
 			url: "https://example.com/doc.pdf",
@@ -452,7 +438,7 @@ describe("initComprehensiveCrawlHandler", () => {
 			progressIntervalMs: 10_000,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 
 		const lastCall = markCrawlProgress.mock.calls[markCrawlProgress.mock.calls.length - 1];
 		expect(lastCall[0]).toEqual({
@@ -474,7 +460,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 		const handler = createHandler({ crawlArticle, updateFetchTimestamp });
 
-		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/doc.pdf" }), buildLambdaContext(), () => {});
 
 		expect(updateFetchTimestamp).toHaveBeenCalledWith({
 			url: "https://example.com/doc.pdf",
@@ -502,7 +488,7 @@ describe("initComprehensiveCrawlHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 
@@ -523,7 +509,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 			const result = await handler(
 				createSqsEvent({ url: "https://example.com/doc.pdf" }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -563,7 +549,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 			await handler(
 				createSqsEvent({ url: "https://example.com/doc.pdf" }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -590,7 +576,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 			const result = await handler(
 				createSqsEvent({ url: "https://example.com/doc.pdf", refresh: true }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -608,7 +594,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 			const result = await handler(
 				createSqsEvent({ url: "https://example.com/doc.pdf" }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -634,7 +620,7 @@ describe("initComprehensiveCrawlHandler", () => {
 
 			const result = await handler(
 				createSqsEvent({ url: "https://example.com/doc.pdf" }, { receiveCount: 2 }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -661,7 +647,7 @@ describe("initComprehensiveCrawlHandler", () => {
 					refresh: true,
 					previousBodyHash: "h".repeat(64),
 				}, { receiveCount: 2 }),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -681,7 +667,7 @@ describe("initComprehensiveCrawlHandler", () => {
 					refresh: true,
 					previousBodyHash: "h".repeat(64),
 				}),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 
@@ -702,7 +688,7 @@ describe("initComprehensiveCrawlHandler", () => {
 					refresh: true,
 					previousBodyHash: "h".repeat(64),
 				}),
-				stubContext,
+				buildLambdaContext(),
 				() => {},
 			);
 

--- a/projects/save-link/src/runtime/domain/crawl-article-state/recrawl-link-initiated-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/recrawl-link-initiated-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initRecrawlLinkInitiatedDlqHandler } from "./recrawl-link-initiated-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string },
@@ -60,7 +46,7 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -113,7 +99,7 @@ describe("initRecrawlLinkInitiatedDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/crawl-article-state/save-anonymous-link-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/save-anonymous-link-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveAnonymousLinkDlqHandler } from "./save-anonymous-link-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string },
@@ -60,7 +46,7 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed" }, 2),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -113,7 +99,7 @@ describe("initSaveAnonymousLinkDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/crawl-article-state/save-link-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/save-link-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveLinkDlqHandler } from "./save-link-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string; userId: string },
@@ -60,7 +46,7 @@ describe("initSaveLinkDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed", userId: "user-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initSaveLinkDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -113,7 +99,7 @@ describe("initSaveLinkDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/crawl-article-state/save-link-raw-html-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/save-link-raw-html-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveLinkRawHtmlDlqHandler } from "./save-link-raw-html-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string; userId: string; title?: string },
@@ -60,7 +46,7 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed", userId: "user-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -113,7 +99,7 @@ describe("initSaveLinkRawHtmlDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/crawl-article-state/save-link-raw-pdf-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/save-link-raw-pdf-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSaveLinkRawPdfDlqHandler } from "./save-link-raw-pdf-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string; userId: string },
@@ -60,7 +46,7 @@ describe("initSaveLinkRawPdfDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed.pdf", userId: "user-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initSaveLinkRawPdfDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -113,7 +99,7 @@ describe("initSaveLinkRawPdfDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/generate-summary/generate-summary-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/generate-summary-dlq-handler.test.ts
@@ -4,7 +4,8 @@ import {
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
 import { initGenerateSummaryDlqHandler } from "./generate-summary-dlq-handler";
-import type { SQSEvent, SQSRecord, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecord, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -14,21 +15,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createRecord(detail: unknown, receiveCount: number, messageId = "msg-1"): SQSRecord {
 	return {
@@ -57,7 +43,7 @@ describe("initGenerateSummaryDlqHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/failed" }, 4), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/failed" }, 4), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
 		expect(transitionAndPersist).toHaveBeenCalledWith(markSummaryExhausted, {
@@ -77,7 +63,7 @@ describe("initGenerateSummaryDlqHandler", () => {
 			logger: noopLogger,
 		});
 
-		const result = await handler({ Records: [] }, stubContext, () => {});
+		const result = await handler({ Records: [] }, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
@@ -93,7 +79,7 @@ describe("initGenerateSummaryDlqHandler", () => {
 
 		const invalidEvent: SQSEvent = { Records: [createRecord({ invalid: true }, 3)] };
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
@@ -111,7 +97,7 @@ describe("initGenerateSummaryDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -139,7 +125,7 @@ describe("initGenerateSummaryDlqHandler", () => {
 			],
 		};
 
-		const result = await handler(event, stubContext, () => {});
+		const result = await handler(event, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-bad" }] });
 		expect(transitionAndPersist).toHaveBeenCalledTimes(2);

--- a/projects/save-link/src/runtime/domain/generate-summary/generate-summary-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/generate-summary-handler.test.ts
@@ -4,7 +4,8 @@ import {
 	markSummarySkipped,
 } from "@packages/domain/article-aggregate";
 import { noopLogger } from "@packages/hutch-logger";
-import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { initGenerateSummaryHandler } from "./generate-summary-handler";
 import type { SummarizeArticle } from "./link-summariser";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
@@ -15,21 +16,6 @@ const stubAttributes: SQSRecordAttributes = {
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string }): SQSEvent {
@@ -93,7 +79,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
 		});
 
-		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		const result = await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [] });
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummaryReady, {
@@ -119,7 +105,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(cached),
 		});
 
-		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		const result = await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [] });
 		expect(deps.summarizeArticle).not.toHaveBeenCalled();
@@ -137,7 +123,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(cached),
 		});
 
-		await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(deps.summarizeArticle).not.toHaveBeenCalled();
 		expect(deps.findArticleContent).not.toHaveBeenCalled();
@@ -161,7 +147,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(cached),
 		});
 
-		await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummaryReady, expect.objectContaining({ url: URL }));
 	});
@@ -176,7 +162,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
 		});
 
-		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		const result = await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [] });
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummarySkipped, {
@@ -195,7 +181,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
 		});
 
-		await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(markSummarySkipped, {
 			url: URL,
@@ -210,7 +196,7 @@ describe("initGenerateSummaryHandler", () => {
 			loadArticle: jest.fn().mockResolvedValue(pendingArticle(URL)),
 		});
 
-		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		const result = await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
@@ -225,7 +211,7 @@ describe("initGenerateSummaryHandler", () => {
 			logger: { ...noopLogger, error },
 		});
 
-		const result = await handler(createSqsEvent({ url: URL }), stubContext, () => {});
+		const result = await handler(createSqsEvent({ url: URL }), buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(deps.summarizeArticle).not.toHaveBeenCalled();
@@ -258,7 +244,7 @@ describe("initGenerateSummaryHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(deps.transitionAndPersist).not.toHaveBeenCalled();

--- a/projects/save-link/src/runtime/domain/generate-summary/summary-generated-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/summary-generated-handler.test.ts
@@ -1,26 +1,12 @@
 import { initSummaryGeneratedHandler } from "./summary-generated-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; inputTokens: number; outputTokens: number }): SQSEvent {
@@ -54,7 +40,7 @@ describe("initSummaryGeneratedHandler", () => {
 			url: "https://example.com/article",
 			inputTokens: 150,
 			outputTokens: 42,
-		}), stubContext, () => {});
+		}), buildLambdaContext(), () => {});
 
 		expect(logger.info).toHaveBeenCalledWith("[GlobalSummaryGenerated]", {
 			url: "https://example.com/article",
@@ -87,7 +73,7 @@ describe("initSummaryGeneratedHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/generate-summary/summary-generation-failed-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/generate-summary/summary-generation-failed-handler.test.ts
@@ -1,28 +1,14 @@
 import { noopLogger, type HutchLogger } from "@packages/hutch-logger";
 import type { ParseErrorEvent } from "@packages/hutch-infra-components";
 import { initSummaryGenerationFailedHandler } from "./summary-generation-failed-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; reason: string; receiveCount: number }): SQSEvent {
@@ -55,7 +41,7 @@ describe("initSummaryGenerationFailedHandler", () => {
 				reason: "deepseek timeout",
 				receiveCount: 3,
 			}),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -92,7 +78,7 @@ describe("initSummaryGenerationFailedHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalid, stubContext, () => {});
+		const result = await handler(invalid, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(infoSpy).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-html/save-link-raw-html-command-handler.test.ts
@@ -4,28 +4,14 @@ import { TierContentExtractedEvent } from "@packages/hutch-infra-components";
 import { initSaveLinkRawHtmlCommandHandler } from "./save-link-raw-html-command-handler";
 import type { FinalizeArticle, FinalizedArticle } from "@packages/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; userId: string; title?: string }): SQSEvent {
@@ -86,7 +72,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/article", userId: "user-1", title: "Captured Title" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -115,7 +101,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -132,7 +118,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		const { handler } = createHandler({ publishEvent, putTierSource });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(calls).toEqual(["putTierSource", "publishEvent"]);
 	});
@@ -155,7 +141,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -183,7 +169,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -205,7 +191,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -230,7 +216,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -252,7 +238,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		});
 		const { handler, deps } = createHandler({ readTierSnapshot });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.logCrawlOutcome).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -271,7 +257,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 		});
 		const { handler, deps } = createHandler({ readTierSnapshot });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.logCrawlOutcome).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -289,7 +275,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/article", userId: "user-1", title: "Captured Title" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -316,7 +302,7 @@ describe("initSaveLinkRawHtmlCommandHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link-raw-pdf/save-link-raw-pdf-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link-raw-pdf/save-link-raw-pdf-command-handler.test.ts
@@ -9,28 +9,14 @@ import type { ParseHtml } from "@packages/article-parser";
 import type { ExtractPdf } from "@packages/crawl-article";
 import type { DownloadMedia } from "@packages/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; userId: string }): SQSEvent {
@@ -108,7 +94,7 @@ describe("initSaveLinkRawPdfCommandHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/x.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -142,7 +128,7 @@ describe("initSaveLinkRawPdfCommandHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/x.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -167,7 +153,7 @@ describe("initSaveLinkRawPdfCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -206,7 +192,7 @@ describe("initSaveLinkRawPdfCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/bad.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/save-link/anonymous-link-saved-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/anonymous-link-saved-handler.test.ts
@@ -1,28 +1,14 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initAnonymousLinkSavedHandler } from "./anonymous-link-saved-handler";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string }): SQSEvent {
@@ -52,7 +38,7 @@ describe("initAnonymousLinkSavedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article" }), buildLambdaContext(), () => {});
 
 		expect(dispatchGenerateSummary).toHaveBeenCalledTimes(1);
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
@@ -70,7 +56,7 @@ describe("initAnonymousLinkSavedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/no-content" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -102,7 +88,7 @@ describe("initAnonymousLinkSavedHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/canonical-content-changed-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/canonical-content-changed-handler.test.ts
@@ -5,28 +5,14 @@ import {
 } from "@packages/domain/article-aggregate";
 import { initCanonicalContentChangedHandler } from "./canonical-content-changed-handler";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 const FIXED_NOW = new Date("2026-05-31T10:00:00.000Z");
@@ -59,7 +45,7 @@ describe("initCanonicalContentChangedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article" }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
 		expect(transitionAndPersist).toHaveBeenCalledWith(markSummaryPending, {
@@ -81,7 +67,7 @@ describe("initCanonicalContentChangedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/no-content" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -114,7 +100,7 @@ describe("initCanonicalContentChangedHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});

--- a/projects/save-link/src/runtime/domain/save-link/link-saved-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/link-saved-handler.test.ts
@@ -1,28 +1,14 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initLinkSavedHandler } from "./link-saved-handler";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; userId: string }): SQSEvent {
@@ -52,7 +38,7 @@ describe("initLinkSavedHandler", () => {
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(dispatchGenerateSummary).toHaveBeenCalledTimes(1);
 		expect(dispatchGenerateSummary).toHaveBeenCalledWith({ url: "https://example.com/article" });
@@ -70,7 +56,7 @@ describe("initLinkSavedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/no-content", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -102,7 +88,7 @@ describe("initLinkSavedHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/recrawl-link-initiated-handler.test.ts
@@ -7,28 +7,14 @@ import type {
 	FinalizedArticle,
 } from "@packages/finalize-article";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string }): SQSEvent {
@@ -96,7 +82,7 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 		const publishEvent = jest.fn().mockResolvedValue(undefined);
 		const handler = createHandler({ publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article" }), buildLambdaContext(), () => {});
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
 		expect(publishEvent).toHaveBeenCalledWith(RecrawlContentExtractedEvent, {
@@ -112,7 +98,7 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/unreachable" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -141,7 +127,7 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/doc.pdf" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -172,7 +158,7 @@ describe("initRecrawlLinkInitiatedHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/refresh-article-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/refresh-article-content-handler.test.ts
@@ -1,7 +1,8 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { RefreshContentExtractedEvent } from "@packages/hutch-infra-components";
 import type { ReadRefreshHtml } from "@packages/test-fixtures/providers/refresh-html";
-import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import { initRefreshArticleContentHandler } from "./refresh-article-content-handler";
 
@@ -10,21 +11,6 @@ const stubAttributes: SQSRecordAttributes = {
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 interface RefreshDetail {
@@ -91,7 +77,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent(DETAIL), stubContext, () => {});
+		await handler(createSqsEvent(DETAIL), buildLambdaContext(), () => {});
 
 		expect(readRefreshHtml).toHaveBeenCalledWith(URL);
 		expect(putTierSource).toHaveBeenCalledWith({
@@ -120,7 +106,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent(DETAIL), stubContext, () => {});
+		await handler(createSqsEvent(DETAIL), buildLambdaContext(), () => {});
 
 		expect(publishEvent).toHaveBeenCalledTimes(1);
 		expect(publishEvent).toHaveBeenCalledWith(RefreshContentExtractedEvent, {
@@ -144,7 +130,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent({ ...DETAIL, bodyHash: "deadbeef".repeat(8) }), stubContext, () => {});
+		await handler(createSqsEvent({ ...DETAIL, bodyHash: "deadbeef".repeat(8) }), buildLambdaContext(), () => {});
 
 		expect(publishEvent).toHaveBeenCalledWith(RefreshContentExtractedEvent, {
 			url: URL,
@@ -175,7 +161,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			logger: noopLogger,
 		});
 
-		await handler(createSqsEvent(DETAIL), stubContext, () => {});
+		await handler(createSqsEvent(DETAIL), buildLambdaContext(), () => {});
 
 		expect(order).toEqual(["readRefreshHtml", "putTierSource", "publishEvent"]);
 	});
@@ -208,7 +194,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(readRefreshHtml).not.toHaveBeenCalled();
@@ -230,7 +216,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			logger: noopLogger,
 		});
 
-		const result = await handler(createSqsEvent(DETAIL), stubContext, () => {});
+		const result = await handler(createSqsEvent(DETAIL), buildLambdaContext(), () => {});
 
 		expect(putTierSource).not.toHaveBeenCalled();
 		expect(publishEvent).not.toHaveBeenCalled();
@@ -251,7 +237,7 @@ describe("initRefreshArticleContentHandler (S3 read + tier-write + publish)", ()
 			logger: noopLogger,
 		});
 
-		const result = await handler(createSqsEvent(DETAIL), stubContext, () => {});
+		const result = await handler(createSqsEvent(DETAIL), buildLambdaContext(), () => {});
 
 		expect(publishEvent).not.toHaveBeenCalled();
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });

--- a/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-anonymous-link-command-handler.test.ts
@@ -9,28 +9,14 @@ import type {
 } from "@packages/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string }): SQSEvent {
@@ -100,7 +86,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 
 		const handler = createHandler({ putTierSource, publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/article" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article" }), buildLambdaContext(), () => {});
 
 		expect(putTierSource).toHaveBeenCalledWith(
 			expect.objectContaining({ url: "https://example.com/article", tier: "tier-1" }),
@@ -120,7 +106,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/unreachable" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -135,7 +121,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, logParseError });
 
-		await handler(createSqsEvent({ url: "https://example.com/unreachable" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/unreachable" }), buildLambdaContext(), () => {});
 
 		expect(logParseError).toHaveBeenCalledWith({
 			url: "https://example.com/unreachable",
@@ -149,7 +135,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, transitionAndPersist });
 
-		await handler(createSqsEvent({ url: "https://example.com/bad" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/bad" }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/bad",
@@ -180,7 +166,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/blob" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -213,7 +199,7 @@ describe("initSaveAnonymousLinkCommandHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/save-link-command-handler.test.ts
@@ -9,28 +9,14 @@ import type {
 } from "@packages/finalize-article";
 import type { PutTierSource } from "../../providers/article-store/put-tier-source";
 import type { EmitSimpleCrawlUnsupported } from "../../dep-bundles/events";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; userId: string }): SQSEvent {
@@ -100,7 +86,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ putTierSource, publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(putTierSource).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -122,7 +108,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ publishEvent, putTierSource });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(calls).toEqual(["putTierSource", "publishEvent"]);
 	});
@@ -138,7 +124,7 @@ describe("initSaveLinkCommandHandler", () => {
 		});
 		const handler = createHandler({ crawlAndFinalizeArticle, updateFetchTimestamp });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(updateFetchTimestamp).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -158,7 +144,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -173,7 +159,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, logParseError });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(logParseError).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -191,7 +177,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ logCrawlOutcome, readTierSnapshot });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(logCrawlOutcome).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -213,7 +199,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, logCrawlOutcome, readTierSnapshot });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(logCrawlOutcome).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -230,7 +216,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, transitionAndPersist });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledWith(markCrawlFailed, {
 			url: "https://example.com/article",
@@ -244,7 +230,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, transitionAndPersist });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -256,7 +242,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, emitSimpleCrawlUnsupported, publishEvent });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(emitSimpleCrawlUnsupported).toHaveBeenCalledWith({
 			url: "https://example.com/article",
@@ -274,7 +260,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const handler = createHandler({ crawlAndFinalizeArticle, markCrawlStage, emitSimpleCrawlUnsupported });
 
-		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/article", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(calls).toEqual([
 			"stage:crawl-fetching",
@@ -291,7 +277,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -306,7 +292,7 @@ describe("initSaveLinkCommandHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/article", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -330,7 +316,7 @@ describe("initSaveLinkCommandHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});

--- a/projects/save-link/src/runtime/domain/save-link/update-fetch-timestamp-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/save-link/update-fetch-timestamp-handler.test.ts
@@ -1,27 +1,13 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { initUpdateFetchTimestampHandler } from "./update-fetch-timestamp-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string; contentFetchedAt: string }): SQSEvent {
@@ -52,7 +38,7 @@ describe("initUpdateFetchTimestampHandler", () => {
 		await handler(createSqsEvent({
 			url: "https://example.com/article",
 			contentFetchedAt: "2026-04-10T12:00:00Z",
-		}), stubContext, () => {});
+		}), buildLambdaContext(), () => {});
 
 		expect(updateFetchTimestamp).toHaveBeenCalledTimes(1);
 		expect(updateFetchTimestamp).toHaveBeenCalledWith({
@@ -81,7 +67,7 @@ describe("initUpdateFetchTimestampHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-dlq-handler.test.ts
@@ -4,7 +4,8 @@ import {
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
 import { initRecrawlContentExtractedDlqHandler } from "./recrawl-content-extracted-dlq-handler";
-import type { SQSEvent, SQSRecord, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecord, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -14,21 +15,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createRecord(detail: unknown, receiveCount: number, messageId = "msg-1"): SQSRecord {
 	return {
@@ -59,7 +45,7 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -81,7 +67,7 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 			logger: noopLogger,
 		});
 
-		const result = await handler({ Records: [] }, stubContext, () => {});
+		const result = await handler({ Records: [] }, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
@@ -97,7 +83,7 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 
 		const invalidEvent: SQSEvent = { Records: [createRecord({ invalid: true }, 3)] };
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
@@ -115,7 +101,7 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -143,7 +129,7 @@ describe("initRecrawlContentExtractedDlqHandler", () => {
 			],
 		};
 
-		const result = await handler(event, stubContext, () => {});
+		const result = await handler(event, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-bad" }] });
 		expect(transitionAndPersist).toHaveBeenCalledTimes(2);

--- a/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/recrawl-content-extracted-handler.test.ts
@@ -12,28 +12,14 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 const FIXED_NOW = new Date("2026-05-12T10:00:00.000Z");
@@ -110,7 +96,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/a" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -138,7 +124,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -166,7 +152,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		const expectedHash = computeCanonicalContentHash(tier1.html);
 		expect(transitionAndPersist).toHaveBeenCalledWith(
@@ -194,7 +180,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledWith(
 			recrawlPromoteTier,
@@ -228,7 +214,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(callOrder).toEqual(["writeCanonicalContent", "transitionAndPersist"]);
 	});
@@ -253,7 +239,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).not.toHaveBeenCalled();
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
@@ -282,7 +268,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -321,7 +307,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).not.toHaveBeenCalled();
 		expect(transitionAndPersist).toHaveBeenCalledWith(recrawlTieKeptCanonical, {
@@ -349,7 +335,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			writeCanonicalContent,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(findContentSourceTier).not.toHaveBeenCalled();
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
@@ -372,7 +358,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -403,7 +389,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			writeCanonicalContent,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -424,7 +410,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -452,7 +438,7 @@ describe("initRecrawlContentExtractedHandler", () => {
 			selectMostCompleteContent: jest.fn().mockResolvedValue({ winner: "tier-0", reason: "tier-0 body wins" }),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
 			recrawlPromoteTier,

--- a/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/refresh-content-extracted-handler.test.ts
@@ -3,7 +3,8 @@ import {
 	refreshContent,
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
-import type { Context, SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { initRefreshContentExtractedHandler } from "./refresh-content-extracted-handler";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
@@ -13,21 +14,6 @@ const stubAttributes: SQSRecordAttributes = {
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 const FIXED_NOW = new Date("2026-05-12T10:00:00.000Z");
@@ -99,7 +85,7 @@ describe("initRefreshContentExtractedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/a" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -116,7 +102,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledWith(
 			refreshContent,
@@ -161,7 +147,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			}],
 		};
 
-		await handler(event, stubContext, () => {});
+		await handler(event, buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledWith(
 			refreshContent,
@@ -184,7 +170,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		const expectedHash = computeCanonicalContentHash(tier1.html);
 		expect(transitionAndPersist).toHaveBeenCalledWith(
@@ -210,7 +196,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).not.toHaveBeenCalled();
 		expect(transitionAndPersist).toHaveBeenCalledWith(
@@ -237,7 +223,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -265,7 +251,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			writeCanonicalContent,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -283,7 +269,7 @@ describe("initRefreshContentExtractedHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a" }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
 			refreshContent,
@@ -308,7 +294,7 @@ describe("initRefreshContentExtractedHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/a" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-dlq-handler.test.ts
@@ -4,7 +4,8 @@ import {
 	type TransitionAndPersist,
 } from "@packages/domain/article-aggregate";
 import { initSelectMostCompleteContentDlqHandler } from "./select-most-complete-content-dlq-handler";
-import type { SQSEvent, SQSRecord, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecord, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -14,21 +15,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createRecord(detail: unknown, receiveCount: number, messageId = "msg-1"): SQSRecord {
 	return {
@@ -62,7 +48,7 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/failed", tier: "tier-1", userId: "user-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -84,7 +70,7 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 			logger: noopLogger,
 		});
 
-		const result = await handler({ Records: [] }, stubContext, () => {});
+		const result = await handler({ Records: [] }, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
@@ -100,7 +86,7 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 
 		const invalid: SQSEvent = { Records: [createRecord({ invalid: true }, 3)] };
 
-		const result = await handler(invalid, stubContext, () => {});
+		const result = await handler(invalid, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
@@ -118,7 +104,7 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/failed", tier: "tier-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -146,7 +132,7 @@ describe("initSelectMostCompleteContentDlqHandler", () => {
 			],
 		};
 
-		const result = await handler(event, stubContext, () => {});
+		const result = await handler(event, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-bad" }] });
 		expect(transitionAndPersist).toHaveBeenCalledTimes(2);

--- a/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/select-most-complete-content-handler.test.ts
@@ -11,28 +11,14 @@ import type { WriteCanonicalContent } from "../../providers/article-store/promot
 import type { FindContentSourceTier } from "../../providers/article-store/find-content-source-tier";
 import { computeCanonicalContentHash } from "../../providers/article-store/compute-canonical-content-hash";
 import type { TierSource, TierSourceMetadata } from "./tier-source.types";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 const FIXED_NOW = new Date("2026-05-12T10:00:00.000Z");
@@ -110,7 +96,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -134,7 +120,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(selectMostCompleteContent).not.toHaveBeenCalled();
 		expect(writeCanonicalContent).toHaveBeenCalledWith({
@@ -173,7 +159,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }), buildLambdaContext(), () => {});
 
 		expect(callOrder).toEqual(["writeCanonicalContent", "transitionAndPersist"]);
 	});
@@ -188,7 +174,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-1"),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -219,7 +205,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(promoteTier, {
 			url: "https://example.com/a",
@@ -246,7 +232,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
 			promoteTier,
@@ -267,7 +253,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		const expectedHash = computeCanonicalContentHash(tier1.html);
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
@@ -297,7 +283,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			publishEvent,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.writeCanonicalContent).not.toHaveBeenCalled();
 		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
@@ -318,7 +304,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 		});
 
 		// Event raised for the freshly re-saved tier-0 (extension re-save after editing an image upstream).
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(publishEvent).not.toHaveBeenCalled();
 		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
@@ -351,7 +337,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			publishEvent,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(publishEvent).not.toHaveBeenCalled();
 		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
@@ -391,7 +377,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			publishEvent,
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.writeCanonicalContent).not.toHaveBeenCalled();
 		expect(deps.transitionAndPersist).not.toHaveBeenCalled();
@@ -409,7 +395,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -440,7 +426,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -465,7 +451,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue("tier-0"),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-1", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/a",
@@ -494,7 +480,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
 
-		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), stubContext, () => {});
+		await handler(createSqsEvent({ url: "https://example.com/a", tier: "tier-0", userId: "user-1" }), buildLambdaContext(), () => {});
 
 		expect(deps.transitionAndPersist).toHaveBeenCalledWith(
 			promoteTier,
@@ -511,7 +497,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			selectMostCompleteContent: jest.fn(), // unreachable on length 1
 			findContentSourceTier: jest.fn().mockResolvedValue(undefined),
 		});
-		await handler2.handler(createSqsEvent({ url: "https://example.com/x", tier: "tier-1" }), stubContext, () => {});
+		await handler2.handler(createSqsEvent({ url: "https://example.com/x", tier: "tier-1" }), buildLambdaContext(), () => {});
 		expect(handler2.deps.selectMostCompleteContent).not.toHaveBeenCalled();
 		expect(handler2.deps.writeCanonicalContent).toHaveBeenCalledWith({
 			url: "https://example.com/x",
@@ -542,7 +528,7 @@ describe("initSelectMostCompleteContentHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
 });

--- a/projects/save-link/src/runtime/domain/select-content/summary-recovery.test.ts
+++ b/projects/save-link/src/runtime/domain/select-content/summary-recovery.test.ts
@@ -12,13 +12,8 @@ import { computeCanonicalContentHash } from "../../providers/article-store/compu
 import type { SummarizeArticle } from "../generate-summary/link-summariser";
 import type { FindArticleContent } from "../../providers/article-store/find-article-content";
 import type { TierSource } from "./tier-source.types";
-import type {
-	Handler,
-	SQSBatchResponse,
-	SQSEvent,
-	SQSRecordAttributes,
-	Context,
-} from "aws-lambda";
+import type { Handler, SQSBatchResponse, SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 /**
  * In-process replay of the production incident: a row whose summary is
@@ -41,21 +36,6 @@ const stubAttributes: SQSRecordAttributes = {
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function sqsEvent(detail: Record<string, unknown>): SQSEvent {
@@ -127,9 +107,9 @@ describe("summary recovery on canonical content change", () => {
 		 * User-facing / pipeline-settling effects are intentionally not routed. */
 		const dispatchEffect: DispatchEffect = async (effect) => {
 			if (effect.kind === "publish-canonical-content-changed") {
-				await canonicalContentChangedHandler(sqsEvent({ url: effect.url }), stubContext, () => {});
+				await canonicalContentChangedHandler(sqsEvent({ url: effect.url }), buildLambdaContext(), () => {});
 			} else if (effect.kind === "generate-summary") {
-				await generateSummaryHandler(sqsEvent({ url: effect.url }), stubContext, () => {});
+				await generateSummaryHandler(sqsEvent({ url: effect.url }), buildLambdaContext(), () => {});
 			}
 		};
 
@@ -167,7 +147,7 @@ describe("summary recovery on canonical content change", () => {
 		const seeded = await store.load(URL);
 		expect(seeded?.summary.kind).toBe("skipped");
 
-		await selectHandler(sqsEvent({ url: URL, tier: "tier-1" }), stubContext, () => {});
+		await selectHandler(sqsEvent({ url: URL, tier: "tier-1" }), buildLambdaContext(), () => {});
 
 		const recovered = await store.load(URL);
 		expect(recovered?.summary.kind).toBe("ready");

--- a/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-dlq-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-dlq-handler.test.ts
@@ -2,7 +2,8 @@ import { noopLogger } from "@packages/hutch-logger";
 import type { TransitionAndPersist } from "@packages/domain/article-aggregate";
 import { markCrawlExhausted } from "@packages/domain/article-aggregate";
 import { initSimpleCrawlUnsupportedPolicyDlqHandler } from "./simple-crawl-unsupported-policy-dlq-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 function attributes(receiveCount: number): SQSRecordAttributes {
 	return {
@@ -12,21 +13,6 @@ function attributes(receiveCount: number): SQSRecordAttributes {
 		ApproximateFirstReceiveTimestamp: "1620000000001",
 	};
 }
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
-};
 
 function createSqsEvent(
 	detail: { url: string; userId?: string; recrawl?: boolean },
@@ -60,7 +46,7 @@ describe("initSimpleCrawlUnsupportedPolicyDlqHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/scan.pdf", userId: "user-1" }, 4),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -96,7 +82,7 @@ describe("initSimpleCrawlUnsupportedPolicyDlqHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/simple-crawl-unsupported-policy/simple-crawl-unsupported-policy-handler.test.ts
@@ -1,28 +1,14 @@
 import { noopLogger } from "@packages/hutch-logger";
 import { ComprehensiveCrawlCommand } from "@packages/hutch-infra-components";
 import { initSimpleCrawlUnsupportedPolicyHandler } from "./simple-crawl-unsupported-policy-handler";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 
 const stubAttributes: SQSRecordAttributes = {
 	ApproximateReceiveCount: "1",
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: {
@@ -58,7 +44,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/doc.pdf", userId: "user-1" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -82,7 +68,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/doc.pdf", recrawl: true }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -105,7 +91,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/doc.pdf", refresh: true }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -132,7 +118,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 				refresh: true,
 				previousBodyHash: "h".repeat(64),
 			}),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -155,7 +141,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 
 		await handler(
 			createSqsEvent({ url: "https://example.com/blob" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -178,7 +164,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 
 		const result = await handler(
 			createSqsEvent({ url: "https://example.com/doc.pdf" }),
-			stubContext,
+			buildLambdaContext(),
 			() => {},
 		);
 
@@ -207,7 +193,7 @@ describe("initSimpleCrawlUnsupportedPolicyHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 		expect(publishEvent).not.toHaveBeenCalled();
 	});

--- a/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.test.ts
@@ -11,7 +11,8 @@ import type {
 	PublishSaveAnonymousLink,
 	PublishUpdateFetchTimestamp,
 } from "@packages/test-fixtures/providers/events";
-import type { SQSEvent, SQSRecordAttributes, Context } from "aws-lambda";
+import type { SQSEvent, SQSRecordAttributes } from "aws-lambda";
+import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import type {
 	CrawlAndFinalizeArticle,
 	CrawlAndFinalizeResult,
@@ -33,21 +34,6 @@ const stubAttributes: SQSRecordAttributes = {
 	SentTimestamp: "1620000000000",
 	SenderId: "TESTID",
 	ApproximateFirstReceiveTimestamp: "1620000000001",
-};
-
-const stubContext: Context = {
-	callbackWaitsForEmptyEventLoop: true,
-	functionName: "test",
-	functionVersion: "1",
-	invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
-	memoryLimitInMB: "128",
-	awsRequestId: "test-request-id",
-	logGroupName: "/aws/lambda/test",
-	logStreamName: "test-stream",
-	getRemainingTimeInMillis: () => 30000,
-	done: () => {},
-	fail: () => {},
-	succeed: () => {},
 };
 
 function createSqsEvent(detail: { url: string }): SQSEvent {
@@ -99,7 +85,7 @@ describe("initStaleCheckHandler", () => {
 
 		const handler = createHandler({ findArticleFreshness, publishSaveAnonymousLink });
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
 		expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: URL_UNDER_TEST });
@@ -125,7 +111,7 @@ describe("initStaleCheckHandler", () => {
 			publishSaveAnonymousLink,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(crawlAndFinalizeArticle).not.toHaveBeenCalled();
 		expect(publishSaveAnonymousLink).not.toHaveBeenCalled();
@@ -144,7 +130,7 @@ describe("initStaleCheckHandler", () => {
 			crawlAndFinalizeArticle,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(crawlAndFinalizeArticle).not.toHaveBeenCalled();
 	});
@@ -167,7 +153,7 @@ describe("initStaleCheckHandler", () => {
 			publishUpdateFetchTimestamp,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(publishUpdateFetchTimestamp).toHaveBeenCalledTimes(1);
 		expect(publishUpdateFetchTimestamp).toHaveBeenCalledWith({
@@ -194,7 +180,7 @@ describe("initStaleCheckHandler", () => {
 			crawlAndFinalizeArticle,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(crawlAndFinalizeArticle).toHaveBeenCalledWith({
 			url: URL_UNDER_TEST,
@@ -225,7 +211,7 @@ describe("initStaleCheckHandler", () => {
 			emitSimpleCrawlUnsupported,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(emitSimpleCrawlUnsupported).toHaveBeenCalledWith({
 			url: URL_UNDER_TEST,
@@ -250,7 +236,7 @@ describe("initStaleCheckHandler", () => {
 			crawlAndFinalizeArticle,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(crawlAndFinalizeArticle).toHaveBeenCalledWith({
 			url: URL_UNDER_TEST,
@@ -285,7 +271,7 @@ describe("initStaleCheckHandler", () => {
 			publishRefreshArticleContent,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(markCrawlStage).toHaveBeenCalledWith({
 			url: URL_UNDER_TEST,
@@ -323,7 +309,7 @@ describe("initStaleCheckHandler", () => {
 			emitSimpleCrawlUnsupported,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(publishRefreshArticleContent).not.toHaveBeenCalled();
 		expect(publishUpdateFetchTimestamp).not.toHaveBeenCalled();
@@ -364,7 +350,7 @@ describe("initStaleCheckHandler", () => {
 			publishRefreshArticleContent,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(publishRefreshArticleContent).toHaveBeenCalledWith({
 			url: URL_UNDER_TEST,
@@ -419,7 +405,7 @@ describe("initStaleCheckHandler", () => {
 			],
 		};
 
-		const result = await handler(batch, stubContext, () => {});
+		const result = await handler(batch, buildLambdaContext(), () => {});
 
 		expect(publishSaveAnonymousLink).toHaveBeenNthCalledWith(1, { url: "https://a.example.com/" });
 		expect(publishSaveAnonymousLink).toHaveBeenNthCalledWith(2, { url: "https://b.example.com/" });
@@ -467,7 +453,7 @@ describe("initStaleCheckHandler", () => {
 			],
 		};
 
-		const result = await handler(batch, stubContext, () => {});
+		const result = await handler(batch, buildLambdaContext(), () => {});
 
 		expect(publishSaveAnonymousLink).toHaveBeenCalledTimes(1);
 		expect(publishSaveAnonymousLink).toHaveBeenCalledWith({ url: "https://a.example.com/" });
@@ -491,7 +477,7 @@ describe("initStaleCheckHandler", () => {
 			}],
 		};
 
-		const result = await handler(invalidEvent, stubContext, () => {});
+		const result = await handler(invalidEvent, buildLambdaContext(), () => {});
 
 		expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "msg-1" }] });
 	});
@@ -519,7 +505,7 @@ describe("initStaleCheckHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).toHaveBeenCalledTimes(1);
 		expect(transitionAndPersist).toHaveBeenCalledWith(
@@ -554,7 +540,7 @@ describe("initStaleCheckHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});
@@ -570,7 +556,7 @@ describe("initStaleCheckHandler", () => {
 			transitionAndPersist,
 		});
 
-		await handler(createSqsEvent({ url: URL_UNDER_TEST }), stubContext, () => {});
+		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
 		expect(transitionAndPersist).not.toHaveBeenCalled();
 	});

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -108,6 +108,10 @@
     "./sqs": {
       "types": "./dist/sqs/index.d.ts",
       "default": "./dist/sqs/index.js"
+    },
+    "./lambda-context": {
+      "types": "./dist/lambda-context/index.d.ts",
+      "default": "./dist/lambda-context/index.js"
     }
   },
   "typesVersions": {
@@ -136,7 +140,8 @@
       "providers/oauth": ["./dist/providers/oauth/index.d.ts"],
       "providers/events": ["./dist/providers/events/index.d.ts"],
       "providers/google-auth": ["./dist/providers/google-auth/index.d.ts"],
-      "sqs": ["./dist/sqs/index.d.ts"]
+      "sqs": ["./dist/sqs/index.d.ts"],
+      "lambda-context": ["./dist/lambda-context/index.d.ts"]
     }
   },
   "private": true,
@@ -161,6 +166,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@types/aws-lambda": "8.10.161",
     "@types/jest": "30.0.0",
     "c8": "11.0.0",
     "concurrently": "10.0.0",

--- a/src/packages/test-fixtures/src/lambda-context/build-lambda-context.test.ts
+++ b/src/packages/test-fixtures/src/lambda-context/build-lambda-context.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { buildLambdaContext } from "./build-lambda-context";
+
+describe("buildLambdaContext", () => {
+	it("builds a Lambda Context stub with stable identifiers", () => {
+		const context = buildLambdaContext();
+
+		assert.equal(context.functionName, "test");
+		assert.equal(context.awsRequestId, "test-request-id");
+		assert.equal(context.getRemainingTimeInMillis(), 30000);
+	});
+
+	it("exposes no-op lifecycle callbacks", () => {
+		const context = buildLambdaContext();
+
+		assert.equal(context.done(), undefined);
+		assert.equal(context.fail("boom"), undefined);
+		assert.equal(context.succeed(undefined), undefined);
+	});
+});

--- a/src/packages/test-fixtures/src/lambda-context/build-lambda-context.ts
+++ b/src/packages/test-fixtures/src/lambda-context/build-lambda-context.ts
@@ -1,0 +1,18 @@
+import type { Context } from "aws-lambda";
+
+export function buildLambdaContext(): Context {
+	return {
+		callbackWaitsForEmptyEventLoop: true,
+		functionName: "test",
+		functionVersion: "1",
+		invokedFunctionArn: "arn:aws:lambda:ap-southeast-2:123456789:function:test",
+		memoryLimitInMB: "128",
+		awsRequestId: "test-request-id",
+		logGroupName: "/aws/lambda/test",
+		logStreamName: "test-stream",
+		getRemainingTimeInMillis: () => 30000,
+		done: () => {},
+		fail: () => {},
+		succeed: () => {},
+	};
+}

--- a/src/packages/test-fixtures/src/lambda-context/index.ts
+++ b/src/packages/test-fixtures/src/lambda-context/index.ts
@@ -1,0 +1,1 @@
+export { buildLambdaContext } from "./build-lambda-context";


### PR DESCRIPTION
## What

The Lambda `Context` stub literal was copy-pasted across ~38 Lambda handler test files (e.g. `subscription-charge-succeeded-handler.test.ts`, `reader-ready-fanout-handler.test.ts`, and the entire `save-link` handler suite), plus a handful of divergent local fakes for the same thing:

- `{} as never` context arguments (`subscription-start-request`, `schedule-trial-feedback-email`)
- a `satisfies Context` const (`send-trial-feedback-email`)
- a per-file `buildLambdaContext()` function (`cancel-subscription`)

## Change

- Add a new `./lambda-context` export to `@packages/test-fixtures` exposing `buildLambdaContext()`, mirroring the existing `./sqs` fixture (export map, `typesVersions`, colocated test, `@types/aws-lambda` devDependency).
- Replace every per-file copy and context fake (42 files total) with the shared fixture, removing the now-unused `Context` type imports.

Net **~520 fewer lines**.

## Verification

- `@packages/test-fixtures:check` — full pass (lint, types, coverage, knip)
- `save-link:check` — full pass (100% coverage)
- `hutch:check` — full pass (with `.envrc` sourced, as the pre-commit hook does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wTcNGPsCbHhztCdEX8XSU

---
_Generated by [Claude Code](https://claude.ai/code/session_013wTcNGPsCbHhztCdEX8XSU)_