### PR TITLE
feat(extension): cap bulk-save page content client-side

### DIFF
--- a/projects/browser-extension-core/src/core.test.ts
+++ b/projects/browser-extension-core/src/core.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import { initInMemoryAuth } from "./auth/in-memory-auth";
 import { UnauthorizedError } from "./auth/unauthorized-error";
-import { BrowserExtensionCore, BULK_SAVE_BATCH_SIZE } from "./core";
+import { BrowserExtensionCore, BULK_SAVE_BATCH_SIZE, MAX_BULK_SAVE_PAGE_CONTENT_BYTES } from "./core";
 import type { CoreError, ReadingList } from "./core";
 import { initInMemoryReadingList } from "./reading-list/in-memory-reading-list";
 import type { BulkSaveResult, BulkSavePage, SaveUrl, SavePages, SaveUrlResult } from "./reading-list/reading-list.types";
@@ -927,6 +927,88 @@ describe("BrowserExtensionCore saveAll", () => {
 		});
 
 		expect(result.tooBig).toEqual([{ url: "https://big.example", mb: 25 }]);
+	});
+
+	it("drops a page whose captured content exceeds the per-page cap and sends it url-only, surfacing it in tooBig", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell } = createFakeShell();
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		const result = await new Promise<BulkSaveResult>((resolve, reject) => {
+			core.once("saved-all-tabs", { success: resolve, failure: reject });
+			core.saveAll("tabs", {
+				pages: [
+					{
+						url: "https://oversize.example",
+						content: { bytes: new ArrayBuffer(MAX_BULK_SAVE_PAGE_CONTENT_BYTES + 1), mediaType: "text/html" },
+					},
+				],
+			});
+		});
+
+		expect(result.saved).toBe(1);
+		expect(result.tooBig).toEqual([{ url: "https://oversize.example", mb: 20 }]);
+		expect(readingList.savePagesCalls).toEqual([{ pages: [{ url: "https://oversize.example" }] }]);
+	});
+
+	it("keeps content for a page at exactly the per-page cap", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell } = createFakeShell();
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		const content = { bytes: new ArrayBuffer(MAX_BULK_SAVE_PAGE_CONTENT_BYTES), mediaType: "text/html" };
+		const result = await new Promise<BulkSaveResult>((resolve, reject) => {
+			core.once("saved-all-tabs", { success: resolve, failure: reject });
+			core.saveAll("tabs", { pages: [{ url: "https://atcap.example", content }] });
+		});
+
+		expect(result.tooBig).toEqual([]);
+		expect(readingList.savePagesCalls).toEqual([{ pages: [{ url: "https://atcap.example", content }] }]);
+	});
+
+	it("degrades a batch of several oversize pages per-page instead of failing wholesale", async () => {
+		const auth = initInMemoryAuth();
+		await auth.login();
+		const readingList = createRecordingReadingList();
+		const { shell } = createFakeShell();
+		const core = BrowserExtensionCore(shell, {
+			auth,
+			logger: HutchLogger.from(noopLogger),
+			readingList,
+		});
+
+		const pages = Array.from({ length: 3 }, (_v, i) => ({
+			url: `https://oversize.example/${i}`,
+			content: { bytes: new ArrayBuffer(MAX_BULK_SAVE_PAGE_CONTENT_BYTES + 1), mediaType: "text/html" },
+		}));
+
+		const result = await new Promise<BulkSaveResult>((resolve, reject) => {
+			core.once("saved-all-tabs", { success: resolve, failure: reject });
+			core.saveAll("tabs", { pages });
+		});
+
+		expect(result.saved).toBe(3);
+		expect(result.failed).toBe(0);
+		expect(result.tooBig).toEqual([
+			{ url: "https://oversize.example/0", mb: 20 },
+			{ url: "https://oversize.example/1", mb: 20 },
+			{ url: "https://oversize.example/2", mb: 20 },
+		]);
+		expect(readingList.savePagesCalls).toEqual([
+			{ pages: pages.map((p) => ({ url: p.url })) },
+		]);
 	});
 
 	it("folds a failing chunk into the failed count and keeps saving the remaining chunks", async () => {

--- a/projects/browser-extension-core/src/core.ts
+++ b/projects/browser-extension-core/src/core.ts
@@ -27,6 +27,22 @@ export interface ReadingList {
  * directly). */
 export const BULK_SAVE_BATCH_SIZE = 20;
 
+/** Per-page captured-content ceiling, mirroring the server's
+ * MAX_PAGE_CONTENT_BYTES (the two packages share no dependency edge, so the
+ * value can't be imported directly). A page whose captured bytes exceed this is
+ * sent URL-only and reported in the result's `tooBig` list — the same outcome
+ * the server produces for an oversize upload — so the client never uploads
+ * content the server would only reject, and a 20-page batch of such pages stays
+ * under MAX_BULK_CONTENT_REQUEST_BYTES and degrades per-page instead of failing
+ * wholesale. Must stay ≤ the server cap. */
+export const MAX_BULK_SAVE_PAGE_CONTENT_BYTES = 20 * 1024 * 1024;
+
+/** Mirrors the server's bytes→MB rounding so a client-dropped page reads with
+ * the same size in the popup's too-big line as a server-dropped one. */
+function bytesToMb(bytes: number): number {
+	return Math.round((bytes / (1024 * 1024)) * 10) / 10;
+}
+
 export type ResultCallbacks<T> = {
 	success: (value: T) => void;
 	failure: (error: CoreError) => void;
@@ -129,8 +145,16 @@ export function BrowserExtensionCore(shell: BrowserShell, deps: { auth: Auth; lo
 
 	async function savePagesInBatches(pages: BulkSavePage[]): Promise<BulkSaveResult> {
 		const summary: BulkSaveResult = { saved: 0, skipped: 0, failed: 0, tooBig: [], skippedUrls: [] };
-		for (let i = 0; i < pages.length; i += BULK_SAVE_BATCH_SIZE) {
-			const batch = pages.slice(i, i + BULK_SAVE_BATCH_SIZE);
+		const capped = pages.map((page) => {
+			if (page.content && page.content.bytes.byteLength > MAX_BULK_SAVE_PAGE_CONTENT_BYTES) {
+				summary.tooBig.push({ url: page.url, mb: bytesToMb(page.content.bytes.byteLength) });
+				const { content: _content, ...urlOnly } = page;
+				return urlOnly;
+			}
+			return page;
+		});
+		for (let i = 0; i < capped.length; i += BULK_SAVE_BATCH_SIZE) {
+			const batch = capped.slice(i, i + BULK_SAVE_BATCH_SIZE);
 			try {
 				const result = await readingList.savePages({ pages: batch });
 				summary.saved += result.saved;


### PR DESCRIPTION
Drop the captured content of any BulkSavePage over a client-side cap
mirroring the server's MAX_PAGE_CONTENT_BYTES before batching, so the page
is sent URL-only and surfaced in the popup's too-big line via the result's
tooBig list. This avoids uploading content the server would only reject,
keeps each 20-page batch under MAX_BULK_CONTENT_REQUEST_BYTES, and lets a
batch of several oversize pages degrade per-page instead of failing
wholesale.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X6yhuSxPFkm7VSfpNijD16