### PR TITLE
feat(hutch): bridge bearer auth to a session cookie for in-app webviews (server — deploy first)

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -693,6 +693,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		createUserWithPasswordHash: deps.createUserWithPasswordHash,
 		findUserByEmail: deps.findUserByEmail,
 		verifyCredentials: deps.verifyCredentials,
+		validateAccessToken: deps.validateAccessToken,
 		createSession: deps.createSession,
 		destroySession: deps.destroySession,
 		countUsers,

--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert";
 import request from "supertest";
-import type { Token } from "@node-oauth/oauth2-server";
 import { useTestServer } from "../../test-app";
-import type { TestAppHarness } from "../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -14,37 +12,8 @@ import {
 } from "@packages/test-fixtures";
 import { initReadabilityParser } from "@packages/article-parser";
 
-import { UserIdSchema } from "@packages/domain/user";
 import { SIREN_MEDIA_TYPE } from "./siren";
-
-const TEST_USER_ID = UserIdSchema.parse("test-user-123");
-
-function createTestToken(): Token {
-	return {
-		accessToken: "test-access-token",
-		accessTokenExpiresAt: new Date(Date.now() + 3600000),
-		refreshToken: "test-refresh-token",
-		refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
-		client: {
-			id: "hutch-firefox-extension",
-			grants: ["authorization_code", "refresh_token"],
-			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
-		},
-		user: { id: TEST_USER_ID },
-	};
-}
-
-async function createAccessToken(
-	harness: TestAppHarness,
-): Promise<string> {
-	const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
-	assert(client, "Test client must exist");
-
-	const testToken = createTestToken();
-	const token = await harness.oauthModel.saveToken(testToken, client, { id: TEST_USER_ID });
-	assert(token, "Token should be saved");
-	return token.accessToken;
-}
+import { createAccessToken, saveAccessTokenForUser } from "../test-helpers/oauth-token";
 
 const useApp = useTestServer();
 
@@ -96,17 +65,12 @@ describe("GET /queue (Siren content negotiation)", () => {
 		assert(loginResult.ok);
 		const userId = loginResult.userId;
 
-		const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
-		assert(client);
-		const userToken = createTestToken();
-		userToken.user = { id: userId };
-		const token = await harness.oauthModel.saveToken(userToken, client, { id: userId });
-		assert(token);
+		const accessToken = await saveAccessTokenForUser(harness, userId);
 
 		const response = await request(harness.server)
 			.get("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
-			.set("Authorization", `Bearer ${token.accessToken}`);
+			.set("Authorization", `Bearer ${accessToken}`);
 
 		expect(response.status).toBe(200);
 		expect(response.body.properties.total).toBe(1);
@@ -359,16 +323,12 @@ describe("POST /queue (Siren save article)", () => {
 					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
 			},
 		});
-		const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
-		assert(client);
-		const testToken = createTestToken();
-		const token = await harness.oauthModel.saveToken(testToken, client, { id: TEST_USER_ID });
-		assert(token);
+		const accessToken = await createAccessToken(harness);
 
 		const response = await request(harness.server)
 			.post("/queue")
 			.set("Accept", SIREN_MEDIA_TYPE)
-			.set("Authorization", `Bearer ${token.accessToken}`)
+			.set("Authorization", `Bearer ${accessToken}`)
 			.set("Content-Type", "application/json")
 			.send({ url: "https://example.com/broken" });
 
@@ -393,6 +353,27 @@ describe("POST /queue (Siren save article)", () => {
 		assert(deleteAction, "expected delete action");
 		expect(deleteAction.method).toBe("POST");
 		expect(deleteAction.href).toContain("/delete");
+	});
+
+	it("includes update-status action on saved article", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
+
+		const response = await request(harness.server)
+			.post("/queue")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.set("Authorization", `Bearer ${accessToken}`)
+			.set("Content-Type", "application/json")
+			.send({ url: "https://example.com/article" });
+
+		const updateStatus = response.body.actions?.find(
+			(a: { name: string }) => a.name === "update-status",
+		);
+		assert(updateStatus, "expected update-status action");
+		expect(updateStatus.method).toBe("POST");
+		expect(updateStatus.href).toContain("/status");
+		expect(updateStatus.type).toBe("application/x-www-form-urlencoded");
+		expect(updateStatus.fields).toEqual([{ name: "status", type: "text" }]);
 	});
 });
 

