### PR TITLE
test(web-shell): assert guest nav keys instead of null import/account checks

### DIFF
--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -130,7 +130,10 @@ describe("Base component", () => {
 		const result = Base(page, { isAuthenticated: false, emailVerified: undefined }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		expect(doc.querySelector('[data-test-nav-item="import"]')).toBeNull();
+		const navItems = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
+			(el) => el.getAttribute("data-test-nav-item"),
+		);
+		expect(navItems).toEqual(["install", "features", "signup"]);
 	});
 
 	it("renders the Account nav item for authenticated full-access users", () => {
@@ -152,7 +155,10 @@ describe("Base component", () => {
 		const result = Base(page, { isAuthenticated: false, emailVerified: undefined }).to("text/html");
 		const doc = new JSDOM(result.body).window.document;
 
-		expect(doc.querySelector('[data-test-nav-item="account"]')).toBeNull();
+		const navItems = Array.from(doc.querySelectorAll("[data-test-nav-item]")).map(
+			(el) => el.getAttribute("data-test-nav-item"),
+		);
+		expect(navItems).toEqual(["install", "features", "signup"]);
 	});
 
 	it("renders the full nav (queue + import + export + account + logout) for an authenticated full-access user", () => {


### PR DESCRIPTION
## Summary

Replaces the two fragile `expect(doc.querySelector(...)).toBeNull()` assertions in `base.component.test.ts` with positive assertions, completing the audit that swaps absence-by-null checks for positive nav-key assertions.

- **"hides the Import Links nav item for unauthenticated requests"** (was line 133) and **"hides the Account nav item for unauthenticated requests"** (was line 155) now collect the rendered `data-test-nav-item` keys for the unauthenticated `Base` and assert they equal the guest set `["install", "features", "signup"]`, mirroring `nav.component.test.ts:160-163`. Equality against the full guest set inherently proves `import`/`account` are absent.
- The two `script[src$="/client-dist/trial-countdown.client.js"]` `.toBeNull()` checks are left as-is — genuine-absence exception, with the selector pinned positively nearby.

## Verification

`pnpm nx run web-shell:check` passes with 100% coverage across all thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyTEzFnDcZQ4b9it1gunck)_