### PR TITLE
feat(hutch): emit human titles + toggle value on Siren actions

### DIFF
--- a/projects/hutch/src/runtime/web/api/api.routes.test.ts
+++ b/projects/hutch/src/runtime/web/api/api.routes.test.ts
@@ -373,7 +373,9 @@ describe("POST /queue (Siren save article)", () => {
 		expect(updateStatus.method).toBe("POST");
 		expect(updateStatus.href).toContain("/status");
 		expect(updateStatus.type).toBe("application/x-www-form-urlencoded");
-		expect(updateStatus.fields).toEqual([{ name: "status", type: "text" }]);
+		expect(updateStatus.fields).toEqual([
+			{ name: "status", type: "text", value: "read" },
+		]);
 	});
 });
 
@@ -695,7 +697,9 @@ describe("Article sub-entity actions", () => {
 		expect(updateStatus.method).toBe("POST");
 		expect(updateStatus.href).toContain("/status");
 		expect(updateStatus.type).toBe("application/x-www-form-urlencoded");
-		expect(updateStatus.fields).toEqual([{ name: "status", type: "text" }]);
+		expect(updateStatus.fields).toEqual([
+			{ name: "status", type: "text", value: "read" },
+		]);
 	});
 });
 

--- a/projects/hutch/src/runtime/web/api/article-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.test.ts
@@ -56,13 +56,14 @@ describe("toArticleSubEntity", () => {
 				{ rel: ["read"], href: `/queue/${ARTICLE_ID}/view` },
 			],
 			actions: [
-				{ name: "delete", href: `/queue/${ARTICLE_ID}/delete`, method: "POST" },
+				{ name: "delete", title: "Delete", href: `/queue/${ARTICLE_ID}/delete`, method: "POST" },
 				{
 					name: "update-status",
+					title: "Mark as read",
 					href: `/queue/${ARTICLE_ID}/status`,
 					method: "POST",
 					type: "application/x-www-form-urlencoded",
-					fields: [{ name: "status", type: "text" }],
+					fields: [{ name: "status", type: "text", value: "read" }],
 				},
 			],
 		});
@@ -73,20 +74,37 @@ describe("toArticleSubEntity", () => {
 		const deleteAction = subEntity.actions?.find((a) => a.name === "delete");
 		expect(deleteAction).toEqual({
 			name: "delete",
+			title: "Delete",
 			href: `/queue/${ARTICLE_ID}/delete`,
 			method: "POST",
 		});
 	});
 
