### PR TITLE
style(inbox): remove duplicate .inbox__error rule

### DIFF
--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
@@ -120,11 +120,6 @@
   margin: 0 0 24px;
 }
 
-.inbox__error {
-  color: var(--error);
-  margin: 0 0 16px;
-}
-
 .inbox__create {
   margin: 0 0 32px;
 }


### PR DESCRIPTION
## Summary

Removes the duplicate `.inbox__error` block (formerly lines 123-126) in `inbox.styles.css`. The limit banner already inherits full styling from the `.inbox__error` rule added by #808.

The duplicate redundantly re-declared `color` and silently overrode the create-failed banner margin from `0 0 24px` to `0 0 16px`.

## Testing

- `pnpm check` passes (all 34 projects, 100% coverage thresholds met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6gT3VvhePD6c6hfe72wTV)_