### PR TITLE
feat(inbox): email forwarding addresses behind ?feature=email (M1)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -48,6 +48,10 @@ export FOUNDING_MEMBER_LIMIT='50'
 # by the Lambda environment / deploy; requireEnv no longer defaults them.
 export PORT='3000'
 export APP_ORIGIN='http://localhost:3000'
+# Domain for the per-user email forwarding addresses (in-<token>@<domain>).
+# Production/staging set this on the Lambda from Pulumi stack config; nothing
+# receives mail yet, so any value renders the address page in local dev.
+export INBOX_ADDRESS_DOMAIN='read.place'
 # Rate-limit rules (requests/seconds). Production sets these on the Lambda; the
 # dev values match the historical requireEnv defaults.
 export RATE_LIMIT_VIEW_CRAWL='1000/3600'

--- a/projects/hutch/Pulumi.prod.yaml
+++ b/projects/hutch/Pulumi.prod.yaml
@@ -32,6 +32,7 @@ config:
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-prod
+  hutch:dynamodbInboxAddressesTable: hutch-inbox-addresses-prod
   hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-prod
   hutch:dynamodbRateLimitsTable: hutch-rate-limits-prod
   hutch:rateLimitViewCrawl: 100/3600
@@ -46,6 +47,7 @@ config:
   hutch:pendingHtmlBucketName: hutch-pending-html-prod
   hutch:pendingPdfBucketName: hutch-pending-pdf-prod
   hutch:userExportBucketName: hutch-user-exports-prod
+  hutch:inboxAddressDomain: read.place
   hutch:alertEmail: readplace+devops@readplace.com
   hutch:expiryCountdown: enabled
   hutch:foundingMemberLimit: '50'

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -19,6 +19,7 @@ config:
   hutch:dynamodbPasswordResetTokensTable: hutch-password-reset-tokens
   hutch:dynamodbPendingSignupsTable: hutch-pending-signups
   hutch:dynamodbImportSessionsTable: hutch-import-sessions-staging
+  hutch:dynamodbInboxAddressesTable: hutch-inbox-addresses-staging
   hutch:dynamodbSubscriptionProvidersTable: hutch-subscription-providers-staging
   hutch:dynamodbRateLimitsTable: hutch-rate-limits-staging
   hutch:rateLimitViewCrawl: 10000/3600
@@ -33,6 +34,7 @@ config:
   hutch:pendingHtmlBucketName: hutch-pending-html-staging
   hutch:pendingPdfBucketName: hutch-pending-pdf-staging
   hutch:userExportBucketName: hutch-user-exports-staging
+  hutch:inboxAddressDomain: staging.read.place
   hutch:alertEmail: readplace+staging@readplace.com
   hutch:expiryCountdown: enabled
   hutch:foundingMemberLimit: '5'

--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -46,6 +46,18 @@ const BUNDLES = [
 		].join("\n"),
 	},
 	{
+		entry: path.join(PROJECT_ROOT, "src/runtime/web/pages/inbox/inbox.client.ts"),
+		outfile: path.join(OUT_DIR, "inbox.client.js"),
+		globalName: "InboxCopy",
+		footer: [
+			"InboxCopy.initInboxCopy({",
+			"  document: window.document,",
+			"  navigator: window.navigator,",
+			"  setTimeoutFn: function (cb, ms) { return window.setTimeout(cb, ms); }",
+			"}).attach();",
+		].join("\n"),
+	},
+	{
 		entry: path.join(
 			PROJECT_ROOT,
 			"src/runtime/web/shared/article-body/progress-bar.client.ts",

--- a/projects/hutch/src/infra/hutch-storage.ts
+++ b/projects/hutch/src/infra/hutch-storage.ts
@@ -12,6 +12,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 	public readonly passwordResetTokensTable: aws.dynamodb.Table;
 	public readonly pendingSignupsTable: aws.dynamodb.Table;
 	public readonly importSessionsTable: aws.dynamodb.Table;
+	public readonly inboxAddressesTable: aws.dynamodb.Table;
 	public readonly subscriptionProvidersTable: aws.dynamodb.Table;
 	public readonly rateLimitsTable: aws.dynamodb.Table;
 
@@ -26,6 +27,7 @@ export class HutchStorage extends pulumi.ComponentResource {
 		passwordResetTokens: string;
 		pendingSignups: string;
 		importSessions: string;
+		inboxAddresses: string;
 		subscriptionProviders: string;
 		rateLimits: string;
 	} }, opts?: pulumi.ComponentResourceOptions) {
@@ -191,6 +193,31 @@ export class HutchStorage extends pulumi.ComponentResource {
 				enabled: true,
 			},
 		}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+
