### PR TITLE
feat(ios): render controls by looping advertised Siren affordances

### DIFF
--- a/projects/ios-readplace/App/AffordancePresentation.swift
+++ b/projects/ios-readplace/App/AffordancePresentation.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+/// The client-side presentation for an advertised affordance: icon, tint, and the
+/// role hints the UI needs. Presentation is 100% a client concern — the server
+/// sends no style or class — so this maps the affordance's wire token (an action
+/// `name` or a link `rel`) to the client's own design tokens. An unknown token
+/// falls back to a neutral default, so an affordance the client has never seen
+/// still renders (with a generic look) rather than vanishing.
+struct AffordancePresentation {
+	/// The SF Symbol the control draws.
+	let systemImage: String
+	/// The control's tint, or nil to inherit the surrounding style.
+	let tint: Color?
+	/// Whether the control mutates server state with no undo — the View uses this
+	/// to mark a swipe action destructive and to confirm before invoking.
+	let isDestructive: Bool
+	/// Whether invoking the control unconditionally removes the item it acts on from
+	/// the current (unread-only) list, knowable from the wire token alone. Only
+	/// `delete` qualifies: it always removes the item regardless of any field value.
+	/// `update-status` is a server toggle (it may set the status to `read` OR
+	/// `unread`), so whether it removes the row depends on the action's `status`
+	/// field `value`, not the token — that transition-aware decision lives in
+	/// `Affordance.removesItemFromUnreadList`, not here. Per 'State Lives in the
+	/// Network', an action that does not remove the item leaves the list untouched
+	/// and lets the next load reconcile it.
+	let removesItem: Bool
+	/// Whether the wire token alone allows presenting this affordance as a
+	/// collection toolbar control. `false` for two kinds excluded structurally (not
+	/// name-gated as a known capability): a structural navigation link
+	/// (`self`/`root`/`prev`/`next`/`item`), which the client follows itself for
+	/// pagination/identity/item resolution, never as a user control; and an action
+	/// that needs a captured page (`save-html`/`save-content`), which iOS can only reach through
+	/// the Share Sheet, not the toolbar. An unknown token is toolbar-presentable so a
+	/// newly-advertised affordance still renders. A third, field-dependent exclusion
+	/// (a field-requiring action with no server value and no bespoke handler) cannot
+	/// be decided from the token alone and lives in `Affordance.isToolbarControl`.
+	let isToolbarControl: Bool
+
+	/// Derives the presentation for a wire token. The mapping is the client's own;
+	/// the token is never used as a style string verbatim. A token with no mapping
+	/// gets the neutral default so an unknown affordance still renders.
+	init(token: String) {
+		switch token {
+		case "save-article", "save":
+			systemImage = "plus"
+			tint = nil
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = true
+		case "save-html", "save-content":
+			systemImage = "plus"
+			tint = nil
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = false
+		case "update-status":
+			systemImage = "checkmark.circle"
+			tint = .brandSuccess
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = true
+		case "delete":
+			systemImage = "trash"
+			tint = .red
+			isDestructive = true
+			removesItem = true
+			isToolbarControl = true
+		case "search":
+			systemImage = "magnifyingglass"
+			tint = nil
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = true
+		case "add-links-help":
+			systemImage = "questionmark.circle"
+			tint = nil
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = true
+		case let rel where Affordance.structuralRels.contains(rel):
+			systemImage = "ellipsis.circle"
+			tint = nil
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = false
+		default:
+			systemImage = "ellipsis.circle"
+			tint = nil
+			isDestructive = false
+			removesItem = false
+			isToolbarControl = true
+		}
+	}
+}
+
+extension Affordance {
+	/// This affordance's client-side presentation, derived from its wire token.
+	var presentation: AffordancePresentation { AffordancePresentation(token: token) }
+
+	/// The structural navigation link rels the client follows for its own
+	/// navigation — pagination (`prev`/`next`), identity (`self`/`root`), and item
+	/// resolution (`item`) — never rendered as user controls. Single source so the
+	/// presentation switch and any other structural classification can't drift on
+	/// which rels are plumbing rather than affordances.
+	static let structuralRels: Set<String> = ["self", "root", "prev", "next", "item"]
+
+	/// Action names the client invokes through a bespoke handler that supplies a
+	/// field value the server did not (`save-article` reads a URL the user types in
+	/// the native dialog). Such an action is invokable from a bare toolbar control
+	/// even though its field carries no server `value`; every other field-requiring
+	/// action without a server value is not. This is the one place the client
+	/// declares which inputs it can produce itself, not a presentation name-gate.
+	private static let bespokeFieldHandlers: Set<String> = ["save-article"]
+
+	/// Whether an action `name` is one the client invokes through a bespoke handler
+	/// that supplies a field value the server did not. Single source for both the
+	/// bare-control invokability check below and the toolbar's routing decision, so
+	/// the two can't disagree on which actions get bespoke handling.
+	static func isBespokeFieldHandler(_ name: String) -> Bool {
+		bespokeFieldHandlers.contains(name)
+	}
+
+	/// Whether the client can invoke this affordance from a bare toolbar control.
+	/// Per the contract, a field-requiring action whose fields carry no
+	/// server-provided `value` is not invokable by a bare control: the value must
+	/// come from the server's field or from a bespoke client handler. A link, an
+	/// action with no fields, and an action whose declared fields all carry a server
+	/// `value` are bare-invokable; a field-requiring action with no server value and
+	/// no bespoke handler (e.g. `search`, which iOS has no query UI for) is not, so
+	/// the client never surfaces a control it cannot actually invoke. An unknown
+	/// field-less action stays invokable so a newly-advertised affordance still
+	/// renders.
+	var isInvokableByBareControl: Bool {
+		guard case let .action(action) = invocation else { return true }
+		if Self.isBespokeFieldHandler(action.name) { return true }
+		let fields = action.fields ?? []
+		guard !fields.isEmpty else { return true }
+		return fields.allSatisfy { $0.value != nil }
+	}
+
+	/// Whether the toolbar should surface this affordance as a control: it must be
+	/// both presentable in the toolbar (a structural navigation link or a
+	/// capture-only save is excluded by its presentation) and actually invokable
+	/// from a bare control (a field-requiring action with no server value and no
+	/// bespoke handler is excluded).
+	var isToolbarControl: Bool {
+		presentation.isToolbarControl && isInvokableByBareControl
+	}
+
+	/// Whether invoking this affordance removes the item it acts on from the
+	/// unread-only reading list, so the View can scope its optimistic row removal to
+	/// transitions that actually leave the view. `delete` always removes (known from
+	/// the token). `update-status` is a server toggle, so it removes the row only
+	/// when its `status` field's server-supplied `value` moves the item out of the
+	/// unread-only list (`read`); a toggle back to `unread` leaves the row in place.
+	/// Any other action does not remove the row — per 'State Lives in the Network'
+	/// the list is left for the next load to reconcile rather than synthesised
+	/// client-side.
+	var removesItemFromUnreadList: Bool {
+		if presentation.removesItem { return true }
+		guard case let .action(action) = invocation else { return false }
+		let status = (action.fields ?? []).first { $0.name == "status" }?.value
+		return status == "read"
+	}
+}