--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -689,6 +689,33 @@ describe("Article sub-entity actions", () => {
 		expect(deleteAction.method).toBe("POST");
 		expect(deleteAction.href).toContain("/delete");
 	});
+
+	it("includes update-status action on article sub-entities in collection", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const accessToken = await createAccessToken(harness);
+
+		await request(harness.server)
+			.post("/queue")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.set("Authorization", `Bearer ${accessToken}`)
+			.set("Content-Type", "application/json")
+			.send({ url: "https://example.com/article" });
+
+		const response = await request(harness.server)
+			.get("/queue")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.set("Authorization", `Bearer ${accessToken}`);
+
+		const entity = response.body.entities[0];
+		const updateStatus = entity.actions?.find(
+			(a: { name: string }) => a.name === "update-status",
+		);
+		assert(updateStatus, "expected update-status action on sub-entity");
+		expect(updateStatus.method).toBe("POST");
+		expect(updateStatus.href).toContain("/status");
+		expect(updateStatus.type).toBe("application/x-www-form-urlencoded");
+		expect(updateStatus.fields).toEqual([{ name: "status", type: "text" }]);
+	});
 });
 
 describe("Content negotiation", () => {

--- a/projects/hutch/src/runtime/web/api/article-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.test.ts
@@ -55,7 +55,38 @@ describe("toArticleSubEntity", () => {
 			links: [
 				{ rel: ["read"], href: `/queue/${ARTICLE_ID}/view` },
 			],
-			actions: [{ name: "delete", href: `/queue/${ARTICLE_ID}/delete`, method: "POST" }],
+			actions: [
+				{ name: "delete", href: `/queue/${ARTICLE_ID}/delete`, method: "POST" },
+				{
+					name: "update-status",
+					href: `/queue/${ARTICLE_ID}/status`,
+					method: "POST",
+					type: "application/x-www-form-urlencoded",
+					fields: [{ name: "status", type: "text" }],
+				},
+			],
+		});
+	});
+
+	it("retains the delete action the browser extension consumes", () => {
+		const subEntity = toArticleSubEntity(makeArticle());
+		const deleteAction = subEntity.actions?.find((a) => a.name === "delete");
+		expect(deleteAction).toEqual({
+			name: "delete",
+			href: `/queue/${ARTICLE_ID}/delete`,
+			method: "POST",
+		});
+	});
+
+	it("emits an update-status action posting the status field as urlencoded", () => {
+		const subEntity = toArticleSubEntity(makeArticle());
+		const updateStatus = subEntity.actions?.find((a) => a.name === "update-status");
+		expect(updateStatus).toEqual({
+			name: "update-status",
+			href: `/queue/${ARTICLE_ID}/status`,
+			method: "POST",
+			type: "application/x-www-form-urlencoded",
+			fields: [{ name: "status", type: "text" }],
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/api/article-siren.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.ts
@@ -30,6 +30,13 @@ export function toArticleSubEntity(article: SavedArticle): SirenSubEntity {
 				href: `/queue/${id}/delete`,
 				method: "POST",
 			},
+			{
+				name: "update-status",
+				href: `/queue/${id}/status`,
+				method: "POST",
+				type: "application/x-www-form-urlencoded",
+				fields: [{ name: "status", type: "text" }],
+			},
 		],
 	};
 }

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -13,6 +13,8 @@ import type {
 	VerifyCredentials,
 } from "@packages/provider-contracts/auth";
 import type { UserId } from "@packages/domain/user";
+import type { ValidateAccessToken } from "@packages/provider-contracts/oauth";
+import { AccessTokenSchema } from "@packages/domain/oauth";
 import type { SendEmail } from "@packages/provider-contracts/email";
 import type {
 	CreateVerificationToken,
@@ -75,6 +77,7 @@ interface AuthDependencies {
 	createUserWithPasswordHash: CreateUserWithPasswordHash;
 	findUserByEmail: FindUserByEmail;
 	verifyCredentials: VerifyCredentials;
+	validateAccessToken: ValidateAccessToken;
 	createSession: CreateSession;
 	destroySession: DestroySession;
 	countUsers: CountUsers;
@@ -438,6 +441,33 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		}
 
 		sendComponent(req, res, Base(VerifyEmailPage({ success: true }), await deps.buildBannerState(req)));
+	});
+
+	/** Mints a browser session cookie from a valid OAuth bearer token so a native
+	 * client's in-app webview can reach cookie-authenticated pages — the reader at
+	 * /queue/:id/view and its htmx poll/mutation XHRs resolve ownership from the
+	 * hutch_sid session, never from a bearer. Grants no new privilege (the bearer
+	 * already authorizes the full API) and is CSRF-safe because browsers never
+	 * auto-attach bearer tokens. The auth router is not behind dualAuth, so the
+	 * endpoint validates the bearer itself; 204 with no redirect keeps it free of
+	 * an open-redirect surface and reusable for any future authenticated webview. */
+	router.post("/auth/session", async (req: Request, res: Response) => {
+		const header = req.headers.authorization;
+		if (!header?.startsWith("Bearer ")) {
+			res.status(401).set("WWW-Authenticate", "Bearer").end();
+			return;
+		}
+		const validated = await deps.validateAccessToken(AccessTokenSchema.parse(header.slice(7)));
+		if (!validated) {
+			res.status(401).set("WWW-Authenticate", 'Bearer error="invalid_token"').end();
+			return;
+		}
+		const sessionId = await deps.createSession({
+			userId: validated.userId,
+			emailVerified: validated.emailVerified,
+		});
+		res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
+		res.status(204).end();
 	});
 
 	router.post("/logout", async (req: Request, res: Response) => {

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -1,46 +1,19 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import type { Token } from "@node-oauth/oauth2-server";
 import { useTestServer } from "../../test-app";
-import type { TestAppHarness } from "../../test-app";
 
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
-import { UserIdSchema } from "@packages/domain/user";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
+import { createAccessToken, saveAccessTokenForUser } from "../test-helpers/oauth-token";
 import { DISPOSABLE_EMAIL_MESSAGE } from "./disposable-email";
 import { SESSION_COOKIE_NAME } from "./session-cookie";
 
 const TEST_FOUNDING_MEMBER_LIMIT = 3;
-
-const TEST_USER_ID = UserIdSchema.parse("test-user-123");
-
-function createTestToken(): Token {
-	return {
-		accessToken: "test-access-token",
-		accessTokenExpiresAt: new Date(Date.now() + 3600000),
-		refreshToken: "test-refresh-token",
-		refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
-		client: {
-			id: "hutch-firefox-extension",
-			grants: ["authorization_code", "refresh_token"],
-			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
-		},
-		user: { id: TEST_USER_ID },
-	};
-}
-
-async function createAccessToken(harness: TestAppHarness): Promise<string> {
-	const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
-	assert(client, "Test client must exist");
-	const token = await harness.oauthModel.saveToken(createTestToken(), client, { id: TEST_USER_ID });
-	assert(token, "Token should be saved");
-	return token.accessToken;
-}
 
 function sessionCookie(response: request.Response): string | undefined {
 	const setCookie = response.headers["set-cookie"];
@@ -1078,17 +1051,12 @@ describe("Auth routes", () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const created = await harness.auth.createUser({ email: "webview@example.com", password: "password123" });
 			assert(created.ok, "user must be created");
-			const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
-			assert(client, "Test client must exist");
-			const userToken = createTestToken();
-			userToken.user = { id: created.userId };
-			const token = await harness.oauthModel.saveToken(userToken, client, { id: created.userId });
-			assert(token, "Token should be saved");
+			const accessToken = await saveAccessTokenForUser(harness, created.userId);
 
 			const agent = request.agent(harness.server);
 			const sessionResponse = await agent
 				.post("/auth/session")
-				.set("Authorization", `Bearer ${token.accessToken}`);
+				.set("Authorization", `Bearer ${accessToken}`);
 			expect(sessionResponse.status).toBe(204);
 
 			const queueResponse = await agent.get("/queue").set("Accept", "text/html");

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -1,17 +1,52 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
+import type { Token } from "@node-oauth/oauth2-server";
 import { useTestServer } from "../../test-app";
+import type { TestAppHarness } from "../../test-app";
 
 import { CheckoutSessionIdSchema } from "@packages/test-fixtures/providers/stripe-checkout";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
+import { UserIdSchema } from "@packages/domain/user";
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 import { DISPOSABLE_EMAIL_MESSAGE } from "./disposable-email";
+import { SESSION_COOKIE_NAME } from "./session-cookie";
 
 const TEST_FOUNDING_MEMBER_LIMIT = 3;
+
+const TEST_USER_ID = UserIdSchema.parse("test-user-123");
+
+function createTestToken(): Token {
+	return {
+		accessToken: "test-access-token",
+		accessTokenExpiresAt: new Date(Date.now() + 3600000),
+		refreshToken: "test-refresh-token",
+		refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
+		client: {
+			id: "hutch-firefox-extension",
+			grants: ["authorization_code", "refresh_token"],
+			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
+		},
+		user: { id: TEST_USER_ID },
+	};
+}
+
+async function createAccessToken(harness: TestAppHarness): Promise<string> {
+	const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
+	assert(client, "Test client must exist");
+	const token = await harness.oauthModel.saveToken(createTestToken(), client, { id: TEST_USER_ID });
+	assert(token, "Token should be saved");
+	return token.accessToken;
+}
+
+function sessionCookie(response: request.Response): string | undefined {
+	const setCookie = response.headers["set-cookie"];
+	const cookies = Array.isArray(setCookie) ? setCookie : [];
+	return cookies.find((c) => c.startsWith(`${SESSION_COOKIE_NAME}=`));
+}
 
 /** A loadedAt value safely older than the bot-defense minimum submit window
  * (2.5s), so the form submission passes the timing gate. */
@@ -999,6 +1034,65 @@ describe("Auth routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/");
+		});
+	});
+
+	describe("POST /auth/session", () => {
+		it("mints an httpOnly session cookie from a valid bearer token and returns 204", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const accessToken = await createAccessToken(harness);
+
+			const response = await request(harness.server)
+				.post("/auth/session")
+				.set("Authorization", `Bearer ${accessToken}`);
+
+			expect(response.status).toBe(204);
+			const cookie = sessionCookie(response);
+			assert(cookie, "expected the hutch_sid session cookie");
+			expect(cookie).toContain("HttpOnly");
+			expect(cookie).toContain("Path=/");
+			expect(cookie).toContain("SameSite=Lax");
+		});
+
+		it("returns 401 and mints no session cookie when no Authorization header is present", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).post("/auth/session");
+
+			expect(response.status).toBe(401);
+			expect(sessionCookie(response)).toBeUndefined();
+		});
+
+		it("returns 401 and mints no session cookie for an invalid bearer token", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server)
+				.post("/auth/session")
+				.set("Authorization", "Bearer not-a-real-token");
+
+			expect(response.status).toBe(401);
+			expect(sessionCookie(response)).toBeUndefined();
+		});
+
+		it("mints a session that authenticates a subsequent browser request", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const created = await harness.auth.createUser({ email: "webview@example.com", password: "password123" });
+			assert(created.ok, "user must be created");
+			const client = await harness.oauthModel.getClient("hutch-firefox-extension", "");
+			assert(client, "Test client must exist");
+			const userToken = createTestToken();
+			userToken.user = { id: created.userId };
+			const token = await harness.oauthModel.saveToken(userToken, client, { id: created.userId });
+			assert(token, "Token should be saved");
+
+			const agent = request.agent(harness.server);
+			const sessionResponse = await agent
+				.post("/auth/session")
+				.set("Authorization", `Bearer ${token.accessToken}`);
+			expect(sessionResponse.status).toBe(204);
+
+			const queueResponse = await agent.get("/queue").set("Accept", "text/html");
+			expect(queueResponse.status).toBe(200);
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/test-helpers/oauth-token.ts
+++ b/projects/hutch/src/runtime/web/test-helpers/oauth-token.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import type { Token } from "@node-oauth/oauth2-server";
+import { type UserId, UserIdSchema } from "@packages/domain/user";
+import type { TestAppHarness } from "../../test-app";
+
+const EXTENSION_CLIENT_ID = "hutch-firefox-extension";
+const TEST_USER_ID = UserIdSchema.parse("test-user-123");
+
+function createTestToken(userId: UserId): Token {
+	return {
+		accessToken: "test-access-token",
+		accessTokenExpiresAt: new Date(Date.now() + 3600000),
+		refreshToken: "test-refresh-token",
+		refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 3600000),
+		client: {
+			id: EXTENSION_CLIENT_ID,
+			grants: ["authorization_code", "refresh_token"],
+			redirectUris: ["http://127.0.0.1:3000/oauth/callback"],
+		},
+		user: { id: userId },
+	};
+}
+
+/** Mints a bearer for `userId` directly through the harness's in-memory OAuth
+ * model. Route tests only need a token the API will accept, so this skips the
+ * PKCE authorize/token exchange that the `*.integration.ts` suites drive on
+ * purpose to cover the real grant flow. */
+export async function saveAccessTokenForUser(
+	harness: TestAppHarness,
+	userId: UserId,
+): Promise<string> {
+	const client = await harness.oauthModel.getClient(EXTENSION_CLIENT_ID, "");
+	assert(client, "Test OAuth client must exist");
+	const token = await harness.oauthModel.saveToken(createTestToken(userId), client, { id: userId });
+	assert(token, "Token should be saved");
+	return token.accessToken;
+}
+
+/** Bearer for the well-known test user — the common case for tests that don't
+ * assert anything about which user owns the token. */
+export function createAccessToken(harness: TestAppHarness): Promise<string> {
+	return saveAccessTokenForUser(harness, TEST_USER_ID);
+}


