### PR TITLE
feat(extensions): render controls by looping advertised Siren affordances

### DIFF
--- a/projects/browser-extension-core/src/core.test.ts
+++ b/projects/browser-extension-core/src/core.test.ts
@@ -64,7 +64,7 @@ function createRecordingReadingList(
 	return {
 		saveCalls,
 		saveUrl,
-		removeUrl: inner.removeUrl,
+		invokeAction: inner.invokeAction,
 		findByUrl: inner.findByUrl,
 		getAllItems: inner.getAllItems,
 	};
@@ -317,6 +317,8 @@ function makeItem(url: string): ReadingListItem {
 		url,
 		title: "Title",
 		savedAt: new Date(0),
+		actions: [],
+		links: [],
 	};
 }
 
@@ -525,14 +527,14 @@ describe("BrowserExtensionCore login/logout", () => {
 	});
 });
 
-describe("BrowserExtensionCore remove/fetch/check", () => {
-	it("removes an item and refreshes the icon", async () => {
+describe("BrowserExtensionCore invoke/fetch/check", () => {
+	it("invokes a per-item action and refreshes the icon", async () => {
 		const readingList = initInMemoryReadingList();
-		const saved = await readingList.saveUrl({ url: "https://r.example", title: "R" });
+		const saved = await readingList.saveUrl({ url: "https://i.example", title: "I" });
 		assert(saved.ok, "save should succeed for a fresh url");
 		const id = saved.item.id;
 		const cap = createCapturingShell({
-			activeTab: { id: 2, url: "https://r.example", title: "R" },
+			activeTab: { id: 3, url: "https://i.example", title: "I" },
 		});
 		const core = BrowserExtensionCore(cap.shell, {
 			auth: loggedInAuth(),
@@ -540,13 +542,35 @@ describe("BrowserExtensionCore remove/fetch/check", () => {
 			readingList,
 		});
 		const results: unknown[] = [];
-		core.on("removed-item", { success: (v) => results.push(v), failure: () => {} });
+		core.on("invoked-item-action", { success: (v) => results.push(v), failure: () => {} });
 
-		core.remove("item", { id });
+		core.invoke("item-action", { id, name: "delete" });
 		await flush();
 
 		expect(results).toHaveLength(1);
-		expect(cap.showDefaultCalls).toEqual([2]);
+		expect(cap.showDefaultCalls).toEqual([3]);
+	});
+
+	it("emits a failure and skips the icon refresh when invoking while logged out", async () => {
+		const cap = createCapturingShell();
+		const auth = loggedInAuth();
+		auth.whenLoggedIn = (() => ({ ok: false, reason: "not-logged-in" })) as WhenLoggedIn;
+		const core = BrowserExtensionCore(cap.shell, {
+			auth,
+			logger,
+			readingList: initInMemoryReadingList(),
+		});
+		const failures: unknown[] = [];
+		core.on("invoked-item-action", { success: () => {}, failure: (e) => failures.push(e) });
+
+		core.invoke("item-action", {
+			id: "any-id" as ReadingListItemId,
+			name: "delete",
+		});
+		await flush();
+
+		expect(failures).toEqual([{ reason: "not-logged-in" }]);
+		expect(cap.showDefaultCalls).toEqual([]);
 	});
 
 	it("fetches the reading list", async () => {

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -1,6 +1,6 @@
 import type { ReadingListItem, ReadingListItemId } from "./domain/reading-list-item.types";
 import type { Auth, GuardedResult } from "./auth/auth.types";
-import type { SaveUrlResult, RemoveUrlResult, SaveUrl, RemoveUrl, FindByUrl, GetAllItems } from "./reading-list/reading-list.types";
+import type { SaveUrlResult, InvokeActionResult, SaveUrl, InvokeAction, FindByUrl, GetAllItems } from "./reading-list/reading-list.types";
 import type { BrowserShell } from "./shell.types";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { createEventBus } from "./event-bus";
@@ -12,7 +12,7 @@ import { initGetShortcutTarget } from "./handle-shortcut-command";
 
 export interface ReadingList {
 	saveUrl: SaveUrl;
-	removeUrl: RemoveUrl;
+	invokeAction: InvokeAction;
 	findByUrl: FindByUrl;
 	getAllItems: GetAllItems;
 }
@@ -35,7 +35,7 @@ export interface Core {
 		resource: "current-tab",
 		data: { url: string; title: string; content?: { bytes: ArrayBuffer; mediaType: string }; tabId?: number },
 	): void;
-	remove(resource: "item", data: { id: ReadingListItemId }): void;
+	invoke(resource: "item-action", data: { id: ReadingListItemId; name: string }): void;
 	fetch(resource: "reading-list"): void;
 	check(resource: "url", data: { url: string }): void;
 
@@ -44,13 +44,13 @@ export interface Core {
 	on(event: "logged-in", handler: ResultCallbacks<void>): void;
 	on(event: "logged-out", handler: () => void): void;
 	on(event: "saved-current-tab", handler: ResultCallbacks<SaveUrlResult>): void;
-	on(event: "removed-item", handler: ResultCallbacks<RemoveUrlResult>): void;
+	on(event: "invoked-item-action", handler: ResultCallbacks<InvokeActionResult>): void;
 	on(event: "fetched-reading-list", handler: ResultCallbacks<ReadingListItem[]>): void;
 	on(event: "checked-url", handler: ResultCallbacks<ReadingListItem | null>): void;
 
 	once(event: "logged-in", handler: ResultCallbacks<void>): void;
 	once(event: "saved-current-tab", handler: ResultCallbacks<SaveUrlResult>): void;
-	once(event: "removed-item", handler: ResultCallbacks<RemoveUrlResult>): void;
+	once(event: "invoked-item-action", handler: ResultCallbacks<InvokeActionResult>): void;
 	once(event: "fetched-reading-list", handler: ResultCallbacks<ReadingListItem[]>): void;
 	once(event: "checked-url", handler: ResultCallbacks<ReadingListItem | null>): void;
 }
@@ -187,11 +187,11 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 			}
 		},
 
-		remove(_resource, data) {
+		invoke(_resource, data) {
 			const guarded = auth.whenLoggedIn(() =>
-				readingList.removeUrl(data.id),
+				readingList.invokeAction({ id: data.id, name: data.name }),
 			);
-			emitResult("removed-item", guarded);
+			emitResult("invoked-item-action", guarded);
 			if (guarded.ok) {
 				guarded.value.then(() => updateActiveTabIcon()).catch(() => {});
 			}

--- a/projects/browser-extension-core/src/domain/reading-list-item.types.ts
+++ b/projects/browser-extension-core/src/domain/reading-list-item.types.ts
@@ -1,10 +1,45 @@
 export type { ReadingListItemId } from "./reading-list-item-id";
 import type { ReadingListItemId } from "./reading-list-item-id";
 
+/** The data shadow of a Siren action that survives the popup<->background
+ * sendMessage boundary. The bound callable (with its href/method/fields) cannot
+ * be cloned across that boundary, so the background walker keeps it; only the
+ * fields a control needs to render and re-invoke travel as data: the action
+ * `name` (the contract key the popup echoes back in an invoke-action message)
+ * and the server's human `title`. No href/method here — invocation is resolved
+ * back in the walker by (item id, action name). */
+export interface ActionDescriptor {
+	name: string;
+	title?: string;
+}
+
+/** The data shadow of a semantic (non-structural) Siren link the popup renders
+ * as a control — the symmetric counterpart of ActionDescriptor for links. The
+ * `rel` is the contract key the client maps to its own presentation (e.g. `read`
+ * is the row's open anchor); `title` is the server's human label (else the
+ * client humanizes the rel); `href` is the already-resolved target the control
+ * opens. Structural rels (self/root/prev/next/item) are the client's own
+ * navigation and are never serialized here. */
+export interface LinkDescriptor {
+	rel: string;
+	title?: string;
+	href: string;
+}
+
 export interface ReadingListItem {
 	id: ReadingListItemId;
 	url: string;
 	title: string;
 	savedAt: Date;
-	readUrl?: string;
+	/** Every per-item affordance the server advertised, in advertised order. The
+	 * popup loops these to render one control each — it never gates a control on a
+	 * per-capability boolean, so a newly-advertised action renders with no popup
+	 * change. */
+	actions: ActionDescriptor[];
+	/** The item's semantic (non-structural) links, serialized symmetrically with
+	 * `actions` so the popup renders each through the same generic loop. `read`
+	 * lives here; the popup's rel->presentation map keeps it as the row's open
+	 * anchor, so a future semantic rel (e.g. `summary`) renders with no client
+	 * change. */
+	links: LinkDescriptor[];
 }

--- a/projects/browser-extension-core/src/index.ts
+++ b/projects/browser-extension-core/src/index.ts
@@ -5,12 +5,14 @@ export type { SetIcon } from "./icon-status";
 export type {
 	ReadingListItem,
 	ReadingListItemId,
+	ActionDescriptor,
+	LinkDescriptor,
 } from "./domain/reading-list-item.types";
 export type {
 	SaveUrlResult,
 	SaveWarning,
 	Message,
-	RemoveUrlResult,
+	InvokeActionResult,
 } from "./reading-list/reading-list.types";
 export type {
 	Auth,
@@ -32,6 +34,7 @@ export {
 	initSaveContentUnderstanding,
 	initDeleteArticleUnderstanding,
 	initListArticlesUnderstanding,
+	genericEntityAction,
 	groupOf,
 	httpCacheable,
 } from "./reading-list/siren-reading-list";
@@ -44,7 +47,7 @@ export type {
 } from "./reading-list/siren-reading-list";
 export type { ContentBodyBuilder } from "./reading-list/content-body-parsers";
 export { pdfContentBody, htmlContentBody } from "./reading-list/content-body-parsers";
-export type { SaveUrl, RemoveUrl, FindByUrl, GetAllItems } from "./reading-list/reading-list.types";
+export type { SaveUrl, InvokeAction, FindByUrl, GetAllItems } from "./reading-list/reading-list.types";
 export type { PopupMessage } from "./popup-message.types";
 export { filterByUrl } from "./popup/filter-by-url";
 export { paginateItems } from "./popup/paginate-items";
@@ -53,6 +56,10 @@ export { relativeTime } from "./popup/relative-time";
 export { buildMessageView } from "./popup/message-view";
 export type { MessageView } from "./popup/message-view";
 export { isAppUrl } from "./popup/is-app-url";
+export { itemDisplay } from "./popup/item-display";
+export type { ItemDisplay } from "./popup/item-display";
+export { actionIcon, actionLabel, actionVariant, humanize, linkLabel, linkPresentation } from "./popup/action-affordance";
+export type { ActionVariant, LinkPresentation } from "./popup/action-affordance";
 export { initSaveProgress } from "./popup/save-progress";
 export type { SavePhase, SaveProgress } from "./popup/save-progress";
 export { initSaveProgressSequencer } from "./popup/save-progress-sequencer";

--- a/projects/browser-extension-core/src/popup-message.types.ts
+++ b/projects/browser-extension-core/src/popup-message.types.ts
@@ -4,7 +4,7 @@ import type { SavePhase } from "./popup/save-progress";
 export type PopupMessage =
 	| { type: "save-current-tab"; url: string; title: string; rawHtml?: string; tabId?: number }
 	| { type: "save-progress"; phase: SavePhase }
-	| { type: "remove-item"; id: ReadingListItemId }
+	| { type: "invoke-action"; id: ReadingListItemId; name: string }
 	| { type: "check-url"; url: string }
 	| { type: "get-all-items" }
 	| { type: "login" }

--- a/projects/browser-extension-core/src/popup/action-affordance.test.ts
+++ b/projects/browser-extension-core/src/popup/action-affordance.test.ts
@@ -1,0 +1,82 @@
+import {
+	actionIcon,
+	actionLabel,
+	actionVariant,
+	humanize,
+	linkLabel,
+	linkPresentation,
+} from "./action-affordance";
+
+describe("humanize", () => {
+	it("title-cases a single word", () => {
+		expect(humanize("delete")).toBe("Delete");
+	});
+
+	it("splits a hyphenated name into title-cased words", () => {
+		expect(humanize("mark-read")).toBe("Mark Read");
+	});
+
+	it("splits an underscored name into title-cased words", () => {
+		expect(humanize("archive_now")).toBe("Archive Now");
+	});
+
+	it("collapses repeated and trailing separators without emitting blank words", () => {
+		expect(humanize("save--link-")).toBe("Save Link");
+	});
+});
+
+describe("actionVariant", () => {
+	it("maps the delete action to the danger variant", () => {
+		expect(actionVariant("delete")).toBe("danger");
+	});
+
+	it("falls back to the default variant for an unknown name", () => {
+		expect(actionVariant("mark-read")).toBe("default");
+	});
+});
+
+describe("actionIcon", () => {
+	it("maps the delete action to its glyph", () => {
+		expect(actionIcon("delete")).toBe("×");
+	});
+
+	it("returns undefined for an action with no bespoke glyph", () => {
+		expect(actionIcon("mark-read")).toBeUndefined();
+	});
+});
+
+describe("actionLabel", () => {
+	it("prefers the server-authored title when present", () => {
+		expect(actionLabel({ name: "delete", title: "Remove from list" })).toBe(
+			"Remove from list",
+		);
+	});
+
+	it("falls back to a humanized name when no title is advertised", () => {
+		expect(actionLabel({ name: "mark-read" })).toBe("Mark Read");
+	});
+});
+
+describe("linkPresentation", () => {
+	it("maps the read rel to the row anchor", () => {
+		expect(linkPresentation("read")).toBe("row-anchor");
+	});
+
+	it("falls back to a standalone control for an unknown semantic rel", () => {
+		expect(linkPresentation("summary")).toBe("control");
+	});
+});
+
+describe("linkLabel", () => {
+	it("prefers the server-authored title when present", () => {
+		expect(
+			linkLabel({ rel: "summary", title: "TL;DR", href: "https://x/summary" }),
+		).toBe("TL;DR");
+	});
+
+	it("falls back to a humanized rel when no title is advertised", () => {
+		expect(linkLabel({ rel: "summary", href: "https://x/summary" })).toBe(
+			"Summary",
+		);
+	});
+});

--- a/projects/browser-extension-core/src/popup/action-affordance.ts
+++ b/projects/browser-extension-core/src/popup/action-affordance.ts
@@ -1,0 +1,76 @@
+import type {
+	ActionDescriptor,
+	LinkDescriptor,
+} from "../domain/reading-list-item.types";
+
+/** A client-side design token, never a server string. The popup maps an action
+ * `name` to one of these and looks up its own CSS class; an unknown name falls
+ * back to `default`. The server never sends a class — presentation is 100%
+ * client-side, so a server-side rename of an action's wire `name` only loses the
+ * bespoke styling (degrading to `default`), it never injects a class. */
+export type ActionVariant = "danger" | "default";
+
+/** The one place the wire vocabulary meets the client's design tokens. Add a row
+ * to give a known action bespoke styling; everything absent is `default`. Keep
+ * this a map of `name` -> token, never a passthrough of the server string. */
+const VARIANT_BY_NAME: Record<string, ActionVariant> = {
+	delete: "danger",
+};
+
+export function actionVariant(name: string): ActionVariant {
+	return VARIANT_BY_NAME[name] ?? "default";
+}
+
+/** The client's own glyph for a known action `name`, or undefined when the
+ * action has no bespoke glyph (the control falls back to its text label). This
+ * is the same one-mapping-with-a-default shape as `actionVariant`: presentation
+ * (here the icon) is derived from the wire `name` client-side, never from a
+ * per-name `if` in the popup. A server-side rename only loses the glyph
+ * (degrading to the label), it never injects one. */
+const ICON_BY_NAME: Record<string, string> = {
+	delete: "×",
+};
+
+export function actionIcon(name: string): string | undefined {
+	return ICON_BY_NAME[name];
+}
+
+/** Turns a wire `name` (`mark-read`, `archive_now`) into a human label when the
+ * server advertised no `title`: split on `-`/`_`, then Title-Case each word so an
+ * unlabelled affordance still renders a readable control instead of a raw slug. */
+export function humanize(name: string): string {
+	return name
+		.split(/[-_]+/)
+		.filter((word) => word.length > 0)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
+/** The control's text and aria-label: the server's `title` when present, else a
+ * humanized `name`. One function so the label and the accessible name never
+ * drift apart. */
+export function actionLabel(action: ActionDescriptor): string {
+	return action.title ?? humanize(action.name);
+}
+
+/** Where a semantic link renders in the popup. `read` is the row's primary open
+ * anchor (the whole row); every other semantic rel renders as a generic
+ * standalone control. This is the link counterpart of `actionVariant` — one
+ * client-side rel->presentation map with a default — so a future semantic rel
+ * (e.g. `summary`) renders as a generic control with zero further client change,
+ * and `read` stays the row anchor without a per-rel `if` in the render loop. */
+export type LinkPresentation = "row-anchor" | "control";
+
+const PRESENTATION_BY_REL: Record<string, LinkPresentation> = {
+	read: "row-anchor",
+};
+
+export function linkPresentation(rel: string): LinkPresentation {
+	return PRESENTATION_BY_REL[rel] ?? "control";
+}
+
+/** The link control's text and aria-label: the server's `title` when present,
+ * else a humanized `rel`. The link counterpart of `actionLabel`. */
+export function linkLabel(link: LinkDescriptor): string {
+	return link.title ?? humanize(link.rel);
+}

--- a/projects/browser-extension-core/src/popup/filter-by-url.test.ts
+++ b/projects/browser-extension-core/src/popup/filter-by-url.test.ts
@@ -10,6 +10,8 @@ function item(url: string): ReadingListItem {
 		url,
 		title: url,
 		savedAt: new Date(),
+		actions: [],
+		links: [],
 	};
 }
 

--- a/projects/browser-extension-core/src/popup/item-display.test.ts
+++ b/projects/browser-extension-core/src/popup/item-display.test.ts
@@ -1,0 +1,21 @@
+import { itemDisplay } from "./item-display";
+
+describe("itemDisplay", () => {
+	it("derives the hostname from the item url", () => {
+		expect(itemDisplay({ url: "https://example.com/article" })).toEqual({
+			hostname: "example.com",
+		});
+	});
+
+	it("yields a blank hostname for an empty url instead of throwing", () => {
+		expect(itemDisplay({ url: "" })).toEqual({
+			hostname: "",
+		});
+	});
+
+	it("yields a blank hostname for a malformed url instead of throwing", () => {
+		expect(itemDisplay({ url: "not a url" })).toEqual({
+			hostname: "",
+		});
+	});
+});

--- a/projects/browser-extension-core/src/popup/item-display.ts
+++ b/projects/browser-extension-core/src/popup/item-display.ts
@@ -1,0 +1,26 @@
+import type { ReadingListItem } from "../domain/reading-list-item.types";
+
+export interface ItemDisplay {
+	hostname: string;
+}
+
+/** Derives the row's display fields from an item whose `url` may be empty or
+ * malformed (the core keeps a degraded entity renderable rather than blanking
+ * the list). The hostname falls back to "" so a bad url yields a blank-domain
+ * row instead of throwing mid-render. Navigation is not derived here: the row
+ * anchor is repointed to the server's looped `read` link, the single
+ * unambiguous anchor source, so this never re-derives an href from a domain
+ * property. */
+export function itemDisplay(item: Pick<ReadingListItem, "url">): ItemDisplay {
+	return {
+		hostname: safeHostname(item.url),
+	};
+}
+
+function safeHostname(url: string): string {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return "";
+	}
+}

--- a/projects/browser-extension-core/src/popup/popup.styles.css
+++ b/projects/browser-extension-core/src/popup/popup.styles.css
@@ -479,6 +479,41 @@ body {
 }
 
 /**
+ * The default presentation the client maps an unknown action `name` (or a
+ * semantic link rel) to: a neutral utility control. A known `name` (e.g. delete)
+ * overrides it with its own variant; this is the fallback so a newly-advertised
+ * affordance still renders a usable control.
+ *
+ * 1. Hover-reveal, matching the delete control, so item controls have one
+ *    consistent visibility — a "Mark as read" control isn't permanently shown
+ *    while delete hides on the same row.
+ */
+.list-view__action {
+  background: transparent;
+  color: var(--popup-label);
+  font-size: 12px;
+  padding: 2px 8px;
+  margin-right: 10px;
+  line-height: 1;
+  border: 1px solid var(--popup-border);
+  border-radius: 4px;
+  flex-shrink: 0;
+  cursor: pointer;
+  opacity: 0; /* 1 */
+  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease;
+}
+
+.list-view__row:hover .list-view__action,
+.list-view__row:focus-within .list-view__action {
+  opacity: 1; /* 1 */
+}
+
+.list-view__action:hover {
+  background: var(--popup-item-hover);
+  color: var(--popup-text);
+}
+
+/**
  * 1. Override the filled primary style — delete is a destructive utility action
  * 2. Hidden by default, shown on row hover
  */

--- a/projects/browser-extension-core/src/reading-list/in-memory-reading-list.test.ts
+++ b/projects/browser-extension-core/src/reading-list/in-memory-reading-list.test.ts
@@ -42,8 +42,8 @@ describe("initInMemoryReadingList", () => {
 		});
 	});
 
-	describe("removeUrl", () => {
-		it("should remove an item and return remaining items", async () => {
+	describe("invokeAction", () => {
+		it("invokes the advertised delete action and returns remaining items", async () => {
 			const list = initInMemoryReadingList();
 			const saveResult = await list.saveUrl({
 				url: "https://example.com/article",
@@ -51,21 +51,57 @@ describe("initInMemoryReadingList", () => {
 			});
 			if (!saveResult.ok) throw new Error("Save failed");
 
-			const removeResult = await list.removeUrl(saveResult.item.id);
+			const result = await list.invokeAction({
+				id: saveResult.item.id,
+				name: "delete",
+			});
 
-			expect(removeResult.ok).toBe(true);
-			if (removeResult.ok) expect(removeResult.items).toEqual([]);
-			expect(
-				await list.findByUrl("https://example.com/article"),
-			).toBeNull();
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.items).toEqual([]);
 		});
 
-		it("should return not-found for unknown ID", async () => {
+		it("returns not-found for an unknown item id", async () => {
 			const list = initInMemoryReadingList();
 
-			const result = await list.removeUrl(
-				"nonexistent-id" as ReadingListItemId,
-			);
+			const result = await list.invokeAction({
+				id: "nonexistent-id" as ReadingListItemId,
+				name: "delete",
+			});
+
+			expect(result).toEqual({ ok: false, reason: "not-found" });
+		});
+
+		it("leaves the item in the list when a non-removing advertised action is invoked", async () => {
+			const list = initInMemoryReadingList();
+			const saveResult = await list.saveUrl({
+				url: "https://example.com/article",
+				title: "Example",
+			});
+			if (!saveResult.ok) throw new Error("Save failed");
+
+			const result = await list.invokeAction({
+				id: saveResult.item.id,
+				name: "update-status",
+			});
+
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.items.map((i) => i.id)).toEqual([
+				saveResult.item.id,
+			]);
+		});
+
+		it("returns not-found for an action the item never advertised", async () => {
+			const list = initInMemoryReadingList();
+			const saveResult = await list.saveUrl({
+				url: "https://example.com/article",
+				title: "Example",
+			});
+			if (!saveResult.ok) throw new Error("Save failed");
+
+			const result = await list.invokeAction({
+				id: saveResult.item.id,
+				name: "mark-read",
+			});
 
 			expect(result).toEqual({ ok: false, reason: "not-found" });
 		});

--- a/projects/browser-extension-core/src/reading-list/in-memory-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/in-memory-reading-list.ts
@@ -5,13 +5,13 @@ import type {
 import type {
 	FindByUrl,
 	GetAllItems,
-	RemoveUrl,
+	InvokeAction,
 	SaveUrl,
 } from "./reading-list.types";
 
 export function initInMemoryReadingList(): {
 	saveUrl: SaveUrl;
-	removeUrl: RemoveUrl;
+	invokeAction: InvokeAction;
 	findByUrl: FindByUrl;
 	getAllItems: GetAllItems;
 } {
@@ -25,22 +25,36 @@ export function initInMemoryReadingList(): {
 		}
 
 		const id = crypto.randomUUID() as ReadingListItemId;
+		/** Mirrors the server's per-item affordances: a removing `delete` and a
+		 * non-removing `update-status`. Advertising both lets the fake exercise an
+		 * action-aware invoke — only `delete` removes — instead of deleting on any
+		 * advertised action, which would mask a walker bug. */
 		const item: ReadingListItem = {
 			id,
 			url,
 			title,
 			savedAt: new Date(),
+			actions: [{ name: "delete" }, { name: "update-status" }],
+			links: [],
 		};
 		items.set(id, item);
 		return { ok: true, item };
 	};
 
+	/** Action names this fake treats as removing the item from the list. Keeping
+	 * the set explicit makes the fake action-aware: only a removing action deletes,
+	 * so a non-removing advertised action (e.g. `update-status`) returns the list
+	 * unchanged rather than masking a bug by deleting on any advertised action. */
+	const REMOVING_ACTIONS = new Set(["delete"]);
 
-	const removeUrl: RemoveUrl = async (id) => {
-		if (!items.has(id)) {
+	const invokeAction: InvokeAction = async ({ id, name }) => {
+		const item = items.get(id);
+		/** The fake mirrors the Siren walker: an item or action the store no longer
+		 * advertises reports not-found. */
+		if (!item?.actions.some((action) => action.name === name)) {
 			return { ok: false, reason: "not-found" };
 		}
-		items.delete(id);
+		if (REMOVING_ACTIONS.has(name)) items.delete(id);
 		return { ok: true, items: Array.from(items.values()) };
 	};
 
@@ -59,7 +73,7 @@ export function initInMemoryReadingList(): {
 
 	return {
 		saveUrl,
-		removeUrl,
+		invokeAction,
 		findByUrl,
 		getAllItems,
 	};

--- a/projects/browser-extension-core/src/reading-list/reading-list.types.ts
+++ b/projects/browser-extension-core/src/reading-list/reading-list.types.ts
@@ -43,7 +43,11 @@ export type SaveUrlResult =
 	  }
 	| { ok: false; messages: Message[] };
 
-export type RemoveUrlResult =
+/** The outcome of invoking one advertised per-item action by (id, name). A
+ * simple entity mutation lands the client back on the collection, so success
+ * carries the new items; `not-found` covers an item or action the server no
+ * longer advertises (the client re-renders the fresh list either way). */
+export type InvokeActionResult =
 	| { ok: true; items: ReadingListItem[] }
 	| { ok: false; reason: "not-found" };
 
@@ -53,9 +57,14 @@ export type SaveUrl = (params: {
 	content?: TabContent;
 }) => Promise<SaveUrlResult>;
 
-export type RemoveUrl = (
-	id: ReadingListItemId,
-) => Promise<RemoveUrlResult>;
+/** Invokes the named action the server advertised on the item with `id`. The
+ * popup learned the `name` from the item's descriptor list and echoes it back;
+ * the walker holds the bound callable and resolves (id, name) to it. Two
+ * same-typed strings, so a named-parameter object guards against a swap. */
+export type InvokeAction = (params: {
+	id: ReadingListItemId;
+	name: string;
+}) => Promise<InvokeActionResult>;
 
 export type FindByUrl = (
 	url: string,

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.test.ts
@@ -143,9 +143,18 @@ function createRoutingFetch(routes: Record<string, RouteHandler>): {
 		const handler = routes[key];
 		if (!handler) throw new Error(`Unexpected fetch: ${key}`);
 		const route = typeof handler === "function" ? handler(init) : handler;
+		/** A conformant server replies in the negotiated Siren media type; default
+		 * it for any body-bearing route that doesn't override Content-Type so the
+		 * client's media-type gate passes. */
+		const headers: Record<string, string> = {
+			...(route.body !== undefined
+				? { "Content-Type": "application/vnd.siren+json" }
+				: {}),
+			...route.headers,
+		};
 		return new Response(route.body ?? null, {
 			status: route.status,
-			headers: route.headers,
+			headers,
 		});
 	};
 	return { fetchFn, calls };
@@ -205,8 +214,7 @@ describe("initExtension", () => {
 			expect(result.items[0].title).toBe("A");
 			expect(result.items[0].id).toBe("1");
 			expect(result.items[0].savedAt).toEqual(new Date("2026-01-15T10:00:00.000Z"));
-			expect(result.items[0].readUrl).toBe("http://localhost:3000/queue/1/view");
-			expect(result.items[0].actions.delete).toBeDefined();
+			expect(result.items[0].boundActions.delete).toBeDefined();
 		});
 
 		it("should bind collection-level actions", async () => {
@@ -337,7 +345,70 @@ describe("initExtension", () => {
 			);
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const result = await start();
-			expect(result.items[0].readUrl).toBeUndefined();
+			expect(result.items[0].links).toEqual([]);
+		});
+
+		it("serializes semantic links symmetrically with actions and excludes structural rels", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								links: [
+									{ rel: ["self"], href: "/queue/1" },
+									{ rel: ["read"], href: "/queue/1/view" },
+									{ rel: ["summary"], href: "/queue/1/summary", title: "TL;DR" },
+								],
+							}),
+						]),
+					},
+				}),
+			);
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const result = await start();
+			/** The structural `self` rel is dropped; the semantic `read` and `summary`
+			 * rels are serialized as descriptors carrying their resolved hrefs, and a
+			 * server-authored link title rides along. */
+			expect(result.items[0].links).toEqual([
+				{ rel: "read", href: "http://localhost:3000/queue/1/view" },
+				{
+					rel: "summary",
+					href: "http://localhost:3000/queue/1/summary",
+					title: "TL;DR",
+				},
+			]);
+		});
+
+		it("drops a semantic link whose href scheme is unactionable", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								links: [
+									{ rel: ["read"], href: "/queue/1/view" },
+									{ rel: ["contact"], href: "mailto:ops@example.com" },
+								],
+							}),
+						]),
+					},
+				}),
+			);
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const result = await start();
+			expect(result.items[0].links).toEqual([
+				{ rel: "read", href: "http://localhost:3000/queue/1/view" },
+			]);
 		});
 
 		it("should handle absolute URL in self link", async () => {
@@ -450,7 +521,7 @@ describe("initExtension", () => {
 			});
 			const start = initExtension(handlers, createDeps(fetchFn));
 			const result = await start();
-			const subResult = await result.items[0].actions.expand();
+			const subResult = await result.items[0].boundActions.expand();
 			expect(subResult.items[0].url).toBe("https://sub.com");
 			expect(subResult.items[0].id).toBe("sub-1");
 		});
@@ -475,10 +546,10 @@ describe("initExtension", () => {
 			);
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const result = await start();
-			expect(result.items[0].actions).toEqual({});
+			expect(result.items[0].boundActions).toEqual({});
 		});
 
-		it("should skip entity actions without matching understanding", async () => {
+		it("binds an entity action without a bespoke handler through the generic invoker", async () => {
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({
 					"GET http://localhost:3000/queue": {
@@ -505,7 +576,7 @@ describe("initExtension", () => {
 			);
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const result = await start();
-			expect(result.items[0].actions["unknown-action"]).toBeUndefined();
+			expect(result.items[0].boundActions["unknown-action"]).toBeDefined();
 		});
 
 		it("should skip collection actions without matching understanding", async () => {
@@ -568,11 +639,11 @@ describe("initExtension", () => {
 			expect(result.items[0].title).toBe("Article");
 			expect(result.items[0].id).toBe("article-1");
 			expect(result.items[0].savedAt).toEqual(new Date(savedAt));
-			expect(result.items[0].actions.delete).toBeDefined();
+			expect(result.items[0].boundActions.delete).toBeDefined();
 			expect(calls).toContain("POST http://localhost:3000/queue");
 		});
 
-		it("should include readUrl when save response has read link", async () => {
+		it("includes the read link descriptor when the save response has a read link", async () => {
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({
 					"GET http://localhost:3000/queue": {
@@ -608,9 +679,9 @@ describe("initExtension", () => {
 			const result = await collection.actions["save-article"]({
 				url: "https://example.com/article",
 			});
-			expect(result.items[0].readUrl).toBe(
-				"http://localhost:3000/queue/article-1/view",
-			);
+			expect(result.items[0].links).toEqual([
+				{ rel: "read", href: "http://localhost:3000/queue/article-1/view" },
+			]);
 		});
 
 		it("should throw when save fails", async () => {
@@ -751,7 +822,7 @@ describe("initExtension", () => {
 			);
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const collection = await start();
-			const result = await collection.items[0].actions.delete();
+			const result = await collection.items[0].boundActions.delete();
 			expect(result.items).toEqual([]);
 			expect(result.actions["save-article"]).toBeDefined();
 			expect(result.actions.search).toBeDefined();
@@ -789,10 +860,10 @@ describe("initExtension", () => {
 			);
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const collection = await start();
-			const result = await collection.items[0].actions.delete();
+			const result = await collection.items[0].boundActions.delete();
 			expect(result.items).toHaveLength(1);
 			expect(result.items[0].url).toBe("https://example.com/b");
-			expect(result.items[0].actions.delete).toBeDefined();
+			expect(result.items[0].boundActions.delete).toBeDefined();
 		});
 
 		it("should throw when delete fails", async () => {
@@ -817,8 +888,8 @@ describe("initExtension", () => {
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const collection = await start();
 			await expect(
-				collection.items[0].actions.delete(),
-			).rejects.toThrow("Delete failed: 404");
+				collection.items[0].boundActions.delete(),
+			).rejects.toThrow("delete target not found");
 		});
 
 		it("sends Prefer: return=representation on delete (RFC 7240)", async () => {
@@ -845,8 +916,190 @@ describe("initExtension", () => {
 			);
 			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
 			const collection = await start();
-			await collection.items[0].actions.delete();
+			await collection.items[0].boundActions.delete();
 			expect(observedPrefer).toBe("return=representation");
+		});
+	});
+
+	describe("generic entity action invoker", () => {
+		function withMarkReadEntity(markRead: RouteHandler) {
+			return createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "article-1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								actions: [
+									{
+										name: "mark-read",
+										href: "/queue/article-1/read",
+										method: "POST",
+										type: "application/x-www-form-urlencoded",
+										fields: [
+											{ name: "status", type: "text", value: "read" },
+										],
+									},
+								],
+							}),
+						]),
+					},
+					"POST http://localhost:3000/queue/article-1/read": markRead,
+				}),
+			);
+		}
+
+		it("POSTs the action's href and returns the refreshed collection", async () => {
+			const remaining = articleEntity({
+				id: "article-2",
+				url: "https://example.com/b",
+				title: "B",
+				savedAt: "2026-01-15T11:00:00.000Z",
+			});
+			const { fetchFn, calls } = withMarkReadEntity({
+				status: 200,
+				body: collectionResponse([remaining]),
+			});
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const collection = await start();
+			const result = await collection.items[0].boundActions["mark-read"]();
+			expect(result.items.map((i) => i.url)).toEqual([
+				"https://example.com/b",
+			]);
+			expect(calls).toContain(
+				"POST http://localhost:3000/queue/article-1/read",
+			);
+		});
+
+		it("builds the body from each declared field's server-supplied value, encoded per type", async () => {
+			let observedBody = "";
+			let observedContentType: string | null = null;
+			const { fetchFn } = withMarkReadEntity((init) => {
+				observedBody = String(init?.body);
+				observedContentType = new Headers(init?.headers).get("Content-Type");
+				return { status: 200, body: collectionResponse() };
+			});
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const collection = await start();
+			/** Invoked with no caller fields — the (id, name) path supplies none, so
+			 * the body must come from the declared field's `value`. */
+			await collection.items[0].boundActions["mark-read"]();
+			expect(observedContentType).toBe("application/x-www-form-urlencoded");
+			expect(observedBody).toBe("status=read");
+		});
+
+		it("coerces a numeric field value to its string form when building the body", async () => {
+			let observedBody = "";
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "article-1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								actions: [
+									{
+										name: "set-priority",
+										href: "/queue/article-1/priority",
+										method: "POST",
+										type: "application/x-www-form-urlencoded",
+										fields: [{ name: "priority", type: "number", value: 3 }],
+									},
+								],
+							}),
+						]),
+					},
+					"POST http://localhost:3000/queue/article-1/priority": (init) => {
+						observedBody = String(init?.body);
+						return { status: 200, body: collectionResponse() };
+					},
+				}),
+			);
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const collection = await start();
+			/** A numeric server value must render/invoke (coerced to "3"), not fail
+			 * the whole-affordance parse and drop the control. */
+			await collection.items[0].boundActions["set-priority"]();
+			expect(observedBody).toBe("priority=3");
+		});
+
+		it("posts an empty body for an action that declares no fields", async () => {
+			let observedBody: unknown = null;
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "article-1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								actions: [
+									{
+										name: "archive",
+										href: "/queue/article-1/archive",
+										method: "POST",
+									},
+								],
+							}),
+						]),
+					},
+					"POST http://localhost:3000/queue/article-1/archive": (init) => {
+						observedBody = JSON.parse(String(init?.body));
+						return { status: 200, body: collectionResponse() };
+					},
+				}),
+			);
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const collection = await start();
+			await collection.items[0].boundActions.archive();
+			expect(observedBody).toEqual({});
+		});
+
+		it("throws when the generic action fails", async () => {
+			const { fetchFn } = withMarkReadEntity({ status: 404 });
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const collection = await start();
+			await expect(
+				collection.items[0].boundActions["mark-read"](),
+			).rejects.toThrow("mark-read target not found");
+		});
+
+		it("does not invoke an action whose href scheme is unactionable", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "article-1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								actions: [
+									{
+										name: "mailto-action",
+										href: "mailto:ops@example.com",
+										method: "POST",
+									},
+								],
+							}),
+						]),
+					},
+				}),
+			);
+			const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+			const collection = await start();
+			await expect(
+				collection.items[0].boundActions["mailto-action"](),
+			).rejects.toThrow("mailto-action action href is not actionable");
 		});
 	});
 
