### PR TITLE
fix(ci): persist review artifact on manual review re-triggers

### DIFF
--- a/.github/workflows/claude-listener.yml
+++ b/.github/workflows/claude-listener.yml
@@ -188,11 +188,14 @@ jobs:
       # separate workflow and cannot read this runner's files, so persist execution_file as
       # an artifact for it. The name carries the PR number because the downstream
       # workflow_run event for an issue_comment-triggered run reports the default branch,
-      # not the PR. Gated on the workflow-authored CLAUDE_REVIEW_REQUEST marker, so it is
-      # inert on every non-review @claude run — the artifact's presence is the review-run
+      # not the PR. Keyed on the workflow-authored CLAUDE_REVIEW_REQUEST marker OR a
+      # reference to the reviewer prompt file: a manual review re-trigger references the
+      # prompt but, typed by hand, drops the HTML marker, so keying on either still
+      # persists the artifact while staying inert on ci-fix/conflict/ad-hoc @claude runs,
+      # which reference different prompt files. The artifact's presence is the review-run
       # signal the auto-fix workflow keys on.
       - name: Save review output for the auto-fix workflow
-        if: steps.claude.outcome == 'success' && github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '<!-- CLAUDE_REVIEW_REQUEST -->')
+        if: steps.claude.outcome == 'success' && github.event_name == 'issue_comment' && github.event.issue.pull_request && (contains(github.event.comment.body, '<!-- CLAUDE_REVIEW_REQUEST -->') || contains(github.event.comment.body, 'claude-PR-code-reviewer.md'))
         uses: actions/upload-artifact@v4
         with:
           name: review-output-${{ github.event.issue.number }}


### PR DESCRIPTION
## Problem

The review → auto-fix hop silently died on **PR #829**. The review ran and found 2 medium issues, but auto-apply never fired.

Root cause: the listener's **"Save review output"** step (which uploads the `review-output-<pr>` artifact the auto-apply workflow keys on) was gated **solely** on the workflow-authored `<!-- CLAUDE_REVIEW_REQUEST -->` marker. The review that actually produced findings was a **manual re-trigger** — a human re-typed the review request after the original automated run crashed. That hand-typed comment **referenced `claude-PR-code-reviewer.md`** (so the agent loaded the reviewer prompt and the review ran fine) but **could not reproduce the HTML marker**. No marker → no artifact → `post-review-comment` logged `No review-output artifact: not a review run, nothing to do.` → no `request-fix`.

(Verified against the GitHub API: the successful review run `28312435672` uploaded zero artifacts; the triggering comment has the `claude-PR-code-reviewer.md` reference but not the marker.)

## Fix

Key the upload on the marker **OR** a reference to the reviewer prompt file:

```yaml
if: steps.claude.outcome == 'success' && github.event_name == 'issue_comment' && github.event.issue.pull_request
    && (contains(github.event.comment.body, '<!-- CLAUDE_REVIEW_REQUEST -->')
        || contains(github.event.comment.body, 'claude-PR-code-reviewer.md'))
```

The substring `claude-PR-code-reviewer.md` matches **only** review requests — not the ci-fix (`claude-PR-CI-failure-fixer.md`), conflict (`claude-PR-conflict-fixer.md`), or auto-apply (`claude-PR-code-review-auto-apply.md`) prompts — so every non-review `@claude` run stays inert. The uploaded `execution_file` always exists on a successful run, so `if-no-files-found: error` is unaffected.

## Scope

This is the **stop-gap** from [the design PR #834](https://github.com/Readplace/readplace.com/pull/834) §6 — it un-sticks the manual-re-trigger failure class today. It does **not** address the deeper prose-count contract (that's the ADR in #834) or the listener-crash leg (owned by `claude-PR-crash-retry`).

After this merges I'll re-post the proper marker-bearing review request on #829 so its 2 medium findings get picked up, then open the follow-up.