### PR TITLE
Keep link count badge in sync during article extraction

### DIFF
--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.component.ts
@@ -4,6 +4,7 @@ import { render } from "@packages/web-shell";
 import type { PageBody } from "@packages/web-shell";
 import { renderInboxArticlesPanel } from "./inbox-articles-panel.component";
 import { buildInboxEmailIframeSrcdoc } from "./inbox-email-iframe-srcdoc";
+import { renderInboxLinkCount } from "./inbox-link-count.component";
 import { INBOX_EMAIL_DETAIL_STYLES } from "./inbox-email-detail.styles";
 import type { InboxEmailDetailViewModel } from "./inbox-email-detail.viewmodel";
 
@@ -17,6 +18,7 @@ export function InboxEmailDetailPage(vm: InboxEmailDetailViewModel): PageBody {
 		? buildInboxEmailIframeSrcdoc({ bodyHtml: vm.bodyHtml })
 		: "";
 	const articlesPanelHtml = renderInboxArticlesPanel(vm.articles);
+	const linkCountHtml = renderInboxLinkCount({ label: vm.linkCountLabel, oob: false });
 	return {
 		seo: {
 			title: "Email — Readplace",
@@ -27,6 +29,8 @@ export function InboxEmailDetailPage(vm: InboxEmailDetailViewModel): PageBody {
 		},
 		styles: INBOX_EMAIL_DETAIL_STYLES,
 		bodyClass: "page-inbox",
-		content: { html: render(INBOX_EMAIL_DETAIL_TEMPLATE, { ...vm, viewSrcdoc, articlesPanelHtml }) },
+		content: {
+			html: render(INBOX_EMAIL_DETAIL_TEMPLATE, { ...vm, viewSrcdoc, articlesPanelHtml, linkCountHtml }),
+		},
 	};
 }

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
@@ -300,8 +300,11 @@ describe("Inbox email detail route", () => {
 		expect(panel.getAttribute("data-articles-status")).toBe("extracting");
 		expect(panel.getAttribute("hx-get")).toContain("/articles");
 		expect(doc.querySelector("[data-test-articles-extracting]")).not.toBeNull();
-		// The header count is withheld until extraction finishes.
-		expect(doc.querySelector("[data-test-inbox-detail-link-count]")).toBeNull();
+		// The header badge is an always-present OOB swap anchor, but withholds the
+		// count until extraction finishes, so it renders empty rather than absent.
+		const linkCount = doc.querySelector("[data-test-inbox-detail-link-count]");
+		assert(linkCount, "the header link-count anchor must render as an OOB swap target");
+		expect(linkCount.textContent).toBe("");
 	});
 
 	it("shows the terminal no-links state once extraction wrote its meta with zero links", async () => {
@@ -354,12 +357,17 @@ describe("Inbox Articles panel poll route", () => {
 		const response = await agent.get(`${articlesPath}&poll=1`);
 
 		expect(response.status).toBe(200);
-		const panel = new JSDOM(response.text).window.document.querySelector(
-			'[data-test-tab-panel="articles"]',
-		);
+		const doc = new JSDOM(response.text).window.document;
+		const panel = doc.querySelector('[data-test-tab-panel="articles"]');
 		assert(panel, "the panel fragment must render");
 		expect(panel.getAttribute("data-articles-status")).toBe("extracting");
 		expect(panel.getAttribute("hx-get")).toContain("poll=2");
+		// The OOB header badge ships with every tick but stays empty while extracting,
+		// so the header keeps withholding the count in lockstep with the panel.
+		const linkCount = doc.querySelector("[data-test-inbox-detail-link-count]");
+		assert(linkCount, "the poll fragment must carry the OOB link-count anchor");
+		expect(linkCount.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(linkCount.textContent).toBe("");
 	});
 
 	it("swaps in the finished card set once extraction wrote its meta", async () => {
@@ -390,5 +398,11 @@ describe("Inbox Articles panel poll route", () => {
 		expect(doc.querySelector("[data-test-inbox-article-title]")?.textContent).toBe(
 			"Crawled headline",
 		);
+		// The terminal tick carries the count as an OOB swap so the header badge catches
+		// up to the swapped-in card set without waiting for a full page reload.
+		const linkCount = doc.querySelector("[data-test-inbox-detail-link-count]");
+		assert(linkCount, "the terminal poll fragment must carry the OOB link-count update");
+		expect(linkCount.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(linkCount.textContent).toBe("1 link");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
@@ -38,6 +38,12 @@
   color: var(--muted-foreground);
 }
 
+/* Withheld during extraction: the badge is an always-present OOB swap anchor, so
+   keep the empty placeholder out of the meta row's flex flow until it has a count. */
+.inbox-email-detail__link-count:empty {
+  display: none;
+}
+
 .inbox-email-detail__tabs {
   display: flex;
   gap: 4px;

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.template.html
@@ -5,11 +5,7 @@
 		<p class="inbox-email-detail__meta">
 			<span data-test-inbox-detail-sender>{{sender}}</span>
 			<time class="inbox-email-detail__received" datetime="{{received.iso}}" data-local-time="{{received.mode}}">{{received.label}}</time>
-			{{#if linkCountLabel}}<span
-				class="inbox-email-detail__link-count"
-				data-test-inbox-detail-link-count
-				>{{linkCountLabel}}</span
-			>{{/if}}
+			{{{linkCountHtml}}}
 		</p>
 	</header>
 

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-link-count.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-link-count.component.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render } from "@packages/web-shell";
+
+const INBOX_LINK_COUNT_TEMPLATE = readFileSync(
+	join(__dirname, "inbox-link-count.template.html"),
+	"utf-8",
+);
+
+/**
+ * The header "12 links" badge, rendered as a stable `id`'d element so the Articles
+ * panel poll can keep it in lockstep with the panel. The full page renders it inline
+ * (`oob: false`); the `/inbox/:id/articles` poll re-emits it with `oob: true` so an
+ * htmx out-of-band swap refreshes the header the instant extraction completes —
+ * otherwise the count would lag the swapped-in card set until a full reload. While
+ * extraction is pending the label is `undefined`, so the badge renders empty (hidden
+ * via `:empty`) and the header makes no count claim before the panel does.
+ */
+export function renderInboxLinkCount(input: { label: string | undefined; oob: boolean }): string {
+	return render(INBOX_LINK_COUNT_TEMPLATE, { label: input.label, oob: input.oob });
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-link-count.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-link-count.template.html
@@ -1,0 +1,1 @@
+<span class="inbox-email-detail__link-count" id="inbox-email-detail-link-count" data-test-inbox-detail-link-count{{#if oob}} hx-swap-oob="outerHTML"{{/if}}>{{label}}</span>

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -25,6 +25,7 @@ import { etagMatches } from "../queue/queue-card/queue-card.etag";
 import { renderInboxArticleCard } from "./inbox-article-card.component";
 import { renderInboxArticlesPanel } from "./inbox-articles-panel.component";
 import { InboxEmailDetailPage } from "./inbox-email-detail.component";
+import { renderInboxLinkCount } from "./inbox-link-count.component";
 import { toInboxEmailDetailViewModel } from "./inbox-email-detail.viewmodel";
 import { InboxEmailsPage } from "./inbox-emails.component";
 import { type InboxEmailLinkSummary, toInboxEmailsViewModel } from "./inbox-emails.viewmodel";
@@ -170,7 +171,18 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 			maxPolls: MAX_POLLS,
 			panelPollCount: requestedPoll + 1,
 		});
-		res.status(200).type("html").send(renderInboxArticlesPanel(vm.articles));
+		// The panel swap only replaces the Articles section, so pair it with an
+		// out-of-band swap of the header badge — otherwise the count would lag the
+		// swapped-in card set until a full reload. While extraction is still pending
+		// the label is undefined, so the OOB badge stays empty and the header keeps
+		// withholding the count in lockstep with the panel.
+		res
+			.status(200)
+			.type("html")
+			.send(
+				renderInboxArticlesPanel(vm.articles) +
+					renderInboxLinkCount({ label: vm.linkCountLabel, oob: true }),
+			);
 	});
 
 	// The literal `links/:ordinal/card` suffix means `/:id` (single segment)


### PR DESCRIPTION
## Summary

Refactors the inbox email detail header to keep the link count badge synchronized with the articles panel during extraction. Previously, the badge was conditionally rendered only when a count was available. Now it's always present as a stable OOB swap target, rendering empty while extraction is pending and updating via out-of-band swap when extraction completes.

## Changes

- **New component:** `renderInboxLinkCount()` — extracts the link count badge into a reusable component that renders with an `id` and optional `hx-swap-oob="outerHTML"` attribute for out-of-band updates
- **Poll response:** The `/inbox/:id/articles?poll=N` endpoint now appends the link count badge as an OOB swap to every response, keeping the header in lockstep with the panel
- **Template refactor:** Replaced conditional `{{#if linkCountLabel}}` rendering with unconditional `{{{linkCountHtml}}}` injection, moving the conditional logic into the component
- **CSS:** Added `.inbox-email-detail__link-count:empty { display: none; }` to hide the empty placeholder during extraction, keeping the meta row's flex layout clean
- **Tests:** Updated assertions to verify the badge always renders (empty while extracting, populated on completion) and carries the OOB swap attribute in poll responses

## Implementation Details

The badge is now a stable anchor point (`id="inbox-email-detail-link-count"`) that htmx can target for out-of-band swaps. While extraction is pending, `label` is `undefined`, so the badge renders empty and is hidden via CSS. Once extraction completes, the terminal poll tick includes the badge with the count as an OOB swap, allowing the header to update instantly without waiting for a full page reload.

https://claude.ai/code/session_011Rgv7zwxRbgXT4VqtD7r1B