### PR TITLE
Create dedicated iOS app OAuth client

### DIFF
--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -58,8 +58,8 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
 
 ## What it does
 
-- **Sign in** with OAuth 2.0 + PKCE against `https://readplace.com`, reusing the
-  extension's public client (`hutch-chrome-extension`). The authorize page opens
+- **Sign in** with OAuth 2.0 + PKCE against `https://readplace.com`, using the
+  app's own public client (`ios-app`). The authorize page opens
   in the **external browser** via the same flow as **Sign up** (below), carrying
   `screen_hint=login` so a logged-out user lands on the web `/login` page and
   returns authenticated through the native `readplace://oauth-callback` deep link.
@@ -307,17 +307,17 @@ exercised on every run, not only when someone builds `make ipa-staging` by hand.
   before** this build ships to TestFlight. They are additive and non-breaking, so
   the server can deploy independently; an older app simply wouldn't see them.
 - **Both Login and Sign up use one small additive server change.** They
-  authenticate as the existing `hutch-chrome-extension` client. The
-  external-browser flow can't observe an HTTPS redirect in another app's tab, so
-  it returns via a native `readplace://oauth-callback` deep link — that scheme is
-  registered on the same client, and `/oauth/authorize` accepts an optional
-  `screen_hint` (`login`/`signup`). Both changes are additive in
-  `built-in-clients.ts` / `oauth.routes.ts` and don't affect the extension. The
-  native scheme is identical across production and staging, so sign-in needs no
-  per-environment callback registration.
+  authenticate as the app's own `ios-app` client. The external-browser flow can't
+  observe an HTTPS redirect in another app's tab, so it returns via a native
+  `readplace://oauth-callback` deep link — that scheme is registered on the
+  `ios-app` client, and `/oauth/authorize` accepts an optional `screen_hint`
+  (`login`/`signup`). Both changes are additive in `built-in-clients.ts` /
+  `oauth.routes.ts` and don't affect the extension. The native scheme is
+  identical across production and staging, so sign-in needs no per-environment
+  callback registration.
 - **The server URL is fixed at build time** in `AppConfig.serverBaseURL` — there
   is no Server field on the sign-in screen. `make ipa` targets production;
   `make ipa-staging` compiles with the `STAGING` condition to target staging.
   Sign-in returns through the native `readplace://oauth-callback` deep link
-  (`AppConfig.nativeCallbackURL`), registered for `hutch-chrome-extension` in
+  (`AppConfig.nativeCallbackURL`), registered for `ios-app` in
   `built-in-clients.ts` and identical across production and staging.

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -8,8 +8,9 @@ the server's `save-html` Siren action — exactly what the extension does.
 
 It lives under `projects/` as an nx project
 (`ios-readplace`). It builds with its own Swift/fastlane toolchain rather
-than pnpm, and its code touches no other project. The production build needs
-**no server-side change**: it reuses the existing public OAuth client and Siren API.
+than pnpm, and its app code touches no other project. It authenticates with its
+own public OAuth client (`ios-app`), registered server-side in
+`built-in-clients.ts`, and otherwise reuses the existing Siren API.
 
 ---
 
@@ -306,15 +307,24 @@ exercised on every run, not only when someone builds `make ipa-staging` by hand.
   `update-status` action and `POST /auth/session` — that must be **deployed
   before** this build ships to TestFlight. They are additive and non-breaking, so
   the server can deploy independently; an older app simply wouldn't see them.
