### PR TITLE
Replace linkedom with regex for style injection to preserve HTML escaping

### DIFF
--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -75,6 +75,30 @@ describe("Base component", () => {
 		expect(main?.querySelector("style")?.textContent).toBe(".lead { color: rebeccapurple; }");
 	});
 
+	it("preserves the reader iframe's double-escaped srcdoc when injecting page styles, so code samples stay text", () => {
+		const srcdoc =
+			"&lt;!doctype html&gt;&lt;body&gt;&lt;code&gt;&amp;lt;input&amp;gt;&lt;/code&gt;&lt;/body&gt;";
+		const page = createTestPageBody({
+			styles: ".reader { color: rebeccapurple; }",
+			content: { html: `<main><iframe data-reader-iframe srcdoc="${srcdoc}"></iframe></main>` },
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+
+		// Byte-level guard: the double-escaping must survive the style injection.
+		// A DOM re-parse would decode one level and hide a degradation, so assert
+		// on the raw output bytes.
+		expect(result.body).toContain("&amp;lt;input&amp;gt;");
+
+		const doc = new JSDOM(result.body).window.document;
+		const iframeSrcdoc = doc.querySelector("iframe[data-reader-iframe]")?.getAttribute("srcdoc");
+		assert(iframeSrcdoc, "reader iframe must carry a srcdoc");
+		const innerDoc = new JSDOM(iframeSrcdoc).window.document;
+		expect(innerDoc.querySelectorAll("input").length).toBe(0);
+
+		const main = doc.querySelector("main");
+		expect(main?.firstElementChild?.tagName).toBe("STYLE");
+	});
+
 	it("should apply bodyClass when provided", () => {
 		const page = createTestPageBody({ bodyClass: "page-home" });
 		const result = Base(page, GUEST_STATE).to("text/html");

--- a/src/packages/web-shell/src/inject-page-styles.ts
+++ b/src/packages/web-shell/src/inject-page-styles.ts
@@ -1,19 +1,25 @@
 import assert from "node:assert";
-import { parseHTML } from "linkedom";
 
 /**
  * Inject page-specific CSS as a <style> element inside <main>, so that htmx
  * navigation (hx-target="main" hx-select="main" hx-swap="outerHTML") swaps the
  * page's CSS atomically with its content. Without this, htmx leaves the
  * previous page's <style> stranded in <head>, defacing the new page's layout.
+ *
+ * Done as a string insert, NOT via linkedom's parseHTML, so the content
+ * survives byte-for-byte. A DOM parse-then-serialize round-trip decodes one
+ * level of HTML escaping, and the reader's iframe `srcdoc` is intentionally
+ * double-escaped: a code sample like `&amp;lt;input&amp;gt;` would collapse to a
+ * live `<input>` inside the framed document. This is the deliberate inverse of
+ * the case where parseHTML is correct because the input crossed a network
+ * boundary and malformed bytes should degrade to undefined; here the input is
+ * trusted server markup whose escaping must be preserved, so a parser would
+ * corrupt it. Do not "restore" parseHTML.
  */
 export function injectPageStylesIntoMain(content: string, styles: string): string {
 	if (!styles) return content;
-	const { document } = parseHTML(`<!DOCTYPE html><html><body>${content}</body></html>`);
-	const main = document.querySelector("main");
-	assert(main, "PageBody.content must contain a <main> element when styles are provided");
-	const styleEl = document.createElement("style");
-	styleEl.textContent = styles;
-	main.insertBefore(styleEl, main.firstChild);
-	return document.body.innerHTML;
+	const styleTag = `<style>${styles}</style>`;
+	const updated = content.replace(/<main(?=[\s/>])[^>]*>/i, (mainTag) => mainTag + styleTag);
+	assert(updated !== content, "PageBody.content must contain a <main> element when styles are provided");
+	return updated;
 }


### PR DESCRIPTION
## Summary

Replace the linkedom-based DOM parsing approach in `injectPageStylesIntoMain` with a simple regex-based string replacement. This fixes a bug where double-escaped HTML entities in iframe `srcdoc` attributes were being decoded during style injection, causing code samples to be incorrectly interpreted as live HTML elements.

## Changes

- **Remove linkedom dependency**: Eliminated the `parseHTML` import and DOM manipulation approach that was inadvertently normalizing HTML entities
- **Implement regex-based injection**: Use a single regex replace to inject the `<style>` tag as the first child of `<main>`, preserving all original HTML escaping in the content
- **Add comprehensive test**: New test case verifies that double-escaped entities in iframe `srcdoc` attributes survive style injection and render correctly in the browser

## Implementation Details

The old approach parsed the entire content string into a DOM tree, which normalized HTML entities (e.g., `&amp;lt;` → `&lt;`). The new approach uses a case-insensitive regex to find the opening `<main>` tag and inserts the style tag immediately after it, leaving all content untouched.

The regex pattern `/<main(?=[\s/>])[^>]*>/i` ensures we match:
- The literal string `<main`
- Followed by whitespace, `>`, or `/` (lookahead, not consumed)
- Any attributes up to the closing `>`

This preserves the exact byte representation of the HTML, which is critical for iframe `srcdoc` attributes that rely on specific escaping levels to render correctly.

https://claude.ai/code/session_01CuLkzq5teRQvdJikCM8JfT