### PR TITLE
Refactor queue article layout from flexbox to CSS grid

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -242,9 +242,14 @@
 }
 
 .queue-article {
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "thumbnail content"
+    "thumbnail actions";
+  align-items: start;
+  column-gap: 0;
+  row-gap: 8px;
   padding: 16px;
   background: var(--card);
 }
@@ -255,7 +260,8 @@
 
 .queue-article__thumbnail-link {
   display: none;
-  flex-shrink: 0;
+  grid-area: thumbnail;
+  margin-right: 16px;
 }
 
 .queue-article__thumbnail-link--loaded {
@@ -263,14 +269,14 @@
 }
 
 .queue-article__thumbnail {
-  width: 80px;
-  height: 80px;
+  width: clamp(56px, 10vw, 80px);
+  height: clamp(56px, 10vw, 80px);
   object-fit: cover;
   border-radius: 6px;
 }
 
 .queue-article__content {
-  flex: 1;
+  grid-area: content;
   min-width: 0;
 }
 
@@ -408,9 +414,10 @@
 }
 
 .queue-article__actions {
+  grid-area: actions;
+  justify-self: end;
   display: flex;
   gap: 4px;
-  flex-shrink: 0;
 }
 
 .queue-article__action-btn {
@@ -512,15 +519,4 @@
   align-items: center;
   font-size: 0.875rem;
   color: var(--muted-foreground);
-}
-
-@media (max-width: 600px) {
-  .queue-article {
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .queue-article__actions {
-    align-self: flex-end;
-  }
 }


### PR DESCRIPTION
## Summary
Converts the `.queue-article` component from a flexbox layout to a CSS grid layout with named grid areas, improving layout control and eliminating the need for media queries.

## Key Changes
- **Layout system**: Changed from `display: flex` to `display: grid` with explicit grid template areas (`thumbnail`, `content`, `actions`)
- **Grid structure**: Defined two-column layout (`auto minmax(0, 1fr)`) with two rows to accommodate thumbnail, content, and actions
- **Thumbnail sizing**: Made responsive with `clamp(56px, 10vw, 80px)` instead of fixed `80px`, improving mobile experience
- **Actions positioning**: Uses `grid-area: actions` and `justify-self: end` for right-alignment instead of flex properties
- **Gap handling**: Separated `column-gap: 0` and `row-gap: 8px` for finer control over spacing
- **Removed media query**: Deleted the `@media (max-width: 600px)` block since grid layout handles responsive behavior without it

## Implementation Details
- Grid areas are explicitly named and positioned, making the layout intent clearer than flex direction changes
- The `minmax(0, 1fr)` column ensures content respects text overflow constraints
- Thumbnail margin-right (`16px`) replaces the flex gap for horizontal spacing
- Actions now use `justify-self: end` instead of `align-self: flex-end`, aligning with grid semantics

https://claude.ai/code/session_01RaJ4CpvUq3oDURjxUigtQ7