### PR TITLE
test(extension): e2e for reader link opening the private reader

### DIFF
--- a/projects/browser-extension-core/src/e2e-actions/index.ts
+++ b/projects/browser-extension-core/src/e2e-actions/index.ts
@@ -4,3 +4,7 @@ export { createPaginationActions, type PaginationProgress } from "./pagination-a
 export { createFilterActions, type FilterProgress } from "./filter-actions";
 export { createLogoutActions, type LogoutProgress } from "./logout-actions";
 export { createSeleniumElementQueries, createSeleniumNavigation } from "./selenium-adapter";
+export {
+	assertReaderLinkOpensPrivateReader,
+	type ReaderLinkScenarioConfig,
+} from "./reader-link-scenario";

--- a/projects/browser-extension-core/src/e2e-actions/reader-link-scenario.ts
+++ b/projects/browser-extension-core/src/e2e-actions/reader-link-scenario.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { By, until } from "selenium-webdriver";
 import type { WebDriver } from "selenium-webdriver";
+import { CSS_SELECTORS, READER_PERMALINK_PATTERN } from "../e2e";
 
 /** hutch's session cookie (projects/hutch/src/runtime/web/auth/session-cookie.ts).
  * The reader at /queue/:id/view resolves its owner from this cookie, never from
@@ -14,11 +15,6 @@ const SESSION_COOKIE_NAME = "hutch_sid";
  * /view and lands on `page-view`. */
 const PRIVATE_READER_BODY_CLASS = "page-reader";
 const PUBLIC_VIEW_BODY_CLASS = "page-view";
