### PR TITLE
docs(skills): hypermedia-api-design — generalize to all clients + cross-client conformance + MCP

### DIFF
--- a/.claude/skills/hypermedia-api-design/SKILL.md
+++ b/.claude/skills/hypermedia-api-design/SKILL.md
@@ -140,6 +140,23 @@ A client binds both levels: collection-level actions (e.g. `save-article`, `sear
 | Synthesising state after a mutation (`allItems.filter(i => i.id !== deletedId)`) | Server is the source of truth; follow the 303 and read the new collection |
 | Exporting an `/api` SDK that knows resource URLs | Becomes another versioned surface; expose only the walker and the entry point |
 | Interpolating unescaped user data into a `messages[].content.body` | The client injects it via `innerHTML`; unescaped server output is markup injection (see "Server-Driven Messages Are Trusted HTML") |
+| Naming a concrete server route or method in client code or comments (`POST /queue/save-html`, "303s to `/queue`") | The client reads `href`/`method` from the response; a route baked into a comment rots and reintroduces the URL coupling the contract removes |
+| Asserting a specific server response body/URL/shape in a client test | A client test should exercise generic protocol handling — follow whatever action/link the response carries — not pin the server's current URLs or shapes |
+
+## Client Conformance
+
+These rules make any client (extension, iOS, MCP, future) behave like a browser over the contract above — "the app is a browser, Siren is HTML." Each prevents a real cross-client failure mode.
+
+| Rule | Why |
+|---|---|
+| Render a control (button, swipe, menu item, tap target) **only if the current response advertised** the matching action/link; hide or disable it otherwise. | A browser shows a Delete button only when the HTML has one. A control for an absent action is a phantom affordance that fails silently — the worst HATEOAS failure mode. |
+| Navigate by the server-supplied link (`rel`), not by a domain property. | Opening a raw `url` property instead of following the `read` link discards the server's chosen destination; if the server re-points the link, the client never follows it. |
+| Resolve every href through one helper: use an `http(s)://` href verbatim, resolve a scheme-less href against the base, treat any other scheme as no href (unactionable). | Per-call-site `base + href` concatenation corrupts an absolute href and mis-resolves other schemes — yet the Evolvability table promises changing an `href` is non-breaking. |
+| Verify the response `Content-Type` is the negotiated media type before parsing; render a standard "unsupported media type" view for anything else. | Negotiating with `Accept` but blind-decoding any 200 body turns a proxy HTML page or a future media type into an opaque "couldn't read the response" instead of an honest "I don't understand this type." The message-content gate already does this — apply it to the response envelope too. |
+| Parse leniently: one malformed link/action must degrade to unactionable, never fail the whole response decode. | An atomic decode that rejects a single odd control blanks the entire page — extend the same tolerance the entity `properties` already get. (Note: Siren requires `href` on links/actions, so a hrefless control is a malformed control, not a valid one.) |
+| Drive search, filter, sort, and pagination from the server's `fields` and links — never client-built params or client-side re-paging. | Hardcoding `?page=` or re-paginating one fetched page client-side hides items past the first page and breaks when the server changes paging; hardcoding a filter field name breaks on a rename. |
+| Don't duplicate server policy (size caps, validation thresholds) in the client; attempt the action and follow the server's fallback/refusal. | A client copy of a server constant goes stale on a server change and mis-routes; the server already advertises the fallback action to follow. |
+| Bind a response's actions through one generic path; don't cherry-pick named affordances into per-operation code with hardcoded shapes. | Per-operation bespoke handling means each new server capability needs new client code and a redeploy; a generic action map exposes whatever the server offers. |
 
 ## Per-Client Implementations
 
@@ -157,10 +174,30 @@ For the full flow see the source — it is the spec: [projects/browser-extension
 
 When adding a capability the extension supports: add an `init*Understanding` keyed by the action name, compose it via `groupOf(...)`, wrap with `httpCacheable(...)` for cacheable GETs, and drive the walker directly rather than adding a method to `initSirenReadingList`.
 
+### MCP: the same doctrine over a different transport
+
+Readplace also exposes its domain over MCP (Model Context Protocol) at `/mcp`; the external AI assistant is the client. MCP shares this skill's core stance — **the server owns the protocol; the client hardcodes one connection and discovers everything else** — so the Client Conformance rules apply to an MCP client too. It diverges in transport and statefulness, so the mapping is partial, not 1:1.
+
+| Siren / HATEOAS | MCP |
+|---|---|
+| Single entry point `/` (the one hardcoded URL) | The server connection — one Streamable HTTP endpoint or stdio command |
+| `Accept` content negotiation, per request | `initialize` capability + protocol-version handshake, once per stateful session |
+| `actions[]` (`name`, `href`, `method`, `fields`); `name` is the contract | Tools (`tools/list` → `name`, `inputSchema`; invoked via `tools/call`); tool `name` is the contract |
+| `action.fields` (declared inputs) | `inputSchema` (JSON Schema) + optional `outputSchema` the client validates the result against |
+| `links[]` by `rel`/`href`, followed not built | Resources (`resources/list` → `uri`; read via `resources/read`); RFC 6570 `uriTemplate` for parameterized access |
+| Opaque `next` link; never build `?page=` | Opaque pagination `cursor`/`nextCursor`; echo unchanged, never parse or persist |
+| `303` back to the collection after a mutation | Server-pushed `notifications/*/list_changed` and `resources/updated` → re-list / re-read |
+| Generic `messages[]` channel; render media types you understand | JSON-RPC error object (the call failed) vs `isError:true` in a result (the operation refused); typed content blocks |
+| (no analog) | Prompts (`prompts/list` / `prompts/get`) — user-initiated; MCP-only |
+
+Divergences a client must respect: MCP fixes the invocation verb (`tools/call`, `resources/read`) instead of declaring a `method` per affordance; capabilities are three flat global registries (tools/resources/prompts), not actions bound to an entity, so a per-item operation is a tool taking the item's id/uri as an argument; and staleness signals are asynchronous server pushes, not a synchronous redirect.
+
+In this repo, hutch is the MCP **server**: the tool set is the single source of truth in `tool-definitions.ts` (`TOOL_DEFINITIONS`), advertised via `tools/list` in `mcp-server.ts`, with no client copy to drift. The WebMCP surface (`webmcp.client.ts`) is a **provider** that registers one local `save_link` tool for an in-browser agent — a provider declares its own shape, so discover-don't-hardcode does not apply to it. Spec: [modelcontextprotocol.io](https://modelcontextprotocol.io).
+
 ## Checklist — Adding a New Capability to the API
 
 1. **Name the action as a capability**, not a domain fact. Check the Evolvability table before picking a name.
-2. **Emit the action on the server** in `collection-siren.ts` (collection-level) or `article-siren.ts` (entity-level). Declare its `fields` with Siren field types.
+2. **Emit the capability on the server** — Siren: an action in `collection-siren.ts` (collection-level) or `article-siren.ts` (entity-level), with its `fields` declared as Siren field types; MCP: a tool in `tool-definitions.ts`, with its `inputSchema`.
 3. **Implement the route handler** behind `wantsSiren(req)`; return `303` for mutations that should land the client back on a collection.
 4. **Add a handler for the action name on each client** that should expose the capability — see [Per-Client Implementations](#per-client-implementations).
 5. **Test server and client independently** — server integration tests, plus each client's own tests. The contract surface (action name + fields + method + response class) is what both sides pin down.

--- a/.claude/skills/hypermedia-api-design/SKILL.md
+++ b/.claude/skills/hypermedia-api-design/SKILL.md
@@ -1,15 +1,15 @@
 ---
-name: extension-api-design
-description: Hypermedia contract between browser-extension-core (client) and hutch (server). Use when adding, renaming, or removing API capabilities that the extension consumes, when the server emits or parses Siren responses, or when the extension's navigation/action flow changes.
+name: hypermedia-api-design
+description: Hypermedia contract between Readplace's hutch server and every client that consumes it — the chrome and firefox extensions, the iOS app, the MCP server, and future clients. Use when adding, renaming, or removing an API capability a client consumes, when the server emits or parses Siren responses, or when any client's navigation/action flow changes.
 ---
 
-# Extension ↔ Hutch API Design
+# Client ↔ Hutch Hypermedia API Design
 
-The extension talks to hutch over a Siren (`application/vnd.siren+json`) hypermedia API. The same URLs serve browsers (`text/html`) via content negotiation. The contract is **the message format plus a stable vocabulary of action names** — not a catalogue of URLs, methods, or request shapes.
+Clients talk to hutch over a Siren (`application/vnd.siren+json`) hypermedia API; the same URLs serve browsers (`text/html`) via content negotiation. This doctrine governs **every** client surface — the chrome and firefox extensions, the iOS app, the MCP server, and any future client — so a server-side view change never forces a client redeploy. The contract is **the message format plus a stable vocabulary of action names** — not a catalogue of URLs, methods, or request shapes.
 
 ## Core Principle: The Server Owns the Protocol
 
-The client knows exactly one URL: the entry point (`/`). From there, the server tells the client:
+A client knows exactly one URL: the entry point (`/`). From there, the server tells the client:
 - Where to navigate next (`links[rel=self]`)
 - What actions are possible (`actions[].name`, `.href`, `.method`, `.fields`)
 - How items relate (`entities[].rel`, entity-level actions/links)
@@ -20,12 +20,12 @@ The client's job is to interpret the Siren format and follow what the server say
 - Server schemas: [projects/hutch/src/runtime/web/api/siren.ts](../../../projects/hutch/src/runtime/web/api/siren.ts)
 - Collection emission: [projects/hutch/src/runtime/web/api/collection-siren.ts](../../../projects/hutch/src/runtime/web/api/collection-siren.ts)
 - Entity emission: [projects/hutch/src/runtime/web/api/article-siren.ts](../../../projects/hutch/src/runtime/web/api/article-siren.ts)
-- Client walker: [projects/browser-extension-core/src/reading-list/siren-reading-list.ts](../../../projects/browser-extension-core/src/reading-list/siren-reading-list.ts)
 - Content negotiation: [projects/hutch/src/runtime/web/content-negotiation.ts](../../../projects/hutch/src/runtime/web/content-negotiation.ts)
+- Client implementations: see [Per-Client Implementations](#per-client-implementations)
 
 ## Content Negotiation, Not Parallel APIs
 
-One URL per capability serves both the browser (HTML) and the extension (Siren) based on `Accept`. Do not add a `/api/*` tree or version prefix — that creates two independent evolutions of the same concept.
+One URL per capability serves both the browser (HTML) and a programmatic client (Siren) based on `Accept`. Do not add a `/api/*` tree or version prefix — that creates two independent evolutions of the same concept.
 
 - `GET /` with `Accept: application/vnd.siren+json` → `303 See Other` → `/queue` (the Siren entry point)
 - `GET /` with `Accept: text/html` → home page
@@ -33,7 +33,7 @@ One URL per capability serves both the browser (HTML) and the extension (Siren) 
 
 Why 303 over the entry point: the server decides where the collection lives; renaming `/queue` to something else is a server-internal change because the client only followed the redirect.
 
-## What the Extension Must Know vs Discover
+## What a Client Must Know vs Discover
 
 | Must know (client code) | Must discover (from server response) |
 |---|---|
@@ -77,29 +77,19 @@ When a breaking change is necessary, add the new capability alongside the old on
 
 ## State Lives in the Network
 
-HTTP caching (`ETag` + `If-None-Match`) is the authoritative cache layer. Do not build a parallel in-client cache of "what articles exist" as the source of truth. The client may keep a short-lived cache of *bound actions* (items the server returned with their `delete` action attached) as a performance optimisation, but the canonical state is always whatever the server returns next.
+HTTP caching (`ETag` + `If-None-Match`) is the authoritative cache layer. Do not build a parallel in-client cache of "what articles exist" as the source of truth. A client may keep a short-lived cache of *bound actions* (items the server returned with their `delete` action attached) as a performance optimisation, but the canonical state is always whatever the server returns next.
 
-- Cache wrapper: `httpCacheable(understanding)` in `siren-reading-list.ts`
+- Cache wrapper: `httpCacheable(understanding)` in the browser extension's `siren-reading-list.ts`
 - Short-lived action cache: `knownItems` in `initSirenReadingList` (cleared on every mutation)
 
 After a mutation, the server drives the client back to the collection via `303 See Other`. `fetch` follows the redirect automatically; the client parses the new collection and that becomes the new truth. Do not synthesise "the new list after delete" client-side — read it from the response.
 
-## The Client Walker Pattern
-
-The client separates three concerns:
-
-1. **Understandings** (`init*Understanding` functions) — one handler per action name the client knows how to invoke. Each handler receives the Siren action descriptor and a context, returns a bound callable.
-2. **Composition** — `groupOf(...)` merges multiple understandings; `httpCacheable(...)` wraps them with ETag caching.
-3. **Walker** — `initExtension(handlers, deps)` returns a no-arg function that fetches the entry point, resolves the `self` link, and parses collections into `{items, actions}` where every item has its own action map.
-
-For the full flow see the JSDoc-free source — it is the spec. The adapter `initSirenReadingList` exists only to bridge this walker to the legacy `SaveUrl`/`RemoveUrl`/`FindByUrl`/`GetAllItems` interface that the popup consumes. New consumers should call the walker directly.
-
 ## Form Fields Are Declared, Not Assumed
 
-The server declares what an action needs via `action.fields`. The client's understanding for a given action asserts the fields it expects and builds the request body from them. When adding a new required input to an action:
+The server declares what an action needs via `action.fields`. A client's handler for a given action asserts the fields it expects and builds the request body from them. When adding a new required input to an action:
 
 1. Server: add a new entry to `fields` and validate it in the route handler.
-2. Client: update the understanding to assert/pass the new field. Old clients will fail loudly (the field is required server-side), which is correct — a client that can't provide required inputs should not silently succeed.
+2. Client: update the handler to assert/pass the new field. Old clients will fail loudly (the field is required server-side), which is correct — a client that can't provide required inputs should not silently succeed.
 
 When adding an optional input, only the server changes; old clients keep working.
 
@@ -135,13 +125,13 @@ The client-side render decisions (per-`type` variant class, the `role` politenes
 | Collection-level | `entity.actions` on the collection | `save-article`, `search` |
 | Entity-level | `entities[].actions` | `delete` |
 
-The client's walker binds both: `result.actions["save-article"]` (collection) and `result.items[i].actions.delete` (entity). Put an action at the level where it makes sense — "delete this article" belongs on the article entity, not the collection.
+A client binds both levels: collection-level actions (e.g. `save-article`, `search`) and the per-entity actions on each item (e.g. `delete`). Put an action at the level where it makes sense — "delete this article" belongs on the article entity, not the collection.
 
 ## Anti-Patterns
 
 | Avoid | Why |
 |---|---|
-| Hard-coding URLs in the extension (e.g. `\`${serverUrl}/queue/${id}/delete\``) | Makes URL changes a coordinated deploy |
+| Hard-coding URLs in a client (e.g. `\`${serverUrl}/queue/${id}/delete\``) | Makes URL changes a coordinated deploy |
 | A `/api/v1/...` route tree parallel to the HTML pages | Two things to keep in sync; versioning creep |
 | Returning JSON with a bespoke shape (`{items: [...], nextPage: ...}`) | Forces every client to re-implement Siren badly |
 | Client-owned pagination URLs (`?page=${current+1}`) | Server can't change pagination without breaking clients; follow the `next` link instead |
@@ -151,12 +141,26 @@ The client's walker binds both: `result.actions["save-article"]` (collection) an
 | Exporting an `/api` SDK that knows resource URLs | Becomes another versioned surface; expose only the walker and the entry point |
 | Interpolating unescaped user data into a `messages[].content.body` | The client injects it via `innerHTML`; unescaped server output is markup injection (see "Server-Driven Messages Are Trusted HTML") |
 
-## Checklist — Adding a New Capability to the Extension API
+## Per-Client Implementations
+
+Every client interprets the same Siren contract above; only the mechanics differ. The contract is shared; the notes below are client-specific.
+
+### Browser extension (the walker pattern)
+
+The browser-extension client separates three concerns:
+
+1. **Understandings** (`init*Understanding` functions) — one handler per action name the client knows how to invoke. Each handler receives the Siren action descriptor and a context, returns a bound callable.
+2. **Composition** — `groupOf(...)` merges multiple understandings; `httpCacheable(...)` wraps them with ETag caching.
+3. **Walker** — `initExtension(handlers, deps)` returns a no-arg function that fetches the entry point, resolves the `self` link, and parses collections into `{items, actions}` where every item has its own action map.
+
+For the full flow see the source — it is the spec: [projects/browser-extension-core/src/reading-list/siren-reading-list.ts](../../../projects/browser-extension-core/src/reading-list/siren-reading-list.ts). The adapter `initSirenReadingList` exists only to bridge this walker to the legacy `SaveUrl`/`RemoveUrl`/`FindByUrl`/`GetAllItems` interface that the popup consumes. New consumers should call the walker directly.
+
+When adding a capability the extension supports: add an `init*Understanding` keyed by the action name, compose it via `groupOf(...)`, wrap with `httpCacheable(...)` for cacheable GETs, and drive the walker directly rather than adding a method to `initSirenReadingList`.
+
+## Checklist — Adding a New Capability to the API
 
 1. **Name the action as a capability**, not a domain fact. Check the Evolvability table before picking a name.
 2. **Emit the action on the server** in `collection-siren.ts` (collection-level) or `article-siren.ts` (entity-level). Declare its `fields` with Siren field types.
 3. **Implement the route handler** behind `wantsSiren(req)`; return `303` for mutations that should land the client back on a collection.
-4. **Add an understanding on the client** — one `init*Understanding` map keyed by the action name.
-5. **Compose it** into the handler set via `groupOf(...)`; wrap with `httpCacheable(...)` if it's a GET that benefits from ETag validation.
-6. **Do not** add a method to `initSirenReadingList` unless the popup's legacy interface needs it. New code should drive the walker directly.
-7. **Test server and client independently** — server integration tests in `api.routes.test.ts`, client walker tests in `siren-reading-list.test.ts`. The contract surface (action name + fields + method + response class) is what both tests pin down.
+4. **Add a handler for the action name on each client** that should expose the capability — see [Per-Client Implementations](#per-client-implementations).
+5. **Test server and client independently** — server integration tests, plus each client's own tests. The contract surface (action name + fields + method + response class) is what both sides pin down.

--- a/.github/workflows/claude-PR-CI-failure-fixer.md
+++ b/.github/workflows/claude-PR-CI-failure-fixer.md
@@ -31,7 +31,7 @@ When fixing CI failures, apply these skills based on the type of failure:
 - **ai-agent-editor** (`.claude/skills/ai-agent-editor/SKILL.md`): When CI fails on skills, `CLAUDE.md`, or other AI-agent documentation (broken links, format checks)
 - **blog-post-editor** (`.claude/skills/blog-post-editor/SKILL.md`): When CI fails on blog post markdown files
 - **crawl-pipeline-rca** (`.claude/skills/crawl-pipeline-rca/SKILL.md`): When CI fails on the article crawl pipeline (state-machine rows stuck non-terminal, multi-Lambda chain timeouts, canary or SLO failures) — apply before bumping Lambda timeouts, SQS visibility, or `maxReceiveCount`
-- **extension-api-design** (`.claude/skills/extension-api-design/SKILL.md`): When CI fails on the Siren contract between the browser extension and the server (action-name mismatches, missing navigation links, malformed entities)
+- **hypermedia-api-design** (`.claude/skills/hypermedia-api-design/SKILL.md`): When CI fails on the Siren/MCP hypermedia contract between the hutch server and any client (chrome/firefox extensions, iOS app, MCP) — action-name mismatches, missing navigation links, malformed entities
 - **infrastructure-design** (`.claude/skills/infrastructure-design/SKILL.md`): When CI fails on Pulumi preview/deploy
 
 ## Diagnosing GitHub Actions Failures

--- a/.github/workflows/claude-PR-code-review-auto-apply.md
+++ b/.github/workflows/claude-PR-code-review-auto-apply.md
@@ -28,7 +28,7 @@ When fixing review issues, apply these skills based on the files being changed:
 - **ai-agent-editor** (`.claude/skills/ai-agent-editor/SKILL.md`): When fixing issues in skills, `CLAUDE.md`, or other AI-agent documentation
 - **blog-post-editor** (`.claude/skills/blog-post-editor/SKILL.md`): When fixing issues in blog post markdown files
 - **crawl-pipeline-rca** (`.claude/skills/crawl-pipeline-rca/SKILL.md`): When fixing issues in the article crawl pipeline (command/event/handler chain over Lambda + EventBridge + SQS)
-- **extension-api-design** (`.claude/skills/extension-api-design/SKILL.md`): When fixing issues in the Siren contract between the browser extension and the server
+- **hypermedia-api-design** (`.claude/skills/hypermedia-api-design/SKILL.md`): When fixing issues in the Siren/MCP hypermedia contract between the hutch server and any client (chrome/firefox extensions, iOS app, MCP)
 - **infrastructure-design** (`.claude/skills/infrastructure-design/SKILL.md`): When fixing Pulumi infrastructure issues
 
 ## Git Push Instructions

--- a/.github/workflows/claude-PR-code-reviewer.md
+++ b/.github/workflows/claude-PR-code-reviewer.md
@@ -85,7 +85,7 @@ When reviewing code, apply these skills based on the files being changed:
 - **ai-agent-editor** (`.claude/skills/ai-agent-editor/SKILL.md`): Review changes to skills, `CLAUDE.md`, or other AI-agent documentation — flag duplicated code, time-bound/plan-bound comments, and prose that should be a reference or table
 - **blog-post-editor** (`.claude/skills/blog-post-editor/SKILL.md`): Review changes to blog post markdown files for authoring conventions
 - **crawl-pipeline-rca** (`.claude/skills/crawl-pipeline-rca/SKILL.md`): Review changes to the command → event → handler chain in the article crawl pipeline — watch for missing terminal-state writes, divergent entry points, and timeout/visibility bumps used as a shortcut
-- **extension-api-design** (`.claude/skills/extension-api-design/SKILL.md`): Review changes to the Siren hypermedia contract between the browser extension and the server (action names, navigation flows, request/response shapes) — server owns the protocol, the extension reads it
+- **hypermedia-api-design** (`.claude/skills/hypermedia-api-design/SKILL.md`): Review changes to the Siren/MCP hypermedia contract between the hutch server and any client (chrome/firefox extensions, iOS app, MCP) — action names, navigation flows, request/response shapes; server owns the protocol, clients read it
 - **infrastructure-design** (`.claude/skills/infrastructure-design/SKILL.md`): Review Pulumi infrastructure changes — flag environment-name branching, hard-coded values that belong in per-stage YAML, and other infra-config drift
 
 ## Summary Guidelines

--- a/.github/workflows/claude-PR-conflict-fixer.md
+++ b/.github/workflows/claude-PR-conflict-fixer.md
@@ -30,5 +30,5 @@ When resolving conflicts, apply these skills based on the files involved:
 - **ai-agent-editor** (`.claude/skills/ai-agent-editor/SKILL.md`): When resolving conflicts in skills, `CLAUDE.md`, or other AI-agent documentation
 - **blog-post-editor** (`.claude/skills/blog-post-editor/SKILL.md`): When resolving conflicts in blog post markdown files
 - **crawl-pipeline-rca** (`.claude/skills/crawl-pipeline-rca/SKILL.md`): When resolving conflicts in the article crawl pipeline (command/event/handler chain) — use the methodology to confirm both sides' state-machine writes survive the merge
-- **extension-api-design** (`.claude/skills/extension-api-design/SKILL.md`): When resolving conflicts that touch the Siren contract between the browser extension and the server (action names, navigation flows, request/response shapes)
+- **hypermedia-api-design** (`.claude/skills/hypermedia-api-design/SKILL.md`): When resolving conflicts that touch the Siren/MCP hypermedia contract between the hutch server and any client (chrome/firefox extensions, iOS app, MCP) — action names, navigation flows, request/response shapes
 - **infrastructure-design** (`.claude/skills/infrastructure-design/SKILL.md`): When resolving conflicts in Pulumi infrastructure

--- a/projects/browser-extension-core/src/popup/message-view.ts
+++ b/projects/browser-extension-core/src/popup/message-view.ts
@@ -6,7 +6,7 @@ import type { Message } from "../reading-list/reading-list.types";
  * unit-testable without a DOM. The popup glue maps this onto elements verbatim.
  *
  * `html` is injected as-is by the glue: every rendered `Message.content.body` is
- * trusted, server-authored, server-escaped HTML (see the extension-api-design
+ * trusted, server-authored, server-escaped HTML (see the hypermedia-api-design
  * contract — "Server-Driven Messages Are Trusted HTML"). `role` upgrades to
  * `alert` (assertive) when any rendered message is an error, otherwise stays
  * `status` (polite). */

--- a/projects/browser-extension-core/src/reading-list/reading-list.types.ts
+++ b/projects/browser-extension-core/src/reading-list/reading-list.types.ts
@@ -24,7 +24,7 @@ export interface SaveWarning {
  * authored, server-side-escaped HTML. The client injects it as HTML, so a body
  * that interpolates any untrusted/user-derived value (a saved URL, a title, an
  * email) without escaping it server-side is markup injection. See the
- * extension-api-design skill, "Server-Driven Messages Are Trusted HTML". */
+ * hypermedia-api-design skill, "Server-Driven Messages Are Trusted HTML". */
 export interface Message {
 	readonly type: "warning" | "error";
 	readonly content: { readonly type: string; readonly body: string };

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -307,7 +307,7 @@ function setListWarning(message: string | null): void {
 // what they mean. `buildMessageView` (tested in browser-extension-core) makes
 // every rendering decision; this glue only paints it. `item.html` is the
 // server-authored text/html body, injected as HTML — trusted by contract (see
-// the Message type / the extension-api-design skill).
+// the Message type / the hypermedia-api-design skill).
 function renderMessages(messages: Message[]): void {
 	const container = document.getElementById("messages");
 	if (!container) return;

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -301,7 +301,7 @@ function setListWarning(message: string | null): void {
 // what they mean. `buildMessageView` (tested in browser-extension-core) makes
 // every rendering decision; this glue only paints it. `item.html` is the
 // server-authored text/html body, injected as HTML — trusted by contract (see
-// the Message type / the extension-api-design skill).
+// the Message type / the hypermedia-api-design skill).
 function renderMessages(messages: Message[]): void {
 	const container = document.getElementById("messages");
 	if (!container) return;

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -88,7 +88,7 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
 
 It speaks `application/vnd.siren+json`, sends `Authorization: Bearer <token>` on
 every request, and refreshes the token once on a `401` — the same contract the
-extension uses. See [`../../.claude/skills/extension-api-design/SKILL.md`](../../.claude/skills/extension-api-design/SKILL.md).
+extension uses. See [`../../.claude/skills/hypermedia-api-design/SKILL.md`](../../.claude/skills/hypermedia-api-design/SKILL.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Generalize the `extension-api-design` skill into **`hypermedia-api-design`** so the Siren/HATEOAS contract doctrine surfaces for **every** client — chrome & firefox extensions, the iOS app, the MCP server, and future clients — not just the browser extension, and encode the findings from a cross-client hypermedia audit (plus fresh MCP research) as durable conformance guidelines.

Two commits, **skill-only** (plus the references that name the skill). No client code behaviour changes — the audit findings are applied as *guidelines*, not fixes.

- **Commit 1 — `docs(skills): generalize extension-api-design into hypermedia-api-design`**
  Faithful generalization: rename the skill + broaden its `description` to trigger for all client surfaces (incl. MCP) and server Siren emission; replace "the extension" wording with client-agnostic wording; relocate the extension-only mechanics (the walker pattern, `init*Understanding`/`groupOf`/`httpCacheable`) into a clearly-labelled **Per-Client Implementations** section. No doctrine added or removed. Updates every reference to the old name: the iOS README link, two `popup.browser.ts` comments, two `browser-extension-core` comments, and the four `.github/workflows/claude-*.md` skill-routing entries (also broadened to all clients).

- **Commit 2 — `docs(skills): add cross-client conformance rules and MCP to hypermedia-api-design`**
  Adds a **Client Conformance** section (8 rules from the audit), two anti-pattern rows, and an **MCP** subsection (Siren↔MCP mapping + divergences + in-repo audit). Extends the capability checklist to cover MCP tool definitions.

---

## Research part 1 — the generic hypermedia client (the yardstick)

From the linked essays + Fielding + the Siren spec, and verified against the in-repo **e2e HATEOAS harness** (the team's existing generic-client exemplar — "a runner that discovers and executes available actions… identify pages by body class, not URL… `isAvailable` must use element-based detection, not URL path checks"):

- Hardcode **exactly one URL** (the entry point); every other URL comes from a response `link.href`/`action.href` and is used **verbatim**.
- Read **method + fields** from the action; the client never decides the verb or field set.
- Render/enable a control **iff** the current response advertises the matching action/link (HATEOAS). Absence ⇒ no control.
- Code against the **media type**, not any endpoint's response shape; negotiate with `Accept` **and** verify the response `Content-Type`.
- Couple only to the **vocabulary** (action `name`s, link `rel`s) — never to URLs, methods, field names, or response shapes.

**Headline finding:** both shipping clients are hypermedia-faithful at the *transport* layer (they follow server hrefs/methods and discover by name/rel), so there are **zero "high"-severity break-on-routine-change gaps**. The divergence is concentrated in the **view layer** (controls rendered regardless of advertised affordances) and in **client-side reimplementation of server navigation** — exactly the "app is a browser, Siren is HTML" test failing. The doctrine that cures it lived in a skill scoped to the extension, invisible to iOS/MCP work; that mis-scoping is itself a contributing cause, and is what commit 1 fixes.

---

## Research part 2 — cross-client audit (browser extension + iOS)

23 verified deviations (17 iOS, 6 extension; 8 medium, 15 low after adversarial verification). Grouped by the theme each became a **Client Conformance** rule for:

| Theme → conformance rule | iOS evidence | Extension evidence |
|---|---|---|
| **Render affordances, don't assume them** (HATEOAS at the view layer) | Delete swipe always shown (`ReadingListView.swift:98-104`, silent no-op when `deleteHref==nil`); "+save" always shown (`:33-40`); `update-status` action never surfaced (`SirenModels.swift:229-231`) | Per-item delete button always rendered (`popup.browser.ts:231-257`) |
| **Navigate by the server link, not a domain property** | Tap opens raw `article.url`, ignoring the parsed `read` link (`ReadingListView.swift:94-97`; `SirenModels.swift:230`) | (correct here: `item.readUrl ?? item.url`) |
| **One scheme-aware href resolver** | `absolute()` keys on `hasPrefix("http")`, blindly prepends base otherwise (`ReadplaceAPI.swift:186-190`) | 8 action sites do `${serverUrl}${href}` with no check (`siren-reading-list.ts:195-403`); only the self-link is scheme-aware (`:583-585`) |
| **Verify the response media type** | any 200 blind-decoded as Siren (`ReadplaceAPI.swift:158-170,192-195`) | same (`siren-reading-list.ts:575-578`) |
| **Drive search/filter/pagination from server fields + links** | (correct: follows `nextHref`) | client-side pagination ignores `next`/`prev` (`siren-reading-list.ts:731-735`, `popup.browser.ts:105-265`); `search` hardcodes `url`/`status`, ignores `action.fields` (`:400-418`) |
| **Don't duplicate server policy** | `SaveSharedPage` hardcodes the server's 10 MiB cap and branches on it (`SaveSharedPage.swift:37,50`) | — |
| **Bind actions through one generic path** | per-operation bespoke decode; cherry-picks `delete`/`read` into typed fields (`ReadplaceAPI.swift:80-201`, `SirenModels.swift:229-231`) | (has the generic `understanding` map — closest to the yardstick) |
| **Parse leniently / comment + test hygiene** | one malformed control fails the whole decode (`SirenModels.swift:5-23`); comments name `/queue/*` routes; a test pins `/queue/a1/delete` | required-`href` zod → whole-collection parse throws |

**Directive-premise corrections (verified):**
- **Siren mandates `href`** on links/actions — a "no-href affordance" can't validly occur; the real issue behind point 4 is the whole-decode blast radius (one malformed control blanks the page).
- **`readplace://` is the iOS OAuth callback deep-link**, not a reading-list href scheme — moot for the data surface.
- **Point 6 (tests asserting server responses) is largely moot** — the tests assert *local fixtures*, not live responses, and production code follows actions verbatim; only cosmetic redundancy remains.
- **Point 3 (skeletons over spinners)** has thin grounding — the web codebase itself has almost no skeletons (`queue-processing-pulse`, `article-body__reader-loading` only); kept out of the conformance rules as it's not a hypermedia coupling.

---

## Research part 3 — MCP parity ("it should work similarly")

**Verdict: partially — yes in stance, partially in mechanics.** MCP is built on the same "server owns the protocol, client discovers at runtime" doctrine: a generic MCP client hardcodes only the connection (one endpoint URL or stdio command) and discovers tools/resources/prompts by descriptor over JSON-RPC — exactly as the Siren walker hardcodes only `/` and follows server-minted actions/links. So the **Client Conformance rules apply to an MCP client too.** It diverges enough to be "partially": a stateful session with a one-time `initialize` capability+version handshake (vs per-request content negotiation), server-initiated async pushes (`list_changed`/`updated` vs a synchronous `303`-back), a fixed invocation verb (`tools/call`) instead of a per-affordance `href`/`method`, and three flat global registries instead of one nested document with per-entity actions.

| Siren / HATEOAS | MCP |
|---|---|
| Single entry point `/` | Server connection — one Streamable HTTP endpoint or stdio command |
| `Accept` content negotiation, per request | `initialize` capability + protocol-version handshake, once per session |
| `actions[]` (`name`/`href`/`method`/`fields`); `name` is the contract | Tools (`tools/list` → `name`, `inputSchema`; `tools/call`); `name` is the contract |
| `action.fields` | `inputSchema` (JSON Schema) + optional `outputSchema` to validate the result |
| `links[]` by `rel`/`href`, followed not built | Resources (`resources/list` → `uri`; `resources/read`); RFC 6570 `uriTemplate` |
| Opaque `next` link; never build `?page=` | Opaque `cursor`/`nextCursor`; echo unchanged, never parse/persist |
| `303` back to the collection after a mutation | `notifications/*/list_changed`, `resources/updated` → re-list/re-read |
| Generic `messages[]` channel | JSON-RPC error (call failed) vs `isError:true` result (operation refused); typed content blocks |
| (no analog) | Prompts (`prompts/list`/`prompts/get`) — user-initiated; MCP-only |

**In-repo MCP audit:** hutch is the MCP **server** and adheres to the doctrine — the tool set is a single source of truth in `tool-definitions.ts` (`TOOL_DEFINITIONS`, 8 tools each with a JSON Schema paired to a Zod validator, kept in lock-step by `tool-definitions.test.ts`), advertised via `tools/list` in `mcp-server.ts`, with **no client copy that could drift**. There is **no in-repo MCP-consuming client** (the real clients are external assistants against `https://readplace.com/mcp`). The WebMCP surface (`webmcp.client.ts`) is a **provider** that registers one local `save_link` tool — a provider declares its own shape, so discover-don't-hardcode does not apply to it. No substantiated server-protocol deviations. (The one doc nit the audit surfaced — the skill front-matter still reading `name: extension-api-design` — is resolved by commit 1.)

Spec: https://modelcontextprotocol.io

---

## Scope & notes

- **Skill-only** change. The cross-client gaps are encoded as *guidelines*; bringing the extension/iOS clients into conformance is separate code work (kept out per the diagnosis-only steer).
- Generalizing the doc is **necessary but not sufficient**: e.g. the conformance rule "resolve hrefs by scheme" exists because both clients string-concatenate hrefs today, against the contract's own promise that changing an `href` is non-breaking.
- A single hypermedia skill (rather than a parallel MCP skill) avoids duplicating ~85% of the doctrine and the drift that would follow — the same "don't run parallel evolutions of one concept" rule the skill itself states.

Based off `main` (not PR #811).

🤖 Research via multi-agent workflows; authored with Claude Code.
