### PR TITLE
feat(extension): open the private reader from saved-article links

### DIFF
--- a/projects/browser-extension-core/src/auth/auth.types.ts
+++ b/projects/browser-extension-core/src/auth/auth.types.ts
@@ -23,6 +23,12 @@ export type RefreshTokens = () => Promise<RefreshResult>;
 
 export type GetAccessToken = () => Promise<string | null>;
 
+/** Mints a browser session cookie from the stored bearer. The reader at
+ * /queue/:id/view authorizes the owner from the hutch_sid cookie, never a
+ * bearer, so a list link followed into a normal tab needs that cookie to land
+ * on the private reader instead of the public /view fallback. */
+export type EnsureWebSession = () => Promise<void>;
+
 export type WhenLoggedIn = <T>(fn: () => T) => GuardedResult<T>;
 
 export interface Auth {
@@ -30,6 +36,7 @@ export interface Auth {
 	logout: Logout;
 	refreshTokens: RefreshTokens;
 	getAccessToken: GetAccessToken;
+	ensureWebSession: EnsureWebSession;
 	whenLoggedIn: WhenLoggedIn;
 }
 
@@ -45,7 +52,7 @@ export interface OAuthAuthDeps {
 	openTab(url: string): Promise<number>;
 	waitForRedirect(params: { tabId: number; urlPrefix: string }): Promise<string>;
 	closeTab(tabId: number): Promise<void>;
-	fetchFn(url: string, init: { method: string; headers: Record<string, string>; body: string }): Promise<{ ok: boolean; status: number; json(): Promise<Record<string, string>> }>;
+	fetchFn(url: string, init: { method: string; headers: Record<string, string>; body?: string; credentials?: "include" }): Promise<{ ok: boolean; status: number; json(): Promise<Record<string, string>> }>;
 	tokenStorage: TokenStorage;
 	logger: HutchLogger;
 }

--- a/projects/browser-extension-core/src/auth/in-memory-auth.test.ts
+++ b/projects/browser-extension-core/src/auth/in-memory-auth.test.ts
@@ -88,6 +88,14 @@ describe("initInMemoryAuth", () => {
 		});
 	});
 