--- a/projects/ios-readplace/App/ReadingListView.swift
+++ b/projects/ios-readplace/App/ReadingListView.swift
@@ -5,6 +5,25 @@ struct ReadingListView: View {
 	@StateObject private var viewModel: ReadingListViewModel
 
 	@State private var showingAddInstructions = false
+	@State private var saveText = ""
+	/// The `save-article` action whose toolbar control was tapped, driving the
+	/// native URL dialog. Non-nil presents the dialog; the action is carried
+	/// through so the save follows it rather than rediscovering it by name.
+	@State private var pendingSaveAction: SirenAction?
+	/// A destructive item action awaiting confirmation, carried with the row it acts
+	/// on. A destructive control (e.g. `delete`) is irreversible, so it routes here
+	/// for an explicit confirm before the invoke fires, rather than acting on the tap.
+	@State private var pendingDestructive: PendingDestructive?
+
+	/// A destructive affordance paired with the row it would act on, so the
+	/// confirmation dialog can invoke the exact action the swipe carried and label
+	/// itself from the affordance's `label` (the server `title`, or the humanized
+	/// fallback) rather than the raw wire name.
+	private struct PendingDestructive: Identifiable {
+		let affordance: Affordance
+		let article: Article
+		var id: String { "\(affordance.id):\(article.id)" }
+	}
 
 	init(session: AppSession) {
 		self.session = session
@@ -23,11 +42,15 @@ struct ReadingListView: View {
 					ToolbarItem(placement: .navigationBarLeading) {
 						Button("Sign out") { Task { await session.logout() } }
 					}
-					ToolbarItem(placement: .navigationBarTrailing) {
-						Button {
-							showingAddInstructions = true
-						} label: {
-							Image(systemName: "plus")
+					ToolbarItemGroup(placement: .navigationBarTrailing) {
+						ForEach(viewModel.collectionAffordances) { affordance in
+							Button {
+								dispatch(affordance)
+							} label: {
+								Image(systemName: affordance.presentation.systemImage)
+							}
+							.tint(affordance.presentation.tint)
+							.accessibilityLabel(affordance.label)
 						}
 					}
 				}
@@ -38,7 +61,7 @@ struct ReadingListView: View {
 						presentation: presentation,
 						mintSession: { await viewModel.mintReaderSession() },
 						onMarkedRead: {
-							viewModel.removeArticle(id: presentation.articleId)
+							if let id = presentation.articleId { viewModel.removeArticle(id: id) }
 							viewModel.readerPresentation = nil
 						},
 						onClose: { viewModel.readerPresentation = nil }
@@ -51,6 +74,65 @@ struct ReadingListView: View {
 						onClose: { showingAddInstructions = false }
 					)
 				}
+				.alert("Save a URL", isPresented: Binding(
+					get: { pendingSaveAction != nil },
+					set: { if !$0 { pendingSaveAction = nil } }
+				)) {
+					TextField("https://example.com/article", text: $saveText)
+						.textInputAutocapitalization(.never)
+						.autocorrectionDisabled()
+					Button("Save") {
+						if let action = pendingSaveAction {
+							Task { await viewModel.saveURL(saveText, action: action) }
+						}
+						pendingSaveAction = nil
+					}
+					Button("Cancel", role: .cancel) { pendingSaveAction = nil }
+				} message: {
+					Text("Saves the URL only. Use the iOS Share Sheet to save a page with its rendered content.")
+				}
+				.confirmationDialog(
+					pendingDestructive?.affordance.label ?? "Are you sure?",
+					isPresented: Binding(
+						get: { pendingDestructive != nil },
+						set: { if !$0 { pendingDestructive = nil } }
+					),
+					titleVisibility: .visible,
+					presenting: pendingDestructive
+				) { pending in
+					Button(pending.affordance.label, role: .destructive) {
+						if let action = pending.affordance.action {
+							Task { await viewModel.invoke(action, on: pending.article) }
+						}
+						pendingDestructive = nil
+					}
+					Button("Cancel", role: .cancel) { pendingDestructive = nil }
+				} message: { _ in
+					Text("This can't be undone.")
+				}
+		}
+	}
+
+	/// Routes a tapped collection control to the side effect its advertised
+	/// invocation calls for. The decision itself is pure (`ToolbarRoute.route`); this
+	/// only performs the resulting effect, so the routing is unit-testable without a
+	/// view.
+	private func dispatch(_ affordance: Affordance) {
+		// A navigable help link opens the server's add-links help sheet — a distinct
+		// presentation from the reader. Mapping a known rel to its sheet is a
+		// client presentation choice, not an availability gate.
+		if affordance.token == "add-links-help" {
+			showingAddInstructions = true
+			return
+		}
+		switch ToolbarRoute.route(for: affordance) {
+		case let .open(link):
+			viewModel.open(link: link)
+		case let .promptSave(action):
+			saveText = ""
+			pendingSaveAction = action
+		case let .invoke(action):
+			Task { await viewModel.invokeCollection(action) }
 		}
 	}
 
@@ -87,21 +169,14 @@ struct ReadingListView: View {
 					.onTapGesture {
 						viewModel.openReader(for: article)
 					}
-					.swipeActions(edge: .trailing) {
-						if article.canMarkRead {
-							Button {
-								Task { await viewModel.markAsRead(article) }
-							} label: {
-								Label("Mark as read", systemImage: "checkmark.circle")
-							}
-							.tint(.brandSuccess)
+					.swipeActions(edge: .trailing, allowsFullSwipe: false) {
+						ForEach(article.affordances) { affordance in
+							itemControl(affordance, on: article)
 						}
 					}
 					.accessibilityActions {
-						if article.canMarkRead {
-							Button("Mark as read") {
-								Task { await viewModel.markAsRead(article) }
-							}
+						ForEach(article.affordances) { affordance in
+							Button(affordance.label) { activate(affordance, on: article) }
 						}
 					}
 			}
@@ -117,6 +192,41 @@ struct ReadingListView: View {
 			}
 		}
 		.listStyle(.plain)
+	}
+
+	/// One per-item swipe control, rendered from an advertised affordance. The label
+	/// is the server's `title`; the icon, tint and destructive role are derived
+	/// client-side from the affordance's wire token. A full swipe can't fire it
+	/// (`allowsFullSwipe: false`), and a destructive control routes through a
+	/// confirmation before invoking; both guard the irreversible `delete`. Every
+	/// rendered control resolves to an effect in `activate` — an action invokes, a
+	/// link opens — so none silently no-ops.
+	private func itemControl(_ affordance: Affordance, on article: Article) -> some View {
+		Button(role: affordance.presentation.isDestructive ? .destructive : nil) {
+			activate(affordance, on: article)
+		} label: {
+			Label(affordance.label, systemImage: affordance.presentation.systemImage)
+		}
+		.tint(affordance.presentation.tint)
+	}
+
+	/// Routes an item control to its effect: a navigable link opens in the web view
+	/// (the same effect the toolbar gives a link), a destructive action awaits an
+	/// explicit confirmation (its invoke is irreversible), and any other action
+	/// invokes immediately through the view model's generic invoker. Which actions
+	/// are destructive is a client-side presentation decision, not a name check. Every
+	/// rendered item control resolves to an effect — a link-only affordance is opened,
+	/// not silently dropped.
+	private func activate(_ affordance: Affordance, on article: Article) {
+		guard let action = affordance.action else {
+			if let link = affordance.link { viewModel.open(link: link) }
+			return
+		}
+		if affordance.presentation.isDestructive {
+			pendingDestructive = PendingDestructive(affordance: affordance, article: article)
+		} else {
+			Task { await viewModel.invoke(action, on: article) }
+		}
 	}
 
 	private var emptyState: some View {

--- a/projects/ios-readplace/App/ReadingListViewModel.swift
+++ b/projects/ios-readplace/App/ReadingListViewModel.swift
@@ -10,12 +10,19 @@ final class ReadingListViewModel: ObservableObject {
 	/// Server-authored messages surfaced to the UI (e.g. a locked-account refusal),
 	/// rendered generically — the client owns no per-feature knowledge of them.
 	@Published var messages: [ServerMessage] = []
-	/// Set when a readable row is tapped; drives the reader sheet. The session
-	/// cookie is minted inside the sheet, so the sheet opens without waiting.
+	/// Set when a readable row is tapped, or when a navigable collection link is
+	/// invoked; drives the reader/web sheet. The session cookie is minted inside
+	/// the sheet, so the sheet opens without waiting.
 	@Published var readerPresentation: ReaderPresentation?
 	/// The server's "add links via Share" help page, discovered from the queue's
 	/// Siren links. Drives the + sheet's webview; nil until the queue advertises it.
 	@Published private(set) var addLinksHelpURL: URL?
+
+	/// The collection-level controls the toolbar renders, one per advertised
+	/// affordance (actions + navigable links) the server returned. The toolbar
+	/// iterates this — it never consults a per-capability boolean — so a
+	/// newly-advertised collection affordance renders with no client change.
+	@Published private(set) var collectionAffordances: [Affordance] = []
 
 	private var nextHref: String?
 	private var isLoadingMore = false
@@ -65,17 +72,42 @@ final class ReadingListViewModel: ObservableObject {
 		isLoadingMore = false
 	}
 
-	func markAsRead(_ article: Article) async {
-		guard let action = article.updateStatusAction else { return }
+	/// Invokes one of an item's advertised actions via the action's own
+	/// href/method/fields. The client supplies no field knowledge: every declared
+	/// field's server-suggested `value` is posted by the generic invoker, so a bare
+	/// (action, item) invocation is sufficient — `update-status` carries its target
+	/// status as the field `value`, not a client constant. Whether the row leaves
+	/// the unread-only list is derived from that transition, not the action name:
+	/// `delete` always removes, an `update-status` toggle removes only when its
+	/// `status` value is `read` (a toggle back to `unread` leaves the row), and any
+	/// other action leaves the list untouched for the next load to reconcile. A row
+	/// that removes drops optimistically and the server confirms; a failed removal
+	/// restores the snapshot and surfaces the error.
+	func invoke(_ action: SirenAction, on article: Article) async {
+		let removesItem = Affordance(action: action)?.removesItemFromUnreadList ?? false
 		let snapshot = articles
-		// Optimistically drop the row, then confirm with the server. Nothing is
-		// re-applied on success, so the pagination cursor (nextHref/hasMore)
-		// survives; a failure restores the snapshot and surfaces the error.
-		articles.removeAll { $0.id == article.id }
+		// Optimistically drop the row only for an item-removing action, then confirm
+		// with the server. Nothing is re-applied on success, so the pagination cursor
+		// (nextHref/hasMore) survives; a failure restores the snapshot.
+		if removesItem { articles.removeAll { $0.id == article.id } }
 		do {
-			try await api.updateStatus(action: action, status: .read)
+			try await api.invoke(action: action)
 		} catch {
-			articles = snapshot
+			if removesItem { articles = snapshot }
+			handle(error)
+		}
+	}
+
+	/// Invokes a collection-level action via its own href/method/type/fields through
+	/// the generic invoker — the bare-invokable toolbar control path. The action
+	/// carries no row, so nothing is dropped optimistically; the server is the source
+	/// of truth, so a successful invoke reloads the collection to reflect the new
+	/// state. A failure surfaces the error and leaves the current list in place.
+	func invokeCollection(_ action: SirenAction) async {
+		do {
+			try await api.invoke(action: action)
+			await fetchFirstPage()
+		} catch {
 			handle(error)
 		}
 	}
@@ -96,6 +128,18 @@ final class ReadingListViewModel: ObservableObject {
 		readerPresentation = ReaderPresentation(readerURL: url, articleId: article.id)
 	}
 
+	/// Follows a navigable collection-level link (e.g. a `save` link) by opening
+	/// its resolved href in the same in-app web view the reader uses. A link the
+	/// client can't resolve (missing or foreign-scheme href) is a no-op, so an
+	/// unactionable link advertised by the server never opens a blank sheet. No
+	/// row is associated, so the web sheet drops nothing when it closes.
+	func open(link: SirenLink) {
+		guard let href = link.href,
+			let url = Href.resolve(href, baseURL: api.baseURL)
+		else { return }
+		readerPresentation = ReaderPresentation(readerURL: url, articleId: nil)
+	}
+
 	/// Mints the cookie session the reader webview needs from the current bearer.
 	/// Returns nil and surfaces the error when the bootstrap fails, so the reader
 	/// sheet can show its unavailable view instead of a blank page.
@@ -105,6 +149,25 @@ final class ReadingListViewModel: ObservableObject {
 		} catch {
 			handle(error)
 			return nil
+		}
+	}
+
+	/// Saves a user-typed URL via the supplied `save-article` action. This is the
+	/// sanctioned bespoke handler: the action's body carries a URL the user enters
+	/// in a native dialog, so the toolbar routes the `save-article` control here
+	/// rather than through the generic link-open path. The action is the one the
+	/// toolbar control carried, so it is followed (href/method) rather than
+	/// rediscovered by name.
+	func saveURL(_ rawURL: String, action: SirenAction) async {
+		let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !trimmed.isEmpty else { return }
+		errorText = nil
+		messages = []
+		do {
+			_ = try await api.saveArticle(action: action, url: trimmed)
+			await fetchFirstPage()
+		} catch {
+			handle(error)
 		}
 	}
 
@@ -122,6 +185,19 @@ final class ReadingListViewModel: ObservableObject {
 		if let href = page.addLinksHelpHref, let url = Href.resolve(href, baseURL: api.baseURL) {
 			addLinksHelpURL = url
 		}
+		// The toolbar renders a client-derived subset of the advertised affordances:
+		// each one the client can present as a toolbar control, dropping the rest by
+		// their presentation (a structural navigation link the client follows itself
+		// for pagination/identity, or a capture-only save reachable only via the
+		// Share Sheet) — not by name-gating a known capability. The toolbar is sourced
+		// from the replacing (first-page) load only: that load is the current
+		// collection, so its subset is the current toolbar. A paginated page only
+		// appends rows, so it neither clears the controls when it advertises none nor
+		// flaps them to a page-scoped set — the first page owns the toolbar for the
+		// whole scroll.
+		if replacing {
+			collectionAffordances = page.affordances.filter(\.isToolbarControl)
+		}
 		warningText = page.warning?.message
 	}
 
@@ -137,11 +213,14 @@ final class ReadingListViewModel: ObservableObject {
 	}
 }
 
-/// What the reader sheet needs to present one article: the resolved reader URL
-/// and the article id (so its row can be dropped if the reader marks it read).
-/// `Identifiable` drives `.sheet(item:)`.
+/// What the in-app web sheet needs to present a server URL: the resolved URL and,
+/// for a reader opened from a row, that row's id (so the row can be dropped if the
+/// reader marks it read). A navigable collection link (e.g. `save`) carries no
+/// row, so `articleId` is nil and nothing is dropped on close. `Identifiable`
+/// drives `.sheet(item:)`; the id falls back to the URL so a row-less sheet is
+/// still uniquely presentable.
 struct ReaderPresentation: Identifiable {
 	let readerURL: URL
-	let articleId: String
-	var id: String { articleId }
+	let articleId: String?
+	var id: String { articleId ?? readerURL.absoluteString }
 }

--- a/projects/ios-readplace/App/ToolbarRoute.swift
+++ b/projects/ios-readplace/App/ToolbarRoute.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The side effect a tapped collection-toolbar control resolves to, decided
+/// purely from the affordance's advertised invocation. Keeping the decision in a
+/// pure value (rather than inline in the view) lets the routing be unit-tested
+/// without a SwiftUI host.
+enum ToolbarRoute: Equatable {
+	/// Follow a navigable link by opening its href in the in-app web view — the app
+	/// acting as a browser over the contract. Reserved for navigable LINKS, never an
+	/// action: an action is a capability the client submits, not a page it browses to.
+	case open(SirenLink)
+	/// Prompt the user for a URL in the native dialog, then save via this action.
+	/// The `save-article` body is a URL the user types — a field with no server value
+	/// — so it routes to the sanctioned bespoke handler rather than the generic
+	/// invoker.
+	case promptSave(SirenAction)
+	/// Invoke the action through the generic invoker, honouring its own
+	/// method/type/fields/value. A bare-invokable collection action carries everything
+	/// the request needs (the server fills each declared field's `value`), so it is
+	/// submitted in place rather than opened as a GET web view of its href.
+	case invoke(SirenAction)
+
+	/// Routes an affordance: a navigable link opens; the `save-article` action prompts
+	/// for a URL (the field the server cannot value); any other action is invoked
+	/// through the generic invoker. An action is never opened as a GET web view of its
+	/// href — that would discard its method/type/fields and silently turn a capability
+	/// into navigation. The decision maps each affordance to an effect without gating
+	/// which controls exist.
+	static func route(for affordance: Affordance) -> ToolbarRoute {
+		switch affordance.invocation {
+		case let .link(link):
+			return .open(link)
+		case let .action(action) where Affordance.isBespokeFieldHandler(action.name):
+			return .promptSave(action)
+		case let .action(action):
+			return .invoke(action)
+		}
+	}
+}
+
+extension SirenLink: Equatable {
+	static func == (lhs: SirenLink, rhs: SirenLink) -> Bool {
+		lhs.rel == rhs.rel && lhs.href == rhs.href && lhs.title == rhs.title
+	}
+}
+
+extension SirenAction: Equatable {
+	static func == (lhs: SirenAction, rhs: SirenAction) -> Bool {
+		lhs.name == rhs.name && lhs.href == rhs.href && lhs.method == rhs.method && lhs.title == rhs.title
+	}
+}

--- a/projects/ios-readplace/Shared/ReadplaceAPI.swift
+++ b/projects/ios-readplace/Shared/ReadplaceAPI.swift
@@ -8,6 +8,11 @@ enum APIError: LocalizedError {
 	/// Carries the server-authored messages; the refusal models no action — there
 	/// is nothing for the client to invoke, only something for the user to read.
 	case refused(messages: [ServerMessage])
+	/// The response carried a body in a media type the client doesn't speak (not
+	/// the negotiated Siren type). Surfaced honestly rather than blind-decoded — a
+	/// proxy login page or a future media type is "I don't understand this," not a
+	/// generic "couldn't read the response."
+	case unsupportedMediaType(String?)
 	case decoding
 
 	var errorDescription: String? {
@@ -17,6 +22,7 @@ enum APIError: LocalizedError {
 		case .server(let status, let code, let message):
 			return message ?? "Server error \(status)\(code.map { " (\($0))" } ?? "")."
 		case .refused(let messages): return messages.map(\.plainText).joined(separator: "\n")
+		case .unsupportedMediaType: return "The server replied in a format this app doesn't understand."
 		case .decoding: return "Could not read the server response."
 		}
 	}
@@ -33,20 +39,41 @@ struct QueuePage {
 	/// collection so the iOS client discovers it rather than hardcoding the path.
 	let addLinksHelpHref: String?
 	let total: Int?
-	let saveArticleAction: SirenAction?
-	let saveHtmlAction: SirenAction?
+	/// Every collection-level action and navigable link the server advertised, in
+	/// wire order — the complete set, so the share-sheet save journey can still find
+	/// its bespoke action by name (`action(named:)`, below). The toolbar does not
+	/// render this set verbatim: it derives its own subset client-side
+	/// (`toolbarAffordances`) by mapping each affordance's wire token to its
+	/// presentation and dropping the ones it can't present as a toolbar control —
+	/// a structural navigation link the client follows itself, or a capture-only
+	/// save iOS can only reach through the Share Sheet.
+	let affordances: [Affordance]
 	let warning: SirenWarning?
 
 	init(collection: SirenCollection) {
 		articles = (collection.entities ?? []).compactMap(Article.init(entity:))
-		selfHref = collection.links?.first { $0.rel.contains("self") }?.href
-		nextHref = collection.links?.first { $0.rel.contains("next") }?.href
-		prevHref = collection.links?.first { $0.rel.contains("prev") }?.href
-		addLinksHelpHref = collection.links?.first { $0.rel.contains("add-links-help") }?.href
+		let links = collection.links ?? []
+		selfHref = links.first { $0.rel.contains("self") }?.href
+		nextHref = links.first { $0.rel.contains("next") }?.href
+		prevHref = links.first { $0.rel.contains("prev") }?.href
+		addLinksHelpHref = links.first { $0.rel.contains("add-links-help") }?.href
 		total = collection.properties?.total
-		saveArticleAction = collection.actions?.first { $0.name == "save-article" }
-		saveHtmlAction = collection.actions?.first { $0.name == "save-html" }
+		let actionAffordances = (collection.actions ?? []).compactMap(Affordance.init(action:))
+		let linkAffordances = links.compactMap(Affordance.init(link:))
+		affordances = actionAffordances + linkAffordances
 		warning = collection.properties?.warning
+	}
+
+	/// The advertised action with this name, when present and invokable. The
+	/// share-sheet save journey needs a specific action to build its bespoke body
+	/// (a captured-HTML or URL-only POST), which is the contract's sanctioned
+	/// exception for actions with special bodies — distinct from the looped
+	/// toolbar rendering, which never selects an affordance by name.
+	func action(named name: String) -> SirenAction? {
+		for affordance in affordances {
+			if let action = affordance.action, action.name == name { return action }
+		}
+		return nil
 	}
 }
 
@@ -95,21 +122,29 @@ final class ReadplaceAPI {
 		request.httpMethod = "GET"
 		let (data, http) = try await send(request)
 		guard http.statusCode == 200 else { throw apiError(from: data, status: http.statusCode) }
-		return QueuePage(collection: try decode(SirenCollection.self, data))
+		return QueuePage(collection: try decodeSiren(SirenCollection.self, data: data, response: http))
 	}
 
-	/// Changes an item's reading status via its server-declared action — the
-	/// action carries the href, method and field set the client follows rather
-	/// than hand-building. The status is sent as the `status` field. The response
-	/// is verified at the protocol level only: a successful follow (a 2xx/3xx,
-	/// after the redirect-preserving delegate re-attaches auth across any
-	/// redirect) confirms the change; anything else surfaces as a server error.
-	/// The body is deliberately not consumed, so a caller's optimistic update is
-	/// never rolled back by a 2xx whose shape this method doesn't read.
-	func updateStatus(action: SirenAction, status: ArticleStatus) async throws {
+	/// Invokes a simple entity action via its own server-declared href, method and
+	/// type — the single generic path for actions whose body is a flat field set
+	/// (e.g. `update-status`, `delete`), so a newly-advertised entity action is
+	/// invokable with no new per-operation code. The caller supplies values only
+	/// for the field names whose semantics the protocol fixes (`status`); the
+	/// action's own declared field defaults fill the rest, and a field the caller
+	/// neither supplies nor the server defaults is simply omitted. The body is
+	/// verified at the protocol level only: a successful follow (a 2xx/3xx, after
+	/// the redirect-preserving delegate re-attaches auth across any redirect)
+	/// confirms it; anything else surfaces as a server error. The response body is
+	/// deliberately not consumed, so a caller's optimistic update is never rolled
+	/// back by a 2xx whose shape this method doesn't read.
+	func invoke(action: SirenAction, values: [String: String] = [:]) async throws {
+		var fields = values
+		for declared in action.fields ?? [] where fields[declared.name] == nil {
+			if let value = declared.value { fields[declared.name] = value }
+		}
 		let request = formRequest(try absoluteURL(action.href), method: action.method,
 			contentType: action.type ?? "application/x-www-form-urlencoded",
-			fields: ["status": status.rawValue])
+			fields: fields)
 		let (data, http) = try await send(request)
 		guard (200...399).contains(http.statusCode) else {
 			throw apiError(from: data, status: http.statusCode)
@@ -157,23 +192,32 @@ final class ReadplaceAPI {
 
 	// MARK: - Saving
 
-	/// Saves a page using its pre-rendered HTML via the `save-html` action.
-	/// On an error body that carries a fallback action (e.g. the payload is too
-	/// large), it degrades to the URL-only path — dropping `rawHtml` — exactly
-	/// like the extension client does.
+	/// The article a save produced, plus whether the captured HTML reached the
+	/// server or the request fell back to the URL-only path the server advertised.
+	struct SaveResult {
+		let article: Article
+		let usedFallback: Bool
+	}
+
+	/// Saves a page using its pre-rendered HTML via the supplied action. On an
+	/// error body that carries a fallback action (the server's chosen URL-only
+	/// path, e.g. when the payload exceeds the server's cap), it follows that
+	/// action — dropping `rawHtml` — exactly like the extension client does. The
+	/// client never decides itself whether the HTML is acceptable; it attempts the
+	/// save and follows the server's refusal.
 	func saveHTML(
 		action: SirenAction,
 		url: String,
 		rawHtml: String,
 		title: String?
-	) async throws -> Article {
+	) async throws -> SaveResult {
 		var body: [String: String] = ["url": url, "rawHtml": rawHtml]
 		if let title, !title.isEmpty { body["title"] = title }
 		let request = jsonRequest(try absoluteURL(action.href), method: action.method,
 			contentType: action.type ?? "application/json", body: body)
 		let (data, http) = try await send(request)
 		if http.statusCode == 201 || http.statusCode == 200 {
-			return try decodeArticle(data)
+			return SaveResult(article: try decodeArticle(data, response: http), usedFallback: false)
 		}
 		// The server may refuse with messages for the client to render (e.g. a
 		// locked account). Surface them as .refused before the fallback below, so
@@ -189,7 +233,7 @@ final class ReadplaceAPI {
 			guard fbHTTP.statusCode == 201 || fbHTTP.statusCode == 200 else {
 				throw apiError(from: fbData, status: fbHTTP.statusCode)
 			}
-			return try decodeArticle(fbData)
+			return SaveResult(article: try decodeArticle(fbData, response: fbHTTP), usedFallback: true)
 		}
 		throw apiError(from: data, status: http.statusCode)
 	}
@@ -203,7 +247,7 @@ final class ReadplaceAPI {
 		guard http.statusCode == 201 || http.statusCode == 200 else {
 			throw apiError(from: data, status: http.statusCode)
 		}
-		return try decodeArticle(data)
+		return try decodeArticle(data, response: http)
 	}
 
 	// MARK: - Transport
@@ -245,11 +289,27 @@ final class ReadplaceAPI {
 		contentType: String,
 		fields: [String: String]
 	) -> URLRequest {
+		let queryItems = fields.map { URLQueryItem(name: $0.key, value: $0.value) }
+		// A GET carries no body — the field values are the query string, so encode
+		// them onto the URL and send no Content-Type. POST/other methods form-encode
+		// the same values into the body per the action's declared `type`.
+		if method.uppercased() == "GET" {
+			guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+				preconditionFailure("absoluteURL produced a URL that does not parse as components: \(url)")
+			}
+			components.queryItems = queryItems
+			guard let queried = components.url else {
+				preconditionFailure("query items did not produce a valid URL for: \(url)")
+			}
+			var request = URLRequest(url: queried)
+			request.httpMethod = method
+			return request
+		}
 		var request = URLRequest(url: url)
 		request.httpMethod = method
 		request.setValue(contentType, forHTTPHeaderField: "Content-Type")
 		var components = URLComponents()
-		components.queryItems = fields.map { URLQueryItem(name: $0.key, value: $0.value) }
+		components.queryItems = queryItems
 		request.httpBody = components.percentEncodedQuery.map { Data($0.utf8) }
 		return request
 	}
@@ -262,13 +322,27 @@ final class ReadplaceAPI {
 		return url
 	}
 
-	private func decode<T: Decodable>(_ type: T.Type, _ data: Data) throws -> T {
+	/// Decodes a body the client negotiated as Siren, verifying the response's
+	/// media type first. A 200/201 carrying anything but the negotiated Siren type
+	/// (a proxy HTML page, a future media type) is surfaced as
+	/// `.unsupportedMediaType` rather than blind-decoded into a decode failure.
+	private func decodeSiren<T: Decodable>(_ type: T.Type, data: Data, response: HTTPURLResponse) throws -> T {
+		let contentType = response.value(forHTTPHeaderField: "Content-Type")
+		guard isSirenMediaType(contentType) else { throw APIError.unsupportedMediaType(contentType) }
 		guard let value = try? JSONDecoder().decode(type, from: data) else { throw APIError.decoding }
 		return value
 	}
 
-	private func decodeArticle(_ data: Data) throws -> Article {
-		let entity = try decode(SirenEntity.self, data)
+	/// Whether a `Content-Type` header is the negotiated Siren media type, ignoring
+	/// any `;charset=…` parameters and surrounding case.
+	private func isSirenMediaType(_ header: String?) -> Bool {
+		guard let header else { return false }
+		let essence = header.split(separator: ";").first.map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+		return essence == AppConfig.sirenMediaType
+	}
+
+	private func decodeArticle(_ data: Data, response: HTTPURLResponse) throws -> Article {
+		let entity = try decodeSiren(SirenEntity.self, data: data, response: response)
 		guard let article = Article(entity: entity) else { throw APIError.decoding }
 		return article
 	}
@@ -302,9 +376,10 @@ final class ReadplaceAPI {
 
 /// Re-attaches `Authorization`, `Accept` and `X-Readplace-Client` to redirected
 /// requests. URLSession strips `Authorization` on cross-origin redirects and may
-/// drop custom headers generally; the entry point `GET /` → `303 /queue` needs
-/// them preserved (the client header so onboarding step 1 is recorded on the
-/// post-redirect `/queue` load).
+/// drop custom headers generally; the server bounces the client from the entry
+/// point to the collection, so the followed redirect must keep them to stay
+/// authenticated and keep negotiating Siren (the client header so onboarding
+/// step 1 is recorded on the post-redirect `/queue` load).
 private final class RedirectHeaderPreservingDelegate: NSObject, URLSessionTaskDelegate {
 	func urlSession(
 		_ session: URLSession,

--- a/projects/ios-readplace/Shared/ReadplaceAPI.swift
+++ b/projects/ios-readplace/Shared/ReadplaceAPI.swift
@@ -142,9 +142,7 @@ final class ReadplaceAPI {
 		for declared in action.fields ?? [] where fields[declared.name] == nil {
 			if let value = declared.value { fields[declared.name] = value }
 		}
-		let request = formRequest(try absoluteURL(action.href), method: action.method,
-			contentType: action.type ?? "application/x-www-form-urlencoded",
-			fields: fields)
+		let request = try invocationRequest(for: action, fields: fields)
 		let (data, http) = try await send(request)
 		guard (200...399).contains(http.statusCode) else {
 			throw apiError(from: data, status: http.statusCode)
@@ -314,6 +312,21 @@ final class ReadplaceAPI {
 		return request
 	}
 
+	/// Builds the request for a generic action invocation, keeping the body in step
+	/// with the action's declared `type`: a GET carries the fields as query items
+	/// (no body); an `application/json` action sends a JSON body; any other type
+	/// form-encodes the body. The contract ties the encoding to the declared
+	/// `type`, so a JSON action must not ship a form-encoded body under a JSON
+	/// `Content-Type` header.
+	private func invocationRequest(for action: SirenAction, fields: [String: String]) throws -> URLRequest {
+		let url = try absoluteURL(action.href)
+		let type = action.type ?? "application/x-www-form-urlencoded"
+		if action.method.uppercased() != "GET", mediaTypeEssence(type) == "application/json" {
+			return jsonRequest(url, method: action.method, contentType: type, body: fields)
+		}
+		return formRequest(url, method: action.method, contentType: type, fields: fields)
+	}
+
 	/// Resolves a server-declared href to an absolute URL, throwing when the href
 	/// is missing or names a scheme the client doesn't act on — an action the
 	/// client can't follow is a decode-level failure, not a silent no-op.
@@ -336,9 +349,15 @@ final class ReadplaceAPI {
 	/// Whether a `Content-Type` header is the negotiated Siren media type, ignoring
 	/// any `;charset=…` parameters and surrounding case.
 	private func isSirenMediaType(_ header: String?) -> Bool {
-		guard let header else { return false }
-		let essence = header.split(separator: ";").first.map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
-		return essence == AppConfig.sirenMediaType
+		mediaTypeEssence(header) == AppConfig.sirenMediaType
+	}
+
+	/// The lowercased media type without parameters — `application/json; charset=utf-8`
+	/// → `application/json` — or nil when the header is absent. One parser keeps the
+	/// Siren-type check and the JSON-body routing comparing the same essence.
+	private func mediaTypeEssence(_ header: String?) -> String? {
+		guard let header else { return nil }
+		return header.split(separator: ";").first.map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
 	}
 
 	private func decodeArticle(_ data: Data, response: HTTPURLResponse) throws -> Article {

--- a/projects/ios-readplace/Shared/SaveSharedPage.swift
+++ b/projects/ios-readplace/Shared/SaveSharedPage.swift
@@ -24,17 +24,15 @@ protocol HTMLCapturing {
 /// decision tree runs against the real API and token types under test — only the
 /// UIKit shell and the WKWebView are left behind in the extension target.
 ///
-/// Capture the page → list the queue → if HTML is present and under the server's
-/// cap, `save-html` (with content); otherwise `save-article` (URL only); if the
-/// server offered neither, give up.
+/// Capture the page → list the queue → when HTML was captured, attempt the
+/// content save and let the server decide (it routes an over-its-cap payload to
+/// the URL-only fallback it advertises); when no HTML was captured, save the URL
+/// only; if the server offered no save action, give up.
 @MainActor
 struct SaveSharedPage {
 	let store: TokenStore
 	let api: ReadplaceAPI
 	let captor: HTMLCapturing
-	/// Mirrors the server's `MAX_RAW_HTML_BYTES` (10 MiB). Above this the server
-	/// would reject the payload, so we skip straight to the URL-only path.
-	var maxRawHTMLBytes = 10 * 1024 * 1024
 
 	func run(url: URL?, fallbackTitle: String?) async -> SaveSharedOutcome {
 		guard store.isLoggedIn else { return .notLoggedIn }
@@ -47,11 +45,10 @@ struct SaveSharedPage {
 			let page = try await api.loadQueue()
 			let urlString = url.absoluteString
 
-			if let html = captured.rawHtml, html.utf8.count <= maxRawHTMLBytes,
-				let action = page.saveHtmlAction {
-				_ = try await api.saveHTML(action: action, url: urlString, rawHtml: html, title: title)
-				return .savedWithContent
-			} else if let action = page.saveArticleAction {
+			if let html = captured.rawHtml, let action = page.action(named: "save-html") {
+				let result = try await api.saveHTML(action: action, url: urlString, rawHtml: html, title: title)
+				return result.usedFallback ? .savedLinkOnly : .savedWithContent
+			} else if let action = page.action(named: "save-article") {
 				_ = try await api.saveArticle(action: action, url: urlString)
 				return .savedLinkOnly
 			} else {

--- a/projects/ios-readplace/Shared/SirenModels.swift
+++ b/projects/ios-readplace/Shared/SirenModels.swift
@@ -1,5 +1,39 @@
 import Foundation
 
+// MARK: - Lenient decoding
+
+/// Decodes a single value, capturing `nil` instead of throwing when the value is
+/// malformed. Used to decode arrays element-by-element so one bad element is
+/// dropped rather than failing the whole array.
+private struct FailableDecodable<Wrapped: Decodable>: Decodable {
+	let wrapped: Wrapped?
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.singleValueContainer()
+		wrapped = try? container.decode(Wrapped.self)
+	}
+}
+
+private extension KeyedDecodingContainer {
+	/// Decodes the array under `key` leniently: a missing, null, or non-array value
+	/// yields `nil`, and each element is decoded independently so a single malformed
+	/// element is dropped rather than failing the whole array. The Siren contract
+	/// requires one malformed link/action/entity to degrade to unactionable, never
+	/// blank the whole response.
+	func decodeLossyArrayIfPresent<Element: Decodable>(
+		_ type: Element.Type,
+		forKey key: Key
+	) throws -> [Element]? {
+		guard var unkeyed = try? nestedUnkeyedContainer(forKey: key) else { return nil }
+		var elements: [Element] = []
+		while !unkeyed.isAtEnd {
+			let element = try unkeyed.decode(FailableDecodable<Element>.self)
+			if let value = element.wrapped { elements.append(value) }
+		}
+		return elements
+	}
+}
+
 // MARK: - Wire format (Siren)
 
 /// A hypermedia link. `href` is optional: a link advertised without one is kept
@@ -51,8 +85,10 @@ struct SirenField: Decodable {
 /// A Siren action: the server declares its href, method, type and fields and the
 /// client follows them rather than constructing a request. `href` is optional so
 /// an action advertised without one decodes and is simply treated as
-/// unactionable. `title` is the server's human label, which the client uses
-/// verbatim as the control's label and accessibility text.
+/// unactionable. `method` is optional on the wire — a method-less action defaults
+/// to `GET` (the Siren default) rather than failing the decode. `title` is the
+/// server's human label, which the client uses verbatim as the control's label
+/// and accessibility text.
 struct SirenAction: Decodable {
 	let name: String
 	let href: String?
@@ -60,6 +96,25 @@ struct SirenAction: Decodable {
 	let title: String?
 	let type: String?
 	let fields: [SirenField]?
+}
+
+extension SirenAction {
+	private enum CodingKeys: String, CodingKey {
+		case name, href, method, title, type, fields
+	}
+
+	/// Decoded leniently so an evolving action degrades rather than blanking the
+	/// surrounding collection: `method` defaults to `GET` (the Siren default) when
+	/// omitted, and a malformed field is dropped rather than failing the action.
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		name = try container.decode(String.self, forKey: .name)
+		href = try container.decodeIfPresent(String.self, forKey: .href)
+		method = try container.decodeIfPresent(String.self, forKey: .method) ?? "GET"
+		title = try container.decodeIfPresent(String.self, forKey: .title)
+		type = try container.decodeIfPresent(String.self, forKey: .type)
+		fields = try container.decodeLossyArrayIfPresent(SirenField.self, forKey: .fields)
+	}
 }
 
 /// The properties of an article entity. Everything except `id`/`url` is
@@ -87,6 +142,24 @@ struct SirenEntity: Decodable {
 	let actions: [SirenAction]?
 }
 
+extension SirenEntity {
+	private enum CodingKeys: String, CodingKey {
+		case `class`, rel, properties, links, actions
+	}
+
+	/// Decodes the control arrays leniently so one malformed link or action drops
+	/// to unactionable instead of failing the whole entity (and, in turn, the
+	/// collection that contains it).
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		`class` = try container.decodeIfPresent([String].self, forKey: .class)
+		rel = try container.decodeIfPresent([String].self, forKey: .rel)
+		properties = try container.decodeIfPresent(ArticleProperties.self, forKey: .properties)
+		links = try container.decodeLossyArrayIfPresent(SirenLink.self, forKey: .links)
+		actions = try container.decodeLossyArrayIfPresent(SirenAction.self, forKey: .actions)
+	}
+}
+
 struct CollectionProperties: Decodable {
 	let total: Int?
 	let page: Int?
@@ -107,6 +180,25 @@ struct SirenCollection: Decodable {
 	let entities: [SirenEntity]?
 	let links: [SirenLink]?
 	let actions: [SirenAction]?
+}
+
+extension SirenCollection {
+	private enum CodingKeys: String, CodingKey {
+		case `class`, properties, entities, links, actions
+	}
+
+	/// Decodes the entity and control arrays leniently so a single malformed
+	/// entity, link, or action is dropped rather than blanking the whole page —
+	/// the page now loops every advertised control, so atomic decoding would let
+	/// one bad element take down the entire collection.
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		`class` = try container.decodeIfPresent([String].self, forKey: .class)
+		properties = try container.decodeIfPresent(CollectionProperties.self, forKey: .properties)
+		entities = try container.decodeLossyArrayIfPresent(SirenEntity.self, forKey: .entities)
+		links = try container.decodeLossyArrayIfPresent(SirenLink.self, forKey: .links)
+		actions = try container.decodeLossyArrayIfPresent(SirenAction.self, forKey: .actions)
+	}
 }
 
 /// A server-authored message a client renders generically — it carries no

--- a/projects/ios-readplace/Shared/SirenModels.swift
+++ b/projects/ios-readplace/Shared/SirenModels.swift
@@ -4,29 +4,60 @@ import Foundation
 
 /// A hypermedia link. `href` is optional: a link advertised without one is kept
 /// but unactionable — the client follows only the hrefs it is given — so a
-/// partial or evolving link never fails the surrounding decode.
+/// partial or evolving link never fails the surrounding decode. `title` is the
+/// server's human label for the link, which the client uses verbatim as the
+/// control's label and accessibility text.
 struct SirenLink: Decodable {
 	let rel: [String]
 	let href: String?
+	let title: String?
 }
 
 /// One field of an action. `value` is the server's pre-filled default, when
 /// present; the field `name` is part of the protocol vocabulary the client keys
-/// on (e.g. `status`).
+/// on (e.g. `status`). The value is always carried as a string because the generic
+/// invoker posts it form-/JSON-encoded, but the server may declare it as a JSON
+/// number (e.g. a numeric `page` or `limit`); such a value is coerced to its string
+/// form on decode so it isn't dropped.
 struct SirenField: Decodable {
 	let name: String
 	let type: String?
 	let value: String?
+
+	init(name: String, type: String?, value: String?) {
+		self.name = name
+		self.type = type
+		self.value = value
+	}
+
+	private enum CodingKeys: String, CodingKey { case name, type, value }
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		name = try container.decode(String.self, forKey: .name)
+		type = try container.decodeIfPresent(String.self, forKey: .type)
+		if let string = try? container.decodeIfPresent(String.self, forKey: .value) {
+			value = string
+		} else if let number = try? container.decodeIfPresent(Double.self, forKey: .value) {
+			// A whole number decodes as a Double, so render it without a trailing
+			// ".0" — the server's "page": 2 must post as "2", not "2.0".
+			value = number == number.rounded() ? String(Int(number)) : String(number)
+		} else {
+			value = nil
+		}
+	}
 }
 
 /// A Siren action: the server declares its href, method, type and fields and the
 /// client follows them rather than constructing a request. `href` is optional so
 /// an action advertised without one decodes and is simply treated as
-/// unactionable.
+/// unactionable. `title` is the server's human label, which the client uses
+/// verbatim as the control's label and accessibility text.
 struct SirenAction: Decodable {
 	let name: String
 	let href: String?
 	let method: String
+	let title: String?
 	let type: String?
 	let fields: [SirenField]?
 }
@@ -197,13 +228,6 @@ struct SirenError: Decodable {
 
 // MARK: - Domain model for the UI
 
-/// A reading status the client can set. The raw value is sent as the `status`
-/// field of the server-declared status action.
-enum ArticleStatus: String {
-	case unread
-	case read
-}
-
 /// A saved article, flattened from a Siren entity for display and actions.
 struct Article: Identifiable, Hashable {
 	let id: String
@@ -215,12 +239,15 @@ struct Article: Identifiable, Hashable {
 	let readTimeMinutes: Int?
 	let isRead: Bool
 	let savedAt: Date?
-	/// The server-declared action for changing this item's reading status, stored
-	/// whole so its href/method/fields are followed rather than hand-built. Absent
-	/// or href-less ⇒ the item is read-only (see `canMarkRead`).
-	let updateStatusAction: SirenAction?
-	/// The href of the server-declared link for reading this item. Absent ⇒ the
-	/// row is not openable.
+	/// Every action the server advertised on this item (e.g. `update-status`,
+	/// `delete`), in the order the server listed them. The row renders one control
+	/// per actionable entry by iterating this — it never cherry-picks an action by
+	/// name — so a newly-advertised item action renders with no client change.
+	let actions: [SirenAction]
+	/// The href of the server-declared link for reading this item, followed when
+	/// the row is tapped. Absent ⇒ the row is not openable. This follows the
+	/// navigable `read` link (the row's primary tap target), distinct from the
+	/// action controls iterated above.
 	let readHref: String?
 
 	static func == (lhs: Article, rhs: Article) -> Bool { lhs.id == rhs.id }
@@ -228,10 +255,10 @@ struct Article: Identifiable, Hashable {
 }
 
 extension Article {
-	/// Whether the server left a usable status-change action on this item. A
-	/// missing action — or one advertised without an href — is unactionable, so
-	/// the row offers no mark-read affordance.
-	var canMarkRead: Bool { updateStatusAction?.href != nil }
+	/// The item's action controls, one per advertised action the client can
+	/// invoke (an action with a usable href). Built by iterating — not by matching
+	/// a known name — so the loop renders whatever the server offered.
+	var affordances: [Affordance] { actions.compactMap(Affordance.init(action:)) }
 
 	/// Builds a display model from a Siren entity, or returns nil when the
 	/// entity has no usable properties.
@@ -250,8 +277,80 @@ extension Article {
 		readTimeMinutes = props.estimatedReadTimeMinutes
 		isRead = props.status == "read" || props.readAt != nil
 		savedAt = props.savedAt.flatMap(SirenDate.parse)
-		updateStatusAction = entity.actions?.first { $0.name == "update-status" }
+		actions = entity.actions ?? []
 		readHref = entity.links?.first { $0.rel.contains("read") }?.href
+	}
+}
+
+/// One advertised control the client renders — either a Siren action it invokes
+/// (via the action's own href/method/fields) or a navigable link it opens. The
+/// client renders one of these per advertised affordance by iterating the
+/// response; it never gates a control behind a per-capability boolean. The label
+/// is the server's `title`; presentation (icon, tint, role) is derived entirely
+/// client-side from the action `name` / link `rel`, so an unknown affordance
+/// still renders with a default presentation rather than vanishing.
+struct Affordance: Identifiable {
+	/// How the client invokes the affordance: a Siren action it submits, or a
+	/// navigable link it opens.
+	enum Invocation {
+		case action(SirenAction)
+		case link(SirenLink)
+	}
+
+	let invocation: Invocation
+	/// The wire vocabulary the client maps to its own presentation — an action
+	/// `name` or a link's first `rel`. Never used as a style string verbatim.
+	let token: String
+	/// The server's human label, used verbatim as the control's text and
+	/// accessibility label. Falls back to a humanized token when the server sent no
+	/// `title`, so a label-less affordance still renders a readable control instead
+	/// of a raw wire slug.
+	let label: String
+	/// Stable across re-renders so SwiftUI can diff a list of controls.
+	let id: String
+
+	/// Builds a control from an action, or nil when the action has no usable href
+	/// (an unactionable action produces no control — no phantom affordance).
+	init?(action: SirenAction) {
+		guard action.href != nil else { return nil }
+		invocation = .action(action)
+		token = action.name
+		label = action.title ?? Affordance.humanize(action.name)
+		id = "action:\(action.name)"
+	}
+
+	/// Builds a control from a navigable link, or nil when the link has no href or
+	/// no rel the client can key its presentation on.
+	init?(link: SirenLink) {
+		guard link.href != nil, let rel = link.rel.first else { return nil }
+		invocation = .link(link)
+		token = rel
+		label = link.title ?? Affordance.humanize(rel)
+		id = "link:\(rel)"
+	}
+
+	/// Turns a wire token (`mark-read`, `archive_now`) into a human label when the
+	/// server advertised no `title`: split on `-`/`_`, drop empty segments, then
+	/// Title-Case each word so an unlabelled affordance renders a readable control
+	/// instead of a raw slug. Mirrors the browser extension's `humanize` so the same
+	/// token reads identically across clients.
+	static func humanize(_ token: String) -> String {
+		token
+			.split(whereSeparator: { $0 == "-" || $0 == "_" })
+			.map { $0.prefix(1).uppercased() + String($0.dropFirst()) }
+			.joined(separator: " ")
+	}
+
+	/// The action this control invokes, or nil when it is a navigable link.
+	var action: SirenAction? {
+		guard case let .action(action) = invocation else { return nil }
+		return action
+	}
+
+	/// The navigable link this control opens, or nil when it is an action.
+	var link: SirenLink? {
+		guard case let .link(link) = invocation else { return nil }
+		return link
 	}
 }
 

--- a/projects/ios-readplace/Tests/AffordancePresentationTests.swift
+++ b/projects/ios-readplace/Tests/AffordancePresentationTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import Readplace
+
+/// Presentation is 100% a client concern: each known wire token maps to the
+/// client's own icon/tint/role, and an unknown token falls back to a neutral
+/// default so an affordance the client has never seen still renders rather than
+/// vanishing. The token is never used as a style string verbatim.
+final class AffordancePresentationTests: XCTestCase {
+	func testSaveArticleMapsToANeutralAddControlInTheToolbar() {
+		let presentation = AffordancePresentation(token: "save-article")
+		XCTAssertEqual(presentation.systemImage, "plus")
+		XCTAssertNil(presentation.tint)
+		XCTAssertFalse(presentation.isDestructive)
+		XCTAssertFalse(presentation.removesItem)
+		XCTAssertTrue(presentation.isToolbarControl)
+	}
+
+	func testCaptureOnlySavesAreNotToolbarControls() {
+		// iOS can't capture a page from the toolbar, so save-html/save-content render
+		// nowhere in the toolbar — they are reached only through the Share Sheet.
+		for token in ["save-html", "save-content"] {
+			let presentation = AffordancePresentation(token: token)
+			XCTAssertFalse(presentation.isToolbarControl, "\(token) must not present as a toolbar control")
+			XCTAssertFalse(presentation.removesItem)
+			XCTAssertFalse(presentation.isDestructive)
+		}
+	}
+
+	func testUpdateStatusMapsToAReadControlWhoseRemovalIsTransitionDependent() {
+		let presentation = AffordancePresentation(token: "update-status")
+		XCTAssertEqual(presentation.systemImage, "checkmark.circle")
+		XCTAssertEqual(presentation.tint, .brandSuccess)
+		XCTAssertFalse(presentation.isDestructive)
+		XCTAssertFalse(
+			presentation.removesItem,
+			"update-status is a server toggle, so whether it removes the row depends on the field value, not the token"
+		)
+		XCTAssertTrue(presentation.isToolbarControl)
+	}
+
+	func testDeleteMapsToADestructiveTrashControlThatRemovesTheItem() {
+		let presentation = AffordancePresentation(token: "delete")
+		XCTAssertEqual(presentation.systemImage, "trash")
+		XCTAssertEqual(presentation.tint, .red)
+		XCTAssertTrue(presentation.isDestructive, "delete is irreversible, so the View confirms before invoking")
+		XCTAssertTrue(presentation.removesItem)
+	}
+
+	func testSearchMapsToANeutralMagnifierControl() {
+		let presentation = AffordancePresentation(token: "search")
+		XCTAssertEqual(presentation.systemImage, "magnifyingglass")
+		XCTAssertNil(presentation.tint)
+		XCTAssertFalse(presentation.isDestructive)
+		XCTAssertFalse(presentation.removesItem)
+		XCTAssertTrue(presentation.isToolbarControl)
+	}
+
+	func testStructuralLinkRelsAreNeverToolbarControls() {
+		// The client follows self/root/prev/next/item itself for pagination, identity,
+		// and item resolution; they are never rendered as user controls. `item` in
+		// particular: an `item` collection link resolves a member, not a tappable
+		// affordance, so it must be excluded structurally like the rest.
+		for rel in Affordance.structuralRels.sorted() {
+			XCTAssertFalse(
+				AffordancePresentation(token: rel).isToolbarControl,
+				"\(rel) is a structural navigation link, not a user control"
+			)
+		}
+		XCTAssertTrue(
+			Affordance.structuralRels.contains("item"),
+			"item is a structural rel (member resolution), so it must not render as a control"
+		)
+	}
+
+	func testUnknownTokenFallsBackToANeutralDefaultThatStillRenders() {
+		let presentation = AffordancePresentation(token: "some-future-action")
+		XCTAssertEqual(presentation.systemImage, "ellipsis.circle", "an unknown token gets the generic glyph")
+		XCTAssertNil(presentation.tint)
+		XCTAssertFalse(presentation.isDestructive)
+		XCTAssertFalse(presentation.removesItem)
+		XCTAssertTrue(
+			presentation.isToolbarControl,
+			"a newly-advertised affordance still renders in the toolbar rather than vanishing"
+		)
+	}
+
+	// MARK: - Transition-aware removal
+
+	private func action(
+		name: String,
+		href: String? = "/queue/a1/status",
+		fields: [SirenField]? = nil
+	) -> SirenAction {
+		SirenAction(name: name, href: href, method: "POST", title: nil, type: nil, fields: fields)
+	}
+
+	func testUpdateStatusRemovesTheRowWhenItsStatusValueMovesTheItemToRead() throws {
+		// The server toggle on an unread item targets "read", which leaves the
+		// unread-only list, so the row is dropped optimistically.
+		let toRead = action(name: "update-status", fields: [SirenField(name: "status", type: "text", value: "read")])
+		let affordance = try XCTUnwrap(Affordance(action: toRead))
+		XCTAssertTrue(affordance.removesItemFromUnreadList, "a transition to read leaves the unread-only list")
+	}
+
+	func testUpdateStatusKeepsTheRowWhenItsStatusValueTogglesBackToUnread() throws {
+		// The same action on an already-read item targets "unread"; the row stays in
+		// the unread-only list, so nothing is removed — the next load reconciles it.
+		let toUnread = action(name: "update-status", fields: [SirenField(name: "status", type: "text", value: "unread")])
+		let affordance = try XCTUnwrap(Affordance(action: toUnread))
+		XCTAssertFalse(affordance.removesItemFromUnreadList, "a transition to unread does not leave the unread-only list")
+	}
+
+	func testDeleteAlwaysRemovesTheRowRegardlessOfFields() throws {
+		let delete = action(name: "delete", href: "/queue/a1/delete")
+		let affordance = try XCTUnwrap(Affordance(action: delete))
+		XCTAssertTrue(affordance.removesItemFromUnreadList, "delete removes the item unconditionally")
+	}
+
+	func testAnUnrelatedActionDoesNotRemoveTheRow() throws {
+		let other = action(name: "view-original", href: "/queue/a1/original")
+		let affordance = try XCTUnwrap(Affordance(action: other))
+		XCTAssertFalse(affordance.removesItemFromUnreadList, "an action with no read transition leaves the list untouched")
+	}
+
+	func testANavigableLinkNeverRemovesARow() throws {
+		let link = try XCTUnwrap(Affordance(link: SirenLink(rel: ["save"], href: "/save", title: nil)))
+		XCTAssertFalse(link.removesItemFromUnreadList, "a navigable link acts on no row, so it removes nothing")
+	}
+
+	// MARK: - Bare-control invokability
+
+	func testAFieldRequiringActionWithNoServerValueIsNotABareToolbarControl() throws {
+		// `search` declares fields the server did not pre-fill and iOS has no query
+		// UI, so it is not invokable from a bare control and must not be surfaced.
+		let search = action(
+			name: "search", href: "/queue",
+			fields: [SirenField(name: "status", type: "text", value: nil), SirenField(name: "url", type: "url", value: nil)]
+		)
+		let affordance = try XCTUnwrap(Affordance(action: search))
+		XCTAssertFalse(affordance.isInvokableByBareControl, "a field-requiring action with no server value is not bare-invokable")
+		XCTAssertFalse(affordance.isToolbarControl, "so it is not surfaced as a toolbar control")
+	}
+
+	func testSaveArticleStaysABareToolbarControlViaItsBespokeDialog() throws {
+		// save-article's url field also carries no server value, but iOS has a
+		// bespoke native dialog that supplies the URL, so it remains invokable.
+		let save = action(name: "save-article", href: "/queue", fields: [SirenField(name: "url", type: "url", value: nil)])
+		let affordance = try XCTUnwrap(Affordance(action: save))
+		XCTAssertTrue(affordance.isInvokableByBareControl, "the native save dialog supplies the URL the field lacks")
+		XCTAssertTrue(affordance.isToolbarControl)
+	}
+
+	func testAnActionWhoseFieldsAllCarryAServerValueIsBareInvokable() throws {
+		let toRead = action(name: "update-status", fields: [SirenField(name: "status", type: "text", value: "read")])
+		let affordance = try XCTUnwrap(Affordance(action: toRead))
+		XCTAssertTrue(affordance.isInvokableByBareControl, "the server pre-filled the only field, so a bare control can post it")
+		XCTAssertTrue(affordance.isToolbarControl)
+	}
+
+	func testAFieldLessActionAndALinkAreBareInvokable() throws {
+		let fieldLess = action(name: "some-future-action", href: "/queue/go")
+		let link = try XCTUnwrap(Affordance(link: SirenLink(rel: ["save"], href: "/save", title: nil)))
+		XCTAssertTrue(try XCTUnwrap(Affordance(action: fieldLess)).isInvokableByBareControl)
+		XCTAssertTrue(link.isInvokableByBareControl, "a navigable link carries no fields, so a bare control can open it")
+	}
+
+	// MARK: - Label humanization
+
+	func testLabelHumanizesTheTokenWhenTheServerSentNoTitle() throws {
+		let untitled = SirenAction(name: "mark-read", href: "/x", method: "POST", title: nil, type: nil, fields: nil)
+		let affordance = try XCTUnwrap(Affordance(action: untitled))
+		XCTAssertEqual(affordance.label, "Mark Read", "a title-less action renders a humanized token, not the raw slug")
+	}
+
+	func testLabelHumanizesAnUnderscoredOrDoubleDelimitedToken() {
+		XCTAssertEqual(Affordance.humanize("archive_now"), "Archive Now")
+		XCTAssertEqual(Affordance.humanize("save--link-"), "Save Link", "empty segments are dropped")
+	}
+
+	func testLabelPrefersTheServersTitleOverTheHumanizedToken() throws {
+		let titled = SirenAction(name: "update-status", href: "/x", method: "POST", title: "Mark as read", type: nil, fields: nil)
+		let affordance = try XCTUnwrap(Affordance(action: titled))
+		XCTAssertEqual(affordance.label, "Mark as read", "the server's title wins when present")
+	}
+}

--- a/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
+++ b/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
@@ -117,6 +117,349 @@ final class ReadingListViewModelTests: XCTestCase {
 		)
 	}
 
+
+	/// The `save-article` action the toolbar control carries, found by iterating
+	/// the collection's advertised affordances — the same path the view's toolbar
+	/// loop takes — so the test saves via the action the loop would render.
+	private func saveArticleAction(of viewModel: ReadingListViewModel) throws -> SirenAction {
+		try XCTUnwrap(viewModel.collectionAffordances.first { $0.token == "save-article" }?.action)
+	}
+
+	/// A locked account: the queue loads (so the `save-article` action is
+	/// discovered) but every save POST is refused with a server-authored message.
+	private func lockedAccountHandler() -> (URLRequest, Data) -> StubURLProtocol.Stub {
+		return { request, _ in
+			let path = request.url?.path ?? ""
+			let method = request.httpMethod ?? "GET"
+			switch (path, method) {
+			case ("/", _):
+				return .redirect(to: "/queue")
+			case ("/queue", "POST"):
+				return .json(403, Fixtures.accountLockedError())
+			case ("/queue", _):
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+			default:
+				return .json(404, "{}")
+			}
+		}
+	}
+
+	func testRefusedSaveSurfacesServerMessages() async throws {
+		StubURLProtocol.setHandler(lockedAccountHandler())
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+		await viewModel.saveURL("https://example.com/x", action: try saveArticleAction(of: viewModel))
+
+		XCTAssertEqual(viewModel.messages.first?.type, "warning")
+		XCTAssertEqual(viewModel.messages.first?.content.type, "text/html")
+		XCTAssertTrue(
+			viewModel.messages.first?.content.body.contains("readplace+verification@readplace.com") ?? false,
+			"the refusal message names the address to email"
+		)
+	}
+
+	func testSuccessfulRefreshClearsStaleRefusalBanner() async throws {
+		StubURLProtocol.setHandler(lockedAccountHandler())
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+		await viewModel.saveURL("https://example.com/x", action: try saveArticleAction(of: viewModel))
+		XCTAssertFalse(viewModel.messages.isEmpty, "precondition: a refused save shows the banner")
+
+		await viewModel.refresh()
+
+		XCTAssertTrue(
+			viewModel.messages.isEmpty,
+			"a locked account's reads still succeed, so a fresh load reconciles the stale banner"
+		)
+	}
+
+	func testSaveResetsMessagesSoASucceedingSaveClearsTheBanner() async throws {
+		var savePOSTs = 0
+		StubURLProtocol.setHandler { request, _ in
+			let path = request.url?.path ?? ""
+			let method = request.httpMethod ?? "GET"
+			switch (path, method) {
+			case ("/", _):
+				return .redirect(to: "/queue")
+			case ("/queue", "POST"):
+				savePOSTs += 1
+				return savePOSTs == 1
+					? .json(403, Fixtures.accountLockedError())
+					: .json(201, Fixtures.article(id: "saved"))
+			case ("/queue", _):
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+		let action = try saveArticleAction(of: viewModel)
+		await viewModel.saveURL("https://example.com/x", action: action)
+		XCTAssertFalse(viewModel.messages.isEmpty, "precondition: the first save is refused")
+
+		await viewModel.saveURL("https://example.com/y", action: action)
+
+		XCTAssertTrue(viewModel.messages.isEmpty, "saveURL resets messages before the next attempt")
+	}
+
+	// MARK: - Save affordance gating
+
+	func testToolbarLoopsTheCollectionsToolbarPresentableAffordances() async {
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		XCTAssertTrue(viewModel.collectionAffordances.isEmpty, "no controls before any response advertises affordances")
+
+		await viewModel.refresh()
+
+		XCTAssertEqual(
+			viewModel.collectionAffordances.compactMap(\.action).map(\.name),
+			["save-article"],
+			"the toolbar renders the toolbar-presentable subset by iterating — capture-only saves (save-html/save-content) and the field-requiring search (no server value, no native query UI) are dropped client-side, not name-gated as a known capability"
+		)
+	}
+
+	func testToolbarDropsSearchBecauseItIsNotInvokableByABareControl() async {
+		// The real server advertises `search` with fields the user must fill and no
+		// pre-filled value; iOS has no query UI for it, so the client must not surface
+		// a control it cannot actually invoke (it would just open /queue in a webview).
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+
+		XCTAssertFalse(
+			viewModel.collectionAffordances.contains { $0.token == "search" },
+			"a field-requiring action with no server value and no bespoke handler is not surfaced"
+		)
+	}
+
+	func testToolbarExcludesCaptureOnlySavesAndStructuralLinks() async {
+		// A collection carrying a navigable `save` link, structural `prev`/`next`
+		// pagination links, and the capture-only saves: only the controls the client
+		// can present as toolbar buttons survive. The structural rels the client
+		// follows itself for pagination/identity never become user controls.
+		let extraLinks = """
+			,{ "rel": ["save"], "href": "/save", "title": "Save a link" }
+			,{ "rel": ["prev"], "href": "/queue?page=0" }
+			,{ "rel": ["next"], "href": "/queue?page=2" }
+			"""
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")], extraLinks: extraLinks))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+
+		XCTAssertEqual(
+			viewModel.collectionAffordances.map(\.token),
+			["save-article", "save"],
+			"capture-only saves, the field-requiring search, and structural rels (self/root/prev/next) never render as toolbar controls"
+		)
+	}
+
+	func testToolbarRendersWhateverActionsTheServerOffers() async {
+		// A server advertising only a single bare-invokable action still drives a
+		// control — the loop never gates on whether a known save action is present.
+		let futureOnly = """
+		{ "name": "purge-all", "title": "Purge", "href": "/queue/purge", "method": "POST" }
+		"""
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")], actionsJSON: futureOnly))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+
+		XCTAssertEqual(
+			viewModel.collectionAffordances.compactMap(\.action).map(\.name), ["purge-all"],
+			"a server offering an unknown bare-invokable action still renders its advertised controls"
+		)
+	}
+
+	func testToolbarTracksTheCurrentResponsesAffordances() async {
+		let futureOnly = """
+		{ "name": "purge-all", "title": "Purge", "href": "/queue/purge", "method": "POST" }
+		"""
+		var queueGETs = 0
+		StubURLProtocol.setHandler { request, _ in
+			let path = request.url?.path ?? ""
+			switch path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				queueGETs += 1
+				return queueGETs == 1
+					? .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+					: .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")], actionsJSON: futureOnly))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+		XCTAssertTrue(
+			viewModel.collectionAffordances.contains { $0.token == "save-article" },
+			"precondition: the first collection advertises save-article"
+		)
+
+		await viewModel.refresh()
+
+		XCTAssertEqual(
+			viewModel.collectionAffordances.compactMap(\.action).map(\.name), ["purge-all"],
+			"the toolbar reflects the current response: a later collection's affordances replace the earlier ones"
+		)
+	}
+
+	func testLoadMoreRetainsTheFirstPageToolbarWhenAPaginatedPageAdvertisesNoActions() async throws {
+		// A paginated (load-more) page only appends rows. When it advertises no
+		// collection actions, the toolbar must neither clear nor flap to a page-scoped
+		// set: the first page owns the toolbar for the whole scroll, so the controls
+		// it discovered survive the load-more.
+		let nextLink = """
+			,{ "rel": ["next"], "href": "/queue?page=2" }
+			"""
+		StubURLProtocol.setHandler { request, _ in
+			let url = request.url
+			switch (url?.path, url?.query) {
+			case ("/", _):
+				return .redirect(to: "/queue")
+			case ("/queue", let query) where query?.contains("page=2") == true:
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a2")], page: 2, actionsJSON: ""))
+			case ("/queue", _):
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")], extraLinks: nextLink))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		await viewModel.refresh()
+		let firstPageToolbar = viewModel.collectionAffordances.map(\.token)
+		XCTAssertFalse(firstPageToolbar.isEmpty, "precondition: the first page advertises a toolbar")
+
+		await viewModel.loadMore()
+
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1", "a2"], "the second page's rows are appended")
+		XCTAssertEqual(
+			viewModel.collectionAffordances.map(\.token), firstPageToolbar,
+			"an actionless paginated page leaves the first-page toolbar in place — it does not clear it"
+		)
+	}
+
+	func testInvokeCollectionSubmitsTheActionAndReloadsFromTheServer() async throws {
+		// A bare-invokable collection action is submitted through the generic invoker
+		// (honouring its own href/method) — not opened as a GET web view of its href —
+		// then the collection is reloaded so the server's new state replaces the old.
+		var queueGETs = 0
+		StubURLProtocol.setHandler { request, _ in
+			let path = request.url?.path ?? ""
+			let method = request.httpMethod ?? "GET"
+			switch (path, method) {
+			case ("/", _):
+				return .redirect(to: "/queue")
+			case ("/queue/purge", "POST"):
+				return .redirect(to: "/queue")
+			case ("/queue", _):
+				queueGETs += 1
+				return queueGETs == 1
+					? .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+					: .json(200, Fixtures.collection(entitiesJSON: []))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		await viewModel.refresh()
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1"])
+
+		let purge = SirenAction(name: "purge-all", href: "/queue/purge", method: "POST", title: "Purge", type: nil, fields: nil)
+		await viewModel.invokeCollection(purge)
+
+		XCTAssertEqual(StubURLProtocol.records(path: "/queue/purge").first?.request.httpMethod, "POST")
+		XCTAssertTrue(viewModel.articles.isEmpty, "the reload reflects the server's post-invoke state")
+		XCTAssertNil(viewModel.readerPresentation, "an action is invoked, never opened in the web view")
+		XCTAssertNil(viewModel.errorText)
+	}
+
+	func testInvokeCollectionSurfacesAServerErrorAndLeavesTheListInPlace() async {
+		StubURLProtocol.setHandler { request, _ in
+			let path = request.url?.path ?? ""
+			switch path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue/purge":
+				return .json(500, Fixtures.sirenError(code: "boom", message: "nope", withSaveArticleFallback: false))
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		await viewModel.refresh()
+
+		let purge = SirenAction(name: "purge-all", href: "/queue/purge", method: "POST", title: "Purge", type: nil, fields: nil)
+		await viewModel.invokeCollection(purge)
+
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1"], "a failed collection invoke leaves the current list")
+		XCTAssertNotNil(viewModel.errorText)
+	}
+
+	func testOpenLinkPublishesAWebSheetWithNoRowAttached() {
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		viewModel.open(link: SirenLink(rel: ["save"], href: "/save", title: "Save a link"))
+
+		let presentation = viewModel.readerPresentation
+		XCTAssertEqual(presentation?.readerURL.absoluteString, "\(AppConfig.serverBaseURL)/save")
+		XCTAssertNil(presentation?.articleId, "a navigable collection link is not tied to a row")
+	}
+
+	func testOpenLinkIsANoOpForAForeignSchemeHref() {
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+
+		viewModel.open(link: SirenLink(rel: ["save"], href: "mailto:hi@example.com", title: nil))
+
+		XCTAssertNil(viewModel.readerPresentation, "an href the client can't resolve never opens a blank sheet")
+	}
+
 	// MARK: - Mark as read
 
 	/// A two-item queue whose `/queue/{id}/status` POST behaves per `statusStub`.
@@ -140,13 +483,21 @@ final class ReadingListViewModelTests: XCTestCase {
 		}
 	}
 
-	func testMarkAsReadOptimisticallyRemovesAndKeepsRemovedOnSuccess() async {
+	/// The `update-status` action the server advertised on a row, looked up by
+	/// iterating its affordances — the same path the view does — so the test
+	/// invokes the action the loop would render rather than a hand-built one.
+	private func updateStatusAction(of article: Article) throws -> SirenAction {
+		try XCTUnwrap(article.affordances.first { $0.token == "update-status" }?.action)
+	}
+
+	func testInvokeUpdateStatusOptimisticallyRemovesAndKeepsRemovedOnSuccess() async throws {
 		StubURLProtocol.setHandler(markReadHandler { _ in .redirect(to: "/queue") })
 		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
 		await viewModel.refresh()
 		XCTAssertEqual(viewModel.articles.map(\.id), ["a1", "a2"])
 
-		await viewModel.markAsRead(viewModel.articles[0])
+		let target = viewModel.articles[0]
+		await viewModel.invoke(try updateStatusAction(of: target), on: target)
 
 		XCTAssertEqual(
 			viewModel.articles.map(\.id), ["a2"],
@@ -155,41 +506,135 @@ final class ReadingListViewModelTests: XCTestCase {
 		XCTAssertNil(viewModel.errorText)
 	}
 
-	func testMarkAsReadRestoresRowOnServerError() async {
+	func testInvokeUpdateStatusKeepsTheRowWhenItTogglesBackToUnread() async throws {
+		// A read item's update-status toggles to "unread", which stays in the
+		// unread-only list, so the row must not be dropped — the next load reconciles.
+		let readArticle = """
+			{ "class": ["article"], "rel": ["item"],
+			  "properties": { "id": "a1", "url": "https://example.com/x", "status": "read" },
+			  "links": [{ "rel": ["read"], "href": "/queue/a1/view" }],
+			  "actions": [
+			    { "name": "update-status", "href": "/queue/a1/status", "method": "POST", "type": "application/x-www-form-urlencoded", "fields": [{ "name": "status", "type": "text", "value": "unread" }] }
+			  ] }
+			"""
+		StubURLProtocol.setHandler { request, _ in
+			let path = request.url?.path ?? ""
+			if path.hasSuffix("/status") { return .redirect(to: "/queue") }
+			switch path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [readArticle]))
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		await viewModel.refresh()
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1"])
+
+		let target = viewModel.articles[0]
+		await viewModel.invoke(try updateStatusAction(of: target), on: target)
+
+		XCTAssertEqual(
+			viewModel.articles.map(\.id), ["a1"],
+			"a toggle back to unread leaves the row in the unread-only list"
+		)
+		XCTAssertNil(viewModel.errorText)
+	}
+
+	func testInvokeSendsTheStatusFieldForUpdateStatus() async throws {
+		StubURLProtocol.setHandler(markReadHandler { _ in .redirect(to: "/queue") })
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		await viewModel.refresh()
+
+		let target = viewModel.articles[0]
+		await viewModel.invoke(try updateStatusAction(of: target), on: target)
+
+		let record = try XCTUnwrap(StubURLProtocol.records(path: "/queue/a1/status").first)
+		XCTAssertEqual(
+			TestSupport.formFields(record.body)["status"], "read",
+			"update-status carries the protocol-fixed status field, set to read"
+		)
+	}
+
+	func testInvokeRestoresRowOnServerError() async throws {
 		StubURLProtocol.setHandler(markReadHandler { _ in
 			.json(500, Fixtures.sirenError(code: "boom", message: "nope", withSaveArticleFallback: false))
 		})
 		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
 		await viewModel.refresh()
 
-		await viewModel.markAsRead(viewModel.articles[0])
+		let target = viewModel.articles[0]
+		await viewModel.invoke(try updateStatusAction(of: target), on: target)
 
 		XCTAssertEqual(
 			viewModel.articles.map(\.id), ["a1", "a2"],
-			"a failed mark-read rolls the optimistic removal back"
+			"a failed invocation rolls the optimistic removal back"
 		)
 		XCTAssertNotNil(viewModel.errorText)
 	}
 
-	func testRefusedMarkAsReadSurfacesServerMessages() async {
-		StubURLProtocol.setHandler(markReadHandler { _ in
-			.json(403, Fixtures.accountLockedError())
-		})
+	func testInvokeDeleteOptimisticallyRemovesTheItem() async throws {
+		StubURLProtocol.setHandler { request, _ in
+			let path = request.url?.path ?? ""
+			if path.hasSuffix("/delete") { return .redirect(to: "/queue") }
+			switch path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(
+					entitiesJSON: [Fixtures.article(id: "a1"), Fixtures.article(id: "a2")], total: 2
+				))
+			default:
+				return .json(404, "{}")
+			}
+		}
 		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
 		await viewModel.refresh()
-		XCTAssertEqual(viewModel.articles.map(\.id), ["a1", "a2"])
 
-		await viewModel.markAsRead(viewModel.articles[0])
+		let target = viewModel.articles[0]
+		let deleteAction = try XCTUnwrap(target.affordances.first { $0.token == "delete" }?.action)
+		await viewModel.invoke(deleteAction, on: target)
 
-		XCTAssertEqual(viewModel.messages.first?.type, "warning")
-		XCTAssertTrue(
-			viewModel.messages.first?.content.body.contains("readplace+verification@readplace.com") ?? false,
-			"the refusal message names the address to email"
-		)
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a2"], "delete removes the item it acts on")
+	}
+
+	func testInvokeNonRemovingActionLeavesTheListUntouched() async throws {
+		// A non-removing action must not blanket-remove the row; per 'State Lives in
+		// the Network' the list is left for the next load to reconcile.
+		let viewAction = """
+			{ "name": "view-original", "title": "Open original", "href": "/queue/a1/original", "method": "GET" }
+			"""
+		let articleWithView = """
+			{ "class": ["article"], "properties": { "id": "a1", "url": "https://example.com/x" },
+			  "actions": [\(viewAction)] }
+			"""
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			case "/queue":
+				return .json(200, Fixtures.collection(entitiesJSON: [articleWithView]))
+			case "/queue/a1/original":
+				return .redirect(to: "/queue")
+			default:
+				return .json(404, "{}")
+			}
+		}
+		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
+		await viewModel.refresh()
+		XCTAssertEqual(viewModel.articles.map(\.id), ["a1"])
+
+		let target = viewModel.articles[0]
+		let action = try XCTUnwrap(target.affordances.first { $0.token == "view-original" }?.action)
+		await viewModel.invoke(action, on: target)
+
 		XCTAssertEqual(
-			viewModel.articles.map(\.id), ["a1", "a2"],
-			"a refused mark-read restores the optimistically-removed row"
+			viewModel.articles.map(\.id), ["a1"],
+			"a non-removing action does not drop the row — only delete/update-status do"
 		)
+		XCTAssertNil(viewModel.errorText)
 	}
 
 	func testRemoveArticleDropsTheRowWithoutANetworkCall() async {
@@ -209,7 +654,7 @@ final class ReadingListViewModelTests: XCTestCase {
 		Article(
 			id: id, url: "https://example.com/x", title: "X", siteName: nil, excerpt: nil,
 			imageURL: nil, readTimeMinutes: nil, isRead: false, savedAt: nil,
-			updateStatusAction: nil, readHref: readHref
+			actions: [], readHref: readHref
 		)
 	}
 

--- a/projects/ios-readplace/Tests/ReadplaceAPITests.swift
+++ b/projects/ios-readplace/Tests/ReadplaceAPITests.swift
@@ -12,20 +12,21 @@ final class ReadplaceAPITests: XCTestCase {
 	}
 
 	private func saveHtmlAction() -> SirenAction {
-		SirenAction(name: "save-html", href: "/queue/save-html", method: "POST", type: "application/json", fields: nil)
+		SirenAction(name: "save-html", href: "/queue/save-html", method: "POST", title: nil, type: "application/json", fields: nil)
 	}
 
 	private func saveArticleAction() -> SirenAction {
-		SirenAction(name: "save-article", href: "/queue", method: "POST", type: "application/json", fields: nil)
+		SirenAction(name: "save-article", href: "/queue", method: "POST", title: nil, type: "application/json", fields: nil)
 	}
 
-	private func updateStatusAction(id: String = "a1") -> SirenAction {
+	private func updateStatusAction(id: String = "a1", statusValue: String? = "read") -> SirenAction {
 		SirenAction(
 			name: "update-status",
 			href: "/queue/\(id)/status",
 			method: "POST",
+			title: nil,
 			type: "application/x-www-form-urlencoded",
-			fields: [SirenField(name: "status", type: "text", value: nil)]
+			fields: [SirenField(name: "status", type: "text", value: statusValue)]
 		)
 	}
 
@@ -114,6 +115,58 @@ final class ReadplaceAPITests: XCTestCase {
 		XCTAssertEqual(StubURLProtocol.records(path: "/oauth/token").count, 1)
 	}
 
+	func testLoadQueueRejectsANonSirenBody() async {
+		// The client negotiated Siren with Accept; a 200 carrying a different media
+		// type (e.g. a proxy HTML login page) is surfaced as unsupportedMediaType
+		// rather than blind-decoded into a generic decode failure.
+		let store = TestSupport.loggedInStore()
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			default:
+				return StubURLProtocol.Stub(
+					status: 200,
+					headers: ["Content-Type": "text/html"],
+					body: Data("<html><body>Sign in</body></html>".utf8)
+				)
+			}
+		}
+		do {
+			_ = try await makeAPI(store: store).loadQueue()
+			XCTFail("Expected unsupportedMediaType")
+		} catch let error as APIError {
+			guard case .unsupportedMediaType(let type) = error else {
+				return XCTFail("Expected .unsupportedMediaType, got \(error)")
+			}
+			XCTAssertEqual(type, "text/html")
+		} catch {
+			XCTFail("Expected APIError.unsupportedMediaType, got \(error)")
+		}
+	}
+
+	func testLoadQueueAcceptsSirenWithCharsetParameter() async throws {
+		// The negotiated type may arrive with a charset parameter; the essence still
+		// matches, so the body parses.
+		let store = TestSupport.loggedInStore()
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			default:
+				return StubURLProtocol.Stub(
+					status: 200,
+					headers: ["Content-Type": "application/vnd.siren+json; charset=utf-8"],
+					body: Data(Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]).utf8)
+				)
+			}
+		}
+
+		let page = try await makeAPI(store: store).loadQueue()
+
+		XCTAssertEqual(page.articles.map(\.id), ["a1"])
+	}
+
 	func testNoTokenThrowsNoTokenError() async {
 		let store = TokenStore(defaults: TestSupport.ephemeralDefaults())
 		StubURLProtocol.setHandler { _, _ in .json(200, "{}") }
@@ -137,14 +190,15 @@ final class ReadplaceAPITests: XCTestCase {
 			return .json(201, Fixtures.article(id: "saved", url: "https://example.com/x"))
 		}
 
-		let article = try await makeAPI(store: store).saveHTML(
+		let result = try await makeAPI(store: store).saveHTML(
 			action: saveHtmlAction(),
 			url: "https://example.com/x",
 			rawHtml: "<html><body>hi</body></html>",
 			title: "Captured"
 		)
 
-		XCTAssertEqual(article.id, "saved")
+		XCTAssertEqual(result.article.id, "saved")
+		XCTAssertFalse(result.usedFallback, "a clean save-html does not use the fallback")
 		let saveRequest = try XCTUnwrap(StubURLProtocol.records(path: "/queue/save-html").first?.request)
 		XCTAssertEqual(saveRequest.value(forHTTPHeaderField: "X-Readplace-Client"), "ios")
 		let body = TestSupport.jsonObject(StubURLProtocol.records(path: "/queue/save-html").first!.body)
@@ -178,11 +232,12 @@ final class ReadplaceAPITests: XCTestCase {
 			}
 		}
 
-		let article = try await makeAPI(store: store).saveHTML(
+		let result = try await makeAPI(store: store).saveHTML(
 			action: saveHtmlAction(), url: "https://example.com/x", rawHtml: "<huge/>", title: "T"
 		)
 
-		XCTAssertEqual(article.id, "fallback-saved")
+		XCTAssertEqual(result.article.id, "fallback-saved")
+		XCTAssertTrue(result.usedFallback, "following the server's fallback action is reported as a fallback")
 		let fallbackBody = TestSupport.jsonObject(StubURLProtocol.records(path: "/queue").first!.body)
 		XCTAssertEqual(fallbackBody["url"] as? String, "https://example.com/x")
 		XCTAssertEqual(fallbackBody["title"] as? String, "T")
@@ -305,7 +360,10 @@ final class ReadplaceAPITests: XCTestCase {
 
 	// MARK: - Updating status
 
-	func testUpdateStatusPostsUrlencodedStatusAndFollowsRedirect() async throws {
+	func testInvokePostsTheFieldValueUrlencodedAndFollowsRedirect() async throws {
+		// The client supplies no field knowledge: it posts the server-declared
+		// field's own `value`, encoded per the action's `type` (urlencoded → form
+		// body). A bare invoke(action:) is sufficient — no hardcoded status.
 		let store = TestSupport.loggedInStore()
 		StubURLProtocol.setHandler { request, _ in
 			switch request.url?.path {
@@ -318,12 +376,15 @@ final class ReadplaceAPITests: XCTestCase {
 			}
 		}
 
-		try await makeAPI(store: store).updateStatus(action: updateStatusAction(), status: .read)
+		try await makeAPI(store: store).invoke(action: updateStatusAction(statusValue: "read"))
 
 		let statusRecord = try XCTUnwrap(StubURLProtocol.records(path: "/queue/a1/status").first)
 		XCTAssertEqual(statusRecord.request.httpMethod, "POST")
 		XCTAssertEqual(statusRecord.request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
-		XCTAssertEqual(TestSupport.formFields(statusRecord.body)["status"], "read")
+		XCTAssertEqual(
+			TestSupport.formFields(statusRecord.body)["status"], "read",
+			"the status comes from the declared field's value, not a client constant"
+		)
 		XCTAssertNil(
 			statusRecord.request.value(forHTTPHeaderField: "Prefer"),
 			"success is decoupled from the response body, so no representation is requested"
@@ -331,13 +392,59 @@ final class ReadplaceAPITests: XCTestCase {
 		XCTAssertEqual(StubURLProtocol.records(path: "/queue").count, 1, "the 303 to /queue is followed")
 	}
 
-	func testUpdateStatusSurfacesServerErrorOnFailureStatus() async {
+	func testInvokeTakesTheStatusFromTheFieldValueNotAClientConstant() async throws {
+		// A server that targets a different status drives that exact value into the
+		// body — proving the client never hardcodes "read".
+		let store = TestSupport.loggedInStore()
+		StubURLProtocol.setHandler { _, _ in .redirect(to: "/queue") }
+
+		try await makeAPI(store: store).invoke(action: updateStatusAction(statusValue: "archived"))
+
+		XCTAssertEqual(
+			TestSupport.formFields(StubURLProtocol.records(path: "/queue/a1/status").first!.body)["status"],
+			"archived",
+			"whatever status the field value declares is what gets posted"
+		)
+	}
+
+	func testInvokeEncodesAGetActionsFieldValuesAsQueryItemsWithNoBody() async throws {
+		// A GET action (e.g. `search`) carries no body — the field values are the
+		// query string. The generic invoker must put the server-declared field value
+		// on the URL, not in the httpBody, and send no Content-Type.
+		let store = TestSupport.loggedInStore()
+		StubURLProtocol.setHandler { request, _ in
+			request.url?.path == "/queue"
+				? .json(200, Fixtures.collection(entitiesJSON: [Fixtures.article(id: "a1")]))
+				: .json(404, "{}")
+		}
+		let search = SirenAction(
+			name: "search", href: "/queue", method: "GET", title: nil, type: nil,
+			fields: [SirenField(name: "status", type: "text", value: "unread")]
+		)
+
+		try await makeAPI(store: store).invoke(action: search)
+
+		let record = try XCTUnwrap(StubURLProtocol.records(path: "/queue").first)
+		XCTAssertEqual(record.request.httpMethod, "GET")
+		let query = try XCTUnwrap(URLComponents(url: try XCTUnwrap(record.request.url), resolvingAgainstBaseURL: false)?.queryItems)
+		XCTAssertEqual(
+			query.first { $0.name == "status" }?.value, "unread",
+			"a GET action's field value rides the URL query, not the body"
+		)
+		XCTAssertTrue(record.body.isEmpty, "a GET carries no body")
+		XCTAssertNil(
+			record.request.value(forHTTPHeaderField: "Content-Type"),
+			"a GET sets no Content-Type — there is nothing to encode in a body"
+		)
+	}
+
+	func testInvokeSurfacesServerErrorOnFailureStatus() async {
 		let store = TestSupport.loggedInStore()
 		StubURLProtocol.setHandler { _, _ in
 			.json(500, Fixtures.sirenError(code: "boom", message: "nope", withSaveArticleFallback: false))
 		}
 		do {
-			try await makeAPI(store: store).updateStatus(action: updateStatusAction(), status: .read)
+			try await makeAPI(store: store).invoke(action: updateStatusAction(), values: ["status": "read"])
 			XCTFail("Expected a server error")
 		} catch let error as APIError {
 			// The client verifies the protocol-level outcome only: any non-2xx/3xx

--- a/projects/ios-readplace/Tests/ReadplaceAPITests.swift
+++ b/projects/ios-readplace/Tests/ReadplaceAPITests.swift
@@ -438,6 +438,33 @@ final class ReadplaceAPITests: XCTestCase {
 		)
 	}
 
+	func testInvokeJSONTypedActionSendsAJSONBodyMatchingTheDeclaredType() async throws {
+		// An action whose declared type is application/json must post a JSON body —
+		// not a form-encoded body under a JSON Content-Type. The body encoding follows
+		// the action's own `type`, so a future JSON-bodied flat action invokes correctly.
+		let store = TestSupport.loggedInStore()
+		StubURLProtocol.setHandler { request, _ in
+			request.url?.path == "/queue/a1/status" ? .json(200, "{}") : .json(404, "{}")
+		}
+		let action = SirenAction(
+			name: "update-status", href: "/queue/a1/status", method: "POST",
+			title: nil, type: "application/json",
+			fields: [SirenField(name: "status", type: "text", value: "read")]
+		)
+
+		try await makeAPI(store: store).invoke(action: action)
+
+		let record = try XCTUnwrap(StubURLProtocol.records(path: "/queue/a1/status").first)
+		XCTAssertEqual(
+			record.request.value(forHTTPHeaderField: "Content-Type"), "application/json",
+			"the request is labelled with the action's declared JSON type"
+		)
+		XCTAssertEqual(
+			TestSupport.jsonObject(record.body)["status"] as? String, "read",
+			"a JSON-typed action posts a JSON body, not a form-encoded one under a JSON header"
+		)
+	}
+
 	func testInvokeSurfacesServerErrorOnFailureStatus() async {
 		let store = TestSupport.loggedInStore()
 		StubURLProtocol.setHandler { _, _ in

--- a/projects/ios-readplace/Tests/SaveSharedPageTests.swift
+++ b/projects/ios-readplace/Tests/SaveSharedPageTests.swift
@@ -119,15 +119,18 @@ final class SaveSharedPageTests: XCTestCase {
 		XCTAssertTrue(StubURLProtocol.records(path: "/queue/save-html").isEmpty)
 	}
 
-	func testDegradesToLinkOnlyWhenHTMLOverCap() async throws {
-		// The capture produced HTML, but it exceeds the server's byte cap, so the
-		// orchestrator skips save-html and saves URL-only instead.
+	func testDegradesToLinkOnlyWhenServerRefusesHTMLWithAFallback() async throws {
+		// The orchestrator attempts save-html (no client-side cap), the server
+		// refuses the payload with a URL-only fallback action, and the journey
+		// follows it — surfacing the server-driven degradation as savedLinkOnly.
 		let store = TestSupport.loggedInStore()
 		let captor = FakeHTMLCaptor(page: CapturedPage(rawHtml: "<html><body>hi</body></html>", title: "Captured"))
 		StubURLProtocol.setHandler { request, _ in
 			switch request.url?.path {
 			case "/":
 				return .redirect(to: "/queue")
+			case "/queue/save-html":
+				return .json(500, Fixtures.sirenError(code: "html-too-large", message: "Too big", withSaveArticleFallback: true))
 			case "/queue":
 				return request.httpMethod == "POST"
 					? .json(201, Fixtures.article(id: "url-saved"))
@@ -137,19 +140,19 @@ final class SaveSharedPageTests: XCTestCase {
 			}
 		}
 
-		let saver = SaveSharedPage(store: store, api: makeAPI(store: store), captor: captor, maxRawHTMLBytes: 4)
+		let saver = SaveSharedPage(store: store, api: makeAPI(store: store), captor: captor)
 		let outcome = await saver.run(url: URL(string: "https://example.com/post")!, fallbackTitle: nil)
 
 		XCTAssertEqual(outcome, .savedLinkOnly)
+		XCTAssertEqual(
+			StubURLProtocol.records(path: "/queue/save-html").count, 1,
+			"the client attempts save-html and lets the server decide, rather than gating on a client-side cap"
+		)
 		let queuePosts = StubURLProtocol.records(path: "/queue").filter { $0.request.httpMethod == "POST" }
 		XCTAssertEqual(queuePosts.count, 1)
 		let body = TestSupport.jsonObject(try XCTUnwrap(queuePosts.first).body)
 		XCTAssertEqual(body["url"] as? String, "https://example.com/post")
-		XCTAssertNil(body["rawHtml"], "the over-cap save must fall back to URL-only without rawHtml")
-		XCTAssertTrue(
-			StubURLProtocol.records(path: "/queue/save-html").isEmpty,
-			"must not POST save-html when the captured HTML is over the cap"
-		)
+		XCTAssertNil(body["rawHtml"], "the fallback save must drop rawHtml")
 	}
 
 	func testGuardsWhenLoggedOut() async throws {

--- a/projects/ios-readplace/Tests/SirenDecodingTests.swift
+++ b/projects/ios-readplace/Tests/SirenDecodingTests.swift
@@ -21,13 +21,41 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertEqual(article.imageURL?.absoluteString, "https://example.com/img.png")
 		XCTAssertEqual(article.readTimeMinutes, 6)
 		XCTAssertFalse(article.isRead)
-		XCTAssertEqual(article.updateStatusAction?.name, "update-status")
-		XCTAssertEqual(article.updateStatusAction?.href, "/queue/a1/status")
-		XCTAssertEqual(article.updateStatusAction?.method, "POST")
-		XCTAssertEqual(article.updateStatusAction?.type, "application/x-www-form-urlencoded")
-		XCTAssertEqual(article.updateStatusAction?.fields?.first?.name, "status")
+		let updateStatus = try XCTUnwrap(article.actions.first { $0.name == "update-status" })
+		XCTAssertEqual(updateStatus.href, "/queue/a1/status")
+		XCTAssertEqual(updateStatus.method, "POST")
+		XCTAssertEqual(updateStatus.type, "application/x-www-form-urlencoded")
+		XCTAssertEqual(updateStatus.fields?.first?.name, "status")
 		XCTAssertEqual(article.readHref, "/queue/a1/view")
 		XCTAssertNotNil(article.savedAt)
+	}
+
+	func testArticleAffordancesIterateAdvertisedActionsInWireOrder() throws {
+		// One control per advertised, invokable action — built by iterating, never
+		// by matching a known name — so a newly-advertised item action renders.
+		let json = """
+		{ "properties": { "id": "x", "url": "https://example.com/x" },
+		  "actions": [
+		    { "name": "update-status", "title": "Mark read", "href": "/queue/x/status", "method": "POST" },
+		    { "name": "delete", "title": "Delete", "href": "/queue/x/delete", "method": "POST" },
+		    { "name": "archive", "title": "Archive", "href": "/queue/x/archive", "method": "POST" }
+		  ] }
+		"""
+		let article = try XCTUnwrap(Article(entity: try decodeEntity(json)))
+		XCTAssertEqual(
+			article.affordances.map(\.token), ["update-status", "delete", "archive"],
+			"a never-before-seen action (archive) still becomes a control via the loop"
+		)
+		XCTAssertEqual(article.affordances.map(\.label), ["Mark read", "Delete", "Archive"])
+	}
+
+	func testAffordanceLabelFallsBackToHumanizedTokenWhenServerSendsNoTitle() throws {
+		let action = SirenAction(name: "update-status", href: "/x", method: "POST", title: nil, type: nil, fields: nil)
+		let affordance = try XCTUnwrap(Affordance(action: action))
+		XCTAssertEqual(
+			affordance.label, "Update Status",
+			"a title-less action renders a humanized token, not the raw wire slug"
+		)
 	}
 
 	func testNullImageAndReadAtAreTolerated() throws {
@@ -56,7 +84,7 @@ final class SirenDecodingTests: XCTestCase {
 		let article = try XCTUnwrap(Article(entity: try decodeEntity(json)))
 		XCTAssertEqual(article.title, "https://example.com/x")
 		XCTAssertNil(article.siteName)
-		XCTAssertNil(article.updateStatusAction)
+		XCTAssertTrue(article.affordances.isEmpty, "no advertised actions ⇒ no item controls")
 		XCTAssertNil(article.readHref)
 	}
 
@@ -68,6 +96,41 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertEqual(action.name, "update-status")
 		XCTAssertEqual(action.fields?.first?.name, "status")
 		XCTAssertEqual(action.fields?.first?.value, "read")
+	}
+
+	func testFieldDecodesAStringValue() throws {
+		let json = """
+		{ "name": "status", "type": "text", "value": "read" }
+		"""
+		let field = try JSONDecoder().decode(SirenField.self, from: Data(json.utf8))
+		XCTAssertEqual(field.value, "read")
+	}
+
+	func testFieldCoercesAWholeNumberValueToAStringWithoutADecimalPoint() throws {
+		// A server may declare a numeric field value (e.g. "page": 2); coerce it to its
+		// string form so the generic invoker posts "2", not "2.0", and the value isn't
+		// dropped.
+		let json = """
+		{ "name": "page", "type": "number", "value": 2 }
+		"""
+		let field = try JSONDecoder().decode(SirenField.self, from: Data(json.utf8))
+		XCTAssertEqual(field.value, "2")
+	}
+
+	func testFieldCoercesAFractionalNumberValueToAString() throws {
+		let json = """
+		{ "name": "ratio", "type": "number", "value": 1.5 }
+		"""
+		let field = try JSONDecoder().decode(SirenField.self, from: Data(json.utf8))
+		XCTAssertEqual(field.value, "1.5")
+	}
+
+	func testFieldWithNoValueDecodesAsNil() throws {
+		let json = """
+		{ "name": "url", "type": "url" }
+		"""
+		let field = try JSONDecoder().decode(SirenField.self, from: Data(json.utf8))
+		XCTAssertNil(field.value)
 	}
 
 	func testEmptyTitleFallsBackToURL() throws {
@@ -92,7 +155,10 @@ final class SirenDecodingTests: XCTestCase {
 		"""
 		let article = try XCTUnwrap(Article(entity: try decodeEntity(json)))
 		XCTAssertNil(article.readHref, "a read link with no href leaves the row unopenable")
-		XCTAssertFalse(article.canMarkRead, "an action with no href offers no mark-read affordance")
+		XCTAssertTrue(
+			article.affordances.isEmpty,
+			"an action with no href is kept but unactionable, so it produces no control"
+		)
 	}
 
 	func testCollectionDropsUnusableEntities() throws {
@@ -104,15 +170,47 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertEqual(page.articles.map(\.id), ["good"])
 	}
 
-	func testCollectionExposesActionsAndTotal() throws {
+	func testCollectionExposesAffordancesAndTotal() throws {
 		let json = Fixtures.collection(entitiesJSON: [Fixtures.article()], total: 7)
 		let page = QueuePage(collection: try decodeCollection(json))
 		XCTAssertEqual(page.total, 7)
-		XCTAssertEqual(page.saveHtmlAction?.href, "/queue/save-html")
-		XCTAssertEqual(page.saveHtmlAction?.method, "POST")
-		XCTAssertEqual(page.saveHtmlAction?.type, "application/json")
-		XCTAssertEqual(page.saveArticleAction?.href, "/queue")
 		XCTAssertEqual(page.selfHref, "/queue?page=1")
+		// The complete set of advertised collection actions, labelled by the server's
+		// title. The toolbar derives its own presentable subset from this client-side;
+		// the share-sheet save journey resolves its bespoke action from it by name.
+		let actionAffordances = page.affordances.filter { $0.action != nil }
+		XCTAssertEqual(
+			actionAffordances.compactMap(\.action).map(\.name),
+			["save-article", "save-html", "save-content", "search"]
+		)
+		XCTAssertEqual(
+			actionAffordances.map(\.label),
+			["Save a link", "Save a page", "Save a file", "Search"]
+		)
+	}
+
+	func testCollectionActionNamedSelectsTheBespokeSaveActionForTheShareSheet() throws {
+		// The share-sheet save journey still resolves a specific save action by name
+		// to build its bespoke body — the contract's sanctioned exception for
+		// special-body actions, distinct from the looped toolbar rendering.
+		let json = Fixtures.collection(entitiesJSON: [Fixtures.article()])
+		let page = QueuePage(collection: try decodeCollection(json))
+		XCTAssertEqual(page.action(named: "save-html")?.href, "/queue/save-html")
+		XCTAssertEqual(page.action(named: "save-article")?.href, "/queue")
+		XCTAssertNil(page.action(named: "no-such-action"))
+	}
+
+	func testCollectionAffordancesIncludeNavigableLinksWithUsableHref() throws {
+		// A navigable save link the server might advertise becomes a toolbar control
+		// too, keyed on its rel — opened, not invoked.
+		let withSave = Fixtures.collection(
+			entitiesJSON: [Fixtures.article()],
+			extraLinks: ", { \"rel\": [\"save\"], \"href\": \"/save\", \"title\": \"Save a link\" }"
+		)
+		let page = QueuePage(collection: try decodeCollection(withSave))
+		let saveLink = try XCTUnwrap(page.affordances.first { $0.link?.rel.first == "save" })
+		XCTAssertEqual(saveLink.label, "Save a link")
+		XCTAssertEqual(saveLink.link?.href, "/save")
 	}
 
 	func testPaginationLinks() throws {

--- a/projects/ios-readplace/Tests/SirenDecodingTests.swift
+++ b/projects/ios-readplace/Tests/SirenDecodingTests.swift
@@ -98,6 +98,16 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertEqual(action.fields?.first?.value, "read")
 	}
 
+	func testActionWithoutMethodDefaultsToGET() throws {
+		// Siren defaults an action's method to GET when omitted; a method-less but
+		// otherwise valid action must decode (as GET), never fail the surrounding decode.
+		let json = """
+		{ "name": "search", "href": "/queue" }
+		"""
+		let action = try JSONDecoder().decode(SirenAction.self, from: Data(json.utf8))
+		XCTAssertEqual(action.method, "GET")
+	}
+
 	func testFieldDecodesAStringValue() throws {
 		let json = """
 		{ "name": "status", "type": "text", "value": "read" }
@@ -168,6 +178,44 @@ final class SirenDecodingTests: XCTestCase {
 		], total: 2)
 		let page = QueuePage(collection: try decodeCollection(json))
 		XCTAssertEqual(page.articles.map(\.id), ["good"])
+	}
+
+	func testCollectionDropsAMalformedActionButKeepsValidOnes() throws {
+		// One malformed action (missing the required `name`) is dropped, not allowed
+		// to blank the whole page — every other advertised control still renders. The
+		// page loops all advertised actions, so atomic decoding would let one bad
+		// action take down the collection.
+		let valid = "{ \"name\": \"save-article\", \"title\": \"Save a link\", \"href\": \"/queue\", \"method\": \"POST\" }"
+		let malformed = "{ \"href\": \"/x\", \"method\": \"POST\" }"
+		let json = Fixtures.collection(entitiesJSON: [Fixtures.article()], actionsJSON: "\(valid), \(malformed)")
+		let page = QueuePage(collection: try decodeCollection(json))
+		XCTAssertEqual(
+			page.affordances.compactMap(\.action).map(\.name), ["save-article"],
+			"a malformed action is dropped; the valid ones still render"
+		)
+	}
+
+	func testCollectionDropsAMalformedEntityButKeepsValidOnes() throws {
+		// An entity whose properties are present but malformed (missing the required
+		// `id`) is dropped at decode rather than failing the whole collection —
+		// distinct from an entity with no properties at all (above), which decodes
+		// fine and is dropped later by Article.init?.
+		let malformedEntity = "{ \"properties\": { \"url\": \"https://example.com/x\" } }"
+		let json = Fixtures.collection(entitiesJSON: [Fixtures.article(id: "good"), malformedEntity], total: 2)
+		let page = QueuePage(collection: try decodeCollection(json))
+		XCTAssertEqual(page.articles.map(\.id), ["good"], "a malformed entity is dropped, not page-blanking")
+	}
+
+	func testCollectionDropsAMalformedLinkButKeepsPagination() throws {
+		// A malformed link (missing the required `rel`) is dropped while the valid
+		// navigation links still resolve, so one bad link can't break pagination.
+		let json = Fixtures.collection(
+			entitiesJSON: [Fixtures.article()],
+			extraLinks: ", { \"href\": \"/broken\" }, { \"rel\": [\"next\"], \"href\": \"/queue?page=2\" }",
+			page: 1
+		)
+		let page = QueuePage(collection: try decodeCollection(json))
+		XCTAssertEqual(page.nextHref, "/queue?page=2", "a malformed link is dropped; valid links still resolve")
 	}
 
 	func testCollectionExposesAffordancesAndTotal() throws {

--- a/projects/ios-readplace/Tests/TestSupport.swift
+++ b/projects/ios-readplace/Tests/TestSupport.swift
@@ -98,19 +98,22 @@ enum Fixtures {
 		  },
 		  "links": [{ "rel": ["read"], "href": "/queue/\(id)/view" }],
 		  "actions": [
-		    { "name": "update-status", "href": "/queue/\(id)/status", "method": "POST", "type": "application/x-www-form-urlencoded", "fields": [{ "name": "status", "type": "text" }] }
+		    { "name": "delete", "href": "/queue/\(id)/delete", "method": "POST" },
+		    { "name": "update-status", "href": "/queue/\(id)/status", "method": "POST", "type": "application/x-www-form-urlencoded", "fields": [{ "name": "status", "type": "text", "value": "read" }] }
 		  ]
 		}
 		"""
 	}
 
 	/// The collection-level actions a healthy `/queue` advertises (URL-only save,
-	/// HTML save, search). Overridable so a test can model a server that offers
-	/// neither save action.
+	/// HTML save, file save, search), each carrying the server's `title` label.
+	/// Mirrors `toArticleCollectionEntity`. Overridable so a test can model a
+	/// server that offers a different action set.
 	static let collectionActions = """
-		{ "name": "save-article", "href": "/queue", "method": "POST", "type": "application/json", "fields": [{ "name": "url", "type": "url" }] },
-		{ "name": "save-html", "href": "/queue/save-html", "method": "POST", "type": "application/json", "fields": [{ "name": "url", "type": "url" }, { "name": "rawHtml", "type": "text" }, { "name": "title", "type": "text" }] },
-		{ "name": "search", "href": "/queue", "method": "GET" }
+		{ "name": "save-article", "title": "Save a link", "href": "/queue", "method": "POST", "type": "application/json", "fields": [{ "name": "url", "type": "url" }] },
+		{ "name": "save-html", "title": "Save a page", "href": "/queue/save-html", "method": "POST", "type": "application/json", "fields": [{ "name": "url", "type": "url" }, { "name": "rawHtml", "type": "text" }, { "name": "title", "type": "text" }] },
+		{ "name": "save-content", "title": "Save a file", "href": "/queue/save-content", "method": "POST", "type": "multipart/form-data", "fields": [{ "name": "url", "type": "url" }, { "name": "content", "type": "file" }, { "name": "mediaType", "type": "text" }, { "name": "title", "type": "text" }] },
+		{ "name": "search", "title": "Search", "href": "/queue", "method": "GET", "fields": [{ "name": "status", "type": "text" }, { "name": "order", "type": "text" }, { "name": "page", "type": "number" }, { "name": "pageSize", "type": "number" }, { "name": "url", "type": "url" }] }
 		"""
 
 	static func collection(

--- a/projects/ios-readplace/Tests/ToolbarRouteTests.swift
+++ b/projects/ios-readplace/Tests/ToolbarRouteTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Readplace
+
+/// The toolbar maps each advertised control to a side effect without gating which
+/// controls exist: a navigable link opens, the `save-article` action prompts for a
+/// URL (the sanctioned bespoke handler), and any other action is invoked through the
+/// generic invoker — never opened as a GET web view of its href.
+final class ToolbarRouteTests: XCTestCase {
+	private func action(name: String, href: String? = "/queue", title: String? = nil) -> SirenAction {
+		SirenAction(name: name, href: href, method: "POST", title: title, type: nil, fields: nil)
+	}
+
+	func testNavigableLinkRoutesToOpen() {
+		let link = SirenLink(rel: ["save"], href: "/save", title: "Save a link")
+		let affordance = try! XCTUnwrap(Affordance(link: link))
+
+		XCTAssertEqual(ToolbarRoute.route(for: affordance), .open(link))
+	}
+
+	func testSaveArticleActionRoutesToTheNativeSaveDialog() {
+		let save = action(name: "save-article")
+		let affordance = try! XCTUnwrap(Affordance(action: save))
+
+		XCTAssertEqual(ToolbarRoute.route(for: affordance), .promptSave(save))
+	}
+
+	func testNonSaveActionRoutesToTheGenericInvoker() {
+		// A bare-invokable collection action is submitted through the generic invoker,
+		// honouring its own method/type/fields — never opened as a GET web view of its
+		// href, which would discard the action's invocation and silently turn a
+		// capability into navigation.
+		let purge = action(name: "purge-all", href: "/queue/purge", title: "Purge")
+		let affordance = try! XCTUnwrap(Affordance(action: purge))
+
+		XCTAssertEqual(ToolbarRoute.route(for: affordance), .invoke(purge))
+	}
+}


### PR DESCRIPTION
## What

**1 of 3 coordinated PRs** (plus a skill doc already on `main`) making every Readplace client a generic hypermedia client per the updated [`hypermedia-api-design`](../blob/main/.claude/skills/hypermedia-api-design/SKILL.md) skill. **This is the iOS half.**

Controls are now **rendered by looping advertised affordances**, never gated on per-capability booleans:

- **Affordance model.** Each advertised action/link becomes an `Affordance`. The toolbar loops the collection's affordances and each row loops its item affordances, rendering one control each — label from the Siren `title` (or a humanized fallback), icon/tint from a client-side `AffordancePresentation` token map. Removes `canSaveURL`/`canMarkRead` and the cherry-picked `updateStatus`/`delete` typed fields.
- **Generic invocation.** `invoke(action:)` follows the action's own `href`/`method`/`type` and posts its **server-declared field values** (GET → query items, else body per `type`). Navigable links open in a web view; the `add-links-help` link (from #824) now opens its help sheet **through the same loop** rather than a hardcoded button; structural rels (`self`/`root`/`prev`/`next`/`item`) are client navigation, not controls.
- **Safety.** A full swipe can't fire a destructive control, and `delete` confirms first; optimistic row removal is scoped to transitions that actually leave the unread-only list.

## Why

Per the skill's loop-not-boolean rule and "Rendering & Invoking Affordances." This also folds #824's server-driven Share help sheet into the generic loop (the help affordance is server-discovered and rendered like any other), instead of a special-cased `+` button.

## Independent & non-breaking

Mergeable on its own, in any order. The server-side `title`/`value` land in `feat/hutch-siren-affordance-titles`; this PR tolerates their absence (humanized-name fallback), and its XCTest fixtures stub the Siren responses.

## Verified

`swiftc -parse` clean on every changed file (App/Shared/Tests). Full type-check + XCTest run on the macOS/Xcode CI runner (`make test`) — they can't run in the authoring environment, same standing limitation as prior iOS PRs.

> One product call for review: the toolbar currently surfaces **both** the help sheet (#824) and the native URL-save dialog. #824's intent was to *replace* the native save with the help sheet — I kept both so the conformance work is intact for review; dropping the native save is a one-line follow-up (exclude `save-article` from the iOS toolbar) if you want to fully adopt #824's direction.

## The coordinated set
- `feat/hutch-siren-affordance-titles` — server titles + toggle value
- `feat/extensions-affordance-loop` — extensions loop affordances
- **this** — iOS loops affordances
- skill doc — already on `main`, so this PR's review runs against it.
