### PR TITLE
Add discriminated union type for YouTube embeds

### DIFF
--- a/src/packages/article-parser/src/parse-embed-url.test.ts
+++ b/src/packages/article-parser/src/parse-embed-url.test.ts
@@ -3,6 +3,7 @@ import { parseYouTubeEmbed } from "./parse-embed-url";
 describe("parseYouTubeEmbed", () => {
 	it("parses a standard /embed/ID player URL", () => {
 		expect(parseYouTubeEmbed("https://www.youtube.com/embed/hVl9B3dTFB4?color=white&modestbranding=1")).toEqual({
+			kind: "video",
 			videoId: "hVl9B3dTFB4",
 			watchUrl: "https://www.youtube.com/watch?v=hVl9B3dTFB4",
 			posterUrl: "https://i.ytimg.com/vi/hVl9B3dTFB4/hqdefault.jpg",
@@ -11,7 +12,7 @@ describe("parseYouTubeEmbed", () => {
 
 	it("parses a youtube-nocookie embed URL", () => {
 		const embed = parseYouTubeEmbed("https://www.youtube-nocookie.com/embed/hVl9B3dTFB4");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 	});
 
 	it("parses a youtu.be short URL", () => {
@@ -21,17 +22,17 @@ describe("parseYouTubeEmbed", () => {
 
 	it("parses a /watch?v=ID URL on m.youtube.com", () => {
 		const embed = parseYouTubeEmbed("https://m.youtube.com/watch?v=hVl9B3dTFB4");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 	});
 
 	it("parses a /shorts/ID URL", () => {
 		const embed = parseYouTubeEmbed("https://www.youtube.com/shorts/hVl9B3dTFB4");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 	});
 
 	it("parses a legacy /v/ID URL", () => {
 		const embed = parseYouTubeEmbed("https://youtube.com/v/hVl9B3dTFB4");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 	});
 
 	it("returns undefined for a non-URL string", () => {
@@ -69,6 +70,7 @@ describe("parseYouTubeEmbed", () => {
 	it("admits a video id whose length is not the historical 11 characters (gate relaxed)", () => {
 		const embed = parseYouTubeEmbed("https://www.youtube.com/embed/short-id");
 		expect(embed).toEqual({
+			kind: "video",
 			videoId: "short-id",
 			watchUrl: "https://www.youtube.com/watch?v=short-id",
 			posterUrl: "https://i.ytimg.com/vi/short-id/hqdefault.jpg",
@@ -77,16 +79,17 @@ describe("parseYouTubeEmbed", () => {
 
 	it("parses a /live/ID permalink URL", () => {
 		const embed = parseYouTubeEmbed("https://www.youtube.com/live/hVl9B3dTFB4");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 	});
 
 	it("parses a /watch?v=ID URL on music.youtube.com", () => {
 		const embed = parseYouTubeEmbed("https://music.youtube.com/watch?v=hVl9B3dTFB4");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 	});
 
 	it("maps a /embed/videoseries playlist to a playlist watch URL with no poster", () => {
 		expect(parseYouTubeEmbed("https://www.youtube.com/embed/videoseries?list=PLabc_123")).toEqual({
+			kind: "playlist",
 			watchUrl: "https://www.youtube.com/playlist?list=PLabc_123",
 		});
 	});
@@ -98,7 +101,7 @@ describe("parseYouTubeEmbed", () => {
 
 	it("prefers the concrete video when an embed carries both a video id and a list", () => {
 		const embed = parseYouTubeEmbed("https://www.youtube.com/embed/hVl9B3dTFB4?list=PLabc_123");
-		expect(embed?.videoId).toBe("hVl9B3dTFB4");
+		expect(embed).toMatchObject({ kind: "video", videoId: "hVl9B3dTFB4" });
 		expect(embed?.watchUrl).toBe("https://www.youtube.com/watch?v=hVl9B3dTFB4");
 	});
 

--- a/src/packages/article-parser/src/parse-embed-url.ts
+++ b/src/packages/article-parser/src/parse-embed-url.ts
@@ -1,8 +1,6 @@
-export interface YouTubeEmbed {
-	videoId?: string;
-	watchUrl: string;
-	posterUrl?: string;
-}
+export type YouTubeEmbed =
+	| { kind: "video"; videoId: string; watchUrl: string; posterUrl: string }
+	| { kind: "playlist"; watchUrl: string };
 
 const URL_SAFE_ID = /^[A-Za-z0-9_-]+$/;
 
@@ -46,6 +44,7 @@ export function parseYouTubeEmbed(rawUrl: string): YouTubeEmbed | undefined {
 function video(id: string | null | undefined): YouTubeEmbed | undefined {
 	if (!id || !URL_SAFE_ID.test(id)) return undefined;
 	return {
+		kind: "video",
 		videoId: id,
 		watchUrl: `https://www.youtube.com/watch?v=${id}`,
 		posterUrl: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
@@ -55,5 +54,5 @@ function video(id: string | null | undefined): YouTubeEmbed | undefined {
 function playlist(url: URL): YouTubeEmbed | undefined {
 	const listId = url.searchParams.get("list");
 	if (!listId || !URL_SAFE_ID.test(listId)) return undefined;
-	return { watchUrl: `https://www.youtube.com/playlist?list=${listId}` };
+	return { kind: "playlist", watchUrl: `https://www.youtube.com/playlist?list=${listId}` };
 }

--- a/src/packages/article-parser/src/readability-parser.ts
+++ b/src/packages/article-parser/src/readability-parser.ts
@@ -266,7 +266,7 @@ function renderEmbedFacade(ctx: {
 	link.setAttribute("href", ctx.embed.watchUrl);
 	link.setAttribute("target", "_blank");
 	link.setAttribute("rel", "noopener noreferrer");
-	if (!ctx.embed.posterUrl) {
+	if (ctx.embed.kind === "playlist") {
 		/* A playlist embed has no single-video thumbnail to rehost, so it can't
 		 * become a poster card; reuse the native-<video> text callout instead so
 		 * the link still survives Readability's empty-<p> prune (it carries text

--- a/src/packages/article-parser/src/replace-embeds-with-facade.test.ts
+++ b/src/packages/article-parser/src/replace-embeds-with-facade.test.ts
@@ -11,7 +11,7 @@ function fakeRenderer(): {
 } {
 	const calls: string[] = [];
 	const render: Parameters<typeof replaceEmbedsWithFacade>[0]["renderFacade"] = (ctx) => {
-		calls.push(ctx.embed.videoId ?? ctx.embed.watchUrl);
+		calls.push(ctx.embed.kind === "video" ? ctx.embed.videoId : ctx.embed.watchUrl);
 		const facade = ctx.document.createElement("p");
 		facade.setAttribute("data-facade", String(calls.length));
 		return facade;


### PR DESCRIPTION
Refactor the `YouTubeEmbed` type from an interface with optional fields to a discriminated union that explicitly distinguishes between video and playlist embeds.

## Summary
This change improves type safety and clarity by using a discriminated union (`kind` field) instead of optional properties. The type now explicitly represents two distinct embed types: videos (with `videoId`, `watchUrl`, and `posterUrl`) and playlists (with only `watchUrl`).

## Key Changes
- **Type definition**: Changed `YouTubeEmbed` from an interface with optional `videoId` and `posterUrl` to a discriminated union with `kind: "video"` and `kind: "playlist"` variants
- **Implementation**: Updated `video()` and `playlist()` helper functions to include the `kind` field in returned objects
- **Tests**: Updated all test assertions to check for the `kind` field and use `toMatchObject()` for more precise expectations
- **Consumer code**: Updated `renderEmbedFacade()` to check `kind === "playlist"` instead of checking for missing `posterUrl`, making the intent clearer

## Benefits
- **Type safety**: TypeScript now prevents accessing `videoId` on playlist embeds or `posterUrl` on video embeds
- **Clarity**: The `kind` field makes the embed type explicit rather than inferred from optional properties
- **Maintainability**: Future code can pattern-match on the `kind` field with confidence

https://claude.ai/code/session_01HMxLxzf2SVQ5BE8qUyhyfb