+		/* Per-user email forwarding addresses (in-<token>@<domain>). The address
+		 * is the PK so the M2 receive path can resolve address → userId and so
+		 * creation can guarantee global uniqueness with a conditional put; the
+		 * userId GSI answers the inbox page's "list my addresses" query. Kept
+		 * forever (no TTL) and disable-only — a freed hash could be re-minted for
+		 * another user and leak their mail — so deletion protection + PITR are on. */
+		this.inboxAddressesTable = new aws.dynamodb.Table(`hutch-inbox-addresses`, {
+			name: args.tableNames.inboxAddresses,
+			billingMode: "PAY_PER_REQUEST",
+			deletionProtectionEnabled: args.deletionProtection,
+			pointInTimeRecovery: { enabled: true },
+			hashKey: "address",
+			attributes: [
+				{ name: "address", type: "S" },
+				{ name: "userId", type: "S" },
+			],
+			globalSecondaryIndexes: [
+				{
+					name: "userId-index",
+					hashKey: "userId",
+					projectionType: "ALL",
+				},
+			],
+		}, { parent: this });
 
 		/* Fixed-window throttle counters (per-IP buckets + the global paid-crawl
 		 * budget), each row one window. Ephemeral by definition — no deletion

--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -39,6 +39,7 @@ const contentBucketName = config.require("contentBucketName");
 const pendingHtmlBucketName = config.require("pendingHtmlBucketName");
 const pendingPdfBucketName = config.require("pendingPdfBucketName");
 const userExportBucketName = config.require("userExportBucketName");
+const inboxAddressDomain = config.require("inboxAddressDomain");
 const alertEmail = config.require("alertEmail");
 const tableNames = {
 	articles: config.require("dynamodbArticlesTable"),
@@ -51,6 +52,7 @@ const tableNames = {
 	passwordResetTokens: config.require("dynamodbPasswordResetTokensTable"),
 	pendingSignups: config.require("dynamodbPendingSignupsTable"),
 	importSessions: config.require("dynamodbImportSessionsTable"),
+	inboxAddresses: config.require("dynamodbInboxAddressesTable"),
 	subscriptionProviders: config.require("dynamodbSubscriptionProvidersTable"),
 	rateLimits: config.require("dynamodbRateLimitsTable"),
 };
@@ -159,6 +161,7 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 		{ arn: storage.passwordResetTokensTable.arn, includeIndexes: false },
 		{ arn: storage.pendingSignupsTable.arn, includeIndexes: false },
 		{ arn: storage.importSessionsTable.arn, includeIndexes: false },
+		{ arn: storage.inboxAddressesTable.arn, includeIndexes: true },
 		{ arn: storage.subscriptionProvidersTable.arn, includeIndexes: true },
 		{ arn: storage.rateLimitsTable.arn, includeIndexes: false },
 	],
@@ -296,6 +299,8 @@ const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
 		DYNAMODB_PASSWORD_RESET_TOKENS_TABLE: storage.passwordResetTokensTable.name,
 		DYNAMODB_PENDING_SIGNUPS_TABLE: storage.pendingSignupsTable.name,
 		DYNAMODB_IMPORT_SESSIONS_TABLE: storage.importSessionsTable.name,
+		DYNAMODB_INBOX_ADDRESSES_TABLE: storage.inboxAddressesTable.name,
+		INBOX_ADDRESS_DOMAIN: inboxAddressDomain,
 		DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE: storage.subscriptionProvidersTable.name,
 		DYNAMODB_RATE_LIMITS_TABLE: storage.rateLimitsTable.name,
 		RATE_LIMIT_VIEW_CRAWL: rateLimitRules.viewCrawl,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -82,6 +82,8 @@ import { initInMemoryPendingHtml } from "@packages/test-fixtures/providers/pendi
 import { initInMemoryPendingPdf } from "@packages/test-fixtures/providers/pending-pdf";
 import { initInMemoryImportSession } from "@packages/test-fixtures/providers/import-session";
 import { initDynamoDbImportSession } from "./providers/import-session/dynamodb-import-session";
+import { initInMemoryInboxAddress } from "@packages/test-fixtures/providers/inbox-address";
+import { initDynamoDbInboxAddress } from "./providers/inbox-address/dynamodb-inbox-address";
 import { initExchangeGoogleCode } from "./providers/google-auth/google-token";
 import { initInMemoryStripeCheckout } from "@packages/test-fixtures/providers/stripe-checkout";
 import { initStripeCheckout } from "./providers/stripe-checkout/stripe-checkout";
@@ -146,6 +148,8 @@ function initProviders() {
 		const pendingHtmlBucketName = requireEnv("PENDING_HTML_BUCKET_NAME");
 		const pendingPdfBucketName = requireEnv("PENDING_PDF_BUCKET_NAME");
 		const importSessionsTable = requireEnv("DYNAMODB_IMPORT_SESSIONS_TABLE");
+		const inboxAddressesTable = requireEnv("DYNAMODB_INBOX_ADDRESSES_TABLE");
+		const inboxAddressDomain = requireEnv("INBOX_ADDRESS_DOMAIN");
 		const subscriptionProvidersTable = requireEnv("DYNAMODB_SUBSCRIPTION_PROVIDERS_TABLE");
 		const rateLimitsTable = requireEnv("DYNAMODB_RATE_LIMITS_TABLE");
 		const trialSchedulerGroupName = requireEnv("TRIAL_SCHEDULER_GROUP_NAME");
@@ -248,6 +252,11 @@ function initProviders() {
 			tableName: importSessionsTable,
 			now: () => new Date(),
 		});
+		const inboxAddressStore = initDynamoDbInboxAddress({
+			client,
+			tableName: inboxAddressesTable,
+			now: () => new Date(),
+		});
 		const { consumeRateLimit } = initDynamoDbRateLimit({
 			client,
 			tableName: rateLimitsTable,
@@ -270,6 +279,8 @@ function initProviders() {
 			readArticleContent,
 			importSessionStore,
 			extractLinksFromPageUrl,
+			inboxAddressStore,
+			inboxAddressDomain,
 			subscriptionProviders,
 			trialScheduler,
 			createSubscriptionOnExistingCustomer: stripeSubscriptions.createSubscriptionOnExistingCustomer,
@@ -430,6 +441,8 @@ function initProviders() {
 	});
 
 	const importSessionStore = initInMemoryImportSession({ now: () => new Date() });
+	const inboxAddressStore = initInMemoryInboxAddress({ now: () => new Date() });
+	const inboxAddressDomain = requireEnv("INBOX_ADDRESS_DOMAIN");
 
 	// In-process counters are valid here because dev runs a single long-lived
 	// server. Defaults are liberal — every local/e2e request shares 127.0.0.1,
@@ -452,6 +465,8 @@ function initProviders() {
 		}),
 		importSessionStore,
 		extractLinksFromPageUrl,
+		inboxAddressStore,
+		inboxAddressDomain,
 		subscriptionProviders: devSubscriptionProviders,
 		trialScheduler: devTrialScheduler,
 		createSubscriptionOnExistingCustomer: devStripeSubscriptions.createSubscriptionOnExistingCustomer,

--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.test.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.test.ts
@@ -1,0 +1,181 @@
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+} from "@packages/hutch-storage-client";
+import { InboxAddressSchema } from "@packages/domain/inbox";
+import { UserIdSchema } from "@packages/domain/user";
+import { initDynamoDbInboxAddress } from "./dynamodb-inbox-address";
+
+type SendFn = DynamoDBDocumentClient["send"];
+
+function createFakeClient(
+	impl: (input: unknown) => unknown,
+): Partial<DynamoDBDocumentClient> {
+	return {
+		send: (async (input: unknown) => impl(input)) as unknown as SendFn,
+	};
+}
+
+interface CapturedCommand {
+	input: {
+		Item?: Record<string, unknown>;
+		Key?: Record<string, unknown>;
+		IndexName?: string;
+		KeyConditionExpression?: string;
+		ConditionExpression?: string;
+		UpdateExpression?: string;
+		ExpressionAttributeValues?: Record<string, unknown>;
+	};
+}
+
+const TABLE = "test-inbox-addresses";
+const USER = UserIdSchema.parse("user-1");
+const DOMAIN = "read.place";
+const NOW = new Date("2026-06-23T00:00:00.000Z");
+
+function conditionalCheckFailed(): ConditionalCheckFailedException {
+	return new ConditionalCheckFailedException({ $metadata: {}, message: "exists" });
+}
+
+describe("initDynamoDbInboxAddress", () => {
+	describe("createAddress", () => {
+		it("conditionally puts a new row guarded on address uniqueness", async () => {
+			const commands: CapturedCommand[] = [];
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient((cmd) => {
+					commands.push(cmd as CapturedCommand);
+					return {};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
+
+			expect(commands).toHaveLength(1);
+			expect(commands[0].input.ConditionExpression).toBe(
+				"attribute_not_exists(address)",
+			);
+			expect(commands[0].input.Item?.address).toBe(entry.address);
+			expect(commands[0].input.Item?.userId).toBe(USER);
+			expect(commands[0].input.Item?.token).toBe(entry.token);
+			expect(commands[0].input.Item?.createdAt).toBe(NOW.toISOString());
+			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+			expect(entry.createdAt).toBe(NOW.toISOString());
+			expect(entry.disabledAt).toBeUndefined();
+		});
+
+		it("regenerates and retries when the address collides, then succeeds", async () => {
+			let calls = 0;
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient(() => {
+					calls++;
+					if (calls === 1) throw conditionalCheckFailed();
+					return {};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
+
+			expect(calls).toBe(2);
+			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+		});
+
+		it("throws after exhausting retries on persistent collisions", async () => {
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient(() => {
+					throw conditionalCheckFailed();
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
+				"Failed to mint a unique inbox address",
+			);
+		});
+
+		it("rethrows errors that are not conditional-check failures", async () => {
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient(() => {
+					throw new Error("throttled");
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
+				"throttled",
+			);
+		});
+	});
+
+	describe("listAddressesByUserId", () => {
+		it("queries the userId GSI and maps rows, normalizing a missing disabledAt to undefined", async () => {
+			let captured: CapturedCommand | undefined;
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient((cmd) => {
+					captured = cmd as CapturedCommand;
+					return {
+						Items: [
+							{
+								address: "in-3f9a2c@read.place",
+								userId: "user-1",
+								token: "3f9a2c",
+								createdAt: "2026-06-20T00:00:00.000Z",
+								disabledAt: null,
+							},
+							{
+								address: "in-abc123@read.place",
+								userId: "user-1",
+								token: "abc123",
+								createdAt: "2026-06-21T00:00:00.000Z",
+								disabledAt: "2026-06-22T00:00:00.000Z",
+							},
+						],
+						Count: 2,
+					};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			const result = await store.listAddressesByUserId(USER);
+
+			expect(captured?.input.IndexName).toBe("userId-index");
+			expect(captured?.input.KeyConditionExpression).toBe("userId = :uid");
+			expect(captured?.input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
+			expect(result).toHaveLength(2);
+			expect(result[0].address).toBe("in-3f9a2c@read.place");
+			expect(result[0].disabledAt).toBeUndefined();
+			expect(result[1].disabledAt).toBe("2026-06-22T00:00:00.000Z");
+		});
+	});
+
+	describe("disableAddress", () => {
+		it("stamps disabledAt with an ownership-guarded conditional update", async () => {
+			let captured: CapturedCommand | undefined;
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient((cmd) => {
+					captured = cmd as CapturedCommand;
+					return {};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+			const address = InboxAddressSchema.parse("in-3f9a2c@read.place");
+
+			await store.disableAddress({ userId: USER, address });
+
+			expect(captured?.input.Key).toEqual({ address });
+			expect(captured?.input.ConditionExpression).toBe("userId = :uid");
+			expect(captured?.input.UpdateExpression).toBe("SET disabledAt = :now");
+			expect(captured?.input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
+			expect(captured?.input.ExpressionAttributeValues?.[":now"]).toBe(
+				NOW.toISOString(),
+			);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
@@ -1,0 +1,75 @@
+import {
+	ConditionalCheckFailedException,
+	type DynamoDBDocumentClient,
+	defineDynamoTable,
+	dynamoField,
+} from "@packages/hutch-storage-client";
+import { z } from "zod";
+import { UserIdSchema } from "@packages/domain/user";
+import {
+	buildInboxAddress,
+	generateInboxToken,
+	INBOX_ADDRESS_MAX_CREATE_ATTEMPTS,
+	InboxAddressSchema,
+	type InboxAddressStore,
+	InboxTokenSchema,
+} from "@packages/domain/inbox";
+
+const InboxAddressRow = z.object({
+	address: InboxAddressSchema,
+	userId: UserIdSchema,
+	token: InboxTokenSchema,
+	createdAt: z.string(),
+	disabledAt: dynamoField(z.string()),
+});
+
+export function initDynamoDbInboxAddress(deps: {
+	client: DynamoDBDocumentClient;
+	tableName: string;
+	now: () => Date;
+}): InboxAddressStore {
+	const table = defineDynamoTable({
+		client: deps.client,
+		tableName: deps.tableName,
+		schema: InboxAddressRow,
+	});
+
+	return {
+		createAddress: async ({ userId, domain }) => {
+			const createdAt = deps.now().toISOString();
+			for (let attempt = 0; attempt < INBOX_ADDRESS_MAX_CREATE_ATTEMPTS; attempt++) {
+				const token = generateInboxToken();
+				const address = buildInboxAddress({ token, domain });
+				try {
+					await table.put({
+						Item: { address, userId, token, createdAt },
+						ConditionExpression: "attribute_not_exists(address)",
+					});
+					return { address, userId, token, createdAt, disabledAt: undefined };
+				} catch (error) {
+					if (error instanceof ConditionalCheckFailedException) continue;
+					throw error;
+				}
+			}
+			throw new Error(
+				`Failed to mint a unique inbox address after ${INBOX_ADDRESS_MAX_CREATE_ATTEMPTS} attempts`,
+			);
+		},
+		listAddressesByUserId: async (userId) => {
+			const { items } = await table.query({
+				IndexName: "userId-index",
+				KeyConditionExpression: "userId = :uid",
+				ExpressionAttributeValues: { ":uid": userId },
+			});
+			return items;
+		},
+		disableAddress: async ({ userId, address }) => {
+			await table.update({
+				Key: { address },
+				ConditionExpression: "userId = :uid",
+				UpdateExpression: "SET disabledAt = :now",
+				ExpressionAttributeValues: { ":uid": userId, ":now": deps.now().toISOString() },
+			});
+		},
+	};
+}

--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
@@ -56,6 +56,14 @@ export function initDynamoDbInboxAddress(deps: {
 			);
 		},
 		listAddressesByUserId: async (userId) => {
+			// The userId-index GSI is replicated asynchronously and DynamoDB offers no
+			// ConsistentRead for secondary indexes, so this read is unavoidably eventually
+			// consistent: an address written moments earlier can be absent, which lets the
+			// create → redirect → list flow briefly render the empty state right after a
+			// successful create. The design absorbs the lag rather than fighting it — the
+			// never-delete + conditional-put invariants bound the worst case to a redundant
+			// address the user owns (a second valid row), never a lost or cross-user-leaked
+			// one, and a reload reconciles once replication catches up.
 			const { items } = await table.query({
 				IndexName: "userId-index",
 				KeyConditionExpression: "userId = :uid",

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -120,6 +120,8 @@ import { initQueueRoutes } from "./web/pages/queue/queue.page";
 import { QUEUE_PATH } from "./web/pages/queue/queue.url";
 import { initImportSessionRoutes } from "./web/pages/import/import.page";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import type { InboxAddressStore } from "@packages/domain/inbox";
+import type { UserId } from "@packages/domain/user";
 import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import type { HttpErrorMessageMapping } from "./web/pages/queue/queue.error";
 import { initSaveRoutes } from "./web/pages/save/save.page";
@@ -128,6 +130,7 @@ import { initViewRoutes } from "./web/pages/view/view.page";
 import type { ExpiryCountdown } from "./web/pages/view/view-expiry";
 import { initAdminRecrawlRoutes } from "./web/pages/admin/recrawl.page";
 import { initExportRoutes } from "./web/pages/export/export.page";
+import { initInboxRoutes } from "./web/pages/inbox/inbox.page";
 import { initAccountRoutes } from "./web/pages/account/account.page";
 import { initAgentSkills } from "./web/agent-skills/agent-skills";
 import { initMcpServer } from "./web/mcp/mcp-server";
@@ -241,6 +244,8 @@ interface AppDependencies {
 	logParseError: LogParseError;
 	importSessionStore: ImportSessionStore;
 	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
+	inboxAddressStore: InboxAddressStore;
+	inboxAddressDomain: string;
 	getChangelogBanner: GetChangelogBanner;
 	now: () => Date;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
@@ -688,9 +693,35 @@ export function createApp(dependencies: AppDependencies): Express {
 	 * here on $default even when the close button is clicked on a /blog page. */
 	app.use(initChangelogDismissRoute({ secureCookies }));
 
