### PR TITLE
fix(reader): render unplayable YouTube embeds as a poster facade

### DIFF
--- a/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.styles.css
+++ b/projects/hutch/src/runtime/web/shared/article-body/reader-slot/reader-iframe.styles.css
@@ -115,6 +115,61 @@ body {
   color: var(--color-text-secondary);
 }
 
+/**
+ * The article-parser replaces an unplayable YouTube <iframe> (the reader body
+ * has no allow-scripts, so the player errors) with this poster card: the video
+ * thumbnail under a play glyph, wrapped in a link to the watch page. The 16:9
+ * box keeps a stable height while the poster loads.
+ */
+.article-body__content .reader-embed-facade {
+  margin: 1.5rem 0;
+}
+
+.article-body__content .reader-embed-facade a {
+  position: relative;
+  display: block;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 4px;
+  background: var(--color-surface);
+}
+
+.article-body__content .reader-embed-facade img {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  border-radius: 0;
+  object-fit: cover;
+}
+
+.article-body__content .reader-embed-facade a::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 68px;
+  height: 48px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.55);
+  transform: translate(-50%, -50%);
+  transition: background 0.15s ease;
+}
+
+.article-body__content .reader-embed-facade a:hover::before {
+  background: var(--color-brand);
+}
+
+.article-body__content .reader-embed-facade a::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-style: solid;
+  border-width: 11px 0 11px 19px;
+  border-color: transparent transparent transparent #fff;
+  transform: translate(-40%, -50%);
+}
+
 .article-body__content pre {
   overflow-x: auto;
   padding: 1rem;

--- a/src/packages/article-parser/src/parse-embed-url.test.ts
+++ b/src/packages/article-parser/src/parse-embed-url.test.ts
@@ -1,0 +1,76 @@
+import { parseYouTubeEmbed } from "./parse-embed-url";
+
+describe("parseYouTubeEmbed", () => {
+	it("parses a standard /embed/ID player URL", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/embed/hVl9B3dTFB4?color=white&modestbranding=1")).toEqual({
+			videoId: "hVl9B3dTFB4",
+			watchUrl: "https://www.youtube.com/watch?v=hVl9B3dTFB4",
+			posterUrl: "https://i.ytimg.com/vi/hVl9B3dTFB4/hqdefault.jpg",
+		});
+	});
+
+	it("parses a youtube-nocookie embed URL", () => {
+		const embed = parseYouTubeEmbed("https://www.youtube-nocookie.com/embed/hVl9B3dTFB4");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+	});
+
+	it("parses a youtu.be short URL", () => {
+		const embed = parseYouTubeEmbed("https://youtu.be/hVl9B3dTFB4");
+		expect(embed?.watchUrl).toBe("https://www.youtube.com/watch?v=hVl9B3dTFB4");
+	});
+
+	it("parses a /watch?v=ID URL on m.youtube.com", () => {
+		const embed = parseYouTubeEmbed("https://m.youtube.com/watch?v=hVl9B3dTFB4");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+	});
+
+	it("parses a /shorts/ID URL", () => {
+		const embed = parseYouTubeEmbed("https://www.youtube.com/shorts/hVl9B3dTFB4");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+	});
+
+	it("parses a legacy /v/ID URL", () => {
+		const embed = parseYouTubeEmbed("https://youtube.com/v/hVl9B3dTFB4");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+	});
+
+	it("returns undefined for a non-URL string", () => {
+		expect(parseYouTubeEmbed("not a url")).toBeUndefined();
+	});
+
+	it("returns undefined for a non-YouTube host", () => {
+		expect(parseYouTubeEmbed("https://player.vimeo.com/video/76979871")).toBeUndefined();
+	});
+
+	it("returns undefined for a look-alike host", () => {
+		expect(parseYouTubeEmbed("https://evil-youtube.com/embed/hVl9B3dTFB4")).toBeUndefined();
+	});
+
+	it("returns undefined when /embed has no id", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/embed")).toBeUndefined();
+	});
+
+	it("returns undefined when /watch has no v parameter", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/watch?list=PL123")).toBeUndefined();
+	});
+
+	it("returns undefined for a youtu.be URL with no path", () => {
+		expect(parseYouTubeEmbed("https://youtu.be/")).toBeUndefined();
+	});
+
+	it("returns undefined for an unrecognised YouTube path", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/channel/UC123")).toBeUndefined();
+	});
+
+	it("returns undefined for the bare YouTube origin", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/")).toBeUndefined();
+	});
+
+	it("returns undefined when the id is the wrong length", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/embed/tooshort")).toBeUndefined();
+	});
+
+	it("returns undefined when the id contains an illegal character", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/embed/abcdefghij!")).toBeUndefined();
+	});
+});