### PR DESCRIPTION
## iOS EPIC 3 — Server half (deploy this first)

> [!IMPORTANT]
> **Deploy ordering: this server PR must ship and deploy *before* the iOS client PR.**
> Both changes are additive, so this is safe to deploy on its own — older shipped
> clients ignore the new action and endpoint. The iOS TestFlight build depends on
> the `update-status` action and `POST /auth/session` existing in production.
> **Client PR (deploy second): #789** (`claude/sleepy-archimedes-6glo4d-ios`).

### Context
TestFlight feedback asked for *swipe-to-mark-read* and an *in-app authenticated reader* (Readplace reader + AI summary) instead of opening the original source site. The reader page (`/queue/:id/view`) and its htmx poll/mutation XHRs are **cookie-session** authenticated (`hutch_sid`), but the iOS app only holds an **OAuth bearer** token. This PR adds the two additive server surfaces that bridge that gap; the iOS client consumes them in #789.

### Changes
- **`update-status` Siren action** on each saved-article sub-entity (`article-siren.ts`). Entity-level, posts `status` as `application/x-www-form-urlencoded` to the existing `POST /queue/:id/status` route (no route change needed — it already validates `req.body.status` via `ArticleStatusSchema` and 303-redirects). The browser extension's `delete` action is **retained** alongside it.
  - Named `update-status` (capability), not `mark-read` (domain state), per the extension-api-design skill.