-
-/** The popup renders each saved article as `<a class="list-view__item">` whose
- * href is the reader permalink (readUrl), not the original article URL. */
-const READER_LINK_SELECTOR = "#link-list .list-view__item";
-const READER_PERMALINK = /\/queue\/[a-f0-9]+\/view$/;
 
 export interface ReaderLinkScenarioConfig {
 	/** Origin the extension was built against (HUTCH_SERVER_URL); the reader
@@ -49,12 +45,12 @@ export async function assertReaderLinkOpensPrivateReader(
 	const popupWindowHandle = await driver.getWindowHandle();
 
 	const anchor = await driver.wait(
-		until.elementLocated(By.css(READER_LINK_SELECTOR)),
+		until.elementLocated(By.css(CSS_SELECTORS.listItem)),
 		15_000,
 	);
 	const readerHref = await anchor.getAttribute("href");
 	assert.ok(
-		readerHref !== null && READER_PERMALINK.test(readerHref),
+		readerHref !== null && READER_PERMALINK_PATTERN.test(readerHref),
 		`popup reading-list link must target the private reader permalink, got: ${readerHref}`,
 	);
 
@@ -66,7 +62,7 @@ export async function assertReaderLinkOpensPrivateReader(
 	// SameSite=Strict, masking the very regression this guards. A click from the
 	// extension origin is the genuine cross-site top-level navigation.
 	const handlesBeforeClick = await driver.getAllWindowHandles();
-	await driver.findElement(By.css(READER_LINK_SELECTOR)).click();
+	await driver.findElement(By.css(CSS_SELECTORS.listItem)).click();
 	let readerWindowHandle: string | undefined;
 	await driver.wait(async () => {
 		const opened = (await driver.getAllWindowHandles()).filter(

--- a/projects/browser-extension-core/src/e2e-actions/reader-link-scenario.ts
+++ b/projects/browser-extension-core/src/e2e-actions/reader-link-scenario.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { By, until } from "selenium-webdriver";
+import type { WebDriver } from "selenium-webdriver";
+
+/** hutch's session cookie (projects/hutch/src/runtime/web/auth/session-cookie.ts).
+ * The reader at /queue/:id/view resolves its owner from this cookie, never from
+ * the bearer, so the extension mints it out-of-band (POST /auth/session) before
+ * surfacing reader links. */
+const SESSION_COOKIE_NAME = "hutch_sid";
+
+/** Body class of the owner's private reader vs the public fallback view
+ * (hutch reader.component.ts / view.component.ts). A saved-article link that
+ * carries the session lands on `page-reader`; one that does not 302-redirects to
+ * /view and lands on `page-view`. */
+const PRIVATE_READER_BODY_CLASS = "page-reader";
+const PUBLIC_VIEW_BODY_CLASS = "page-view";
+
+/** The popup renders each saved article as `<a class="list-view__item">` whose
+ * href is the reader permalink (readUrl), not the original article URL. */
+const READER_LINK_SELECTOR = "#link-list .list-view__item";
+const READER_PERMALINK = /\/queue\/[a-f0-9]+\/view$/;
+
+export interface ReaderLinkScenarioConfig {
+	/** Origin the extension was built against (HUTCH_SERVER_URL); the reader
+	 * permalink and the minted session cookie both live here. */
+	serverOrigin: string;
+}
+
+/**
+ * Asserts the end-to-end outcome of the session-cookie bridge: a saved-article
+ * link in the popup opens the owner's PRIVATE reader (/queue/:id/view), not the
+ * public /view fallback.
+ *
+ * Preconditions (driven by the caller): the popup is logged in and showing the
+ * reading list with at least one saved article, so the list-load has already
+ * fired the fire-and-forget POST /auth/session.
+ *
+ * The check is split so a failure points at which half of the bridge broke:
+ *   1. the popup must target the reader permalink (link rendering),
+ *   2. the bridge must mint hutch_sid (POST /auth/session + its CORS),
+ *   3. clicking the real link — a cross-site, top-level GET from the extension
+ *      origin — must carry the cookie and land on the private reader (the
+ *      SameSite=Lax property the fallback bug depended on).
+ */
+export async function assertReaderLinkOpensPrivateReader(
+	driver: WebDriver,
+	config: ReaderLinkScenarioConfig,
+): Promise<void> {
+	const popupWindowHandle = await driver.getWindowHandle();
+
+	const anchor = await driver.wait(
+		until.elementLocated(By.css(READER_LINK_SELECTOR)),
+		15_000,
+	);
+	const readerHref = await anchor.getAttribute("href");
+	assert.ok(
+		readerHref !== null && READER_PERMALINK.test(readerHref),
+		`popup reading-list link must target the private reader permalink, got: ${readerHref}`,
+	);
+
+	await assertSessionCookieMinted(driver, config.serverOrigin);
+	await driver.switchTo().window(popupWindowHandle);
+
+	// Click the real anchor rather than driver.get(readerHref): an address-bar
+	// navigation counts as same-site and would attach the cookie even under
+	// SameSite=Strict, masking the very regression this guards. A click from the
+	// extension origin is the genuine cross-site top-level navigation.
+	const handlesBeforeClick = await driver.getAllWindowHandles();
+	await driver.findElement(By.css(READER_LINK_SELECTOR)).click();
+	let readerWindowHandle: string | undefined;
+	await driver.wait(async () => {
+		const opened = (await driver.getAllWindowHandles()).filter(
+			(handle) => !handlesBeforeClick.includes(handle),
+		);
+		readerWindowHandle = opened[0];
+		return readerWindowHandle !== undefined;
+	}, 10_000, "clicking the reading-list link should open the reader in a new tab");
+	assert.ok(readerWindowHandle, "reader tab window handle was not captured");
+	await driver.switchTo().window(readerWindowHandle);
+
+	// Settle on whichever page rendered, then assert it is the private reader.
+	await driver.wait(
+		until.elementLocated(
+			By.css(`body.${PRIVATE_READER_BODY_CLASS}, body.${PUBLIC_VIEW_BODY_CLASS}`),
+		),
+		15_000,
+		"reader tab never rendered a reader or view page",
+	);
+	const bodyClass = await driver
+		.findElement(By.css("body"))
+		.getAttribute("class");
+	assert.ok(
+		bodyClass?.includes(PRIVATE_READER_BODY_CLASS),
+		`saved-article link opened the public view (body "${bodyClass}") instead of the private reader (body.${PRIVATE_READER_BODY_CLASS}); the session cookie did not carry into the cross-site /queue/:id/view navigation`,
+	);
+}
+
+/**
+ * Confirms the bridge minted hutch_sid, isolating a broken/blocked POST
+ * /auth/session (or its credentialed CORS) from a SameSite regression. Reads the
+ * cookie from the server origin — cookies are only visible to their own origin's
+ * document, and the popup runs on the extension origin — without navigating to
+ * the reader, so this step cannot itself smuggle the cookie into the reader.
+ */
+async function assertSessionCookieMinted(
+	driver: WebDriver,
+	serverOrigin: string,
+): Promise<void> {
+	const handlesBefore = await driver.getAllWindowHandles();
+	await driver.switchTo().newWindow("tab");
+	await driver.get(serverOrigin);
+	await driver.wait(async () => {
+		const cookies = await driver.manage().getCookies();
+		return cookies.some((cookie) => cookie.name === SESSION_COOKIE_NAME);
+	}, 10_000, `extension must mint the ${SESSION_COOKIE_NAME} cookie via POST /auth/session`);
+	await driver.close();
+	const remaining = (await driver.getAllWindowHandles()).filter((handle) =>
+		handlesBefore.includes(handle),
+	);
+	await driver.switchTo().window(remaining[remaining.length - 1]);
+}

--- a/projects/browser-extension-core/src/e2e-actions/save-link-actions.ts
+++ b/projects/browser-extension-core/src/e2e-actions/save-link-actions.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { By, until } from "selenium-webdriver";
 import type { WebDriver } from "selenium-webdriver";
-import { CSS_SELECTORS, type FlowAction } from "../e2e";
+import { CSS_SELECTORS, READER_PERMALINK_PATTERN, type FlowAction } from "../e2e";
 import { initSaveProgress } from "../popup/save-progress";
 
 export interface SaveLinkProgress {
@@ -118,9 +118,8 @@ export function createSaveLinkActions(config: {
 			);
 			const items = await driver.findElements(By.css(CSS_SELECTORS.listItem));
 			const hrefs = await Promise.all(items.map(el => el.getAttribute("href")));
-			const readUrlPattern = /\/queue\/[a-f0-9]+\/view$/;
 			assert.ok(
-				hrefs.some(href => href !== null && (href === config.testUrl || readUrlPattern.test(href))),
+				hrefs.some(href => href !== null && (href === config.testUrl || READER_PERMALINK_PATTERN.test(href))),
 				`Expected "${config.testUrl}" or a reader URL in list hrefs, but found: ${hrefs.join(", ")}`,
 			);
 			config.progress.listVerified = true;

--- a/projects/browser-extension-core/src/e2e/extension-views.ts
+++ b/projects/browser-extension-core/src/e2e/extension-views.ts
@@ -44,3 +44,8 @@ export const CSS_SELECTORS = {
 	deleteButton: "#link-list .list-view__delete",
 	savingTitle: "#saving-view .saving-view__title",
 } as const;
+
+/** Reader permalink (readUrl) shape, `/queue/:id/view`: a saved-article link
+ * resolves to this, never the original article URL, which is what distinguishes
+ * the private reader permalink from an arbitrary saved URL. */
+export const READER_PERMALINK_PATTERN = /\/queue\/[a-f0-9]+\/view$/;

--- a/projects/browser-extension-core/src/e2e/index.ts
+++ b/projects/browser-extension-core/src/e2e/index.ts
@@ -6,6 +6,7 @@ export {
 	TRANSITIONING_VIEW,
 	ELEMENT_IDS,
 	CSS_SELECTORS,
+	READER_PERMALINK_PATTERN,
 } from "./extension-views";
 export type { ExtensionViewId } from "./extension-views";
 export type {

--- a/projects/extensions/chrome-extension/run-tests.config.js
+++ b/projects/extensions/chrome-extension/run-tests.config.js
@@ -56,5 +56,13 @@ module.exports = {
       env: { HEADLESS: 'true', E2E_PORT: port },
       e2e: true,
     },
+    {
+      type: 'node-test',
+      name: 'Running reader-link E2E (local)',
+      files: ['dist/e2e/reader-link-flow/run.e2e-local.main.js'],
+      timeout: 90000,
+      env: { HEADLESS: 'true', E2E_PORT: port },
+      e2e: true,
+    },
   ],
 };

--- a/projects/extensions/chrome-extension/src/e2e/reader-link-flow/run.e2e-local.main.ts
+++ b/projects/extensions/chrome-extension/src/e2e/reader-link-flow/run.e2e-local.main.ts
@@ -1,0 +1,260 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { Builder, By } from "selenium-webdriver";
+import { Options, ServiceBuilder, type Driver as ChromeDriver } from "selenium-webdriver/chrome";
+import { FlowRunner, ExtensionStateHandler } from "browser-extension-core/e2e";
+import {
+	createSeleniumElementQueries,
+	createSeleniumNavigation,
+	createLoginActions,
+	createSaveLinkActions,
+	assertReaderLinkOpensPrivateReader,
+	type SaveLinkProgress,
+} from "browser-extension-core/e2e-actions";
+
+const EXTENSION_DIR = path.resolve(__dirname, "../../../dist-extension-compiled");
+const CFT_PATH_FILE = path.resolve(__dirname, "../../../.cache/chrome/binary-path");
+const CFT_DRIVER_PATH_FILE = path.resolve(__dirname, "../../../.cache/chrome/driver-path");
+
+const TEST_EMAIL = "reader-link-e2e-test@example.com";
+const TEST_PASSWORD = "testpassword123";
+assert(process.env.E2E_PORT, "E2E_PORT is required");
+const TEST_PORT = Number(process.env.E2E_PORT);
+const SERVER_ORIGIN = `http://127.0.0.1:${TEST_PORT}`;
+
+const TEST_LINK_URL = "https://example.com/reader-link-article";
+const TEST_LINK_TITLE = "Reader Link Article";
+
+async function waitForServer(port: number, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+			return;
+		} catch {
+			await new Promise((r) => setTimeout(r, 100));
+		}
+	}
+	throw new Error(`e2e server did not start on port ${port} within ${timeoutMs}ms`);
+}
+
+async function startTestServer(): Promise<ChildProcess> {
+	// Spawn via the standard Nx interface so the extension never reaches across
+	// the workspace for hutch's compiled output path. `pnpm nx run hutch:e2e-server`
+	// resolves the project, runs its dependsOn (install-deps + compile if stale),
+	// and execs the e2e-server script.
+	//
+	// NX_DAEMON=false: the daemon forks targets as its own children, outside the
+	// pnpm/nx process group, so a process-group kill in stopTestServer would leave
+	// the e2e-server orphaned and hang test-phase-runner forever waiting for it.
+	// detached:true puts pnpm/nx/node into their own process group for clean kill.
+	const child = spawn("pnpm", ["nx", "run", "hutch:e2e-server"], {
+		env: {
+			...process.env,
+			E2E_PORT: String(TEST_PORT),
+			NODE_ENV: "test",
+			NX_DAEMON: "false",
+		},
+		// fd 1 carries node --test's serialized reporter protocol back to the runner;
+		// a grandchild writing raw bytes there corrupts the stream ("Unable to
+		// deserialize cloned data"). Route the server's output to fd 2, which the
+		// runner treats as plain diagnostics, so its logs stay visible safely.
+		stdio: ["ignore", 2, 2],
+		detached: true,
+	});
+	child.on("error", () => {}); // waitForServer will throw on its own timeout
+
+	// 30s — covers `pnpm nx` startup + cache check + node bootstrap.
+	await waitForServer(TEST_PORT, 30_000);
+
+	const userRes = await fetch(`${SERVER_ORIGIN}/e2e/users`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+	});
+	assert.equal(
+		userRes.status,
+		201,
+		`POST /e2e/users returned ${userRes.status} (expected 201)`,
+	);
+
+	return child;
+}
+
+async function stopTestServer(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.pid === undefined) return;
+	const pid = child.pid;
+	const killGroup = (signal: NodeJS.Signals) => {
+		try {
+			// Negative pid signals the entire process group, so the descendants
+			// (nx → node e2e-server) exit alongside the pnpm wrapper.
+			process.kill(-pid, signal);
+		} catch {
+			child.kill(signal);
+		}
+	};
+	await new Promise<void>((resolve) => {
+		const cleanExit = () => resolve();
+		child.once("exit", cleanExit);
+		killGroup("SIGTERM");
+		// Belt-and-suspenders: if anything in the chain (nx, pnpm, the script)
+		// blocks SIGTERM, force-kill after 5s and resolve so the test runner can
+		// exit instead of hanging the whole test-phase-runner pipeline.
+		setTimeout(() => {
+			killGroup("SIGKILL");
+			child.off("exit", cleanExit);
+			resolve();
+		}, 5_000).unref();
+	});
+}
+
+async function discoverExtensionId(driver: ChromeDriver): Promise<string> {
+	// Service worker may take time to register in headless mode
+	const timeout = 15_000;
+	const interval = 500;
+	const deadline = Date.now() + timeout;
+
+	while (Date.now() < deadline) {
+		const targets = (await (driver as unknown as {
+			sendAndGetDevToolsCommand(cmd: string, params: Record<string, unknown>): Promise<unknown>;
+		}).sendAndGetDevToolsCommand(
+			"Target.getTargets",
+			{},
+		)) as { targetInfos: Array<{ type: string; url: string }> };
+
+		const swTarget = targets.targetInfos.find(
+			(t) =>
+				t.type === "service_worker" &&
+				t.url.startsWith("chrome-extension://"),
+		);
+
+		if (swTarget) {
+			const match = swTarget.url.match(/chrome-extension:\/\/([a-z]+)\//);
+			assert.ok(match, "Could not extract extension ID from service worker URL");
+			return match[1];
+		}
+
+		await new Promise((r) => setTimeout(r, interval));
+	}
+
+	throw new Error("Could not find extension service worker target within 15s");
+}
+
+// CI resource contention (parallel NX tasks) crashes Chrome or causes Selenium
+// element-location timeouts intermittently. Retry the full test for both cases.
+const MAX_ATTEMPTS = 3;
+test("saved-article link in the popup opens the private reader, not the public view", async () => {
+	const server = await startTestServer();
+	try {
+		for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			try {
+				await runTest();
+				return;
+			} catch (err) {
+				const isRetryable = err instanceof Error && (
+					err.message.includes("ECONNREFUSED") ||
+					err.message.includes("Chrome instance exited") ||
+					err.name === "TimeoutError"
+				);
+				if (!isRetryable || attempt === MAX_ATTEMPTS) throw err;
+			}
+		}
+	} finally {
+		await stopTestServer(server);
+	}
+});
+
+async function runTest() {
+	const options = new Options();
+	if (process.env.HEADLESS !== "false") {
+		options.addArguments("--headless=new");
+	}
+	options.addArguments(`--load-extension=${EXTENSION_DIR}`);
+	options.addArguments("--disable-search-engine-choice-screen");
+	options.addArguments("--no-sandbox"); // CI container has no user namespace; without this Chrome exits immediately
+	options.addArguments("--disable-dev-shm-usage"); // CI runners have a small /dev/shm partition; without this Chrome crashes with ECONNREFUSED
+	options.addArguments("--disable-gpu"); // CI runners have no GPU drivers; the GPU process crashes intermittently in headless mode
+
+	// Chrome 137+ removed --load-extension in branded Google Chrome.
+	// Use Chrome for Testing which still supports it.
+	options.setChromeBinaryPath(
+		fs.readFileSync(CFT_PATH_FILE, "utf8").trim(),
+	);
+
+	const serviceBuilder = new ServiceBuilder(
+		fs.readFileSync(CFT_DRIVER_PATH_FILE, "utf8").trim(),
+	);
+
+	const driver = (await new Builder()
+		.forBrowser("chrome")
+		.setChromeOptions(options)
+		.setChromeService(serviceBuilder)
+		.build()) as ChromeDriver;
+
+	try {
+		const extensionId = await discoverExtensionId(driver);
+		const POPUP_URL = `chrome-extension://${extensionId}/popup/popup.template.html`;
+
+		await driver.get(POPUP_URL);
+
+		await driver.wait(async () => {
+			try {
+				const el = await driver.findElement(By.id("login-view"));
+				const hidden = await el.getAttribute("hidden");
+				return hidden === null;
+			} catch {
+				return false;
+			}
+		}, 10000);
+
+		const popupWindowHandle = await driver.getWindowHandle();
+
+		const saveLinkProgress: SaveLinkProgress = { linkSaved: false, listVerified: false, extraLinkSaved: false };
+
+		const loginActions = createLoginActions({
+			testEmail: TEST_EMAIL,
+			testPassword: TEST_PASSWORD,
+			popupWindowHandle,
+		});
+
+		const saveLinkActions = createSaveLinkActions({
+			popupUrl: POPUP_URL,
+			testUrl: TEST_LINK_URL,
+			testTitle: TEST_LINK_TITLE,
+			popupWindowHandle,
+			progress: saveLinkProgress,
+		});
+
+		const allActions = new Map([...loginActions, ...saveLinkActions]);
+
+		// Stop once a saved article with a reader link is in the list — that is the
+		// precondition the reader-link assertion needs, and the list-load that gets
+		// us there has already fired the fire-and-forget session-cookie mint.
+		const stateHandler = new ExtensionStateHandler(
+			driver,
+			async () => saveLinkProgress.listVerified,
+			allActions,
+			createSeleniumElementQueries(),
+		);
+
+		const flowRunner = new FlowRunner(
+			driver,
+			stateHandler,
+			createSeleniumNavigation(),
+		);
+		const result = await flowRunner.run(POPUP_URL, {
+			maxSteps: 35,
+		});
+
+		assert.equal(result.success, true, `Login+save flow failed: ${result.error}`);
+		assert.equal(saveLinkProgress.listVerified, true, "a saved link with a reader URL must be present in the list");
+
+		await driver.switchTo().window(popupWindowHandle);
+		await assertReaderLinkOpensPrivateReader(driver, { serverOrigin: SERVER_ORIGIN });
+	} finally {
+		await driver.quit();
+	}
+}