--- a/src/packages/article-parser/src/parse-embed-url.test.ts
+++ b/src/packages/article-parser/src/parse-embed-url.test.ts
@@ -66,11 +66,51 @@ describe("parseYouTubeEmbed", () => {
 		expect(parseYouTubeEmbed("https://www.youtube.com/")).toBeUndefined();
 	});
 
-	it("returns undefined when the id is the wrong length", () => {
-		expect(parseYouTubeEmbed("https://www.youtube.com/embed/tooshort")).toBeUndefined();
+	it("admits a video id whose length is not the historical 11 characters (gate relaxed)", () => {
+		const embed = parseYouTubeEmbed("https://www.youtube.com/embed/short-id");
+		expect(embed).toEqual({
+			videoId: "short-id",
+			watchUrl: "https://www.youtube.com/watch?v=short-id",
+			posterUrl: "https://i.ytimg.com/vi/short-id/hqdefault.jpg",
+		});
 	});
 
-	it("returns undefined when the id contains an illegal character", () => {
+	it("parses a /live/ID permalink URL", () => {
+		const embed = parseYouTubeEmbed("https://www.youtube.com/live/hVl9B3dTFB4");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+	});
+
+	it("parses a /watch?v=ID URL on music.youtube.com", () => {
+		const embed = parseYouTubeEmbed("https://music.youtube.com/watch?v=hVl9B3dTFB4");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+	});
+
+	it("maps a /embed/videoseries playlist to a playlist watch URL with no poster", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/embed/videoseries?list=PLabc_123")).toEqual({
+			watchUrl: "https://www.youtube.com/playlist?list=PLabc_123",
+		});
+	});
+
+	it("maps a /playlist?list=ID URL to a playlist watch URL", () => {
+		const embed = parseYouTubeEmbed("https://www.youtube.com/playlist?list=PLabc_123");
+		expect(embed?.watchUrl).toBe("https://www.youtube.com/playlist?list=PLabc_123");
+	});
+
+	it("prefers the concrete video when an embed carries both a video id and a list", () => {
+		const embed = parseYouTubeEmbed("https://www.youtube.com/embed/hVl9B3dTFB4?list=PLabc_123");
+		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed?.watchUrl).toBe("https://www.youtube.com/watch?v=hVl9B3dTFB4");
+	});
+
+	it("returns undefined for a videoseries embed with no list", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/embed/videoseries")).toBeUndefined();
+	});
+
+	it("returns undefined when the video id contains an illegal character", () => {
 		expect(parseYouTubeEmbed("https://www.youtube.com/embed/abcdefghij!")).toBeUndefined();
+	});
+
+	it("returns undefined when the playlist id contains an illegal character", () => {
+		expect(parseYouTubeEmbed("https://www.youtube.com/playlist?list=PL/../evil")).toBeUndefined();
 	});
 });

--- a/src/packages/article-parser/src/parse-embed-url.ts
+++ b/src/packages/article-parser/src/parse-embed-url.ts
@@ -1,0 +1,47 @@
+export interface YouTubeEmbed {
+	videoId: string;
+	watchUrl: string;
+	posterUrl: string;
+}
+
+const YOUTUBE_VIDEO_ID = /^[A-Za-z0-9_-]{11}$/;
+
+const YOUTUBE_HOSTS = new Set([
+	"youtube.com",
+	"m.youtube.com",
+	"youtube-nocookie.com",
+]);
+
+/* Every field is derived from the validated 11-character id, never from the
+ * raw href, so a javascript:/data:/foreign-origin src cannot be smuggled into
+ * the facade's link or poster. Returns undefined for anything that is not a
+ * recognisable YouTube video URL. */
+export function parseYouTubeEmbed(rawUrl: string): YouTubeEmbed | undefined {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return undefined;
+	}
+	const videoId = extractVideoId(url);
+	if (!videoId || !YOUTUBE_VIDEO_ID.test(videoId)) return undefined;
+	return {
+		videoId,
+		watchUrl: `https://www.youtube.com/watch?v=${videoId}`,
+		posterUrl: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+	};
+}
+
+function extractVideoId(url: URL): string | undefined {
+	const host = url.hostname.replace(/^www\./, "");
+	const segments = url.pathname.split("/").filter(Boolean);
+	if (host === "youtu.be") return segments[0];
+	if (!YOUTUBE_HOSTS.has(host)) return undefined;
+	const [first, second] = segments;
+	if (first === "embed" || first === "shorts" || first === "v") return second;
+	if (first === "watch") {
+		const fromQuery = url.searchParams.get("v");
+		return fromQuery === null ? undefined : fromQuery;
+	}
+	return undefined;
+}