-- **Both Login and Sign up use one small additive server change.** They
-  authenticate as the app's own `ios-app` client. The external-browser flow can't
-  observe an HTTPS redirect in another app's tab, so it returns via a native
-  `readplace://oauth-callback` deep link — that scheme is registered on the
-  `ios-app` client, and `/oauth/authorize` accepts an optional `screen_hint`
-  (`login`/`signup`). Both changes are additive in `built-in-clients.ts` /
-  `oauth.routes.ts` and don't affect the extension. The native scheme is
-  identical across production and staging, so sign-in needs no per-environment
-  callback registration.
+- **Both Login and Sign up authenticate as the app's own `ios-app` client.** The
+  external-browser flow can't observe an HTTPS redirect in another app's tab, so
+  it returns via a native `readplace://oauth-callback` deep link, registered on
+  the `ios-app` client; `/oauth/authorize` accepts an optional `screen_hint`
+  (`login`/`signup`). Adding the `ios-app` client is additive, but switching the
+  app onto it is a one-time breaking change for existing installs: earlier builds
+  authenticated as `hutch-chrome-extension`, and `readplace://oauth-callback` has
+  been removed from that client so the deep link belongs to `ios-app` alone. A
+  refresh token minted under the old client is rejected once the app sends
+  `client_id=ios-app`, so each existing install must sign in again once (the live
+  access token keeps working until it expires, so the forced re-login is deferred,
+  not immediate). Deploy the server with the `ios-app` client before the build
+  that uses it — an older build still sending `hutch-chrome-extension` +
+  `readplace://oauth-callback` can no longer start a login. This one-time
+  re-login is an acceptable cost for proper client isolation because the app
+  ships only via TestFlight / sideload (not the App Store), where the tester pool
+  updates quickly. The native scheme is identical across production and staging,
+  so sign-in needs no per-environment callback registration.
 - **The server URL is fixed at build time** in `AppConfig.serverBaseURL` — there
   is no Server field on the sign-in screen. `make ipa` targets production;
   `make ipa-staging` compiles with the `STAGING` condition to target staging.