+	describe("ensureWebSession", () => {
+		it("should resolve without error", async () => {
+			const auth = initInMemoryAuth();
+
+			await expect(auth.ensureWebSession()).resolves.toBeUndefined();
+		});
+	});
+
 	describe("logout", () => {
 		it("should return not-logged-in after logout", async () => {
 			const auth = initInMemoryAuth();

--- a/projects/browser-extension-core/src/auth/in-memory-auth.ts
+++ b/projects/browser-extension-core/src/auth/in-memory-auth.ts
@@ -1,4 +1,4 @@
-import type { Auth, GetAccessToken, Login, Logout, RefreshTokens, WhenLoggedIn } from "./auth.types";
+import type { Auth, EnsureWebSession, GetAccessToken, Login, Logout, RefreshTokens, WhenLoggedIn } from "./auth.types";
 
 export function initInMemoryAuth(): Auth {
 	let loggedIn = false;
@@ -20,6 +20,8 @@ export function initInMemoryAuth(): Auth {
 		return loggedIn ? "in-memory-token" : null;
 	};
 
+	const ensureWebSession: EnsureWebSession = async () => {};
+
 	const whenLoggedIn: WhenLoggedIn = (fn) => {
 		if (!loggedIn) {
 			return { ok: false, reason: "not-logged-in" };
@@ -39,6 +41,7 @@ export function initInMemoryAuth(): Auth {
 		logout,
 		refreshTokens,
 		getAccessToken,
+		ensureWebSession,
 		whenLoggedIn,
 	};
 }

--- a/projects/browser-extension-core/src/auth/oauth-auth.test.ts
+++ b/projects/browser-extension-core/src/auth/oauth-auth.test.ts
@@ -222,7 +222,7 @@ describe("initOAuthAuth", () => {
 		it("should revoke tokens on the server", async () => {
 			const tokenStorage = createInMemoryTokenStorage();
 			let revokeUrl = "";
-			let revokeOptions: { method: string; headers: Record<string, string>; body: string } | undefined;
+			let revokeOptions: { method: string; headers: Record<string, string>; body?: string } | undefined;
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (url, init) => {
@@ -268,6 +268,50 @@ describe("initOAuthAuth", () => {
 
 			const result = auth.whenLoggedIn(() => "value");
 			expect(result).toEqual({ ok: false, reason: "not-logged-in" });
+		});
+	});
+
+	describe("ensureWebSession", () => {
+		it("posts the bearer token to /auth/session with credentials to mint the reader cookie", async () => {
+			let sessionUrl = "";
+			let sessionInit:
+				| { method: string; headers: Record<string, string>; body?: string; credentials?: string }
+				| undefined;
+			const deps = createInMemoryOAuthDeps({
+				fetchFn: async (url, init) => {
+					if (url.endsWith("/auth/session")) {
+						sessionUrl = url;
+						sessionInit = init;
+					}
+					return { ok: true, status: 200, json: async () => ({ access_token: "access-123", refresh_token: "refresh-456" }) };
+				},
+			});
+			const auth = await initOAuthAuth(deps);
+			await auth.login();
+
+			await auth.ensureWebSession();
+
+			expect(sessionUrl).toBe("http://localhost:3000/auth/session");
+			expect(sessionInit).toEqual({
+				method: "POST",
+				headers: { Authorization: "Bearer access-123" },
+				credentials: "include",
+			});
+		});
+
+		it("does nothing when there is no stored token", async () => {
+			let sessionCalled = false;
+			const deps = createInMemoryOAuthDeps({
+				fetchFn: async (url) => {
+					if (url.endsWith("/auth/session")) sessionCalled = true;
+					return { ok: true, status: 200, json: async () => ({ access_token: "access-123", refresh_token: "refresh-456" }) };
+				},
+			});
+			const auth = await initOAuthAuth(deps);
+
+			await auth.ensureWebSession();
+
+			expect(sessionCalled).toBe(false);
 		});
 	});
 
@@ -330,7 +374,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return {
 							ok: true as boolean,
 							status: 200,
@@ -400,7 +444,7 @@ describe("initOAuthAuth", () => {
 				tokenStorage,
 				fetchFn: async (url, init) => {
 					capturedUrl = url;
-					capturedBody = init.body;
+					capturedBody = init.body ?? "";
 					return {
 						ok: true as boolean,
 						status: 200,
@@ -427,7 +471,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return {
 							ok: true as boolean,
 							status: 200,
@@ -463,7 +507,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return {
 							ok: true as boolean,
 							status: 200,
@@ -529,7 +573,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return { ok: false as boolean, status: 400, json: async () => ({}) };
 					}
 					return {
@@ -555,7 +599,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return { ok: false as boolean, status: 400, json: async () => ({}) };
 					}
 					return {
@@ -583,7 +627,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return {
 							ok: true as boolean,
 							status: 200,
@@ -615,8 +659,8 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					capturedBody = init.body;
-					if (init.body.includes("grant_type=refresh_token")) {
+					capturedBody = init.body ?? "";
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return {
 							ok: true as boolean,
 							status: 200,
@@ -670,7 +714,7 @@ describe("initOAuthAuth", () => {
 			const deps = createInMemoryOAuthDeps({
 				tokenStorage,
 				fetchFn: async (_url, init) => {
-					if (init.body.includes("grant_type=refresh_token")) {
+					if (init.body?.includes("grant_type=refresh_token")) {
 						return {
 							ok: true as boolean,
 							status: 200,

--- a/projects/browser-extension-core/src/auth/oauth-auth.ts
+++ b/projects/browser-extension-core/src/auth/oauth-auth.ts
@@ -123,6 +123,16 @@ export async function initOAuthAuth(deps: OAuthAuthDeps): Promise<Auth> {
 		return storedTokens?.accessToken ?? null;
 	};
 
+	const ensureWebSession = async (): Promise<void> => {
+		const token = await getAccessToken();
+		if (!token) return;
+		await deps.fetchFn(`${deps.serverUrl}/auth/session`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}` },
+			credentials: "include",
+		});
+	};
+
 	const logout = async (): Promise<void> => {
 		const serverUrl = deps.serverUrl;
 		const tokens = await deps.tokenStorage.getTokens();
@@ -158,5 +168,5 @@ export async function initOAuthAuth(deps: OAuthAuthDeps): Promise<Auth> {
 		await refreshTokens().catch(() => {});
 	}
 
-	return { login, logout, refreshTokens, getAccessToken, whenLoggedIn };
+	return { login, logout, refreshTokens, getAccessToken, ensureWebSession, whenLoggedIn };
 }

--- a/projects/browser-extension-core/src/core.test.ts
+++ b/projects/browser-extension-core/src/core.test.ts
@@ -194,6 +194,36 @@ describe("BrowserExtensionCore save", () => {
 		expect(showSavedCalls).toEqual([]);
 		expect(showDefaultCalls).toEqual([7]);
 	});
+
+	it("mints a web session when a save is not saveable and drops into the reader list", async () => {
+		const auth = loggedInAuth();
+		let mintCalls = 0;
+		auth.ensureWebSession = async () => {
+			mintCalls += 1;
+		};
+		const readingList = createRecordingReadingList({
+			saveResult: { ok: false, reason: "not-saveable", items: [] },
+		});
+		const { shell, iconUpdated } = createFakeShell({
+			id: 7,
+			url: "https://active.example",
+			title: "Active",
+		});
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		core.save("current-tab", {
+			url: "https://example.com/article",
+			title: "Article",
+			tabId: 42,
+		});
+
+		await iconUpdated;
+		expect(mintCalls).toBe(1);
+	});
 });
 
 type ShortcutHandler = () => void;
@@ -276,6 +306,7 @@ function loggedInAuth(): Auth {
 		logout: async () => {},
 		refreshTokens: async () => ({ ok: true }),
 		getAccessToken: async () => "token",
+		ensureWebSession: async () => {},
 		whenLoggedIn,
 	};
 }
@@ -535,6 +566,71 @@ describe("BrowserExtensionCore remove/fetch/check", () => {
 
 		expect(results).toHaveLength(1);
 		expect(results[0]).toHaveLength(1);
+	});
+
+	it("mints a web session when fetching the reading list while logged in", async () => {
+		const readingList = initInMemoryReadingList();
+		await readingList.saveUrl({ url: "https://w.example", title: "W" });
+		const cap = createCapturingShell();
+		const auth = loggedInAuth();
+		let mintCalls = 0;
+		auth.ensureWebSession = async () => {
+			mintCalls += 1;
+		};
+		const core = BrowserExtensionCore(cap.shell, { auth, logger, readingList });
+
+		core.fetch("reading-list");
+		await flush();
+
+		expect(mintCalls).toBe(1);
+	});
+
+	it("does not mint a web session when fetching the reading list while logged out", async () => {
+		const cap = createCapturingShell();
+		const auth = loggedInAuth();
+		auth.whenLoggedIn = (() => ({ ok: false, reason: "not-logged-in" })) as WhenLoggedIn;
+		let mintCalls = 0;
+		auth.ensureWebSession = async () => {
+			mintCalls += 1;
+		};
+		const core = BrowserExtensionCore(cap.shell, {
+			auth,
+			logger,
+			readingList: initInMemoryReadingList(),
+		});
+
+		core.fetch("reading-list");
+		await flush();
+
+		expect(mintCalls).toBe(0);
+	});
+
+	it("serves the list and logs when minting the web session fails", async () => {
+		const readingList = initInMemoryReadingList();
+		await readingList.saveUrl({ url: "https://e.example", title: "E" });
+		const cap = createCapturingShell();
+		const auth = loggedInAuth();
+		auth.ensureWebSession = async () => {
+			throw new Error("mint failed");
+		};
+		const warns: unknown[][] = [];
+		const capturingLogger = HutchLogger.from({
+			...noopLogger,
+			warn: (...args) => warns.push(args),
+		});
+		const core = BrowserExtensionCore(cap.shell, {
+			auth,
+			logger: capturingLogger,
+			readingList,
+		});
+		const results: ReadingListItem[][] = [];
+		core.on("fetched-reading-list", { success: (v) => results.push(v), failure: () => {} });
+
+		core.fetch("reading-list");
+		await flush();
+
+		expect(results).toHaveLength(1);
+		expect(warns).toHaveLength(1);
 	});
 
 	it("checks a url", async () => {

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -103,6 +103,17 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 		}
 	}
 
+	/** Mint the browser session cookie so a reader link (/queue/:id/view, whose
+	 * owner is resolved from the hutch_sid cookie, never the bearer) opens the
+	 * private reader instead of the public /view. Fired whenever the popup is about
+	 * to surface reader links — the list load and the not-saveable drop-into-list.
+	 * Fire-and-forget: a failure only degrades that one navigation to the public page. */
+	function establishWebSession(): void {
+		auth
+			.ensureWebSession()
+			.catch((error) => logger.warn("Failed to mint web session for reader links", error));
+	}
+
 	return {
 		init() {
 			eventBus.emit("pre-init");
@@ -166,11 +177,12 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 			if (guarded.ok) {
 				const { tabId } = data;
 				guarded.value
-					.then((result) =>
-						tabId != null && result.ok
+					.then((result) => {
+						if (!result.ok) establishWebSession();
+						return tabId != null && result.ok
 							? shell.setIcon.showSaved(tabId)
-							: updateActiveTabIcon(),
-					)
+							: updateActiveTabIcon();
+					})
 					.catch(() => {});
 			}
 		},
@@ -188,6 +200,7 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 		fetch(_resource) {
 			const guarded = auth.whenLoggedIn(() => readingList.getAllItems());
 			emitResult("fetched-reading-list", guarded);
+			if (guarded.ok) establishWebSession();
 		},
 
 		check(_resource, data) {

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -583,21 +583,29 @@ export function createApp(dependencies: AppDependencies): Express {
 		}),
 	);
 
+	const isAllowedExtensionOrigin = (origin: string | undefined): boolean =>
+		!origin ||
+		origin === appOrigin ||
+		origin === "https://hutch-app.com" ||
+		/^(moz|chrome)-extension:\/\//.test(origin);
+
 	const extensionCors = cors({
-		origin: (origin, callback) => {
-			if (
-				!origin ||
-				origin === appOrigin ||
-				origin === "https://hutch-app.com" ||
-				/^(moz|chrome)-extension:\/\//.test(origin)
-			) {
-				callback(null, true);
-			} else {
-				callback(null, false);
-			}
-		},
+		origin: (origin, callback) => callback(null, isAllowedExtensionOrigin(origin)),
 		methods: ["GET", "POST", "PUT", "DELETE"],
 		allowedHeaders: ["Authorization", "Content-Type", "Accept", "Prefer"],
+		maxAge: 86400,
+	});
+
+	/** The session-cookie bridge is the only extension endpoint that needs
+	 * credentialed CORS: the extension POSTs with credentials:"include" so the
+	 * browser stores the Set-Cookie hutch_sid. credentials:true (which also
+	 * reflects the specific Origin instead of "*") stays scoped to this route
+	 * rather than loosening the bearer-only endpoints. */
+	const sessionBridgeCors = cors({
+		origin: (origin, callback) => callback(null, isAllowedExtensionOrigin(origin)),
+		methods: ["POST"],
+		allowedHeaders: ["Authorization", "Content-Type"],
+		credentials: true,
 		maxAge: 86400,
 	});
 
@@ -761,6 +769,7 @@ export function createApp(dependencies: AppDependencies): Express {
 			signup: deps.rateLimitRules.signup,
 		},
 	});
+	app.use("/auth/session", sessionBridgeCors);
 	app.use(authRouter);
 
 	if (deps.googleAuth) {

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -1062,6 +1062,37 @@ describe("Auth routes", () => {
 			const queueResponse = await agent.get("/queue").set("Accept", "text/html");
 			expect(queueResponse.status).toBe(200);
 		});
+
+		it("answers the extension's credentialed CORS preflight", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const extensionOrigin = "chrome-extension://abcdefghijklmnopabcdefghijklmnop";
+
+			const response = await request(harness.server)
+				.options("/auth/session")
+				.set("Origin", extensionOrigin)
+				.set("Access-Control-Request-Method", "POST")
+				.set("Access-Control-Request-Headers", "authorization");
+
+			expect(response.status).toBe(204);
+			expect(response.headers["access-control-allow-origin"]).toBe(extensionOrigin);
+			expect(response.headers["access-control-allow-credentials"]).toBe("true");
+		});
+
+		it("returns credentialed CORS headers so the extension can store the minted cookie", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const accessToken = await createAccessToken(harness);
+			const extensionOrigin = "moz-extension://d3b07384-d113-4ec6-a7b8-5f7e3b4c9a12";
+
+			const response = await request(harness.server)
+				.post("/auth/session")
+				.set("Origin", extensionOrigin)
+				.set("Authorization", `Bearer ${accessToken}`);
+
+			expect(response.status).toBe(204);
+			expect(response.headers["access-control-allow-origin"]).toBe(extensionOrigin);
+			expect(response.headers["access-control-allow-credentials"]).toBe("true");
+			assert(sessionCookie(response), "expected the hutch_sid session cookie");
+		});
 	});
 
 	describe("Google sign-in button", () => {


### PR DESCRIPTION
## Why

Clicking a saved-article link in the browser extension opened the **public** `/view/<url>` page instead of the user's **private reader**, even though they're logged in to the extension.

Root cause is an auth-channel mismatch, not the link itself:

- The popup link is already correct: `item.readUrl ?? item.url`, where `readUrl` is `…/queue/:id/view` (the private reader).
- `/queue/:id/view` resolves the owner from the **`hutch_sid` session cookie** (`req.userId`), never from a bearer. It's also declared **before** `dualAuth`, so an anonymous request is silently redirected to the public `/view` page rather than to `/login`.
- The extension only holds an **OAuth bearer**. Opening a reader link spawns a normal browser tab that carries no `hutch_sid` cookie → anonymous → public view.

PR #788 shipped `POST /auth/session` (bearer → session cookie) "server — deploy first" for exactly this, but no client used it yet, and the endpoint wasn't wired for the extension's cross-origin credentialed call.

## What

**Client (`browser-extension-core`, inherited by both Chrome and Firefox — no popup/manifest change):**
- New `Auth.ensureWebSession()` mints the `hutch_sid` cookie from the stored bearer via `POST /auth/session` with `credentials:"include"`.
- `core` fires it whenever the popup is about to surface reader links — the reading-list load (`fetch("reading-list")`) and the "not-saveable" drop-into-list path. The existing `readUrl ?? url` anchor then opens the authenticated private reader.

**Server (`hutch`):**
- `/auth/session` is the first extension endpoint to use a **credentialed** cross-origin POST, so it gets scoped CORS — `OPTIONS` preflight + `Access-Control-Allow-Credentials: true` — mirroring the existing `extensionCors` pattern used by `/`, `/queue`, `/oauth/token`. Credentials are **not** loosened for the bearer-only endpoints.
- The `hutch_sid` cookie stays `SameSite=Lax` + `HttpOnly` + `Secure`. Under `host_permissions`, Chromium treats the extension fetch as first-party to `readplace.com`, so a Lax cookie both stores and is sent on the subsequent top-level navigation.

## Verification

- `pnpm check` green for `hutch`, `browser-extension-core`, `chrome-extension`, `firefox-extension` (100% coverage held; the pre-commit hook ran the full workspace check).
- New unit tests: `ensureWebSession` posts the bearer with `credentials:"include"` (and no-ops logged-out); `core` mints on list-fetch and on the not-saveable save, swallows mint failures.
- New integration tests: `OPTIONS /auth/session` preflight returns the reflected origin + `Allow-Credentials: true`; the credentialed POST returns those headers and still mints the cookie.
- Validated by a 4-lens adversarial review (runtime cookie deposit, server reachability, diff/coverage, failure modes) — the two CORS blockers it found are fixed here.

## Known limitations / follow-ups (from the review)

These degrade gracefully to the **public** reader (today's behaviour), so they don't regress anything, but are worth a follow-up:

1. **First-open race.** The mint is fire-and-forget, so on the very first popup open of a browser session (cookie cleared on browser close — no `maxAge`), a click *before* the `POST /auth/session` round-trip lands has no cookie yet. Steady-state is fine (re-minted on every list open). The fully race-free option is to intercept the anchor click → await the mint → open the tab; not done here to preserve native anchor affordances (middle/cmd-click, copy-link).
2. **Real-browser confirmation (esp. Firefox).** The cookie deposit + top-level-nav send is verified by unit/integration tests, not an E2E in a real extension build. Worth an E2E asserting a reader link lands on `/queue/:id/view`, not `/view` — particularly on Firefox, where the cross-origin credentialed handling is stricter.
3. **Session-row churn.** Each mint calls `createSession`, writing a fresh (TTL'd) `hutch_sid` row per popup-list-open; could be short-circuited when a valid cookie already exists.
4. **Local/dev is a no-op** (`HUTCH_SERVER_URL=http://127.0.0.1:3000` ≠ the `host_permissions` host), so this is only exercisable against an https `readplace.com` build.

## Test plan

- [ ] Load the built extension against `readplace.com`, log in, open the popup, click a saved article → lands on the private `/queue/:id/view` reader (Mark-as-read button + progress), not `/view`.
- [ ] Repeat in Firefox.
