### PR TITLE
feat: replace iOS paste flow with server-driven Share help sheet

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -158,6 +158,7 @@ import { HomePage } from "./web/pages/home";
 import { McpConnectPage } from "./web/pages/mcp";
 import { PrivacyPage } from "./web/pages/privacy";
 import { TermsPage } from "./web/pages/terms";
+import { HelpAddLinksPage } from "./web/pages/help";
 import { E2EFixturePage } from "./web/pages/e2e-fixture";
 import { createE2EFixturePdf } from "./web/pages/e2e-fixture-pdf";
 import { initInstallRoutes } from "./web/pages/install";
@@ -637,6 +638,14 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	app.get("/terms", async (req: Request, res: Response) => {
 		sendComponent(req, res, Base(TermsPage(), await buildBannerState(req)));
+	});
+
+	// Bare (HtmlPage, not Base) so the iOS Share-help sheet can render it in a
+	// WKWebView without site chrome; public like /privacy. The iOS client reaches
+	// it via the add-links-help link rel in the /queue Siren collection, so the
+	// copy ships via a hutch deploy rather than an App Store review.
+	app.get("/help/add-links", (req: Request, res: Response) => {
+		sendComponent(req, res, HelpAddLinksPage());
 	});
 
 	// Path-uniqued article fixture for staging e2e tests. The :id segment is

--- a/projects/hutch/src/runtime/web/api/collection-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.test.ts
@@ -112,6 +112,22 @@ describe("toArticleCollectionEntity", () => {
 		expect(entity.links).toContainEqual({ rel: ["root"], href: "/queue" });
 	});
 
