### PR TITLE
Centralize locale constant across date formatting modules

### DIFF
--- a/src/packages/web-shell/src/local-time.format.ts
+++ b/src/packages/web-shell/src/local-time.format.ts
@@ -17,7 +17,7 @@ export interface LocalTime {
 
 export type LocalTimeStyle = "datetime" | "date";
 
-const LOCALE = "en-US";
+export const LOCALE = "en-US";
 
 /** Explicit component options rather than dateStyle/timeStyle, which cannot be
  * combined with timeZoneName. hour12:false yields a 24-hour clock (09:00, not

--- a/src/packages/web-shell/src/trial-countdown.format.ts
+++ b/src/packages/web-shell/src/trial-countdown.format.ts
@@ -1,3 +1,5 @@
+import { LOCALE } from "./local-time.format";
+
 export interface TrialRemaining {
 	days: number;
 	hours: number;
@@ -52,7 +54,7 @@ export function deriveTrialEscalation(
 }
 
 function formatEndDate(endsAtIso: string): string {
-	return new Date(endsAtIso).toLocaleDateString("en-US", {
+	return new Date(endsAtIso).toLocaleDateString(LOCALE, {
 		day: "numeric",
 		month: "short",
 		year: "numeric",


### PR DESCRIPTION
## Summary
Extracted the hardcoded locale string into a shared constant to ensure consistent date formatting across the application and reduce duplication.

## Changes
- Exported `LOCALE` constant from `local-time.format.ts` to make it reusable across modules
- Updated `trial-countdown.format.ts` to import and use the shared `LOCALE` constant instead of the hardcoded `"en-US"` string

## Implementation Details
The `LOCALE` constant (`"en-US"`) is now defined in a single location (`local-time.format.ts`) and imported where needed. This ensures that any future changes to the application's locale preference only need to be updated in one place, improving maintainability and reducing the risk of inconsistent formatting across date-related features.

https://claude.ai/code/session_018NPG6UwR8zy6xzzfFztJPH