### PR TITLE
feat(ios): add Sign up via external Chrome reusing the browser session

### DIFF
--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -147,6 +147,23 @@ describe("OAuth routes", () => {
 			expect(response.status).toBe(400);
 			expect(response.body.error).toBe("invalid_request");
 		});
+
+		it("names the offending parameter for an unsupported screen_hint value", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get("/oauth/authorize").query({
+				client_id: TEST_CLIENT_ID,
+				redirect_uri: TEST_REDIRECT_URI,
+				response_type: "code",
+				code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+				code_challenge_method: "S256",
+				screen_hint: "register",
+			});
+
+			expect(response.status).toBe(400);
+			expect(response.body.error).toBe("invalid_request");
+			expect(response.body.error_description).toContain("screen_hint");
+		});
 	});
 
 	describe("POST /oauth/authorize", () => {

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.test.ts
@@ -41,6 +41,46 @@ describe("OAuth routes", () => {
 			expect(response.headers.location).toContain("/login");
 		});
 
+		it("redirects to signup with the authorize URL as return when screen_hint=signup and unauthenticated", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get("/oauth/authorize").query({
+				client_id: TEST_CLIENT_ID,
+				redirect_uri: TEST_REDIRECT_URI,
+				response_type: "code",
+				code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+				code_challenge_method: "S256",
+				screen_hint: "signup",
+			});
+
+			expect(response.status).toBe(303);
+			const location = response.headers.location;
+			expect(location.startsWith("/signup?return=")).toBe(true);
+			const returnUrl = new URLSearchParams(location.split("?")[1]).get("return");
+			assert(returnUrl, "signup redirect must carry a return param");
+			expect(returnUrl.startsWith("/oauth/authorize")).toBe(true);
+			expect(returnUrl).toContain("screen_hint=signup");
+		});
+
+		it("redirects to login (not signup) with the authorize URL as return when screen_hint is absent and unauthenticated", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).get("/oauth/authorize").query({
+				client_id: TEST_CLIENT_ID,
+				redirect_uri: TEST_REDIRECT_URI,
+				response_type: "code",
+				code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+				code_challenge_method: "S256",
+			});
+
+			expect(response.status).toBe(303);
+			const location = response.headers.location;
+			expect(location.startsWith("/login?return=")).toBe(true);
+			const returnUrl = new URLSearchParams(location.split("?")[1]).get("return");
+			assert(returnUrl, "login redirect must carry a return param");
+			expect(returnUrl.startsWith("/oauth/authorize")).toBe(true);
+		});
+
 		it("shows authorization form when authenticated", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			await harness.auth.createUser({

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -37,6 +37,18 @@ const revokeBodySchema = z.object({
 	token: z.string().min(1),
 });
 
+/**
+ * Turns a Zod parse failure into an `error_description` that names the offending
+ * parameter(s), so an unsupported value (e.g. `screen_hint=register`) is easy to
+ * identify in the 400 response instead of a generic "invalid parameters".
+ */
+function describeInvalidParams(error: z.ZodError): string {
+	const detail = error.issues
+		.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+		.join("; ");
+	return `Invalid request parameters — ${detail}`;
+}
+
 const SUPPORTED_GRANTS = new Set(["authorization_code", "refresh_token"]);
 
 const registerBodySchema = z.object({
@@ -167,7 +179,7 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 		if (!parsed.success) {
 			res.status(400).json({
 				error: "invalid_request",
-				error_description: "Missing or invalid parameters",
+				error_description: describeInvalidParams(parsed.error),
 			});
 			return;
 		}

--- a/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
+++ b/projects/hutch/src/runtime/web/oauth/oauth.routes.ts
@@ -24,6 +24,7 @@ const authorizeQuerySchema = z.object({
 	code_challenge: z.string().min(43).max(128),
 	code_challenge_method: z.literal("S256"),
 	state: z.string().optional(),
+	screen_hint: z.enum(["login", "signup"]).optional(),
 });
 
 const denyBodySchema = z.object({
@@ -192,7 +193,8 @@ export function initOAuthRoutes(deps: OAuthRouteDeps): Router {
 
 		if (!req.userId) {
 			const returnUrl = encodeURIComponent(req.originalUrl);
-			res.redirect(303, `/login?return=${returnUrl}`);
+			const authPath = parsed.data.screen_hint === "signup" ? "/signup" : "/login";
+			res.redirect(303, `${authPath}?return=${returnUrl}`);
 			return;
 		}
 

--- a/projects/ios-readplace-poc/App/AppSession.swift
+++ b/projects/ios-readplace-poc/App/AppSession.swift
@@ -19,10 +19,33 @@ final class AppSession: ObservableObject {
 		isLoggedIn = store.isLoggedIn
 	}
 
+	/// Completes the in-app WKWebView login: forwards to the redirect-aware
+	/// overload with the https callback, so the token exchange's `redirect_uri`
+	/// matches the one the WKWebView flow authorized with.
+	func completeSignIn(
+		callbackURL: URL,
+		verifier: String,
+		expectedState: String,
+		onExchangeStarted: () -> Void
+	) async -> Result<Void, Error> {
+		await completeSignIn(
+			callbackURL: callbackURL,
+			verifier: verifier,
+			expectedState: expectedState,
+			redirectURI: makeOAuth().redirectURI,
+			onExchangeStarted: onExchangeStarted
+		)
+	}
+
 	/// Completes sign-in after the authorization web flow redirects to the
 	/// callback URL: validate the callback, exchange the code for tokens, flip
 	/// the session to logged-in. The deterministic half of the OAuth flow — the
-	/// preceding WKWebView redirect is the OS boundary, exercised by hand.
+	/// preceding web redirect (WKWebView for login, external browser for signup)
+	/// is the OS boundary, exercised by hand.
+	///
+	/// `redirectURI` must equal the one the authorize request used, because the
+	/// OAuth server checks it by exact string at token time: the https callback
+	/// for WKWebView login, the native custom scheme for external-browser signup.
 	///
 	/// `onExchangeStarted` fires once, only after the callback validates and the
 	/// network code exchange begins — never for a rejected callback — so the
@@ -31,6 +54,7 @@ final class AppSession: ObservableObject {
 		callbackURL: URL,
 		verifier: String,
 		expectedState: String,
+		redirectURI: String,
 		onExchangeStarted: () -> Void
 	) async -> Result<Void, Error> {
 		let items = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
@@ -42,7 +66,7 @@ final class AppSession: ObservableObject {
 
 		do {
 			onExchangeStarted()
-			try await makeOAuth().exchangeCode(code, verifier: verifier)
+			try await makeOAuth().exchangeCode(code, verifier: verifier, redirectURI: redirectURI)
 			refreshLoginState()
 			return .success(())
 		} catch {

--- a/projects/ios-readplace-poc/App/Info.plist
+++ b/projects/ios-readplace-poc/App/Info.plist
@@ -41,5 +41,21 @@
 		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.readplace.oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>readplace</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechrome</string>
+		<string>googlechromes</string>
+	</array>
 </dict>
 </plist>

--- a/projects/ios-readplace-poc/App/LoginView.swift
+++ b/projects/ios-readplace-poc/App/LoginView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct LoginView: View {
 	@EnvironmentObject private var session: AppSession
+	/// Owned by `RootView`, which handles the `readplace://oauth-callback` deep
+	/// link, so a failed external-browser Sign up can surface here while this
+	/// view is still on screen.
+	@Binding var signupErrorText: String?
 	@State private var showingAuth = false
 	@State private var errorText: String?
 
@@ -21,19 +25,38 @@ struct LoginView: View {
 						.foregroundStyle(.secondary)
 				}
 
-				Button {
-					errorText = nil
-					showingAuth = true
-				} label: {
-					Text("Login")
-						.font(.headline)
-						.frame(maxWidth: .infinity)
-						.padding(.vertical, 14)
+				VStack(spacing: 14) {
+					Button {
+						errorText = nil
+						signupErrorText = nil
+						showingAuth = true
+					} label: {
+						Text("Login")
+							.font(.headline)
+							.frame(maxWidth: .infinity)
+							.padding(.vertical, 14)
+					}
+					.buttonStyle(.borderedProminent)
+
+					Button {
+						startSignup()
+					} label: {
+						Text("Don't have an account? Sign up")
+							.font(.footnote)
+					}
+					.buttonStyle(.plain)
+					.foregroundStyle(.tint)
 				}
-				.buttonStyle(.borderedProminent)
 
 				if let errorText {
 					Text(errorText)
+						.font(.footnote)
+						.foregroundStyle(.red)
+						.multilineTextAlignment(.center)
+				}
+
+				if let signupErrorText {
+					Text(signupErrorText)
 						.font(.footnote)
 						.foregroundStyle(.red)
 						.multilineTextAlignment(.center)
@@ -55,5 +78,16 @@ struct LoginView: View {
 				.environmentObject(session)
 			}
 		}
+	}
+
+	/// Opens `/oauth/authorize` in the external browser (Chrome if installed, to
+	/// reuse its session). A fresh `start()` overwrites any prior pending record,
+	/// so an abandoned earlier attempt can't strand stale secrets. The result
+	/// arrives later via the `readplace://oauth-callback` deep link (`RootView`).
+	@MainActor
+	private func startSignup() {
+		errorText = nil
+		signupErrorText = nil
+		makeSignupFlow(session: session).start()
 	}
 }

--- a/projects/ios-readplace-poc/App/ReadplacePOCApp.swift
+++ b/projects/ios-readplace-poc/App/ReadplacePOCApp.swift
@@ -14,12 +14,27 @@ struct ReadplacePOCApp: App {
 
 struct RootView: View {
 	@EnvironmentObject private var session: AppSession
+	@State private var signupErrorText: String?
 
 	var body: some View {
-		if session.isLoggedIn {
-			ReadingListView(session: session)
-		} else {
-			LoginView()
+		Group {
+			if session.isLoggedIn {
+				ReadingListView(session: session)
+			} else {
+				LoginView(signupErrorText: $signupErrorText)
+			}
+		}
+		.onOpenURL { url in
+			guard url.scheme == AppConfig.callbackURLScheme, url.host == "oauth-callback" else { return }
+			Task { @MainActor in
+				// `nil` means no pending Sign up — an unexpected deep link, ignored.
+				// A malformed or hijacked callback (wrong/absent state or code) is
+				// rejected inside completeSignIn against the pending record's state.
+				guard let result = await makeSignupFlow(session: session).complete(url) else { return }
+				if case .failure(let error) = result {
+					signupErrorText = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+				}
+			}
 		}
 	}
 }

--- a/projects/ios-readplace-poc/App/ReadplacePOCApp.swift
+++ b/projects/ios-readplace-poc/App/ReadplacePOCApp.swift
@@ -25,7 +25,7 @@ struct RootView: View {
 			}
 		}
 		.onOpenURL { url in
-			guard url.scheme == AppConfig.callbackURLScheme, url.host == "oauth-callback" else { return }
+			guard url.scheme == AppConfig.callbackURLScheme, url.host == AppConfig.nativeCallbackHost else { return }
 			Task { @MainActor in
 				// `nil` means no pending Sign up — an unexpected deep link, ignored.
 				// A malformed or hijacked callback (wrong/absent state or code) is

--- a/projects/ios-readplace-poc/App/SignupOpeners.swift
+++ b/projects/ios-readplace-poc/App/SignupOpeners.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+/// The browser seam the UI-free `WebSignup` core opens through, kept in the App
+/// target so the tested core stays free of UIKit. `.system` is backed by the
+/// live `UIApplication`; tests inject their own closures.
+///
+/// `canOpen` needs the queried schemes (`googlechrome`/`googlechromes`) declared
+/// in `Info.plist`'s `LSApplicationQueriesSchemes`, or it silently returns false
+/// and the flow always falls back to the default browser.
+struct ExternalBrowser {
+	let canOpen: (URL) -> Bool
+	let open: (URL) -> Void
+
+	static let system = ExternalBrowser(
+		canOpen: { UIApplication.shared.canOpenURL($0) },
+		open: { UIApplication.shared.open($0) }
+	)
+}
+
+/// Composition root for the external-browser Sign up flow: resolves the shared
+/// App Group store and wires the live browser + session into a `SignupFlow`.
+/// Both the Sign up button (`start`) and the deep-link callback (`complete`)
+/// build the flow this way; they share state only through the persisted store,
+/// so a cold relaunch on the callback still finds the pending record.
+@MainActor
+func makeSignupFlow(session: AppSession) -> SignupFlow {
+	let group = TokenStore.resolvedAppGroupId
+	guard let defaults = UserDefaults(suiteName: group) else {
+		preconditionFailure("App Group \(group) is required for the Sign up flow")
+	}
+	let store = SignupPendingStore(defaults: defaults)
+	let oauth = session.makeOAuth()
+	let browser = ExternalBrowser.system
+	return initWebSignup(deps: WebSignupDependencies(
+		makeAuthorizationRequest: oauth.makeSignupAuthorizationRequest,
+		pendingStore: store,
+		canOpenURL: browser.canOpen,
+		openURL: browser.open,
+		exchange: { callbackURL, pending in
+			await session.completeSignIn(
+				callbackURL: callbackURL,
+				verifier: pending.verifier,
+				expectedState: pending.state,
+				redirectURI: pending.redirectURI,
+				onExchangeStarted: {}
+			)
+		}
+	))
+}

--- a/projects/ios-readplace-poc/README.md
+++ b/projects/ios-readplace-poc/README.md
@@ -63,6 +63,15 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
   `https://readplace.com/oauth/callback` redirect. The authorize page is shown
   in an in-app `WKWebView`; the redirect is intercepted to grab the code — the
   native analogue of the extension opening a tab and waiting for the redirect.
+- **Sign up** by opening `/oauth/authorize` in the **external browser** — Chrome
+  if installed (`googlechromes://`), else the default — so an existing Chrome
+  session is reused. The redirect is a native `readplace://oauth-callback` deep
+  link and the request carries `screen_hint=signup`: an already-logged-in Chrome
+  passes straight to consent, while a new/logged-out user lands on the web
+  `/signup` page and returns authenticated. This mirrors the browser extension's
+  tab-based flow (which the WKWebView login can't, since it can't see Chrome's
+  cookies); the in-flight PKCE secrets are persisted to the App Group so a cold
+  relaunch via the deep link can still finish the token exchange.
 - **List** your reading list by walking the Siren API: `GET /` → `303` → `/queue`
   collection, rendering each article (title, site, excerpt, thumbnail, read
   state), with pull-to-refresh, infinite scroll via the `next` link, and
@@ -220,11 +229,18 @@ cases:
   degrading to URL-only when the capture is empty or the HTML is over the cap,
   short-circuiting before any network call when logged out or when there's no
   link, and reporting no-op when the server advertises no save action.
+- **Sign up flow**: the native authorize request (`readplace://oauth-callback`
+  redirect + `screen_hint=signup`, same PKCE shape as login), the deep-link
+  callback exchanging the code with the native `redirect_uri` and flipping the
+  session logged-in, the Chrome-scheme selection (rewrite to `googlechromes://`
+  when Chrome is available, byte-equal HTTPS fallback otherwise), the
+  `SignupPendingStore` save/load/clear round-trip, and the flow persisting the
+  PKCE secrets before opening the browser (so a kill mid-hop can't lose them).
 
 `make test` then runs a **staging smoke pass** (`make test-staging`): it
 recompiles the app, extension and tests with the `STAGING` condition and runs
 `AppConfigTests` under it. The full suite can't run under `STAGING` — the OAuth
-tests pin the production redirect URI — but compiling everything proves the
+and Sign-up tests pin the production redirect URI/host — but compiling everything proves the
 staging build stays green, and the smoke test asserts the `#if STAGING` server
 selection resolves to the staging stack. CI runs `make test`, so this path is
 exercised on every run, not only when someone builds `make ipa-staging` by hand.
@@ -251,12 +267,16 @@ exercised on every run, not only when someone builds `make ipa-staging` by hand.
 - **Tapping an item** opens the original article URL in an in-app Safari view.
   The server's reader (`/queue/{id}/view`) needs a cookie session this
   token-based POC doesn't hold, so it isn't used.
-- **Production needs no server change**: the app authenticates as the existing
-  `hutch-chrome-extension` client and uses its registered HTTPS callback. Custom
-  URL schemes are rejected by the server's redirect allowlist, which is why the
-  flow intercepts the HTTPS callback inside the web view. (Staging sign-in needs
-  the staging callback registered for that client — see the `make ipa-staging`
-  note above.)
+- **Login needs no server change; Sign up adds a small additive one.** Both
+  authenticate as the existing `hutch-chrome-extension` client. The WKWebView
+  **login** intercepts that client's registered HTTPS callback. The
+  external-browser **Sign up** can't observe an HTTPS redirect in another app's
+  tab, so it returns via a native `readplace://oauth-callback` deep link — that
+  scheme is now registered on the same client, and `/oauth/authorize` accepts an
+  optional `screen_hint=signup` (both changes are additive in
+  `built-in-clients.ts` / `oauth.routes.ts`; they don't affect the extension or
+  the login flow). (Staging sign-in needs the staging callback registered for
+  that client — see the `make ipa-staging` note above.)
 - **The server URL is fixed at build time** in `AppConfig.serverBaseURL` — there
   is no Server field on the sign-in screen. `make ipa` targets production;
   `make ipa-staging` compiles with the `STAGING` condition to target staging. The

--- a/projects/ios-readplace-poc/Shared/AppConfig.swift
+++ b/projects/ios-readplace-poc/Shared/AppConfig.swift
@@ -62,12 +62,18 @@ enum AppConfig {
 	/// redirect in another app's tab.
 	static let callbackURLScheme = "readplace"
 
-	/// Native redirect URI for the external-browser Sign up flow. Registered on
-	/// the `hutch-chrome-extension` client in the server's
-	/// `src/packages/domain/src/oauth/built-in-clients.ts`; it must match there
-	/// exactly because the OAuth server checks `redirect_uri` by exact string at
-	/// both authorize and token time.
-	static let nativeCallbackURL = "\(callbackURLScheme)://oauth-callback"
+	/// Host component of `nativeCallbackURL`. `RootView.onOpenURL` matches the
+	/// incoming deep link's host against this constant, so the registered URI and
+	/// the deep-link parse site share one source instead of two equal literals.
+	static let nativeCallbackHost = "oauth-callback"
+
+	/// Native redirect URI for the external-browser Sign up flow, composed from
+	/// the scheme + host above so what we register can't disagree with what the
+	/// deep-link handler accepts. Must equal `IOS_NATIVE_OAUTH_CALLBACK_URI` in
+	/// the server's `src/packages/domain/src/oauth/built-in-clients.ts` — the
+	/// OAuth server matches `redirect_uri` by exact string at authorize and token
+	/// time — and `SignupFlowTests` pins the value so a change fails a test.
+	static let nativeCallbackURL = "\(callbackURLScheme)://\(nativeCallbackHost)"
 
 	/// A Safari-like user agent. Embedded WKWebViews are sometimes refused by
 	/// Google's sign-in ("disallowed_useragent"); presenting a stock Safari UA

--- a/projects/ios-readplace-poc/Shared/AppConfig.swift
+++ b/projects/ios-readplace-poc/Shared/AppConfig.swift
@@ -56,6 +56,19 @@ enum AppConfig {
 	/// Path appended to the base URL to form the registered redirect URI.
 	static let callbackPath = "/oauth/callback"
 
+	/// Custom URL scheme the OS routes back to this app. Declared in
+	/// `Info.plist`'s `CFBundleURLTypes`; used by the external-browser "Sign up"
+	/// flow, which (unlike the in-app WKWebView login) can't observe an https
+	/// redirect in another app's tab.
+	static let callbackURLScheme = "readplace"
+
+	/// Native redirect URI for the external-browser Sign up flow. Registered on
+	/// the `hutch-chrome-extension` client in the server's
+	/// `src/packages/domain/src/oauth/built-in-clients.ts`; it must match there
+	/// exactly because the OAuth server checks `redirect_uri` by exact string at
+	/// both authorize and token time.
+	static let nativeCallbackURL = "\(callbackURLScheme)://oauth-callback"
+
 	/// A Safari-like user agent. Embedded WKWebViews are sometimes refused by
 	/// Google's sign-in ("disallowed_useragent"); presenting a stock Safari UA
 	/// avoids that. Email/password sign-in works regardless.

--- a/projects/ios-readplace-poc/Shared/OAuthService.swift
+++ b/projects/ios-readplace-poc/Shared/OAuthService.swift
@@ -41,14 +41,31 @@ struct OAuthService {
 	private var revokeEndpoint: URL { URL(string: "\(baseURL)/oauth/revoke")! }
 	var redirectURI: String { "\(baseURL)\(AppConfig.callbackPath)" }
 
-	/// Builds the `/oauth/authorize` URL with a fresh PKCE verifier + state.
+	/// The custom-scheme redirect used by the external-browser Sign up flow. The
+	/// in-app WKWebView login keeps using the https `redirectURI`.
+	var nativeRedirectURI: String { AppConfig.nativeCallbackURL }
+
+	/// Builds the in-app WKWebView `/oauth/authorize` URL (https callback) with a
+	/// fresh PKCE verifier + state.
 	func makeAuthorizationRequest() -> AuthorizationRequest {
+		makeAuthorizationRequest(redirectURI: redirectURI, screenHint: nil)
+	}
+
+	/// Builds the external-browser Sign up `/oauth/authorize` URL: the native
+	/// custom-scheme callback plus `screen_hint=signup`, which routes an
+	/// unauthenticated user to `/signup` (an already-authenticated Chrome session
+	/// passes straight through to consent, ignoring the hint).
+	func makeSignupAuthorizationRequest() -> AuthorizationRequest {
+		makeAuthorizationRequest(redirectURI: nativeRedirectURI, screenHint: "signup")
+	}
+
+	private func makeAuthorizationRequest(redirectURI: String, screenHint: String?) -> AuthorizationRequest {
 		let verifier = PKCE.makeCodeVerifier()
 		let challenge = PKCE.challenge(for: verifier)
 		let state = PKCE.makeState()
 
 		var components = URLComponents(string: "\(baseURL)/oauth/authorize")!
-		components.queryItems = [
+		var items = [
 			URLQueryItem(name: "client_id", value: AppConfig.clientId),
 			URLQueryItem(name: "redirect_uri", value: redirectURI),
 			URLQueryItem(name: "response_type", value: "code"),
@@ -56,6 +73,8 @@ struct OAuthService {
 			URLQueryItem(name: "code_challenge_method", value: "S256"),
 			URLQueryItem(name: "state", value: state),
 		]
+		if let screenHint { items.append(URLQueryItem(name: "screen_hint", value: screenHint)) }
+		components.queryItems = items
 		return AuthorizationRequest(
 			url: components.url!,
 			redirectURI: redirectURI,
@@ -64,9 +83,19 @@ struct OAuthService {
 		)
 	}
 
-	/// Exchanges the authorization code for tokens and persists them.
+	/// Exchanges the authorization code for tokens and persists them, against the
+	/// in-app WKWebView login's https callback.
 	@discardableResult
 	func exchangeCode(_ code: String, verifier: String) async throws -> OAuthTokens {
+		try await exchangeCode(code, verifier: verifier, redirectURI: redirectURI)
+	}
+
+	/// Token exchange with an explicit `redirect_uri`, so the external-browser
+	/// Sign up flow can send the native custom scheme. The OAuth server checks
+	/// `redirect_uri` by exact string against the authorize request, so this must
+	/// equal the `redirect_uri` that minted the code.
+	@discardableResult
+	func exchangeCode(_ code: String, verifier: String, redirectURI: String) async throws -> OAuthTokens {
 		let body = formBody([
 			"grant_type": "authorization_code",
 			"code": code,

--- a/projects/ios-readplace-poc/Shared/SignupPendingStore.swift
+++ b/projects/ios-readplace-poc/Shared/SignupPendingStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The in-flight PKCE secrets for an external-browser Sign up, captured before
+/// the browser opens so the `readplace://oauth-callback` deep link can finish
+/// the token exchange even after a cold relaunch (the app may be terminated
+/// while Chrome runs the web flow).
+struct PendingSignup: Equatable {
+	let verifier: String
+	let state: String
+	let redirectURI: String
+}
+
+/// Persists a single `PendingSignup` in the shared App Group so it survives the
+/// app being backgrounded — or killed — during the external-browser hop. The
+/// backing `UserDefaults` is injected (the App Group suite in the running app,
+/// an ephemeral suite in tests) rather than resolved here.
+struct SignupPendingStore {
+	private let defaults: UserDefaults
+
+	private enum Key {
+		static let verifier = "signup.pending.verifier"
+		static let state = "signup.pending.state"
+		static let redirectURI = "signup.pending.redirectURI"
+	}
+
+	init(defaults: UserDefaults) {
+		self.defaults = defaults
+	}
+
+	func save(_ pending: PendingSignup) {
+		defaults.set(pending.verifier, forKey: Key.verifier)
+		defaults.set(pending.state, forKey: Key.state)
+		defaults.set(pending.redirectURI, forKey: Key.redirectURI)
+	}
+
+	func load() -> PendingSignup? {
+		guard
+			let verifier = defaults.string(forKey: Key.verifier),
+			let state = defaults.string(forKey: Key.state),
+			let redirectURI = defaults.string(forKey: Key.redirectURI)
+		else { return nil }
+		return PendingSignup(verifier: verifier, state: state, redirectURI: redirectURI)
+	}
+
+	func clear() {
+		defaults.removeObject(forKey: Key.verifier)
+		defaults.removeObject(forKey: Key.state)
+		defaults.removeObject(forKey: Key.redirectURI)
+	}
+}

--- a/projects/ios-readplace-poc/Shared/WebSignup.swift
+++ b/projects/ios-readplace-poc/Shared/WebSignup.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Rewrites an `https` authorize URL to Chrome's `googlechromes` scheme so the
+/// OS opens it in Chrome (reusing the user's Chrome session) when Chrome is
+/// installed; otherwise returns the URL unchanged so the default browser opens
+/// it. Host, path and query are preserved either way.
+///
+/// `canOpen` is injected (it wraps `UIApplication.canOpenURL` in the app, a stub
+/// in tests). Chrome documents `googlechrome://` for http and `googlechromes://`
+/// for https; the authorize URL is always https, so we use `googlechromes`.
+func chromeURLForHTTPS(_ httpsURL: URL, canOpen: (URL) -> Bool) -> URL {
+	guard canOpen(URL(string: "googlechromes://")!) else { return httpsURL }
+	var components = URLComponents(url: httpsURL, resolvingAgainstBaseURL: false)
+	components?.scheme = "googlechromes"
+	return components?.url ?? httpsURL
+}
+
+/// The seams the UI-free Sign up core needs, injected so tests never launch a
+/// browser or hit the network: how to build the authorize request, where to
+/// persist the in-flight secrets, how to detect/open the browser, and how to
+/// exchange the returned code.
+struct WebSignupDependencies {
+	let makeAuthorizationRequest: () -> AuthorizationRequest
+	let pendingStore: SignupPendingStore
+	let canOpenURL: (URL) -> Bool
+	let openURL: (URL) -> Void
+	let exchange: (_ callbackURL: URL, _ pending: PendingSignup) async -> Result<Void, Error>
+}
+
+/// The UI-free core of the external-browser Sign up flow. `start` is invoked
+/// from the Sign up button; `complete` from the `readplace://oauth-callback`
+/// deep link (possibly in a fresh process after a cold relaunch).
+struct SignupFlow {
+	let start: () -> Void
+	/// Returns `nil` when there is no pending record (an unexpected deep link),
+	/// otherwise the result of exchanging the returned code.
+	let complete: (URL) async -> Result<Void, Error>?
+}
+
+/// Partial application (`init*`) wiring the injected seams into a `SignupFlow`.
+func initWebSignup(deps: WebSignupDependencies) -> SignupFlow {
+	SignupFlow(
+		start: {
+			let request = deps.makeAuthorizationRequest()
+			// Persist BEFORE opening the browser: the app may be killed during the
+			// external-browser hop, so the deep-link callback must be able to read
+			// these back from a cold launch.
+			deps.pendingStore.save(PendingSignup(
+				verifier: request.codeVerifier,
+				state: request.state,
+				redirectURI: request.redirectURI
+			))
+			deps.openURL(chromeURLForHTTPS(request.url, canOpen: deps.canOpenURL))
+		},
+		complete: { callbackURL in
+			guard let pending = deps.pendingStore.load() else { return nil }
+			deps.pendingStore.clear()
+			return await deps.exchange(callbackURL, pending)
+		}
+	)
+}

--- a/projects/ios-readplace-poc/Tests/SignupFlowTests.swift
+++ b/projects/ios-readplace-poc/Tests/SignupFlowTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import Readplace
+
+/// Coverage of the external-browser "Sign up" flow: the native authorize request
+/// it builds, the `readplace://oauth-callback` deep link that finishes it, the
+/// Chrome-scheme selection, and the App-Group persistence that lets it survive a
+/// cold relaunch. The network is faked by `StubURLProtocol`; the browser is a
+/// fake opener so no UI launches.
+@MainActor
+final class SignupFlowTests: XCTestCase {
+	nonisolated override func setUp() {
+		super.setUp()
+		StubURLProtocol.reset()
+	}
+
+	private func makeService(store: TokenStore) -> OAuthService {
+		OAuthService(baseURL: AppConfig.serverBaseURL, store: store, sessionConfiguration: TestSupport.stubbedConfiguration())
+	}
+
+	func testSignupAuthorizationRequestUsesNativeRedirectAndScreenHint() {
+		let request = makeService(store: TestSupport.loggedInStore()).makeSignupAuthorizationRequest()
+
+		let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false)!
+		XCTAssertEqual(components.host, "readplace.com")
+		XCTAssertEqual(components.path, "/oauth/authorize")
+		let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+		XCTAssertEqual(items["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(items["redirect_uri"], "readplace://oauth-callback")
+		XCTAssertEqual(items["response_type"], "code")
+		XCTAssertEqual(items["code_challenge_method"], "S256")
+		XCTAssertEqual(items["screen_hint"], "signup")
+		XCTAssertEqual(items["code_challenge"], PKCE.challenge(for: request.codeVerifier))
+		XCTAssertFalse((items["state"] ?? "").isEmpty)
+		XCTAssertEqual(request.redirectURI, "readplace://oauth-callback")
+	}
+
+	func testCallbackDeepLinkCompletesSignInWithNativeRedirect() async throws {
+		let store = TokenStore(defaults: TestSupport.ephemeralDefaults())
+		let session = AppSession(store: store, sessionConfiguration: TestSupport.stubbedConfiguration())
+		let pendingStore = SignupPendingStore(defaults: TestSupport.ephemeralDefaults())
+		pendingStore.save(PendingSignup(verifier: "v", state: "S", redirectURI: AppConfig.nativeCallbackURL))
+		XCTAssertFalse(session.isLoggedIn)
+
+		StubURLProtocol.setHandler { request, _ in
+			XCTAssertEqual(request.url?.path, "/oauth/token")
+			return .json(200, Fixtures.tokenResponse(access: "fresh-access", refresh: "fresh-refresh"))
+		}
+
+		let flow = initWebSignup(deps: WebSignupDependencies(
+			makeAuthorizationRequest: makeService(store: store).makeSignupAuthorizationRequest,
+			pendingStore: pendingStore,
+			canOpenURL: { _ in false },
+			openURL: { _ in },
+			exchange: { callbackURL, pending in
+				await session.completeSignIn(
+					callbackURL: callbackURL,
+					verifier: pending.verifier,
+					expectedState: pending.state,
+					redirectURI: pending.redirectURI,
+					onExchangeStarted: {}
+				)
+			}
+		))
+
+		let result = await flow.complete(URL(string: "readplace://oauth-callback?code=abc&state=S")!)
+
+		guard case .success? = result else { return XCTFail("Expected .success, got \(String(describing: result))") }
+		XCTAssertTrue(session.isLoggedIn, "RootView keys off isLoggedIn to show the reading list")
+		XCTAssertEqual(store.tokens?.accessToken, "fresh-access")
+		XCTAssertNil(pendingStore.load(), "the pending record must be cleared once the callback is consumed")
+
+		let body = TestSupport.formFields(try XCTUnwrap(StubURLProtocol.records(path: "/oauth/token").first).body)
+		XCTAssertEqual(body["grant_type"], "authorization_code")
+		XCTAssertEqual(body["code"], "abc")
+		XCTAssertEqual(body["code_verifier"], "v")
+		XCTAssertEqual(body["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(body["redirect_uri"], "readplace://oauth-callback")
+	}
+
+	func testChromeURLForHTTPSRewritesSchemeWhenChromeAvailable() {
+		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=hutch-chrome-extension&state=abc")!
+		var probed: URL?
+		let chrome = chromeURLForHTTPS(https, canOpen: { probed = $0; return true })
+
+		XCTAssertEqual(probed?.scheme, "googlechromes", "Chrome availability is probed with the https scheme variant")
+		let components = URLComponents(url: chrome, resolvingAgainstBaseURL: false)!
+		XCTAssertEqual(components.scheme, "googlechromes")
+		XCTAssertEqual(components.host, "readplace.com")
+		XCTAssertEqual(components.path, "/oauth/authorize")
+		XCTAssertEqual(components.percentEncodedQuery, "client_id=hutch-chrome-extension&state=abc")
+	}
+
+	func testChromeURLForHTTPSReturnsHTTPSUnchangedWhenChromeUnavailable() {
+		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=hutch-chrome-extension&state=abc")!
+		let fallback = chromeURLForHTTPS(https, canOpen: { _ in false })
+
+		XCTAssertEqual(fallback, https)
+		XCTAssertEqual(fallback.absoluteString, https.absoluteString)
+	}
+
+	func testSignupPendingStoreRoundTrip() {
+		let store = SignupPendingStore(defaults: TestSupport.ephemeralDefaults())
+		XCTAssertNil(store.load())
+
+		let pending = PendingSignup(verifier: "ver", state: "st", redirectURI: AppConfig.nativeCallbackURL)
+		store.save(pending)
+		XCTAssertEqual(store.load(), pending)
+
+		store.clear()
+		XCTAssertNil(store.load())
+	}
+
+	func testSignupFlowPersistsSecretsBeforeOpeningBrowser() throws {
+		let store = SignupPendingStore(defaults: TestSupport.ephemeralDefaults())
+		let oauth = makeService(store: TestSupport.loggedInStore())
+
+		var openedURL: URL?
+		var pendingWhenOpened: PendingSignup?
+		let flow = initWebSignup(deps: WebSignupDependencies(
+			makeAuthorizationRequest: oauth.makeSignupAuthorizationRequest,
+			pendingStore: store,
+			canOpenURL: { _ in false },
+			openURL: { url in
+				openedURL = url
+				pendingWhenOpened = store.load()
+			},
+			exchange: { _, _ in .success(()) }
+		))
+
+		flow.start()
+
+		let pending = try XCTUnwrap(pendingWhenOpened, "secrets must be persisted before the browser opens — a kill mid-hop must not lose them")
+		XCTAssertEqual(store.load(), pending, "the persisted record must outlive start()")
+		XCTAssertEqual(pending.redirectURI, "readplace://oauth-callback")
+
+		let opened = try XCTUnwrap(openedURL)
+		let items = Dictionary(uniqueKeysWithValues: (URLComponents(url: opened, resolvingAgainstBaseURL: false)?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+		XCTAssertEqual(items["state"], pending.state, "the opened authorize URL carries the persisted state")
+		XCTAssertEqual(items["redirect_uri"], "readplace://oauth-callback")
+		XCTAssertEqual(items["screen_hint"], "signup")
+	}
+}

--- a/projects/ios-readplace-poc/Tests/SignupFlowTests.swift
+++ b/projects/ios-readplace-poc/Tests/SignupFlowTests.swift
@@ -25,13 +25,13 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
 		XCTAssertEqual(items["client_id"], "hutch-chrome-extension")
-		XCTAssertEqual(items["redirect_uri"], "readplace://oauth-callback")
+		XCTAssertEqual(items["redirect_uri"], AppConfig.nativeCallbackURL)
 		XCTAssertEqual(items["response_type"], "code")
 		XCTAssertEqual(items["code_challenge_method"], "S256")
 		XCTAssertEqual(items["screen_hint"], "signup")
 		XCTAssertEqual(items["code_challenge"], PKCE.challenge(for: request.codeVerifier))
 		XCTAssertFalse((items["state"] ?? "").isEmpty)
-		XCTAssertEqual(request.redirectURI, "readplace://oauth-callback")
+		XCTAssertEqual(request.redirectURI, AppConfig.nativeCallbackURL)
 	}
 
 	func testCallbackDeepLinkCompletesSignInWithNativeRedirect() async throws {
@@ -62,7 +62,7 @@ final class SignupFlowTests: XCTestCase {
 			}
 		))
 
-		let result = await flow.complete(URL(string: "readplace://oauth-callback?code=abc&state=S")!)
+		let result = await flow.complete(URL(string: "\(AppConfig.nativeCallbackURL)?code=abc&state=S")!)
 
 		guard case .success? = result else { return XCTFail("Expected .success, got \(String(describing: result))") }
 		XCTAssertTrue(session.isLoggedIn, "RootView keys off isLoggedIn to show the reading list")
@@ -74,7 +74,7 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(body["code"], "abc")
 		XCTAssertEqual(body["code_verifier"], "v")
 		XCTAssertEqual(body["client_id"], "hutch-chrome-extension")
-		XCTAssertEqual(body["redirect_uri"], "readplace://oauth-callback")
+		XCTAssertEqual(body["redirect_uri"], AppConfig.nativeCallbackURL)
 	}
 
 	func testChromeURLForHTTPSRewritesSchemeWhenChromeAvailable() {
@@ -131,12 +131,23 @@ final class SignupFlowTests: XCTestCase {
 
 		let pending = try XCTUnwrap(pendingWhenOpened, "secrets must be persisted before the browser opens — a kill mid-hop must not lose them")
 		XCTAssertEqual(store.load(), pending, "the persisted record must outlive start()")
-		XCTAssertEqual(pending.redirectURI, "readplace://oauth-callback")
+		XCTAssertEqual(pending.redirectURI, AppConfig.nativeCallbackURL)
 
 		let opened = try XCTUnwrap(openedURL)
 		let items = Dictionary(uniqueKeysWithValues: (URLComponents(url: opened, resolvingAgainstBaseURL: false)?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
 		XCTAssertEqual(items["state"], pending.state, "the opened authorize URL carries the persisted state")
-		XCTAssertEqual(items["redirect_uri"], "readplace://oauth-callback")
+		XCTAssertEqual(items["redirect_uri"], AppConfig.nativeCallbackURL)
 		XCTAssertEqual(items["screen_hint"], "signup")
+	}
+
+	func testNativeCallbackURLPinnedToServerRegisteredValue() {
+		// Pinned cross-language contract: the server registers this exact string as
+		// a redirect_uri for the hutch-chrome-extension client
+		// (IOS_NATIVE_OAUTH_CALLBACK_URI in built-in-clients.ts) and matches it by
+		// exact string at token time. A change here must be mirrored there, and
+		// composing the URI from scheme + host keeps the deep-link parser in step.
+		XCTAssertEqual(AppConfig.nativeCallbackURL, "readplace://oauth-callback")
+		XCTAssertEqual(AppConfig.callbackURLScheme, "readplace")
+		XCTAssertEqual(AppConfig.nativeCallbackHost, "oauth-callback")
 	}
 }

--- a/src/packages/domain/src/oauth/built-in-clients.test.ts
+++ b/src/packages/domain/src/oauth/built-in-clients.test.ts
@@ -45,6 +45,18 @@ describe("isBuiltInRedirectUri", () => {
 		);
 	});
 
+	it("accepts the iOS native custom-scheme callback on the Chrome extension client", () => {
+		const chromeClient = getBuiltInClient("hutch-chrome-extension");
+		assert(chromeClient, "Chrome client must exist");
+		assert.equal(
+			isBuiltInRedirectUri({
+				client: chromeClient,
+				redirectUri: "readplace://oauth-callback",
+			}),
+			true,
+		);
+	});
+
 	it("accepts any 127.0.0.1 port on the loopback callback path", () => {
 		assert.equal(
 			isBuiltInRedirectUri({ client, redirectUri: "http://127.0.0.1:49999/oauth/callback" }),

--- a/src/packages/domain/src/oauth/built-in-clients.test.ts
+++ b/src/packages/domain/src/oauth/built-in-clients.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { getBuiltInClient, isBuiltInRedirectUri } from "./built-in-clients";
+import {
+	IOS_NATIVE_OAUTH_CALLBACK_URI,
+	getBuiltInClient,
+	isBuiltInRedirectUri,
+} from "./built-in-clients";
 
 describe("getBuiltInClient", () => {
 	it("returns the registered Firefox extension client", () => {
@@ -51,10 +55,19 @@ describe("isBuiltInRedirectUri", () => {
 		assert.equal(
 			isBuiltInRedirectUri({
 				client: chromeClient,
-				redirectUri: "readplace://oauth-callback",
+				redirectUri: IOS_NATIVE_OAUTH_CALLBACK_URI,
 			}),
 			true,
 		);
+	});
+
+	it("pins the iOS native callback URI string the iOS app must send verbatim", () => {
+		// The iOS app derives this same value from AppConfig.callbackURLScheme +
+		// nativeCallbackHost and sends it as redirect_uri at authorize AND token
+		// time, where the OAuth server matches by exact string. Pinning the literal
+		// makes a server-side edit fail here instead of only breaking the (network-
+		// stubbed) iOS signup path at runtime; mirror any change in AppConfig.swift.
+		assert.equal(IOS_NATIVE_OAUTH_CALLBACK_URI, "readplace://oauth-callback");
 	});
 
 	it("accepts any 127.0.0.1 port on the loopback callback path", () => {

--- a/src/packages/domain/src/oauth/built-in-clients.ts
+++ b/src/packages/domain/src/oauth/built-in-clients.ts
@@ -30,6 +30,12 @@ const BUILT_IN_OAUTH_CLIENTS: Record<string, OAuthClient> = {
 			"https://hkncrxpii6.execute-api.ap-southeast-2.amazonaws.com/oauth/callback",
 			"http://127.0.0.1:3000/oauth/callback",
 			"http://127.0.0.1:3001/oauth/callback",
+			// iOS Sign up opens /oauth/authorize in external Chrome (to reuse the
+			// browser session) and gets the code back via this native custom scheme,
+			// which the OS routes to the app — the in-app WKWebView login keeps using
+			// the https callback above. Mirrors AppConfig.nativeCallbackURL in
+			// ios-readplace-poc; keep both in sync.
+			"readplace://oauth-callback",
 		],
 		grants: ["authorization_code", "refresh_token"],
 	},

--- a/src/packages/domain/src/oauth/built-in-clients.ts
+++ b/src/packages/domain/src/oauth/built-in-clients.ts
@@ -2,6 +2,18 @@ import type { OAuthClient } from "./oauth.types";
 import { OAuthClientIdSchema } from "./oauth.schema";
 
 /**
+ * Custom-scheme redirect URI for the iOS app's external-browser "Sign up" flow:
+ * the OS routes `readplace://oauth-callback` back to the app with the auth code.
+ * The OAuth server matches `redirect_uri` by exact string at both authorize and
+ * token time, so this single constant — not a loose literal — is the server-side
+ * source of truth. The iOS app composes the identical value from
+ * `AppConfig.callbackURLScheme`/`nativeCallbackHost`; both sides pin it in tests
+ * (`built-in-clients.test.ts` here, `SignupFlowTests` there) so a change fails a
+ * test instead of silently breaking the signup token exchange.
+ */
+export const IOS_NATIVE_OAUTH_CALLBACK_URI = "readplace://oauth-callback";
+
+/**
  * Readplace's own browser extensions are first-party OAuth clients with fixed,
  * pre-provisioned identities — they are not self-registered through Dynamic
  * Client Registration, so the authorization server always knows them as
@@ -30,12 +42,7 @@ const BUILT_IN_OAUTH_CLIENTS: Record<string, OAuthClient> = {
 			"https://hkncrxpii6.execute-api.ap-southeast-2.amazonaws.com/oauth/callback",
 			"http://127.0.0.1:3000/oauth/callback",
 			"http://127.0.0.1:3001/oauth/callback",
-			// iOS Sign up opens /oauth/authorize in external Chrome (to reuse the
-			// browser session) and gets the code back via this native custom scheme,
-			// which the OS routes to the app — the in-app WKWebView login keeps using
-			// the https callback above. Mirrors AppConfig.nativeCallbackURL in
-			// ios-readplace-poc; keep both in sync.
-			"readplace://oauth-callback",
+			IOS_NATIVE_OAUTH_CALLBACK_URI,
 		],
 		grants: ["authorization_code", "refresh_token"],
 	},


### PR DESCRIPTION
## What & why

Adds a **"Sign up"** entry to the iOS app, modelled on how the browser extension already authenticates. Tapping it opens `/oauth/authorize` in the **external browser** (Chrome if installed, else the default) so an **existing Chrome session is reused** — an already-logged-in user goes straight through to consent without re-entering credentials, and never dead-ends on `/queue`. Brand-new users land on the web `/signup` page and return into the app authenticated. The existing WKWebView **Login** flow is left completely untouched.

The decisive requirement was Chrome-session reuse, which the in-app WKWebView (and `ASWebAuthenticationSession`) can't do — they don't share Chrome's cookie jar. So the flow opens Chrome and returns via a native `readplace://oauth-callback` deep link.

### The three paths
1. **Already logged into Chrome** (key case): authorize sees the session cookie → consent → Approve → `readplace://oauth-callback?code=…`. No login/signup form.
2. **New / logged-out**: `screen_hint=signup` → web `/signup` → returns to the (now-authenticated) authorize URL → consent → callback.
3. **No Chrome**: the same HTTPS authorize URL opens in the default browser; identical flow.

## Server changes (both additive — extension & login unaffected)
- `oauth.routes.ts`: `/oauth/authorize` accepts an optional `screen_hint=signup` that routes an **unauthenticated** user to `/signup` instead of `/login` (no hint → `/login`, exactly as before).
- `built-in-clients.ts`: register `readplace://oauth-callback` on the existing **`hutch-chrome-extension`** client. Reusing this client (rather than a new one) keeps refresh tokens — which are client-bound — working for every existing user.

## iOS changes
- **`WebSignup.swift`** — UI-free core: `chromeURLForHTTPS` (rewrite to `googlechromes://` when available, else byte-equal HTTPS), plus `SignupFlow` / `initWebSignup(deps:)` with all browser/network seams injected.
- **`SignupPendingStore.swift`** — persists the in-flight PKCE secrets to the App Group **before** opening the browser, so a cold relaunch via the deep link can still finish the exchange.
- **`OAuthService` / `AppSession`** — gain `redirect_uri`-aware overloads (`makeSignupAuthorizationRequest`, `exchangeCode(…redirectURI:)`, `completeSignIn(…redirectURI:)`); the existing https-callback methods forward to them, so login behaviour is byte-for-byte preserved.
- **`SignupOpeners.swift`** — thin `ExternalBrowser` UIKit seam + composition root wiring the live browser/session into a `SignupFlow`.
- **`LoginView` / `ReadplacePOCApp`** — a subtle "Don't have an account? Sign up" link below Login, and a `.onOpenURL` handler that drives the token exchange (state/code validated in `completeSignIn`; PKCE + single-use codes guard against custom-scheme hijacking).
- **`Info.plist`** — registers the `readplace` scheme (`CFBundleURLTypes`) and the Chrome query schemes (`LSApplicationQueriesSchemes`).

## Tests
- **Server**: unauthenticated authorize with `screen_hint=signup` → `303 /signup?return=…`; without it → `/login?return=…`; `readplace://oauth-callback` accepted for `hutch-chrome-extension`.
- **iOS** (`SignupFlowTests`): the native authorize request shape; the deep-link callback exchanging the code with the native `redirect_uri` and flipping the session logged-in; the Chrome-scheme selection (both branches); the `SignupPendingStore` round-trip; and persistence happening **before** the browser opens.

## Verification
- `pnpm check` — green across all 31 projects (100% coverage held); the new server tests pass and existing OAuth route tests are unchanged.
- iOS `make test` runs on macOS CI (no Swift toolchain in this environment); existing `OAuthServiceTests`/`LoginFlowTests` stay green because their asserted `redirect_uri` remains the HTTPS callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaSN5GnfmN4svKVqqeh7ri

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaSN5GnfmN4svKVqqeh7ri)_