--- a/src/packages/article-parser/src/parse-embed-url.ts
+++ b/src/packages/article-parser/src/parse-embed-url.ts
@@ -1,21 +1,28 @@
 export interface YouTubeEmbed {
-	videoId: string;
+	videoId?: string;
 	watchUrl: string;
-	posterUrl: string;
+	posterUrl?: string;
 }
 
-const YOUTUBE_VIDEO_ID = /^[A-Za-z0-9_-]{11}$/;
+const URL_SAFE_ID = /^[A-Za-z0-9_-]+$/;
 
 const YOUTUBE_HOSTS = new Set([
 	"youtube.com",
 	"m.youtube.com",
+	"music.youtube.com",
 	"youtube-nocookie.com",
 ]);
 
-/* Every field is derived from the validated 11-character id, never from the
- * raw href, so a javascript:/data:/foreign-origin src cannot be smuggled into
- * the facade's link or poster. Returns undefined for anything that is not a
- * recognisable YouTube video URL. */
+const VIDEO_PATH_PREFIXES = new Set(["embed", "shorts", "v", "live"]);
+
+/* The trust boundary is the host allow-list: a URL that doesn't parse to a known
+ * YouTube host (checked after stripping a leading `www.`) is rejected outright,
+ * so a `javascript:`/`data:` or foreign-origin src can never reach the facade.
+ * The watch link and poster are then rebuilt from a path/query token constrained
+ * to URL-safe id characters — never the raw href — so nothing can smuggle an
+ * extra path segment, query parameter, or origin through. The id length is
+ * deliberately unconstrained: any recognisable YouTube embed is admitted,
+ * whether a single video or a playlist. Returns undefined for everything else. */
 export function parseYouTubeEmbed(rawUrl: string): YouTubeEmbed | undefined {
 	let url: URL;
 	try {
@@ -23,25 +30,30 @@ export function parseYouTubeEmbed(rawUrl: string): YouTubeEmbed | undefined {
 	} catch {
 		return undefined;
 	}
-	const videoId = extractVideoId(url);
-	if (!videoId || !YOUTUBE_VIDEO_ID.test(videoId)) return undefined;
+	const host = url.hostname.replace(/^www\./, "");
+	const segments = url.pathname.split("/").filter(Boolean);
+	if (host === "youtu.be") return video(segments[0]);
+	if (!YOUTUBE_HOSTS.has(host)) return undefined;
+	const [first, second] = segments;
+	if (VIDEO_PATH_PREFIXES.has(first)) {
+		return second === "videoseries" ? playlist(url) : video(second);
+	}
+	if (first === "watch") return video(url.searchParams.get("v"));
+	if (first === "playlist") return playlist(url);
+	return undefined;
+}
+
+function video(id: string | null | undefined): YouTubeEmbed | undefined {
+	if (!id || !URL_SAFE_ID.test(id)) return undefined;
 	return {
-		videoId,
-		watchUrl: `https://www.youtube.com/watch?v=${videoId}`,
-		posterUrl: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+		videoId: id,
+		watchUrl: `https://www.youtube.com/watch?v=${id}`,
+		posterUrl: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
 	};
 }
 
-function extractVideoId(url: URL): string | undefined {
-	const host = url.hostname.replace(/^www\./, "");
-	const segments = url.pathname.split("/").filter(Boolean);
-	if (host === "youtu.be") return segments[0];
-	if (!YOUTUBE_HOSTS.has(host)) return undefined;
-	const [first, second] = segments;
-	if (first === "embed" || first === "shorts" || first === "v") return second;
-	if (first === "watch") {
-		const fromQuery = url.searchParams.get("v");
-		return fromQuery === null ? undefined : fromQuery;
-	}
-	return undefined;
+function playlist(url: URL): YouTubeEmbed | undefined {
+	const listId = url.searchParams.get("list");
+	if (!listId || !URL_SAFE_ID.test(listId)) return undefined;
+	return { watchUrl: `https://www.youtube.com/playlist?list=${listId}` };
 }

--- a/src/packages/article-parser/src/readability-parser.test.ts
+++ b/src/packages/article-parser/src/readability-parser.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
 import { initReadabilityParser } from "./readability-parser";
 import { noExtract, noTransform, skipCrawl } from "@packages/site-rules";
 import type { SiteRules } from "@packages/site-rules";
@@ -81,10 +82,32 @@ describe("initReadabilityParser", () => {
 
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.article.content).not.toContain("youtube.com/embed");
+			const { document } = parseHTML(result.article.content);
+			expect(document.querySelectorAll("iframe")).toHaveLength(0);
 			expect(result.article.content).toContain("reader-embed-facade");
 			expect(result.article.content).toContain("https://www.youtube.com/watch?v=hVl9B3dTFB4");
 			expect(result.article.content).toContain("https://i.ytimg.com/vi/hVl9B3dTFB4/hqdefault.jpg");
+		}
+	});
+
+	it("replaces a surviving YouTube playlist embed with a text callout linking to the playlist", () => {
+		const html = `
+		<html><head><title>Playlist Article</title></head><body><article>
+		<h1>Playlist Article</h1>
+		<p>An intro paragraph with enough words for readability to score this as a genuine article body worth extracting.</p>
+		<p><iframe src="https://www.youtube.com/embed/videoseries?list=PLabc_123" title="YouTube playlist" allowfullscreen></iframe></p>
+		<p>A closing paragraph with additional words so readability keeps scoring the surrounding article content properly.</p>
+		</article></body></html>`;
+		const { parseHtml } = initParser();
+
+		const result = parseHtml({ url: "https://example.com/playlist-post", html, thumbnailUrl: null });
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			const { document } = parseHTML(result.article.content);
+			expect(document.querySelectorAll("iframe")).toHaveLength(0);
+			expect(result.article.content).toContain("reader-video-placeholder");
+			expect(result.article.content).toContain("https://www.youtube.com/playlist?list=PLabc_123");
 		}
 	});
 

