### PR TITLE
Route add-links-help link to native sheet in toolbar

### DIFF
--- a/projects/ios-readplace/App/AffordancePresentation.swift
+++ b/projects/ios-readplace/App/AffordancePresentation.swift
@@ -120,6 +120,16 @@ extension Affordance {
 		bespokeFieldHandlers.contains(name)
 	}
 
+	/// Whether a link `rel` is one the client renders through its own in-app
+	/// presentation rather than browsing to the href in the web view. The
+	/// `add-links-help` link opens the native add-link instructions sheet — a help
+	/// affordance the client presents itself — so the toolbar routes it to that
+	/// sheet instead of opening its href as a page. Single source for the routing
+	/// decision, mirroring `isBespokeFieldHandler` for actions.
+	static func isAddLinksHelp(_ rel: String) -> Bool {
+		rel == "add-links-help"
+	}
+
 	/// Whether the client can invoke this affordance from a bare toolbar control.
 	/// Per the contract, a field-requiring action whose fields carry no
 	/// server-provided `value` is not invokable by a bare control: the value must

--- a/projects/ios-readplace/App/ReadingListView.swift
+++ b/projects/ios-readplace/App/ReadingListView.swift
@@ -114,18 +114,13 @@ struct ReadingListView: View {
 	}
 
 	/// Routes a tapped collection control to the side effect its advertised
-	/// invocation calls for. The decision itself is pure (`ToolbarRoute.route`); this
-	/// only performs the resulting effect, so the routing is unit-testable without a
-	/// view.
+	/// invocation calls for. The decision itself is pure (`ToolbarRoute.route`),
+	/// including which sheet a control presents; this only performs the resulting
+	/// effect, so the routing is unit-testable without a view.
 	private func dispatch(_ affordance: Affordance) {
-		// A navigable help link opens the server's add-links help sheet — a distinct
-		// presentation from the reader. Mapping a known rel to its sheet is a
-		// client presentation choice, not an availability gate.
-		if affordance.token == "add-links-help" {
-			showingAddInstructions = true
-			return
-		}
 		switch ToolbarRoute.route(for: affordance) {
+		case .presentAddLinksHelp:
+			showingAddInstructions = true
 		case let .open(link):
 			viewModel.open(link: link)
 		case let .promptSave(action):

--- a/projects/ios-readplace/App/ToolbarRoute.swift
+++ b/projects/ios-readplace/App/ToolbarRoute.swift
@@ -19,15 +19,23 @@ enum ToolbarRoute: Equatable {
 	/// the request needs (the server fills each declared field's `value`), so it is
 	/// submitted in place rather than opened as a GET web view of its href.
 	case invoke(SirenAction)
+	/// Present the native add-link instructions sheet. The `add-links-help` link is a
+	/// help affordance the client renders as its own sheet (reading the href from the
+	/// view model) rather than browsing to the page, so which sheet a control presents
+	/// is decided here, not by a name check in the view.
+	case presentAddLinksHelp
 
-	/// Routes an affordance: a navigable link opens; the `save-article` action prompts
-	/// for a URL (the field the server cannot value); any other action is invoked
-	/// through the generic invoker. An action is never opened as a GET web view of its
-	/// href — that would discard its method/type/fields and silently turn a capability
-	/// into navigation. The decision maps each affordance to an effect without gating
-	/// which controls exist.
+	/// Routes an affordance: the `add-links-help` link presents the native help sheet;
+	/// any other navigable link opens in the web view; the `save-article` action
+	/// prompts for a URL (the field the server cannot value); any other action is
+	/// invoked through the generic invoker. An action is never opened as a GET web view
+	/// of its href — that would discard its method/type/fields and silently turn a
+	/// capability into navigation. The decision maps each affordance to an effect
+	/// without gating which controls exist.
 	static func route(for affordance: Affordance) -> ToolbarRoute {
 		switch affordance.invocation {
+		case .link where Affordance.isAddLinksHelp(affordance.token):
+			return .presentAddLinksHelp
 		case let .link(link):
 			return .open(link)
 		case let .action(action) where Affordance.isBespokeFieldHandler(action.name):

--- a/projects/ios-readplace/Tests/ToolbarRouteTests.swift
+++ b/projects/ios-readplace/Tests/ToolbarRouteTests.swift
@@ -2,9 +2,10 @@ import XCTest
 @testable import Readplace
 
 /// The toolbar maps each advertised control to a side effect without gating which
-/// controls exist: a navigable link opens, the `save-article` action prompts for a
-/// URL (the sanctioned bespoke handler), and any other action is invoked through the
-/// generic invoker — never opened as a GET web view of its href.
+/// controls exist: the `add-links-help` link presents the native help sheet, any
+/// other navigable link opens, the `save-article` action prompts for a URL (the
+/// sanctioned bespoke handler), and any other action is invoked through the generic
+/// invoker — never opened as a GET web view of its href.
 final class ToolbarRouteTests: XCTestCase {
 	private func action(name: String, href: String? = "/queue", title: String? = nil) -> SirenAction {
 		SirenAction(name: name, href: href, method: "POST", title: title, type: nil, fields: nil)
@@ -15,6 +16,16 @@ final class ToolbarRouteTests: XCTestCase {
 		let affordance = try! XCTUnwrap(Affordance(link: link))
 
 		XCTAssertEqual(ToolbarRoute.route(for: affordance), .open(link))
+	}
+
+	func testAddLinksHelpLinkRoutesToTheNativeHelpSheet() {
+		// The `add-links-help` link is a help affordance the client presents as its own
+		// native instructions sheet, not browsed to as a page — so which sheet a control
+		// presents is decided here, never by a name check in the view.
+		let link = SirenLink(rel: ["add-links-help"], href: "/import", title: "Import links")
+		let affordance = try! XCTUnwrap(Affordance(link: link))
+
+		XCTAssertEqual(ToolbarRoute.route(for: affordance), .presentAddLinksHelp)
 	}
 
 	func testSaveArticleActionRoutesToTheNativeSaveDialog() {


### PR DESCRIPTION
Moves the routing decision for the `add-links-help` link from the view layer to the pure routing layer, making it testable without a view and establishing a single source of truth for which affordances receive custom client-side handling.

## Changes

- **ToolbarRoute**: Added `presentAddLinksHelp` case to represent the native help sheet presentation, and updated `route(for:)` to detect `add-links-help` links and return this case before checking other link types
- **ReadingListView**: Removed the inline `affordance.token == "add-links-help"` check from `dispatch(_:)`, replacing it with a switch case on the routed result
- **AffordancePresentation**: Added `isAddLinksHelp(_:)` static method as the single source for identifying help links, mirroring the existing `isBespokeFieldHandler` pattern for actions
- **ToolbarRouteTests**: Added test verifying that `add-links-help` links route to `.presentAddLinksHelp`
- **Documentation**: Updated comments in ToolbarRoute and ToolbarRouteTests to reflect the new routing behavior

This change follows the established pattern where routing decisions are made in the pure `ToolbarRoute` layer (testable without a view) rather than in the view, and establishes `AffordancePresentation` as the single source for identifying affordances that receive custom client-side handling.

https://claude.ai/code/session_013bFh8c8HcU9pziocWfjgGq