### PR TITLE
test(hutch): pin trial-countdown selector with semantic-class-only fixture

### DIFF
--- a/projects/hutch/src/runtime/web/trial-countdown.client.test.ts
+++ b/projects/hutch/src/runtime/web/trial-countdown.client.test.ts
@@ -30,6 +30,27 @@ function buildFixture(opts: {
 	</body></html>`;
 }
 
+/** Same markup as buildFixture but WITHOUT the data-test-trial-countdown hook,
+ * so the only handle on the element is the semantic .trial-countdown class. This
+ * is what pins SELECTOR=".trial-countdown"; a fixture carrying the test attribute
+ * would pass identically against the old [data-test-trial-countdown] selector. */
+function buildSemanticOnlyFixture(opts: {
+	endsAtIso: string;
+	serverNowIso: string;
+	state: "active" | "expired" | "cancellation-scheduled";
+	escalation: string;
+	text: string;
+}): string {
+	return `<!DOCTYPE html><html><body>
+		<p class="trial-countdown trial-countdown--${opts.escalation}"
+		   data-trial-ends-at-iso="${opts.endsAtIso}"
+		   data-server-now-iso="${opts.serverNowIso}"
+		   data-trial-state="${opts.state}"
+		   role="timer"
+		   aria-live="off">${opts.text}</p>
+	</body></html>`;
+}
+
 function createDom(html: string) {
 	const dom = new JSDOM(html, { url: "https://readplace.com/queue" });
 	return { window: dom.window, document: dom.window.document };
@@ -88,6 +109,12 @@ function advanceClock(clock: FakeClock, ms: number): void {
 
 function getCountdownElement(doc: Document): Element {
 	const el = doc.querySelector("[data-test-trial-countdown]");
+	assert(el, "trial countdown element must exist in fixture");
+	return el;
+}
+
+function getCountdownElementByRole(doc: Document): Element {
+	const el = doc.querySelector("[role=timer]");
 	assert(el, "trial countdown element must exist in fixture");
 	return el;
 }
@@ -480,5 +507,30 @@ describe("initTrialCountdown — stop()", () => {
 		Object.defineProperty(document, "hidden", { configurable: true, value: false });
 		document.dispatchEvent(new (document.defaultView as Window & typeof globalThis).Event("visibilitychange"));
 		expect(clock.timers.size).toBe(0);
+	});
+});
+
+describe("initTrialCountdown — locates the element by its semantic class", () => {
+	it("ticks an element that carries only .trial-countdown (no data-test hook), pinning SELECTOR to the semantic class", () => {
+		const serverNow = "2026-01-01T00:00:00.000Z";
+		const endsAt = new Date(Date.parse(serverNow) + 5 * ONE_MINUTE_MS).toISOString();
+		const { document } = createDom(
+			buildSemanticOnlyFixture({
+				endsAtIso: endsAt,
+				serverNowIso: serverNow,
+				state: "active",
+				escalation: "critical",
+				text: "placeholder",
+			}),
+		);
+
+		const clock = createFakeClock(document, Date.parse(serverNow));
+		initTrialCountdown(clock.deps).attach();
+
+		const el = getCountdownElementByRole(document);
+		expect(el.textContent).toBe("5m 0s left in your free trial");
+
+		advanceClock(clock, ONE_SECOND_MS);
+		expect(el.textContent).toBe("4m 59s left in your free trial");
 	});
 });


### PR DESCRIPTION
## Why

`trial-countdown.client.ts` selects its element with `SELECTOR = ".trial-countdown"` (the semantic class), swapped in from the old `[data-test-trial-countdown]` attribute. But the client test suite couldn't tell the two apart:

- `buildFixture` rendered every fixture with **both** `class="trial-countdown"` **and** `data-test-trial-countdown`.
- `getCountdownElement` located the element via `[data-test-trial-countdown]`.

So the suite passed identically whether `SELECTOR` was the old attribute or the new class — the swap was **not pinned**.

## What

Add a single fixture/test variant that carries **only** the semantic `.trial-countdown` class (no `data-test-trial-countdown` hook), located via `[role=timer]`:

- `buildSemanticOnlyFixture` — same markup as `buildFixture` minus the `data-test` attribute.
- `getCountdownElementByRole` — locates via `[role=timer]`.
- One test asserting the countdown ticks (`5m 0s` → `4m 59s`).

## Verification

Confirmed the new test actually pins the swap:

- With the old `SELECTOR = "[data-test-trial-countdown]"`: the new test **fails** (`querySelector` returns null, the no-op controller never ticks, text stays `placeholder`) while the other 16 tests still pass — exactly the gap this closes.
- With `SELECTOR = ".trial-countdown"`: all 17 tests pass.

`pnpm check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQVrBRDrNkpiCYW6Ljcwzu)_