@@ -878,7 +1131,7 @@ describe("initExtension", () => {
 				url: "https://example.com/article",
 			});
 			expect(result.items[0].url).toBe("https://example.com/article");
-			expect(result.items[0].actions.delete).toBeDefined();
+			expect(result.items[0].boundActions.delete).toBeDefined();
 			expect(calls).toContain(
 				"GET http://localhost:3000/queue?url=https%3A%2F%2Fexample.com%2Farticle",
 			);
@@ -2167,7 +2420,7 @@ describe("toReadingListItem error handling", () => {
 		);
 	});
 
-	it("throws when server response entity properties are missing required fields", async () => {
+	it("degrades an entity missing non-identity fields to a renderable item instead of failing the collection", async () => {
 		const { fetchFn } = createRoutingFetch(
 			withEntryPoint({
 				"GET http://localhost:3000/queue": {
@@ -2179,7 +2432,11 @@ describe("toReadingListItem error handling", () => {
 			}),
 		);
 		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
-		await expect(start()).rejects.toThrow();
+		const result = await start();
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0].id).toBe("1");
+		expect(result.items[0].url).toBe("https://example.com");
+		expect(result.items[0].title).toBe("");
 	});
 });
 
@@ -2242,7 +2499,7 @@ describe("initSirenReadingList", () => {
 			expect(calls[0]).toBe("GET http://localhost:3000/");
 		});
 
-		it("should include readUrl when server returns a read link", async () => {
+		it("includes the read link descriptor when the server returns a read link", async () => {
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({
 					"GET http://localhost:3000/queue": {
@@ -2279,9 +2536,9 @@ describe("initSirenReadingList", () => {
 				title: "Ignored",
 			});
 			const item = (result as Extract<typeof result, { ok: true }>).item;
-			expect(item.readUrl).toBe(
-				"http://localhost:3000/queue/article-1/view",
-			);
+			expect(item.links).toEqual([
+				{ rel: "read", href: "http://localhost:3000/queue/article-1/view" },
+			]);
 		});
 
 		it("should throw when server returns an error on save", async () => {
@@ -2535,9 +2792,10 @@ describe("initSirenReadingList", () => {
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
 			await list.saveUrl({ url: "https://example.com/a", title: "A" });
-			const result = await list.removeUrl(
-				"article-1" as ReadingListItemId,
-			);
+			const result = await list.invokeAction({
+				id: "article-1" as ReadingListItemId,
+				name: "delete",
+			});
 			assert.equal(result.ok, true);
 			assert.deepEqual(
 				(result as Extract<typeof result, { ok: true }>).items.length,
@@ -2589,7 +2847,7 @@ describe("initSirenReadingList", () => {
 		});
 	});
 
-	describe("removeUrl", () => {
+	describe("invokeAction delete path", () => {
 		it("should return fresh items from server after delete", async () => {
 			const remaining = articleEntity({
 				id: "article-2",
@@ -2619,9 +2877,10 @@ describe("initSirenReadingList", () => {
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
 			await list.getAllItems();
-			const result = await list.removeUrl(
-				"article-1" as ReadingListItemId,
-			);
+			const result = await list.invokeAction({
+				id: "article-1" as ReadingListItemId,
+				name: "delete",
+			});
 			assert.equal(result.ok, true);
 			const items = (result as Extract<typeof result, { ok: true }>).items;
 			expect(items).toHaveLength(1);
@@ -2652,9 +2911,10 @@ describe("initSirenReadingList", () => {
 				}),
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
-			const result = await list.removeUrl(
-				"article-1" as ReadingListItemId,
-			);
+			const result = await list.invokeAction({
+				id: "article-1" as ReadingListItemId,
+				name: "delete",
+			});
 			assert.equal(result.ok, true);
 			expect(calls).toContain(
 				"POST http://localhost:3000/queue/article-1/delete",
@@ -2681,9 +2941,10 @@ describe("initSirenReadingList", () => {
 				}),
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
-			const result = await list.removeUrl(
-				"article-1" as ReadingListItemId,
-			);
+			const result = await list.invokeAction({
+				id: "article-1" as ReadingListItemId,
+				name: "delete",
+			});
 			expect(result).toEqual({ ok: false, reason: "not-found" });
 		});
 
@@ -2708,8 +2969,8 @@ describe("initSirenReadingList", () => {
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
 			await expect(
-				list.removeUrl("article-1" as ReadingListItemId),
-			).rejects.toThrow("Delete failed: 500");
+				list.invokeAction({ id: "article-1" as ReadingListItemId, name: "delete" }),
+			).rejects.toThrow("delete failed: 500");
 		});
 
 		it("should propagate network errors from delete", async () => {
@@ -2732,16 +2993,19 @@ describe("initSirenReadingList", () => {
 							savedAt: "2026-01-15T10:00:00.000Z",
 						}),
 					]),
-					{ status: 200 },
+					{
+						status: 200,
+						headers: { "Content-Type": "application/vnd.siren+json" },
+					},
 				);
 			};
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
 			await expect(
-				list.removeUrl("article-1" as ReadingListItemId),
+				list.invokeAction({ id: "article-1" as ReadingListItemId, name: "delete" }),
 			).rejects.toThrow("Network unreachable");
 		});
 
-		it("should throw when entity has no delete action", async () => {
+		it("returns not-found when the entity advertises no delete action", async () => {
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({
 					"GET http://localhost:3000/queue": {
@@ -2759,9 +3023,8 @@ describe("initSirenReadingList", () => {
 				}),
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
-			await expect(
-				list.removeUrl("article-1" as ReadingListItemId),
-			).rejects.toThrow("No delete action found for item article-1");
+			const result = await list.invokeAction({ id: "article-1" as ReadingListItemId, name: "delete" });
+			expect(result).toEqual({ ok: false, reason: "not-found" });
 		});
 
 		it("should throw when fallback collection fetch fails", async () => {
@@ -2772,11 +3035,11 @@ describe("initSirenReadingList", () => {
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
 			await expect(
-				list.removeUrl("article-1" as ReadingListItemId),
+				list.invokeAction({ id: "article-1" as ReadingListItemId, name: "delete" }),
 			).rejects.toThrow("Navigation failed: 500");
 		});
 
-		it("should throw when fallback collection has no matching entity", async () => {
+		it("returns not-found when the fallback collection has no matching entity", async () => {
 			const { fetchFn } = createRoutingFetch(
 				withEntryPoint({
 					"GET http://localhost:3000/queue": {
@@ -2789,9 +3052,128 @@ describe("initSirenReadingList", () => {
 				}),
 			);
 			const list = initSirenReadingList(createAdapterDeps(fetchFn));
-			await expect(
-				list.removeUrl("article-1" as ReadingListItemId),
-			).rejects.toThrow("No delete action found for item article-1");
+			const result = await list.invokeAction({ id: "article-1" as ReadingListItemId, name: "delete" });
+			expect(result).toEqual({ ok: false, reason: "not-found" });
+		});
+
+		it("invokeAction invokes the named action and returns the refreshed list", async () => {
+			const remaining = articleEntity({
+				id: "article-2",
+				url: "https://example.com/b",
+				title: "B",
+				savedAt: "2026-01-15T11:00:00.000Z",
+			});
+			const { fetchFn, calls } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "article-1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								actions: [
+									{
+										name: "mark-read",
+										href: "/queue/article-1/read",
+										method: "POST",
+									},
+								],
+							}),
+							remaining,
+						]),
+					},
+					"POST http://localhost:3000/queue/article-1/read": {
+						status: 200,
+						body: collectionResponse([remaining]),
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			await list.getAllItems();
+			const result = await list.invokeAction({
+				id: "article-1" as ReadingListItemId,
+				name: "mark-read",
+			});
+			assert.equal(result.ok, true);
+			const items = (result as Extract<typeof result, { ok: true }>).items;
+			expect(items.map((i) => i.url)).toEqual(["https://example.com/b"]);
+			expect(calls).toContain(
+				"POST http://localhost:3000/queue/article-1/read",
+			);
+		});
+
+		it("invokeAction applies update-status via the (id, name) path with the declared value as urlencoded form data", async () => {
+			let observedBody = "";
+			let observedContentType: string | null = null;
+			const remaining = articleEntity({
+				id: "article-2",
+				url: "https://example.com/b",
+				title: "B",
+				savedAt: "2026-01-15T11:00:00.000Z",
+			});
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse([
+							articleEntity({
+								id: "article-1",
+								url: "https://example.com/a",
+								title: "A",
+								savedAt: "2026-01-15T10:00:00.000Z",
+								actions: [
+									{
+										name: "update-status",
+										href: "/queue/article-1/status",
+										method: "POST",
+										type: "application/x-www-form-urlencoded",
+										fields: [
+											{ name: "status", type: "text", value: "read" },
+										],
+									},
+								],
+							}),
+							remaining,
+						]),
+					},
+					"POST http://localhost:3000/queue/article-1/status": (init) => {
+						observedBody = String(init?.body);
+						observedContentType = new Headers(init?.headers).get("Content-Type");
+						return { status: 200, body: collectionResponse([remaining]) };
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			await list.getAllItems();
+			/** The popup re-invokes by (id, name) only — no field knowledge crosses
+			 * the boundary — so the server must still receive status=read, sourced
+			 * from the action's declared field value and urlencoded per its type. */
+			const result = await list.invokeAction({
+				id: "article-1" as ReadingListItemId,
+				name: "update-status",
+			});
+			assert.equal(result.ok, true);
+			expect(observedContentType).toBe("application/x-www-form-urlencoded");
+			expect(observedBody).toBe("status=read");
+		});
+
+		it("invokeAction returns not-found for an item the server does not advertise", async () => {
+			const { fetchFn } = createRoutingFetch(
+				withEntryPoint({
+					"GET http://localhost:3000/queue": {
+						status: 200,
+						body: collectionResponse(),
+					},
+				}),
+			);
+			const list = initSirenReadingList(createAdapterDeps(fetchFn));
+			const result = await list.invokeAction({
+				id: "ghost" as ReadingListItemId,
+				name: "mark-read",
+			});
+			expect(result).toEqual({ ok: false, reason: "not-found" });
 		});
 	});
 
@@ -3004,5 +3386,479 @@ describe("initSirenReadingList", () => {
 				"No access token available",
 			);
 		});
+	});
+});
+
+describe("hypermedia conformance", () => {
+	it("renders an unsupported-media-type failure instead of blind-decoding a non-Siren response", async () => {
+		const { fetchFn } = createRoutingFetch({
+			"GET http://localhost:3000/": {
+				status: 200,
+				body: "<html>a proxy login page</html>",
+				headers: { "Content-Type": "text/html" },
+			},
+		});
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		await expect(start()).rejects.toThrow("Unsupported media type: text/html");
+	});
+
+	it("reports (none) when a 200 response carries no Content-Type at all", async () => {
+		const fetchFn: ExtensionDeps["fetchFn"] = async () =>
+			new Response(null, { status: 200 });
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		await expect(start()).rejects.toThrow("Unsupported media type: (none)");
+	});
+
+	it("treats a non-http(s) read href as no read URL (unactionable scheme)", async () => {
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse([
+						articleEntity({
+							id: "1",
+							url: "https://example.com/a",
+							title: "A",
+							savedAt: "2026-01-15T10:00:00.000Z",
+							links: [{ rel: ["read"], href: "mailto:reader@example.com" }],
+						}),
+					]),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items[0].links).toEqual([]);
+	});
+
+	it("uses an absolute read href verbatim rather than concatenating it onto the base", async () => {
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse([
+						articleEntity({
+							id: "1",
+							url: "https://example.com/a",
+							title: "A",
+							savedAt: "2026-01-15T10:00:00.000Z",
+							links: [{ rel: ["read"], href: "https://cdn.example.com/read/1" }],
+						}),
+					]),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items[0].links).toEqual([
+			{ rel: "read", href: "https://cdn.example.com/read/1" },
+		]);
+	});
+
+	it("degrades an entity whose properties omit url, title and savedAt", async () => {
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse([{ properties: { id: "stub" } }]),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items[0].id).toBe("stub");
+		expect(result.items[0].url).toBe("");
+		expect(result.items[0].title).toBe("");
+		expect(result.items[0].savedAt).toEqual(new Date(0));
+	});
+
+	it("serializes no action descriptors for an entity with no actions", async () => {
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse([
+						articleEntity({
+							id: "1",
+							url: "https://example.com/a",
+							title: "A",
+							savedAt: "2026-01-15T10:00:00.000Z",
+							actions: [],
+						}),
+					]),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items[0].actions).toEqual([]);
+	});
+
+	it("serializes each advertised action as a {name, title} descriptor on the item", async () => {
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse([
+						articleEntity({
+							id: "1",
+							url: "https://example.com/a",
+							title: "A",
+							savedAt: "2026-01-15T10:00:00.000Z",
+							actions: [
+								{
+									name: "delete",
+									title: "Remove from list",
+									href: "/queue/1/delete",
+									method: "POST",
+								},
+								{ name: "mark-read", href: "/queue/1/read", method: "POST" },
+							],
+						}),
+					]),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items[0].actions).toEqual([
+			{ name: "delete", title: "Remove from list" },
+			{ name: "mark-read" },
+		]);
+	});
+
+	it("drops a malformed (hrefless) entity action but keeps the valid ones", async () => {
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse([
+						articleEntity({
+							id: "1",
+							url: "https://example.com/a",
+							title: "A",
+							savedAt: "2026-01-15T10:00:00.000Z",
+							actions: [
+								{ name: "broken", method: "POST" },
+								{ name: "delete", href: "/queue/1/delete", method: "POST" },
+							],
+						}),
+					]),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items[0].actions.map((a) => a.name)).toEqual(["delete"]);
+	});
+
+	it("follows the collection's next link so items past the first page are reachable", async () => {
+		const page1 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue" },
+				{ rel: ["next"], href: "/queue?page=2" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const page2 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "2",
+					url: "https://example.com/b",
+					title: "B",
+					savedAt: "2026-01-15T11:00:00.000Z",
+				}),
+			],
+			links: [{ rel: ["self"], href: "/queue?page=2" }],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch({
+			"GET http://localhost:3000/": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue?page=2": { status: 200, body: page2 },
+		});
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items.map((i) => i.id)).toEqual(["1", "2"]);
+	});
+
+	it("stops following navigation pages when a next page errors", async () => {
+		const page1 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue" },
+				{ rel: ["next"], href: "/queue?page=2" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch({
+			"GET http://localhost:3000/": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue?page=2": { status: 500 },
+		});
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items.map((i) => i.id)).toEqual(["1"]);
+	});
+
+	it("ignores a navigation next link whose scheme is unactionable", async () => {
+		const page1 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue" },
+				{ rel: ["next"], href: "mailto:more@example.com" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch({
+			"GET http://localhost:3000/": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue": { status: 200, body: page1 },
+		});
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items.map((i) => i.id)).toEqual(["1"]);
+	});
+
+	it("aggregates every search page by following the search response's next link", async () => {
+		const searchPage1 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue?status=unread" },
+				{ rel: ["next"], href: "/queue?status=unread&page=2" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const searchPage2 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "2",
+					url: "https://example.com/b",
+					title: "B",
+					savedAt: "2026-01-15T11:00:00.000Z",
+				}),
+			],
+			links: [{ rel: ["self"], href: "/queue?status=unread&page=2" }],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse(),
+				},
+				"GET http://localhost:3000/queue?status=unread": {
+					status: 200,
+					body: searchPage1,
+				},
+				"GET http://localhost:3000/queue?status=unread&page=2": {
+					status: 200,
+					body: searchPage2,
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const collection = await start();
+		const result = await collection.actions.search({ status: "unread" });
+		expect(result.items.map((i) => i.id)).toEqual(["1", "2"]);
+	});
+
+	it("stops following search pages when a later page errors, returning what it has", async () => {
+		const searchPage1 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue?status=unread" },
+				{ rel: ["next"], href: "/queue?status=unread&page=2" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse(),
+				},
+				"GET http://localhost:3000/queue?status=unread": {
+					status: 200,
+					body: searchPage1,
+				},
+				"GET http://localhost:3000/queue?status=unread&page=2": { status: 500 },
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const collection = await start();
+		const result = await collection.actions.search({ status: "unread" });
+		expect(result.items.map((i) => i.id)).toEqual(["1"]);
+	});
+
+	it("stops navigation when the next link points back to a page already visited", async () => {
+		const page = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue" },
+				{ rel: ["next"], href: "/queue" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch({
+			"GET http://localhost:3000/": { status: 200, body: page },
+			"GET http://localhost:3000/queue": { status: 200, body: page },
+		});
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items.map((i) => i.id)).toEqual(["1"]);
+	});
+
+	it("stops navigation when the next links form a repeating cycle", async () => {
+		const page1 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue" },
+				{ rel: ["next"], href: "/queue?page=2" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const page2 = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "2",
+					url: "https://example.com/b",
+					title: "B",
+					savedAt: "2026-01-15T11:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue?page=2" },
+				{ rel: ["next"], href: "/queue?page=2" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch({
+			"GET http://localhost:3000/": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue": { status: 200, body: page1 },
+			"GET http://localhost:3000/queue?page=2": { status: 200, body: page2 },
+		});
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const result = await start();
+		expect(result.items.map((i) => i.id)).toEqual(["1", "2"]);
+	});
+
+	it("stops a search whose next link points back to a page already fetched", async () => {
+		const searchPage = JSON.stringify({
+			class: ["collection", "articles"],
+			entities: [
+				articleEntity({
+					id: "1",
+					url: "https://example.com/a",
+					title: "A",
+					savedAt: "2026-01-15T10:00:00.000Z",
+				}),
+			],
+			links: [
+				{ rel: ["self"], href: "/queue?status=unread" },
+				{ rel: ["next"], href: "/queue?status=unread" },
+			],
+			actions: COLLECTION_ACTIONS,
+		});
+		const { fetchFn } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: collectionResponse(),
+				},
+				"GET http://localhost:3000/queue?status=unread": {
+					status: 200,
+					body: searchPage,
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const collection = await start();
+		const result = await collection.actions.search({ status: "unread" });
+		expect(result.items.map((i) => i.id)).toEqual(["1"]);
+	});
+
+	it("sends no params for a search action that declares no fields", async () => {
+		const fieldlessSearch = [
+			COLLECTION_ACTIONS[0],
+			{ name: "search", href: "/queue", method: "GET" },
+		];
+		const { fetchFn, calls } = createRoutingFetch(
+			withEntryPoint({
+				"GET http://localhost:3000/queue": {
+					status: 200,
+					body: JSON.stringify({
+						class: ["collection", "articles"],
+						entities: [],
+						links: [{ rel: ["self"], href: "/queue" }],
+						actions: fieldlessSearch,
+					}),
+				},
+			}),
+		);
+		const start = initExtension(createUnderstandings(), createDeps(fetchFn));
+		const collection = await start();
+		const result = await collection.actions.search({ url: "https://example.com/x" });
+		expect(result.items).toEqual([]);
+		expect(calls).toContain("GET http://localhost:3000/queue");
 	});
 });

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
@@ -843,6 +843,10 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 			logger: deps.logger,
 		}),
 		initDeleteArticleUnderstanding(),
+		/** search carries its own `httpCacheable` ETag layer so the understanding is
+		 * cacheable on its own terms, not by silently relying on the walker's
+		 * navigation cache also seeing the GET. Both layers share one If-None-Match
+		 * path, so a search GET passing through both stays correct. */
 		httpCacheable(initListArticlesUnderstanding()),
 	);
 	const start = initExtension(understandings, deps);