+	it("advertises the add-links-help link", () => {
+		const result: FindArticlesResult = {
+			articles: [],
+			total: 0,
+			page: 1,
+			pageSize: 20,
+		};
+
+		const entity = toArticleCollectionEntity(result, {});
+
+		expect(entity.links).toContainEqual({
+			rel: ["add-links-help"],
+			href: "/help/add-links",
+		});
+	});
+
 	it("includes next link when more pages exist", () => {
 		const result: FindArticlesResult = {
 			articles: Array.from({ length: 20 }, (_, i) => makeArticle(`${i}`)),
@@ -140,7 +156,7 @@ describe("toArticleCollectionEntity", () => {
 		expect(prevLink?.href).toContain("page=1");
 	});
 
-	it("last page has only self and root links", () => {
+	it("last page omits the next link", () => {
 		const result: FindArticlesResult = {
 			articles: [makeArticle("1"), makeArticle("2")],
 			total: 22,
@@ -151,10 +167,10 @@ describe("toArticleCollectionEntity", () => {
 		const entity = toArticleCollectionEntity(result, { page: 2, pageSize: 20 });
 
 		const linkRels = entity.links?.map((l) => l.rel[0]);
-		expect(linkRels).toEqual(["self", "root", "prev"]);
+		expect(linkRels).toEqual(["self", "root", "add-links-help", "prev"]);
 	});
 
-	it("first page has only self and root links", () => {
+	it("single page omits both pagination links", () => {
 		const result: FindArticlesResult = {
 			articles: [makeArticle("1")],
 			total: 1,
@@ -165,7 +181,7 @@ describe("toArticleCollectionEntity", () => {
 		const entity = toArticleCollectionEntity(result, {});
 
 		const linkRels = entity.links?.map((l) => l.rel[0]);
-		expect(linkRels).toEqual(["self", "root"]);
+		expect(linkRels).toEqual(["self", "root", "add-links-help"]);
 	});
 
 	it("preserves query params in pagination links", () => {

--- a/projects/hutch/src/runtime/web/api/collection-siren.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.ts
@@ -43,6 +43,10 @@ export function toArticleCollectionEntity(
 		{ rel: ["root"], href: "/queue" },
 	];
 
+	// The add-links-help rel is the client contract; the href stays
+	// server-internal so the bare help page can move without a client release.
+	links.push({ rel: ["add-links-help"], href: "/help/add-links" });
+
 	if (page > 1) {
 		links.push({
 			rel: ["prev"],

--- a/projects/hutch/src/runtime/web/pages/help/add-links.component.ts
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.component.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { HtmlPage, render } from "@packages/web-shell";
+import type { Component } from "@packages/web-shell";
+
+const HELP_ADD_LINKS_TEMPLATE = readFileSync(
+	join(__dirname, "add-links.template.html"),
+	"utf-8",
+);
+
+export function HelpAddLinksPage(): Component {
+	return HtmlPage(render(HELP_ADD_LINKS_TEMPLATE, {}));
+}

--- a/projects/hutch/src/runtime/web/pages/help/add-links.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.route.test.ts
@@ -18,16 +18,18 @@ describe("GET /help/add-links", () => {
 		expect(response.headers["content-type"]).toMatch(/text\/html/);
 
 		const doc = new JSDOM(response.text).window.document;
-		expect(doc.querySelector(".help__title")?.textContent).toBe("Add links with Share");
-		const steps = Array.from(doc.querySelectorAll(".help__step")).map(
-			(el) => el.textContent?.trim(),
+		expect(doc.querySelector("[data-test-help-title]")?.textContent).toBe(
+			"Add links with Share",
 		);
+		const steps = Array.from(
+			doc.querySelectorAll("[data-test-help-step]"),
+		).map((el) => el.textContent?.trim());
 		expect(steps).toEqual([
 			"Open a link in any app.",
 			"Tap Share.",
 			"Choose Readplace.",
 		]);
-		expect(doc.querySelector(".help__note")?.textContent).toContain(
+		expect(doc.querySelector("[data-test-help-note]")?.textContent).toContain(
 			"captures the full page",
 		);
 	});

--- a/projects/hutch/src/runtime/web/pages/help/add-links.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.route.test.ts
@@ -1,0 +1,45 @@
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { useTestServer } from "../../../test-app";
+import {
+	TEST_APP_ORIGIN,
+	createDefaultTestAppFixture,
+} from "@packages/test-fixtures";
+
+const useApp = useTestServer();
+
+describe("GET /help/add-links", () => {
+	it("renders the Share instructions as HTML for a logged-out visitor", async () => {
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(server).get("/help/add-links");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/text\/html/);
+
+		const doc = new JSDOM(response.text).window.document;
+		expect(doc.querySelector(".help__title")?.textContent).toBe("Add links with Share");
+		const steps = Array.from(doc.querySelectorAll(".help__step")).map(
+			(el) => el.textContent?.trim(),
+		);
+		expect(steps).toEqual([
+			"Open a link in any app.",
+			"Tap Share.",
+			"Choose Readplace.",
+		]);
+		expect(doc.querySelector(".help__note")?.textContent).toContain(
+			"captures the full page",
+		);
+	});
+
+	it("falls through to HTML when text/markdown is requested", async () => {
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(server)
+			.get("/help/add-links")
+			.set("Accept", "text/markdown");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toMatch(/text\/html/);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/help/add-links.template.html
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.template.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
+    <title>Add links with Share — Readplace</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --help-bg: #ffffff;
+        --help-text: #1a202c;
+        --help-text-secondary: #5a6170;
+        --help-brand: #c8702a;
+        --help-surface: #f7f8fa;
+        --help-border: #e2e5ea;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --help-bg: #121212;
+          --help-text: #e4e4e4;
+          --help-text-secondary: #9ba1ae;
+          --help-brand: #d4833a;
+          --help-surface: #1a1a1a;
+          --help-border: #2e2e2e;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--help-bg);
+        color: var(--help-text);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .help {
+        max-width: 32rem;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem;
+      }
+
+      .help__title {
+        margin: 0 0 1.5rem;
+        font-size: 1.5rem;
+        font-weight: 700;
+        line-height: 1.3;
+      }
+
+      .help__steps {
+        margin: 0 0 1.5rem;
+        padding: 0;
+        list-style: none;
+        counter-reset: help-step;
+      }
+
+      .help__step {
+        counter-increment: help-step;
+        position: relative;
+        padding: 0.75rem 0 0.75rem 3rem;
+        font-size: 1.0625rem;
+        border-bottom: 1px solid var(--help-border);
+      }
+
+      .help__step:last-child {
+        border-bottom: 0;
+      }
+
+      .help__step::before {
+        content: counter(help-step);
+        position: absolute;
+        left: 0;
+        top: 0.65rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        background: var(--help-surface);
+        color: var(--help-brand);
+        border-radius: 6px;
+        font-weight: 600;
+      }
+
+      .help__note {
+        margin: 0;
+        padding: 1rem 1.25rem;
+        background: var(--help-surface);
+        border-radius: 8px;
+        color: var(--help-text-secondary);
+        font-size: 0.9375rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="help">
+      <h1 class="help__title">Add links with Share</h1>
+      <ol class="help__steps">
+        <li class="help__step">Open a link in any app.</li>
+        <li class="help__step">Tap Share.</li>
+        <li class="help__step">Choose Readplace.</li>
+      </ol>
+      <p class="help__note">Sharing captures the full page — even on sites that block crawlers.</p>
+    </main>
+  </body>
+</html>

--- a/projects/hutch/src/runtime/web/pages/help/add-links.template.html
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.template.html
@@ -100,13 +100,13 @@
   </head>
   <body>
     <main class="help">
-      <h1 class="help__title">Add links with Share</h1>
+      <h1 class="help__title" data-test-help-title>Add links with Share</h1>
       <ol class="help__steps">
-        <li class="help__step">Open a link in any app.</li>
-        <li class="help__step">Tap Share.</li>
-        <li class="help__step">Choose Readplace.</li>
+        <li class="help__step" data-test-help-step>Open a link in any app.</li>
+        <li class="help__step" data-test-help-step>Tap Share.</li>
+        <li class="help__step" data-test-help-step>Choose Readplace.</li>
       </ol>
-      <p class="help__note">Sharing captures the full page — even on sites that block crawlers.</p>
+      <p class="help__note" data-test-help-note>Sharing captures the full page — even on sites that block crawlers.</p>
     </main>
   </body>
 </html>

--- a/projects/hutch/src/runtime/web/pages/help/index.ts
+++ b/projects/hutch/src/runtime/web/pages/help/index.ts
@@ -1,0 +1,1 @@
+export { HelpAddLinksPage } from "./add-links.component";

--- a/projects/ios-readplace/App/AddLinkInstructionsView.swift
+++ b/projects/ios-readplace/App/AddLinkInstructionsView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// The sheet shown when the user taps + on the reading list. Rather than an
+/// in-app paste box (removed), it teaches adding links through the iOS Share
+/// menu by rendering the server's `GET /help/add-links` page in a webview, so
+/// the copy ships via a hutch deploy rather than an App Store release. The help
+/// URL is discovered from the queue's Siren links; when it is missing (the queue
+/// hasn't loaded, or the link wasn't advertised) or the page fails to load, the
+/// sheet shows a local fallback that still teaches Share rather than a blank or
+/// dead-end page.
+struct AddLinkInstructionsView: View {
+	let helpURL: URL?
+	let onClose: () -> Void
+
+	@State private var isLoading = true
+	@State private var loadFailed = false
+
+	var body: some View {
+		NavigationStack {
+			content
+				.navigationTitle("Add a link")
+				.navigationBarTitleDisplayMode(.inline)
+				.toolbar {
+					ToolbarItem(placement: .navigationBarLeading) {
+						Button("Back to Queue", action: onClose)
+					}
+				}
+		}
+	}
+
+	@ViewBuilder
+	private var content: some View {
+		if let helpURL, !loadFailed {
+			ZStack {
+				WebPageView(
+					url: helpURL,
+					onFinish: { isLoading = false },
+					onFail: {
+						isLoading = false
+						loadFailed = true
+					}
+				)
+				if isLoading {
+					ProgressView()
+				}
+			}
+		} else {
+			fallback
+		}
+	}
+
+	/// A self-contained native version of the help page, shown when the webview
+	/// can't be displayed. It still delivers the core instruction so the feature
+	/// degrades gracefully; "Back to Queue" lives in the toolbar above.
+	private var fallback: some View {
+		VStack(spacing: 12) {
+			Image(systemName: "square.and.arrow.up")
+				.font(.system(size: 40))
+				.foregroundStyle(.secondary)
+			Text("Add links with Share")
+				.font(.headline)
+			Text("Open a link in any app, tap Share, then choose Readplace.")
+				.font(.subheadline)
+				.foregroundStyle(.secondary)
+				.multilineTextAlignment(.center)
+		}
+		.padding(40)
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+	}
+}

--- a/projects/ios-readplace/App/AddLinkInstructionsView.swift
+++ b/projects/ios-readplace/App/AddLinkInstructionsView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 /// The sheet shown when the user taps + on the reading list. Rather than an
 /// in-app paste box (removed), it teaches adding links through the iOS Share
-/// menu by rendering the server's `GET /help/add-links` page in a webview, so
-/// the copy ships via a hutch deploy rather than an App Store release. The help
-/// URL is discovered from the queue's Siren links; when it is missing (the queue
-/// hasn't loaded, or the link wasn't advertised) or the page fails to load, the
-/// sheet shows a local fallback that still teaches Share rather than a blank or
-/// dead-end page.
+/// menu by rendering the server's help page in a webview, so the copy ships via
+/// a hutch deploy rather than an App Store release. The help URL is discovered
+/// from the queue's `add-links-help` link `rel` (never a hard-coded route); when
+/// it is missing (the queue hasn't loaded, or the link wasn't advertised) or the
+/// page fails to load, the sheet shows a local fallback that still teaches Share
+/// rather than a blank or dead-end page.
 struct AddLinkInstructionsView: View {
 	let helpURL: URL?
 	let onClose: () -> Void

--- a/projects/ios-readplace/App/ReadingListView.swift
+++ b/projects/ios-readplace/App/ReadingListView.swift
@@ -4,8 +4,7 @@ struct ReadingListView: View {
 	@ObservedObject var session: AppSession
 	@StateObject private var viewModel: ReadingListViewModel
 
-	@State private var showingSaveDialog = false
-	@State private var saveText = ""
+	@State private var showingAddInstructions = false
 
 	init(session: AppSession) {
 		self.session = session
@@ -26,8 +25,7 @@ struct ReadingListView: View {
 					}
 					ToolbarItem(placement: .navigationBarTrailing) {
 						Button {
-							saveText = ""
-							showingSaveDialog = true
+							showingAddInstructions = true
 						} label: {
 							Image(systemName: "plus")
 						}
@@ -47,14 +45,11 @@ struct ReadingListView: View {
 					)
 					.ignoresSafeArea()
 				}
-				.alert("Save a URL", isPresented: $showingSaveDialog) {
-					TextField("https://example.com/article", text: $saveText)
-						.textInputAutocapitalization(.never)
-						.autocorrectionDisabled()
-					Button("Save") { Task { await viewModel.saveURL(saveText) } }
-					Button("Cancel", role: .cancel) {}
-				} message: {
-					Text("Saves the URL only. Use the iOS Share Sheet to save a page with its rendered content.")
+				.sheet(isPresented: $showingAddInstructions) {
+					AddLinkInstructionsView(
+						helpURL: viewModel.addLinksHelpURL,
+						onClose: { showingAddInstructions = false }
+					)
 				}
 		}
 	}
@@ -68,12 +63,6 @@ struct ReadingListView: View {
 				emptyState
 			} else {
 				list
-			}
-
-			if viewModel.isSaving {
-				ProgressView("Saving…")
-					.padding()
-					.background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
 			}
 		}
 		.overlay(alignment: .bottom) {
@@ -137,7 +126,7 @@ struct ReadingListView: View {
 				.foregroundStyle(.secondary)
 			Text("Nothing saved yet")
 				.font(.headline)
-			Text("Share a link to Readplace, or tap + to save a URL.")
+			Text("Open a link in any app, tap Share, and choose Readplace. Tap + for help.")
 				.font(.subheadline)
 				.foregroundStyle(.secondary)
 				.multilineTextAlignment(.center)

--- a/projects/ios-readplace/App/ReadingListViewModel.swift
+++ b/projects/ios-readplace/App/ReadingListViewModel.swift
@@ -4,7 +4,6 @@ import Foundation
 final class ReadingListViewModel: ObservableObject {
 	@Published private(set) var articles: [Article] = []
 	@Published private(set) var isLoading = false
-	@Published private(set) var isSaving = false
 	@Published private(set) var hasMore = false
 	@Published var errorText: String?
 	@Published var warningText: String?
@@ -14,10 +13,12 @@ final class ReadingListViewModel: ObservableObject {
 	/// Set when a readable row is tapped; drives the reader sheet. The session
 	/// cookie is minted inside the sheet, so the sheet opens without waiting.
 	@Published var readerPresentation: ReaderPresentation?
+	/// The server's "add links via Share" help page, discovered from the queue's
+	/// Siren links. Drives the + sheet's webview; nil until the queue advertises it.
+	@Published private(set) var addLinksHelpURL: URL?
 
 	private var nextHref: String?
 	private var isLoadingMore = false
-	private var saveArticleAction: SirenAction?
 
 	private let api: ReadplaceAPI
 	private let onSessionExpired: () -> Void
@@ -41,7 +42,7 @@ final class ReadingListViewModel: ObservableObject {
 		errorText = nil
 		// A locked account's reads still succeed, so a fresh load reconciles a
 		// stale refusal banner (e.g. after verifying elsewhere): clear it here,
-		// then re-surface it only if the next save is refused again.
+		// then re-surface it only if a later write (e.g. mark-as-read) is refused.
 		messages = []
 		do {
 			let page = try await api.loadQueue()
@@ -107,21 +108,6 @@ final class ReadingListViewModel: ObservableObject {
 		}
 	}
 
-	func saveURL(_ rawURL: String) async {
-		let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
-		guard !trimmed.isEmpty, let action = saveArticleAction else { return }
-		isSaving = true
-		errorText = nil
-		messages = []
-		do {
-			_ = try await api.saveArticle(action: action, url: trimmed)
-			await fetchFirstPage()
-		} catch {
-			handle(error)
-		}
-		isSaving = false
-	}
-
 	private func apply(_ page: QueuePage, replacing: Bool) {
 		if replacing {
 			articles = page.articles
@@ -131,7 +117,11 @@ final class ReadingListViewModel: ObservableObject {
 		}
 		nextHref = page.nextHref
 		hasMore = page.nextHref != nil
-		if let save = page.saveArticleAction { saveArticleAction = save }
+		// Mirror the conditional assignment of other discovered links: a later page
+		// that omits the help link must not clear a URL we already resolved.
+		if let href = page.addLinksHelpHref, let url = Href.resolve(href, baseURL: api.baseURL) {
+			addLinksHelpURL = url
+		}
 		warningText = page.warning?.message
 	}
 

--- a/projects/ios-readplace/App/WebPageView.swift
+++ b/projects/ios-readplace/App/WebPageView.swift
@@ -3,11 +3,11 @@ import WebKit
 
 /// A minimal WKWebView wrapper that loads a single public URL — no cookie
 /// injection and no JS bridge, unlike the reader-specific `ReaderWebView`. A
-/// navigation delegate reports first-load completion and failure through
-/// closures so the presenting view can drive its loading and error overlays.
-/// Per the `ReaderWebView`/web-auth precedent, this WKWebView glue is an OS
-/// boundary left untested; the URL it loads is discovered by the view model,
-/// which is.
+/// navigation delegate reports first-load completion, and failure — a transport
+/// error or an HTTP error status — through closures so the presenting view can
+/// drive its loading and error overlays. Per the `ReaderWebView`/web-auth
+/// precedent, this WKWebView glue is an OS boundary left untested; the URL it
+/// loads is discovered by the view model, which is.
 struct WebPageView: UIViewControllerRepresentable {
 	let url: URL
 	let onFinish: () -> Void
@@ -39,6 +39,23 @@ struct WebPageView: UIViewControllerRepresentable {
 		init(onFinish: @escaping () -> Void, onFail: @escaping () -> Void) {
 			self.onFinish = onFinish
 			self.onFail = onFail
+		}
+
+		/// WKWebView delivers a 4xx/5xx through `didFinish`, not `didFail`, so without
+		/// rejecting the response here the sheet would paint the server's error body.
+		/// Cancelling routes an error status to `onFail`, surfacing the native Share
+		/// fallback instead.
+		func webView(
+			_ webView: WKWebView,
+			decidePolicyFor navigationResponse: WKNavigationResponse,
+			decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+		) {
+			if let http = navigationResponse.response as? HTTPURLResponse, http.statusCode >= 400 {
+				decisionHandler(.cancel)
+				onFail()
+				return
+			}
+			decisionHandler(.allow)
 		}
 
 		func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/projects/ios-readplace/App/WebPageView.swift
+++ b/projects/ios-readplace/App/WebPageView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import WebKit
+
+/// A minimal WKWebView wrapper that loads a single public URL — no cookie
+/// injection and no JS bridge, unlike the reader-specific `ReaderWebView`. A
+/// navigation delegate reports first-load completion and failure through
+/// closures so the presenting view can drive its loading and error overlays.
+/// Per the `ReaderWebView`/web-auth precedent, this WKWebView glue is an OS
+/// boundary left untested; the URL it loads is discovered by the view model,
+/// which is.
+struct WebPageView: UIViewControllerRepresentable {
+	let url: URL
+	let onFinish: () -> Void
+	let onFail: () -> Void
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator(onFinish: onFinish, onFail: onFail)
+	}
+
+	func makeUIViewController(context: Context) -> UIViewController {
+		let controller = UIViewController()
+		let webView = WKWebView(frame: .zero)
+		webView.navigationDelegate = context.coordinator
+		// Let the sheet's background show through until the page paints, so the
+		// load blends into the system light/dark sheet instead of flashing white.
+		webView.isOpaque = false
+		webView.backgroundColor = .systemBackground
+		controller.view = webView
+		webView.load(URLRequest(url: url))
+		return controller
+	}
+
+	func updateUIViewController(_ controller: UIViewController, context: Context) {}
+
+	final class Coordinator: NSObject, WKNavigationDelegate {
+		private let onFinish: () -> Void
+		private let onFail: () -> Void
+
+		init(onFinish: @escaping () -> Void, onFail: @escaping () -> Void) {
+			self.onFinish = onFinish
+			self.onFail = onFail
+		}
+
+		func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+			onFinish()
+		}
+
+		func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+			onFail()
+		}
+
+		func webView(
+			_ webView: WKWebView,
+			didFailProvisionalNavigation navigation: WKNavigation!,
+			withError error: Error
+		) {
+			onFail()
+		}
+	}
+}

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -96,8 +96,12 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
   `POST /queue/save-html`. If the token is missing, capture fails, or the HTML is
   over the 10 MiB server limit, it degrades to the URL-only `save-article` path —
   mirroring the extension's own fallback.
-- **Save a URL** from inside the app (the `+` button) via the URL-only
-  `save-article` action, as a quick way to see the list update.
+- **Add links via Share**: the `+` button opens a sheet whose `WKWebView` renders
+  the server's `GET /help/add-links` page — discovered from the `add-links-help`
+  link `rel` on the queue collection, never a hard-coded path — so the
+  instructions ship via a hutch deploy rather than an App Store release. A
+  **Back to Queue** button dismisses it. There is no in-app paste box; capturing
+  a page is the Share Extension's job.
 
 It speaks `application/vnd.siren+json`, sends `Authorization: Bearer <token>` on
 every request, and refreshes the token once on a `401` — the same contract the

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -97,11 +97,10 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
   over the 10 MiB server limit, it degrades to the URL-only `save-article` path —
   mirroring the extension's own fallback.
 - **Add links via Share**: the `+` button opens a sheet whose `WKWebView` renders
-  the server's `GET /help/add-links` page — discovered from the `add-links-help`
-  link `rel` on the queue collection, never a hard-coded path — so the
-  instructions ship via a hutch deploy rather than an App Store release. A
-  **Back to Queue** button dismisses it. There is no in-app paste box; capturing
-  a page is the Share Extension's job.
+  the server's help page — discovered from the `add-links-help` link `rel` on the
+  queue collection, never a hard-coded path — so the instructions ship via a hutch
+  deploy rather than an App Store release. A **Back to Queue** button dismisses it.
+  There is no in-app paste box; capturing a page is the Share Extension's job.
 
 It speaks `application/vnd.siren+json`, sends `Authorization: Bearer <token>` on
 every request, and refreshes the token once on a `401` — the same contract the

--- a/projects/ios-readplace/Shared/ReadplaceAPI.swift
+++ b/projects/ios-readplace/Shared/ReadplaceAPI.swift
@@ -29,6 +29,9 @@ struct QueuePage {
 	let selfHref: String?
 	let nextHref: String?
 	let prevHref: String?
+	/// Href of the server's "add links via Share" help page, advertised on the
+	/// collection so the iOS client discovers it rather than hardcoding the path.
+	let addLinksHelpHref: String?
 	let total: Int?
 	let saveArticleAction: SirenAction?
 	let saveHtmlAction: SirenAction?
@@ -39,6 +42,7 @@ struct QueuePage {
 		selfHref = collection.links?.first { $0.rel.contains("self") }?.href
 		nextHref = collection.links?.first { $0.rel.contains("next") }?.href
 		prevHref = collection.links?.first { $0.rel.contains("prev") }?.href
+		addLinksHelpHref = collection.links?.first { $0.rel.contains("add-links-help") }?.href
 		total = collection.properties?.total
 		saveArticleAction = collection.actions?.first { $0.name == "save-article" }
 		saveHtmlAction = collection.actions?.first { $0.name == "save-html" }

--- a/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
+++ b/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
@@ -17,84 +17,46 @@ final class ReadingListViewModelTests: XCTestCase {
 		return ReadingListViewModel(api: api, onSessionExpired: {})
 	}
 
-	/// A locked account: the queue loads (so the `save-article` action is
-	/// discovered) but every save POST is refused with a server-authored message.
-	private func lockedAccountHandler() -> (URLRequest, Data) -> StubURLProtocol.Stub {
+	// MARK: - Add-links help discovery
+
+	/// A single-page `/queue` whose collection carries the given extra links.
+	private func queueHandler(extraLinks: String = "") -> (URLRequest, Data) -> StubURLProtocol.Stub {
 		return { request, _ in
-			let path = request.url?.path ?? ""
-			let method = request.httpMethod ?? "GET"
-			switch (path, method) {
-			case ("/", _):
+			switch request.url?.path ?? "" {
+			case "/":
 				return .redirect(to: "/queue")
-			case ("/queue", "POST"):
-				return .json(403, Fixtures.accountLockedError())
-			case ("/queue", _):
-				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+			case "/queue":
+				return .json(200, Fixtures.collection(
+					entitiesJSON: [Fixtures.article(id: "a1")],
+					extraLinks: extraLinks
+				))
 			default:
 				return .json(404, "{}")
 			}
 		}
 	}
 
-	func testRefusedSaveSurfacesServerMessages() async {
-		StubURLProtocol.setHandler(lockedAccountHandler())
+	func testRefreshDiscoversAddLinksHelpURL() async {
+		StubURLProtocol.setHandler(queueHandler(
+			extraLinks: ", { \"rel\": [\"add-links-help\"], \"href\": \"/help/add-links\" }"
+		))
 		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
 
 		await viewModel.refresh()
-		await viewModel.saveURL("https://example.com/x")
 
-		XCTAssertEqual(viewModel.messages.first?.type, "warning")
-		XCTAssertEqual(viewModel.messages.first?.content.type, "text/html")
-		XCTAssertTrue(
-			viewModel.messages.first?.content.body.contains("readplace+verification@readplace.com") ?? false,
-			"the refusal message names the address to email"
+		XCTAssertEqual(
+			viewModel.addLinksHelpURL?.absoluteString,
+			"\(AppConfig.serverBaseURL)/help/add-links"
 		)
 	}
 
-	func testSuccessfulRefreshClearsStaleRefusalBanner() async {
-		StubURLProtocol.setHandler(lockedAccountHandler())
+	func testAddLinksHelpURLIsNilWhenCollectionOmitsTheLink() async {
+		StubURLProtocol.setHandler(queueHandler())
 		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
 
 		await viewModel.refresh()
-		await viewModel.saveURL("https://example.com/x")
-		XCTAssertFalse(viewModel.messages.isEmpty, "precondition: a refused save shows the banner")
 
-		await viewModel.refresh()
-
-		XCTAssertTrue(
-			viewModel.messages.isEmpty,
-			"a locked account's reads still succeed, so a fresh load reconciles the stale banner"
-		)
-	}
-
-	func testSaveResetsMessagesSoASucceedingSaveClearsTheBanner() async {
-		var savePOSTs = 0
-		StubURLProtocol.setHandler { request, _ in
-			let path = request.url?.path ?? ""
-			let method = request.httpMethod ?? "GET"
-			switch (path, method) {
-			case ("/", _):
-				return .redirect(to: "/queue")
-			case ("/queue", "POST"):
-				savePOSTs += 1
-				return savePOSTs == 1
-					? .json(403, Fixtures.accountLockedError())
-					: .json(201, Fixtures.article(id: "saved"))
-			case ("/queue", _):
-				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
-			default:
-				return .json(404, "{}")
-			}
-		}
-		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
-
-		await viewModel.refresh()
-		await viewModel.saveURL("https://example.com/x")
-		XCTAssertFalse(viewModel.messages.isEmpty, "precondition: the first save is refused")
-
-		await viewModel.saveURL("https://example.com/y")
-
-		XCTAssertTrue(viewModel.messages.isEmpty, "saveURL resets messages before the next attempt")
+		XCTAssertNil(viewModel.addLinksHelpURL)
 	}
 
 	// MARK: - Mark as read
@@ -149,6 +111,27 @@ final class ReadingListViewModelTests: XCTestCase {
 			"a failed mark-read rolls the optimistic removal back"
 		)
 		XCTAssertNotNil(viewModel.errorText)
+	}
+
+	func testRefusedMarkAsReadSurfacesServerMessages() async {
+		StubURLProtocol.setHandler(markReadHandler { _ in
+			.json(403, Fixtures.accountLockedError())
+		})
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		await viewModel.refresh()
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1", "a2"])
+
+		await viewModel.markAsRead(viewModel.articles[0])
+
+		XCTAssertEqual(viewModel.messages.first?.type, "warning")
+		XCTAssertTrue(
+			viewModel.messages.first?.content.body.contains("readplace+verification@readplace.com") ?? false,
+			"the refusal message names the address to email"
+		)
+		XCTAssertEqual(
+			viewModel.articles.map(\.id), ["a1", "a2"],
+			"a refused mark-read restores the optimistically-removed row"
+		)
 	}
 
 	func testRemoveArticleDropsTheRowWithoutANetworkCall() async {

--- a/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
+++ b/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
@@ -36,6 +36,33 @@ final class ReadingListViewModelTests: XCTestCase {
 		}
 	}
 
+	/// A two-page `/queue`: the first page advertises both a `next` link and the
+	/// `add-links-help` link; the second page (followed via `next`) omits the help
+	/// link, modelling a server that stops advertising it on a later page.
+	private func twoPageHelpHandler() -> (URLRequest, Data) -> StubURLProtocol.Stub {
+		return { request, _ in
+			switch (request.url?.path ?? "", request.url?.query ?? "") {
+			case ("/", _):
+				return .redirect(to: "/queue")
+			case ("/queue", "page=2"):
+				return .json(200, Fixtures.collection(
+					entitiesJSON: [Fixtures.article(id: "a2")],
+					page: 2,
+					total: 2
+				))
+			case ("/queue", _):
+				return .json(200, Fixtures.collection(
+					entitiesJSON: [Fixtures.article(id: "a1")],
+					extraLinks: ", { \"rel\": [\"next\"], \"href\": \"/queue?page=2\" }"
+						+ ", { \"rel\": [\"add-links-help\"], \"href\": \"/help/add-links\" }",
+					total: 2
+				))
+			default:
+				return .json(404, "{}")
+			}
+		}
+	}
+
 	func testRefreshDiscoversAddLinksHelpURL() async {
 		StubURLProtocol.setHandler(queueHandler(
 			extraLinks: ", { \"rel\": [\"add-links-help\"], \"href\": \"/help/add-links\" }"
@@ -57,6 +84,37 @@ final class ReadingListViewModelTests: XCTestCase {
 		await viewModel.refresh()
 
 		XCTAssertNil(viewModel.addLinksHelpURL)
+	}
+
+	func testAddLinksHelpURLSurvivesALaterPageThatOmitsTheLink() async {
+		StubURLProtocol.setHandler(twoPageHelpHandler())
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+		let resolved = viewModel.addLinksHelpURL
+		XCTAssertNotNil(resolved, "the first page advertises the help link")
+
+		await viewModel.loadMore()
+
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1", "a2"], "the next page is appended")
+		XCTAssertEqual(
+			viewModel.addLinksHelpURL, resolved,
+			"a later page that omits the help link must not clear an already-resolved URL"
+		)
+	}
+
+	func testAddLinksHelpURLStaysNilForAnUnresolvableHelpHref() async {
+		StubURLProtocol.setHandler(queueHandler(
+			extraLinks: ", { \"rel\": [\"add-links-help\"], \"href\": \"mailto:help@example.com\" }"
+		))
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+
+		XCTAssertNil(
+			viewModel.addLinksHelpURL,
+			"a help href the client can't resolve (foreign scheme) is treated as absent"
+		)
 	}
 
 	// MARK: - Mark as read

--- a/projects/ios-readplace/Tests/SirenDecodingTests.swift
+++ b/projects/ios-readplace/Tests/SirenDecodingTests.swift
@@ -131,6 +131,18 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertNil(lastPage.prevHref)
 	}
 
+	func testAddLinksHelpLinkDecodes() throws {
+		let withHelp = Fixtures.collection(
+			entitiesJSON: [Fixtures.article()],
+			extraLinks: ", { \"rel\": [\"add-links-help\"], \"href\": \"/help/add-links\" }"
+		)
+		let page = QueuePage(collection: try decodeCollection(withHelp))
+		XCTAssertEqual(page.addLinksHelpHref, "/help/add-links")
+
+		let withoutHelp = Fixtures.collection(entitiesJSON: [Fixtures.article()])
+		XCTAssertNil(QueuePage(collection: try decodeCollection(withoutHelp)).addLinksHelpHref)
+	}
+
 	func testEmptyCollection() throws {
 		let json = """
 		{ "class": ["collection", "articles"], "properties": { "total": 0, "page": 1, "pageSize": 20 }, "links": [{ "rel": ["self"], "href": "/queue" }], "actions": [] }


### PR DESCRIPTION
## Why

The iOS **+** button opened an in-app URL paste box that saved a URL-only stub — strictly worse than the Share Extension, which captures a page's fully rendered HTML (even on sites that block crawlers). This replaces that inferior paste box with a sheet that teaches adding links through the iOS **Share** menu.

Per the product decision, the instructional content is **served from the hutch web server** and shown in an in-app `WKWebView`, so the copy (and future screenshots) can be edited online and shipped via the normal web deploy — never gated behind an App Store review. This matches the codebase's hypermedia/SSR philosophy.

## What

**hutch (`projects/hutch/`)**
- New **bare, public, `noindex`** help page at `GET /help/add-links`, rendered via `HtmlPage` (no site chrome) — a self-contained mobile-styled document with a system font stack and `prefers-color-scheme` light/dark so it blends into the iOS sheet.
- Advertise an `add-links-help` link `rel` on the `/queue` Siren collection so the client **discovers** the URL rather than hardcoding the path. Additive and backward-compatible — existing clients read only the rels they know.

**iOS (`projects/ios-readplace/`)**
- New `AddLinkInstructionsView` (the slide-up sheet) with a **Back to Queue** toolbar button, a `ProgressView` while the page loads, and a **local native fallback** that still teaches Share when the page can't load or the link isn't advertised.
- New minimal `WebPageView` — a lightweight public `WKWebView` (no cookie injection, no JS bridge), distinct from the reader-specific `ReaderWebView`.
- `QueuePage`/view model now discover `addLinksHelpURL` from the queue collection (resolved through the shared `Href.resolve` helper); the **+** button opens the sheet.
- Removed the dead in-app paste-save (`saveURL`/`isSaving`) and its tests. The Share Extension's save path (`saveArticle`/`saveHTML`) is untouched.
- Preserved the locked-account refusal banner via the still-live mark-as-read path (added `testRefusedMarkAsReadSurfacesServerMessages`).

## Testing

- `pnpm check` (all 34 projects) passes — lint, types, unit + integration tests, 100% coverage, knip, unused-css. The hutch route test runs against the compiled `dist`, confirming the template is copied by `copy-static-assets` (the production path).
- iOS unit tests added for help-URL discovery (present → resolved URL; absent → nil), decode-layer parsing, and the refused mark-as-read banner. iOS `xcodebuild`/simulator tests run on macOS CI (`make test`); they could not be executed in this Linux session.

## Out of scope

Screenshots in the help page, a CMS-backed editor for the copy, and any change to the Share Extension or `ReadplaceAPI.saveArticle/saveHTML`. No infra/event changes — the new route rides the existing API-Gateway-fronted hutch Lambda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2dLaHa8uZGCfMGazr5QqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2dLaHa8uZGCfMGazr5QqR)_