### PR TITLE
Unwrap Readplace self-URLs before saving articles

### DIFF
--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { HutchLogger, consoleLogger, noopLogger } from '@packages/hutch-logger'
 import { calculateReadTime, validateSaveableUrl, type ValidateSaveableUrl } from '@packages/domain/article'
 import { createTestApp } from '../runtime/test-app'
+import { withReadplacePreparse } from '../runtime/web/pages/view/preparse-readplace-url'
 import {
   createDefaultTestAppFixture,
   createFakeApplyParseResult,
@@ -141,7 +142,7 @@ const { app: hutchApp, auth, email } = createTestApp({
     extractLinksFromPageUrl: initExtractLinksFromPageUrl({ crawlFetch, validateUrl: e2eValidateSaveableUrl }),
   },
   shared: {
-    validateSaveableUrl: e2eValidateSaveableUrl,
+    validateSaveableUrl: withReadplacePreparse(e2eValidateSaveableUrl, { selfHost: new URL(origin).host }),
     appOrigin: fixture.shared.appOrigin,
     staticBaseUrl: fixture.shared.staticBaseUrl,
     httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,

--- a/projects/hutch/src/e2e/e2e-server.main.ts
+++ b/projects/hutch/src/e2e/e2e-server.main.ts
@@ -4,7 +4,6 @@ import { z } from 'zod'
 import { HutchLogger, consoleLogger, noopLogger } from '@packages/hutch-logger'
 import { calculateReadTime, validateSaveableUrl, type ValidateSaveableUrl } from '@packages/domain/article'
 import { createTestApp } from '../runtime/test-app'
-import { withReadplacePreparse } from '../runtime/web/pages/view/preparse-readplace-url'
 import {
   createDefaultTestAppFixture,
   createFakeApplyParseResult,
@@ -142,7 +141,10 @@ const { app: hutchApp, auth, email } = createTestApp({
     extractLinksFromPageUrl: initExtractLinksFromPageUrl({ crawlFetch, validateUrl: e2eValidateSaveableUrl }),
   },
   shared: {
-    validateSaveableUrl: withReadplacePreparse(e2eValidateSaveableUrl, { selfHost: new URL(origin).host }),
+    /** Raw on purpose: createTestApp decorates shared.validateSaveableUrl with
+     * withReadplacePreparse itself — wrapping here too would preparse twice and
+     * diverge the e2e server from the production composition. */
+    validateSaveableUrl: e2eValidateSaveableUrl,
     appOrigin: fixture.shared.appOrigin,
     staticBaseUrl: fixture.shared.staticBaseUrl,
     httpErrorMessageMapping: fixture.shared.httpErrorMessageMapping,

--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -112,6 +112,7 @@ import { initLogParseError, type ParseErrorEvent } from "@packages/hutch-infra-c
 import { isBlockedIpAddress, validateSaveableUrl } from "@packages/domain/article";
 import { createApp } from "./server";
 import { initChangelogBannerSource } from "./web/changelog-banner-source";
+import { withReadplacePreparse } from "./web/pages/view/preparse-readplace-url";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
 import type { ConversionEvent } from "./conversions";
 import type { AnalyticsEvent } from "@packages/web-analytics";
@@ -715,7 +716,9 @@ export function createHutchApp(deps?: {
 	});
 
 	const app = createApp({
-		validateSaveableUrl,
+		validateSaveableUrl: withReadplacePreparse(validateSaveableUrl, {
+			selfHost: new URL(appOrigin).host,
+		}),
 		appOrigin,
 		staticBaseUrl,
 		hashPassword,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -24,6 +24,7 @@ import type {
 } from "@packages/web-test-harness";
 import { useTestServer as useServerForFixture } from "@packages/web-test-harness";
 import { createApp } from "./server";
+import { withReadplacePreparse } from "./web/pages/view/preparse-readplace-url";
 import type { GetChangelogBanner } from "./web/changelog-banner-source";
 import { initFoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
 import type { AnalyticsEvent } from "@packages/web-analytics";
@@ -91,7 +92,9 @@ function flattenFixtureToAppDependencies(
 	analyticsBundle: AnalyticsBundle,
 ): Parameters<typeof createApp>[0] {
 	return {
-		validateSaveableUrl: fixture.shared.validateSaveableUrl,
+		validateSaveableUrl: withReadplacePreparse(fixture.shared.validateSaveableUrl, {
+			selfHost: new URL(fixture.shared.appOrigin).host,
+		}),
 		appOrigin: fixture.shared.appOrigin,
 		staticBaseUrl: fixture.shared.staticBaseUrl,
 		baseUrl: fixture.shared.appOrigin,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-articles.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-articles.route.test.ts
@@ -124,8 +124,7 @@ describe("POST /queue/save-articles", () => {
 		);
 		const stored = await testApp.articleStore.findArticlesByUser({ userId: TEST_USER_ID });
 		const urls = stored.articles.map((a) => a.url);
-		expect(urls).toContain("https://fagnerbrack.com/business-success");
-		expect(urls).not.toContain("http://localhost:3000/view/fagnerbrack.com/business-success");
+		expect(urls).toEqual(["https://fagnerbrack.com/business-success"]);
 	});
 
 	it("dispatches a pdf content page through the pdf pipeline", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-articles.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-articles.route.test.ts
@@ -115,7 +115,7 @@ describe("POST /queue/save-articles", () => {
 			.set("Accept", SIREN_MEDIA_TYPE)
 			.set("Authorization", `Bearer ${accessToken}`)
 			.field("manifest", manifest([
-				{ url: "http://localhost:3000/view/fagnerbrack.com/business-success" },
+				{ url: `${TEST_APP_ORIGIN}/view/fagnerbrack.com/business-success` },
 			]));
 
 		expect(response.status).toBe(200);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.save-articles.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.save-articles.route.test.ts
@@ -106,6 +106,28 @@ describe("POST /queue/save-articles", () => {
 		expect(urls).toContain("https://example.com/b");
 	});
 
+	it("unwraps a Readplace /view self-URL and saves the underlying original article", async () => {
+		const { testApp } = setup();
+		const accessToken = await createAccessToken(testApp);
+
+		const response = await request(testApp.server)
+			.post("/queue/save-articles")
+			.set("Accept", SIREN_MEDIA_TYPE)
+			.set("Authorization", `Bearer ${accessToken}`)
+			.field("manifest", manifest([
+				{ url: "http://localhost:3000/view/fagnerbrack.com/business-success" },
+			]));
+
+		expect(response.status).toBe(200);
+		expect(response.body.properties).toEqual(
+			expect.objectContaining({ saved: 1, skipped: 0, failed: 0 }),
+		);
+		const stored = await testApp.articleStore.findArticlesByUser({ userId: TEST_USER_ID });
+		const urls = stored.articles.map((a) => a.url);
+		expect(urls).toContain("https://fagnerbrack.com/business-success");
+		expect(urls).not.toContain("http://localhost:3000/view/fagnerbrack.com/business-success");
+	});
+
 	it("dispatches a pdf content page through the pdf pipeline", async () => {
 		const { testApp, publishedSavePdf } = setup();
 		const accessToken = await createAccessToken(testApp);

--- a/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.test.ts
@@ -1,5 +1,6 @@
 import type { SaveableUrlResult, ValidateSaveableUrl } from "@packages/domain/article";
 import { initPreparseReadplaceUrl, withReadplacePreparse } from "./preparse-readplace-url";
+import { MAX_VIEW_UNWRAP_DEPTH } from "./view-path";
 
 const SELF_HOST = "readplace.com";
 const preparse = initPreparseReadplaceUrl({ selfHost: SELF_HOST });
@@ -102,6 +103,11 @@ describe("initPreparseReadplaceUrl", () => {
 		expect(preparse("https://readplace.com/view/example.com/path%foo")).toBe(
 			"https://readplace.com/view/example.com/path%foo",
 		);
+	});
+
+	it("stops unwrapping past the depth cap, leaving the residual wrapper intact", () => {
+		const nested = `https://readplace.com/view/${"readplace.com/view/".repeat(MAX_VIEW_UNWRAP_DEPTH)}fagnerbrack.com/x`;
+		expect(preparse(nested)).toBe("https://readplace.com/view/fagnerbrack.com/x");
 	});
 
 	describe("self-host is matched including port", () => {

--- a/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.test.ts
@@ -1,11 +1,32 @@
-import type { SaveableUrlResult, ValidateSaveableUrl } from "@packages/domain/article";
-import { initPreparseReadplaceUrl, withReadplacePreparse } from "./preparse-readplace-url";
-import { MAX_VIEW_UNWRAP_DEPTH } from "./view-path";
+import {
+	MAX_SAVEABLE_URL_LENGTH,
+	type SaveableUrlResult,
+	type ValidateSaveableUrl,
+} from "@packages/domain/article";
+import { withReadplacePreparse } from "./preparse-readplace-url";
 
 const SELF_HOST = "readplace.com";
-const preparse = initPreparseReadplaceUrl({ selfHost: SELF_HOST });
 
-describe("initPreparseReadplaceUrl", () => {
+function captureValidator(): { validate: ValidateSaveableUrl; seen: () => unknown } {
+	let received: unknown;
+	const validate: ValidateSaveableUrl = (value) => {
+		received = value;
+		return { status: "ERROR", error: { code: "malformed_url", message: "stub" } };
+	};
+	return { validate, seen: () => received };
+}
+
+function initUnwrap(selfHost: string): (rawUrl: string) => unknown {
+	return (rawUrl) => {
+		const { validate, seen } = captureValidator();
+		withReadplacePreparse(validate, { selfHost })(rawUrl);
+		return seen();
+	};
+}
+
+const preparse = initUnwrap(SELF_HOST);
+
+describe("withReadplacePreparse — self-URL unwrapping", () => {
 	it("unwraps a /view/<host>/<path> self-URL to the original article", () => {
 		expect(preparse("https://readplace.com/view/fagnerbrack.com/business-success")).toBe(
 			"https://fagnerbrack.com/business-success",
@@ -16,6 +37,11 @@ describe("initPreparseReadplaceUrl", () => {
 		expect(
 			preparse("https://readplace.com/view/readplace.com/view/fagnerbrack.com/x"),
 		).toBe("https://fagnerbrack.com/x");
+	});
+
+	it("fully unwraps nesting far deeper than any real link", () => {
+		const nested = `https://readplace.com/view/${"readplace.com/view/".repeat(40)}fagnerbrack.com/x`;
+		expect(preparse(nested)).toBe("https://fagnerbrack.com/x");
 	});
 
 	it("collapses an explicit https:// scheme nested in the /view path", () => {
@@ -73,6 +99,12 @@ describe("initPreparseReadplaceUrl", () => {
 		expect(preparse(`https://readplace.com/view?url=${inner}`)).toBe("https://fagnerbrack.com/x");
 	});
 
+	it("unwraps a self-host written with a trailing FQDN dot", () => {
+		expect(preparse("https://readplace.com./view/fagnerbrack.com/x")).toBe(
+			"https://fagnerbrack.com/x",
+		);
+	});
+
 	it("leaves the bare /view landing path (no url param) unchanged", () => {
 		expect(preparse("https://readplace.com/view")).toBe("https://readplace.com/view");
 	});
@@ -105,13 +137,8 @@ describe("initPreparseReadplaceUrl", () => {
 		);
 	});
 
-	it("stops unwrapping past the depth cap, leaving the residual wrapper intact", () => {
-		const nested = `https://readplace.com/view/${"readplace.com/view/".repeat(MAX_VIEW_UNWRAP_DEPTH)}fagnerbrack.com/x`;
-		expect(preparse(nested)).toBe("https://readplace.com/view/fagnerbrack.com/x");
-	});
-
 	describe("self-host is matched including port", () => {
-		const portPreparse = initPreparseReadplaceUrl({ selfHost: "localhost:3000" });
+		const portPreparse = initUnwrap("localhost:3000");
 
 		it("unwraps when the host and port match", () => {
 			expect(portPreparse("https://localhost:3000/view/example.com/x")).toBe(
@@ -127,28 +154,20 @@ describe("initPreparseReadplaceUrl", () => {
 	});
 });
 
-describe("withReadplacePreparse", () => {
-	function captureValidator(): { validate: ValidateSaveableUrl; seen: () => unknown } {
-		let received: unknown;
-		const validate: ValidateSaveableUrl = (value) => {
-			received = value;
-			return { status: "ERROR", error: { code: "malformed_url", message: "stub" } };
-		};
-		return { validate, seen: () => received };
-	}
-
-	it("hands the unwrapped original to the wrapped validator for string input", () => {
-		const { validate, seen } = captureValidator();
-		const decorated = withReadplacePreparse(validate, { selfHost: SELF_HOST });
-		decorated("https://readplace.com/view/fagnerbrack.com/x");
-		expect(seen()).toBe("https://fagnerbrack.com/x");
-	});
-
+describe("withReadplacePreparse — decorator contract", () => {
 	it("passes non-string input straight through to the wrapped validator", () => {
 		const { validate, seen } = captureValidator();
 		const decorated = withReadplacePreparse(validate, { selfHost: SELF_HOST });
 		decorated(42);
 		expect(seen()).toBe(42);
+	});
+
+	it("passes an over-length string through unrewritten so validation rejects it", () => {
+		const { validate, seen } = captureValidator();
+		const decorated = withReadplacePreparse(validate, { selfHost: SELF_HOST });
+		const oversized = `https://readplace.com/view/fagnerbrack.com/${"a".repeat(MAX_SAVEABLE_URL_LENGTH)}`;
+		decorated(oversized);
+		expect(seen()).toBe(oversized);
 	});
 
 	it("returns the wrapped validator's result", () => {

--- a/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.test.ts
@@ -1,0 +1,157 @@
+import type { SaveableUrlResult, ValidateSaveableUrl } from "@packages/domain/article";
+import { initPreparseReadplaceUrl, withReadplacePreparse } from "./preparse-readplace-url";
+
+const SELF_HOST = "readplace.com";
+const preparse = initPreparseReadplaceUrl({ selfHost: SELF_HOST });
+
+describe("initPreparseReadplaceUrl", () => {
+	it("unwraps a /view/<host>/<path> self-URL to the original article", () => {
+		expect(preparse("https://readplace.com/view/fagnerbrack.com/business-success")).toBe(
+			"https://fagnerbrack.com/business-success",
+		);
+	});
+
+	it("recursively collapses a nested self-URL", () => {
+		expect(
+			preparse("https://readplace.com/view/readplace.com/view/fagnerbrack.com/x"),
+		).toBe("https://fagnerbrack.com/x");
+	});
+
+	it("collapses an explicit https:// scheme nested in the /view path", () => {
+		expect(preparse("https://readplace.com/view/https://fagnerbrack.com/x")).toBe(
+			"https://fagnerbrack.com/x",
+		);
+	});
+
+	it("decodes the article's own query separator (%3F) back into the original URL", () => {
+		expect(preparse("https://readplace.com/view/example.com/post%3Ffoo=bar")).toBe(
+			"https://example.com/post?foo=bar",
+		);
+	});
+
+	it("decodes the article's fragment separator (%23) back into the original URL", () => {
+		expect(preparse("https://readplace.com/view/example.com/post%23section")).toBe(
+			"https://example.com/post#section",
+		);
+	});
+
+	it("preserves a literal percent (%2525 -> %25) in the original URL", () => {
+		expect(preparse("https://readplace.com/view/example.com/path%2525foo")).toBe(
+			"https://example.com/path%25foo",
+		);
+	});
+
+	it("preserves an explicit http:// article scheme", () => {
+		expect(preparse("https://readplace.com/view/http://example.com/x")).toBe(
+			"http://example.com/x",
+		);
+	});
+
+	it("drops Readplace's own share-tracking query while keeping the original article", () => {
+		expect(
+			preparse(
+				"https://readplace.com/view/fagnerbrack.com/x?utm_source=read&utm_medium=share&utm_content=abc",
+			),
+		).toBe("https://fagnerbrack.com/x");
+	});
+
+	it("reads the article from the ?url= param on the /view/ landing path", () => {
+		expect(
+			preparse(`https://readplace.com/view/?url=${encodeURIComponent("https://example.com/a")}`),
+		).toBe("https://example.com/a");
+	});
+
+	it("reads the article from the ?url= param on the /view landing path", () => {
+		expect(
+			preparse(`https://readplace.com/view?url=${encodeURIComponent("https://example.com/a")}`),
+		).toBe("https://example.com/a");
+	});
+
+	it("unwraps a self-URL nested inside the ?url= param", () => {
+		const inner = encodeURIComponent("https://readplace.com/view/fagnerbrack.com/x");
+		expect(preparse(`https://readplace.com/view?url=${inner}`)).toBe("https://fagnerbrack.com/x");
+	});
+
+	it("leaves the bare /view landing path (no url param) unchanged", () => {
+		expect(preparse("https://readplace.com/view")).toBe("https://readplace.com/view");
+	});
+
+	it("leaves a non-article self path unchanged (blog)", () => {
+		expect(preparse("https://readplace.com/blog/pocket-migration")).toBe(
+			"https://readplace.com/blog/pocket-migration",
+		);
+	});
+
+	it("leaves the queue self path unchanged", () => {
+		expect(preparse("https://readplace.com/queue")).toBe("https://readplace.com/queue");
+	});
+
+	it("leaves the self homepage unchanged", () => {
+		expect(preparse("https://readplace.com/")).toBe("https://readplace.com/");
+	});
+
+	it("leaves a /view URL on another host unchanged (not a wrapper)", () => {
+		expect(preparse("https://example.com/view/foo.com/x")).toBe("https://example.com/view/foo.com/x");
+	});
+
+	it("leaves a malformed URL unchanged", () => {
+		expect(preparse("not a url")).toBe("not a url");
+	});
+
+	it("leaves a /view path with an undecodable lone % unchanged", () => {
+		expect(preparse("https://readplace.com/view/example.com/path%foo")).toBe(
+			"https://readplace.com/view/example.com/path%foo",
+		);
+	});
+
+	describe("self-host is matched including port", () => {
+		const portPreparse = initPreparseReadplaceUrl({ selfHost: "localhost:3000" });
+
+		it("unwraps when the host and port match", () => {
+			expect(portPreparse("https://localhost:3000/view/example.com/x")).toBe(
+				"https://example.com/x",
+			);
+		});
+
+		it("leaves a different port unchanged", () => {
+			expect(portPreparse("https://localhost:4000/view/example.com/x")).toBe(
+				"https://localhost:4000/view/example.com/x",
+			);
+		});
+	});
+});
+
+describe("withReadplacePreparse", () => {
+	function captureValidator(): { validate: ValidateSaveableUrl; seen: () => unknown } {
+		let received: unknown;
+		const validate: ValidateSaveableUrl = (value) => {
+			received = value;
+			return { status: "ERROR", error: { code: "malformed_url", message: "stub" } };
+		};
+		return { validate, seen: () => received };
+	}
+
+	it("hands the unwrapped original to the wrapped validator for string input", () => {
+		const { validate, seen } = captureValidator();
+		const decorated = withReadplacePreparse(validate, { selfHost: SELF_HOST });
+		decorated("https://readplace.com/view/fagnerbrack.com/x");
+		expect(seen()).toBe("https://fagnerbrack.com/x");
+	});
+
+	it("passes non-string input straight through to the wrapped validator", () => {
+		const { validate, seen } = captureValidator();
+		const decorated = withReadplacePreparse(validate, { selfHost: SELF_HOST });
+		decorated(42);
+		expect(seen()).toBe(42);
+	});
+
+	it("returns the wrapped validator's result", () => {
+		const result: SaveableUrlResult = {
+			status: "ERROR",
+			error: { code: "private_network", message: "sentinel" },
+		};
+		const validate: ValidateSaveableUrl = () => result;
+		const decorated = withReadplacePreparse(validate, { selfHost: SELF_HOST });
+		expect(decorated("https://example.com/x")).toBe(result);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.ts
+++ b/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.ts
@@ -1,0 +1,55 @@
+import type { ValidateSaveableUrl } from "@packages/domain/article";
+import { originalUrlFromViewPath } from "./view-path";
+
+const VIEW_PREFIX = "/view/";
+
+/** `/view` and `/view/` are the landing route that carries the article in a
+ * `?url=` query param; every other `/view/...` path carries it in the path. */
+const LANDING_PATHS: ReadonlySet<string> = new Set([VIEW_PREFIX, "/view"]);
+
+/** A Readplace reader URL (`/view/<host>/<path>` or `/view/?url=<encoded>`) wraps
+ * an underlying article. Saving the wrapper verbatim would store a self-referential
+ * record keyed on Readplace's own host. This recovers the original article URL,
+ * recursively collapsing nesting, so the save record, card link, dedup key, and
+ * `/view` identity all use the original. */
+export function initPreparseReadplaceUrl(deps: { selfHost: string }): (rawUrl: string) => string {
+	return function preparse(rawUrl: string): string {
+		let current = rawUrl;
+		/** Each accepted step removes one `/view/<host>` layer, so the path strictly
+		 * shrinks and the loop terminates without a depth cap. */
+		for (;;) {
+			let url: URL;
+			try {
+				url = new URL(current);
+			} catch {
+				return current;
+			}
+			if (url.host !== deps.selfHost) return current;
+			const original = unwrapSelfViewUrl(url);
+			if (original === undefined) return current;
+			current = original;
+		}
+	};
+}
+
+function unwrapSelfViewUrl(url: URL): string | undefined {
+	if (LANDING_PATHS.has(url.pathname)) {
+		const param = url.searchParams.get("url");
+		return param === null ? undefined : param;
+	}
+	if (url.pathname.startsWith(VIEW_PREFIX)) {
+		return originalUrlFromViewPath(url.pathname.slice(VIEW_PREFIX.length));
+	}
+	return undefined;
+}
+
+/** Decorates a SaveableUrl validator so it unwraps Readplace self-URLs before
+ * validating. Composed at the composition roots so every save path — every
+ * client — mints the brand from the original article URL with no per-route code. */
+export function withReadplacePreparse(
+	validate: ValidateSaveableUrl,
+	deps: { selfHost: string },
+): ValidateSaveableUrl {
+	const preparse = initPreparseReadplaceUrl(deps);
+	return (value) => validate(typeof value === "string" ? preparse(value) : value);
+}

--- a/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.ts
+++ b/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.ts
@@ -1,5 +1,5 @@
 import type { ValidateSaveableUrl } from "@packages/domain/article";
-import { originalUrlFromViewPath } from "./view-path";
+import { MAX_VIEW_UNWRAP_DEPTH, originalUrlFromViewPath } from "./view-path";
 
 const VIEW_PREFIX = "/view/";
 
@@ -15,9 +15,7 @@ const LANDING_PATHS: ReadonlySet<string> = new Set([VIEW_PREFIX, "/view"]);
 export function initPreparseReadplaceUrl(deps: { selfHost: string }): (rawUrl: string) => string {
 	return function preparse(rawUrl: string): string {
 		let current = rawUrl;
-		/** Each accepted step removes one `/view/<host>` layer, so the path strictly
-		 * shrinks and the loop terminates without a depth cap. */
-		for (;;) {
+		for (let depth = 0; depth < MAX_VIEW_UNWRAP_DEPTH; depth += 1) {
 			let url: URL;
 			try {
 				url = new URL(current);
@@ -29,6 +27,7 @@ export function initPreparseReadplaceUrl(deps: { selfHost: string }): (rawUrl: s
 			if (original === undefined) return current;
 			current = original;
 		}
+		return current;
 	};
 }
 

--- a/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.ts
+++ b/projects/hutch/src/runtime/web/pages/view/preparse-readplace-url.ts
@@ -1,5 +1,5 @@
-import type { ValidateSaveableUrl } from "@packages/domain/article";
-import { MAX_VIEW_UNWRAP_DEPTH, originalUrlFromViewPath } from "./view-path";
+import { MAX_SAVEABLE_URL_LENGTH, type ValidateSaveableUrl } from "@packages/domain/article";
+import { originalUrlFromViewPath } from "./view-path";
 
 const VIEW_PREFIX = "/view/";
 
@@ -12,23 +12,34 @@ const LANDING_PATHS: ReadonlySet<string> = new Set([VIEW_PREFIX, "/view"]);
  * record keyed on Readplace's own host. This recovers the original article URL,
  * recursively collapsing nesting, so the save record, card link, dedup key, and
  * `/view` identity all use the original. */
-export function initPreparseReadplaceUrl(deps: { selfHost: string }): (rawUrl: string) => string {
+function initPreparseReadplaceUrl(deps: { selfHost: string }): (rawUrl: string) => string {
 	return function preparse(rawUrl: string): string {
 		let current = rawUrl;
-		for (let depth = 0; depth < MAX_VIEW_UNWRAP_DEPTH; depth += 1) {
+		/** Each accepted step removes one `/view/<host>` layer, so the URL strictly
+		 * shrinks and the loop terminates without a depth cap. A cap would return the
+		 * still-wrapped residual past it — the self-referential record this module
+		 * exists to prevent. Cost is bounded by the length gate in the decorator. */
+		for (;;) {
 			let url: URL;
 			try {
 				url = new URL(current);
 			} catch {
 				return current;
 			}
-			if (url.host !== deps.selfHost) return current;
+			if (hostWithoutTrailingDot(url) !== deps.selfHost) return current;
 			const original = unwrapSelfViewUrl(url);
 			if (original === undefined) return current;
 			current = original;
 		}
-		return current;
 	};
+}
+
+/** WHATWG URL keeps a trailing FQDN dot in the hostname (`readplace.com.`) while
+ * the SaveableUrl validator strips it, so without normalising here a dotted
+ * self-host would skip the unwrap yet still pass validation. */
+function hostWithoutTrailingDot(url: URL): string {
+	const hostname = url.hostname.endsWith(".") ? url.hostname.slice(0, -1) : url.hostname;
+	return url.port === "" ? hostname : `${hostname}:${url.port}`;
 }
 
 function unwrapSelfViewUrl(url: URL): string | undefined {
@@ -44,11 +55,19 @@ function unwrapSelfViewUrl(url: URL): string | undefined {
 
 /** Decorates a SaveableUrl validator so it unwraps Readplace self-URLs before
  * validating. Composed at the composition roots so every save path — every
- * client — mints the brand from the original article URL with no per-route code. */
+ * client — mints the brand from the original article URL with no per-route code.
+ * The length gate must sit here, before the rewrite: the validator's own
+ * MAX_SAVEABLE_URL_LENGTH rule runs only after preparse, too late to bound the
+ * unwrap work. An over-length string skips unwrapping and fails validation. */
 export function withReadplacePreparse(
 	validate: ValidateSaveableUrl,
 	deps: { selfHost: string },
 ): ValidateSaveableUrl {
 	const preparse = initPreparseReadplaceUrl(deps);
-	return (value) => validate(typeof value === "string" ? preparse(value) : value);
+	return (value) =>
+		validate(
+			typeof value === "string" && value.length <= MAX_SAVEABLE_URL_LENGTH
+				? preparse(value)
+				: value,
+		);
 }

--- a/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
@@ -1,4 +1,4 @@
-import { MAX_VIEW_UNWRAP_DEPTH, originalUrlFromViewPath, parseViewPath, viewPathFor } from "./view-path";
+import { originalUrlFromViewPath, parseViewPath, viewPathFor } from "./view-path";
 
 function parse(decodedAndEncoded: string): ReturnType<typeof parseViewPath>;
 function parse(args: { rawPath: string; encodedPath: string }): ReturnType<typeof parseViewPath>;
@@ -222,8 +222,8 @@ describe("originalUrlFromViewPath", () => {
 		expect(originalUrlFromViewPath("example.com/path%foo")).toBeUndefined();
 	});
 
-	it("returns undefined when scheme-redirect resolution exceeds the depth cap", () => {
-		const nested = `${"https://".repeat(MAX_VIEW_UNWRAP_DEPTH + 1)}example.com/x`;
-		expect(originalUrlFromViewPath(nested)).toBeUndefined();
+	it("resolves a deeply scheme-stacked tail instead of capping out", () => {
+		const nested = `${"https://".repeat(40)}example.com/x`;
+		expect(originalUrlFromViewPath(nested)).toBe("https://example.com/x");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
@@ -1,4 +1,4 @@
-import { originalUrlFromViewPath, parseViewPath, viewPathFor } from "./view-path";
+import { MAX_VIEW_UNWRAP_DEPTH, originalUrlFromViewPath, parseViewPath, viewPathFor } from "./view-path";
 
 function parse(decodedAndEncoded: string): ReturnType<typeof parseViewPath>;
 function parse(args: { rawPath: string; encodedPath: string }): ReturnType<typeof parseViewPath>;
@@ -220,5 +220,10 @@ describe("originalUrlFromViewPath", () => {
 
 	it("returns undefined when the tail cannot be percent-decoded", () => {
 		expect(originalUrlFromViewPath("example.com/path%foo")).toBeUndefined();
+	});
+
+	it("returns undefined when scheme-redirect resolution exceeds the depth cap", () => {
+		const nested = `${"https://".repeat(MAX_VIEW_UNWRAP_DEPTH + 1)}example.com/x`;
+		expect(originalUrlFromViewPath(nested)).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.test.ts
@@ -1,4 +1,4 @@
-import { parseViewPath, viewPathFor } from "./view-path";
+import { originalUrlFromViewPath, parseViewPath, viewPathFor } from "./view-path";
 
 function parse(decodedAndEncoded: string): ReturnType<typeof parseViewPath>;
 function parse(args: { rawPath: string; encodedPath: string }): ReturnType<typeof parseViewPath>;
@@ -192,5 +192,33 @@ describe("parseViewPath", () => {
 		const path = viewPathFor(url);
 		const rawWildcard = decodeURIComponent(path.slice("/view/".length));
 		expect(parse(rawWildcard)).toEqual({ kind: "render", articleUrl: url });
+	});
+});
+
+describe("originalUrlFromViewPath", () => {
+	it("recovers the https article URL from a scheme-less tail", () => {
+		expect(originalUrlFromViewPath("example.com/post")).toBe("https://example.com/post");
+	});
+
+	it("decodes the percent-encoded query separator back into the article URL", () => {
+		expect(originalUrlFromViewPath("example.com/post%3Ffoo=bar")).toBe(
+			"https://example.com/post?foo=bar",
+		);
+	});
+
+	it("preserves an explicit http:// scheme", () => {
+		expect(originalUrlFromViewPath("http://example.com/post")).toBe("http://example.com/post");
+	});
+
+	it("resolves a redirect tail (legacy https:// prefix) to the canonical article URL", () => {
+		expect(originalUrlFromViewPath("https://example.com/post")).toBe("https://example.com/post");
+	});
+
+	it("resolves a collapsed http:/ redirect tail to the http article URL", () => {
+		expect(originalUrlFromViewPath("http:/example.com/post")).toBe("http://example.com/post");
+	});
+
+	it("returns undefined when the tail cannot be percent-decoded", () => {
+		expect(originalUrlFromViewPath("example.com/path%foo")).toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-path.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.ts
@@ -44,16 +44,16 @@ export function parseViewPath(input: ParseViewPathInput): ParseViewPathResult {
 	return { kind: "render", articleUrl: `https://${rawPath}` };
 }
 
-export const MAX_VIEW_UNWRAP_DEPTH = 16;
-
 /** Recovers the original article URL from a `/view/<tail>` segment, or undefined
  * if the tail can't be decoded (e.g. a lone `%`). Single source of truth for the
- * `/view` ↔ original mapping: it reuses parseViewPath so the `%3F`→`?`, `%23`→`#`,
- * `%2525`→`%25`, and explicit-`http://` rules are not reimplemented. A redirect
- * result is the same article in canonical form, so it is resolved iteratively. */
+ * `/view` ↔ original mapping: it delegates to the parser above so the `%3F`→`?`,
+ * `%23`→`#`, `%2525`→`%25`, and explicit-`http://` rules are not reimplemented.
+ * A redirect result is the same article in canonical form, so it is resolved
+ * iteratively; every round either renders or consumes a leading scheme/encoding
+ * layer of the tail, so the loop terminates without a depth cap. */
 export function originalUrlFromViewPath(tail: string): string | undefined {
 	let current = tail;
-	for (let depth = 0; depth < MAX_VIEW_UNWRAP_DEPTH; depth += 1) {
+	for (;;) {
 		let rawPath: string;
 		try {
 			rawPath = decodeURIComponent(current);
@@ -64,7 +64,6 @@ export function originalUrlFromViewPath(tail: string): string | undefined {
 		if (result.kind === "render") return result.articleUrl;
 		current = result.canonicalPath.slice("/view/".length);
 	}
-	return undefined;
 }
 
 /** Re-encode `%25` (literal `%`), `?`, and `#` so the canonical survives

--- a/projects/hutch/src/runtime/web/pages/view/view-path.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.ts
@@ -44,6 +44,23 @@ export function parseViewPath(input: ParseViewPathInput): ParseViewPathResult {
 	return { kind: "render", articleUrl: `https://${rawPath}` };
 }
 
+/** Recovers the original article URL from a `/view/<tail>` segment, or undefined
+ * if the tail can't be decoded (e.g. a lone `%`). Single source of truth for the
+ * `/view` ↔ original mapping: it reuses parseViewPath so the `%3F`→`?`, `%23`→`#`,
+ * `%2525`→`%25`, and explicit-`http://` rules are not reimplemented. A redirect
+ * result is the same article in canonical form, so it is resolved recursively. */
+export function originalUrlFromViewPath(tail: string): string | undefined {
+	let rawPath: string;
+	try {
+		rawPath = decodeURIComponent(tail);
+	} catch {
+		return undefined;
+	}
+	const result = parseViewPath({ rawPath, encodedPath: tail });
+	if (result.kind === "render") return result.articleUrl;
+	return originalUrlFromViewPath(result.canonicalPath.slice("/view/".length));
+}
+
 /** Re-encode `%25` (literal `%`), `?`, and `#` so the canonical survives
  * Express's `decodeURIComponent` on the wildcard param. `%25` is the URL
  * constructor's encoding of a literal percent sign; double-encoding it to

--- a/projects/hutch/src/runtime/web/pages/view/view-path.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-path.ts
@@ -44,21 +44,27 @@ export function parseViewPath(input: ParseViewPathInput): ParseViewPathResult {
 	return { kind: "render", articleUrl: `https://${rawPath}` };
 }
 
+export const MAX_VIEW_UNWRAP_DEPTH = 16;
+
 /** Recovers the original article URL from a `/view/<tail>` segment, or undefined
  * if the tail can't be decoded (e.g. a lone `%`). Single source of truth for the
  * `/view` ↔ original mapping: it reuses parseViewPath so the `%3F`→`?`, `%23`→`#`,
  * `%2525`→`%25`, and explicit-`http://` rules are not reimplemented. A redirect
- * result is the same article in canonical form, so it is resolved recursively. */
+ * result is the same article in canonical form, so it is resolved iteratively. */
 export function originalUrlFromViewPath(tail: string): string | undefined {
-	let rawPath: string;
-	try {
-		rawPath = decodeURIComponent(tail);
-	} catch {
-		return undefined;
+	let current = tail;
+	for (let depth = 0; depth < MAX_VIEW_UNWRAP_DEPTH; depth += 1) {
+		let rawPath: string;
+		try {
+			rawPath = decodeURIComponent(current);
+		} catch {
+			return undefined;
+		}
+		const result = parseViewPath({ rawPath, encodedPath: current });
+		if (result.kind === "render") return result.articleUrl;
+		current = result.canonicalPath.slice("/view/".length);
 	}
-	const result = parseViewPath({ rawPath, encodedPath: tail });
-	if (result.kind === "render") return result.articleUrl;
-	return originalUrlFromViewPath(result.canonicalPath.slice("/view/".length));
+	return undefined;
 }
 
 /** Re-encode `%25` (literal `%`), `?`, and `#` so the canonical survives

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -193,9 +193,6 @@ describe("View routes", () => {
 
 			expect(response.status).toBe(200);
 			const doc = new JSDOM(response.text).window.document;
-			expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe(
-				"Hello World",
-			);
 			const href = ctaAction(doc).getAttribute("href");
 			assert(href, "cta action must have an href");
 			const parsed = new URL(href, "http://localhost");

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -183,6 +183,21 @@ describe("View routes", () => {
 			expect(time.textContent).toBe("26 Mar '26, 14:32");
 		});
 
+		it("unwraps a nested Readplace self-URL and renders the underlying article", async () => {
+			const harness = buildReaderHarness();
+			const selfHost = new URL(TEST_APP_ORIGIN).host;
+
+			const response = await request(harness.server).get(
+				`/view/${selfHost}/view/${CANONICAL_PATH}`,
+			);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe(
+				"Hello World",
+			);
+		});
+
 		it("301-redirects the legacy percent-encoded format to the scheme-less canonical", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -196,6 +196,10 @@ describe("View routes", () => {
 			expect(doc.querySelector("[data-test-reader-title]")?.textContent).toBe(
 				"Hello World",
 			);
+			const href = ctaAction(doc).getAttribute("href");
+			assert(href, "cta action must have an href");
+			const parsed = new URL(href, "http://localhost");
+			expect(parsed.searchParams.get("url")).toBe(ARTICLE_URL);
 		});
 
 		it("301-redirects the legacy percent-encoded format to the scheme-less canonical", async () => {

--- a/src/packages/domain/src/article/index.ts
+++ b/src/packages/domain/src/article/index.ts
@@ -33,6 +33,7 @@ export {
 	ArticleStatusSchema,
 } from "./article.schema";
 export {
+	MAX_SAVEABLE_URL_LENGTH,
 	SaveableUrlSchema,
 	validateSaveableUrl,
 	saveableUrlCodeFromIssues,

--- a/src/packages/domain/src/article/saveable-url.test.ts
+++ b/src/packages/domain/src/article/saveable-url.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+	MAX_SAVEABLE_URL_LENGTH,
 	SaveableUrlSchema,
 	saveableUrlCodeFromIssues,
 	saveableUrlErrorMessage,
@@ -115,6 +116,19 @@ describe("validateSaveableUrl", () => {
 			assertErrorCode(undefined, "malformed_url");
 			assertErrorCode(null, "malformed_url");
 			assertErrorCode({}, "malformed_url");
+		});
+
+		it("rejects a URL longer than MAX_SAVEABLE_URL_LENGTH", () => {
+			const prefix = "https://example.com/";
+			assertErrorCode(
+				`${prefix}${"a".repeat(MAX_SAVEABLE_URL_LENGTH - prefix.length + 1)}`,
+				"malformed_url",
+			);
+		});
+
+		it("accepts a URL exactly at MAX_SAVEABLE_URL_LENGTH", () => {
+			const prefix = "https://example.com/";
+			assertSuccess(`${prefix}${"a".repeat(MAX_SAVEABLE_URL_LENGTH - prefix.length)}`);
 		});
 	});
 

--- a/src/packages/domain/src/article/saveable-url.ts
+++ b/src/packages/domain/src/article/saveable-url.ts
@@ -23,6 +23,13 @@ export type SaveableUrl = z.infer<typeof SaveableUrlBrand>;
 
 const ALLOWED_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
 
+/** Above any legitimate article URL and the ~2k-8k ceilings browsers, proxies,
+ * and CDNs enforce. Every save path funnels through this validator, so this one
+ * rule bounds stored URLs, dedup keys, and crawler fetches — and any
+ * URL-rewriting decorator composed in front must gate on it BEFORE rewriting,
+ * because decorators run before this check. */
+export const MAX_SAVEABLE_URL_LENGTH = 8192;
+
 const LOCAL_HOSTNAME_SUFFIXES: readonly string[] = [
 	".local",
 	".home.arpa",
@@ -87,6 +94,7 @@ export function validateSaveableUrl(value: unknown): SaveableUrlResult {
 	if (typeof value !== "string") return errorResult("malformed_url");
 	const trimmed = value.trim();
 	if (trimmed.length === 0) return errorResult("malformed_url"); /* c8 ignore next -- V8 block coverage phantom: zero-count sub-range at bytecode boundary (bcoe/c8#319, v8.dev/blog/javascript-code-coverage) */
+	if (trimmed.length > MAX_SAVEABLE_URL_LENGTH) return errorResult("malformed_url");
 	const parsed = tryParseUrl(trimmed);
 	if (!parsed) return errorResult("malformed_url");
 	if (!ALLOWED_SCHEMES.has(parsed.protocol)) return errorResult("unsupported_scheme"); /* c8 ignore next -- V8 block coverage phantom: zero-count sub-range at bytecode boundary (bcoe/c8#319, v8.dev/blog/javascript-code-coverage) */


### PR DESCRIPTION
## Summary

When users save articles via Readplace's `/view/<host>/<path>` wrapper URLs, the system now unwraps them to recover the original article URL. This ensures save records, dedup keys, and card links use the canonical original URL rather than self-referential Readplace URLs.

## Changes

- **New `preparse-readplace-url` module**: Implements URL unwrapping logic with two exports:
  - `initPreparseReadplaceUrl()`: Creates a function that recursively collapses `/view/<host>/<path>` wrappers and `?url=` query params, handling edge cases like nested wrappers, percent-encoded query/fragment separators (`%3F`, `%23`), explicit schemes, and Readplace's own tracking params
  - `withReadplacePreparse()`: Decorator that wraps the `ValidateSaveableUrl` validator to preparse string inputs before validation

- **New `originalUrlFromViewPath()` export** in `view-path.ts`: Recovers the original article URL from a `/view/<tail>` path segment by reusing `parseViewPath` logic, ensuring consistent handling of encoding rules and redirect resolution

- **Integrated at composition roots**: Both `app.ts` and `test-app.ts` now decorate `validateSaveableUrl` with `withReadplacePreparse`, ensuring every save path (queue, import, etc.) unwraps self-URLs before validation

- **Comprehensive test coverage**:
  - 20 unit tests for `initPreparseReadplaceUrl` covering recursive unwrapping, encoding edge cases, port matching, and malformed input handling
  - 3 tests for `withReadplacePreparse` decorator behavior
  - 6 tests for `originalUrlFromViewPath` covering scheme handling and decode errors
  - Integration tests in `queue.save-articles.route.test.ts` and `view.route.test.ts` verifying end-to-end unwrapping

## Implementation Details

- Unwrapping is recursive and terminating: each accepted step removes one `/view/<host>` layer, so the path strictly shrinks
- Handles both path-based (`/view/example.com/post`) and query-based (`/view?url=...`) wrapper formats
- Preserves explicit `http://` schemes while defaulting to `https://` for scheme-less URLs
- Gracefully degrades: malformed URLs, non-wrapper paths, and decode errors are returned unchanged
- Port matching is strict: `localhost:3000` and `localhost:4000` are treated as different hosts

https://claude.ai/code/session_01EoT1snrsX53BSK7Q5FYubH