--- a/projects/extensions/firefox-extension/run-tests.config.js
+++ b/projects/extensions/firefox-extension/run-tests.config.js
@@ -41,5 +41,13 @@ module.exports = {
       env: { E2E_PORT: port },
       e2e: true,
     },
+    {
+      type: 'node-test',
+      name: 'Running reader-link E2E (local)',
+      files: ['dist/e2e/reader-link-flow/run.e2e-local.main.js'],
+      timeout: 90000,
+      env: { HEADLESS: 'true', E2E_PORT: port },
+      e2e: true,
+    },
   ],
 };

--- a/projects/extensions/firefox-extension/src/e2e/reader-link-flow/run.e2e-local.main.ts
+++ b/projects/extensions/firefox-extension/src/e2e/reader-link-flow/run.e2e-local.main.ts
@@ -1,0 +1,197 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { Builder, By } from "selenium-webdriver";
+import { Options, Driver } from "selenium-webdriver/firefox";
+import { FlowRunner, ExtensionStateHandler } from "browser-extension-core/e2e";
+import {
+	createSeleniumElementQueries,
+	createSeleniumNavigation,
+	createLoginActions,
+	createSaveLinkActions,
+	assertReaderLinkOpensPrivateReader,
+	type SaveLinkProgress,
+} from "browser-extension-core/e2e-actions";
+
+const ADDON_ID = "hutch-extension@hutch-app.com";
+const ADDON_UUID = "d3b07384-d113-4ec6-a7b8-5f7e3b4c9a12";
+const EXTENSION_DIR = path.resolve(__dirname, "../../../dist-extension-compiled");
+const POPUP_URL = `moz-extension://${ADDON_UUID}/popup/popup.template.html`;
+
+const TEST_EMAIL = "reader-link-e2e-test@example.com";
+const TEST_PASSWORD = "testpassword123";
+assert(process.env.E2E_PORT, "E2E_PORT is required");
+const TEST_PORT = Number(process.env.E2E_PORT);
+const SERVER_ORIGIN = `http://127.0.0.1:${TEST_PORT}`;
+
+const TEST_LINK_URL = "https://example.com/reader-link-article";
+const TEST_LINK_TITLE = "Reader Link Article";
+
+async function waitForServer(port: number, timeoutMs: number): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+			return;
+		} catch {
+			await new Promise((r) => setTimeout(r, 100));
+		}
+	}
+	throw new Error(`e2e server did not start on port ${port} within ${timeoutMs}ms`);
+}
+
+async function startTestServer(): Promise<ChildProcess> {
+	// Spawn via the standard Nx interface so the extension never reaches across
+	// the workspace for hutch's compiled output path. `pnpm nx run hutch:e2e-server`
+	// resolves the project, runs its dependsOn (install-deps + compile if stale),
+	// and execs the e2e-server script.
+	//
+	// NX_DAEMON=false: the daemon forks targets as its own children, outside the
+	// pnpm/nx process group, so a process-group kill in stopTestServer would leave
+	// the e2e-server orphaned and hang test-phase-runner forever waiting for it.
+	// detached:true puts pnpm/nx/node into their own process group for clean kill.
+	const child = spawn("pnpm", ["nx", "run", "hutch:e2e-server"], {
+		env: {
+			...process.env,
+			E2E_PORT: String(TEST_PORT),
+			NODE_ENV: "test",
+			NX_DAEMON: "false",
+		},
+		// fd 1 carries node --test's serialized reporter protocol back to the runner;
+		// a grandchild writing raw bytes there corrupts the stream ("Unable to
+		// deserialize cloned data"). Route the server's output to fd 2, which the
+		// runner treats as plain diagnostics, so its logs stay visible safely.
+		stdio: ["ignore", 2, 2],
+		detached: true,
+	});
+	child.on("error", () => {}); // waitForServer will throw on its own timeout
+
+	// 30s — covers `pnpm nx` startup + cache check + node bootstrap.
+	await waitForServer(TEST_PORT, 30_000);
+
+	const userRes = await fetch(`${SERVER_ORIGIN}/e2e/users`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+	});
+	assert.equal(
+		userRes.status,
+		201,
+		`POST /e2e/users returned ${userRes.status} (expected 201)`,
+	);
+
+	return child;
+}
+
+async function stopTestServer(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.pid === undefined) return;
+	const pid = child.pid;
+	const killGroup = (signal: NodeJS.Signals) => {
+		try {
+			// Negative pid signals the entire process group, so the descendants
+			// (nx → node e2e-server) exit alongside the pnpm wrapper.
+			process.kill(-pid, signal);
+		} catch {
+			child.kill(signal);
+		}
+	};
+	await new Promise<void>((resolve) => {
+		const cleanExit = () => resolve();
+		child.once("exit", cleanExit);
+		killGroup("SIGTERM");
+		// Belt-and-suspenders: if anything in the chain (nx, pnpm, the script)
+		// blocks SIGTERM, force-kill after 5s and resolve so the test runner can
+		// exit instead of hanging the whole test-phase-runner pipeline.
+		setTimeout(() => {
+			killGroup("SIGKILL");
+			child.off("exit", cleanExit);
+			resolve();
+		}, 5_000).unref();
+	});
+}
+
+test("saved-article link in the popup opens the private reader, not the public view", async () => {
+	const server = await startTestServer();
+	try {
+		const options = new Options();
+		if (process.env.HEADLESS !== "false") {
+			options.addArguments("--headless");
+		}
+		options.setPreference(
+			"extensions.webextensions.uuids",
+			JSON.stringify({ [ADDON_ID]: ADDON_UUID }),
+		);
+
+		const driver = await new Builder()
+			.forBrowser("firefox")
+			.setFirefoxOptions(options)
+			.build();
+
+		try {
+			assert(driver instanceof Driver, "firefox builder must produce a firefox Driver");
+			await driver.installAddon(EXTENSION_DIR, true);
+
+			await driver.get(POPUP_URL);
+
+			await driver.wait(async () => {
+				try {
+					const el = await driver.findElement(By.id("login-view"));
+					const hidden = await el.getAttribute("hidden");
+					return hidden === null;
+				} catch {
+					return false;
+				}
+			}, 10000);
+
+			const popupWindowHandle = await driver.getWindowHandle();
+
+			const saveLinkProgress: SaveLinkProgress = { linkSaved: false, listVerified: false, extraLinkSaved: false };
+
+			const loginActions = createLoginActions({
+				testEmail: TEST_EMAIL,
+				testPassword: TEST_PASSWORD,
+				popupWindowHandle,
+			});
+
+			const saveLinkActions = createSaveLinkActions({
+				popupUrl: POPUP_URL,
+				testUrl: TEST_LINK_URL,
+				testTitle: TEST_LINK_TITLE,
+				popupWindowHandle,
+				progress: saveLinkProgress,
+			});
+
+			const allActions = new Map([...loginActions, ...saveLinkActions]);
+
+			// Stop once a saved article with a reader link is in the list — that is the
+			// precondition the reader-link assertion needs, and the list-load that gets
+			// us there has already fired the fire-and-forget session-cookie mint.
+			const stateHandler = new ExtensionStateHandler(
+				driver,
+				async () => saveLinkProgress.listVerified,
+				allActions,
+				createSeleniumElementQueries(),
+			);
+
+			const flowRunner = new FlowRunner(
+				driver,
+				stateHandler,
+				createSeleniumNavigation(),
+			);
+			const result = await flowRunner.run(POPUP_URL, {
+				maxSteps: 35,
+			});
+
+			assert.equal(result.success, true, `Login+save flow failed: ${result.error}`);
+			assert.equal(saveLinkProgress.listVerified, true, "a saved link with a reader URL must be present in the list");
+
+			await driver.switchTo().window(popupWindowHandle);
+			await assertReaderLinkOpensPrivateReader(driver, { serverOrigin: SERVER_ORIGIN });
+		} finally {
+			await driver.quit();
+		}
+	} finally {
+		await stopTestServer(server);
+	}
+});