+	/** Every account-creation path (password, trial, checkout, Google) funnels
+	 * its user creation through these two deps, so wrapping them here provisions
+	 * exactly one forwarding address per new account at the single composition
+	 * seam. Best-effort: a failure is logged for alerting but never blocks
+	 * signup — the inbox page's "Create Inbox Email" CTA is the recovery path. */
+	const provisionInboxAddressOnSignup = async (userId: UserId): Promise<void> => {
+		try {
+			await deps.inboxAddressStore.createAddress({ userId, domain: deps.inboxAddressDomain });
+		} catch (error) {
+			deps.logError(
+				"[Inbox] Failed to provision a forwarding address at signup",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+		}
+	};
+	const createUserWithPasswordHash: CreateUserWithPasswordHash = async (input) => {
+		const result = await deps.createUserWithPasswordHash(input);
+		if (result.ok) await provisionInboxAddressOnSignup(result.userId);
+		return result;
+	};
+	const createGoogleUser: CreateGoogleUser = async (input) => {
+		const result = await deps.createGoogleUser(input);
+		if (result.ok) await provisionInboxAddressOnSignup(result.userId);
+		return result;
+	};
+
 	const authRouter = initAuthRoutes({
 		hashPassword: deps.hashPassword,
-		createUserWithPasswordHash: deps.createUserWithPasswordHash,
+		createUserWithPasswordHash,
 		findUserByEmail: deps.findUserByEmail,
 		verifyCredentials: deps.verifyCredentials,
 		createSession: deps.createSession,
@@ -737,7 +768,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			staticBaseUrl,
 			secureCookies,
 			createSession: deps.createSession,
-			createGoogleUser: deps.createGoogleUser,
+			createGoogleUser,
 			findUserByEmail: deps.findUserByEmail,
 			countUsers,
 			markEmailVerified: deps.markEmailVerified,
@@ -892,6 +923,15 @@ export function createApp(dependencies: AppDependencies): Express {
 		buildBannerState,
 	});
 	app.use("/export", requireAuth, exportRouter);
+
+	const inboxRouter = initInboxRoutes({
+		featureToggle,
+		inboxAddressStore: deps.inboxAddressStore,
+		inboxAddressDomain: deps.inboxAddressDomain,
+		logError: deps.logError,
+		buildBannerState,
+	});
+	app.use("/inbox", requireAuth, inboxRouter);
 
 	const accountRouter = initAccountRoutes({
 		getEffectiveAccess,

--- a/projects/hutch/src/runtime/test-app.test.ts
+++ b/projects/hutch/src/runtime/test-app.test.ts
@@ -64,6 +64,7 @@ describe("createTestApp + createDefaultTestAppFixture", () => {
 			},
 			admin: fixture.admin,
 			importSession: fixture.importSession,
+			inboxAddress: fixture.inboxAddress,
 			shared: fixture.shared,
 			stripe: fixture.stripe,
 			pendingSignup: fixture.pendingSignup,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -157,6 +157,8 @@ function flattenFixtureToAppDependencies(
 		recrawlServiceToken: fixture.admin.recrawlServiceToken,
 		importSessionStore: fixture.importSession.importSessionStore,
 		extractLinksFromPageUrl: fixture.importSession.extractLinksFromPageUrl,
+		inboxAddressStore: fixture.inboxAddress.inboxAddressStore,
+		inboxAddressDomain: fixture.inboxAddress.inboxAddressDomain,
 		getChangelogBanner: async () => undefined,
 		now: fixture.shared.now,
 		retrieveCheckoutSession: fixture.stripe.retrieveCheckoutSession,

--- a/projects/hutch/src/runtime/web/banner-state.test.ts
+++ b/projects/hutch/src/runtime/web/banner-state.test.ts
@@ -30,7 +30,11 @@ describe("initBuildBannerState", () => {
 
 		const result = await buildBannerState({});
 
-		expect(result).toEqual({ isAuthenticated: false, emailVerified: undefined });
+		expect(result).toEqual({
+			isAuthenticated: false,
+			emailVerified: undefined,
+			emailFeatureEnabled: false,
+		});
 		expect(getEffectiveAccess).not.toHaveBeenCalled();
 	});
 
@@ -178,6 +182,7 @@ describe("initBuildBannerState", () => {
 			expect(result).toEqual({
 				isAuthenticated: false,
 				emailVerified: undefined,
+				emailFeatureEnabled: false,
 				changelogBanner: CHANGELOG,
 			});
 			expect(getEffectiveAccess).not.toHaveBeenCalled();

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.client.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { fireEvent } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
+import { initInboxCopy } from "./inbox.client";
+
+const ADDRESS = "in-3f9a2c@read.place";
+
+interface NavigatorStub {
+	clipboard?: { writeText(text: string): Promise<void> };
+}
+
+function buildDom(options: { malformed?: boolean } = {}): Document {
+	const malformed = options.malformed
+		? `<button type="button" data-inbox-copy hidden>Copy</button>`
+		: "";
+	const dom = new JSDOM(`<!DOCTYPE html><html><body>
+		<input data-inbox-address="${ADDRESS}" value="${ADDRESS}" readonly />
+		<button type="button" data-inbox-copy data-inbox-address="${ADDRESS}" hidden>Copy</button>
+		${malformed}
+	</body></html>`);
+	return dom.window.document;
+}
+
+function setup(options: { navigator?: NavigatorStub; malformed?: boolean } = {}) {
+	const document = buildDom({ malformed: options.malformed });
+	const navigator: NavigatorStub = options.navigator ?? {
+		clipboard: { writeText: jest.fn(() => Promise.resolve()) },
+	};
+	const ctrl = initInboxCopy({ document, navigator, setTimeoutFn: setTimeout });
+	return { document, navigator, ctrl };
+}
+
+function copyButton(doc: Document): HTMLButtonElement {
+	const btn = doc.querySelector<HTMLButtonElement>("[data-inbox-copy][data-inbox-address]");
+	assert(btn, "well-formed copy button must exist in fixture");
+	return btn;
+}
+
+async function flushPromises(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+beforeEach(() => {
+	jest.useFakeTimers();
+});
+
+afterEach(() => {
+	jest.useRealTimers();
+});
+
+describe("initInboxCopy", () => {
+	it("leaves the copy button hidden when the clipboard API is unavailable", () => {
+		const { document, ctrl } = setup({ navigator: {} });
+
+		ctrl.attach();
+
+		expect(copyButton(document).hidden).toBe(true);
+	});
+
+	it("reveals the copy button and copies the address on click, flashing then restoring the label", async () => {
+		const writeText = jest.fn(() => Promise.resolve());
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		ctrl.attach();
+		const btn = copyButton(document);
+		expect(btn.hidden).toBe(false);
+
+		fireEvent.click(btn);
+		expect(writeText).toHaveBeenCalledWith(ADDRESS);
+
+		await flushPromises();
+		expect(btn.textContent).toBe("Copied");
+
+		jest.advanceTimersByTime(2000);
+		expect(btn.textContent).toBe("Copy");
+	});
+
+	it("shows a manual-copy hint when writeText rejects", async () => {
+		const writeText = jest.fn(() => Promise.reject(new Error("denied")));
+		const { document, ctrl } = setup({ navigator: { clipboard: { writeText } } });
+		ctrl.attach();
+		const btn = copyButton(document);
+
+		fireEvent.click(btn);
+		await flushPromises();
+
+		expect(btn.textContent).toBe("Press Ctrl+C");
+	});
+
+	it("skips a malformed copy button that carries no address", () => {
+		const { document, ctrl } = setup({ malformed: true });
+
+		ctrl.attach();
+
+		const malformed = document.querySelector("[data-inbox-copy]:not([data-inbox-address])");
+		expect(malformed?.hasAttribute("hidden")).toBe(true);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.client.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.client.ts
@@ -1,0 +1,59 @@
+interface InboxClipboard {
+	writeText(text: string): Promise<void>;
+}
+
+interface InboxNavigator {
+	clipboard?: InboxClipboard;
+}
+
+type InboxTimerId = ReturnType<typeof setTimeout>;
+
+interface InboxCopyDeps {
+	document: Document;
+	navigator: InboxNavigator;
+	setTimeoutFn: (cb: () => void, ms: number) => InboxTimerId;
+}
+
+interface InboxCopyController {
+	attach(): void;
+}
+
+export function initInboxCopy(deps: InboxCopyDeps): InboxCopyController {
+	const RESET_MS = 2000;
+	const COPIED_LABEL = "Copied";
+	const FAILED_LABEL = "Press Ctrl+C";
+
+	function flash(button: HTMLButtonElement, message: string): void {
+		const original = button.textContent;
+		button.textContent = message;
+		deps.setTimeoutFn(() => {
+			button.textContent = original;
+		}, RESET_MS);
+	}
+
+	function wire(button: HTMLButtonElement, clipboard: InboxClipboard): void {
+		const address = button.getAttribute("data-inbox-address");
+		if (address === null) return;
+		// Revealed only here: the no-JS baseline is the selectable read-only
+		// field, so the button stays hidden until the clipboard API is present.
+		button.hidden = false;
+		button.addEventListener("click", () => {
+			clipboard.writeText(address).then(
+				() => flash(button, COPIED_LABEL),
+				() => flash(button, FAILED_LABEL),
+			);
+		});
+	}
+
+	function attach(): void {
+		const clipboard = deps.navigator.clipboard;
+		if (clipboard === undefined) return;
+		for (const button of Array.from(
+			deps.document.querySelectorAll<HTMLButtonElement>("[data-inbox-copy]"),
+		)) {
+			wire(button, clipboard);
+		}
+	}
+
+	return { attach };
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	type InboxAddressEntry,
+	InboxAddressSchema,
+	InboxTokenSchema,
+} from "@packages/domain/inbox";
+import { UserIdSchema } from "@packages/domain/user";
+import { InboxPage } from "./inbox.component";
+
+function entry(overrides: Partial<InboxAddressEntry> = {}): InboxAddressEntry {
+	return {
+		address: InboxAddressSchema.parse("in-3f9a2c@read.place"),
+		userId: UserIdSchema.parse("user-1"),
+		token: InboxTokenSchema.parse("3f9a2c"),
+		createdAt: "2026-06-23T00:00:00.000Z",
+		disabledAt: undefined,
+		...overrides,
+	};
+}
+
+function parse(html: string): Document {
+	return new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`).window.document;
+}
+
+describe("InboxPage", () => {
+	it("noindexes the page and ships the copy-enhancement script", () => {
+		const page = InboxPage({ addresses: [] });
+		assert.equal(page.seo.robots, "noindex, nofollow");
+		assert.equal(page.bodyClass, "page-inbox");
+		assert.match(page.scripts ?? "", /inbox\.client\.js/);
+	});
+
+	it("shows an empty state with a create CTA and no list when the user has no addresses", () => {
+		const doc = parse(InboxPage({ addresses: [] }).content.html);
+		assert.ok(doc.querySelector("[data-test-inbox-empty]"), "empty state must render");
+		assert.ok(doc.querySelector("[data-test-inbox-create]"), "create CTA must render");
+		assert.equal(doc.querySelector("[data-test-inbox-list]"), null);
+	});
+
+	it("renders each address into a selectable read-only field with a copy button", () => {
+		const doc = parse(InboxPage({ addresses: [entry()] }).content.html);
+		const field = doc.querySelector(".inbox__address-field");
+		assert.equal(field?.getAttribute("value"), "in-3f9a2c@read.place");
+		assert.equal(field?.getAttribute("readonly"), "");
+		const copy = doc.querySelector("[data-inbox-copy]");
+		assert.equal(copy?.getAttribute("data-inbox-address"), "in-3f9a2c@read.place");
+		assert.equal(copy?.hasAttribute("hidden"), true);
+	});
+
+	it("shows a Disable action for enabled addresses and a Disabled marker (no action) for disabled ones", () => {
+		const doc = parse(
+			InboxPage({
+				addresses: [
+					entry(),
+					entry({
+						address: InboxAddressSchema.parse("in-abc123@read.place"),
+						token: InboxTokenSchema.parse("abc123"),
+						disabledAt: "2026-06-22T00:00:00.000Z",
+					}),
+				],
+			}).content.html,
+		);
+		assert.equal(doc.querySelectorAll("[data-test-inbox-item]").length, 2);
+		const statuses = Array.from(doc.querySelectorAll("[data-test-inbox-status]")).map((el) =>
+			el.getAttribute("data-test-inbox-status"),
+		);
+		assert.deepEqual(statuses, ["enabled", "disabled"]);
+		assert.equal(doc.querySelectorAll("[data-test-inbox-disable]").length, 1);
+	});
+
+	it("points the create and disable forms at the flag-carrying routes", () => {
+		const doc = parse(InboxPage({ addresses: [entry()] }).content.html);
+		assert.equal(
+			doc.querySelector(".inbox__create")?.getAttribute("action"),
+			"/inbox/create?feature=email",
+		);
+		assert.equal(
+			doc.querySelector(".inbox__disable")?.getAttribute("action"),
+			"/inbox/disable?feature=email",
+		);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { EMAIL_FEATURE, render } from "@packages/web-shell";
+import type { PageBody } from "@packages/web-shell";
+import type { InboxAddressEntry } from "@packages/domain/inbox";
+import { INBOX_STYLES } from "./inbox.styles";
+
+const INBOX_TEMPLATE = readFileSync(join(__dirname, "inbox.template.html"), "utf-8");
+
+const INBOX_SCRIPT = `<script src="/client-dist/inbox.client.js" defer></script>`;
+
+/** The create/disable forms must carry the per-request flag in their action so
+ * the gated POST routes stay reachable when submitted from the flagged page. */
+const INBOX_QUERY = `?feature=${EMAIL_FEATURE}`;
+
+export function InboxPage(params: { addresses: InboxAddressEntry[] }): PageBody {
+	const content = render(INBOX_TEMPLATE, {
+		hasAddresses: params.addresses.length > 0,
+		addresses: params.addresses.map((entry) => ({
+			address: entry.address,
+			enabled: entry.disabledAt === undefined,
+		})),
+		createAction: `/inbox/create${INBOX_QUERY}`,
+		disableAction: `/inbox/disable${INBOX_QUERY}`,
+	});
+
+	return {
+		seo: {
+			title: "Your forwarding addresses — Readplace",
+			description: "Your personal email forwarding addresses for Readplace.",
+			canonicalUrl: "/inbox",
+			robots: "noindex, nofollow",
+		},
+		styles: INBOX_STYLES,
+		bodyClass: "page-inbox",
+		content: { html: content },
+		scripts: INBOX_SCRIPT,
+	};
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert";
+import type { Request, Response, Router } from "express";
+import express from "express";
+import { z } from "zod";
+import { EMAIL_FEATURE, sendComponent } from "@packages/web-shell";
+import { InboxAddressSchema } from "@packages/domain/inbox";
+import type { InboxAddressStore } from "@packages/domain/inbox";
+import { Base } from "../../base.component";
+import type { BuildBannerState } from "../../banner-state";
+import type { QuerystringFeatureToggle } from "../../feature-toggle";
+import { InboxPage } from "./inbox.component";
+
+interface InboxDependencies {
+	featureToggle: QuerystringFeatureToggle;
+	inboxAddressStore: InboxAddressStore;
+	inboxAddressDomain: string;
+	logError: (message: string, error?: Error) => void;
+	buildBannerState: BuildBannerState;
+}
+
+const DisableAddressSchema = z.object({ address: InboxAddressSchema });
+
+export function initInboxRoutes(deps: InboxDependencies): Router {
+	const router = express.Router();
+	const inboxPath = `/inbox?feature=${EMAIL_FEATURE}`;
+
+	/** Hidden by default: without the per-request flag the whole surface 404s, so
+	 * production traffic never sees it until the flag is flipped on a request. */
+	router.use((req: Request, res: Response, next: express.NextFunction) => {
+		if (!deps.featureToggle.isEnabled(req, EMAIL_FEATURE)) {
+			res.status(404).type("html").send("");
+			return;
+		}
+		next();
+	});
+
+	router.get("/", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const addresses = await deps.inboxAddressStore.listAddressesByUserId(req.userId);
+		sendComponent(req, res, Base(InboxPage({ addresses }), await deps.buildBannerState(req)));
+	});
+
+	router.post("/create", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		try {
+			await deps.inboxAddressStore.createAddress({
+				userId: req.userId,
+				domain: deps.inboxAddressDomain,
+			});
+		} catch (error) {
+			deps.logError(
+				"[Inbox] Failed to create a forwarding address",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+		}
+		res.redirect(303, inboxPath);
+	});
+
+	router.post("/disable", async (req: Request, res: Response) => {
+		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const userId = req.userId;
+		const parsed = DisableAddressSchema.safeParse(req.body);
+		if (parsed.success) {
+			// Confirm ownership before disabling so a forged address for someone
+			// else's row never reaches the (also ownership-guarded) store write.
+			const owned = await deps.inboxAddressStore.listAddressesByUserId(userId);
+			if (owned.some((entry) => entry.address === parsed.data.address)) {
+				await deps.inboxAddressStore.disableAddress({ userId, address: parsed.data.address });
+			}
+		}
+		res.redirect(303, inboxPath);
+	});
+
+	return router;
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -28,6 +28,30 @@ function addressFieldValue(html: string): string | null | undefined {
 		?.getAttribute("value");
 }
 
+/** Emulates a browser submitting a nav entry's GET form: the action's own query
+ * string is discarded and replaced by the serialized form controls (the hidden
+ * inputs), so the resulting URL is the action path plus the hidden-input query.
+ * This is the only faithful way to assert the entry reaches its target — asserting
+ * the entry is merely present misses a dropped gate flag. */
+function navFormSubmissionTarget(html: string, key: string): string {
+	const form = new JSDOM(html).window.document
+		.querySelector(`[data-test-nav-item="${key}"]`)
+		?.closest("form");
+	assert(form, `nav item ${key} must render inside a form`);
+	assert.equal(form.getAttribute("method"), "GET", "this helper emulates a GET submit");
+	const action = form.getAttribute("action");
+	assert(action, "nav form must declare an action");
+	const params = new URLSearchParams();
+	for (const input of form.querySelectorAll('input[type="hidden"]')) {
+		const name = input.getAttribute("name");
+		const value = input.getAttribute("value");
+		assert(name, "hidden input must declare a name");
+		assert(value !== null, "hidden input must declare a value");
+		params.set(name, value);
+	}
+	return `${new URL(action, "https://internal.invalid").pathname}?${params}`;
+}
+
 describe("Inbox routes", () => {
 	describe("GET /inbox (gating)", () => {
 		it("redirects an unauthenticated visitor to /login", async () => {
@@ -71,6 +95,21 @@ describe("Inbox routes", () => {
 
 			const withoutFlag = await agent.get("/queue");
 			expect(navItemKeys(withoutFlag.text)).not.toContain("inbox");
+		});
+
+		it("reaches the inbox (200) when the Inbox nav entry's GET form is followed", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const page = await agent.get("/queue?feature=email");
+			const target = navFormSubmissionTarget(page.text, "inbox");
+
+			const response = await agent.get(target);
+
+			expect(response.status).toBe(200);
+			expect(
+				new JSDOM(response.text).window.document.querySelector("[data-test-inbox-empty]"),
+			).not.toBeNull();
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { loginAgent, useTestServer } from "../../../test-app";
+
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "@packages/test-fixtures";
+
+const useApp = useTestServer();
+
+/** Older than the bot-defense minimum submit window (2.5s) so signup passes. */
+function freshLoadedAt(): string {
+	return String(Date.now() - 5000);
+}
+
+function navItemKeys(html: string): (string | null)[] {
+	const doc = new JSDOM(html).window.document;
+	return Array.from(doc.querySelectorAll("[data-test-nav-item]")).map((el) =>
+		el.getAttribute("data-test-nav-item"),
+	);
+}
+
+function addressFieldValue(html: string): string | null | undefined {
+	return new JSDOM(html).window.document
+		.querySelector(".inbox__address-field")
+		?.getAttribute("value");
+}
+
+describe("Inbox routes", () => {
+	describe("GET /inbox (gating)", () => {
+		it("redirects an unauthenticated visitor to /login", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const response = await request(harness.server).get("/inbox?feature=email");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/login");
+		});
+
+		it("returns 404 for an authenticated user without the email feature flag", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox");
+
+			expect(response.status).toBe(404);
+		});
+
+		it("renders the empty state with a create CTA when the flagged user has no addresses", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox?feature=email");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-inbox-empty]")).not.toBeNull();
+			expect(doc.querySelector("[data-test-inbox-create]")).not.toBeNull();
+			expect(doc.querySelector("[data-test-inbox-list]")).toBeNull();
+		});
+	});
+
+	describe("nav entry", () => {
+		it("shows the Inbox nav entry only when the email feature flag is present", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const withFlag = await agent.get("/queue?feature=email");
+			expect(navItemKeys(withFlag.text)).toContain("inbox");
+
+			const withoutFlag = await agent.get("/queue");
+			expect(navItemKeys(withoutFlag.text)).not.toContain("inbox");
+		});
+	});
+
+	describe("POST /inbox/create", () => {
+		it("creates an address and surfaces it on the next visit", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const created = await agent.post("/inbox/create?feature=email");
+			expect(created.status).toBe(303);
+			expect(created.headers.location).toBe("/inbox?feature=email");
+
+			const listed = await agent.get("/inbox?feature=email");
+			expect(addressFieldValue(listed.text)).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+		});
+
+		it("returns 404 without the feature flag", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/inbox/create");
+
+			expect(response.status).toBe(404);
+		});
+
+		it("redirects gracefully and logs when address creation fails", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const errors: string[] = [];
+			fixture.shared.logError = (message) => {
+				errors.push(message);
+			};
+			fixture.inboxAddress.inboxAddressStore.createAddress = async () => {
+				throw new Error("dynamo down");
+			};
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/inbox/create?feature=email");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox?feature=email");
+			expect(errors.some((m) => m.includes("[Inbox] Failed to create"))).toBe(true);
+		});
+	});
+
+	describe("POST /inbox/disable", () => {
+		it("disables an address the user owns", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email");
+			const address = addressFieldValue((await agent.get("/inbox?feature=email")).text);
+			expect(address).not.toBeNull();
+
+			const response = await agent
+				.post("/inbox/disable?feature=email")
+				.type("form")
+				.send({ address: address ?? "" });
+
+			expect(response.status).toBe(303);
+			const after = new JSDOM((await agent.get("/inbox?feature=email")).text).window.document;
+			expect(after.querySelector('[data-test-inbox-status="disabled"]')).not.toBeNull();
+			expect(after.querySelector("[data-test-inbox-disable]")).toBeNull();
+		});
+
+		it("ignores a request whose body is not a valid address", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email");
+
+			const response = await agent
+				.post("/inbox/disable?feature=email")
+				.type("form")
+				.send({ address: "not-an-address" });
+
+			expect(response.status).toBe(303);
+			const after = new JSDOM((await agent.get("/inbox?feature=email")).text).window.document;
+			expect(after.querySelector('[data-test-inbox-status="enabled"]')).not.toBeNull();
+		});
+
+		it("does not disable an address the user does not own", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email");
+
+			const response = await agent
+				.post("/inbox/disable?feature=email")
+				.type("form")
+				.send({ address: "in-zzzzzz@read.place" });
+
+			expect(response.status).toBe(303);
+			const after = new JSDOM((await agent.get("/inbox?feature=email")).text).window.document;
+			expect(after.querySelector('[data-test-inbox-status="enabled"]')).not.toBeNull();
+		});
+	});
+
+	describe("signup provisioning", () => {
+		it("provisions one forwarding address when a new account is created", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "new@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+			expect(response.status).toBe(303);
+
+			const user = await fixture.auth.findUserByEmail("new@example.com");
+			assert(user, "signup must persist a user");
+			const addresses = await fixture.inboxAddress.inboxAddressStore.listAddressesByUserId(
+				user.userId,
+			);
+			expect(addresses).toHaveLength(1);
+		});
+
+		it("still completes signup when address provisioning throws", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const errors: string[] = [];
+			fixture.shared.logError = (message) => {
+				errors.push(message);
+			};
+			fixture.inboxAddress.inboxAddressStore.createAddress = async () => {
+				throw new Error("dynamo down");
+			};
+			const harness = useApp(fixture);
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "resilient@example.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(303);
+			expect(errors.some((m) => m.includes("[Inbox] Failed to provision"))).toBe(true);
+		});
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
@@ -1,0 +1,149 @@
+.inbox {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 20px;
+}
+
+.inbox__header {
+  margin-bottom: 32px;
+}
+
+.inbox__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--foreground);
+  margin: 0 0 4px;
+}
+
+.inbox__subtitle {
+  font-size: 1rem;
+  color: var(--muted-foreground);
+  margin: 0;
+}
+
+.inbox__list {
+  list-style: none;
+  margin: 0 0 24px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.inbox__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+}
+
+.inbox__address-field {
+  flex: 1 1 200px;
+  min-width: 0;
+  padding: 8px 12px;
+  font-size: 0.95rem;
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.inbox__copy-btn {
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.inbox__copy-btn:hover {
+  opacity: 0.9;
+}
+
+.inbox__status {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.inbox__status--enabled {
+  color: var(--success);
+}
+
+.inbox__status--disabled {
+  color: var(--muted-foreground);
+}
+
+.inbox__disable {
+  margin: 0;
+}
+
+.inbox__disable-btn {
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  color: var(--muted-foreground);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.inbox__disable-btn:hover {
+  color: var(--foreground);
+}
+
+.inbox__empty {
+  color: var(--muted-foreground);
+  margin: 0 0 24px;
+}
+
+.inbox__create {
+  margin: 0 0 32px;
+}
+
+.inbox__create-btn {
+  display: inline-block;
+  padding: 12px 32px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.inbox__create-btn:hover {
+  opacity: 0.9;
+}
+
+.inbox__instructions {
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+}
+
+.inbox__instructions-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--foreground);
+  margin: 0 0 8px;
+}
+
+.inbox__steps {
+  margin: 0 0 16px;
+  padding-left: 24px;
+  color: var(--muted-foreground);
+  line-height: 1.8;
+}
+
+.inbox__note {
+  color: var(--muted-foreground);
+  font-size: 0.9rem;
+  margin: 0;
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const stylesPath = join(__dirname, "inbox.styles.css");
+export const INBOX_STYLES = readFileSync(stylesPath, "utf-8");

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
@@ -1,0 +1,42 @@
+    <main class="inbox">
+      <div class="inbox__header">
+        <h1 class="inbox__title">Your forwarding addresses</h1>
+        <p class="inbox__subtitle">Forward any newsletter to one of these addresses and it lands in Readplace. I'll pull out the links and queue them up for you to read later.</p>
+      </div>
+
+      {{#if hasAddresses}}
+      <ul class="inbox__list" data-test-inbox-list>
+        {{#each addresses}}
+        <li class="inbox__item" data-test-inbox-item>
+          <input class="inbox__address-field" type="text" value="{{this.address}}" readonly aria-label="Forwarding address" data-inbox-address="{{this.address}}" />
+          <button type="button" class="inbox__copy-btn" data-inbox-copy data-inbox-address="{{this.address}}" hidden>Copy</button>
+          {{#if this.enabled}}
+          <span class="inbox__status inbox__status--enabled" data-test-inbox-status="enabled">Active</span>
+          <form action="{{../disableAction}}" method="POST" class="inbox__disable">
+            <input type="hidden" name="address" value="{{this.address}}" />
+            <button type="submit" class="inbox__disable-btn" data-test-inbox-disable>Disable</button>
+          </form>
+          {{else}}
+          <span class="inbox__status inbox__status--disabled" data-test-inbox-status="disabled">Disabled</span>
+          {{/if}}
+        </li>
+        {{/each}}
+      </ul>
+      {{else}}
+      <p class="inbox__empty" data-test-inbox-empty>You don't have a forwarding address yet. Create one to get started.</p>
+      {{/if}}
+
+      <form action="{{createAction}}" method="POST" class="inbox__create">
+        <button type="submit" class="inbox__create-btn" data-test-inbox-create>Create Inbox Email</button>
+      </form>
+
+      <section class="inbox__instructions">
+        <h2 class="inbox__instructions-title">How it works</h2>
+        <ol class="inbox__steps">
+          <li>Create a forwarding address and copy it.</li>
+          <li>In your email app, forward a newsletter (or set up forwarding) to it.</li>
+          <li>New issues show up here automatically.</li>
+        </ol>
+        <p class="inbox__note">This is new — right now it just gives you the address. Reading forwarded mail in Readplace is coming next.</p>
+      </section>
+    </main>

--- a/src/packages/domain/package.json
+++ b/src/packages/domain/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/import-session/index.d.ts",
       "default": "./dist/import-session/index.js"
     },
+    "./inbox": {
+      "types": "./dist/inbox/index.d.ts",
+      "default": "./dist/inbox/index.js"
+    },
     "./rate-limit": {
       "types": "./dist/rate-limit/index.d.ts",
       "default": "./dist/rate-limit/index.js"
@@ -41,6 +45,7 @@
       "user": ["./dist/user/index.d.ts"],
       "oauth": ["./dist/oauth/index.d.ts"],
       "import-session": ["./dist/import-session/index.d.ts"],
+      "inbox": ["./dist/inbox/index.d.ts"],
       "rate-limit": ["./dist/rate-limit/index.d.ts"]
     }
   },

--- a/src/packages/domain/src/inbox/inbox-address.schema.ts
+++ b/src/packages/domain/src/inbox/inbox-address.schema.ts
@@ -1,0 +1,46 @@
+import { randomInt } from "node:crypto";
+import { z } from "zod";
+
+/** Opaque per-newsletter token in a forwarding address. Six lowercase base36
+ * characters (a–z0–9) — short enough to be memorable/typeable, ~2.2B
+ * combinations. Disposable and disable-able, so the smaller keyspace (vs a
+ * 128-bit token) is an accepted trade-off; creation guards uniqueness with a
+ * conditional put + bounded retry. */
+export const InboxTokenSchema = z
+	.string()
+	.regex(/^[0-9a-z]{6}$/)
+	.brand<"InboxToken">();
+
+export type InboxToken = z.infer<typeof InboxTokenSchema>;
+
+/** A full forwarding address, `in-<token>@<domain>`. Branded so a raw string
+ * can't stand in for one without passing through the parser. */
+export const InboxAddressSchema = z
+	.string()
+	.regex(/^in-[0-9a-z]{6}@[a-z0-9.-]+$/)
+	.brand<"InboxAddress">();
+
+export type InboxAddress = z.infer<typeof InboxAddressSchema>;
+
+export const INBOX_TOKEN_LENGTH = 6;
+const INBOX_TOKEN_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/** Attempts the conditional-put address creation makes before giving up. A
+ * collision at the 2.2B keyspace is already vanishingly rare; exhausting this
+ * many retries signals a real fault, so the caller throws rather than degrading
+ * silently. */
+export const INBOX_ADDRESS_MAX_CREATE_ATTEMPTS = 5;
+
+/** randomInt is unbiased (rejection-sampled), so each character is drawn
+ * uniformly from the 36-symbol alphabet — no modulo skew. */
+export function generateInboxToken(): InboxToken {
+	const chars = Array.from(
+		{ length: INBOX_TOKEN_LENGTH },
+		() => INBOX_TOKEN_ALPHABET[randomInt(INBOX_TOKEN_ALPHABET.length)],
+	);
+	return InboxTokenSchema.parse(chars.join(""));
+}
+
+export function buildInboxAddress(input: { token: InboxToken; domain: string }): InboxAddress {
+	return InboxAddressSchema.parse(`in-${input.token}@${input.domain}`);
+}

--- a/src/packages/domain/src/inbox/inbox-address.test.ts
+++ b/src/packages/domain/src/inbox/inbox-address.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import {
+	buildInboxAddress,
+	generateInboxToken,
+	INBOX_TOKEN_LENGTH,
+	InboxTokenSchema,
+} from "./inbox-address.schema";
+
+describe("generateInboxToken", () => {
+	it("produces a six-character lowercase base36 token", () => {
+		const token = generateInboxToken();
+		assert.match(token, /^[0-9a-z]{6}$/);
+		assert.equal(token.length, INBOX_TOKEN_LENGTH);
+	});
+
+	it("returns a value the token schema accepts", () => {
+		const token = generateInboxToken();
+		assert.equal(InboxTokenSchema.parse(token), token);
+	});
+});
+
+describe("buildInboxAddress", () => {
+	it("composes the local-part prefix, token, and domain into an address", () => {
+		const token = InboxTokenSchema.parse("3f9a2c");
+		assert.equal(
+			buildInboxAddress({ token, domain: "read.place" }),
+			"in-3f9a2c@read.place",
+		);
+	});
+
+	it("uses the supplied domain so per-environment domains render correctly", () => {
+		const token = InboxTokenSchema.parse("abc123");
+		assert.equal(
+			buildInboxAddress({ token, domain: "staging.read.place" }),
+			"in-abc123@staging.read.place",
+		);
+	});
+
+	it("accepts a freshly generated token", () => {
+		const address = buildInboxAddress({ token: generateInboxToken(), domain: "read.place" });
+		assert.match(address, /^in-[0-9a-z]{6}@read\.place$/);
+	});
+});

--- a/src/packages/domain/src/inbox/inbox-address.types.ts
+++ b/src/packages/domain/src/inbox/inbox-address.types.ts
@@ -1,0 +1,23 @@
+import type { UserId } from "../user";
+import type { InboxAddress, InboxToken } from "./inbox-address.schema";
+
+/** One forwarding address owned by a user. Addresses are never deleted — a hash
+ * that was once minted for one user must never be re-mintable for another, or
+ * their forwarded mail could leak — so disabling sets `disabledAt` and the row
+ * stays. `disabledAt === undefined` means the address is live. */
+export interface InboxAddressEntry {
+	address: InboxAddress;
+	userId: UserId;
+	token: InboxToken;
+	createdAt: string;
+	disabledAt: string | undefined;
+}
+
+export interface InboxAddressStore {
+	/** Mints a fresh address for the user. A user may hold many (one per
+	 * newsletter). Guards global uniqueness with a conditional put + bounded
+	 * retry; throws on retry exhaustion so the failure surfaces to alerting. */
+	createAddress: (input: { userId: UserId; domain: string }) => Promise<InboxAddressEntry>;
+	listAddressesByUserId: (userId: UserId) => Promise<InboxAddressEntry[]>;
+	disableAddress: (input: { userId: UserId; address: InboxAddress }) => Promise<void>;
+}

--- a/src/packages/domain/src/inbox/inbox-address.types.ts
+++ b/src/packages/domain/src/inbox/inbox-address.types.ts
@@ -18,6 +18,10 @@ export interface InboxAddressStore {
 	 * newsletter). Guards global uniqueness with a conditional put + bounded
 	 * retry; throws on retry exhaustion so the failure surfaces to alerting. */
 	createAddress: (input: { userId: UserId; domain: string }) => Promise<InboxAddressEntry>;
+	/** Every address the user owns (1:N). The production adapter reads a DynamoDB
+	 * GSI, which is eventually consistent — an address created moments earlier may
+	 * be absent from the result — so callers must not assume read-your-write. The
+	 * in-memory fixture is strongly consistent and so will not surface the lag. */
 	listAddressesByUserId: (userId: UserId) => Promise<InboxAddressEntry[]>;
 	disableAddress: (input: { userId: UserId; address: InboxAddress }) => Promise<void>;
 }

--- a/src/packages/domain/src/inbox/index.ts
+++ b/src/packages/domain/src/inbox/index.ts
@@ -1,0 +1,11 @@
+export type { InboxAddressEntry, InboxAddressStore } from "./inbox-address.types";
+export {
+	InboxTokenSchema,
+	type InboxToken,
+	InboxAddressSchema,
+	type InboxAddress,
+	INBOX_TOKEN_LENGTH,
+	INBOX_ADDRESS_MAX_CREATE_ATTEMPTS,
+	generateInboxToken,
+	buildInboxAddress,
+} from "./inbox-address.schema";

--- a/src/packages/domain/src/index.ts
+++ b/src/packages/domain/src/index.ts
@@ -3,4 +3,5 @@ export * from "./article-aggregate";
 export * from "./user";
 export * from "./oauth";
 export * from "./import-session";
+export * from "./inbox";
 export * from "./rate-limit";

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -93,6 +93,10 @@
       "types": "./dist/providers/import-session/index.d.ts",
       "default": "./dist/providers/import-session/index.js"
     },
+    "./providers/inbox-address": {
+      "types": "./dist/providers/inbox-address/index.d.ts",
+      "default": "./dist/providers/inbox-address/index.js"
+    },
     "./providers/oauth": {
       "types": "./dist/providers/oauth/index.d.ts",
       "default": "./dist/providers/oauth/index.js"
@@ -137,6 +141,7 @@
       "providers/subscription-providers": ["./dist/providers/subscription-providers/index.d.ts"],
       "providers/trial-scheduler": ["./dist/providers/trial-scheduler/index.d.ts"],
       "providers/import-session": ["./dist/providers/import-session/index.d.ts"],
+      "providers/inbox-address": ["./dist/providers/inbox-address/index.d.ts"],
       "providers/oauth": ["./dist/providers/oauth/index.d.ts"],
       "providers/events": ["./dist/providers/events/index.d.ts"],
       "providers/google-auth": ["./dist/providers/google-auth/index.d.ts"],

--- a/src/packages/test-fixtures/src/fixture.ts
+++ b/src/packages/test-fixtures/src/fixture.ts
@@ -25,6 +25,7 @@ import { initInMemoryStripeSubscriptions } from "./providers/stripe-subscription
 import { initInMemorySubscriptionProviders } from "./providers/subscription-providers/in-memory-subscription-providers";
 import { initInMemoryTrialScheduler } from "./providers/trial-scheduler/in-memory-trial-scheduler";
 import { initInMemoryImportSession } from "./providers/import-session/in-memory-import-session";
+import { initInMemoryInboxAddress } from "./providers/inbox-address/in-memory-inbox-address";
 import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import { initInMemorySaveLinkRawHtmlCommand } from "./providers/events/in-memory-save-link-raw-html-command";
 import { initInMemorySaveLinkRawPdfCommand } from "./providers/events/in-memory-save-link-raw-pdf-command";
@@ -379,6 +380,10 @@ export function createDefaultTestAppFixture(appOrigin: string): TestAppFixture {
 		importSession: {
 			importSessionStore: initInMemoryImportSession({ now: () => new Date() }),
 			extractLinksFromPageUrl: stubExtractLinksFromPageUrl,
+		},
+		inboxAddress: {
+			inboxAddressStore: initInMemoryInboxAddress({ now: () => new Date() }),
+			inboxAddressDomain: "read.place",
 		},
 		shared: {
 			validateSaveableUrl,

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
@@ -1,0 +1,66 @@
+import { UserIdSchema } from "@packages/domain/user";
+import { InboxAddressSchema } from "@packages/domain/inbox";
+import { initInMemoryInboxAddress } from "./in-memory-inbox-address";
+
+const owner = UserIdSchema.parse("00000000000000000000000000000001");
+const otherUser = UserIdSchema.parse("00000000000000000000000000000002");
+const DOMAIN = "read.place";
+
+describe("initInMemoryInboxAddress", () => {
+	it("creates an enabled address scoped to the owner", async () => {
+		const store = initInMemoryInboxAddress({
+			now: () => new Date("2026-06-23T00:00:00.000Z"),
+		});
+
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
+
+		expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+		expect(entry.userId).toBe(owner);
+		expect(entry.createdAt).toBe("2026-06-23T00:00:00.000Z");
+		expect(entry.disabledAt).toBeUndefined();
+	});
+
+	it("lists only the requesting user's addresses", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		await store.createAddress({ userId: owner, domain: DOMAIN });
+		await store.createAddress({ userId: owner, domain: DOMAIN });
+		await store.createAddress({ userId: otherUser, domain: DOMAIN });
+
+		const ownerAddresses = await store.listAddressesByUserId(owner);
+		const otherAddresses = await store.listAddressesByUserId(otherUser);
+
+		expect(ownerAddresses).toHaveLength(2);
+		expect(otherAddresses).toHaveLength(1);
+	});
+
+	it("disables an owned address by stamping disabledAt", async () => {
+		const store = initInMemoryInboxAddress({
+			now: () => new Date("2026-06-23T12:00:00.000Z"),
+		});
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
+
+		await store.disableAddress({ userId: owner, address: entry.address });
+
+		const [refreshed] = await store.listAddressesByUserId(owner);
+		expect(refreshed.disabledAt).toBe("2026-06-23T12:00:00.000Z");
+	});
+
+	it("ignores a disable for an address that does not exist", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		const missing = InboxAddressSchema.parse("in-3f9a2c@read.place");
+
+		await store.disableAddress({ userId: owner, address: missing });
+
+		expect(await store.listAddressesByUserId(owner)).toHaveLength(0);
+	});
+
+	it("ignores a disable requested by a non-owner", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
+
+		await store.disableAddress({ userId: otherUser, address: entry.address });
+
+		const [refreshed] = await store.listAddressesByUserId(owner);
+		expect(refreshed.disabledAt).toBeUndefined();
+	});
+});

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
@@ -1,0 +1,34 @@
+import {
+	buildInboxAddress,
+	generateInboxToken,
+	type InboxAddressEntry,
+	type InboxAddressStore,
+} from "@packages/domain/inbox";
+
+export function initInMemoryInboxAddress(deps: { now: () => Date }): InboxAddressStore {
+	const rows = new Map<string, InboxAddressEntry>();
+
+	return {
+		createAddress: async ({ userId, domain }) => {
+			const token = generateInboxToken();
+			const address = buildInboxAddress({ token, domain });
+			const entry: InboxAddressEntry = {
+				address,
+				userId,
+				token,
+				createdAt: deps.now().toISOString(),
+				disabledAt: undefined,
+			};
+			rows.set(address, entry);
+			return entry;
+		},
+		listAddressesByUserId: async (userId) =>
+			[...rows.values()].filter((row) => row.userId === userId),
+		disableAddress: async ({ userId, address }) => {
+			const row = rows.get(address);
+			if (row === undefined) return;
+			if (row.userId !== userId) return;
+			rows.set(address, { ...row, disabledAt: deps.now().toISOString() });
+		},
+	};
+}

--- a/src/packages/test-fixtures/src/providers/inbox-address/index.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/index.ts
@@ -1,0 +1,1 @@
+export * from "./in-memory-inbox-address";

--- a/src/packages/web-shell/src/banner-state.test.ts
+++ b/src/packages/web-shell/src/banner-state.test.ts
@@ -37,6 +37,12 @@ describe("bannerStateFromRequest", () => {
 	it("leaves currentPath undefined when the source carries no originalUrl", () => {
 		expect(bannerStateFromRequest({}).currentPath).toBeUndefined();
 	});
+
+	it("sets emailFeatureEnabled only when the query carries feature=email", () => {
+		expect(bannerStateFromRequest({ query: { feature: "email" } }).emailFeatureEnabled).toBe(true);
+		expect(bannerStateFromRequest({ query: { feature: "audio" } }).emailFeatureEnabled).toBe(false);
+		expect(bannerStateFromRequest({}).emailFeatureEnabled).toBe(false);
+	});
 });
 
 describe("buildGuestNavItems", () => {
@@ -66,7 +72,7 @@ describe("buildGuestNavItems", () => {
 
 describe("buildNavGroups", () => {
 	it("groups full-access items into Library (queue, import, export) and Account (account, sign out)", () => {
-		const groups = buildNavGroups({ accessIsReadOnly: false });
+		const groups = buildNavGroups({ accessIsReadOnly: false, emailFeatureEnabled: false });
 		expect(groups.map((g) => g.key)).toEqual(["library", "account"]);
 		const [library, account] = groups;
 		expect(library?.label).toBe("Library");
@@ -76,14 +82,22 @@ describe("buildNavGroups", () => {
 	});
 
 	it("omits import and account for a read-only user, leaving Library (queue, export) and Account (sign out)", () => {
-		const groups = buildNavGroups({ accessIsReadOnly: true });
+		const groups = buildNavGroups({ accessIsReadOnly: true, emailFeatureEnabled: false });
 		const [library, account] = groups;
 		expect(library?.items.map((i) => i.key)).toEqual(["queue", "export"]);
 		expect(account?.items.map((i) => i.key)).toEqual(["logout"]);
 	});
 
+	it("appends the Inbox entry to Library when the email feature is enabled", () => {
+		const groups = buildNavGroups({ accessIsReadOnly: false, emailFeatureEnabled: true });
+		const [library] = groups;
+		expect(library?.items.map((i) => i.key)).toEqual(["queue", "import", "export", "inbox"]);
+	});
+
 	it("assigns a Font Awesome solid icon to every nav item", () => {
-		const items = buildNavGroups({ accessIsReadOnly: false }).flatMap((g) => g.items);
+		const items = buildNavGroups({ accessIsReadOnly: false, emailFeatureEnabled: true }).flatMap(
+			(g) => g.items,
+		);
 		for (const item of items) {
 			expect(item.icon).toMatch(/^fa-solid fa-[a-z-]+$/);
 		}

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -92,6 +92,14 @@ export interface NavItem {
 	icon: string;
 	trackSource: string;
 	trackContent: string;
+	/** Extra query params the entry must deliver to its target, rendered as
+	 * hidden inputs beside the UTM trio. A GET submit serializes the form's
+	 * fields into the target's query string and discards the action's own query
+	 * (the same browser behaviour the UTM dual-transmission above works around),
+	 * so these inputs are how NAV_INBOX carries `feature=email` to the
+	 * flag-gated /inbox route — without them the gate 404s. Undefined for
+	 * entries that need no extra params. */
+	hiddenParams?: Record<string, string>;
 }
 
 const NAV_SOURCE = "header-nav";
@@ -105,6 +113,7 @@ function navItem(input: {
 	path: string;
 	method: "GET" | "POST";
 	icon: string;
+	hiddenParams?: Record<string, string>;
 }): NavItem {
 	return {
 		key: input.key,
@@ -114,6 +123,7 @@ function navItem(input: {
 		icon: input.icon,
 		trackSource: NAV_SOURCE,
 		trackContent: input.key,
+		hiddenParams: input.hiddenParams,
 	};
 }
 
@@ -176,7 +186,7 @@ export interface BannerState {
 const NAV_QUEUE = navItem({ key: "queue", label: "Queue", path: "/queue", method: "GET", icon: "fa-solid fa-inbox" });
 const NAV_IMPORT = navItem({ key: "import", label: "Import Links", path: "/import", method: "GET", icon: "fa-solid fa-file-import" });
 const NAV_EXPORT = navItem({ key: "export", label: "Export", path: "/export", method: "GET", icon: "fa-solid fa-file-export" });
-const NAV_INBOX = navItem({ key: "inbox", label: "Inbox", path: "/inbox", method: "GET", icon: "fa-solid fa-envelope" });
+const NAV_INBOX = navItem({ key: "inbox", label: "Inbox", path: "/inbox", method: "GET", icon: "fa-solid fa-envelope", hiddenParams: { feature: EMAIL_FEATURE } });
 const NAV_ACCOUNT = navItem({ key: "account", label: "Account", path: "/account", method: "GET", icon: "fa-solid fa-user" });
 const NAV_LOGOUT = navItem({ key: "logout", label: "Sign out", path: "/logout", method: "POST", icon: "fa-solid fa-right-from-bracket" });
 const NAV_INSTALL = navItem({ key: "install", label: "Install", path: "/install", method: "GET", icon: "fa-solid fa-download" });

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -35,17 +35,29 @@ export interface BannerStateSource {
 	 * post the page the reader is on (the dismiss route cannot rely on `Referer`,
 	 * which helmet's default `no-referrer` policy strips). */
 	originalUrl?: string;
+	/** The request's parsed query string. Express populates it on every request,
+	 * so passing the request as the source supplies it structurally;
+	 * `bannerStateFromRequest` reads `query.feature` to gate the email-feature
+	 * nav entry without the shell importing the host's feature toggle. */
+	query?: Record<string, unknown>;
 }
 
 export type NavItemKey =
 	| "queue"
 	| "import"
 	| "export"
+	| "inbox"
 	| "account"
 	| "logout"
 	| "install"
 	| "features"
 	| "signup";
+
+/** The querystring feature flag that reveals the email-forwarding surface. The
+ * single source of truth for the string, shared so the consuming site's route
+ * gate (`featureToggle.isEnabled(req, EMAIL_FEATURE)`) and this shell's nav
+ * derivation agree without the shell importing the host's feature toggle. */
+export const EMAIL_FEATURE = "email";
 
 /** Logical section a nav item belongs to. The header renders one section per
  * group so related destinations sit together and new destinations slot into an
@@ -155,11 +167,16 @@ export interface BannerState {
 	 * rendering site supplies no request URL; the dismiss route then falls back
 	 * to "/". */
 	currentPath?: string;
+	/** True when the request carries `?feature=email`. Reveals the Inbox nav
+	 * entry; the per-request querystring toggle keeps the surface hidden by
+	 * default until the flag is flipped on a request. */
+	emailFeatureEnabled?: boolean;
 }
 
 const NAV_QUEUE = navItem({ key: "queue", label: "Queue", path: "/queue", method: "GET", icon: "fa-solid fa-inbox" });
 const NAV_IMPORT = navItem({ key: "import", label: "Import Links", path: "/import", method: "GET", icon: "fa-solid fa-file-import" });
 const NAV_EXPORT = navItem({ key: "export", label: "Export", path: "/export", method: "GET", icon: "fa-solid fa-file-export" });
+const NAV_INBOX = navItem({ key: "inbox", label: "Inbox", path: "/inbox", method: "GET", icon: "fa-solid fa-envelope" });
 const NAV_ACCOUNT = navItem({ key: "account", label: "Account", path: "/account", method: "GET", icon: "fa-solid fa-user" });
 const NAV_LOGOUT = navItem({ key: "logout", label: "Sign out", path: "/logout", method: "POST", icon: "fa-solid fa-right-from-bracket" });
 const NAV_INSTALL = navItem({ key: "install", label: "Install", path: "/install", method: "GET", icon: "fa-solid fa-download" });
@@ -180,12 +197,16 @@ export function buildGuestNavItems(): NavItem[] {
  * rendered order stays queue → import → export → account → logout. */
 export function buildNavGroups(input: {
 	accessIsReadOnly: boolean;
+	emailFeatureEnabled: boolean;
 }): NavGroup[] {
 	const library: NavItem[] = [NAV_QUEUE];
 	if (!input.accessIsReadOnly) {
 		library.push(NAV_IMPORT);
 	}
 	library.push(NAV_EXPORT);
+	if (input.emailFeatureEnabled) {
+		library.push(NAV_INBOX);
+	}
 	const account: NavItem[] = [];
 	if (!input.accessIsReadOnly) {
 		account.push(NAV_ACCOUNT);
@@ -203,5 +224,6 @@ export function bannerStateFromRequest(source: BannerStateSource): BannerState {
 		emailVerified: source.emailVerified,
 		verification: source.verificationStatus,
 		currentPath: source.originalUrl,
+		emailFeatureEnabled: source.query?.feature === EMAIL_FEATURE,
 	};
 }

--- a/src/packages/web-shell/src/base.component.ts
+++ b/src/packages/web-shell/src/base.component.ts
@@ -269,6 +269,7 @@ export function initBase(config: BaseConfig): RenderBase {
 				variant: headerVariant,
 				isAuthenticated: state.isAuthenticated,
 				accessIsReadOnly: state.accessIsReadOnly ?? false,
+				emailFeatureEnabled: state.emailFeatureEnabled ?? false,
 				trialCounter: state.trial,
 			}),
 			content: injectPageStylesIntoMain(body.content.html, body.styles),

--- a/src/packages/web-shell/src/index.ts
+++ b/src/packages/web-shell/src/index.ts
@@ -23,6 +23,7 @@ export {
 	bannerStateFromRequest,
 	buildGuestNavItems,
 	buildNavGroups,
+	EMAIL_FEATURE,
 } from "./banner-state";
 export type {
 	BannerState,

--- a/src/packages/web-shell/src/nav.component.test.ts
+++ b/src/packages/web-shell/src/nav.component.test.ts
@@ -150,6 +150,23 @@ describe("Nav component", () => {
 		expect(libraryItems).toEqual(["queue", "import", "export", "inbox"]);
 	});
 
+	it("carries feature=email as a hidden input on the Inbox entry so its GET form keeps the gate flag", () => {
+		const doc = parse(
+			Nav({ variant: "default", isAuthenticated: true, accessIsReadOnly: false, emailFeatureEnabled: true }),
+		);
+
+		const inboxForm = doc.querySelector('[data-test-nav-item="inbox"]')?.closest("form");
+		assert(inboxForm, "inbox nav item must be inside a form");
+		expect(inboxForm.getAttribute("method")).toBe("GET");
+		const feature = inboxForm.querySelector('input[type="hidden"][name="feature"]');
+		assert(feature, "inbox form must carry the feature flag as a hidden input");
+		expect(feature.getAttribute("value")).toBe("email");
+
+		const queueForm = doc.querySelector('[data-test-nav-item="queue"]')?.closest("form");
+		assert(queueForm, "queue nav item must be inside a form");
+		expect(queueForm.querySelector('input[type="hidden"][name="feature"]')).toBeNull();
+	});
+
 	it("renders an aria-hidden Font Awesome icon alongside each label without polluting the accessible name", () => {
 		const doc = parse(
 			Nav({

--- a/src/packages/web-shell/src/nav.component.test.ts
+++ b/src/packages/web-shell/src/nav.component.test.ts
@@ -22,6 +22,7 @@ describe("Nav component", () => {
 				variant: "default",
 				isAuthenticated: true,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 			}),
 		);
 
@@ -38,6 +39,7 @@ describe("Nav component", () => {
 				variant: "default",
 				isAuthenticated: true,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 				trialCounter: ACTIVE_TRIAL,
 			}),
 		);
@@ -59,6 +61,7 @@ describe("Nav component", () => {
 				variant: "default",
 				isAuthenticated: true,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 				trialCounter: { state: "expired" },
 			}),
 		);
@@ -78,6 +81,7 @@ describe("Nav component", () => {
 				variant: "default",
 				isAuthenticated: true,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 			}),
 		);
 
@@ -101,6 +105,7 @@ describe("Nav component", () => {
 				variant: "default",
 				isAuthenticated: true,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 			}),
 		);
 
@@ -126,12 +131,32 @@ describe("Nav component", () => {
 		expect(accountItems).toEqual(["account", "logout"]);
 	});
 
+	it("omits the Inbox entry by default and appends it after Export when the email feature is enabled", () => {
+		const withoutFlag = Array.from(
+			parse(
+				Nav({ variant: "default", isAuthenticated: true, accessIsReadOnly: false, emailFeatureEnabled: false }),
+			).querySelectorAll("[data-test-nav-item]"),
+		).map((el) => el.getAttribute("data-test-nav-item"));
+		expect(withoutFlag).not.toContain("inbox");
+
+		const withFlag = parse(
+			Nav({ variant: "default", isAuthenticated: true, accessIsReadOnly: false, emailFeatureEnabled: true }),
+		);
+		const libraryItems = Array.from(
+			withFlag
+				.querySelector('[data-test-nav-group="library"]')
+				?.querySelectorAll("[data-test-nav-item]") ?? [],
+		).map((el) => el.getAttribute("data-test-nav-item"));
+		expect(libraryItems).toEqual(["queue", "import", "export", "inbox"]);
+	});
+
 	it("renders an aria-hidden Font Awesome icon alongside each label without polluting the accessible name", () => {
 		const doc = parse(
 			Nav({
 				variant: "default",
 				isAuthenticated: true,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 			}),
 		);
 
@@ -150,6 +175,7 @@ describe("Nav component", () => {
 				variant: "default",
 				isAuthenticated: false,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 			}),
 		);
 
@@ -174,6 +200,7 @@ describe("Nav component", () => {
 				variant: "transparent",
 				isAuthenticated: false,
 				accessIsReadOnly: false,
+				emailFeatureEnabled: false,
 			}),
 		);
 

--- a/src/packages/web-shell/src/nav.component.ts
+++ b/src/packages/web-shell/src/nav.component.ts
@@ -7,6 +7,9 @@ export interface NavProps {
 	variant: "default" | "transparent";
 	isAuthenticated: boolean;
 	accessIsReadOnly: boolean;
+	/** When true, the authenticated nav includes the Inbox entry. Gated by the
+	 * per-request `?feature=email` toggle so the surface stays hidden by default. */
+	emailFeatureEnabled: boolean;
 	/** Absence means the user is not on a trial — no countdown rendered.
 	 * Pre-auth pages (login, signup, forgot-password) build banner state from
 	 * the request synchronously and never populate this field, which is correct:
@@ -44,7 +47,10 @@ export function Nav(props: NavProps): string {
 		trialEndsAtIso: endsAtIsoFor(trial),
 		serverNowIso: serverNowIsoFor(trial),
 		navGroups: props.isAuthenticated
-			? buildNavGroups({ accessIsReadOnly: props.accessIsReadOnly })
+			? buildNavGroups({
+					accessIsReadOnly: props.accessIsReadOnly,
+					emailFeatureEnabled: props.emailFeatureEnabled,
+				})
 			: undefined,
 		navItems: props.isAuthenticated ? undefined : buildGuestNavItems(),
 		navVariant: props.isAuthenticated ? "authenticated" : "guest",

--- a/src/packages/web-shell/src/nav.template.ts
+++ b/src/packages/web-shell/src/nav.template.ts
@@ -27,6 +27,7 @@ export const NAV_TEMPLATE = `  <header class="header{{#if transparent}} header--
                   <input type="hidden" name="utm_source" value="{{trackSource}}">
                   <input type="hidden" name="utm_medium" value="internal">
                   <input type="hidden" name="utm_content" value="{{trackContent}}">
+                  {{#each hiddenParams}}<input type="hidden" name="{{@key}}" value="{{this}}">{{/each}}
                   <button type="submit" class="nav__link" data-test-nav-item="{{key}}"><i class="nav__icon {{icon}}" aria-hidden="true"></i><span class="nav__label">{{label}}</span></button>
                 </form>
               </li>
@@ -41,6 +42,7 @@ export const NAV_TEMPLATE = `  <header class="header{{#if transparent}} header--
               <input type="hidden" name="utm_source" value="{{trackSource}}">
               <input type="hidden" name="utm_medium" value="internal">
               <input type="hidden" name="utm_content" value="{{trackContent}}">
+              {{#each hiddenParams}}<input type="hidden" name="{{@key}}" value="{{this}}">{{/each}}
               <button type="submit" class="nav__link" data-test-nav-item="{{key}}"><i class="nav__icon {{icon}}" aria-hidden="true"></i><span class="nav__label">{{label}}</span></button>
             </form>
           </li>

--- a/src/packages/web-test-harness/src/bundle.types.ts
+++ b/src/packages/web-test-harness/src/bundle.types.ts
@@ -3,6 +3,7 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import type { LogParseError } from "@packages/hutch-infra-components";
 import type { ArticleMetadata, Minutes, ValidateSaveableUrl } from "@packages/domain/article";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import type { InboxAddressStore } from "@packages/domain/inbox";
 import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
 import type { ParseArticle } from "@packages/article-parser";
 import type {
@@ -307,6 +308,11 @@ export interface ImportSessionBundle {
 	extractLinksFromPageUrl: ExtractLinksFromPageUrl;
 }
 
+export interface InboxAddressBundle {
+	inboxAddressStore: InboxAddressStore;
+	inboxAddressDomain: string;
+}
+
 export interface BotDefenseBundle {
 	logger: HutchLogger.Typed<BotDefenseEvent>;
 	events: BotDefenseEvent[];
@@ -344,6 +350,7 @@ export interface TestAppFixture {
 	google: GoogleAuthBundle | undefined;
 	admin: AdminBundle;
 	importSession: ImportSessionBundle;
+	inboxAddress: InboxAddressBundle;
 	shared: SharedBundle;
 	stripe: StripeCheckoutBundle;
 	pendingSignup: PendingSignupBundle;

--- a/src/packages/web-test-harness/src/index.ts
+++ b/src/packages/web-test-harness/src/index.ts
@@ -13,6 +13,7 @@ export type {
 	GoogleAuthBundle,
 	HttpErrorMessageMapping,
 	ImportSessionBundle,
+	InboxAddressBundle,
 	OAuthBundle,
 	ParserBundle,
 	PasswordResetBundle,


### PR DESCRIPTION
## Email Forwarding — Milestone 1

Lays the foundation for the email-forwarding feature: every user gets opaque forwarding addresses `in-<token>@<domain>`. **M1 builds only the address itself** — minting, listing, disabling, and displaying it. Nothing receives or parses mail yet (that's M2+).

Everything is **hidden by default** behind the existing per-request `?feature=email` toggle, so production traffic sees no new surface until the flag is flipped on a request. The flag gates *visibility*, never *quality* — the table, store, error handling, and tests are all production-grade.

### What a flagged user can do
Open the new **Inbox** nav entry → land on **"Your forwarding addresses"** → see their addresses, **copy** each, **create** more (one per newsletter), and **disable** ones they no longer want.

### Deliverable 1 — token + mapping (internal)
- **Domain** (`@packages/domain/inbox`): branded `InboxToken` / `InboxAddress` zod schemas, a 6-char lowercase base36 token generator (`randomInt`, unbiased), and a pure `buildInboxAddress({ token, domain })`.
- **Store** (`inbox-addresses` DynamoDB table): PK `address` (globally unique; answers the future receive-path lookup), GSI `userId-index` (lists a user's addresses — **1:N**). `createAddress` does a conditional put `attribute_not_exists(address)` with bounded retry, **throwing on exhaustion** so the failure surfaces to alerting. Addresses are **never deleted** — a freed hash could be re-minted for another user and leak their mail — so `disableAddress` stamps a nullable `disabledAt` and the row stays.
- **Provisioning at signup**: one address is auto-created at account creation, wired once at the `createApp` composition seam so **all** signup paths (password, trial, checkout, Google) are covered. Best-effort: a failure is logged for alerting but never blocks signup.

### Deliverable 2 — gated page + nav
- `emailFeatureEnabled` threads `BannerState → NavProps → buildNavGroups`; the shell re-derives it from the request query (no cross-project import — `EMAIL_FEATURE` is the single shared constant).
- `/inbox` route (GET list, POST create, POST disable) 404s without the flag. Manage-addresses page is HTML-only and `noindex`.
- **Copy** uses a zero-JS baseline (selectable read-only field) plus a progressive-enhancement button revealed only when `navigator.clipboard` exists.

### Decisions reflected (J1–J6)
| | |
|---|---|
| Domain | prod `read.place`, staging `staging.read.place` (subdomain whose MX can point at SES independently in M2) |
| Prefix / token | `in-` + 6-char base36 — shortest memorable form |
| Backfill | none; new accounts auto-create one, empty state shows a **Create Inbox Email** CTA |
| Collisions | conditional put + retry → throw (alerting) + graceful UI error |
| Lifecycle | disable via `disabledAt`, never delete |
| Flag | per-request only, but fully production-ready |

### Out of scope (M2+)
Inbound mail (SES/MX, receive Lambda, parsing), stored emails, the email-list/detail pages, link crawling, quarantine/rate-limits, and a persistent flag store.

### Testing
`pnpm check` green across all 31 projects (type-check, lint, tests, coverage, knip, unused-css); infra type-checks clean. New unit/integration/component/client tests cover the store retry loop, the gated route (404 vs 200, create, disable owned/invalid/non-owned), nav visibility, copy-to-clipboard, and signup provisioning (including the best-effort failure path).

### ⚠️ One thing to confirm
I set `INBOX_ADDRESS_DOMAIN` to **`read.place`** (prod) and **`staging.read.place`** (staging) in the Pulumi stack configs, and `read.place` in `.envrc` for local dev. Since you own `read.place`, change the staging value if you'd prefer a different testable subdomain — it must be the real eventual *receive* domain per env so addresses don't need re-minting later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZHuNK5kneRfXGtqiVJSsk)_