### PR TITLE
Add logging to Siren decoding errors in ReadplaceAPI

### DIFF
--- a/projects/ios-readplace/Shared/ReadplaceAPI.swift
+++ b/projects/ios-readplace/Shared/ReadplaceAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 enum APIError: LocalizedError {
 	case noToken
@@ -82,6 +83,8 @@ struct QueuePage {
 /// Bearer token, refreshes once on `401`, and follows server-declared hrefs
 /// rather than constructing them.
 final class ReadplaceAPI {
+	private static let logger = Logger(subsystem: "com.readplace", category: "ReadplaceAPI")
+
 	let baseURL: String
 	private let store: TokenStore
 	private let oauth: OAuthService
@@ -342,8 +345,15 @@ final class ReadplaceAPI {
 	private func decodeSiren<T: Decodable>(_ type: T.Type, data: Data, response: HTTPURLResponse) throws -> T {
 		let contentType = response.value(forHTTPHeaderField: "Content-Type")
 		guard isSirenMediaType(contentType) else { throw APIError.unsupportedMediaType(contentType) }
-		guard let value = try? JSONDecoder().decode(type, from: data) else { throw APIError.decoding }
-		return value
+		do {
+			return try JSONDecoder().decode(type, from: data)
+		} catch {
+			// The surfaced error stays the opaque `.decoding`; the underlying
+			// DecodingError (which key/type mismatched) is only ever for the logs.
+			// Marked private: a value-mismatch context can quote response bytes.
+			Self.logger.error("Siren decode failed: \(String(describing: error), privacy: .private)")
+			throw APIError.decoding
+		}
 	}
 
 	/// Whether a `Content-Type` header is the negotiated Siren media type, ignoring

--- a/projects/ios-readplace/Tests/ReadplaceAPITests.swift
+++ b/projects/ios-readplace/Tests/ReadplaceAPITests.swift
@@ -167,6 +167,35 @@ final class ReadplaceAPITests: XCTestCase {
 		XCTAssertEqual(page.articles.map(\.id), ["a1"])
 	}
 
+	func testLoadQueueSurfacesADecodeFailureForAMalformedSirenBody() async {
+		// A 200 carrying the negotiated Siren type but a body that fails a root decode
+		// (an array where the collection object is expected) is surfaced as the opaque
+		// .decoding — the underlying DecodingError is logged, never handed to the caller.
+		let store = TestSupport.loggedInStore()
+		StubURLProtocol.setHandler { request, _ in
+			switch request.url?.path {
+			case "/":
+				return .redirect(to: "/queue")
+			default:
+				return StubURLProtocol.Stub(
+					status: 200,
+					headers: ["Content-Type": AppConfig.sirenMediaType],
+					body: Data("[1,2,3]".utf8)
+				)
+			}
+		}
+		do {
+			_ = try await makeAPI(store: store).loadQueue()
+			XCTFail("Expected decoding")
+		} catch let error as APIError {
+			guard case .decoding = error else {
+				return XCTFail("Expected .decoding, got \(error)")
+			}
+		} catch {
+			XCTFail("Expected APIError.decoding, got \(error)")
+		}
+	}
+
 	func testNoTokenThrowsNoTokenError() async {
 		let store = TokenStore(defaults: TestSupport.ephemeralDefaults())
 		StubURLProtocol.setHandler { _, _ in .json(200, "{}") }


### PR DESCRIPTION
## Summary
Improves observability of JSON decoding failures in the Siren API response handler by adding structured logging via `os.Logger`, while maintaining the opaque public error surface.

## Changes
- Import `os` framework for logging support
- Add static `Logger` instance to `ReadplaceAPI` with subsystem `"com.readplace"` and category `"ReadplaceAPI"`
- Refactor `decodeSiren` error handling from try-catch-throw to explicit do-catch block
- Log underlying `DecodingError` details (with `privacy: .private` to protect response bytes) before throwing the public `APIError.decoding`

## Implementation Details
The change preserves the existing API contract—callers still receive the opaque `.decoding` error—while enabling debugging via system logs. The underlying `DecodingError` (which reveals key/type mismatches) is marked private to prevent accidental logging of sensitive response data. This follows the Swift logging conventions outlined in the project guidelines.

https://claude.ai/code/session_01SHqes9Vni1Z1vUKn3grjWL