### PR TITLE
refactor(extract-links): use named params for isSameSite page arg

### DIFF
--- a/src/packages/extract-links-from-page/src/extract-links-from-page.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.ts
@@ -55,10 +55,9 @@ const GET_DOMAIN_OPTIONS = { allowPrivateDomains: true };
  * Public Suffix List keeps the boundary correct under multi-part suffixes
  * (bbc.co.uk stays distinct from theguardian.co.uk). IP literals have no
  * registrable domain, so they fall back to exact-host matching. */
-function isSameSite(linkHost: string, pageHost: string, pageDomain: string | null): boolean {
-	if (linkHost === pageHost) return true;
-	if (pageDomain === null) return false;
-	return getDomain(linkHost, GET_DOMAIN_OPTIONS) === pageDomain;
+function isSameSite(linkHost: string, page: { host: string; domain: string | null }): boolean {
+	if (page.domain === null) return linkHost === page.host;
+	return getDomain(linkHost, GET_DOMAIN_OPTIONS) === page.domain;
 }
 
 function harvestLinks(html: string, baseUrl: string, sourceUrl: string): ImportLinksResult {
@@ -70,7 +69,7 @@ function harvestLinks(html: string, baseUrl: string, sourceUrl: string): ImportL
 	const raw = anchors
 		.map((anchor) => resolveHref(anchor.getAttribute("href"), base))
 		.filter((url): url is string => url !== undefined)
-		.filter((url) => !isSameSite(new URL(url).host, base.host, pageDomain))
+		.filter((url) => !isSameSite(new URL(url).host, { host: base.host, domain: pageDomain }))
 		.filter((url) => url !== sourceNormalized);
 	return collectImportLinks(raw);
 }


### PR DESCRIPTION
## Summary

Refactors `isSameSite` in `src/packages/extract-links-from-page/src/extract-links-from-page.ts` to follow the **Named Parameters Over Positional** guideline. The function previously took two consecutive same-typed parameters (`pageHost: string, pageDomain: string | null`) that were easy to transpose; they are now grouped into a single `page: { host: string; domain: string | null }` object.

## Changes

- `isSameSite(linkHost: string, page: { host: string; domain: string | null })` — page host/domain grouped into one object.
- The IP / no-registrable-domain fallback is folded into the `page.domain === null` branch, which now returns `linkHost === page.host`, keeping the exact-host comparison in one place.
- Updated the call site in `harvestLinks` to pass `{ host: base.host, domain: pageDomain }`.

## Verification

- `pnpm nx run extract-links-from-page:check` — lint, type-check, knip, all **29 tests** pass, **100%** coverage (statements/branches/functions/lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141xpARdv7wSUZeJ2BHJd1o)_