### PR TITLE
fix(ios): gate VoiceOver mark-as-read action on canMarkRead

### DIFF
--- a/projects/ios-readplace/App/ReadingListView.swift
+++ b/projects/ios-readplace/App/ReadingListView.swift
@@ -108,8 +108,12 @@ struct ReadingListView: View {
 							.tint(.green)
 						}
 					}
-					.accessibilityAction(named: "Mark as read") {
-						Task { await viewModel.markAsRead(article) }
+					.accessibilityActions {
+						if article.canMarkRead {
+							Button("Mark as read") {
+								Task { await viewModel.markAsRead(article) }
+							}
+						}
 					}
 			}
 


### PR DESCRIPTION
## Summary

In `projects/ios-readplace/App/ReadingListView.swift`, the `swipeActions` "Mark as read" button is already gated on `article.canMarkRead`, but the equivalent VoiceOver `.accessibilityAction(named: "Mark as read")` was applied unconditionally. On a read-only row (no usable update-status action), VoiceOver would still advertise a "Mark as read" action that no-ops or produces a spurious error.

This change replaces the unconditional `.accessibilityAction(named:)` with `.accessibilityActions { if article.canMarkRead { ... } }`, mirroring the conditional gate used by the swipe action so the action is only exposed to assistive technology when it can actually do something.

## Changes
- Gate the VoiceOver mark-as-read action on `article.canMarkRead`, matching the `swipeActions` button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC2VSHBaE288VwxaSaApQx)_