### PR TITLE
docs(extract-links): trim redundant PSL example from isSameSite comment

### DIFF
--- a/src/packages/extract-links-from-page/src/extract-links-from-page.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.ts
@@ -51,10 +51,9 @@ function resolveHref(href: string | null, base: URL): string | undefined {
 const GET_DOMAIN_OPTIONS = { allowPrivateDomains: true };
 
 /** Same site means the same registrable (eTLD+1) domain, not just the same
- * host, so a subdomain page also drops its parent and sibling subdomains. The
- * Public Suffix List keeps the boundary correct under multi-part suffixes
- * (bbc.co.uk stays distinct from theguardian.co.uk). IP literals have no
- * registrable domain, so they fall back to exact-host matching. */
+ * host, so a subdomain page also drops its parent and sibling subdomains. IP
+ * literals have no registrable domain, so they fall back to exact-host
+ * matching. */
 function isSameSite(linkHost: string, page: { host: string; domain: string | null }): boolean {
 	if (page.domain === null) return linkHost === page.host;
 	return getDomain(linkHost, GET_DOMAIN_OPTIONS) === page.domain;


### PR DESCRIPTION
## Summary

Trims the `isSameSite` doc comment in `extract-links-from-page.ts` to drop the `bbc.co.uk` vs `theguardian.co.uk` sentence, which merely restated what the multi-part-suffix test already verifies.

The comment now keeps only the non-obvious *why*:
- The `allowPrivateDomains` rationale already lives on `GET_DOMAIN_OPTIONS`.
- IP literals have no registrable domain, so they fall back to exact-host matching.

Per the project guideline that comments explain *why*, not *what* — the example restated behaviour the test pins down, so it was noise.

## Verification

`pnpm nx run @packages/extract-links-from-page:check` passes (100% coverage, 29 tests). No code behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MssvAm5rQsAhym2vVZm7uJ)_