--- a/src/packages/article-parser/src/readability-parser.test.ts
+++ b/src/packages/article-parser/src/readability-parser.test.ts
@@ -67,6 +67,27 @@ describe("initReadabilityParser", () => {
 		}
 	});
 
+	it("replaces a surviving YouTube embed with a poster-card facade and drops the iframe", () => {
+		const html = `
+		<html><head><title>Embed Article</title></head><body><article>
+		<h1>Embed Article</h1>
+		<p>An intro paragraph with enough words for readability to score this as a genuine article body worth extracting.</p>
+		<p><iframe src="https://www.youtube.com/embed/hVl9B3dTFB4?color=white&modestbranding=1" title="YouTube video player" allowfullscreen></iframe></p>
+		<p>A closing paragraph with additional words so readability keeps scoring the surrounding article content properly.</p>
+		</article></body></html>`;
+		const { parseHtml } = initParser();
+
+		const result = parseHtml({ url: "https://techhut.tv/windows-lite-ltsc-microsoft", html, thumbnailUrl: null });
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.article.content).not.toContain("youtube.com/embed");
+			expect(result.article.content).toContain("reader-embed-facade");
+			expect(result.article.content).toContain("https://www.youtube.com/watch?v=hVl9B3dTFB4");
+			expect(result.article.content).toContain("https://i.ytimg.com/vi/hVl9B3dTFB4/hqdefault.jpg");
+		}
+	});
+
 	it("should calculate word count from extracted text", async () => {
 		const { parseArticle } = initParser();
 

--- a/src/packages/article-parser/src/readability-parser.ts
+++ b/src/packages/article-parser/src/readability-parser.ts
@@ -254,16 +254,33 @@ function renderVideoPlaceholder(ctx: {
 	return placeholder;
 }
 
+const EMBED_PLAYLIST_LEAD = "Watch this playlist on ";
+const EMBED_PLAYLIST_LABEL = "YouTube";
+const EMBED_PLAYLIST_TRAILING = " →";
+
 function renderEmbedFacade(ctx: {
 	document: Document;
 	embed: YouTubeEmbed;
 }): Element {
-	const wrapper = ctx.document.createElement("p");
-	wrapper.setAttribute("class", "reader-embed-facade");
 	const link = ctx.document.createElement("a");
 	link.setAttribute("href", ctx.embed.watchUrl);
 	link.setAttribute("target", "_blank");
 	link.setAttribute("rel", "noopener noreferrer");
+	if (!ctx.embed.posterUrl) {
+		/* A playlist embed has no single-video thumbnail to rehost, so it can't
+		 * become a poster card; reuse the native-<video> text callout instead so
+		 * the link still survives Readability's empty-<p> prune (it carries text
+		 * rather than an <img>). */
+		const callout = ctx.document.createElement("p");
+		callout.setAttribute("class", "reader-video-placeholder");
+		callout.appendChild(ctx.document.createTextNode(EMBED_PLAYLIST_LEAD));
+		link.appendChild(ctx.document.createTextNode(EMBED_PLAYLIST_LABEL));
+		callout.appendChild(link);
+		callout.appendChild(ctx.document.createTextNode(EMBED_PLAYLIST_TRAILING));
+		return callout;
+	}
+	const wrapper = ctx.document.createElement("p");
+	wrapper.setAttribute("class", "reader-embed-facade");
 	const poster = ctx.document.createElement("img");
 	poster.setAttribute("src", ctx.embed.posterUrl);
 	poster.setAttribute("alt", "Watch on YouTube");

--- a/src/packages/article-parser/src/readability-parser.ts
+++ b/src/packages/article-parser/src/readability-parser.ts
@@ -4,7 +4,9 @@ import { parseHTML } from "linkedom";
 import type { CrawlArticle } from "@packages/crawl-article";
 import type { ParseArticle, ParseHtml } from "./article-parser.types";
 import type { SiteArticleContent, SiteRules } from "@packages/site-rules";
+import type { YouTubeEmbed } from "./parse-embed-url";
 import { promoteBrParagraphHosts } from "./promote-br-paragraph-hosts";
+import { replaceEmbedsWithFacade } from "./replace-embeds-with-facade";
 import { replaceVideosWithPlaceholder } from "./replace-videos-with-placeholder";
 import { resolveRelativeUrls } from "./resolve-relative-urls";
 
@@ -48,6 +50,7 @@ export function initReadabilityParser(deps: {
 				originalUrl: params.url,
 				renderPlaceholder: renderVideoPlaceholder,
 			});
+			replaceEmbedsWithFacade({ document, renderFacade: renderEmbedFacade });
 			/* Site rules may mutate the document in place (e.g. LinkedIn
 			 * rebuilding `\n\n` `white-space: pre-wrap` paragraphs) before
 			 * Readability scores it. */
@@ -65,13 +68,14 @@ export function initReadabilityParser(deps: {
 			 * inline-post shape). In place, so a false match can't drop the
 			 * article — Readability still scores the whole document. */
 			promoteBrParagraphHosts(document);
-			/* `reader-video-placeholder` joins Readability's default
-			 * `CLASSES_TO_PRESERVE` (concat'd internally) so the CSS hook
-			 * survives `_cleanClasses`; the <p> tag is also exempt from
-			 * `_cleanConditionally`, keeping the link-bearing callout from
-			 * being dropped for link density. */
+			/* `reader-video-placeholder` and `reader-embed-facade` join
+			 * Readability's default `CLASSES_TO_PRESERVE` (concat'd internally) so
+			 * the CSS hooks survive `_cleanClasses`; the <p> tag is also exempt
+			 * from `_cleanConditionally`, and a <p> carrying an <img> survives
+			 * empty-paragraph removal, keeping the link-bearing callout and the
+			 * poster card from being dropped. */
 			parsed = new Readability(document, {
-				classesToPreserve: ["reader-video-placeholder"],
+				classesToPreserve: ["reader-video-placeholder", "reader-embed-facade"],
 			}).parse();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -248,4 +252,23 @@ function renderVideoPlaceholder(ctx: {
 	placeholder.appendChild(link);
 	placeholder.appendChild(ctx.document.createTextNode(VIDEO_PLACEHOLDER_TRAILING));
 	return placeholder;
+}
+
+function renderEmbedFacade(ctx: {
+	document: Document;
+	embed: YouTubeEmbed;
+}): Element {
+	const wrapper = ctx.document.createElement("p");
+	wrapper.setAttribute("class", "reader-embed-facade");
+	const link = ctx.document.createElement("a");
+	link.setAttribute("href", ctx.embed.watchUrl);
+	link.setAttribute("target", "_blank");
+	link.setAttribute("rel", "noopener noreferrer");
+	const poster = ctx.document.createElement("img");
+	poster.setAttribute("src", ctx.embed.posterUrl);
+	poster.setAttribute("alt", "Watch on YouTube");
+	poster.setAttribute("loading", "lazy");
+	link.appendChild(poster);
+	wrapper.appendChild(link);
+	return wrapper;
 }

--- a/src/packages/article-parser/src/replace-embeds-with-facade.test.ts
+++ b/src/packages/article-parser/src/replace-embeds-with-facade.test.ts
@@ -1,0 +1,111 @@
+import { parseHTML } from "linkedom";
+import { replaceEmbedsWithFacade } from "./replace-embeds-with-facade";
+
+function parse(html: string): Document {
+	return parseHTML(html).document;
+}
+
+function fakeRenderer(): {
+	render: Parameters<typeof replaceEmbedsWithFacade>[0]["renderFacade"];
+	calls: string[];
+} {
+	const calls: string[] = [];
+	const render: Parameters<typeof replaceEmbedsWithFacade>[0]["renderFacade"] = (ctx) => {
+		calls.push(ctx.embed.videoId);
+		const facade = ctx.document.createElement("p");
+		facade.setAttribute("data-facade", String(calls.length));
+		return facade;
+	};
+	return { render, calls };
+}
+
+const YT = "https://www.youtube.com/embed/hVl9B3dTFB4";
+
+describe("replaceEmbedsWithFacade", () => {
+	it("replaces a YouTube iframe with the rendered facade and drops the iframe", () => {
+		const document = parse(
+			`<html><body><article><p>Before</p><p><iframe src="${YT}"></iframe></p><p>After</p></article></body></html>`,
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+
+		expect(document.querySelectorAll("iframe")).toHaveLength(0);
+		expect(document.querySelectorAll("p[data-facade]")).toHaveLength(1);
+		expect(calls).toEqual(["hVl9B3dTFB4"]);
+	});
+
+	it("leaves a non-YouTube iframe untouched", () => {
+		const document = parse(
+			'<html><body><article><iframe src="https://player.vimeo.com/video/76979871"></iframe></article></body></html>',
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+
+		expect(document.querySelectorAll("iframe")).toHaveLength(1);
+		expect(document.querySelectorAll("p[data-facade]")).toHaveLength(0);
+		expect(calls).toEqual([]);
+	});
+
+	it("leaves an iframe without a src untouched", () => {
+		const document = parse(
+			"<html><body><article><iframe></iframe></article></body></html>",
+		);
+		const { render } = fakeRenderer();
+
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+
+		expect(document.querySelectorAll("iframe")).toHaveLength(1);
+		expect(document.querySelectorAll("p[data-facade]")).toHaveLength(0);
+	});
+
+	it("replaces every YouTube iframe in document order and keeps siblings stable", () => {
+		const document = parse(
+			"<html><body><article>" +
+				`<p>p1</p><iframe src="https://www.youtube.com/embed/aaaaaaaaaaa"></iframe>` +
+				`<p>p2</p><iframe src="https://youtu.be/bbbbbbbbbbb"></iframe>` +
+				`<p>p3</p><iframe src="https://vimeo.com/keep-me"></iframe>` +
+				"<p>p4</p>" +
+				"</article></body></html>",
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+
+		expect(calls).toEqual(["aaaaaaaaaaa", "bbbbbbbbbbb"]);
+		expect(document.querySelectorAll("p[data-facade]")).toHaveLength(2);
+		expect(document.querySelector('iframe[src="https://vimeo.com/keep-me"]')).not.toBeNull();
+		const texts = Array.from(document.querySelectorAll("p"))
+			.filter((el) => !el.hasAttribute("data-facade"))
+			.map((el) => el.textContent);
+		expect(texts).toEqual(["p1", "p2", "p3", "p4"]);
+	});
+
+	it("is a no-op when the document has no iframe", () => {
+		const document = parse(
+			"<html><body><article><p>Just text.</p></article></body></html>",
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+
+		expect(calls).toEqual([]);
+		expect(document.querySelector("article")?.innerHTML).toContain("Just text.");
+	});
+
+	it("is idempotent — a second pass finds no YouTube iframe to replace", () => {
+		const document = parse(
+			`<html><body><article><p><iframe src="${YT}"></iframe></p></article></body></html>`,
+		);
+		const { render, calls } = fakeRenderer();
+
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+		const callsAfterFirst = calls.length;
+		replaceEmbedsWithFacade({ document, renderFacade: render });
+
+		expect(callsAfterFirst).toBe(1);
+		expect(calls.length).toBe(callsAfterFirst);
+		expect(document.querySelectorAll("iframe")).toHaveLength(0);
+	});
+});

--- a/src/packages/article-parser/src/replace-embeds-with-facade.test.ts
+++ b/src/packages/article-parser/src/replace-embeds-with-facade.test.ts
@@ -11,7 +11,7 @@ function fakeRenderer(): {
 } {
 	const calls: string[] = [];
 	const render: Parameters<typeof replaceEmbedsWithFacade>[0]["renderFacade"] = (ctx) => {
-		calls.push(ctx.embed.videoId);
+		calls.push(ctx.embed.videoId ?? ctx.embed.watchUrl);
 		const facade = ctx.document.createElement("p");
 		facade.setAttribute("data-facade", String(calls.length));
 		return facade;
@@ -75,7 +75,8 @@ describe("replaceEmbedsWithFacade", () => {
 
 		expect(calls).toEqual(["aaaaaaaaaaa", "bbbbbbbbbbb"]);
 		expect(document.querySelectorAll("p[data-facade]")).toHaveLength(2);
-		expect(document.querySelector('iframe[src="https://vimeo.com/keep-me"]')).not.toBeNull();
+		const remaining = Array.from(document.querySelectorAll("iframe")).map((f) => f.getAttribute("src"));
+		expect(remaining).toEqual(["https://vimeo.com/keep-me"]);
 		const texts = Array.from(document.querySelectorAll("p"))
 			.filter((el) => !el.hasAttribute("data-facade"))
 			.map((el) => el.textContent);

--- a/src/packages/article-parser/src/replace-embeds-with-facade.ts
+++ b/src/packages/article-parser/src/replace-embeds-with-facade.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert";
+import { type YouTubeEmbed, parseYouTubeEmbed } from "./parse-embed-url";
+
+/* A YouTube <iframe> embed never plays in the reader: the body renders inside a
+ * sandboxed iframe with no allow-scripts, so the player's JS is blocked and the
+ * frame collapses to YouTube's own error thumbnail. Replace each such embed with
+ * a static poster card (built by the injected `renderFacade`) that links to the
+ * watch page — pure HTML that needs no script permission. Runs before
+ * Readability so the unplayable frame is gone before extraction scores it. */
+export function replaceEmbedsWithFacade(params: {
+	document: Document;
+	renderFacade: (ctx: { document: Document; embed: YouTubeEmbed }) => Element;
+}): void {
+	const iframes = Array.from(params.document.querySelectorAll("iframe"));
+	for (const iframe of iframes) {
+		const src = iframe.getAttribute("src");
+		if (!src) continue;
+		const embed = parseYouTubeEmbed(src);
+		if (!embed) continue;
+		const facade = params.renderFacade({ document: params.document, embed });
+		const parent = iframe.parentNode;
+		assert(parent, "Iframe element selected from the document must have a parent node");
+		parent.insertBefore(facade, iframe);
+		iframe.remove();
+	}
+}

--- a/src/packages/article-parser/src/resolve-relative-urls.test.ts
+++ b/src/packages/article-parser/src/resolve-relative-urls.test.ts
@@ -59,6 +59,26 @@ describe("resolveRelativeUrls", () => {
 		);
 	});
 
+	it("should normalise a camelCase srcSet to lowercase and resolve it", () => {
+		const html = '<img srcSet="/img/small.jpg 1x, /img/large.jpg 2x" src="/img/small.jpg">';
+		const result = resolveRelativeUrls({ html, baseUrl });
+		expect(result).toContain(
+			'srcset="https://example.com/img/small.jpg 1x, https://example.com/img/large.jpg 2x"',
+		);
+		expect(result).not.toContain("srcSet");
+	});
+
+	it("should resolve a Next.js camelCase srcSet with relative /_next/image candidates", () => {
+		const html =
+			'<img srcSet="/_next/image?url=%2Fa.png&w=640&q=75 640w, /_next/image?url=%2Fa.png&w=1920&q=75 1920w" src="https://cdn.example.com/a.png">';
+		const result = resolveRelativeUrls({ html, baseUrl });
+		expect(result).toContain(
+			"srcset=\"https://example.com/_next/image?url=%2Fa.png&w=640&q=75 640w",
+		);
+		expect(result).toContain("https://example.com/_next/image?url=%2Fa.png&w=1920&q=75 1920w");
+		expect(result).not.toContain("srcSet");
+	});
+
 	it("should resolve video[src] and audio[src] attributes", () => {
 		const html = '<video src="/media/video.mp4"></video><audio src="/media/audio.mp3"></audio>';
 		const result = resolveRelativeUrls({ html, baseUrl });

--- a/src/packages/article-parser/src/resolve-relative-urls.ts
+++ b/src/packages/article-parser/src/resolve-relative-urls.ts
@@ -21,7 +21,7 @@ export function resolveRelativeUrls(params: {
 		resolveAttribute(a, "href", base);
 	}
 
-	for (const el of document.querySelectorAll("[srcset]")) {
+	for (const el of document.querySelectorAll("img, source")) {
 		resolveSrcset(el, base);
 	}
 
@@ -30,8 +30,19 @@ export function resolveRelativeUrls(params: {
 	return root.innerHTML;
 }
 
+/* Server-rendered React/Next.js markup emits camelCase `srcSet`, which linkedom
+ * (and the downstream image-rehoster and reader) treat as a distinct attribute
+ * from `srcset` — so an un-normalised camelCase srcset is never absolutised or
+ * mirrored to the CDN, and its relative `/_next/image?...` candidates resolve
+ * against the reader origin and 404. Look the attribute up case-insensitively
+ * and write it back as lowercase `srcset` so every later stage sees it. */
 function resolveSrcset(element: Element, base: URL): void {
-	const value = element.getAttribute("srcset");
+	const attrName = element
+		.getAttributeNames()
+		.find((name) => name.toLowerCase() === "srcset");
+	if (!attrName) return;
+
+	const value = element.getAttribute(attrName);
 	if (!value) return;
 
 	const entries = parseSrcset(value);
@@ -48,6 +59,7 @@ function resolveSrcset(element: Element, base: URL): void {
 		})
 		.join(", ");
 
+	if (attrName !== "srcset") element.removeAttribute(attrName);
 	element.setAttribute("srcset", resolved);
 }
 


### PR DESCRIPTION
## Problem

A saved article containing a YouTube embed (e.g. `techhut.tv/windows-lite-ltsc-microsoft`) renders a broken video: YouTube's `meh7.png` error thumbnail, plus a console `Blocked script execution in 'about:srcdoc'`.

**Root cause (verified against the prod S3 canonical + crawl logs):**
- Mozilla Readability deliberately **preserves** youtube/vimeo/etc. embed `<iframe>`s (its `_allowedVideoRegex`), so a raw `<iframe src="youtube.com/embed/…">` is baked into the stored `content.html` at crawl time.
- The reader renders that HTML in a sandbox **without `allow-scripts`** (a deliberate invariant — crawled HTML must never run JS in the same-origin reader). YouTube's player is JS, so it can't bootstrap and collapses to its error state.

Sandbox flags are inherited by nested frames, so the embed can't be "allowed" without `allow-scripts` on the whole reader iframe — and that, combined with `allow-same-origin`, would be a full same-origin sandbox escape. So the fix has to remove the unplayable embed upstream and emit static HTML.

## Change

At parse time — mirroring the existing native `<video>` → placeholder substitution — replace each **YouTube** embed with a static **poster card**: the video thumbnail under a play glyph, wrapped in a link to the watch page. It's pure HTML that needs no script permission, so the reader sandbox is untouched, and the poster `<img>` rides the existing image-rehosting pipeline (rehosted to the article CDN, private + cached).

- `parse-embed-url.ts` — pure YouTube URL classifier → `{ videoId, watchUrl, posterUrl }`. Handles `/embed/ID`, `/shorts/ID`, `/v/ID`, `watch?v=ID`, `youtu.be/ID`, `youtube-nocookie`; validates the 11-char id and builds URLs **from the parsed id** (never the raw href, so no `javascript:`/`data:`/foreign-origin smuggling).
- `replace-embeds-with-facade.ts` — swaps matching `<iframe>`s for the facade; idempotent; non-YouTube iframes untouched.
- `readability-parser.ts` — runs the pass **before** Readability; adds `reader-embed-facade` to `classesToPreserve`; the `<p>`-wrapped, `<img>`-bearing facade survives Readability's cleaning.
- `reader-iframe.styles.css` — `.reader-embed-facade` 16:9 poster card + CSS play button.

No sandbox / CSP change. No render-time or backfill work — already-broken articles are fixed by re-saving + recrawl.

## Scope

**YouTube only.** Vimeo/Dailymotion/Twitch still fall through unchanged; `parse-embed-url` leaves room to add providers (or an inline-playback lightbox) later without rework.

## Testing

- New unit suites: `parse-embed-url.test.ts` (every URL form + validation branches), `replace-embeds-with-facade.test.ts` (replace/ignore/idempotent/order).
- Integration: `readability-parser.test.ts` asserts the `techhut.tv/windows-lite-ltsc-microsoft` repro yields the facade and **no** `<iframe>`.
- `article-parser`, `hutch`, and `save-link` checks all pass at **100% coverage**; `unused-css` clean.

## Follow-ups (separate)
- Image `srcSet` 404s: the CDN-rewrite skips the camelCase `srcSet`, and the LLM tier-selector actively prefers the broken relative-`srcSet` candidate.
- Non-YouTube embeds and optional inline (lightbox) playback.