--- a/projects/ios-readplace/Shared/AppConfig.swift
+++ b/projects/ios-readplace/Shared/AppConfig.swift
@@ -20,11 +20,11 @@ enum ServerEnvironment {
 
 /// Central configuration for the Readplace iOS app.
 ///
-/// The app reuses the server's existing public OAuth/PKCE client
-/// (`hutch-chrome-extension`) and talks to the Siren API like the browser
-/// extension. The native `readplace://oauth-callback` redirect is registered on
-/// that client in `built-in-clients.ts` and is identical across production and
-/// staging, so sign-in needs no per-environment callback registration.
+/// The app authenticates with its own dedicated public OAuth/PKCE client
+/// (`ios-app`) registered in `built-in-clients.ts`, and talks to the Siren API
+/// like the browser extension. The native `readplace://oauth-callback` redirect
+/// is registered on that client and is identical across production and staging,
+/// so sign-in needs no per-environment callback registration.
 enum AppConfig {
 	/// The server this build targets, fixed at compile time. Builds with the
 	/// `STAGING` Swift compilation condition select staging; every other build
@@ -38,7 +38,7 @@ enum AppConfig {
 
 	/// A registered public PKCE client whose allow-listed redirect URIs include the
 	/// native `readplace://oauth-callback` deep link the auth flow returns through.
-	static let clientId = "hutch-chrome-extension"
+	static let clientId = "ios-app"
 
 	/// The Siren hypermedia media type the API speaks.
 	static let sirenMediaType = "application/vnd.siren+json"

--- a/projects/ios-readplace/Tests/LoginFlowTests.swift
+++ b/projects/ios-readplace/Tests/LoginFlowTests.swift
@@ -26,7 +26,7 @@ final class LoginFlowTests: XCTestCase {
 		XCTAssertEqual(components.host, "readplace.com")
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
-		XCTAssertEqual(items["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(items["client_id"], "ios-app")
 		XCTAssertEqual(items["redirect_uri"], AppConfig.nativeCallbackURL)
 		XCTAssertEqual(items["response_type"], "code")
 		XCTAssertEqual(items["code_challenge_method"], "S256")
@@ -63,7 +63,7 @@ final class LoginFlowTests: XCTestCase {
 		XCTAssertEqual(body["grant_type"], "authorization_code")
 		XCTAssertEqual(body["code"], "abc")
 		XCTAssertEqual(body["code_verifier"], "v")
-		XCTAssertEqual(body["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(body["client_id"], "ios-app")
 		XCTAssertEqual(body["redirect_uri"], AppConfig.nativeCallbackURL)
 	}
 

--- a/projects/ios-readplace/Tests/OAuthServiceTests.swift
+++ b/projects/ios-readplace/Tests/OAuthServiceTests.swift
@@ -30,7 +30,7 @@ final class OAuthServiceTests: XCTestCase {
 		XCTAssertEqual(body["grant_type"], "authorization_code")
 		XCTAssertEqual(body["code"], "AUTH_CODE")
 		XCTAssertEqual(body["code_verifier"], "VERIFIER")
-		XCTAssertEqual(body["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(body["client_id"], "ios-app")
 		XCTAssertEqual(body["redirect_uri"], AppConfig.nativeCallbackURL)
 	}
 

--- a/projects/ios-readplace/Tests/SignupFlowTests.swift
+++ b/projects/ios-readplace/Tests/SignupFlowTests.swift
@@ -24,7 +24,7 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(components.host, "readplace.com")
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
-		XCTAssertEqual(items["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(items["client_id"], "ios-app")
 		XCTAssertEqual(items["redirect_uri"], AppConfig.nativeCallbackURL)
 		XCTAssertEqual(items["response_type"], "code")
 		XCTAssertEqual(items["code_challenge_method"], "S256")
@@ -71,12 +71,12 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(body["grant_type"], "authorization_code")
 		XCTAssertEqual(body["code"], "abc")
 		XCTAssertEqual(body["code_verifier"], "v")
-		XCTAssertEqual(body["client_id"], "hutch-chrome-extension")
+		XCTAssertEqual(body["client_id"], "ios-app")
 		XCTAssertEqual(body["redirect_uri"], AppConfig.nativeCallbackURL)
 	}
 
 	func testChromeURLForHTTPSRewritesSchemeWhenChromeAvailable() {
-		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=hutch-chrome-extension&state=abc")!
+		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=ios-app&state=abc")!
 		var probed: URL?
 		let chrome = chromeURLForHTTPS(https, canOpen: { probed = $0; return true })
 
@@ -85,11 +85,11 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(components.scheme, "googlechromes")
 		XCTAssertEqual(components.host, "readplace.com")
 		XCTAssertEqual(components.path, "/oauth/authorize")
-		XCTAssertEqual(components.percentEncodedQuery, "client_id=hutch-chrome-extension&state=abc")
+		XCTAssertEqual(components.percentEncodedQuery, "client_id=ios-app&state=abc")
 	}
 
 	func testChromeURLForHTTPSReturnsHTTPSUnchangedWhenChromeUnavailable() {
-		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=hutch-chrome-extension&state=abc")!
+		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=ios-app&state=abc")!
 		let fallback = chromeURLForHTTPS(https, canOpen: { _ in false })
 
 		XCTAssertEqual(fallback, https)
@@ -139,7 +139,7 @@ final class SignupFlowTests: XCTestCase {
 
 	func testNativeCallbackURLPinnedToServerRegisteredValue() {
 		// Pinned cross-language contract: the server registers this exact string as
-		// a redirect_uri for the hutch-chrome-extension client
+		// a redirect_uri for the ios-app client
 		// (IOS_NATIVE_OAUTH_CALLBACK_URI in built-in-clients.ts) and matches it by
 		// exact string at token time. A change here must be mirrored there, and
 		// composing the URI from scheme + host keeps the deep-link parser in step.

--- a/src/packages/domain/src/oauth/built-in-clients.test.ts
+++ b/src/packages/domain/src/oauth/built-in-clients.test.ts
@@ -20,6 +20,14 @@ describe("getBuiltInClient", () => {
 		assert.equal(client.name, "Readplace Chrome Extension");
 	});
 
+	it("returns the registered iOS app client", () => {
+		const client = getBuiltInClient("ios-app");
+		assert(client, "iOS client should be defined");
+		assert.equal(client.name, "Readplace iOS App");
+		assert.ok(client.grants.includes("authorization_code"));
+		assert.ok(client.grants.includes("refresh_token"));
+	});
+
 	it("returns undefined for an unknown client ID", () => {
 		assert.equal(getBuiltInClient("unknown-client"), undefined);
 	});
@@ -36,7 +44,7 @@ describe("isBuiltInRedirectUri", () => {
 		);
 	});
 
-	it("accepts the iOS staging callback listed on the Chrome extension client", () => {
+	it("accepts the staging deployment callback listed on the Chrome extension client", () => {
 		const chromeClient = getBuiltInClient("hutch-chrome-extension");
 		assert(chromeClient, "Chrome client must exist");
 		assert.equal(
@@ -49,7 +57,19 @@ describe("isBuiltInRedirectUri", () => {
 		);
 	});
 
-	it("accepts the iOS native custom-scheme callback on the Chrome extension client", () => {
+	it("accepts the iOS native custom-scheme callback on the iOS app client", () => {
+		const iosClient = getBuiltInClient("ios-app");
+		assert(iosClient, "iOS client must exist");
+		assert.equal(
+			isBuiltInRedirectUri({
+				client: iosClient,
+				redirectUri: IOS_NATIVE_OAUTH_CALLBACK_URI,
+			}),
+			true,
+		);
+	});
+
+	it("rejects the iOS native custom-scheme callback on the Chrome extension client", () => {
 		const chromeClient = getBuiltInClient("hutch-chrome-extension");
 		assert(chromeClient, "Chrome client must exist");
 		assert.equal(
@@ -57,7 +77,7 @@ describe("isBuiltInRedirectUri", () => {
 				client: chromeClient,
 				redirectUri: IOS_NATIVE_OAUTH_CALLBACK_URI,
 			}),
-			true,
+			false,
 		);
 	});
 

--- a/src/packages/domain/src/oauth/built-in-clients.ts
+++ b/src/packages/domain/src/oauth/built-in-clients.ts
@@ -36,14 +36,20 @@ const BUILT_IN_OAUTH_CLIENTS: Record<string, OAuthClient> = {
 		redirectUris: [
 			"https://readplace.com/oauth/callback",
 			"https://hutch-app.com/oauth/callback",
-			// iOS staging build's OAuth callback: the staging stack's API Gateway
-			// endpoint (staging has no custom domain). Mirrors ServerEnvironment.staging
-			// in ios-readplace's AppConfig.swift — keep both in sync.
+			// The staging deployment's web OAuth callback: the staging stack's API
+			// Gateway endpoint (staging has no custom domain). Mirrors
+			// ServerEnvironment.staging in ios-readplace's AppConfig.swift — keep both
+			// in sync.
 			"https://hkncrxpii6.execute-api.ap-southeast-2.amazonaws.com/oauth/callback",
 			"http://127.0.0.1:3000/oauth/callback",
 			"http://127.0.0.1:3001/oauth/callback",
-			IOS_NATIVE_OAUTH_CALLBACK_URI,
 		],
+		grants: ["authorization_code", "refresh_token"],
+	},
+	"ios-app": {
+		id: OAuthClientIdSchema.parse("ios-app"),
+		name: "Readplace iOS App",
+		redirectUris: [IOS_NATIVE_OAUTH_CALLBACK_URI],
 		grants: ["authorization_code", "refresh_token"],
 	},
 };


### PR DESCRIPTION
## Summary

Separates the iOS app's OAuth authentication from the Chrome extension client by creating a dedicated `ios-app` public client. The iOS app now authenticates with its own client ID instead of reusing the extension's `hutch-chrome-extension` client.

## Changes

- **Server-side OAuth configuration** (`built-in-clients.ts`):
  - Created new `ios-app` OAuth client with ID `ios-app`
  - Registered the native `readplace://oauth-callback` deep link exclusively on the `ios-app` client
  - Removed the native callback URI from the `hutch-chrome-extension` client's redirect URIs
  - Updated comments to clarify staging deployment vs. iOS-specific callbacks

- **iOS app configuration** (`AppConfig.swift`):
  - Changed `clientId` from `"hutch-chrome-extension"` to `"ios-app"`
  - Updated documentation to reflect the app's own dedicated client

- **iOS app tests** (`SignupFlowTests.swift`, `LoginFlowTests.swift`, `OAuthServiceTests.swift`):
  - Updated all OAuth flow assertions to expect `client_id=ios-app`
  - Updated test comments to reference the correct client

- **Server-side OAuth tests** (`built-in-clients.test.ts`):
  - Added test case for the new `ios-app` client registration
  - Updated redirect URI validation tests to verify the native callback is accepted only by the iOS client
  - Changed Chrome extension test to verify it now rejects the iOS native callback
  - Updated test descriptions for clarity

- **Documentation** (`projects/ios-readplace/README.md`):
  - Updated architecture documentation to explain the app uses its own `ios-app` client
  - Clarified that the native callback is registered on the `ios-app` client, not the extension's

## Implementation Details

The iOS native callback URI (`readplace://oauth-callback`) is now exclusively registered on the `ios-app` client. This provides proper client isolation: the Chrome extension uses HTTPS redirects to `readplace.com`, while the iOS app uses the native deep link. Both clients support the same grant types (`authorization_code` and `refresh_token`) for their respective OAuth flows.

https://claude.ai/code/session_01DiK8K3vWJks5XeU2RZJwRJ