### PR TITLE
Redirect authenticated users from home page to /queue

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -627,6 +627,10 @@ export function createApp(dependencies: AppDependencies): Express {
 	/** Firefox extensions enforce CORS preflight for fetches with non-simple headers (Accept: application/vnd.siren+json, Authorization). Register OPTIONS so the preflight succeeds; without this it returns 404 and firefox aborts the fetch with NetworkError. */
 	app.options("/", extensionCors);
 	app.get("/", extensionCors, async (req: Request, res: Response) => {
+		if (req.userId) {
+			res.redirect(303, QUEUE_PATH);
+			return;
+		}
 		if (wantsSiren(req) && !wantsMarkdown(req)) {
 			res.redirect(303, QUEUE_PATH);
 			return;

--- a/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { useTestServer } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -10,6 +10,19 @@ import {
 const TEST_FOUNDING_MEMBER_LIMIT = 3;
 
 const useApp = useTestServer();
+
+describe("GET / (authenticated)", () => {
+	it("should redirect a logged-in visitor straight to /queue", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
+
+		const response = await agent.get("/");
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
+	});
+});
 
 describe("GET /", () => {
 	it("should return 200 and HTML content", async () => {

--- a/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.static.route.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { useTestServer } from "../../../test-app";
+import { useTestServer, loginAgent } from "../../../test-app";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -157,6 +157,17 @@ describe("GET / with Accept: text/markdown", () => {
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toBe("text/markdown; charset=utf-8");
 		expect(response.headers.location).toBeUndefined();
+	});
+
+	it("redirects a logged-in visitor to /queue instead of serving the markdown landing page", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const agent = await loginAgent(harness.server, auth);
+
+		const response = await agent.get("/").set("Accept", "text/markdown");
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/queue");
 	});
 
 	it("converts the comparison table into markdown table syntax", async () => {


### PR DESCRIPTION
## Summary
Authenticated users visiting the home page (`GET /`) are now redirected to `/queue` instead of seeing the landing page content. This applies to both HTML and markdown content negotiation.

## Changes
- **Server route handler** (`server.ts`): Added authentication check at the start of the `GET /` handler to redirect logged-in users (those with `req.userId`) to `/queue` with a 303 status code, before any content negotiation logic
- **Test coverage**: Added two integration tests to verify the redirect behavior:
  - `home.route.test.ts`: Tests that authenticated users receive a 303 redirect to `/queue` when accessing `/`
  - `home.static.route.test.ts`: Tests that authenticated users are redirected even when requesting markdown content via `Accept: text/markdown` header
- **Test utilities**: Imported `loginAgent` helper in both test files to support authenticated request testing

## Implementation Details
The redirect check is placed at the beginning of the route handler, before the existing Siren/markdown content negotiation logic. This ensures all authenticated visitors are redirected regardless of their `Accept` header preferences, keeping the landing page exclusively for unauthenticated users.

https://claude.ai/code/session_01212tyY5z2Fs1JbbPXxT7Mg