### PR TITLE
fix(ios): isolate the minted hutch_sid cookie from the shared jar

### DIFF
--- a/projects/ios-readplace/App/AppSession.swift
+++ b/projects/ios-readplace/App/AppSession.swift
@@ -24,7 +24,11 @@ final class AppSession: ObservableObject {
 	private let store: TokenStore
 	private let sessionConfiguration: URLSessionConfiguration
 
-	init(store: TokenStore = TokenStore(), sessionConfiguration: URLSessionConfiguration = .default) {
+	// Defaults to an ephemeral configuration so the API/OAuth sessions keep their
+	// cookie jar in an isolated, in-memory store rather than process-wide
+	// `HTTPCookieStorage.shared` — the minted `hutch_sid` reader cookie must not
+	// linger in the shared jar where it would outlive a sign-out.
+	init(store: TokenStore = TokenStore(), sessionConfiguration: URLSessionConfiguration = .ephemeral) {
 		self.store = store
 		self.sessionConfiguration = sessionConfiguration
 		self.isLoggedIn = store.isLoggedIn
@@ -64,13 +68,26 @@ final class AppSession: ObservableObject {
 	/// Graceful sign-out: revoke server-side, then clear local state.
 	func logout() async {
 		await makeOAuth().revoke()
+		clearSessionCookie()
 		isLoggedIn = false
 	}
 
 	/// Local sign-out used when the session is already invalid (refresh failed).
 	func forceLogout() {
 		store.clear()
+		clearSessionCookie()
 		isLoggedIn = false
+	}
+
+	/// Drops the minted browser session cookie (`hutch_sid`) on sign-out so it
+	/// doesn't linger in the API session's cookie jar for the next sign-in in the
+	/// same process. The jar is the configuration's own isolated store (never
+	/// `HTTPCookieStorage.shared`), so this clears only this app's copy.
+	private func clearSessionCookie() {
+		let storage = sessionConfiguration.httpCookieStorage
+		for cookie in storage?.cookies ?? [] where cookie.name == AppConfig.sessionCookieName {
+			storage?.deleteCookie(cookie)
+		}
 	}
 
 	func makeAPI() -> ReadplaceAPI {

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -238,14 +238,16 @@ cases:
   back to the collection and verifying the status at the protocol level only (any
   non-2xx/3xx surfaces a generic server error — no per-code special-casing),
   `bootstrapSession` reading the session cookie from the store URLSession parsed
-  (refreshing the bearer once if expired), and missing-token handling.
+  (refreshing the bearer once if expired) while keeping the minted `hutch_sid`
+  out of the process-wide shared cookie jar, and missing-token handling.
 - **TokenStore / URL detection**: persistence and partial-token edge cases;
   http(s)-only link extraction that ignores `mailto:`/`tel:`.
 - **Login & share-save journeys**: the two orchestration seams end-to-end through
   the real session/API types. Sign-in — `completeSignIn` exchanging the code and
   flipping the session to logged-in (and rejecting a state-mismatched callback
   without exchanging the code), then a reading-list load preserving the bearer
-  token across the entry-point `303`.
+  token across the entry-point `303`, and both sign-out paths (`logout` /
+  `forceLogout`) dropping the minted `hutch_sid` session cookie.
   Share-save — `SaveSharedPage` saving rendered HTML when it's under the cap,
   degrading to URL-only when the capture is empty or the HTML is over the cap,
   short-circuiting before any network call when logged out or when there's no

--- a/projects/ios-readplace/Shared/ReadplaceAPI.swift
+++ b/projects/ios-readplace/Shared/ReadplaceAPI.swift
@@ -56,7 +56,11 @@ final class ReadplaceAPI {
 	private let oauth: OAuthService
 	private let session: URLSession
 
-	init(baseURL: String, store: TokenStore, sessionConfiguration: URLSessionConfiguration = .default) {
+	// Defaults to an ephemeral configuration so the session's cookie jar is its
+	// own isolated, in-memory store rather than process-wide `HTTPCookieStorage.shared`:
+	// the `hutch_sid` cookie minted by `bootstrapSession` must not linger in the
+	// shared jar where it would outlive the session and leak across sign-outs.
+	init(baseURL: String, store: TokenStore, sessionConfiguration: URLSessionConfiguration = .ephemeral) {
 		self.baseURL = baseURL
 		self.store = store
 		self.oauth = OAuthService(baseURL: baseURL, store: store, sessionConfiguration: sessionConfiguration)
@@ -127,7 +131,9 @@ final class ReadplaceAPI {
 		return cookie
 	}
 
-	/// Reads the session cookie by name from the store URLSession parsed it into.
+	/// Reads the session cookie by name from the session's own cookie jar, which
+	/// the configuration isolates (an ephemeral store, not `HTTPCookieStorage.shared`)
+	/// so the cookie URLSession just parsed never touches the process-wide jar.
 	/// The cookie spec forbids folding repeated `Set-Cookie` headers into one
 	/// comma-joined value, so re-splitting `allHeaderFields` is unsafe once a
 	/// response sets more than one cookie; reading the already-parsed cookie back

--- a/projects/ios-readplace/Tests/LoginFlowTests.swift
+++ b/projects/ios-readplace/Tests/LoginFlowTests.swift
@@ -84,6 +84,35 @@ final class LoginFlowTests: XCTestCase {
 		XCTAssertTrue(StubURLProtocol.records.isEmpty, "a rejected callback must not exchange the code")
 	}
 
+	func testForceLogoutClearsTheMintedSessionCookie() {
+		let config = TestSupport.stubbedConfiguration()
+		config.httpCookieStorage?.setCookie(TestSupport.sessionCookie(value: "sess-abc"))
+		let session = AppSession(store: TestSupport.loggedInStore(), sessionConfiguration: config)
+
+		session.forceLogout()
+
+		XCTAssertFalse(session.isLoggedIn)
+		XCTAssertNil(
+			config.httpCookieStorage?.cookies?.first { $0.name == AppConfig.sessionCookieName },
+			"the minted hutch_sid cookie must not survive a forced sign-out"
+		)
+	}
+
+	func testLogoutClearsTheMintedSessionCookie() async {
+		let config = TestSupport.stubbedConfiguration()
+		config.httpCookieStorage?.setCookie(TestSupport.sessionCookie(value: "sess-abc"))
+		StubURLProtocol.setHandler { _, _ in .json(200, "{}") }
+		let session = AppSession(store: TestSupport.loggedInStore(), sessionConfiguration: config)
+
+		await session.logout()
+
+		XCTAssertFalse(session.isLoggedIn)
+		XCTAssertNil(
+			config.httpCookieStorage?.cookies?.first { $0.name == AppConfig.sessionCookieName },
+			"the minted hutch_sid cookie must not survive sign-out"
+		)
+	}
+
 	func testLoggedInThenLoadQueueRendersArticles() async throws {
 		let store = TestSupport.loggedInStore(access: "access-1")
 		let session = AppSession(store: store, sessionConfiguration: TestSupport.stubbedConfiguration())

--- a/projects/ios-readplace/Tests/ReadplaceAPITests.swift
+++ b/projects/ios-readplace/Tests/ReadplaceAPITests.swift
@@ -386,4 +386,21 @@ final class ReadplaceAPITests: XCTestCase {
 		XCTAssertEqual(sessionAttempts, 2, "should retry once after refreshing the bearer")
 		XCTAssertEqual(store.tokens?.accessToken, "fresh-access")
 	}
+
+	func testBootstrapSessionKeepsTheCookieOutOfTheSharedJar() async throws {
+		let host = try XCTUnwrap(URL(string: AppConfig.serverBaseURL)?.host)
+		for stale in HTTPCookieStorage.shared.cookies?.filter({ $0.name == AppConfig.sessionCookieName }) ?? [] {
+			HTTPCookieStorage.shared.deleteCookie(stale)
+		}
+		StubURLProtocol.setHandler { _, _ in
+			StubURLProtocol.Stub(status: 204, headers: ["Set-Cookie": "hutch_sid=isolated; Path=/; Domain=\(host)"])
+		}
+
+		_ = try await makeAPI(store: TestSupport.loggedInStore()).bootstrapSession()
+
+		XCTAssertNil(
+			HTTPCookieStorage.shared.cookies?.first { $0.name == AppConfig.sessionCookieName },
+			"the minted hutch_sid cookie must never land in the process-wide shared jar"
+		)
+	}
 }

--- a/projects/ios-readplace/Tests/TestSupport.swift
+++ b/projects/ios-readplace/Tests/TestSupport.swift
@@ -18,6 +18,17 @@ enum TestSupport {
 		return config
 	}
 
+	/// A `hutch_sid` session cookie scoped to the server host, for seeding a
+	/// cookie jar before asserting sign-out clears it.
+	static func sessionCookie(value: String) -> HTTPCookie {
+		HTTPCookie(properties: [
+			.name: AppConfig.sessionCookieName,
+			.value: value,
+			.domain: URL(string: AppConfig.serverBaseURL)!.host!,
+			.path: "/",
+		])!
+	}
+
 	/// A token store pre-seeded with a logged-in session.
 	static func loggedInStore(
 		access: String = "access-1",


### PR DESCRIPTION
## Problem

The reader session cookie minted by `ReadplaceAPI.bootstrapSession` (`POST /auth/session` → `Set-Cookie: hutch_sid=…`) was parsed into the **process-wide** `HTTPCookieStorage.shared`, because both the API and OAuth `URLSession`s defaulted to `URLSessionConfiguration.default`. `sessionCookie(from:url:)` then read the cookie back out of that shared jar.

Consequences:
- The minted `hutch_sid` lingered in the shared jar for the rest of the process lifetime — outliving the reader sheet and surviving sign-out.
- The share extension's `ReadplaceAPI` (constructed without a config) shared the same exposure.

## Fix

Both levers the task called for, applied as defence in depth:

1. **Isolated cookie jar.** Default the `ReadplaceAPI` and `AppSession` session configurations to `.ephemeral`. Foundation has no public standalone `HTTPCookieStorage` initializer; an ephemeral configuration is the supported way to give a session its own isolated, in-memory cookie store that is never `HTTPCookieStorage.shared`. `sessionCookie` now reads the cookie the same session just parsed, without touching the shared jar. This matches the existing `.nonPersistent()` posture already used by `ReaderWebView`, and the tests already run on `.ephemeral`.
2. **Clear on sign-out.** `logout()` and `forceLogout()` now drop the `hutch_sid` cookie from the configuration's jar, so a minted cookie can't survive into the next sign-in within the same process run.

## Tests

- `ReadplaceAPITests.testBootstrapSessionKeepsTheCookieOutOfTheSharedJar` — bootstrapping never lands `hutch_sid` in `HTTPCookieStorage.shared`.
- `LoginFlowTests.testForceLogoutClearsTheMintedSessionCookie` / `testLogoutClearsTheMintedSessionCookie` — both sign-out paths remove the cookie.
- `TestSupport.sessionCookie(value:)` helper for seeding the jar.

Note: the iOS project's Swift tests run on macOS (via `xcodebuild`); they were not executed in this Linux session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018SgYeX54uQY5jSFSJqFGf8)_