### PR TITLE
Terminal stale state for articles panel when extraction times out

### DIFF
--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-articles-panel.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-articles-panel.component.ts
@@ -19,6 +19,6 @@ export function renderInboxArticlesPanel(vm: ArticlesPanelViewModel): string {
 	return render(INBOX_ARTICLES_PANEL_TEMPLATE, {
 		...vm,
 		articleHtmls: vm.cards.map(renderInboxArticleCard),
-		panelStatus: vm.isExtracting ? "extracting" : "terminal",
+		panelStatus: vm.isExtracting ? "extracting" : vm.isStalePending ? "stale" : "terminal",
 	});
 }

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-articles-panel.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-articles-panel.template.html
@@ -9,6 +9,11 @@
 		Looking for links…
 	</p>
 	{{else}}
+	{{#if isStalePending}}
+	<p class="inbox-email-detail__articles-stale" data-test-articles-stale>
+		We couldn’t scan this email for links. The original message is still available on the View tab.
+	</p>
+	{{else}}
 	{{#if isEmpty}}
 	<p class="inbox-email-detail__articles-empty" data-test-articles-empty>
 		No links found in this email.
@@ -21,6 +26,7 @@
 	<div class="inbox-email-detail__articles" data-test-inbox-articles>
 		{{#each articleHtmls}}{{{this}}}{{/each}}
 	</div>
+	{{/if}}
 	{{/if}}
 	{{/if}}
 </section>

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
@@ -362,6 +362,24 @@ describe("Inbox Articles panel poll route", () => {
 		expect(panel.getAttribute("hx-get")).toContain("poll=2");
 	});
 
+	it("gives up to a terminal stale notice once the poll budget is spent without a meta barrier", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		await seed(fixture, "received");
+
+		const response = await agent.get(`${articlesPath}&poll=301`);
+
+		expect(response.status).toBe(200);
+		const doc = new JSDOM(response.text).window.document;
+		const panel = doc.querySelector('[data-test-tab-panel="articles"]');
+		assert(panel, "the panel fragment must render");
+		expect(panel.getAttribute("data-articles-status")).toBe("stale");
+		expect(panel.getAttribute("hx-get")).toBeNull();
+		expect(doc.querySelector("[data-test-articles-stale]")).not.toBeNull();
+		expect(doc.querySelector("[data-test-articles-extracting]")).toBeNull();
+	});
+
 	it("swaps in the finished card set once extraction wrote its meta", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const harness = useApp(fixture);

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
@@ -84,6 +84,7 @@
 
 .inbox-email-detail__articles-empty,
 .inbox-email-detail__articles-truncated,
+.inbox-email-detail__articles-stale,
 .inbox-email-detail__articles-pending {
   color: var(--muted-foreground);
   font-size: 0.9rem;

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.test.ts
@@ -114,11 +114,24 @@ describe("toInboxEmailDetailViewModel", () => {
 		expect(vm.linkCountLabel).toBeUndefined();
 	});
 
-	it("stops the page-level poll once the budget is spent but keeps the extracting state", () => {
+	it("gives up to a terminal stale state once the budget is spent without a meta barrier", () => {
 		const vm = build({ links: [], linksMeta: undefined, panelPollCount: 301 });
 
-		expect(vm.articles.isExtracting).toBe(true);
+		// A permanent extract-DLQ failure or a pre-feature email never writes its
+		// meta barrier, so the spinner must terminate rather than poll forever.
+		expect(vm.articles.isExtracting).toBe(false);
+		expect(vm.articles.isStalePending).toBe(true);
 		expect(vm.articles.panelPollUrl).toBeUndefined();
+		// No trustworthy count while extraction never finished.
+		expect(vm.linkCountLabel).toBeUndefined();
+	});
+
+	it("stays extracting on the last budgeted poll, before the give-up threshold", () => {
+		const vm = build({ links: [], linksMeta: undefined, panelPollCount: 300 });
+
+		expect(vm.articles.isExtracting).toBe(true);
+		expect(vm.articles.isStalePending).toBe(false);
+		expect(vm.articles.panelPollUrl).toContain("poll=300");
 	});
 
 	it("never polls a non-received email's articles panel", () => {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.ts
@@ -17,9 +17,15 @@ export interface ArticlesPanelViewModel {
 	cards: InboxLinkCardViewModel[];
 	isEmpty: boolean;
 	/** True while extraction has not yet written its meta barrier (a just-received
-	 * email): the panel shows a polling "Looking for links…" state instead of the
-	 * terminal "No links found", so a non-terminal state is never shown as terminal. */
+	 * email) and the poll budget is unspent: the panel shows a polling "Looking for
+	 * links…" state instead of the terminal "No links found", so a non-terminal
+	 * state is never shown as terminal. Goes false once `isStalePending` takes over. */
 	isExtracting: boolean;
+	/** True when the poll budget is spent but extraction never wrote its meta
+	 * barrier — a permanent extract-DLQ failure or a pre-feature email that predates
+	 * the meta row. The panel gives up on "Looking for links…" and shows a terminal
+	 * notice instead of polling forever. Mirrors the queue card's `isStalePending`. */
+	isStalePending: boolean;
 	/** Present only while `isExtracting` and within the poll budget — drives the
 	 * page-level htmx poll that swaps the finished card set in on completion. */
 	panelPollUrl: string | undefined;
@@ -67,15 +73,20 @@ export function toInboxEmailDetailViewModel(input: {
 	// No meta row yet means the async extractor has not finished for this received
 	// email — keep polling rather than asserting it has zero links. Non-received
 	// emails never run extraction, so they are terminal immediately.
-	const isExtracting = input.entry.status === "received" && input.linksMeta === undefined;
+	const awaitingMeta = input.entry.status === "received" && input.linksMeta === undefined;
 	const panelPollCount = input.panelPollCount ?? INITIAL_POLL_COUNT;
-	const panelPollUrl =
-		isExtracting && panelPollCount <= input.maxPolls
-			? buildInboxArticlesPollUrl({
-					emailId: input.entry.receivedAtMessageId,
-					pollCount: panelPollCount,
-				})
-			: undefined;
+	const withinPollBudget = panelPollCount <= input.maxPolls;
+	// Once the budget is spent without a meta barrier the extractor is never coming
+	// back (permanent extract-DLQ failure, or a pre-feature email with no meta row),
+	// so we give up on the spinner and show a terminal notice instead of polling on.
+	const isStalePending = awaitingMeta && !withinPollBudget;
+	const isExtracting = awaitingMeta && withinPollBudget;
+	const panelPollUrl = isExtracting
+		? buildInboxArticlesPollUrl({
+				emailId: input.entry.receivedAtMessageId,
+				pollCount: panelPollCount,
+			})
+		: undefined;
 	return {
 		subject: input.entry.subject === "" ? "(no subject)" : input.entry.subject,
 		sender: input.entry.senderEmail === "" ? "(unknown sender)" : input.entry.senderEmail,
@@ -86,15 +97,17 @@ export function toInboxEmailDetailViewModel(input: {
 		bodyHtml: input.bodyHtml ?? "",
 		unavailableMessage:
 			"This message couldn’t be displayed here; the original email is preserved.",
-		// Suppressed mid-extraction so the header never claims a count before the
-		// panel does; shown once extraction has written its barrier.
-		linkCountLabel: isExtracting
+		// Suppressed until extraction writes its barrier so the header never claims a
+		// count the panel can't back — this covers both the live spinner and the
+		// terminal give-up, neither of which has a trustworthy count.
+		linkCountLabel: awaitingMeta
 			? undefined
 			: buildLinkCountLabel({ count: cards.length, truncated }),
 		articles: {
 			cards,
 			isEmpty: cards.length === 0,
 			isExtracting,
+			isStalePending,
 			panelPollUrl,
 			truncatedNotice: truncated
 				? `Showing the first ${cards.length} links found in this email.`


### PR DESCRIPTION
## Summary

Adds a terminal "stale pending" state to the articles panel when the extraction poll budget is exhausted without receiving a meta barrier from the async link extractor. This prevents the spinner from polling indefinitely on permanent extract-DLQ failures or pre-feature emails that never write a meta row.

## Changes

- **ArticlesPanelViewModel**: Added `isStalePending` boolean to distinguish between active extraction (spinner) and permanent extraction failure (terminal notice)
- **toInboxEmailDetailViewModel**: Refactored extraction state logic to compute three distinct states:
  - `awaitingMeta`: extraction hasn't finished yet
  - `isExtracting`: awaiting meta AND within poll budget (shows spinner, continues polling)
  - `isStalePending`: awaiting meta AND poll budget spent (shows terminal notice, stops polling)
- **Template & Component**: Added conditional rendering for stale notice and updated panel status to distinguish "stale" from "terminal"
- **Styling**: Added `.inbox-email-detail__articles-stale` class for consistent muted styling
- **Tests**: Added integration test verifying stale state at poll=301 (beyond 300-poll budget) and unit test confirming extraction stops at budget threshold

## Implementation Details

The poll budget threshold is 300 polls (checked via `panelPollCount <= input.maxPolls`). Once exceeded without a meta barrier, the panel gives up on the spinner and displays a user-facing notice: "We couldn't scan this email for links. The original message is still available on the View tab."

This covers two failure modes:
1. Permanent extract-DLQ failures where the extractor crashed and never recovers
2. Pre-feature emails that predate the meta row schema and will never write one

The `linkCountLabel` remains suppressed in both extracting and stale states since neither has a trustworthy link count.

https://claude.ai/code/session_01FUtNjDzqjEjUYNQ4UbxEcM