### PR TITLE
Add LocalTime formatting for timezone-aware instant display

### DIFF
--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -210,6 +210,21 @@ const BUNDLES = [
 		].join("\n"),
 	},
 	{
+		entry: path.join(PROJECT_ROOT, "src/runtime/web/local-time.client.ts"),
+		outfile: path.join(OUT_DIR, "local-time.client.js"),
+		globalName: "LocalTime",
+		footer: [
+			// Loaded globally with `defer`, so the DOM is parsed before this runs
+			// and the initial scan sees every server-rendered baseline. The swap
+			// listener re-localises instants that arrive inside a swapped <main>.
+			"LocalTime.initLocalTime({",
+			"  document: window.document,",
+			"  timeZone: function () { return Intl.DateTimeFormat().resolvedOptions().timeZone; },",
+			"  addSwapListener: function (cb) { document.body.addEventListener('htmx:afterSwap', cb); }",
+			"}).attach();",
+		].join("\n"),
+	},
+	{
 		entry: path.join(
 			PROJECT_ROOT,
 			"src/runtime/web/pages/view/expiry-counter.client.ts",

--- a/projects/hutch/src/runtime/web/base.component.ts
+++ b/projects/hutch/src/runtime/web/base.component.ts
@@ -5,6 +5,10 @@ import { getEnv, requireEnv } from "@packages/require-env";
  * WebMCP tools (save_link) on load, regardless of which page it landed on. */
 const WEBMCP_SCRIPT = `<script src="/client-dist/webmcp.client.js" defer></script>`;
 
+/** Loaded on every page so any server-rendered `<time data-local-time>` baseline
+ * (inbox, queue, account) is rewritten into the viewer's local timezone. */
+const LOCAL_TIME_SCRIPT = `<script src="/client-dist/local-time.client.js" defer></script>`;
+
 /** Hutch's configured shell renderer. The presentational layout lives in
  * @packages/web-shell; this composition point binds it to hutch's runtime
  * config (the static-asset origin and the dev livereload flag) so every page
@@ -12,5 +16,5 @@ const WEBMCP_SCRIPT = `<script src="/client-dist/webmcp.client.js" defer></scrip
 export const Base = initBase({
 	staticBaseUrl: requireEnv("STATIC_BASE_URL"),
 	liveReload: Boolean(getEnv("LIVERELOAD")),
-	siteScripts: WEBMCP_SCRIPT,
+	siteScripts: WEBMCP_SCRIPT + LOCAL_TIME_SCRIPT,
 });

--- a/projects/hutch/src/runtime/web/local-time.client.test.ts
+++ b/projects/hutch/src/runtime/web/local-time.client.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { initLocalTime } from "./local-time.client";
+
+const SYDNEY = "Australia/Sydney";
+
+function initWithDom(
+	bodyHtml: string,
+	timeZone = SYDNEY,
+): {
+	document: Document;
+	triggerSwap: () => void;
+} {
+	const dom = new JSDOM(`<!DOCTYPE html><html><body>${bodyHtml}</body></html>`);
+	let swapListener: (() => void) | undefined;
+	initLocalTime({
+		document: dom.window.document,
+		timeZone: () => timeZone,
+		addSwapListener: (listener) => {
+			swapListener = listener;
+		},
+	}).attach();
+	return {
+		document: dom.window.document,
+		triggerSwap: () => {
+			assert(swapListener, "a swap listener must be registered");
+			swapListener();
+		},
+	};
+}
+
+describe("initLocalTime", () => {
+	it("rewrites a datetime element into the browser zone with the abbreviation", () => {
+		const { document } = initWithDom(
+			`<time datetime="2026-06-24T09:00:00.000Z" data-local-time="datetime">24 June 2026, 09:00 UTC</time>`,
+		);
+		expect(document.querySelector("time")?.textContent).toBe(
+			"24 June 2026, 19:00 AEST",
+		);
+	});
+
+	it("rewrites a date element into the browser zone, fixing midnight ±1-day drift", () => {
+		const { document } = initWithDom(
+			`<time datetime="2026-06-23T15:00:00.000Z" data-local-time="date">23 June 2026</time>`,
+		);
+		expect(document.querySelector("time")?.textContent).toBe("24 June 2026");
+	});
+
+	it("leaves relative text in place and only sets the localised absolute instant as a title", () => {
+		const { document } = initWithDom(
+			`<time datetime="2026-06-24T09:00:00.000Z" data-local-time="relative">5m ago</time>`,
+		);
+		const el = document.querySelector("time");
+		assert(el, "time element must render");
+		expect(el.textContent).toBe("5m ago");
+		expect(el.getAttribute("title")).toBe("24 June 2026, 19:00 AEST");
+	});
+
+	it("skips an element with a missing or unparseable datetime", () => {
+		const { document } = initWithDom(
+			`<time data-local-time="datetime">no datetime</time><time datetime="not-a-date" data-local-time="datetime">bad</time>`,
+		);
+		const [missing, unparseable] = Array.from(document.querySelectorAll("time"));
+		expect(missing.textContent).toBe("no datetime");
+		expect(unparseable.textContent).toBe("bad");
+	});
+
+	it("re-localises elements inserted after an htmx swap", () => {
+		const { document, triggerSwap } = initWithDom("");
+		document.body.innerHTML = `<time datetime="2026-06-24T09:00:00.000Z" data-local-time="datetime">24 June 2026, 09:00 UTC</time>`;
+		triggerSwap();
+		expect(document.querySelector("time")?.textContent).toBe(
+			"24 June 2026, 19:00 AEST",
+		);
+	});
+});

--- a/projects/hutch/src/runtime/web/local-time.client.ts
+++ b/projects/hutch/src/runtime/web/local-time.client.ts
@@ -24,10 +24,9 @@ function isParseableIso(iso: string | null): iso is string {
 }
 
 export function initLocalTime(deps: LocalTimeDeps): { attach(): void } {
-	function localize(el: Element): void {
+	function localize(el: Element, timeZone: string): void {
 		const iso = el.getAttribute("datetime");
 		if (!isParseableIso(iso)) return;
-		const timeZone = deps.timeZone();
 		const mode = el.getAttribute("data-local-time");
 		if (mode === "relative") {
 			// Relative text ("5m ago") is timezone-neutral, so leave it visible and
@@ -40,9 +39,12 @@ export function initLocalTime(deps: LocalTimeDeps): { attach(): void } {
 	}
 
 	function scan(): void {
+		// The viewer's zone is constant for the page, so resolve it once per scan
+		// rather than per element — a polling queue re-scans every few seconds.
+		const timeZone = deps.timeZone();
 		const elements = deps.document.querySelectorAll(SELECTOR);
 		for (let i = 0; i < elements.length; i++) {
-			localize(elements[i]);
+			localize(elements[i], timeZone);
 		}
 	}
 

--- a/projects/hutch/src/runtime/web/local-time.client.ts
+++ b/projects/hutch/src/runtime/web/local-time.client.ts
@@ -1,0 +1,55 @@
+/**
+ * Progressive enhancement for every stored instant the server renders as a
+ * `<time datetime="…" data-local-time="…">` baseline. The server emits a
+ * UTC-labelled value (unambiguous without JavaScript); this enhancer rewrites
+ * each one into the browser's resolved timezone, and re-runs on htmx swaps so
+ * boosted navigations stay localised. Dependencies are injected so the browser
+ * wiring lives in build-client-bundles.js and the module stays unit-testable.
+ */
+import {
+	formatLocalInstant,
+	type LocalTimeStyle,
+} from "@packages/web-shell/local-time.format";
+
+export interface LocalTimeDeps {
+	document: Document;
+	timeZone: () => string;
+	addSwapListener: (cb: () => void) => void;
+}
+
+const SELECTOR = "[data-local-time]";
+
+function isParseableIso(iso: string | null): iso is string {
+	return iso !== null && !Number.isNaN(Date.parse(iso));
+}
+
+export function initLocalTime(deps: LocalTimeDeps): { attach(): void } {
+	function localize(el: Element): void {
+		const iso = el.getAttribute("datetime");
+		if (!isParseableIso(iso)) return;
+		const timeZone = deps.timeZone();
+		const mode = el.getAttribute("data-local-time");
+		if (mode === "relative") {
+			// Relative text ("5m ago") is timezone-neutral, so leave it visible and
+			// only surface the localised absolute instant as a hover tooltip.
+			el.setAttribute("title", formatLocalInstant({ iso, style: "datetime", timeZone }));
+			return;
+		}
+		const style: LocalTimeStyle = mode === "datetime" ? "datetime" : "date";
+		el.textContent = formatLocalInstant({ iso, style, timeZone });
+	}
+
+	function scan(): void {
+		const elements = deps.document.querySelectorAll(SELECTOR);
+		for (let i = 0; i < elements.length; i++) {
+			localize(elements[i]);
+		}
+	}
+
+	function attach(): void {
+		scan();
+		deps.addSwapListener(scan);
+	}
+
+	return { attach };
+}

--- a/projects/hutch/src/runtime/web/pages/account/account.template.html
+++ b/projects/hutch/src/runtime/web/pages/account/account.template.html
@@ -14,7 +14,7 @@
         {{#if showCancellingNotice}}
         <p class="account-card__notice" data-test-cancelling-notice>Cancellation in progress — refresh in a few seconds to see the update.</p>
         {{/if}}
-        <p class="account-card__status" data-test-account-status>{{statusLine}}</p>
+        <p class="account-card__status" data-test-account-status>{{statusLine}}{{#if statusDate}}<time class="account-card__status-date" datetime="{{statusDate.iso}}" data-local-time="{{statusDate.mode}}">{{statusDate.label}}</time>{{statusDateTail}}{{/if}}</p>
         {{/if}}
         <div class="account-card__actions">
           {{#each actions}}

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
@@ -21,6 +21,13 @@ describe("toAccountViewModel — state", () => {
 		);
 		assert.equal(vm.trialDaysLeft, 1);
 		assert.equal(vm.trialDaysLeftWord, "day");
+		assert.equal(vm.statusLine, "Your free trial ends on ");
+		assert.deepEqual(vm.statusDate, {
+			iso: trialEndsAt,
+			label: "24 May 2026",
+			mode: "date",
+		});
+		assert.equal(vm.statusDateTail, " — 1 day left.");
 	});
 
 	it("shows zero-remainder day boundary correctly", () => {
@@ -127,7 +134,13 @@ describe("toAccountViewModel — actions", () => {
 
 		assert.equal(vm.state, "cancellation-scheduled");
 		assert.equal(vm.stateClass, "account-card account-card--cancellation-scheduled");
-		assert.equal(vm.statusLine, `Your subscription ends on ${new Date("2026-06-22T10:00:00.000Z").toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}.`);
+		assert.equal(vm.statusLine, "Your subscription ends on ");
+		assert.deepEqual(vm.statusDate, {
+			iso: "2026-06-22T10:00:00.000Z",
+			label: "22 June 2026",
+			mode: "date",
+		});
+		assert.equal(vm.statusDateTail, ".");
 		const keys = vm.actions.map((a) => a.key);
 		assert.deepEqual(keys, ["reactivate-form"]);
 		assert.equal(vm.actions[0].variant, "primary");
@@ -149,7 +162,13 @@ describe("toAccountViewModel — actions", () => {
 		);
 
 		assert.equal(vm.state, "cancellation-scheduled");
-		assert.equal(vm.statusLine, `Your subscription ends on ${new Date("2026-06-05T00:00:00.000Z").toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}.`);
+		assert.equal(vm.statusLine, "Your subscription ends on ");
+		assert.deepEqual(vm.statusDate, {
+			iso: "2026-06-05T00:00:00.000Z",
+			label: "5 June 2026",
+			mode: "date",
+		});
+		assert.equal(vm.statusDateTail, ".");
 		const keys = vm.actions.map((a) => a.key);
 		assert.deepEqual(keys, ["reactivate-form"]);
 	});

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.test.ts
@@ -19,8 +19,6 @@ describe("toAccountViewModel — state", () => {
 			{ cancelling: false, errorPaymentMethod: false },
 			now,
 		);
-		assert.equal(vm.trialDaysLeft, 1);
-		assert.equal(vm.trialDaysLeftWord, "day");
 		assert.equal(vm.statusLine, "Your free trial ends on ");
 		assert.deepEqual(vm.statusDate, {
 			iso: trialEndsAt,
@@ -44,8 +42,7 @@ describe("toAccountViewModel — state", () => {
 			{ cancelling: false, errorPaymentMethod: false },
 			now,
 		);
-		assert.equal(vm.trialDaysLeft, 1);
-		assert.equal(vm.trialDaysLeftWord, "day");
+		assert.equal(vm.statusDateTail, " — 1 day left.");
 	});
 });
 

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
@@ -1,6 +1,6 @@
 import { decomposeTimeLeft } from "@packages/time-left";
 import type { EffectiveAccess } from "../../../domain/access/effective-access";
-import { withInternalTracking } from "@packages/web-shell";
+import { type LocalTime, toAbsoluteDate, withInternalTracking } from "@packages/web-shell";
 import {
 	ACCOUNT_CANCEL_URL,
 	ACCOUNT_REACTIVATE_URL,
@@ -31,7 +31,12 @@ export interface AccountViewModel {
 	state: AccountCardState;
 	stateClass: string;
 	heading: string;
+	/** Leading sentence text. For the trial-countdown and cancellation-scheduled
+	 * states this is only the text before the date — `statusDate`/`statusDateTail`
+	 * carry the rest so the date renders as a localisable `<time>` element. */
 	statusLine: string;
+	statusDate?: LocalTime;
+	statusDateTail?: string;
 	trialEndsAtIso?: string;
 	trialEndsAtFormatted?: string;
 	trialDaysLeft?: number;
@@ -155,7 +160,9 @@ export function toAccountViewModel(
 			const { daysLeft, daysLeftWord } = formatTrialDaysLeft(trialEndsAt, now);
 			return {
 				...baseFor("trial", [SUBSCRIBE_ACTION]),
-				statusLine: `Your free trial ends on ${formatTrialEndsAt(trialEndsAt)} — ${daysLeft} ${daysLeftWord} left.`,
+				statusLine: "Your free trial ends on ",
+				statusDate: toAbsoluteDate({ iso: trialEndsAt }),
+				statusDateTail: ` — ${daysLeft} ${daysLeftWord} left.`,
 				trialEndsAtIso: trialEndsAt,
 				trialEndsAtFormatted: formatTrialEndsAt(trialEndsAt),
 				trialDaysLeft: daysLeft,
@@ -165,7 +172,9 @@ export function toAccountViewModel(
 		case "cancellation-scheduled":
 			return {
 				...baseFor("cancellation-scheduled", [REACTIVATE_FORM_ACTION]),
-				statusLine: `Your subscription ends on ${formatTrialEndsAt(access.cancellationEffectiveAt)}.`,
+				statusLine: "Your subscription ends on ",
+				statusDate: toAbsoluteDate({ iso: access.cancellationEffectiveAt }),
+				statusDateTail: ".",
 			};
 		case "inactive":
 			return {

--- a/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.view-model.ts
@@ -37,21 +37,9 @@ export interface AccountViewModel {
 	statusLine: string;
 	statusDate?: LocalTime;
 	statusDateTail?: string;
-	trialEndsAtIso?: string;
-	trialEndsAtFormatted?: string;
-	trialDaysLeft?: number;
-	trialDaysLeftWord?: "day" | "days";
 	showCancellingNotice: boolean;
 	stateIsErrorPaymentMethod: boolean;
 	actions: AccountAction[];
-}
-
-function formatTrialEndsAt(iso: string): string {
-	return new Date(iso).toLocaleDateString("en-AU", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
 }
 
 function formatTrialDaysLeft(trialEndsAt: string, now: Date): { daysLeft: number; daysLeftWord: "day" | "days" } {
@@ -163,10 +151,6 @@ export function toAccountViewModel(
 				statusLine: "Your free trial ends on ",
 				statusDate: toAbsoluteDate({ iso: trialEndsAt }),
 				statusDateTail: ` — ${daysLeft} ${daysLeftWord} left.`,
-				trialEndsAtIso: trialEndsAt,
-				trialEndsAtFormatted: formatTrialEndsAt(trialEndsAt),
-				trialDaysLeft: daysLeft,
-				trialDaysLeftWord: daysLeftWord,
 			};
 		}
 		case "cancellation-scheduled":

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
@@ -105,6 +105,15 @@ describe("Inbox email detail route", () => {
 		expect(doc.querySelector('meta[name="robots"]')?.getAttribute("content")).toBe(
 			"noindex, nofollow",
 		);
+
+		// The received instant renders as a localisable <time> baseline: it carries
+		// the stored UTC ISO in datetime, the datetime enhancement mode, and an
+		// unambiguous UTC-labelled text for the no-JavaScript case.
+		const received = doc.querySelector(".inbox-email-detail__received");
+		assert(received, "received time element must render");
+		expect(received.getAttribute("datetime")).toBe("2026-06-24T09:00:00.000Z");
+		expect(received.getAttribute("data-local-time")).toBe("datetime");
+		expect(received.textContent).toBe("24 June 2026, 09:00 UTC");
 	});
 
 	it("renders a text-only received email's plain text in the View tab, not a blank frame", async () => {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.template.html
@@ -4,7 +4,7 @@
 		<h1 class="inbox-email-detail__subject" data-test-inbox-detail-subject>{{subject}}</h1>
 		<p class="inbox-email-detail__meta">
 			<span data-test-inbox-detail-sender>{{sender}}</span>
-			<span class="inbox-email-detail__received">{{receivedAtLabel}}</span>
+			<time class="inbox-email-detail__received" datetime="{{received.iso}}" data-local-time="{{received.mode}}">{{received.label}}</time>
 		</p>
 	</header>
 

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.test.ts
@@ -35,6 +35,19 @@ describe("toInboxEmailDetailViewModel", () => {
 		expect(vm.tabs[0].ariaCurrent).toBe("page");
 	});
 
+	it("exposes the received instant as a UTC-baselined datetime LocalTime", () => {
+		const vm = toInboxEmailDetailViewModel({
+			entry: entry({ receivedAt: "2026-06-24T09:00:00.000Z" }),
+			bodyHtml: "<p>hi</p>",
+		});
+
+		expect(vm.received).toEqual({
+			iso: "2026-06-24T09:00:00.000Z",
+			label: "24 June 2026, 09:00 UTC",
+			mode: "datetime",
+		});
+	});
+
 	it("shows the unavailable panel for a received email whose body is not readable", () => {
 		const vm = toInboxEmailDetailViewModel({
 			entry: entry({ status: "received" }),

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.ts
@@ -1,11 +1,11 @@
-import { EMAIL_FEATURE } from "@packages/web-shell";
+import { EMAIL_FEATURE, type LocalTime, toAbsoluteDateTime } from "@packages/web-shell";
 import type { InboxEmailEntry } from "@packages/domain/inbox";
 import { type MailTab, buildMailTabs } from "./mail-tabs";
 
 export interface InboxEmailDetailViewModel {
 	subject: string;
 	sender: string;
-	receivedAtLabel: string;
+	received: LocalTime;
 	backHref: string;
 	tabs: MailTab[];
 	/** A `received` email with its body present renders in the iframe; every
@@ -25,10 +25,7 @@ export function toInboxEmailDetailViewModel(input: {
 	return {
 		subject: input.entry.subject === "" ? "(no subject)" : input.entry.subject,
 		sender: input.entry.senderEmail === "" ? "(unknown sender)" : input.entry.senderEmail,
-		receivedAtLabel: new Date(input.entry.receivedAt).toLocaleString("en-AU", {
-			dateStyle: "medium",
-			timeStyle: "short",
-		}),
+		received: toAbsoluteDateTime({ iso: input.entry.receivedAt }),
 		backHref: `/inbox?feature=${EMAIL_FEATURE}`,
 		tabs: buildMailTabs("view"),
 		canRenderBody,

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.route.test.ts
@@ -107,6 +107,10 @@ describe("Inbox emails list route", () => {
 
 	it("renders received, unparsed, and rejected emails newest-first with badges and links", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		// Pin the clock so the relative-mode assertion stays deterministic: under the
+		// default real-time clock these fixed receivedAt instants would eventually
+		// cross the relative cutoff and render as `date` instead of `relative`.
+		fixture.shared.now = () => new Date("2026-06-24T12:00:00.000Z");
 		const harness = useApp(fixture);
 		const agent = await loginAgent(harness.server, harness.auth);
 		await seedEmails(fixture, (userId) => [
@@ -164,7 +168,7 @@ describe("Inbox emails list route", () => {
 		assert(time, "received time element must render");
 		expect(time.tagName).toBe("TIME");
 		expect(time.getAttribute("datetime")).toBe("2026-06-24T09:00:00.000Z");
-		expect(time.getAttribute("data-local-time")).not.toBeNull();
+		expect(time.getAttribute("data-local-time")).toBe("relative");
 
 		// Non-received rows surface a status badge; the received row does not.
 		expect(rows[0].querySelector("[data-test-inbox-email-status]")).toBeNull();

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.route.test.ts
@@ -158,6 +158,14 @@ describe("Inbox emails list route", () => {
 			"(no subject)",
 		);
 
+		// The received time renders as a localisable <time> baseline carrying the
+		// stored UTC ISO in datetime and an enhancement mode for the client script.
+		const time = rows[0].querySelector("[data-test-inbox-email-time]");
+		assert(time, "received time element must render");
+		expect(time.tagName).toBe("TIME");
+		expect(time.getAttribute("datetime")).toBe("2026-06-24T09:00:00.000Z");
+		expect(time.getAttribute("data-local-time")).not.toBeNull();
+
 		// Non-received rows surface a status badge; the received row does not.
 		expect(rows[0].querySelector("[data-test-inbox-email-status]")).toBeNull();
 		expect(

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.template.html
@@ -25,7 +25,7 @@
 					data-test-inbox-email-status="{{status}}"
 					>{{statusLabel}}</span
 				>{{/if}}
-				<span class="inbox-emails__time" data-test-inbox-email-time>{{receivedAgo}}</span>
+				<time class="inbox-emails__time" data-test-inbox-email-time datetime="{{received.iso}}" data-local-time="{{received.mode}}">{{received.label}}</time>
 			</a>
 		</li>
 		{{/each}}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.test.ts
@@ -71,28 +71,34 @@ describe("toInboxEmailsViewModel", () => {
 		}
 	});
 
-	it("formats the received time relative to now across each granularity", () => {
+	it("formats the received time as a relative LocalTime across each granularity", () => {
 		const rows = toInboxEmailsViewModel(
 			[
 				entry({ receivedAt: ago(30_000) }),
 				entry({ receivedAt: ago(5 * 60_000) }),
 				entry({ receivedAt: ago(3 * 3_600_000) }),
 				entry({ receivedAt: ago(2 * 86_400_000) }),
-				entry({ receivedAt: ago(60 * 86_400_000) }),
 			],
 			{ now: NOW },
 		).rows;
 
-		expect(rows[0].receivedAgo).toBe("just now");
-		expect(rows[1].receivedAgo).toBe("5m ago");
-		expect(rows[2].receivedAgo).toBe("3h ago");
-		expect(rows[3].receivedAgo).toBe("2d ago");
-		expect(rows[4].receivedAgo).toBe(
-			new Date(ago(60 * 86_400_000)).toLocaleDateString("en-AU", {
-				day: "numeric",
-				month: "short",
-				year: "numeric",
-			}),
-		);
+		expect(rows.map((row) => row.received.label)).toEqual([
+			"just now",
+			"5m ago",
+			"3h ago",
+			"2d ago",
+		]);
+		expect(rows.every((row) => row.received.mode === "relative")).toBe(true);
+	});
+
+	it("falls back to a UTC-baselined absolute date past the 30-day cutoff", () => {
+		const iso = ago(60 * 86_400_000);
+		const [row] = toInboxEmailsViewModel([entry({ receivedAt: iso })], { now: NOW }).rows;
+
+		expect(row.received).toEqual({
+			iso,
+			label: "25 Apr 2026",
+			mode: "date",
+		});
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.ts
@@ -1,11 +1,11 @@
-import { EMAIL_FEATURE } from "@packages/web-shell";
+import { EMAIL_FEATURE, type LocalTime, toRelativeOrDate } from "@packages/web-shell";
 import type { InboxEmailEntry, InboxEmailStatus } from "@packages/domain/inbox";
 
 export interface InboxEmailRowViewModel {
 	href: string;
 	sender: string;
 	subject: string;
-	receivedAgo: string;
+	received: LocalTime;
 	status: InboxEmailStatus;
 	statusLabel: string;
 	/** `received` mail renders normally; rejected/unparsed rows surface a badge
@@ -25,23 +25,6 @@ const STATUS_LABEL: Record<InboxEmailStatus, string> = {
 	unparsed: "Couldn’t render",
 };
 
-function formatReceivedAgo(receivedAt: string, now: Date): string {
-	const diffMs = now.getTime() - new Date(receivedAt).getTime();
-	const diffMinutes = Math.floor(diffMs / 60000);
-	const diffHours = Math.floor(diffMs / 3600000);
-	const diffDays = Math.floor(diffMs / 86400000);
-
-	if (diffMinutes < 1) return "just now";
-	if (diffMinutes < 60) return `${diffMinutes}m ago`;
-	if (diffHours < 24) return `${diffHours}h ago`;
-	if (diffDays < 30) return `${diffDays}d ago`;
-	return new Date(receivedAt).toLocaleDateString("en-AU", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
-}
-
 export function toInboxEmailsViewModel(
 	entries: InboxEmailEntry[],
 	options: { now: Date },
@@ -52,7 +35,7 @@ export function toInboxEmailsViewModel(
 			href: `/inbox/${encodeURIComponent(entry.receivedAtMessageId)}?feature=${EMAIL_FEATURE}`,
 			sender: entry.senderEmail === "" ? "(unknown sender)" : entry.senderEmail,
 			subject: entry.subject === "" ? "(no subject)" : entry.subject,
-			receivedAgo: formatReceivedAgo(entry.receivedAt, options.now),
+			received: toRelativeOrDate({ iso: entry.receivedAt, now: options.now }),
 			status: entry.status,
 			statusLabel: STATUS_LABEL[entry.status],
 			needsBadge: entry.status !== "received",

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
@@ -17,7 +17,7 @@ function makeViewModel(
 		url: "https://example.com/article",
 		status: "unread",
 		isUnread: true,
-		savedAgo: "10m ago",
+		saved: { iso: "2025-06-01T12:50:00.000Z", label: "10m ago", mode: "relative" },
 		hasContent: false,
 		actions: [],
 		isStalePending: false,

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
@@ -8,7 +8,7 @@
 		<div class="queue-article__meta">
 			{{#if isUnread}}<span class="queue-article__status queue-article__status--unread" data-test-read-status="unread"><span class="sr-only">Unread</span></span>{{else}}<span class="queue-article__status queue-article__status--read" data-test-read-status="read"><span class="sr-only">Read</span></span>{{/if}}
 			<a class="queue-article__url{{urlEmptyClass}}" href="{{url}}" target="_blank" rel="noopener" data-test-article-url>{{siteName}}</a>
-			<span>{{savedAgo}}</span>
+			<time datetime="{{saved.iso}}" data-local-time="{{saved.mode}}">{{saved.label}}</time>
 		</div>
 		<p class="queue-article__excerpt">{{excerpt}}</p>
 		<p class="queue-article__processing{{processingHiddenClass}}" data-test-processing>Processing…</p>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -60,7 +60,8 @@ describe("toQueueViewModel", () => {
 			now: NOW,
 		});
 
-		expect(vm.articles[0].savedAgo).toBe("1h ago");
+		expect(vm.articles[0].saved.label).toBe("1h ago");
+		expect(vm.articles[0].saved.mode).toBe("relative");
 	});
 
 	it("should format recent date as minutes ago", () => {
@@ -71,7 +72,7 @@ describe("toQueueViewModel", () => {
 			now: NOW,
 		});
 
-		expect(vm.articles[0].savedAgo).toBe("10m ago");
+		expect(vm.articles[0].saved.label).toBe("10m ago");
 	});
 
 	it("should calculate totalPages", () => {
@@ -181,7 +182,7 @@ describe("toQueueViewModel", () => {
 			now: NOW,
 		});
 
-		expect(vm.articles[0].savedAgo).toBe("3d ago");
+		expect(vm.articles[0].saved.label).toBe("3d ago");
 	});
 
 	it("should format date older than 30 days as full date", () => {
@@ -192,7 +193,11 @@ describe("toQueueViewModel", () => {
 			now: NOW,
 		});
 
-		expect(vm.articles[0].savedAgo).toBe("1 Apr 2025");
+		expect(vm.articles[0].saved).toEqual({
+			iso: "2025-04-01T12:00:00.000Z",
+			label: "1 Apr 2025",
+			mode: "date",
+		});
 	});
 
 	it("should format very recent date as just now", () => {
@@ -203,7 +208,7 @@ describe("toQueueViewModel", () => {
 			now: NOW,
 		});
 
-		expect(vm.articles[0].savedAgo).toBe("just now");
+		expect(vm.articles[0].saved.label).toBe("just now");
 	});
 
 	it("should generate next pagination URL when more pages exist", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -1,4 +1,5 @@
 import type { SavedArticle, SaveableUrlErrorCode } from "@packages/domain/article";
+import { type LocalTime, toRelativeOrDate } from "@packages/web-shell";
 import type { FindArticlesResult } from "@packages/provider-contracts/article-store";
 import { pickExcerpt } from "../../../providers/article-summary/article-summary.helpers";
 import type { ArticleCrawl } from "@packages/provider-contracts/article-crawl";
@@ -40,7 +41,7 @@ export interface QueueArticleViewModel {
 	url: string;
 	status: string;
 	isUnread: boolean;
-	savedAgo: string;
+	saved: LocalTime;
 	imageUrl?: string;
 	hasContent: boolean;
 	actions: ArticleAction[];
@@ -116,23 +117,6 @@ function toSubscriptionBannerState(access: EffectiveAccess, now: Date): Subscrip
 	}
 }
 
-function formatRelativeDate(date: Date, now: Date): string {
-	const diffMs = now.getTime() - date.getTime();
-	const diffMinutes = Math.floor(diffMs / 60000);
-	const diffHours = Math.floor(diffMs / 3600000);
-	const diffDays = Math.floor(diffMs / 86400000);
-
-	if (diffMinutes < 1) return "just now";
-	if (diffMinutes < 60) return `${diffMinutes}m ago`;
-	if (diffHours < 24) return `${diffHours}h ago`;
-	if (diffDays < 30) return `${diffDays}d ago`;
-	return date.toLocaleDateString("en-AU", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
-}
-
 function toArticleActions(
 	article: { id: string; status: string },
 	returnQuery: string,
@@ -200,7 +184,7 @@ export function toQueueArticleViewModel(params: {
 		url: article.url,
 		status: article.status,
 		isUnread: article.status === "unread",
-		savedAgo: formatRelativeDate(article.savedAt, now),
+		saved: toRelativeOrDate({ iso: article.savedAt.toISOString(), now }),
 		imageUrl: article.metadata.imageUrl,
 		hasContent: Boolean(article.content),
 		actions: toArticleActions({ id, status: article.status }, returnQuery),

--- a/src/packages/web-shell/package.json
+++ b/src/packages/web-shell/package.json
@@ -12,11 +12,16 @@
     "./trial-countdown.format": {
       "types": "./dist/trial-countdown.format.d.ts",
       "default": "./dist/trial-countdown.format.js"
+    },
+    "./local-time.format": {
+      "types": "./dist/local-time.format.d.ts",
+      "default": "./dist/local-time.format.js"
     }
   },
   "typesVersions": {
     "*": {
-      "trial-countdown.format": ["./dist/trial-countdown.format.d.ts"]
+      "trial-countdown.format": ["./dist/trial-countdown.format.d.ts"],
+      "local-time.format": ["./dist/local-time.format.d.ts"]
     }
   },
   "private": true,

--- a/src/packages/web-shell/src/index.ts
+++ b/src/packages/web-shell/src/index.ts
@@ -21,6 +21,17 @@ export type {
 	TrialRemaining,
 } from "./trial-countdown.format";
 export {
+	formatLocalInstant,
+	toAbsoluteDate,
+	toAbsoluteDateTime,
+	toRelativeOrDate,
+} from "./local-time.format";
+export type {
+	LocalTime,
+	LocalTimeMode,
+	LocalTimeStyle,
+} from "./local-time.format";
+export {
 	bannerStateFromRequest,
 	buildGuestNavItems,
 	buildNavGroups,

--- a/src/packages/web-shell/src/local-time.format.test.ts
+++ b/src/packages/web-shell/src/local-time.format.test.ts
@@ -1,0 +1,103 @@
+import {
+	formatLocalInstant,
+	toAbsoluteDate,
+	toAbsoluteDateTime,
+	toRelativeOrDate,
+} from "./local-time.format";
+
+const ISO = "2026-06-24T09:00:00.000Z";
+
+describe("formatLocalInstant", () => {
+	it("renders a UTC datetime with a 24-hour clock and the zone abbreviation", () => {
+		expect(formatLocalInstant({ iso: ISO, style: "datetime", timeZone: "UTC" })).toBe(
+			"24 June 2026, 09:00 UTC",
+		);
+	});
+
+	it("localises the datetime into the given zone, shifting the clock and the abbreviation", () => {
+		expect(
+			formatLocalInstant({ iso: ISO, style: "datetime", timeZone: "Australia/Sydney" }),
+		).toBe("24 June 2026, 19:00 AEST");
+		expect(
+			formatLocalInstant({ iso: ISO, style: "datetime", timeZone: "America/New_York" }),
+		).toBe("24 June 2026, 05:00 GMT-4");
+	});
+
+	it("falls back to a GMT offset for a zone without an abbreviation", () => {
+		expect(
+			formatLocalInstant({ iso: ISO, style: "datetime", timeZone: "Asia/Kolkata" }),
+		).toBe("24 June 2026, 14:30 GMT+5:30");
+	});
+
+	it("renders a bare calendar date with no zone suffix", () => {
+		expect(formatLocalInstant({ iso: ISO, style: "date", timeZone: "UTC" })).toBe(
+			"24 June 2026",
+		);
+	});
+
+	it("uses the runtime's resolved zone when no timeZone is passed", () => {
+		const withExplicitUtc = formatLocalInstant({
+			iso: ISO,
+			style: "datetime",
+			timeZone: "UTC",
+		});
+		const withResolvedZone = formatLocalInstant({ iso: ISO, style: "datetime" });
+		// The test process runs in UTC, so the resolved-zone path matches the
+		// explicit-UTC path — exercising the no-timeZone branch deterministically.
+		expect(withResolvedZone).toBe(withExplicitUtc);
+	});
+});
+
+describe("toAbsoluteDateTime", () => {
+	it("carries the iso, datetime mode, and UTC baseline label", () => {
+		expect(toAbsoluteDateTime({ iso: ISO })).toEqual({
+			iso: ISO,
+			label: "24 June 2026, 09:00 UTC",
+			mode: "datetime",
+		});
+	});
+});
+
+describe("toAbsoluteDate", () => {
+	it("carries the iso, date mode, and UTC baseline label", () => {
+		expect(toAbsoluteDate({ iso: ISO })).toEqual({
+			iso: ISO,
+			label: "24 June 2026",
+			mode: "date",
+		});
+	});
+});
+
+describe("toRelativeOrDate", () => {
+	const now = new Date("2026-06-24T12:00:00.000Z");
+	const ago = (ms: number) => new Date(now.getTime() - ms).toISOString();
+
+	it("reports 'just now' under a minute", () => {
+		expect(toRelativeOrDate({ iso: ago(30_000), now })).toEqual({
+			iso: ago(30_000),
+			label: "just now",
+			mode: "relative",
+		});
+	});
+
+	it("reports minutes under an hour", () => {
+		expect(toRelativeOrDate({ iso: ago(5 * 60_000), now }).label).toBe("5m ago");
+	});
+
+	it("reports hours under a day", () => {
+		expect(toRelativeOrDate({ iso: ago(3 * 3_600_000), now }).label).toBe("3h ago");
+	});
+
+	it("reports days under the 30-day cutoff", () => {
+		expect(toRelativeOrDate({ iso: ago(2 * 86_400_000), now }).label).toBe("2d ago");
+	});
+
+	it("falls back to an absolute UTC date past the cutoff", () => {
+		const iso = ago(60 * 86_400_000);
+		expect(toRelativeOrDate({ iso, now })).toEqual({
+			iso,
+			label: "25 Apr 2026",
+			mode: "date",
+		});
+	});
+});

--- a/src/packages/web-shell/src/local-time.format.test.ts
+++ b/src/packages/web-shell/src/local-time.format.test.ts
@@ -34,18 +34,6 @@ describe("formatLocalInstant", () => {
 			"24 June 2026",
 		);
 	});
-
-	it("uses the runtime's resolved zone when no timeZone is passed", () => {
-		const withExplicitUtc = formatLocalInstant({
-			iso: ISO,
-			style: "datetime",
-			timeZone: "UTC",
-		});
-		const withResolvedZone = formatLocalInstant({ iso: ISO, style: "datetime" });
-		// The test process runs in UTC, so the resolved-zone path matches the
-		// explicit-UTC path — exercising the no-timeZone branch deterministically.
-		expect(withResolvedZone).toBe(withExplicitUtc);
-	});
 });
 
 describe("toAbsoluteDateTime", () => {

--- a/src/packages/web-shell/src/local-time.format.ts
+++ b/src/packages/web-shell/src/local-time.format.ts
@@ -42,11 +42,10 @@ const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
 export function formatLocalInstant(input: {
 	iso: string;
 	style: LocalTimeStyle;
-	timeZone?: string;
+	timeZone: string;
 }): string {
 	const base = input.style === "datetime" ? DATETIME_OPTIONS : DATE_OPTIONS;
-	const options = input.timeZone ? { ...base, timeZone: input.timeZone } : base;
-	return new Date(input.iso).toLocaleString(LOCALE, options);
+	return new Date(input.iso).toLocaleString(LOCALE, { ...base, timeZone: input.timeZone });
 }
 
 export function toAbsoluteDateTime(input: { iso: string }): LocalTime {

--- a/src/packages/web-shell/src/local-time.format.ts
+++ b/src/packages/web-shell/src/local-time.format.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure, browser-and-node-safe instant formatting shared by the SSR view-models
+ * and the `local-time.client.ts` enhancer. The server renders a UTC-labelled
+ * baseline so the value is unambiguous without JavaScript; the client re-runs
+ * the same formatter with the browser's resolved zone to localise it.
+ */
+
+export type LocalTimeMode = "datetime" | "date" | "relative";
+
+/** The view-model → template contract for a single stored instant. The template
+ * renders one uniform `<time datetime="{{iso}}" data-local-time="{{mode}}">` */
+export interface LocalTime {
+	iso: string;
+	label: string;
+	mode: LocalTimeMode;
+}
+
+export type LocalTimeStyle = "datetime" | "date";
+
+const LOCALE = "en-AU";
+
+/** Explicit component options rather than dateStyle/timeStyle, which cannot be
+ * combined with timeZoneName. hour12:false yields a 24-hour clock (09:00, not
+ * 9:00 am); timeZoneName:"short" yields the abbreviation (UTC, AEST) and
+ * auto-falls back to a GMT offset (GMT+5:30) for zones without one. */
+const DATETIME_OPTIONS: Intl.DateTimeFormatOptions = {
+	day: "numeric",
+	month: "short",
+	year: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+	timeZoneName: "short",
+};
+
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+	day: "numeric",
+	month: "short",
+	year: "numeric",
+};
+
+export function formatLocalInstant(input: {
+	iso: string;
+	style: LocalTimeStyle;
+	timeZone?: string;
+}): string {
+	const base = input.style === "datetime" ? DATETIME_OPTIONS : DATE_OPTIONS;
+	const options = input.timeZone ? { ...base, timeZone: input.timeZone } : base;
+	return new Date(input.iso).toLocaleString(LOCALE, options);
+}
+
+export function toAbsoluteDateTime(input: { iso: string }): LocalTime {
+	return {
+		iso: input.iso,
+		label: formatLocalInstant({ iso: input.iso, style: "datetime", timeZone: "UTC" }),
+		mode: "datetime",
+	};
+}
+
+export function toAbsoluteDate(input: { iso: string }): LocalTime {
+	return {
+		iso: input.iso,
+		label: formatLocalInstant({ iso: input.iso, style: "date", timeZone: "UTC" }),
+		mode: "date",
+	};
+}
+
+const ONE_MINUTE_MS = 60_000;
+const ONE_HOUR_MS = 3_600_000;
+const ONE_DAY_MS = 86_400_000;
+const RELATIVE_DAYS_CUTOFF = 30;
+
+/** Recent instants render as a timezone-neutral relative string ("5m ago");
+ * once past the cutoff they fall back to an absolute calendar date so the row
+ * still reads sensibly. Consolidates the relative-time logic that was
+ * duplicated across the inbox list and the queue. */
+export function toRelativeOrDate(input: { iso: string; now: Date }): LocalTime {
+	const { iso, now } = input;
+	const diffMs = now.getTime() - new Date(iso).getTime();
+	const diffMinutes = Math.floor(diffMs / ONE_MINUTE_MS);
+	const diffHours = Math.floor(diffMs / ONE_HOUR_MS);
+	const diffDays = Math.floor(diffMs / ONE_DAY_MS);
+
+	if (diffMinutes < 1) return { iso, label: "just now", mode: "relative" };
+	if (diffMinutes < 60) return { iso, label: `${diffMinutes}m ago`, mode: "relative" };
+	if (diffHours < 24) return { iso, label: `${diffHours}h ago`, mode: "relative" };
+	if (diffDays < RELATIVE_DAYS_CUTOFF)
+		return { iso, label: `${diffDays}d ago`, mode: "relative" };
+	return toAbsoluteDate({ iso });
+}


### PR DESCRIPTION
## Summary

Introduces a shared `LocalTime` formatting system that enables progressive enhancement of server-rendered timestamps across the application. The server renders UTC-baselined instants unambiguously (no JavaScript required), and the client enhances them into the viewer's local timezone via a new `local-time.client` script.

## Key Changes

- **New `local-time.format` module** (`@packages/web-shell`): Pure, isomorphic formatting functions for instants
  - `formatLocalInstant()`: Formats an ISO string into a localized datetime/date string with timezone abbreviation or GMT offset
  - `toAbsoluteDateTime()` / `toAbsoluteDate()`: Wraps instants in a `LocalTime` view-model with UTC-baselined labels
  - `toRelativeOrDate()`: Formats recent instants as relative text ("5m ago"), falling back to absolute dates past a 30-day cutoff
  - Comprehensive test coverage for all formatting paths and timezone edge cases

- **New `local-time.client` enhancer**: Progressive enhancement script that rewrites server-rendered `<time data-local-time>` elements into the browser's resolved timezone
  - Handles three modes: `datetime` (full localization), `date` (calendar date), `relative` (timezone-neutral text with absolute instant as title)
  - Re-scans and re-localizes on htmx swaps so boosted navigations stay current
  - Dependency injection for testability; wired in `build-client-bundles.js`

- **Consolidates duplicated relative-time logic**: Removes `formatReceivedAgo()` from inbox view-model and `formatRelativeDate()` from queue view-model, replacing both with `toRelativeOrDate()`

- **Updates view-models to use `LocalTime`**:
  - `InboxEmailsViewModel`: `receivedAgo: string` → `received: LocalTime`
  - `QueueArticleViewModel`: `savedAgo: string` → `saved: LocalTime`
  - `InboxEmailDetailViewModel`: `receivedAtLabel: string` → `received: LocalTime`
  - `AccountViewModel`: Splits `statusLine` into `statusLine` (text before date) + `statusDate: LocalTime` + `statusDateTail` (text after) so dates render as localisable `<time>` elements

- **Updates templates** to render `<time datetime="{{iso}}" data-local-time="{{mode}}">{{label}}</time>` for all instants

- **Exports from `@packages/web-shell`**: New `LocalTime`, `LocalTimeMode`, `LocalTimeStyle` types and all formatting functions are now public exports

## Implementation Details

- Uses `Intl.DateTimeFormat` with explicit component options (not `dateStyle`/`timeStyle`) to enable timezone abbreviations and GMT offset fallbacks
- Locale fixed to `en-AU` for consistent date formatting across all instants
- Server always renders UTC baseline (`timeZone: "UTC"`) so the value is unambiguous without JavaScript
- Client resolves the browser's timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` and re-renders
- Relative text is timezone-neutral and left in place; absolute instant surfaces as a hover title for context
- All tests updated to verify `LocalTime` structure (iso, label, mode) rather than string labels

https://claude.ai/code/session_01FXDxD6zyZqWbuTidM3baLo