### PR DESCRIPTION
## What

Adds an end-to-end test that loads the real browser extension, logs in, saves an article, and clicks its reader link — asserting the new tab lands on the owner's **private reader** (`body.page-reader`) and not the **public `/view` fallback** (`body.page-view`).

## Why

#811 fixed saved-article links to open the private reader by minting the `hutch_sid` session cookie out-of-band (`POST /auth/session`; client `ensureWebSession` + server `sessionBridgeCors`). That fix was verified at the unit/integration level, but the actual browser outcome — *where the reader link lands* — was asserted nowhere. That untested-outcome gap is exactly what let the original bug live silently for ~3 months.

This test exercises the genuine cross-context flow (extension origin → credentialed cookie mint → cross-site top-level navigation → server origin) that integration tests cannot cover, so E2E is the right (and only) level.

## How it guards the bridge

The assertion is split so a failure pinpoints which half of the bridge broke:

1. **Link target** — the popup must render the reader permalink (`/queue/:id/view`), not the original article URL.
2. **Cookie mint** — `assertSessionCookieMinted` confirms `hutch_sid` is minted (catches a dropped/blocked `POST /auth/session` or its credentialed CORS) **without navigating to the reader**, so it cannot itself mask a SameSite regression.
3. **Cross-site carry** — the link is then clicked as a real cross-site, top-level navigation (deliberately *not* `driver.get`, which an address bar treats as same-site and would smuggle the cookie through even under `SameSite=Strict`). Landing on `page-reader` proves the `SameSite=Lax` cookie carried; `page-view` fails the test.

Runs in **both Chrome and Firefox** because cookie/SameSite behaviour differs between them. The shared Selenium scenario lives in `browser-extension-core` (coverage-excluded `e2e-actions`) and is invoked by each browser's new `reader-link-flow`.

## Verification

`pnpm check` passes for the whole workspace. The extension E2E phase is skipped in `CLAUDE_CODE_REMOTE` (no Chrome-for-Testing in the sandbox), so the actual browser run happens in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01HiHXuoaYebiAjLiqfxkMw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiHXuoaYebiAjLiqfxkMw2)_