### PR TITLE
test(extract-links): clarify PSL differential block documents, not guards

### DIFF
--- a/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
+++ b/src/packages/extract-links-from-page/src/extract-links-from-page.test.ts
@@ -461,7 +461,7 @@ describe("initExtractLinksFromPageUrl", () => {
 	});
 });
 
-describe("registrable-domain rule: getDomain({ allowPrivateDomains: true }) over a hand-crafted label rule", () => {
+describe("documents why a Public Suffix List, not label-slicing, decides the registrable domain (production guarded by the bbc.co.uk, ycombinator, and github.io behavioral tests above)", () => {
 	const lastTwoLabels = (host: string) => host.split(".").slice(-2).join(".");
 	const lastThreeLabels = (host: string) => host.split(".").slice(-3).join(".");
 


### PR DESCRIPTION
## Summary

The `describe` block at line 464 of `extract-links-from-page.test.ts` compares the `tldts` `getDomain` library against test-only `lastTwoLabels`/`lastThreeLabels` helpers. It never exercises the production same-site decision (`GET_DOMAIN_OPTIONS` / `isSameSite` / `harvestLinks`), so it **documents** why a Public Suffix List is needed rather than **guards** the behavior.

This renames the describe block so its name makes that intent explicit and points to the three behavioral tests that already pin the production decision through `initExtractLinksFromPageUrl`:

- `bbc.co.uk` — keeps a different registrable domain that shares a multi-part public suffix
- `ycombinator` — drops parent/sibling subdomains sharing the registrable domain
- `github.io` — keeps sibling tenants of a PSL private-section platform

### Why rename instead of fold into a comment

The alternative — folding the contrast into a comment on `GET_DOMAIN_OPTIONS` — was rejected because:

- Project guidelines treat discretionary comments as a last resort requiring explicit human approval.
- `GET_DOMAIN_OPTIONS` and `isSameSite` already carry comments explaining the PSL rationale.
- Keeping the differential tests preserves them as executable documentation that can't silently rot, while the rename removes the ambiguity about what they guard.

## Verification

`pnpm nx run extract-links-from-page:check` passes — 29 tests green, 100% coverage across statements/branches/functions/lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmwN2GhNXPTpfeaQ6pqkx2)_