--- a/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
+++ b/projects/browser-extension-core/src/reading-list/siren-reading-list.ts
@@ -1,14 +1,18 @@
 import "../zod-config";
 import { z } from "zod";
 import type { HutchLogger } from "@packages/hutch-logger";
-import type { ReadingListItem } from "../domain/reading-list-item.types";
+import type {
+	ActionDescriptor,
+	LinkDescriptor,
+	ReadingListItem,
+} from "../domain/reading-list-item.types";
 import { ReadingListItemIdSchema } from "../domain/reading-list-item-id";
 import { UnauthorizedError } from "../auth/unauthorized-error";
 import type {
 	FindByUrl,
 	GetAllItems,
+	InvokeAction,
 	Message,
-	RemoveUrl,
 	SaveUrl,
 	SaveWarning,
 } from "./reading-list.types";
@@ -20,6 +24,57 @@ const SIREN_MEDIA_TYPE = "application/vnd.siren+json";
 // provides the same asserts-value narrowing for runtime invariants.
 function assert(value: unknown, message: string): asserts value {
 	if (!value) throw new Error(message);
+}
+
+/** Thrown when a response carries a media type the client can't parse as Siren.
+ * A browser negotiating with Accept would render an "I don't understand this
+ * type" page rather than blind-decoding a proxy's HTML or a future media type. */
+class UnsupportedMediaTypeError extends Error {
+	constructor(public readonly contentType: string | null) {
+		super(`Unsupported media type: ${contentType ?? "(none)"}`);
+	}
+}
+
+/** Thrown when invoking an advertised entity action 404s: the item is gone (or
+ * the server no longer offers the action). A typed signal so the adapter detects
+ * not-found by class, not by regex-matching an error message ending in "404" —
+ * the message is presentation, not a contract. */
+class ItemGoneError extends Error {
+	constructor(actionName: string) {
+		super(`${actionName} target not found`);
+	}
+}
+
+/** Asserts a mutation response is ok, distinguishing a 404 (the item/action is
+ * gone — a typed ItemGoneError the adapter maps to not-found) from any other
+ * failure (a generic Error the adapter propagates). */
+function assertMutationOk(deps: { response: Response; actionName: string }): void {
+	if (deps.response.status === 404) throw new ItemGoneError(deps.actionName);
+	assert(deps.response.ok, `${deps.actionName} failed: ${deps.response.status}`);
+}
+
+/** The one href resolver every call site shares. An `http(s)://` href is used
+ * verbatim (so a server that re-points a link to an absolute URL keeps working);
+ * a scheme-less href is resolved against the base; any other scheme is no href
+ * (unactionable), so a `mailto:`/`javascript:` href never becomes a fetch target.
+ * `base + href` concatenation at each call site corrupts an absolute href and
+ * mis-resolves other schemes — the contract promises changing an href is
+ * non-breaking, which only holds if resolution is uniform. */
+function resolveHref(deps: { base: string; href: string }): string | undefined {
+	if (/^https?:\/\//i.test(deps.href)) return deps.href;
+	if (/^[a-z][a-z0-9+.-]*:/i.test(deps.href)) return undefined;
+	return new URL(deps.href, deps.base).toString();
+}
+
+/** Reads a Siren body, refusing any response whose Content-Type is not the
+ * negotiated Siren media type. A 304-from-cache synthesises the Siren type, so a
+ * cache hit still passes. */
+async function readSirenBody(response: Response): Promise<unknown> {
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes(SIREN_MEDIA_TYPE)) {
+		throw new UnsupportedMediaTypeError(contentType);
+	}
+	return response.json();
 }
 
 /** Thrown when the server rejects a save by returning the current collection
@@ -36,32 +91,72 @@ class NotSaveableError extends Error {
 	}
 }
 
+/** Only the identity field (`id`) is required: an evolving or stub entity that
+ * omits `title`/`url`/`savedAt` must degrade to a renderable row, not blank the
+ * whole collection. The render layer fills sensible blanks for the absent ones. */
 const SirenPropertiesSchema = z.object({
 	id: ReadingListItemIdSchema,
-	url: z.string(),
-	title: z.string(),
-	savedAt: z.string(),
+	url: z.string().default(""),
+	title: z.string().default(""),
+	savedAt: z.string().optional(),
 });
 
 const SirenLinkSchema = z.object({
 	rel: z.array(z.string()),
 	href: z.string(),
+	/** The human label the server authored for this link (mirrors the server's
+	 * SirenLink.title). When a semantic link is rendered as a control, the client
+	 * uses it as the label; absent, the client humanizes the rel. */
+	title: z.string().optional(),
 });
 
 const SirenActionSchema = z.object({
 	name: z.string(),
+	/** The human label the server authored for this affordance. A client uses it
+	 * as the control's text and its aria-label/tooltip; absent, the client
+	 * humanizes `name`. Presentation (style/icon) is never derived from it. */
+	title: z.string().optional(),
 	href: z.string(),
 	method: z.string(),
 	type: z.string().optional(),
 	fields: z
-		.array(z.object({ name: z.string(), type: z.string() }))
+		.array(
+			z.object({
+				name: z.string(),
+				type: z.string(),
+				/** The server-suggested target value for this field. A generic client
+				 * invoked by (id, name) supplies no field knowledge, so the body is
+				 * built from each declared field's own `value` — this is what makes a
+				 * bare invocation carry the right inputs (e.g. update-status's
+				 * status=read) without the caller knowing the field. Accepts a number
+				 * so a numeric server value coerces to a string at body-build time
+				 * rather than failing the whole-affordance parse and dropping the
+				 * control. */
+				value: z.union([z.string(), z.number()]).optional(),
+			}),
+		)
 		.optional(),
 });
 
