### PR TITLE
Test embed facade link security attributes

### DIFF
--- a/src/packages/article-parser/src/readability-parser.test.ts
+++ b/src/packages/article-parser/src/readability-parser.test.ts
@@ -87,6 +87,9 @@ describe("initReadabilityParser", () => {
 			expect(result.article.content).toContain("reader-embed-facade");
 			expect(result.article.content).toContain("https://www.youtube.com/watch?v=hVl9B3dTFB4");
 			expect(result.article.content).toContain("https://i.ytimg.com/vi/hVl9B3dTFB4/hqdefault.jpg");
+			const facadeLink = document.querySelector(".reader-embed-facade a");
+			expect(facadeLink?.getAttribute("target")).toBe("_blank");
+			expect(facadeLink?.getAttribute("rel")).toBe("noopener noreferrer");
 		}
 	});
 


### PR DESCRIPTION
## Summary
Add test assertions to verify that embedded content facade links have proper security attributes set (`target="_blank"` and `rel="noopener noreferrer"`).

## Changes
- Added test assertions in `readability-parser.test.ts` to verify that YouTube embed facade links include:
  - `target="_blank"` attribute to open links in a new tab
  - `rel="noopener noreferrer"` attribute to prevent window.opener access and referrer leakage

## Details
These assertions ensure that when the readability parser generates embed facades for external content (like YouTube videos), the resulting links follow security best practices to protect users from potential security vulnerabilities when opening external links.

https://claude.ai/code/session_013dCX69GaHSWBZHPoTtXRqG