### PR TITLE
docs(test-driven-design): fix Uniform Interface GOOD example to strip discriminant

### DIFF
--- a/.claude/skills/test-driven-design/SKILL.md
+++ b/.claude/skills/test-driven-design/SKILL.md
@@ -51,7 +51,7 @@ If none of these shapes fit and the new case genuinely requires editing existing
 
 ### Uniform Interface Over Conditionals
 
-Prefer one path that treats every case alike over a conditional that branches to reconstruct per-case shapes. When the input already satisfies the output type, pass it through rather than re-discriminating it.
+Prefer one path that treats every case alike over a conditional that branches to reconstruct per-case shapes. When every input arm already carries the output type's fields, strip any extra discriminant rather than re-discriminating each arm by hand.
 
 ```typescript
 // ❌ BAD - Branches on a discriminant to rebuild each arm by hand

--- a/.claude/skills/test-driven-design/SKILL.md
+++ b/.claude/skills/test-driven-design/SKILL.md
@@ -60,9 +60,12 @@ const failure: CoreError =
 		? { reason: "not-logged-in" }
 		: { reason: "error", error: result.error };
 
-// ✅ GOOD - Each input arm already satisfies CoreError; pass it through
-const failure: CoreError = result;
+// ✅ GOOD - Strip the discriminant once; every arm flows through the same path
+const { ok: _ok, ...failure } = result;
+eventBus.emit(event, "failure", failure satisfies CoreError);
 ```
+
+A plain pass-through (`const failure: CoreError = result`) is tempting but wrong when `result` carries extra own-enumerable fields beyond `CoreError` — here the `ok` discriminant. The type checks, but those fields leak through at runtime and break a strict `toEqual` on the emitted value. Rest-destructure the discriminant away so the runtime shape matches the type.
 
 ### Dependency Injection Over Mocks
 


### PR DESCRIPTION
## Summary

The "Uniform Interface Over Conditionals" GOOD example in the test-driven-design skill used `const failure: CoreError = result`, a plain pass-through that **leaks the `ok` discriminant at runtime**. The assignment type-checks (the input arm satisfies `CoreError`), but the extra own-enumerable `ok` field rides along on the emitted object — the exact pattern that broke CI against #675's strict `toEqual`.

This replaces the GOOD example with the shipped rest-destructure from `projects/browser-extension-core/src/core.ts`:

```typescript
const { ok: _ok, ...failure } = result;
eventBus.emit(event, "failure", failure satisfies CoreError);
```

and adds a caveat explaining that plain pass-through only emits a clean value when the input carries no extra own-enumerable fields beyond the output type.

## Verification

- `pnpm nx run browser-extension-core:check` — all targets pass, 100% coverage
- Pre-commit hook (`nx run-many --target=check --all`) green across all 31 projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJZJhXmjRDZnagzPeaJx8J)_