+/** Parses an array leniently: a single malformed element (e.g. a hrefless
+ * control, which Siren forbids) is dropped to unactionable rather than failing
+ * the whole array — the same tolerance entity `properties` already get. */
+function lenientArray<T>(element: z.ZodType<T>): z.ZodType<T[]> {
+	return z
+		.array(z.unknown())
+		.optional()
+		.transform((items) =>
+			(items ?? []).flatMap((item) => {
+				const parsed = element.safeParse(item);
+				return parsed.success ? [parsed.data] : [];
+			}),
+		);
+}
+
 const SirenSubEntitySchema = z.object({
 	properties: z.record(z.string(), z.unknown()).optional(),
-	links: z.array(SirenLinkSchema).optional(),
-	actions: z.array(SirenActionSchema).optional(),
+	links: lenientArray(SirenLinkSchema),
+	actions: lenientArray(SirenActionSchema),
 });
 
 const SirenErrorSchema = z.object({
@@ -74,6 +169,9 @@ const SirenErrorSchema = z.object({
 });
 
 type SirenAction = z.infer<typeof SirenActionSchema>;
+/** The post-parse shape: `links`/`actions` are always arrays (the lenient
+ * transform supplies `[]`). `resolveItem` re-parses whatever it is handed
+ * (a raw or already-parsed entity), so its input is `unknown`. */
 type SirenSubEntity = z.infer<typeof SirenSubEntitySchema>;
 
 /** `content.type` is `z.string()`, not `z.literal("text/html")`: the client
@@ -120,9 +218,9 @@ const SirenWarningSchema = z.object({
 const SirenCollectionResponseSchema = z.object({
 	class: z.array(z.string()).optional(),
 	properties: z.record(z.string(), z.unknown()).optional(),
-	entities: z.array(SirenSubEntitySchema).optional(),
-	links: z.array(SirenLinkSchema).optional(),
-	actions: z.array(SirenActionSchema).optional(),
+	entities: z.array(SirenSubEntitySchema).default([]),
+	links: lenientArray(SirenLinkSchema),
+	actions: lenientArray(SirenActionSchema),
 });
 
 function extractCollectionWarning(
@@ -145,8 +243,8 @@ type DoFetch = (url: string, init?: DoFetchInit) => Promise<Response>;
 type ActionContext = {
 	serverUrl: string;
 	doFetch: DoFetch;
-	resolveItem: (entity: SirenSubEntity) => ArticleItem;
-	parseCollection: (body: SirenCollectionResponse) => NavigationResult;
+	resolveItem: (entity: unknown) => ArticleItem;
+	parseCollection: (body: SirenCollectionResponse) => Promise<NavigationResult>;
 };
 
 type ActionHandler = (
@@ -163,13 +261,20 @@ export type NavigationResult = {
 	actions: Record<string, BoundAction>;
 };
 
+/** The walker's in-memory item. It keeps the cross-boundary `ReadingListItem`
+ * intact — including its serializable `actions` descriptors, which DO survive
+ * the popup sendMessage boundary — and adds `boundActions`: the bound callables
+ * the walker invokes, keyed by action name. The callables can't be cloned across
+ * the boundary, so they live only here; the popup re-invokes by (id, name) and
+ * the walker resolves the name back to its `boundActions` entry. */
 export type ArticleItem = ReadingListItem & {
-	actions: Record<string, BoundAction>;
+	boundActions: Record<string, BoundAction>;
 };
 
-function findLinkHref(entity: SirenSubEntity, rel: string): string | undefined {
-	return entity.links?.find((link) => link.rel.includes(rel))?.href; /* c8 ignore next -- V8 block coverage phantom: zero-count sub-range inside ?.find()?. chained optionals (bcoe/c8#319, v8.dev/blog/javascript-code-coverage) */
-}
+/** Rels the client follows for its OWN navigation (pagination/identity), never
+ * rendered as user controls. Everything else is a semantic link the client may
+ * render through the generic link loop. */
+const STRUCTURAL_LINK_RELS = new Set(["self", "root", "prev", "next", "item"]);
 
 function toReadingListItem(
 	entity: SirenSubEntity,
@@ -177,13 +282,33 @@ function toReadingListItem(
 ): ReadingListItem {
 	assert(entity.properties, "Server response entity missing properties");
 	const props = SirenPropertiesSchema.parse(entity.properties);
-	const readHref = findLinkHref(entity, "read");
+	/** Semantic (non-structural) links serialized symmetrically with actions: one
+	 * descriptor per link whose href resolves, carrying the resolved target so the
+	 * popup renders each through the same generic loop. A structural rel is the
+	 * client's own navigation and is excluded. */
+	const links: LinkDescriptor[] = [];
+	for (const link of entity.links) {
+		if (link.rel.some((rel) => STRUCTURAL_LINK_RELS.has(rel))) continue;
+		const href = resolveHref({ base: serverUrl, href: link.href });
+		if (href === undefined) continue;
+		for (const rel of link.rel) {
+			const descriptor: LinkDescriptor = { rel, href };
+			if (link.title !== undefined) descriptor.title = link.title;
+			links.push(descriptor);
+		}
+	}
+	const actions: ActionDescriptor[] = entity.actions.map((action) => {
+		const descriptor: ActionDescriptor = { name: action.name };
+		if (action.title !== undefined) descriptor.title = action.title;
+		return descriptor;
+	});
 	return {
 		id: props.id,
 		url: props.url,
 		title: props.title,
-		savedAt: new Date(props.savedAt),
-		readUrl: readHref ? `${serverUrl}${readHref}` : undefined,
+		savedAt: props.savedAt ? new Date(props.savedAt) : new Date(0),
+		actions,
+		links,
 	};
 }
 
@@ -192,8 +317,10 @@ export function initSaveArticleUnderstanding(): Map<string, ActionHandler> {
 	handlers.set("save-article", (sirenAction, context) => {
 		return async (fields) => {
 			assert(fields?.url, "save-article requires a url field");
+			const actionUrl = resolveHref({ base: context.serverUrl, href: sirenAction.href });
+			assert(actionUrl, "save-article action href is not actionable");
 			const response = await context.doFetch(
-				`${context.serverUrl}${sirenAction.href}`,
+				actionUrl,
 				{
 					method: sirenAction.method,
 					headers: {
@@ -217,14 +344,15 @@ export function initSaveArticleUnderstanding(): Map<string, ActionHandler> {
 				throwIfBlocked(body);
 				const collection = SirenCollectionResponseSchema.safeParse(body);
 				if (collection.success && collection.data.class?.includes("collection")) {
+					const parsed = await context.parseCollection(collection.data);
 					throw new NotSaveableError(
-						context.parseCollection(collection.data).items,
+						parsed.items,
 						extractCollectionWarning(collection.data),
 					);
 				}
 				throw new Error(`Save failed: ${response.status}`);
 			}
-			const body = SirenSubEntitySchema.parse(await response.json());
+			const body = SirenSubEntitySchema.parse(await readSirenBody(response));
 			const item = context.resolveItem(body);
 			return { items: [item], actions: {} };
 		};
@@ -245,8 +373,10 @@ export function initSaveHtmlUnderstanding(deps: {
 				rawHtml: fields.rawHtml,
 			};
 			if (fields.title) body.title = fields.title;
+			const actionUrl = resolveHref({ base: context.serverUrl, href: sirenAction.href });
+			assert(actionUrl, "save-html action href is not actionable");
 			const response = await context.doFetch(
-				`${context.serverUrl}${sirenAction.href}`,
+				actionUrl,
 				{
 					method: sirenAction.method,
 					headers: {
@@ -256,51 +386,57 @@ export function initSaveHtmlUnderstanding(deps: {
 				},
 			);
 			if (!response.ok) {
-				/** The server may carry a fallback action inside a Siren error body — follow it with {url, title} (dropping rawHtml) to degrade onto the URL-only save path. */
-				const errorJson = await response.json().catch(() => null);
-				throwIfBlocked(errorJson);
-				const errorParsed = SirenErrorSchema.safeParse(errorJson);
-				if (!errorParsed.success) {
-					throw new Error(`Save failed: ${response.status}`);
-				}
-				const errorActions = errorParsed.data.actions;
-				if (errorActions === undefined) {
-					throw new Error(`Save failed: ${response.status}`);
-				}
-				if (errorActions.length === 0) {
-					throw new Error(`Save failed: ${response.status}`);
-				}
-				const fallbackAction = errorActions[0];
-				deps.logger.warn(errorParsed.data.properties.message);
-				const fallbackBody: Record<string, string> = { url: fields.url };
-				if (fields.title) fallbackBody.title = fields.title;
-				const fallbackContentType = fallbackAction.type === undefined
-					? "application/json"
-					: fallbackAction.type;
-				const fallbackResponse = await context.doFetch(
-					`${context.serverUrl}${fallbackAction.href}`,
-					{
-						method: fallbackAction.method,
-						headers: { "Content-Type": fallbackContentType },
-						body: JSON.stringify(fallbackBody),
-					},
-				);
-				assert(
-					fallbackResponse.ok,
-					`Save failed: ${fallbackResponse.status}`,
-				);
-				const fallbackResponseBody = SirenSubEntitySchema.parse(
-					await fallbackResponse.json(),
-				);
-				const fallbackItem = context.resolveItem(fallbackResponseBody);
-				return { items: [fallbackItem], actions: {} };
+				const fallbackFields: Record<string, string> = { url: fields.url };
+				if (fields.title) fallbackFields.title = fields.title;
+				return followSaveFallback({
+					response,
+					context,
+					logger: deps.logger,
+					fallbackFields,
+				});
 			}
-			const responseBody = SirenSubEntitySchema.parse(await response.json());
+			const responseBody = SirenSubEntitySchema.parse(await readSirenBody(response));
 			const item = context.resolveItem(responseBody);
 			return { items: [item], actions: {} };
 		};
 	});
 	return handlers;
+}
+
+/** The shared fallback the server advertises inside a Siren error body when a
+ * rich save (save-html / save-content) can't be honoured: follow whatever action
+ * it carries to degrade onto a URL-only save. The client owns no policy about
+ * when a fallback applies (no size caps, no thresholds) — it attempts the rich
+ * save and follows the refusal the server returns. */
+async function followSaveFallback(args: {
+	response: Response;
+	context: ActionContext;
+	logger: HutchLogger;
+	fallbackFields: Record<string, string>;
+}): Promise<NavigationResult> {
+	const { response, context, logger, fallbackFields } = args;
+	const errorJson = await response.json().catch(() => null);
+	throwIfBlocked(errorJson);
+	const errorParsed = SirenErrorSchema.safeParse(errorJson);
+	assert(errorParsed.success, `Save failed: ${response.status}`);
+	const errorActions = errorParsed.data.actions ?? [];
+	assert(errorActions.length > 0, `Save failed: ${response.status}`);
+	const fallbackAction = errorActions[0];
+	logger.warn(errorParsed.data.properties.message);
+	const fallbackUrl = resolveHref({ base: context.serverUrl, href: fallbackAction.href });
+	assert(fallbackUrl, "Save fallback action href is not actionable");
+	const fallbackContentType = fallbackAction.type ?? "application/json";
+	const fallbackResponse = await context.doFetch(fallbackUrl, {
+		method: fallbackAction.method,
+		headers: { "Content-Type": fallbackContentType },
+		body: JSON.stringify(fallbackFields),
+	});
+	assert(fallbackResponse.ok, `Save failed: ${fallbackResponse.status}`);
+	const fallbackResponseBody = SirenSubEntitySchema.parse(
+		await readSirenBody(fallbackResponse),
+	);
+	const fallbackItem = context.resolveItem(fallbackResponseBody);
+	return { items: [fallbackItem], actions: {} };
 }
 
 export function initSaveContentUnderstanding(deps: {
@@ -320,53 +456,26 @@ export function initSaveContentUnderstanding(deps: {
 			formData.append("mediaType", input.mediaType);
 			if (input.title) formData.append("title", input.title);
 			formData.append("content", blob, filename);
+			const actionUrl = resolveHref({ base: context.serverUrl, href: sirenAction.href });
+			assert(actionUrl, "save-content action href is not actionable");
 			const response = await context.doFetch(
-				`${context.serverUrl}${sirenAction.href}`,
+				actionUrl,
 				{
 					method: sirenAction.method,
 					body: formData,
 				},
 			);
 			if (!response.ok) {
-				const errorJson = await response.json().catch(() => null);
-				throwIfBlocked(errorJson);
-				const errorParsed = SirenErrorSchema.safeParse(errorJson);
-				if (!errorParsed.success) {
-					throw new Error(`Save failed: ${response.status}`);
-				}
-				const errorActions = errorParsed.data.actions;
-				if (errorActions === undefined) {
-					throw new Error(`Save failed: ${response.status}`);
-				}
-				if (errorActions.length === 0) {
-					throw new Error(`Save failed: ${response.status}`);
-				}
-				const fallbackAction = errorActions[0];
-				deps.logger.warn(errorParsed.data.properties.message);
-				const fallbackBody: Record<string, string> = { url: input.url };
-				if (input.title) fallbackBody.title = input.title;
-				const fallbackContentType = fallbackAction.type === undefined
-					? "application/json"
-					: fallbackAction.type;
-				const fallbackResponse = await context.doFetch(
-					`${context.serverUrl}${fallbackAction.href}`,
-					{
-						method: fallbackAction.method,
-						headers: { "Content-Type": fallbackContentType },
-						body: JSON.stringify(fallbackBody),
-					},
-				);
-				assert(
-					fallbackResponse.ok,
-					`Save failed: ${fallbackResponse.status}`,
-				);
-				const fallbackResponseBody = SirenSubEntitySchema.parse(
-					await fallbackResponse.json(),
-				);
-				const fallbackItem = context.resolveItem(fallbackResponseBody);
-				return { items: [fallbackItem], actions: {} };
+				const fallbackFields: Record<string, string> = { url: input.url };
+				if (input.title) fallbackFields.title = input.title;
+				return followSaveFallback({
+					response,
+					context,
+					logger: deps.logger,
+					fallbackFields,
+				});
 			}
-			const responseBody = SirenSubEntitySchema.parse(await response.json());
+			const responseBody = SirenSubEntitySchema.parse(await readSirenBody(response));
 			const item = context.resolveItem(responseBody);
 			return { items: [item], actions: {} };
 		};
@@ -378,45 +487,146 @@ export function initDeleteArticleUnderstanding(): Map<string, ActionHandler> {
 	const handlers = new Map<string, ActionHandler>();
 	handlers.set("delete", (sirenAction, context) => {
 		return async () => {
+			const actionUrl = resolveHref({ base: context.serverUrl, href: sirenAction.href });
+			assert(actionUrl, "delete action href is not actionable");
 			/** Signal that the client will process a representation in the
 			 * response (RFC 7240). */
 			const response = await context.doFetch(
-				`${context.serverUrl}${sirenAction.href}`,
+				actionUrl,
 				{
 					method: sirenAction.method,
 					headers: { Prefer: "return=representation" },
 				},
 			);
-			assert(response.ok, `Delete failed: ${response.status}`);
-			const body = SirenCollectionResponseSchema.parse(await response.json());
-			return context.parseCollection(body);
+			assertMutationOk({ response, actionName: "delete" });
+			const body = SirenCollectionResponseSchema.parse(await readSirenBody(response));
+			return await context.parseCollection(body);
 		};
 	});
 	return handlers;
+}
+
+/** The fallback understanding for any simple entity action the client has no
+ * bespoke handler for: invoke the action by ITS OWN declared href/method/fields
+ * and follow the collection the server returns. One generic path means a
+ * newly-advertised entity action (e.g. `mark-read`, `archive`) is invokable with
+ * no new client code — the contract's "bind a response's actions through one
+ * generic path" rule. Only the fields the server declared for the action are
+ * sent (never a client-invented name); a fieldless action posts an empty body.
+ * Bespoke handlers (e.g. `delete`) still take precedence where they are
+ * registered — this is the default for everything else.
+ *
+ * The body comes from each DECLARED field's own server-supplied `value`, not
+ * from caller-supplied fields: the (id, name) popup path re-invokes by name with
+ * no field knowledge, so the server is the one place the target value can come
+ * from (e.g. update-status declares `status` with `value: "read"`). The body is
+ * encoded per the action's declared `type`: `x-www-form-urlencoded` builds a
+ * URLSearchParams (and sets that Content-Type), anything else is JSON. */
+export function genericEntityAction(
+	sirenAction: SirenAction,
+	context: ActionContext,
+): BoundAction {
+	return async () => {
+		const actionUrl = resolveHref({ base: context.serverUrl, href: sirenAction.href });
+		assert(actionUrl, `${sirenAction.name} action href is not actionable`);
+		const values: Record<string, string> = {};
+		for (const field of sirenAction.fields ?? []) {
+			/** A numeric server value coerces to its string form so URLSearchParams /
+			 * JSON both carry it; the union above keeps a numeric `value` from failing
+			 * the affordance parse. */
+			if (field.value !== undefined) values[field.name] = String(field.value);
+		}
+		const contentType = sirenAction.type ?? "application/json";
+		const isForm = contentType.includes("application/x-www-form-urlencoded");
+		const body = isForm
+			? new URLSearchParams(values).toString()
+			: JSON.stringify(values);
+		/** Signal that the client will process a representation in the response
+		 * (RFC 7240) so the mutation lands back on the collection. */
+		const response = await context.doFetch(actionUrl, {
+			method: sirenAction.method,
+			headers: {
+				"Content-Type": contentType,
+				Prefer: "return=representation",
+			},
+			body,
+		});
+		assertMutationOk({ response, actionName: sirenAction.name });
+		const collection = SirenCollectionResponseSchema.parse(await readSirenBody(response));
+		return await context.parseCollection(collection);
+	};
 }
 
 export function initListArticlesUnderstanding(): Map<string, ActionHandler> {
 	const handlers = new Map<string, ActionHandler>();
 	handlers.set("search", (sirenAction, context) => {
 		return async (fields) => {
-			const filterUrl = new URL(
-				`${context.serverUrl}${sirenAction.href}`,
-			);
-			if (fields?.url) filterUrl.searchParams.set("url", fields.url);
-			if (fields?.status)
-				filterUrl.searchParams.set("status", fields.status);
-			const response = await context.doFetch(filterUrl.toString(), {
+			const actionUrl = resolveHref({ base: context.serverUrl, href: sirenAction.href });
+			assert(actionUrl, "search action href is not actionable");
+			const filterUrl = new URL(actionUrl);
+			/** Only the fields the server declared for this action are sent — never
+			 * a client-invented param name. A renamed field on the server simply
+			 * stops matching, instead of the client hardcoding `url`/`status`. */
+			for (const field of sirenAction.fields ?? []) {
+				const value = fields?.[field.name];
+				if (value !== undefined) filterUrl.searchParams.set(field.name, value);
+			}
+			const items = await collectPages({
+				firstUrl: filterUrl.toString(),
 				method: sirenAction.method,
+				context,
 			});
-			if (!response.ok) return { items: [], actions: {} };
-			const body = SirenCollectionResponseSchema.parse(await response.json());
-			const items = (body.entities ?? []).map((e) =>
-				context.resolveItem(e),
-			);
 			return { items, actions: {} };
 		};
 	});
 	return handlers;
+}
+
+/** The next page URL the server advertised, resolved through the one href helper,
+ * or undefined when there is no further page. The client never builds a `?page=`
+ * param — it follows the opaque `next` href the server returns. */
+function nextPageUrl(deps: {
+	body: SirenCollectionResponse;
+	base: string;
+}): string | undefined {
+	const nextHref = deps.body.links.find((link) => link.rel.includes("next"))?.href;
+	return nextHref ? resolveHref({ base: deps.base, href: nextHref }) : undefined;
+}
+
+/** The one pagination walk both navigation and search share: gather the items of
+ * the first page, then follow the server's `next` links until there is none, so
+ * no saved item is unreachable past page 1. A `visited` set stops a repeating or
+ * self-referential `next` href from looping forever — an ETag 304 re-yields the
+ * same `next`, so without the guard a server that points `next` back at a page
+ * already seen never terminates. The first page is either supplied pre-fetched
+ * (navigation already read it to resolve the `self` link) or fetched from
+ * `firstUrl` (search); both then loop through the identical follow-next path. */
+async function collectPages(args: {
+	context: ActionContext;
+	method: string;
+	firstUrl: string;
+	firstBody?: SirenCollectionResponse;
+}): Promise<ArticleItem[]> {
+	const { context, method, firstUrl, firstBody } = args;
+	const items: ArticleItem[] = [];
+	const visited = new Set<string>();
+
+	let nextUrl: string | undefined = firstUrl;
+	if (firstBody) {
+		for (const entity of firstBody.entities) items.push(context.resolveItem(entity));
+		visited.add(firstUrl);
+		nextUrl = nextPageUrl({ body: firstBody, base: context.serverUrl });
+	}
+
+	while (nextUrl && !visited.has(nextUrl)) {
+		visited.add(nextUrl);
+		const response = await context.doFetch(nextUrl, { method });
+		if (!response.ok) return items;
+		const body = SirenCollectionResponseSchema.parse(await readSirenBody(response));
+		for (const entity of body.entities) items.push(context.resolveItem(entity));
+		nextUrl = nextPageUrl({ body, base: context.serverUrl });
+	}
+	return items;
 }
 
 export function groupOf(
@@ -529,19 +739,24 @@ export function initExtension(
 	}
 
 	function resolveItem(
-		entity: SirenSubEntity,
+		entityInput: unknown,
 		doFetch: DoFetch,
 	): ArticleItem {
+		const entity = SirenSubEntitySchema.parse(entityInput);
 		const item = toReadingListItem(entity, deps.serverUrl);
-		const itemActions: Record<string, BoundAction> = {};
+		const boundActions: Record<string, BoundAction> = {};
 		const context = createActionContext(doFetch);
-		for (const sirenAction of entity.actions ?? []) {
+		/** Every advertised entity action is bound, not just the ones with a
+		 * bespoke handler: a registered handler wins where present (e.g. `delete`),
+		 * otherwise the generic invoker handles it, so any newly-advertised simple
+		 * entity action is invokable with no new client code. */
+		for (const sirenAction of entity.actions) {
 			const handler = handlers.get(sirenAction.name);
-			if (handler) {
-				itemActions[sirenAction.name] = handler(sirenAction, context);
-			}
+			boundActions[sirenAction.name] = handler
+				? handler(sirenAction, context)
+				: genericEntityAction(sirenAction, context);
 		}
-		return { ...item, actions: itemActions };
+		return { ...item, boundActions };
 	}
 
 	function bindCollectionActions(
@@ -559,12 +774,21 @@ export function initExtension(
 		return bound;
 	}
 
-	function parseResponse(
+	async function parseResponse(
 		body: SirenCollectionResponse,
 		doFetch: DoFetch,
-	): NavigationResult {
-		const items = (body.entities ?? []).map((e) => resolveItem(e, doFetch));
-		const actions = bindCollectionActions(body.actions ?? [], doFetch);
+	): Promise<NavigationResult> {
+		const context = createActionContext(doFetch);
+		/** The self link is resolved before any parse, so the first page's URL is
+		 * known and can seed the visited set against a self-referential `next`. */
+		assert(resolvedUrl, "Collection self link must be resolved before parsing");
+		const items = await collectPages({
+			context,
+			method: "GET",
+			firstUrl: resolvedUrl,
+			firstBody: body,
+		});
+		const actions = bindCollectionActions(body.actions, doFetch);
 		return { items, actions };
 	}
 
@@ -575,14 +799,14 @@ export function initExtension(
 		const response = await doFetch(targetUrl, { method: "GET" });
 		assert(response.ok, `Navigation failed: ${response.status}`);
 
-		const body = SirenCollectionResponseSchema.parse(await response.json());
+		const body = SirenCollectionResponseSchema.parse(await readSirenBody(response));
 
 		if (!resolvedUrl) {
-			const selfLink = body.links?.find((l) => l.rel.includes("self"));
+			const selfLink = body.links.find((l) => l.rel.includes("self"));
 			assert(selfLink, "Collection response missing self link");
-			resolvedUrl = selfLink.href.startsWith("/")
-				? `${deps.serverUrl}${selfLink.href}`
-				: selfLink.href;
+			const selfUrl = resolveHref({ base: deps.serverUrl, href: selfLink.href });
+			assert(selfUrl, "Collection self link is not actionable");
+			resolvedUrl = selfUrl;
 
 			const cachedEntry = navigationCache.get(targetUrl);
 			if (cachedEntry && resolvedUrl !== targetUrl) {
@@ -604,7 +828,7 @@ export interface SirenReadingListDeps {
 
 export function initSirenReadingList(deps: SirenReadingListDeps): {
 	saveUrl: SaveUrl;
-	removeUrl: RemoveUrl;
+	invokeAction: InvokeAction;
 	findByUrl: FindByUrl;
 	getAllItems: GetAllItems;
 } {
@@ -693,21 +917,28 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 		}
 	};
 
-	const removeUrl: RemoveUrl = async (id) => {
+	const invokeAction: InvokeAction = async ({ id, name }) => {
 		let item = knownItems.get(id);
 		if (!item) {
 			const collection = await start();
 			trackItems(collection.items);
 			item = knownItems.get(id);
 		}
-		assert(item?.actions.delete, `No delete action found for item ${id}`);
+		const boundAction = item?.boundActions[name];
+		/** The item is gone (or never advertised this action): the server no
+		 * longer offers it, so report not-found and let the popup re-render the
+		 * fresh list rather than throwing a generic failure. */
+		if (!boundAction) return { ok: false, reason: "not-found" };
 		try {
-			const result = await item.actions.delete();
+			const result = await boundAction();
 			knownItems.clear();
 			trackItems(result.items);
 			return { ok: true, items: result.items };
 		} catch (err) {
-			if (err instanceof Error && err.message === "Delete failed: 404") {
+			/** Any advertised action whose target 404s means the item is gone. The
+			 * invoker throws a typed ItemGoneError, so not-found is detected by class
+			 * rather than by regex-matching the error message. */
+			if (err instanceof ItemGoneError) {
 				return { ok: false, reason: "not-found" };
 			}
 			throw err;
@@ -734,5 +965,5 @@ export function initSirenReadingList(deps: SirenReadingListDeps): {
 		return collection.items;
 	};
 
-	return { saveUrl, removeUrl, findByUrl, getAllItems };
+	return { saveUrl, invokeAction, findByUrl, getAllItems };
 }

--- a/projects/browser-extension-core/src/save-current-tab.test.ts
+++ b/projects/browser-extension-core/src/save-current-tab.test.ts
@@ -68,6 +68,8 @@ describe("initSaveCurrentTab", () => {
 				url: params.url,
 				title: params.title,
 				savedAt: new Date(),
+				actions: [],
+				links: [],
 			} };
 		};
 		const saveCurrentTab = initSaveCurrentTab({ saveUrl });

--- a/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/background/background.browser.ts
@@ -12,7 +12,7 @@ import {
 	captureActiveTabBytes,
 	type SavePhase,
 	type SaveUrlResult,
-	type RemoveUrlResult,
+	type InvokeActionResult,
 	type TokenStorage,
 } from "browser-extension-core";
 import { initCreateContextMenus } from "./create-context-menus";
@@ -256,15 +256,15 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 					pending.then(sendResponse);
 					break;
 				}
-				case "remove-item": {
+				case "invoke-action": {
 					const pending = new Promise<unknown>((resolve) => {
-						core.once("removed-item", {
-							success: (value: RemoveUrlResult) =>
+						core.once("invoked-item-action", {
+							success: (value: InvokeActionResult) =>
 								resolve({ ok: true, value }),
 							failure: (err) => resolve({ ok: false, ...err }),
 						});
 					});
-					core.remove("item", { id: message.id });
+					core.invoke("item-action", { id: message.id, name: message.name });
 					pending.then(sendResponse);
 					break;
 				}

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -170,17 +170,15 @@ function renderLinks(items: ReadingListItem[]) {
 	const linkList = document.getElementById("link-list");
 	const emptyList = document.getElementById("empty-list");
 	const noMatches = document.getElementById("no-matches");
-	const listError = document.getElementById("list-error");
 
 	if (!linkList) throw new Error("link-list element not found");
 	if (!emptyList) throw new Error("empty-list element not found");
 	if (!noMatches) throw new Error("no-matches element not found");
-	if (!listError) throw new Error("list-error element not found");
 
 	linkList.innerHTML = "";
 	emptyList.hidden = true;
 	noMatches.hidden = true;
-	listError.hidden = true;
+	setListError(null);
 
 	if (allItems.length === 0) {
 		emptyList.hidden = false;
@@ -298,6 +296,12 @@ function renderLinks(items: ReadingListItem[]) {
 						 * longer advertises this action. Reload so the stale phantom row
 						 * drops instead of lingering until the popup is reopened. */
 						await loadAllItems();
+					} else {
+						/** Generic failure (server 5xx / transient network) — the
+						 * not-logged-in case already returned above. The action didn't
+						 * apply and the row is unchanged, so surface an error instead of
+						 * hiding the spinner with no feedback at all. */
+						setListError("Couldn't complete that action. Try again?");
 					}
 				} finally {
 					if (overlay) overlay.hidden = true;
@@ -329,9 +333,7 @@ async function loadAllItems() {
 	}
 
 	if (!result.ok) {
-		const listError = document.getElementById("list-error");
-		if (!listError) throw new Error("list-error element not found");
-		listError.hidden = false;
+		setListError("Failed to load links");
 		return;
 	}
 
@@ -348,6 +350,20 @@ function setListWarning(message: string | null): void {
 	} else {
 		warningEl.textContent = "";
 		warningEl.hidden = true;
+	}
+}
+
+// Each caller passes its own message so the surface never shows a stale one — a
+// failed action and a failed load read differently. Error counterpart of
+// setListWarning.
+function setListError(message: string | null): void {
+	const errorEl = document.getElementById("list-error");
+	if (!errorEl) throw new Error("list-error element not found");
+	if (message) {
+		errorEl.textContent = message;
+		errorEl.hidden = false;
+	} else {
+		errorEl.hidden = true;
 	}
 }
 

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -293,6 +293,11 @@ function renderLinks(items: ReadingListItem[]) {
 					if (result.ok && result.value.ok) {
 						allItems = result.value.items;
 						renderLinks(filterItems());
+					} else if (result.ok) {
+						/** not-found: the item was removed elsewhere or the server no
+						 * longer advertises this action. Reload so the stale phantom row
+						 * drops instead of lingering until the popup is reopened. */
+						await loadAllItems();
 					}
 				} finally {
 					if (overlay) overlay.hidden = true;

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -6,11 +6,21 @@ import type {
 	SavePhase,
 	GuardedResult,
 	SaveUrlResult,
-	RemoveUrlResult,
+	InvokeActionResult,
 	Message,
+	ActionVariant,
 } from "browser-extension-core";
-import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, installShortcuts, isCmdD, initSaveProgress, initSaveProgressSequencer, buildMessageView } from "browser-extension-core";
+import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, itemDisplay, installShortcuts, isCmdD, initSaveProgress, initSaveProgressSequencer, buildMessageView, actionLabel, actionVariant, actionIcon, linkLabel, linkPresentation } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+
+/** The client's own presentation map: an action variant -> the popup's CSS
+ * class. The server never sends a class; the variant comes from mapping the
+ * action `name` client-side (actionVariant), and an unknown name falls back to
+ * the default. */
+const ACTION_CLASS_BY_VARIANT: Record<ActionVariant, string> = {
+	danger: "list-view__delete",
+	default: "list-view__action",
+};
 
 declare const __APP_DOMAINS__: string[];
 
@@ -86,8 +96,10 @@ async function finishSavingProgress(): Promise<void> {
 	});
 }
 
-function send(message: PopupMessage): Promise<unknown> {
-	return browser.runtime.sendMessage(message);
+/** Isolated boundary wrapper: the single contained assertion for the untyped
+ * webextension-polyfill response, so call sites stay free of `as`. */
+function send<T>(message: PopupMessage): Promise<T> {
+	return browser.runtime.sendMessage(message) as Promise<T>;
 }
 
 async function performLogout() {
@@ -193,13 +205,12 @@ function renderLinks(items: ReadingListItem[]) {
 		const row = document.createElement("div");
 		row.className = "list-view__row";
 
+		const { hostname } = itemDisplay(item);
+
 		const itemLink = document.createElement("a");
 		itemLink.className = "list-view__item";
-		itemLink.href = item.readUrl ?? item.url;
 		itemLink.target = "_blank";
 		itemLink.rel = "noopener noreferrer";
-
-		const hostname = new URL(item.url).hostname;
 
 		const avatar = document.createElement("div");
 		avatar.className = "list-view__avatar";
@@ -228,36 +239,68 @@ function renderLinks(items: ReadingListItem[]) {
 		itemLink.appendChild(textContainer);
 		itemLink.appendChild(time);
 
-		const deleteButton = document.createElement("button");
-		deleteButton.className = "list-view__delete";
-		deleteButton.textContent = "\u00D7";
-		deleteButton.title = "Remove from list";
-		deleteButton.setAttribute("aria-label", "Remove from list");
-		deleteButton.addEventListener("click", async () => {
-			const overlay = document.getElementById("spinner-overlay");
-			if (overlay) overlay.hidden = false;
-			try {
-				const result = (await send({
-					type: "remove-item",
-					id: item.id,
-				})) as GuardedResult<RemoveUrlResult>;
-
-				if (isNotLoggedIn(result)) {
-					await performLogout();
-					return;
-				}
-
-				if (result.ok && result.value.ok) {
-					allItems = result.value.items;
-					renderLinks(filterItems());
-				}
-			} finally {
-				if (overlay) overlay.hidden = true;
-			}
-		});
-
 		row.appendChild(itemLink);
-		row.appendChild(deleteButton);
+
+		// One control per advertised SEMANTIC link \u2014 loop the item's link
+		// descriptors generically. `read` (row-anchor presentation) drives the
+		// row's primary open anchor; any other semantic rel renders as a standalone
+		// link control, so a future rel (e.g. `summary`) renders with no popup
+		// change. Presentation comes from the one client-side rel map, never a
+		// per-rel `if`.
+		for (const link of item.links) {
+			if (linkPresentation(link.rel) === "row-anchor") {
+				itemLink.href = link.href;
+				continue;
+			}
+			const label = linkLabel(link);
+			const control = document.createElement("a");
+			control.className = "list-view__action";
+			control.href = link.href;
+			control.target = "_blank";
+			control.rel = "noopener noreferrer";
+			control.textContent = label;
+			control.title = label;
+			control.setAttribute("aria-label", label);
+			row.appendChild(control);
+		}
+
+		// One control per advertised affordance \u2014 loop the item's action
+		// descriptors and render a button each. No per-capability boolean and no
+		// hardcoded "does the client know action X" check, so a newly-advertised
+		// server action renders here with no popup change.
+		for (const action of item.actions) {
+			const button = document.createElement("button");
+			button.className = ACTION_CLASS_BY_VARIANT[actionVariant(action.name)];
+			const label = actionLabel(action);
+			button.textContent = actionIcon(action.name) ?? label;
+			button.title = label;
+			button.setAttribute("aria-label", label);
+			button.addEventListener("click", async () => {
+				const overlay = document.getElementById("spinner-overlay");
+				if (overlay) overlay.hidden = false;
+				try {
+					const result = await send<GuardedResult<InvokeActionResult>>({
+						type: "invoke-action",
+						id: item.id,
+						name: action.name,
+					});
+
+					if (isNotLoggedIn(result)) {
+						await performLogout();
+						return;
+					}
+
+					if (result.ok && result.value.ok) {
+						allItems = result.value.items;
+						renderLinks(filterItems());
+					}
+				} finally {
+					if (overlay) overlay.hidden = true;
+				}
+			});
+			row.appendChild(button);
+		}
+
 		linkList.appendChild(row);
 	}
 
@@ -271,9 +314,9 @@ function filterItems(): ReadingListItem[] {
 }
 
 async function loadAllItems() {
-	const result = (await send({
+	const result = await send<GuardedResult<ReadingListItem[]>>({
 		type: "get-all-items",
-	})) as GuardedResult<ReadingListItem[]>;
+	});
 
 	if (isNotLoggedIn(result)) {
 		await performLogout();
@@ -359,10 +402,10 @@ async function saveAndShowList() {
 		return;
 	}
 
-	const checkResult = (await send({
+	const checkResult = await send<GuardedResult<ReadingListItem | null>>({
 		type: "check-url",
 		url: activeTab.url,
-	})) as GuardedResult<ReadingListItem | null>;
+	});
 
 	if (isNotLoggedIn(checkResult)) {
 		await performLogout();
@@ -378,12 +421,12 @@ async function saveAndShowList() {
 		return;
 	}
 
-	const saveResult = (await send({
+	const saveResult = await send<GuardedResult<SaveUrlResult>>({
 		type: "save-current-tab",
 		url: activeTab.url,
 		title: activeTab.title,
 		tabId: activeTab.tabId,
-	})) as GuardedResult<SaveUrlResult>;
+	});
 
 	if (isNotLoggedIn(saveResult)) {
 		await performLogout();
@@ -421,11 +464,11 @@ document.getElementById("login-button")?.addEventListener("click", async () => {
 	if (loginError) loginError.hidden = true;
 
 	try {
-		const result = (await send({ type: "login" })) as {
+		const result = await send<{
 			ok: boolean;
 			reason?: string;
 			error?: { message?: string };
-		};
+		}>({ type: "login" });
 		if (!result.ok) {
 			if (loginError) {
 				loginError.textContent = `Login failed: ${result.reason ?? "unknown"} — ${result.error?.message ?? ""}`;

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.browser.ts
@@ -363,6 +363,7 @@ function setListError(message: string | null): void {
 		errorEl.textContent = message;
 		errorEl.hidden = false;
 	} else {
+		errorEl.textContent = "";
 		errorEl.hidden = true;
 	}
 }
@@ -545,7 +546,6 @@ if (shortcutHint) {
 saveAndShowList().catch((error) => {
 	logger.error("Failed to initialize popup:", error);
 	showView("list-view");
-	const listError = document.getElementById("list-error");
-	if (listError) listError.hidden = false;
+	setListError("Failed to load links");
 });
 /* c8 ignore stop */

--- a/projects/extensions/chrome-extension/src/runtime/popup/popup.template.html
+++ b/projects/extensions/chrome-extension/src/runtime/popup/popup.template.html
@@ -59,7 +59,7 @@
     <div id="pagination" class="pagination" hidden></div>
     <p id="empty-list" class="list-view__empty" hidden>No unread links</p>
     <p id="no-matches" class="list-view__empty" hidden>No matching links</p>
-    <p id="list-error" class="list-view__error" hidden>Failed to load links</p>
+    <p id="list-error" class="list-view__error" hidden></p>
   </div>
 
   <div id="saving-view" class="view saving-view">

--- a/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/background/background.browser.ts
@@ -12,7 +12,7 @@ import {
 	captureActiveTabBytes,
 	type SavePhase,
 	type SaveUrlResult,
-	type RemoveUrlResult,
+	type InvokeActionResult,
 	type TokenStorage,
 } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
@@ -215,7 +215,7 @@ function broadcastSaveProgress(phase: SavePhase): void {
 const POPUP_MESSAGE_TYPES = new Set([
 	"save-current-tab",
 	"save-progress",
-	"remove-item",
+	"invoke-action",
 	"check-url",
 	"get-all-items",
 	"login",
@@ -296,15 +296,15 @@ browser.runtime.onMessage.addListener((raw, _sender, sendResponse) => {
 					pending.then(sendResponse);
 					break;
 				}
-				case "remove-item": {
+				case "invoke-action": {
 					const pending = new Promise<unknown>((resolve) => {
-						core.once("removed-item", {
-							success: (value: RemoveUrlResult) =>
+						core.once("invoked-item-action", {
+							success: (value: InvokeActionResult) =>
 								resolve({ ok: true, value }),
 							failure: (err) => resolve({ ok: false, ...err }),
 						});
 					});
-					core.remove("item", { id: message.id });
+					core.invoke("item-action", { id: message.id, name: message.name });
 					pending.then(sendResponse);
 					break;
 				}

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -285,6 +285,11 @@ function renderLinks(items: ReadingListItem[]) {
 					if (result.ok && result.value.ok) {
 						allItems = result.value.items;
 						renderLinks(filterItems());
+					} else if (result.ok) {
+						/** not-found: the item was removed elsewhere or the server no
+						 * longer advertises this action. Reload so the stale phantom row
+						 * drops instead of lingering until the popup is reopened. */
+						await loadAllItems();
 					}
 				} finally {
 					if (overlay) overlay.hidden = true;

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -4,11 +4,21 @@ import type {
 	PopupMessage,
 	GuardedResult,
 	SaveUrlResult,
-	RemoveUrlResult,
+	InvokeActionResult,
 	Message,
+	ActionVariant,
 } from "browser-extension-core";
-import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, installShortcuts, isCmdD, initSaveProgress, initSaveProgressSequencer, buildMessageView } from "browser-extension-core";
+import { filterByUrl, paginateItems, avatarColor, relativeTime, isAppUrl, itemDisplay, installShortcuts, isCmdD, initSaveProgress, initSaveProgressSequencer, buildMessageView, actionLabel, actionVariant, actionIcon, linkLabel, linkPresentation } from "browser-extension-core";
 import { HutchLogger, consoleLogger } from "@packages/hutch-logger";
+
+/** The client's own presentation map: an action variant -> the popup's CSS
+ * class. The server never sends a class; the variant comes from mapping the
+ * action `name` client-side (actionVariant), and an unknown name falls back to
+ * the default. */
+const ACTION_CLASS_BY_VARIANT: Record<ActionVariant, string> = {
+	danger: "list-view__delete",
+	default: "list-view__action",
+};
 
 declare const __APP_DOMAINS__: string[];
 
@@ -187,13 +197,12 @@ function renderLinks(items: ReadingListItem[]) {
 		const row = document.createElement("div");
 		row.className = "list-view__row";
 
+		const { hostname } = itemDisplay(item);
+
 		const itemLink = document.createElement("a");
 		itemLink.className = "list-view__item";
-		itemLink.href = item.readUrl ?? item.url;
 		itemLink.target = "_blank";
 		itemLink.rel = "noopener noreferrer";
-
-		const hostname = new URL(item.url).hostname;
 
 		const avatar = document.createElement("div");
 		avatar.className = "list-view__avatar";
@@ -222,36 +231,68 @@ function renderLinks(items: ReadingListItem[]) {
 		itemLink.appendChild(textContainer);
 		itemLink.appendChild(time);
 
-		const deleteButton = document.createElement("button");
-		deleteButton.className = "list-view__delete";
-		deleteButton.textContent = "\u00D7";
-		deleteButton.title = "Remove from list";
-		deleteButton.setAttribute("aria-label", "Remove from list");
-		deleteButton.addEventListener("click", async () => {
-			const overlay = document.getElementById("spinner-overlay");
-			if (overlay) overlay.hidden = false;
-			try {
-				const result = await send<GuardedResult<RemoveUrlResult>>({
-					type: "remove-item",
-					id: item.id,
-				});
-
-				if (isNotLoggedIn(result)) {
-					await performLogout();
-					return;
-				}
-
-				if (result.ok && result.value.ok) {
-					allItems = result.value.items;
-					renderLinks(filterItems());
-				}
-			} finally {
-				if (overlay) overlay.hidden = true;
-			}
-		});
-
 		row.appendChild(itemLink);
-		row.appendChild(deleteButton);
+
+		// One control per advertised SEMANTIC link \u2014 loop the item's link
+		// descriptors generically. `read` (row-anchor presentation) drives the
+		// row's primary open anchor; any other semantic rel renders as a standalone
+		// link control, so a future rel (e.g. `summary`) renders with no popup
+		// change. Presentation comes from the one client-side rel map, never a
+		// per-rel `if`.
+		for (const link of item.links) {
+			if (linkPresentation(link.rel) === "row-anchor") {
+				itemLink.href = link.href;
+				continue;
+			}
+			const label = linkLabel(link);
+			const control = document.createElement("a");
+			control.className = "list-view__action";
+			control.href = link.href;
+			control.target = "_blank";
+			control.rel = "noopener noreferrer";
+			control.textContent = label;
+			control.title = label;
+			control.setAttribute("aria-label", label);
+			row.appendChild(control);
+		}
+
+		// One control per advertised affordance \u2014 loop the item's action
+		// descriptors and render a button each. No per-capability boolean and no
+		// hardcoded "does the client know action X" check, so a newly-advertised
+		// server action renders here with no popup change.
+		for (const action of item.actions) {
+			const button = document.createElement("button");
+			button.className = ACTION_CLASS_BY_VARIANT[actionVariant(action.name)];
+			const label = actionLabel(action);
+			button.textContent = actionIcon(action.name) ?? label;
+			button.title = label;
+			button.setAttribute("aria-label", label);
+			button.addEventListener("click", async () => {
+				const overlay = document.getElementById("spinner-overlay");
+				if (overlay) overlay.hidden = false;
+				try {
+					const result = await send<GuardedResult<InvokeActionResult>>({
+						type: "invoke-action",
+						id: item.id,
+						name: action.name,
+					});
+
+					if (isNotLoggedIn(result)) {
+						await performLogout();
+						return;
+					}
+
+					if (result.ok && result.value.ok) {
+						allItems = result.value.items;
+						renderLinks(filterItems());
+					}
+				} finally {
+					if (overlay) overlay.hidden = true;
+				}
+			});
+			row.appendChild(button);
+		}
+
 		linkList.appendChild(row);
 	}
 

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -162,17 +162,15 @@ function renderLinks(items: ReadingListItem[]) {
 	const linkList = document.getElementById("link-list");
 	const emptyList = document.getElementById("empty-list");
 	const noMatches = document.getElementById("no-matches");
-	const listError = document.getElementById("list-error");
 
 	if (!linkList) throw new Error("link-list element not found");
 	if (!emptyList) throw new Error("empty-list element not found");
 	if (!noMatches) throw new Error("no-matches element not found");
-	if (!listError) throw new Error("list-error element not found");
 
 	linkList.innerHTML = "";
 	emptyList.hidden = true;
 	noMatches.hidden = true;
-	listError.hidden = true;
+	setListError(null);
 
 	if (allItems.length === 0) {
 		emptyList.hidden = false;
@@ -290,6 +288,12 @@ function renderLinks(items: ReadingListItem[]) {
 						 * longer advertises this action. Reload so the stale phantom row
 						 * drops instead of lingering until the popup is reopened. */
 						await loadAllItems();
+					} else {
+						/** Generic failure (server 5xx / transient network) — the
+						 * not-logged-in case already returned above. The action didn't
+						 * apply and the row is unchanged, so surface an error instead of
+						 * hiding the spinner with no feedback at all. */
+						setListError("Couldn't complete that action. Try again?");
 					}
 				} finally {
 					if (overlay) overlay.hidden = true;
@@ -321,9 +325,7 @@ async function loadAllItems() {
 	}
 
 	if (!result.ok) {
-		const listError = document.getElementById("list-error");
-		if (!listError) throw new Error("list-error element not found");
-		listError.hidden = false;
+		setListError("Failed to load links");
 		return;
 	}
 
@@ -340,6 +342,20 @@ function setListWarning(message: string | null): void {
 	} else {
 		warningEl.textContent = "";
 		warningEl.hidden = true;
+	}
+}
+
+// Each caller passes its own message so the surface never shows a stale one — a
+// failed action and a failed load read differently. Error counterpart of
+// setListWarning.
+function setListError(message: string | null): void {
+	const errorEl = document.getElementById("list-error");
+	if (!errorEl) throw new Error("list-error element not found");
+	if (message) {
+		errorEl.textContent = message;
+		errorEl.hidden = false;
+	} else {
+		errorEl.hidden = true;
 	}
 }
 

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.browser.ts
@@ -355,6 +355,7 @@ function setListError(message: string | null): void {
 		errorEl.textContent = message;
 		errorEl.hidden = false;
 	} else {
+		errorEl.textContent = "";
 		errorEl.hidden = true;
 	}
 }
@@ -537,7 +538,6 @@ if (shortcutHint) {
 saveAndShowList().catch((error) => {
 	logger.error("Failed to initialize popup:", error);
 	showView("list-view");
-	const listError = document.getElementById("list-error");
-	if (listError) listError.hidden = false;
+	setListError("Failed to load links");
 });
 /* c8 ignore stop */

--- a/projects/extensions/firefox-extension/src/runtime/popup/popup.template.html
+++ b/projects/extensions/firefox-extension/src/runtime/popup/popup.template.html
@@ -59,7 +59,7 @@
     <div id="pagination" class="pagination" hidden></div>
     <p id="empty-list" class="list-view__empty" hidden>No unread links</p>
     <p id="no-matches" class="list-view__empty" hidden>No matching links</p>
-    <p id="list-error" class="list-view__error" hidden>Failed to load links</p>
+    <p id="list-error" class="list-view__error" hidden></p>
   </div>
 
   <div id="saving-view" class="view saving-view">


### PR DESCRIPTION
## What

**1 of 3 coordinated PRs** (plus a skill doc already on `main`) making every Readplace client a generic hypermedia client per the updated [`hypermedia-api-design`](../blob/main/.claude/skills/hypermedia-api-design/SKILL.md) skill. **This is the browser-extension half** — `browser-extension-core` + the chrome & firefox wrappers.

Controls are now **rendered by looping the affordances the server advertised**, never gated on per-capability booleans:

- **Affordance descriptors across the boundary.** Each item's advertised actions are serialized as `{name, title}` descriptors over the popup↔background `sendMessage` boundary (no `href`/`method` leaks); the popup loops them and renders one control each — label from `title`, style/icon from a **client-side `name`→token map** (`popup/action-affordance.ts`). Replaces the `canDelete` boolean.
- **Generic invoker.** A generic entity-action invoker follows any action's own `href`/`method`/`type` and posts its **server-declared field values** encoded per the declared `type`, reached via an `invoke-action` message keyed by `(id, name)` — so any advertised action is invokable with no new client code.
- **Protocol hardening, all from the skill.** Verify the response `Content-Type` before parsing; parse `links`/`actions` leniently; follow `next`-link pagination with a cycle guard; build `search` from the action's declared `fields`; resolve every href through one scheme-aware helper; loop semantic links (`read` stays the row anchor) via `item-display.ts`.

## Why

Per the skill's "Render controls by iterating advertised affordances … never per-capability boolean flags" and "Rendering & Invoking Affordances." A newly-advertised server action now renders and invokes with **zero client change**.

## Independent & non-breaking

Mergeable on its own, in any order. The server-side `title`/`value` land in `feat/hutch-siren-affordance-titles`; this PR tolerates their absence (humanized-name fallback), and its tests stub the Siren responses they exercise.

## Verified

`pnpm check` green: `browser-extension-core`, `chrome-extension`, `firefox-extension` all pass at **100% coverage** (lint, types, tests, knip). New pure logic (`action-affordance`, `item-display`, the generic invoker, descriptor serialization) is unit-tested; popup glue stays Selenium-E2E per the existing `c8 ignore`.

## The coordinated set
- `feat/hutch-siren-affordance-titles` — server titles + toggle value
- **this** — extensions loop affordances
- `feat/ios-affordance-loop` — iOS app loops affordances
- skill doc — already on `main`, so this PR's review runs against it.
