### PR TITLE
feat(inbox): cap forwarding addresses per user and gate creation to write-access

### DIFF
--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.test.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.test.ts
@@ -2,7 +2,11 @@ import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
 } from "@packages/hutch-storage-client";
-import { InboxAddressSchema } from "@packages/domain/inbox";
+import {
+	INBOX_ADDRESS_MAX_PER_USER,
+	InboxAddressLimitReachedError,
+	InboxAddressSchema,
+} from "@packages/domain/inbox";
 import { UserIdSchema } from "@packages/domain/user";
 import { initDynamoDbInboxAddress } from "./dynamodb-inbox-address";
 
@@ -39,11 +43,29 @@ function conditionalCheckFailed(): ConditionalCheckFailedException {
 
 describe("initDynamoDbInboxAddress", () => {
 	describe("createAddress", () => {
+		// createAddress first reads the user's rows off the GSI to enforce the
+		// per-user cap, then conditionally puts. Tests branch the fake on the query
+		// (IndexName) vs the put (Item) so the cap-count read stays out of the way of
+		// the put-retry assertions.
+		function liveRows(count: number): Record<string, unknown>[] {
+			return Array.from({ length: count }, (_, i) => {
+				const token = String(i).padStart(6, "0");
+				return {
+					address: `in-${token}@read.place`,
+					userId: USER,
+					token,
+					createdAt: NOW.toISOString(),
+					disabledAt: null,
+				};
+			});
+		}
+
 		it("conditionally puts a new row guarded on address uniqueness", async () => {
 			const commands: CapturedCommand[] = [];
 			const store = initDynamoDbInboxAddress({
 				client: createFakeClient((cmd) => {
 					commands.push(cmd as CapturedCommand);
+					if ((cmd as CapturedCommand).input.IndexName) return { Items: [], Count: 0 };
 					return {};
 				}) as DynamoDBDocumentClient,
 				tableName: TABLE,
@@ -52,25 +74,25 @@ describe("initDynamoDbInboxAddress", () => {
 
 			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
 
-			expect(commands).toHaveLength(1);
-			expect(commands[0].input.ConditionExpression).toBe(
-				"attribute_not_exists(address)",
-			);
-			expect(commands[0].input.Item?.address).toBe(entry.address);
-			expect(commands[0].input.Item?.userId).toBe(USER);
-			expect(commands[0].input.Item?.token).toBe(entry.token);
-			expect(commands[0].input.Item?.createdAt).toBe(NOW.toISOString());
+			const puts = commands.filter((c) => c.input.Item);
+			expect(puts).toHaveLength(1);
+			expect(puts[0].input.ConditionExpression).toBe("attribute_not_exists(address)");
+			expect(puts[0].input.Item?.address).toBe(entry.address);
+			expect(puts[0].input.Item?.userId).toBe(USER);
+			expect(puts[0].input.Item?.token).toBe(entry.token);
+			expect(puts[0].input.Item?.createdAt).toBe(NOW.toISOString());
 			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
 			expect(entry.createdAt).toBe(NOW.toISOString());
 			expect(entry.disabledAt).toBeUndefined();
 		});
 
 		it("regenerates and retries when the address collides, then succeeds", async () => {
-			let calls = 0;
+			let puts = 0;
 			const store = initDynamoDbInboxAddress({
-				client: createFakeClient(() => {
-					calls++;
-					if (calls === 1) throw conditionalCheckFailed();
+				client: createFakeClient((cmd) => {
+					if ((cmd as CapturedCommand).input.IndexName) return { Items: [], Count: 0 };
+					puts++;
+					if (puts === 1) throw conditionalCheckFailed();
 					return {};
 				}) as DynamoDBDocumentClient,
 				tableName: TABLE,
@@ -79,13 +101,14 @@ describe("initDynamoDbInboxAddress", () => {
 
 			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
 
-			expect(calls).toBe(2);
+			expect(puts).toBe(2);
 			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
 		});
 
 		it("throws after exhausting retries on persistent collisions", async () => {
 			const store = initDynamoDbInboxAddress({
-				client: createFakeClient(() => {
+				client: createFakeClient((cmd) => {
+					if ((cmd as CapturedCommand).input.IndexName) return { Items: [], Count: 0 };
 					throw conditionalCheckFailed();
 				}) as DynamoDBDocumentClient,
 				tableName: TABLE,
@@ -99,7 +122,8 @@ describe("initDynamoDbInboxAddress", () => {
 
 		it("rethrows errors that are not conditional-check failures", async () => {
 			const store = initDynamoDbInboxAddress({
-				client: createFakeClient(() => {
+				client: createFakeClient((cmd) => {
+					if ((cmd as CapturedCommand).input.IndexName) return { Items: [], Count: 0 };
 					throw new Error("throttled");
 				}) as DynamoDBDocumentClient,
 				tableName: TABLE,
@@ -109,6 +133,51 @@ describe("initDynamoDbInboxAddress", () => {
 			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
 				"throttled",
 			);
+		});
+
+		it("throws InboxAddressLimitReachedError and issues no put once the user holds the live cap", async () => {
+			const commands: CapturedCommand[] = [];
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient((cmd) => {
+					commands.push(cmd as CapturedCommand);
+					if ((cmd as CapturedCommand).input.IndexName) {
+						const Items = liveRows(INBOX_ADDRESS_MAX_PER_USER);
+						return { Items, Count: Items.length };
+					}
+					return {};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
+				InboxAddressLimitReachedError,
+			);
+			expect(commands.some((c) => c.input.Item)).toBe(false);
+		});
+
+		it("counts only live rows toward the cap: a user whose cap-worth of rows are all disabled can still create", async () => {
+			const commands: CapturedCommand[] = [];
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient((cmd) => {
+					commands.push(cmd as CapturedCommand);
+					if ((cmd as CapturedCommand).input.IndexName) {
+						const Items = liveRows(INBOX_ADDRESS_MAX_PER_USER).map((row) => ({
+							...row,
+							disabledAt: "2026-06-22T00:00:00.000Z",
+						}));
+						return { Items, Count: Items.length };
+					}
+					return {};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+
+			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
+
+			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+			expect(commands.some((c) => c.input.Item)).toBe(true);
 		});
 	});
 

--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
@@ -10,6 +10,8 @@ import {
 	buildInboxAddress,
 	generateInboxToken,
 	INBOX_ADDRESS_MAX_CREATE_ATTEMPTS,
+	INBOX_ADDRESS_MAX_PER_USER,
+	InboxAddressLimitReachedError,
 	InboxAddressSchema,
 	type InboxAddressStore,
 	InboxTokenSchema,
@@ -34,8 +36,37 @@ export function initDynamoDbInboxAddress(deps: {
 		schema: InboxAddressRow,
 	});
 
+	const listAddressesByUserId: InboxAddressStore["listAddressesByUserId"] = async (userId) => {
+		// The userId-index GSI is replicated asynchronously and DynamoDB offers no
+		// ConsistentRead for secondary indexes, so this read is unavoidably eventually
+		// consistent: an address written moments earlier can be absent, which lets the
+		// create → redirect → list flow briefly render the empty state right after a
+		// successful create. The design absorbs the lag rather than fighting it — the
+		// never-delete + conditional-put invariants bound the worst case to a redundant
+		// address the user owns (a second valid row), never a lost or cross-user-leaked
+		// one, and a reload reconciles once replication catches up.
+		const { items } = await table.query({
+			IndexName: "userId-index",
+			KeyConditionExpression: "userId = :uid",
+			ExpressionAttributeValues: { ":uid": userId },
+		});
+		return items;
+	};
+
 	return {
 		createAddress: async ({ userId, domain }) => {
+			// Bound the live addresses a user can hold. disabledAt is not a key
+			// attribute, so the cap is counted in code over the GSI rows rather than
+			// pushed into a COUNT query. The GSI is eventually consistent, so this is a
+			// soft guardrail (a racing pair of creates may briefly land one over the
+			// cap) — fine, since the cap exists to stop an unbounded create loop, not
+			// to enforce an exact-to-the-row ceiling.
+			const live = (await listAddressesByUserId(userId)).filter(
+				(entry) => entry.disabledAt === undefined,
+			);
+			if (live.length >= INBOX_ADDRESS_MAX_PER_USER) {
+				throw new InboxAddressLimitReachedError(INBOX_ADDRESS_MAX_PER_USER);
+			}
 			const createdAt = deps.now().toISOString();
 			for (let attempt = 0; attempt < INBOX_ADDRESS_MAX_CREATE_ATTEMPTS; attempt++) {
 				const token = generateInboxToken();
@@ -55,22 +86,7 @@ export function initDynamoDbInboxAddress(deps: {
 				`Failed to mint a unique inbox address after ${INBOX_ADDRESS_MAX_CREATE_ATTEMPTS} attempts`,
 			);
 		},
-		listAddressesByUserId: async (userId) => {
-			// The userId-index GSI is replicated asynchronously and DynamoDB offers no
-			// ConsistentRead for secondary indexes, so this read is unavoidably eventually
-			// consistent: an address written moments earlier can be absent, which lets the
-			// create → redirect → list flow briefly render the empty state right after a
-			// successful create. The design absorbs the lag rather than fighting it — the
-			// never-delete + conditional-put invariants bound the worst case to a redundant
-			// address the user owns (a second valid row), never a lost or cross-user-leaked
-			// one, and a reload reconciles once replication catches up.
-			const { items } = await table.query({
-				IndexName: "userId-index",
-				KeyConditionExpression: "userId = :uid",
-				ExpressionAttributeValues: { ":uid": userId },
-			});
-			return items;
-		},
+		listAddressesByUserId,
 		disableAddress: async ({ userId, address }) => {
 			await table.update({
 				Key: { address },

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -943,6 +943,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		inboxAddressDomain: deps.inboxAddressDomain,
 		logError: deps.logError,
 		buildBannerState,
+		requireNotLocked,
 		requireWriteAccess,
 	});
 	app.use("/inbox", requireAuth, inboxRouter);

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -943,6 +943,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		inboxAddressDomain: deps.inboxAddressDomain,
 		logError: deps.logError,
 		buildBannerState,
+		requireWriteAccess,
 	});
 	app.use("/inbox", requireAuth, inboxRouter);
 

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import {
+	INBOX_ADDRESS_MAX_PER_USER,
 	type InboxAddressEntry,
 	InboxAddressSchema,
 	InboxTokenSchema,
@@ -25,21 +26,21 @@ function parse(html: string): Document {
 
 describe("InboxPage", () => {
 	it("noindexes the page and ships the copy-enhancement script", () => {
-		const page = InboxPage({ addresses: [] });
+		const page = InboxPage({ addresses: [], limitReached: false });
 		assert.equal(page.seo.robots, "noindex, nofollow");
 		assert.equal(page.bodyClass, "page-inbox");
 		assert.match(page.scripts ?? "", /inbox\.client\.js/);
 	});
 
 	it("shows an empty state with a create CTA and no list when the user has no addresses", () => {
-		const doc = parse(InboxPage({ addresses: [] }).content.html);
+		const doc = parse(InboxPage({ addresses: [], limitReached: false }).content.html);
 		assert.ok(doc.querySelector("[data-test-inbox-empty]"), "empty state must render");
 		assert.ok(doc.querySelector("[data-test-inbox-create]"), "create CTA must render");
 		assert.equal(doc.querySelector("[data-test-inbox-list]"), null);
 	});
 
 	it("renders each address into a selectable read-only field with a copy button", () => {
-		const doc = parse(InboxPage({ addresses: [entry()] }).content.html);
+		const doc = parse(InboxPage({ addresses: [entry()], limitReached: false }).content.html);
 		const field = doc.querySelector(".inbox__address-field");
 		assert.equal(field?.getAttribute("value"), "in-3f9a2c@read.place");
 		assert.equal(field?.getAttribute("readonly"), "");
@@ -60,6 +61,7 @@ describe("InboxPage", () => {
 						disabledAt: "2026-06-22T00:00:00.000Z",
 					}),
 				],
+				limitReached: false,
 			}).content.html,
 		);
 
@@ -101,6 +103,7 @@ describe("InboxPage", () => {
 						disabledAt: "2026-06-22T00:00:00.000Z",
 					}),
 				],
+				limitReached: false,
 			}).content.html,
 		);
 		assert.equal(doc.querySelectorAll("[data-test-inbox-item]").length, 2);
@@ -112,7 +115,7 @@ describe("InboxPage", () => {
 	});
 
 	it("points the create and disable forms at the flag-carrying routes", () => {
-		const doc = parse(InboxPage({ addresses: [entry()] }).content.html);
+		const doc = parse(InboxPage({ addresses: [entry()], limitReached: false }).content.html);
 		assert.equal(
 			doc.querySelector(".inbox__create")?.getAttribute("action"),
 			"/inbox/create?feature=email",
@@ -121,5 +124,15 @@ describe("InboxPage", () => {
 			doc.querySelector(".inbox__disable")?.getAttribute("action"),
 			"/inbox/disable?feature=email",
 		);
+	});
+
+	it("shows the per-user limit message naming the cap only when the limit is reached", () => {
+		const without = parse(InboxPage({ addresses: [entry()], limitReached: false }).content.html);
+		assert.equal(without.querySelector("[data-test-inbox-limit]"), null);
+
+		const withLimit = parse(InboxPage({ addresses: [entry()], limitReached: true }).content.html);
+		const message = withLimit.querySelector("[data-test-inbox-limit]");
+		assert.ok(message, "limit message must render when the cap is reached");
+		assert.match(message.textContent ?? "", new RegExp(String(INBOX_ADDRESS_MAX_PER_USER)));
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { EMAIL_FEATURE, render } from "@packages/web-shell";
 import type { PageBody } from "@packages/web-shell";
-import type { InboxAddressEntry } from "@packages/domain/inbox";
+import { INBOX_ADDRESS_MAX_PER_USER, type InboxAddressEntry } from "@packages/domain/inbox";
 import { INBOX_STYLES } from "./inbox.styles";
 
 const INBOX_TEMPLATE = readFileSync(join(__dirname, "inbox.template.html"), "utf-8");
@@ -16,6 +16,7 @@ const INBOX_QUERY = `?feature=${EMAIL_FEATURE}`;
 export function InboxPage(params: {
 	addresses: InboxAddressEntry[];
 	createFailed?: boolean;
+	limitReached: boolean;
 }): PageBody {
 	const content = render(INBOX_TEMPLATE, {
 		createFailed: params.createFailed === true,
@@ -24,6 +25,8 @@ export function InboxPage(params: {
 			address: entry.address,
 			enabled: entry.disabledAt === undefined,
 		})),
+		limitReached: params.limitReached,
+		maxAddresses: INBOX_ADDRESS_MAX_PER_USER,
 		createAction: `/inbox/create${INBOX_QUERY}`,
 		disableAction: `/inbox/disable${INBOX_QUERY}`,
 	});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -16,10 +16,13 @@ interface InboxDependencies {
 	inboxAddressDomain: string;
 	logError: (message: string, error?: Error) => void;
 	buildBannerState: BuildBannerState;
-	/** Gates address minting to full-access accounts. A read-only / trial-expired
-	 * user is blocked from the save flow, and a forwarding address is a save-flow
-	 * input, so creating one is a write action — applied only to /create, mirroring
-	 * the import commit gate. Viewing and disabling existing addresses stay open. */
+	/** Save gates applied only to /create, the sole route that mints an address —
+	 * a forwarding address is a save-flow input, so creating one is a write action.
+	 * Mirrors the import commit gate, which runs both: `requireNotLocked` blocks a
+	 * locked (unverified-past-window) account, `requireWriteAccess` blocks a
+	 * read-only (trial-expired / cancelled) account. Viewing and disabling existing
+	 * addresses stay open — disabling reduces footprint and is harmless. */
+	requireNotLocked: RequestHandler;
 	requireWriteAccess: RequestHandler;
 }
 
@@ -52,7 +55,7 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 		);
 	});
 
-	router.post("/create", deps.requireWriteAccess, async (req: Request, res: Response) => {
+	router.post("/create", deps.requireNotLocked, deps.requireWriteAccess, async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		try {
 			await deps.inboxAddressStore.createAddress({

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert";
-import type { Request, Response, Router } from "express";
+import type { Request, RequestHandler, Response, Router } from "express";
 import express from "express";
 import { z } from "zod";
 import { EMAIL_FEATURE, sendComponent } from "@packages/web-shell";
-import { InboxAddressSchema } from "@packages/domain/inbox";
+import { InboxAddressLimitReachedError, InboxAddressSchema } from "@packages/domain/inbox";
 import type { InboxAddressStore } from "@packages/domain/inbox";
 import { Base } from "../../base.component";
 import type { BuildBannerState } from "../../banner-state";
@@ -16,6 +16,11 @@ interface InboxDependencies {
 	inboxAddressDomain: string;
 	logError: (message: string, error?: Error) => void;
 	buildBannerState: BuildBannerState;
+	/** Gates address minting to full-access accounts. A read-only / trial-expired
+	 * user is blocked from the save flow, and a forwarding address is a save-flow
+	 * input, so creating one is a write action — applied only to /create, mirroring
+	 * the import commit gate. Viewing and disabling existing addresses stay open. */
+	requireWriteAccess: RequestHandler;
 }
 
 const DisableAddressSchema = z.object({ address: InboxAddressSchema });
@@ -39,14 +44,15 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const addresses = await deps.inboxAddressStore.listAddressesByUserId(req.userId);
 		const createFailed = req.query.error === "create";
+		const limitReached = req.query.error === "limit";
 		sendComponent(
 			req,
 			res,
-			Base(InboxPage({ addresses, createFailed }), await deps.buildBannerState(req)),
+			Base(InboxPage({ addresses, createFailed, limitReached }), await deps.buildBannerState(req)),
 		);
 	});
 
-	router.post("/create", async (req: Request, res: Response) => {
+	router.post("/create", deps.requireWriteAccess, async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		try {
 			await deps.inboxAddressStore.createAddress({
@@ -54,6 +60,12 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 				domain: deps.inboxAddressDomain,
 			});
 		} catch (error) {
+			// Hitting the per-user cap is expected user behaviour, not a fault — echo
+			// it back as a friendly message instead of logging an alerting-worthy error.
+			if (error instanceof InboxAddressLimitReachedError) {
+				res.redirect(303, `${inboxPath}&error=limit`);
+				return;
+			}
 			deps.logError(
 				"[Inbox] Failed to create a forwarding address",
 				error instanceof Error ? error : new Error(String(error)),

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -12,6 +12,15 @@ import {
 const useApp = useTestServer();
 const ONE_DAY_MS = 86_400_000;
 
+/** A fixture whose server clock runs `days` ahead of real time, so a freshly
+ * created user lands past the 7-day verification window — i.e. locked — with no
+ * way to backdate `registeredAt` directly. */
+function fixtureClockedDaysAhead(days: number) {
+	const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+	fixture.shared.now = () => new Date(Date.now() + days * ONE_DAY_MS);
+	return fixture;
+}
+
 /** Older than the bot-defense minimum submit window (2.5s) so signup passes. */
 function freshLoadedAt(): string {
 	return String(Date.now() - 5000);
@@ -166,6 +175,20 @@ describe("Inbox routes", () => {
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/queue?inactive=1");
+			const listed = await agent.get("/inbox?feature=email");
+			expect(addressFieldValue(listed.text)).toBeUndefined();
+		});
+
+		it("blocks a locked user with the account-locked screen and mints nothing", async () => {
+			const harness = useApp(fixtureClockedDaysAhead(8));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/inbox/create?feature=email").set("Accept", "text/html");
+
+			expect(response.status).toBe(403);
+			expect(
+				new JSDOM(response.text).window.document.querySelector("h1")?.textContent,
+			).toBe("Your account is locked");
 			const listed = await agent.get("/inbox?feature=email");
 			expect(addressFieldValue(listed.text)).toBeUndefined();
 		});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
+import { InboxAddressLimitReachedError } from "@packages/domain/inbox";
 import { loginAgent, useTestServer } from "../../../test-app";
 
 import {
@@ -9,6 +10,7 @@ import {
 } from "@packages/test-fixtures";
 
 const useApp = useTestServer();
+const ONE_DAY_MS = 86_400_000;
 
 /** Older than the bot-defense minimum submit window (2.5s) so signup passes. */
 function freshLoadedAt(): string {
@@ -97,6 +99,21 @@ describe("Inbox routes", () => {
 			expect(navItemKeys(withoutFlag.text)).not.toContain("inbox");
 		});
 
+		it("hides the Inbox nav entry from a read-only user even with the flag present", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			const userId = (await harness.auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "seeded login user must exist");
+			await harness.subscriptionProviders.upsertTrialing({
+				userId,
+				trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+			});
+
+			const page = await agent.get("/queue?feature=email");
+
+			expect(navItemKeys(page.text)).not.toContain("inbox");
+		});
+
 		it("reaches the inbox (200) when the Inbox nav entry's GET form is followed", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
@@ -133,6 +150,47 @@ describe("Inbox routes", () => {
 			const response = await agent.post("/inbox/create");
 
 			expect(response.status).toBe(404);
+		});
+
+		it("redirects a read-only user to /queue?inactive=1 and mints nothing", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			const userId = (await harness.auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "seeded login user must exist");
+			await harness.subscriptionProviders.upsertTrialing({
+				userId,
+				trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+			});
+
+			const response = await agent.post("/inbox/create?feature=email").set("Accept", "text/html");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?inactive=1");
+			const listed = await agent.get("/inbox?feature=email");
+			expect(addressFieldValue(listed.text)).toBeUndefined();
+		});
+
+		it("surfaces the per-user limit message without logging an error when the cap is reached", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const errors: string[] = [];
+			fixture.shared.logError = (message) => {
+				errors.push(message);
+			};
+			fixture.inboxAddress.inboxAddressStore.createAddress = async () => {
+				throw new InboxAddressLimitReachedError(25);
+			};
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/inbox/create?feature=email");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox?feature=email&error=limit");
+			expect(errors.some((m) => m.includes("[Inbox] Failed to create"))).toBe(false);
+
+			const listed = await agent.get("/inbox?feature=email&error=limit");
+			const doc = new JSDOM(listed.text).window.document;
+			expect(doc.querySelector("[data-test-inbox-limit]")).not.toBeNull();
 		});
 
 		it("redirects gracefully and logs when address creation fails", async () => {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
@@ -120,6 +120,11 @@
   margin: 0 0 24px;
 }
 
+.inbox__error {
+  color: var(--error);
+  margin: 0 0 16px;
+}
+
 .inbox__create {
   margin: 0 0 32px;
 }

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
@@ -31,6 +31,10 @@
       <p class="inbox__empty" data-test-inbox-empty>You don't have a forwarding address yet. Create one to get started.</p>
       {{/if}}
 
+      {{#if limitReached}}
+      <p class="inbox__error" data-test-inbox-limit role="alert">You've reached the maximum of {{maxAddresses}} forwarding addresses. Disable any you no longer need before creating more.</p>
+      {{/if}}
+
       <form action="{{createAction}}" method="POST" class="inbox__create">
         <button type="submit" class="inbox__create-btn" data-test-inbox-create>Create Inbox Email</button>
       </form>

--- a/src/packages/domain/src/inbox/inbox-address.schema.ts
+++ b/src/packages/domain/src/inbox/inbox-address.schema.ts
@@ -31,6 +31,25 @@ const INBOX_TOKEN_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
  * silently. */
 export const INBOX_ADDRESS_MAX_CREATE_ATTEMPTS = 5;
 
+/** Upper bound on the *live* addresses one user may hold. Without it a create
+ * loop — e.g. an account hammering POST /inbox/create — mints rows without
+ * limit, and every row is permanent (a freed hash could be re-minted for
+ * another user and leak their mail, so disabling stamps `disabledAt` rather
+ * than deleting). Counting only live rows caps the active footprint while
+ * leaving a recovery path: disable one you no longer need to free a slot.
+ * Generous enough that honest one-per-newsletter use never reaches it. */
+export const INBOX_ADDRESS_MAX_PER_USER = 25;
+
+/** Raised when a user is already at {@link INBOX_ADDRESS_MAX_PER_USER}. Distinct
+ * from a minting fault so callers can surface a friendly limit message without
+ * logging an alerting-worthy error. */
+export class InboxAddressLimitReachedError extends Error {
+	constructor(readonly limit: number) {
+		super(`Inbox address limit of ${limit} reached`);
+		this.name = "InboxAddressLimitReachedError";
+	}
+}
+
 /** randomInt is unbiased (rejection-sampled), so each character is drawn
  * uniformly from the 36-symbol alphabet — no modulo skew. */
 export function generateInboxToken(): InboxToken {

--- a/src/packages/domain/src/inbox/inbox-address.test.ts
+++ b/src/packages/domain/src/inbox/inbox-address.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import {
 	buildInboxAddress,
 	generateInboxToken,
+	INBOX_ADDRESS_MAX_PER_USER,
 	INBOX_TOKEN_LENGTH,
+	InboxAddressLimitReachedError,
 	InboxTokenSchema,
 } from "./inbox-address.schema";
 
@@ -39,5 +41,15 @@ describe("buildInboxAddress", () => {
 	it("accepts a freshly generated token", () => {
 		const address = buildInboxAddress({ token: generateInboxToken(), domain: "read.place" });
 		assert.match(address, /^in-[0-9a-z]{6}@read\.place$/);
+	});
+});
+
+describe("InboxAddressLimitReachedError", () => {
+	it("carries the cap it was raised against and names it in the message", () => {
+		const error = new InboxAddressLimitReachedError(INBOX_ADDRESS_MAX_PER_USER);
+		assert.ok(error instanceof Error);
+		assert.equal(error.name, "InboxAddressLimitReachedError");
+		assert.equal(error.limit, INBOX_ADDRESS_MAX_PER_USER);
+		assert.match(error.message, new RegExp(String(INBOX_ADDRESS_MAX_PER_USER)));
 	});
 });

--- a/src/packages/domain/src/inbox/inbox-address.types.ts
+++ b/src/packages/domain/src/inbox/inbox-address.types.ts
@@ -15,8 +15,10 @@ export interface InboxAddressEntry {
 
 export interface InboxAddressStore {
 	/** Mints a fresh address for the user. A user may hold many (one per
-	 * newsletter). Guards global uniqueness with a conditional put + bounded
-	 * retry; throws on retry exhaustion so the failure surfaces to alerting. */
+	 * newsletter) up to `INBOX_ADDRESS_MAX_PER_USER`; at the cap it throws
+	 * `InboxAddressLimitReachedError` so callers can surface a friendly limit
+	 * message. Guards global uniqueness with a conditional put + bounded retry;
+	 * throws on retry exhaustion so the failure surfaces to alerting. */
 	createAddress: (input: { userId: UserId; domain: string }) => Promise<InboxAddressEntry>;
 	/** Every address the user owns (1:N). The production adapter reads a DynamoDB
 	 * GSI, which is eventually consistent — an address created moments earlier may

--- a/src/packages/domain/src/inbox/index.ts
+++ b/src/packages/domain/src/inbox/index.ts
@@ -6,6 +6,8 @@ export {
 	type InboxAddress,
 	INBOX_TOKEN_LENGTH,
 	INBOX_ADDRESS_MAX_CREATE_ATTEMPTS,
+	INBOX_ADDRESS_MAX_PER_USER,
+	InboxAddressLimitReachedError,
 	generateInboxToken,
 	buildInboxAddress,
 } from "./inbox-address.schema";

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
@@ -1,6 +1,10 @@
 import { ConditionalCheckFailedException } from "@packages/hutch-storage-client";
 import { UserIdSchema } from "@packages/domain/user";
-import { InboxAddressSchema } from "@packages/domain/inbox";
+import {
+	INBOX_ADDRESS_MAX_PER_USER,
+	InboxAddressLimitReachedError,
+	InboxAddressSchema,
+} from "@packages/domain/inbox";
 import { initInMemoryInboxAddress } from "./in-memory-inbox-address";
 
 const owner = UserIdSchema.parse("00000000000000000000000000000001");
@@ -32,6 +36,36 @@ describe("initInMemoryInboxAddress", () => {
 
 		expect(ownerAddresses).toHaveLength(2);
 		expect(otherAddresses).toHaveLength(1);
+	});
+
+	it("throws InboxAddressLimitReachedError once the user holds the per-user cap of live addresses", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		for (let i = 0; i < INBOX_ADDRESS_MAX_PER_USER; i++) {
+			await store.createAddress({ userId: owner, domain: DOMAIN });
+		}
+
+		await expect(store.createAddress({ userId: owner, domain: DOMAIN })).rejects.toThrow(
+			InboxAddressLimitReachedError,
+		);
+		// The cap is per-user: a different user is unaffected.
+		await expect(
+			store.createAddress({ userId: otherUser, domain: DOMAIN }),
+		).resolves.toBeDefined();
+	});
+
+	it("frees a slot when a live address is disabled, since only live addresses count toward the cap", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		const first = await store.createAddress({ userId: owner, domain: DOMAIN });
+		for (let i = 1; i < INBOX_ADDRESS_MAX_PER_USER; i++) {
+			await store.createAddress({ userId: owner, domain: DOMAIN });
+		}
+		await expect(store.createAddress({ userId: owner, domain: DOMAIN })).rejects.toThrow(
+			InboxAddressLimitReachedError,
+		);
+
+		await store.disableAddress({ userId: owner, address: first.address });
+
+		await expect(store.createAddress({ userId: owner, domain: DOMAIN })).resolves.toBeDefined();
 	});
 
 	it("disables an owned address by stamping disabledAt", async () => {

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
@@ -2,6 +2,8 @@ import { ConditionalCheckFailedException } from "@packages/hutch-storage-client"
 import {
 	buildInboxAddress,
 	generateInboxToken,
+	INBOX_ADDRESS_MAX_PER_USER,
+	InboxAddressLimitReachedError,
 	type InboxAddressEntry,
 	type InboxAddressStore,
 } from "@packages/domain/inbox";
@@ -11,6 +13,12 @@ export function initInMemoryInboxAddress(deps: { now: () => Date }): InboxAddres
 
 	return {
 		createAddress: async ({ userId, domain }) => {
+			const live = [...rows.values()].filter(
+				(row) => row.userId === userId && row.disabledAt === undefined,
+			);
+			if (live.length >= INBOX_ADDRESS_MAX_PER_USER) {
+				throw new InboxAddressLimitReachedError(INBOX_ADDRESS_MAX_PER_USER);
+			}
 			const token = generateInboxToken();
 			const address = buildInboxAddress({ token, domain });
 			const entry: InboxAddressEntry = {

--- a/src/packages/web-shell/src/banner-state.test.ts
+++ b/src/packages/web-shell/src/banner-state.test.ts
@@ -94,6 +94,12 @@ describe("buildNavGroups", () => {
 		expect(library?.items.map((i) => i.key)).toEqual(["queue", "import", "export", "inbox"]);
 	});
 
+	it("omits the Inbox entry for a read-only user even when the email feature is enabled", () => {
+		const groups = buildNavGroups({ accessIsReadOnly: true, emailFeatureEnabled: true });
+		const [library] = groups;
+		expect(library?.items.map((i) => i.key)).toEqual(["queue", "export"]);
+	});
+
 	it("assigns a Font Awesome solid icon to every nav item", () => {
 		const items = buildNavGroups({ accessIsReadOnly: false, emailFeatureEnabled: true }).flatMap(
 			(g) => g.items,

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -214,7 +214,10 @@ export function buildNavGroups(input: {
 		library.push(NAV_IMPORT);
 	}
 	library.push(NAV_EXPORT);
-	if (input.emailFeatureEnabled) {
+	// Minting an address is a write action gated by requireWriteAccess, so a
+	// read-only user gets no Inbox entry — matching Import, which is hidden the
+	// same way. They keep access to existing addresses by direct link.
+	if (input.emailFeatureEnabled && !input.accessIsReadOnly) {
 		library.push(NAV_INBOX);
 	}
 	const account: NavItem[] = [];


### PR DESCRIPTION
## Bound inbox address creation

Follow-up hardening on the email-forwarding M1 work (#783). Minting a forwarding address was **unbounded** and reachable by **read-only / trial-expired** accounts that are otherwise blocked from the save flow: `/inbox` is mounted with `requireAuth` only, and `NAV_INBOX` was pushed outside the `accessIsReadOnly` guard in `buildNavGroups`. So a read-only user both saw the Inbox nav entry and could `POST /inbox/create` without limit.

### Per-user cap
- New `INBOX_ADDRESS_MAX_PER_USER` (25). Both the DynamoDB adapter and the in-memory fixture count the user's **live** addresses before minting and throw `InboxAddressLimitReachedError` at the cap.
- The cap counts only **live** rows (`disabledAt === undefined`): this still tops out an unbounded `POST /inbox/create` loop (it maxes out at the cap), while keeping a coherent recovery path — disabling one you no longer need frees a slot, matching the message shown.
- Rows are never deleted (a freed hash could be re-minted and leak mail), so the bound is on the live working set, not total rows.
- `createAddress` distinguishes the cap from a real minting fault, so the route can surface a friendly limit message without an alerting-worthy log.

### Read-only gating
- `POST /inbox/create` now runs behind `requireWriteAccess`, mirroring the import-commit gate. A read-only user is redirected to `/queue?inactive=1` and mints nothing.
- `NAV_INBOX` is hidden for read-only users (moved inside the `accessIsReadOnly` guard), matching how Import is hidden.
- Viewing and **disabling** existing addresses stay open to read-only users (disabling reduces footprint and is harmless), the same way the import upload/review pages stay public.

### Tests
- **Domain:** `InboxAddressLimitReachedError` carries and names its cap.
- **Stores:** in-memory + DynamoDB adapter — throws at the live cap, is per-user, frees a slot on disable, counts only live rows, and issues no put once capped.
- **Nav:** read-only user does not get the Inbox entry even with the flag.
- **Route:** read-only `create` → `/queue?inactive=1` (nothing minted); cap → `&error=limit` redirect, no error logged, limit message rendered.
- **Component:** limit message renders only when the cap is reached and names the cap.

`pnpm check` green across all 34 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015CXWTDtLmq6Uw2pE6yuPF2)_