### PR TITLE
feat(ios): full-width Sign up button with web-matching icons on Login

### DIFF
--- a/projects/ios-readplace/App/LoginView.swift
+++ b/projects/ios-readplace/App/LoginView.swift
@@ -26,7 +26,7 @@ struct LoginView: View {
 					Button {
 						startLogin()
 					} label: {
-						Text("Login")
+						Label("Login", systemImage: "rectangle.portrait.and.arrow.right")
 							.font(.headline)
 							.frame(maxWidth: .infinity)
 							.padding(.vertical, 14)
@@ -36,11 +36,12 @@ struct LoginView: View {
 					Button {
 						startSignup()
 					} label: {
-						Text("Don't have an account? Sign up")
-							.font(.footnote)
+						Label("Sign up", systemImage: "person.badge.plus")
+							.font(.headline)
+							.frame(maxWidth: .infinity)
+							.padding(.vertical, 14)
 					}
-					.buttonStyle(.plain)
-					.foregroundStyle(.tint)
+					.buttonStyle(.bordered)
 				}
 
 				if let authErrorText {


### PR DESCRIPTION
## Context

The iOS Login screen (`projects/ios-readplace/App/LoginView.swift`) had two UX problems:

1. **Tap target too small.** "Don't have an account? Sign up" was a `.font(.footnote)` (~13pt) `Button` with `.buttonStyle(.plain)` and tinted text — its hit area was just the text bounds, below the 44×44pt minimum from Apple's HIG and `BRAND_GUIDELINES.md`, and tinted text alone reads as a label, not a control.
2. **No web-matching iconography.** Readplace web's nav uses Font Awesome glyphs (`fa-user-plus` for Sign up, `fa-arrow-right-to-bracket` for the enter/login action); the iOS buttons carried no icons.

## The change

A single presentational edit to the button `VStack` in `LoginView.swift`:

- **Sign up** becomes a full-width `.bordered` button stacked under **Login**, mirroring the Login button's own metrics (`.frame(maxWidth: .infinity)` + `.padding(.vertical, 14)`) for a ~full-width × ~48pt hit area — comfortably past 44pt — with outlined chrome that reads as a control.
- Both buttons use `Label` with SF Symbols mapping to the web's nav glyphs:
  - `person.badge.plus` → `fa-user-plus` (Sign up)
  - `rectangle.portrait.and.arrow.right` → `fa-arrow-right-to-bracket` (Login)
- `Label` keeps VoiceOver announcing just "Login" / "Sign up" (the symbol is decorative).

Both symbols exist at the project's iOS 16.0 deployment target (`person.badge.plus` since iOS 13, `rectangle.portrait.and.arrow.right` since iOS 16).

## What's unchanged

Tap handlers (`startLogin` / `startSignup`), the top `books.vertical.fill` brand symbol, the footer caption, OAuth/routing, and the system-blue tint — no `AccentColor`/brand amber introduced. The inline "Don't have an account?" prose is dropped; the outlined Sign up button directly under Login communicates the same thing.

## Verification

Purely presentational — no new logic, so no new test. The existing OAuth/session tests (`SignupFlowTests`, `LoginFlowTests`) assert authorize-request/deep-link/PKCE behavior and don't reference the changed button copy, font, or style, so they stay green. iOS is orthogonal to the JS `pnpm check` gate; the Swift build + simulator pass runs in CI's `ios-tests` job (`make test`), since this Linux environment has no Xcode/iOS SDK to compile `SwiftUI` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ket6whxJjVM95p1R79UMfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ket6whxJjVM95p1R79UMfB)_