### PR TITLE
feat(inbox): surface a graceful error when create fails

### DIFF
--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
@@ -13,8 +13,12 @@ const INBOX_SCRIPT = `<script src="/client-dist/inbox.client.js" defer></script>
  * the gated POST routes stay reachable when submitted from the flagged page. */
 const INBOX_QUERY = `?feature=${EMAIL_FEATURE}`;
 
-export function InboxPage(params: { addresses: InboxAddressEntry[] }): PageBody {
+export function InboxPage(params: {
+	addresses: InboxAddressEntry[];
+	createFailed?: boolean;
+}): PageBody {
 	const content = render(INBOX_TEMPLATE, {
+		createFailed: params.createFailed === true,
 		hasAddresses: params.addresses.length > 0,
 		addresses: params.addresses.map((entry) => ({
 			address: entry.address,

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -23,6 +23,7 @@ const DisableAddressSchema = z.object({ address: InboxAddressSchema });
 export function initInboxRoutes(deps: InboxDependencies): Router {
 	const router = express.Router();
 	const inboxPath = `/inbox?feature=${EMAIL_FEATURE}`;
+	const inboxCreateFailedPath = `${inboxPath}&error=create`;
 
 	/** Hidden by default: without the per-request flag the whole surface 404s, so
 	 * production traffic never sees it until the flag is flipped on a request. */
@@ -37,7 +38,12 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 	router.get("/", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const addresses = await deps.inboxAddressStore.listAddressesByUserId(req.userId);
-		sendComponent(req, res, Base(InboxPage({ addresses }), await deps.buildBannerState(req)));
+		const createFailed = req.query.error === "create";
+		sendComponent(
+			req,
+			res,
+			Base(InboxPage({ addresses, createFailed }), await deps.buildBannerState(req)),
+		);
 	});
 
 	router.post("/create", async (req: Request, res: Response) => {
@@ -52,6 +58,8 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 				"[Inbox] Failed to create a forwarding address",
 				error instanceof Error ? error : new Error(String(error)),
 			);
+			res.redirect(303, inboxCreateFailedPath);
+			return;
 		}
 		res.redirect(303, inboxPath);
 	});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -150,8 +150,37 @@ describe("Inbox routes", () => {
 			const response = await agent.post("/inbox/create?feature=email");
 
 			expect(response.status).toBe(303);
-			expect(response.headers.location).toBe("/inbox?feature=email");
+			expect(response.headers.location).toBe("/inbox?feature=email&error=create");
 			expect(errors.some((m) => m.includes("[Inbox] Failed to create"))).toBe(true);
+		});
+
+		it("renders a graceful error indicator on the redirect target after a failed create", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			fixture.shared.logError = () => {};
+			fixture.inboxAddress.inboxAddressStore.createAddress = async () => {
+				throw new Error("dynamo down");
+			};
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const created = await agent.post("/inbox/create?feature=email");
+			const landing = await agent.get(created.headers.location);
+
+			expect(landing.status).toBe(200);
+			expect(
+				new JSDOM(landing.text).window.document.querySelector("[data-test-inbox-error]"),
+			).not.toBeNull();
+		});
+
+		it("does not render the error indicator on a normal visit", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox?feature=email");
+
+			expect(
+				new JSDOM(response.text).window.document.querySelector("[data-test-inbox-error]"),
+			).toBeNull();
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
@@ -21,6 +21,16 @@
   margin: 0;
 }
 
+.inbox__error {
+  margin: 0 0 24px;
+  padding: 12px 16px;
+  color: var(--error);
+  background: var(--card);
+  border: 1px solid var(--error);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+}
+
 .inbox__list {
   list-style: none;
   margin: 0 0 24px;

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
@@ -4,6 +4,10 @@
         <p class="inbox__subtitle">Forward any newsletter to one of these addresses and it lands in Readplace. I'll pull out the links and queue them up for you to read later.</p>
       </div>
 
+      {{#if createFailed}}
+      <p class="inbox__error" role="alert" data-test-inbox-error>We couldn't create a forwarding address just now. Please try again in a moment.</p>
+      {{/if}}
+
       {{#if hasAddresses}}
       <ul class="inbox__list" data-test-inbox-list>
         {{#each addresses}}


### PR DESCRIPTION
## Graceful UI error for failed `POST /inbox/create`

Follow-up to #783. The create catch in `inbox.page.ts` previously logged the failure and silently redirected to `/inbox?feature=email`, so a failed create looked like a no-op to the user — contradicting the PR #783 decisions table, which promises a **"graceful UI error"** on collision/creation failure.

### What changed
- **`inbox.page.ts`** — the create catch now redirects to `/inbox?feature=email&error=create` (instead of the plain inbox path). The GET route reads `req.query.error === "create"` and threads `createFailed` into the page. This mirrors the established `/account` error-redirect pattern (`?error=payment_method`), so it's zero-JS and survives a full page load.
- **`inbox.component.ts`** — `InboxPage` accepts an optional `createFailed` flag.
- **`inbox.template.html`** — renders an `role="alert"` banner (`data-test-inbox-error`) above the list when `createFailed` is set: *"We couldn't create a forwarding address just now. Please try again in a moment."*
- **`inbox.styles.css`** — `.inbox__error` styling using the shared `--error` token.

### Tests
- Updated the existing failed-create test to assert the new redirect location (`…&error=create`).
- Added a route test that follows the redirect and asserts `[data-test-inbox-error]` renders.
- Added a route test asserting the indicator is absent on a normal visit.

`pnpm check` green across all 34 projects (type-check, lint, tests, 100% coverage, knip, unused-css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011kHoTsoqpXg9NGf3nJFTAp)_