### PR TITLE
fix(inbox): mirror DynamoDB ownership guard in in-memory inbox address fixture

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1240,6 +1240,9 @@ importers:
       '@packages/hutch-logger':
         specifier: workspace:*
         version: link:../hutch-logger
+      '@packages/hutch-storage-client':
+        specifier: workspace:*
+        version: link:../hutch-storage-client
       '@packages/provider-contracts':
         specifier: workspace:*
         version: link:../provider-contracts

--- a/src/packages/domain/src/inbox/inbox-address.types.ts
+++ b/src/packages/domain/src/inbox/inbox-address.types.ts
@@ -23,5 +23,9 @@ export interface InboxAddressStore {
 	 * be absent from the result — so callers must not assume read-your-write. The
 	 * in-memory fixture is strongly consistent and so will not surface the lag. */
 	listAddressesByUserId: (userId: UserId) => Promise<InboxAddressEntry[]>;
+	/** Stamps `disabledAt` on an address the user owns. The write is
+	 * ownership-guarded: disabling an address that does not exist or belongs to
+	 * another user throws `ConditionalCheckFailedException` rather than silently
+	 * succeeding, so a forged address can never reach a foreign row. */
 	disableAddress: (input: { userId: UserId; address: InboxAddress }) => Promise<void>;
 }

--- a/src/packages/test-fixtures/package.json
+++ b/src/packages/test-fixtures/package.json
@@ -166,6 +166,7 @@
     "@packages/domain": "workspace:*",
     "@packages/extract-links-from-page": "workspace:*",
     "@packages/hutch-logger": "workspace:*",
+    "@packages/hutch-storage-client": "workspace:*",
     "@packages/provider-contracts": "workspace:*",
     "@packages/web-test-harness": "workspace:*",
     "zod": "4.4.3"

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from "@packages/hutch-storage-client";
 import { UserIdSchema } from "@packages/domain/user";
 import { InboxAddressSchema } from "@packages/domain/inbox";
 import { initInMemoryInboxAddress } from "./in-memory-inbox-address";
@@ -45,20 +46,24 @@ describe("initInMemoryInboxAddress", () => {
 		expect(refreshed.disabledAt).toBe("2026-06-23T12:00:00.000Z");
 	});
 
-	it("ignores a disable for an address that does not exist", async () => {
+	it("rejects a disable for an address that does not exist", async () => {
 		const store = initInMemoryInboxAddress({ now: () => new Date() });
 		const missing = InboxAddressSchema.parse("in-3f9a2c@read.place");
 
-		await store.disableAddress({ userId: owner, address: missing });
+		await expect(
+			store.disableAddress({ userId: owner, address: missing }),
+		).rejects.toThrow(ConditionalCheckFailedException);
 
 		expect(await store.listAddressesByUserId(owner)).toHaveLength(0);
 	});
 
-	it("ignores a disable requested by a non-owner", async () => {
+	it("rejects a disable requested by a non-owner", async () => {
 		const store = initInMemoryInboxAddress({ now: () => new Date() });
 		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
 
-		await store.disableAddress({ userId: otherUser, address: entry.address });
+		await expect(
+			store.disableAddress({ userId: otherUser, address: entry.address }),
+		).rejects.toThrow(ConditionalCheckFailedException);
 
 		const [refreshed] = await store.listAddressesByUserId(owner);
 		expect(refreshed.disabledAt).toBeUndefined();

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
@@ -1,3 +1,4 @@
+import { ConditionalCheckFailedException } from "@packages/hutch-storage-client";
 import {
 	buildInboxAddress,
 	generateInboxToken,
@@ -26,8 +27,12 @@ export function initInMemoryInboxAddress(deps: { now: () => Date }): InboxAddres
 			[...rows.values()].filter((row) => row.userId === userId),
 		disableAddress: async ({ userId, address }) => {
 			const row = rows.get(address);
-			if (row === undefined) return;
-			if (row.userId !== userId) return;
+			if (row === undefined || row.userId !== userId) {
+				throw new ConditionalCheckFailedException({
+					$metadata: {},
+					message: "The conditional request failed",
+				});
+			}
 			rows.set(address, { ...row, disabledAt: deps.now().toISOString() });
 		},
 	};


### PR DESCRIPTION
## Problem

The in-memory `InboxAddress` fixture and the production DynamoDB adapter disagreed on what `disableAddress` does for a **missing** or **non-owned** address:

- `in-memory-inbox-address.ts` silently **no-op'd** — returned without writing.
- `dynamodb-inbox-address.ts` uses `ConditionExpression: "userId = :uid"`, which **throws `ConditionalCheckFailedException`** in those cases.

That ownership guard is deliberate defense-in-depth — `inbox.page.ts` refers to it as "the (also ownership-guarded) store write" so a forged address for someone else's row can never disable it. Because the fixture diverged from production, a test exercising a forged/missing address would pass against the fixture while production threw, violating the test-driven-design rule that in-memory fixtures must mirror production behaviour.

## Change

Picked the **throw** contract (keeping production's security guard intact, untouched) and aligned the fixture to it:

- `disableAddress` in the in-memory fixture now throws `ConditionalCheckFailedException` when the address is missing or owned by another user, matching the DynamoDB adapter exactly.
- Updated the two affected fixture tests (`rejects a disable for an address that does not exist`, `rejects a disable requested by a non-owner`) to assert the throw rather than a silent no-op.
- Added `@packages/hutch-storage-client` as a workspace dependency of `@packages/test-fixtures` (source of the shared exception type).
- Documented the shared ownership-guard contract on the `InboxAddressStore.disableAddress` interface in `@packages/domain`.

## Verification

- `pnpm nx run @packages/test-fixtures:check` — passes, 100% coverage on the fixture.
- Full `pnpm check` (pre-commit hook) — passes across all 34 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L98gpRMRpyub3ZKUWNS9mW)_