-	it("emits an update-status action posting the status field as urlencoded", () => {
-		const subEntity = toArticleSubEntity(makeArticle());
+	it("toggles an unread item to a server-driven Mark as read with the target value", () => {
+		const subEntity = toArticleSubEntity(makeArticle({ status: "unread" }));
 		const updateStatus = subEntity.actions?.find((a) => a.name === "update-status");
 		expect(updateStatus).toEqual({
 			name: "update-status",
+			title: "Mark as read",
 			href: `/queue/${ARTICLE_ID}/status`,
 			method: "POST",
 			type: "application/x-www-form-urlencoded",
-			fields: [{ name: "status", type: "text" }],
+			fields: [{ name: "status", type: "text", value: "read" }],
+		});
+	});
+
+	it("toggles a read item to a server-driven Mark as unread with the target value", () => {
+		const subEntity = toArticleSubEntity(
+			makeArticle({ status: "read", readAt: new Date("2026-03-04T12:00:00.000Z") }),
+		);
+		const updateStatus = subEntity.actions?.find((a) => a.name === "update-status");
+		expect(updateStatus).toEqual({
+			name: "update-status",
+			title: "Mark as unread",
+			href: `/queue/${ARTICLE_ID}/status`,
+			method: "POST",
+			type: "application/x-www-form-urlencoded",
+			fields: [{ name: "status", type: "text", value: "unread" }],
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/api/article-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.test.ts
@@ -53,7 +53,7 @@ describe("toArticleSubEntity", () => {
 				readAt: null,
 			},
 			links: [
-				{ rel: ["read"], href: `/queue/${ARTICLE_ID}/view` },
+				{ rel: ["read"], title: "Read", href: `/queue/${ARTICLE_ID}/view` },
 			],
 			actions: [
 				{ name: "delete", title: "Delete", href: `/queue/${ARTICLE_ID}/delete`, method: "POST" },
@@ -113,8 +113,18 @@ describe("toArticleSubEntity", () => {
 		const subEntity = toArticleSubEntity(article);
 
 		expect(subEntity.links).toEqual([
-			{ rel: ["read"], href: `/queue/${ARTICLE_ID}/view` },
+			{ rel: ["read"], title: "Read", href: `/queue/${ARTICLE_ID}/view` },
 		]);
+	});
+
+	it("titles the read link so looping clients use a server-authored label", () => {
+		const subEntity = toArticleSubEntity(makeArticle());
+		const readLink = subEntity.links?.find((l) => l.rel.includes("read"));
+		expect(readLink).toEqual({
+			rel: ["read"],
+			title: "Read",
+			href: `/queue/${ARTICLE_ID}/view`,
+		});
 	});
 
 	it("maps readAt when present", () => {

--- a/projects/hutch/src/runtime/web/api/article-siren.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.ts
@@ -7,6 +7,9 @@ export function toArticleSubEntity(article: SavedArticle): SirenSubEntity {
 		{ rel: ["read"], href: `/queue/${id}/view` },
 	];
 
+	const isRead = article.status === "read";
+	const targetStatus = isRead ? "unread" : "read";
+
 	return {
 		class: ["article"],
 		rel: ["item"],
@@ -27,15 +30,17 @@ export function toArticleSubEntity(article: SavedArticle): SirenSubEntity {
 		actions: [
 			{
 				name: "delete",
+				title: "Delete",
 				href: `/queue/${id}/delete`,
 				method: "POST",
 			},
 			{
 				name: "update-status",
+				title: isRead ? "Mark as unread" : "Mark as read",
 				href: `/queue/${id}/status`,
 				method: "POST",
 				type: "application/x-www-form-urlencoded",
-				fields: [{ name: "status", type: "text" }],
+				fields: [{ name: "status", type: "text", value: targetStatus }],
 			},
 		],
 	};

--- a/projects/hutch/src/runtime/web/api/article-siren.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.ts
@@ -4,7 +4,7 @@ import type { SirenEntity, SirenLink, SirenSubEntity } from "./siren";
 export function toArticleSubEntity(article: SavedArticle): SirenSubEntity {
 	const id = article.id.value;
 	const links: SirenLink[] = [
-		{ rel: ["read"], href: `/queue/${id}/view` },
+		{ rel: ["read"], title: "Read", href: `/queue/${id}/view` },
 	];
 
 	const isRead = article.status === "read";

--- a/projects/hutch/src/runtime/web/api/collection-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.test.ts
@@ -112,7 +112,7 @@ describe("toArticleCollectionEntity", () => {
 		expect(entity.links).toContainEqual({ rel: ["root"], href: "/queue" });
 	});
 
-	it("advertises the add-links-help link", () => {
+	it("advertises a titled add-links-help link so looping clients use a server-authored label", () => {
 		const result: FindArticlesResult = {
 			articles: [],
 			total: 0,
@@ -124,6 +124,7 @@ describe("toArticleCollectionEntity", () => {
 
 		expect(entity.links).toContainEqual({
 			rel: ["add-links-help"],
+			title: "How to add links",
 			href: "/help/add-links",
 		});
 	});

--- a/projects/hutch/src/runtime/web/api/collection-siren.test.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.test.ts
@@ -216,6 +216,28 @@ describe("toArticleCollectionEntity", () => {
 		const saveAction = entity.actions?.find((a) => a.name === "save-article");
 		expect(saveAction?.method).toBe("POST");
 		expect(saveAction?.fields?.some((f) => f.name === "url")).toBe(true);
+		expect(saveAction?.title).toBe("Save a link");
+	});
+
+	it("gives every advertised action a human title", () => {
+		const result: FindArticlesResult = {
+			articles: [],
+			total: 0,
+			page: 1,
+			pageSize: 20,
+		};
+
+		const entity = toArticleCollectionEntity(result, {});
+
+		const titles = Object.fromEntries(
+			(entity.actions ?? []).map((a) => [a.name, a.title]),
+		);
+		expect(titles).toEqual({
+			"save-article": "Save a link",
+			"save-html": "Save a page",
+			"save-content": "Save a file",
+			search: "Search",
+		});
 	});
 
 	it("includes search action with filter fields", () => {

--- a/projects/hutch/src/runtime/web/api/collection-siren.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.ts
@@ -45,7 +45,11 @@ export function toArticleCollectionEntity(
 
 	// The add-links-help rel is the client contract; the href stays
 	// server-internal so the bare help page can move without a client release.
-	links.push({ rel: ["add-links-help"], href: "/help/add-links" });
+	links.push({
+		rel: ["add-links-help"],
+		title: "How to add links",
+		href: "/help/add-links",
+	});
 
 	if (page > 1) {
 		links.push({

--- a/projects/hutch/src/runtime/web/api/collection-siren.ts
+++ b/projects/hutch/src/runtime/web/api/collection-siren.ts
@@ -72,6 +72,7 @@ export function toArticleCollectionEntity(
 		actions: [
 			{
 				name: "save-article",
+				title: "Save a link",
 				href: "/queue",
 				method: "POST",
 				type: "application/json",
@@ -79,6 +80,7 @@ export function toArticleCollectionEntity(
 			},
 			{
 				name: "save-html",
+				title: "Save a page",
 				href: "/queue/save-html",
 				method: "POST",
 				type: "application/json",
@@ -90,6 +92,7 @@ export function toArticleCollectionEntity(
 			},
 			{
 				name: "save-content",
+				title: "Save a file",
 				href: "/queue/save-content",
 				method: "POST",
 				type: "multipart/form-data",
@@ -102,6 +105,7 @@ export function toArticleCollectionEntity(
 			},
 			{
 				name: "search",
+				title: "Search",
 				href: "/queue",
 				method: "GET",
 				fields: [

--- a/projects/hutch/src/runtime/web/api/siren.ts
+++ b/projects/hutch/src/runtime/web/api/siren.ts
@@ -8,6 +8,7 @@ export interface SirenAction {
 	name: string;
 	href: string;
 	method: string;
+	title?: string;
 	type?: string;
 	fields?: SirenField[];
 }
@@ -15,6 +16,7 @@ export interface SirenAction {
 export interface SirenLink {
 	rel: string[];
 	href: string;
+	title?: string;
 }
 
 export interface SirenEntity {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -519,6 +519,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 					actions: [
 						{
 							name: "save-article",
+							title: "Save a link",
 							href: QUEUE_PATH,
 							method: "POST",
 							type: "application/json",
@@ -657,6 +658,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 
 			const buildFallbackAction = () => ({
 				name: "save-article",
+				title: "Save a link",
 				href: QUEUE_PATH,
 				method: "POST",
 				type: "application/json",

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-content.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-content.route.test.ts
@@ -235,7 +235,9 @@ describe("POST /queue/save-content validation", () => {
 		const fallback = response.body.actions.find(
 			(a: { name: string }) => a.name === "save-article",
 		);
-		expect(fallback).toBeDefined();
+		expect(fallback).toEqual(
+			expect.objectContaining({ title: "Save a link", href: "/queue" }),
+		);
 	});
 
 	it("returns 422 when the content field is missing", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-html.route.test.ts
@@ -241,7 +241,7 @@ describe("POST /queue/save-html", () => {
 			(a: { name: string }) => a.name === "save-article",
 		);
 		expect(fallback).toEqual(
-			expect.objectContaining({ href: "/queue", method: "POST" }),
+			expect.objectContaining({ title: "Save a link", href: "/queue", method: "POST" }),
 		);
 		const fallbackFields = fallback.fields.map((f: { name: string }) => f.name);
 		expect(fallbackFields).toEqual(["url"]);

--- a/projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.test.ts
@@ -54,9 +54,9 @@ describe("initSaveContentLimitHandler", () => {
 			class: ["error"],
 			properties: expect.objectContaining({ code: "content-too-large" }),
 		}));
-		const body = calls.body as { actions: { name: string; href: string }[] };
+		const body = calls.body as { actions: { name: string; title: string; href: string }[] };
 		expect(body.actions[0]).toEqual(
-			expect.objectContaining({ name: "save-article", href: "/queue" }),
+			expect.objectContaining({ name: "save-article", title: "Save a link", href: "/queue" }),
 		);
 		expect(next).not.toHaveBeenCalled();
 	});

--- a/projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/save-content-limit-handler.ts
@@ -35,6 +35,7 @@ export function initSaveContentLimitHandler(deps: {
 					actions: [
 						{
 							name: "save-article",
+							title: "Save a link",
 							href: "/queue",
 							method: "POST",
 							type: "application/json",


### PR DESCRIPTION
## What

**1 of 3 coordinated PRs** (plus a skill doc already committed to `main`) that make every Readplace client a generic hypermedia client per the updated [`hypermedia-api-design`](../blob/main/.claude/skills/hypermedia-api-design/SKILL.md) skill. **This is the server half.**

The clients render controls by *looping* advertised affordances and invoke field-bearing actions from *server-declared* field values. This PR gives the Siren API exactly what that needs — additively:

- Add optional `title` to `SirenAction`/`SirenLink` (`api/siren.ts`). (`value` already existed on `SirenField`; what's new is that the toggle below now **populates** it.)
- Emit a human `title` on every advertised action: `save-article` → "Save a link", `save-html` → "Save a page", `save-content` → "Save a file", `search` → "Search", `delete` → "Delete" — including the `save-article` fallbacks surfaced on payload-too-large recovery entities (`html-too-large`, the save-content limit, and the `invalid-save-content` fallback), so the capability reads identically everywhere.
- Make per-item `update-status` a **server-driven toggle**: an *unread* item advertises "Mark as read" with the `status` field `value: read`; a *read* item advertises "Mark as unread" with `value: unread`. A bare client control can then invoke it with **no client-side field knowledge**.

## Why

Per the skill: *"Label from the affordance's Siren `title`"* and *"invoke an action via its own href/method/type and server-declared field values."* The server owns the label and the field value; the client only renders and follows. This is the in-band data the looped clients consume.

## Independent & non-breaking

Purely additive — existing clients ignore the new fields. This PR is mergeable on its own, in any order: the extension and iOS PRs tolerate these titles/values being absent (they fall back to a humanized name).

## Verified

`pnpm check` green across all 34 projects at 100% coverage; `collection-siren`/`article-siren`/`api.routes` tests updated for the titles and the state-dependent toggle, plus `save-content-limit-handler`/`queue.save-html`/`queue.save-content` tests asserting the titled recovery fallbacks.

## The coordinated set
- **this** — server titles + toggle value
- `feat/extensions-affordance-loop` — chrome/firefox + browser-extension-core loop affordances
- `feat/ios-affordance-loop` — iOS app loops affordances
- skill doc — already on `main` (`docs(skills): document looped-affordance rendering in hypermedia-api-design`), so this PR's review runs against it.
