### PR TITLE
Configure custom domains for staging environment

### DIFF
--- a/projects/blog-site/Pulumi.staging.yaml
+++ b/projects/blog-site/Pulumi.staging.yaml
@@ -3,6 +3,6 @@ config:
   aws:allowedAccountIds:
     - '572337278115'
   blog-site:stage: staging
-  blog-site:staticBaseUrl: https://d2uoxssv1ey7em.cloudfront.net
+  blog-site:staticBaseUrl: https://static.readplace-staging.com
   blog-site:hutchStack: organization/hutch/staging
 encryptionsalt: v1:K6HCDCWECIo=:v1:fGew/55ZZHhWixd9:fDj8bwCv+lgi5ALA8d79WMkFj/gm6w==

--- a/projects/hutch/Pulumi.staging.yaml
+++ b/projects/hutch/Pulumi.staging.yaml
@@ -5,9 +5,14 @@ config:
   hutch:stage: staging
   hutch:nodeEnv: development
   hutch:platformStack: organization/platform/staging
+  hutch:domains:
+    - readplace-staging.com
+  hutch:redirectSubdomains:
+    - host: www.readplace-staging.com
+      zoneName: readplace-staging.com
   hutch:deletionProtection: false
   hutch:staticDomains:
-    - d2uoxssv1ey7em.cloudfront.net
+    - static.readplace-staging.com
   hutch:staticBucketName: hutch-static-assets-staging
   hutch:dynamodbArticlesTable: hutch-articles-cda0a08
   hutch:dynamodbUserArticlesTable: hutch-user-articles-8226beb

--- a/projects/save-link/Pulumi.staging.yaml
+++ b/projects/save-link/Pulumi.staging.yaml
@@ -12,5 +12,6 @@ config:
   save-link:contentBucketName: hutch-article-content-staging
   save-link:pendingHtmlBucketName: hutch-pending-html-staging
   save-link:pendingPdfBucketName: hutch-pending-pdf-staging
+  save-link:contentMediaCdnDomain: cdn.readplace-staging.com
 
 encryptionsalt: v1:UOuPAPopzKA=:v1:R9v//2alhEYfLugF:HuZRBtgwdPawWU7VHPvdJ9bsYqJR9w==


### PR DESCRIPTION
## Summary
Updates staging environment configuration across hutch, blog-site, and save-link projects to use custom domains instead of CloudFront distribution URLs.

## Changes
- **hutch**: Added `readplace-staging.com` as primary domain with www subdomain redirect, replaced CloudFront static domain (`d2uoxssv1ey7em.cloudfront.net`) with `static.readplace-staging.com`
- **blog-site**: Updated static asset base URL from CloudFront distribution to `static.readplace-staging.com`
- **save-link**: Added CDN domain configuration (`cdn.readplace-staging.com`) for content media delivery

## Details
These configuration changes enable the staging environment to use branded custom domains instead of AWS CloudFront distribution URLs, improving consistency with production infrastructure and enabling proper domain-based routing and SSL certificate management.

https://claude.ai/code/session_014tCgtdixuYZV859nZGGoba