### PR TITLE
test(hutch): assert internal-clicks dashboard widget surfaces utm_content as element

### DIFF
--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -86,6 +86,15 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 		expect(opens).toContain("\\/view$");
 	});
 
+	it("the internal-clicks widget surfaces utm_content as the element so the dashboard shows which tab/button was clicked (e.g. install-tabs → firefox), not just the section", () => {
+		const queries = widgetQueries();
+		const clicks = queries.find((q) => q.includes(`event = "${ANALYTICS_EVENTS.click}"`));
+		expect(clicks).toBeDefined();
+		expect(clicks).toContain('coalesce(utm_source, "-") as section');
+		expect(clicks).toContain('coalesce(utm_content, "-") as element');
+		expect(clicks).toContain("stats count(*) as clicks by section, element");
+	});
+
 	it("every stream used by an emitter (STREAMS) is referenced by at least one widget query — adding a new stream without a widget fails CI", () => {
 		const referenced = collectReferencedStreams();
 		const declared = new Set(Object.values(STREAMS));


### PR DESCRIPTION
## Context

Starting point: the **Internal clicks by section / element** dashboard widget showed a row `install-tabs / - / 1` — an install-tab click with no element. The ask was to get the *name of the clicked tab* to show up as the element.

## Finding: the behaviour is already implemented

Tracing the path end-to-end, the clicked tab's name is already recorded as the dashboard element:

- **Tab href** — `install.component.ts:61` builds each tab with `withInternalTracking('/install?client=${key}', { source: 'install-tabs', content: key })`, so `utm_content` is the tab key (`firefox` / `chrome` / `iphone`). `content` is a **required** field, so it can't silently go missing. Asserted exactly in `install.route.test.ts:265-277`.
- **Click event** — the analytics middleware records `utm_content` as the element (`analytics.ts:242-244`), covered by `analytics.test.ts:171-186`.
- **Dashboard** — the widget maps `element = coalesce(utm_content, "-")` (`analytics-dashboard.ts:390`).

So a normal tab click already lands as `install-tabs / firefox`. The `-` row was an off-markup hit (a click reaching `/install` with the `install-tabs` source but no `utm_content` — e.g. recorded as the feature went live, or a hand-edited / bot-followed URL); it won't recur for real tab clicks.

A route-level test that follows a tab and asserts the emitted click was attempted, but the pageview/click middleware (`createAnalyticsMiddleware`) is composed in the Lambda entry (`lambda.main.ts:28-46`), not in `createApp`/the test harness — so internal `click` events are never produced in-harness. That seam lives in a composition root the harness intentionally doesn't run, so it was reverted rather than faked with an artificial mini-app.

## Change

The one genuinely missing, non-redundant guard was at the dashboard layer: nothing asserted the internal-clicks widget surfaces `utm_content` as the element. This adds that test to the existing drift-prevention suite, so a future query edit that drops or renames the `element = utm_content` alias (silently blanking the column) fails CI.

Test-only; no runtime behaviour change. `pnpm nx run hutch:check` passes (lint, type-check, tests, 100% coverage, knip, unused-css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu3AG6oxdweewxvXs8QxCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu3AG6oxdweewxvXs8QxCg)_