- **`POST /auth/session`** (`auth.page.ts`): reads `Authorization: Bearer`, validates it with `validateAccessToken`, mints a session via `createSession`, sets the `hutch_sid` cookie (reusing the existing `sessionCookieOptions`), and returns **204** (no body, no redirect). 401 on missing/invalid bearer.
  - Grants **no new privilege** — the bearer already authorizes the full API. CSRF-safe (browsers never auto-attach bearer tokens). Cookie is httpOnly, host-scoped, `SameSite=Lax`, and `Secure` in HTTPS deployments. No `:id` coupling and no redirect → no open-redirect surface, reusable for any future authenticated webview.
  - Wires `validateAccessToken` into `initAuthRoutes` (`server.ts`); the value already existed at the composition root.

No new env vars, no Lambda/EventBridge changes.

### Tests (all green via `pnpm nx run hutch:check`)
- `article-siren.test.ts`: asserts `update-status` is emitted (name/href/method/type/`status` field) **and** `delete` is retained.
- `api.routes.test.ts`: asserts `update-status` on article sub-entities in a live collection response.
- `auth.route.test.ts`: `POST /auth/session` — valid bearer → 204 + `Set-Cookie: hutch_sid`; missing/invalid bearer → 401 with no session cookie; plus an end-to-end test that the minted cookie authenticates a subsequent browser request.

### Verification
```
pnpm nx run hutch:check          # ✅ lint + tests + 100% coverage thresholds
curl -i -X POST $ORIGIN/auth/session -H "Authorization: Bearer <token>"   # → 204 + Set-Cookie: hutch_sid
# replay that cookie on GET /queue/:id/view → reader HTML
GET /queue -H "Accept: application/vnd.siren+json" -H "Authorization: Bearer <token>"  # each entity carries update-status
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHhi7r5FRpJZwhcoNcdikx