### PR TITLE
Simplify ReaderLinkPath documentation

### DIFF
--- a/projects/hutch/src/runtime/web/api/article-siren.ts
+++ b/projects/hutch/src/runtime/web/api/article-siren.ts
@@ -1,9 +1,7 @@
 import type { SavedArticle } from "@packages/domain/article";
 import type { SirenEntity, SirenLink, SirenSubEntity } from "./siren";
 
-/** Which reader the `read` link points at. The hypermedia `rel` stays `read`;
- * only the href varies, so swapping it is non-breaking. The iOS app gets `app`
- * (the chromeless reader); browsers and the extension get `view` (the full shell). */
+/** The hypermedia `rel` stays `read`; only the href varies, so swapping it is non-breaking. */
 export type ReaderLinkPath = "view" | "app";
 
 export function toArticleSubEntity(


### PR DESCRIPTION
## Summary
Simplified the JSDoc comment for the `ReaderLinkPath` type by removing implementation details that are no longer relevant or accurate.

## Changes
- Removed outdated explanation about which reader each path points to (iOS app vs. browsers/extension)
- Kept the essential information about the hypermedia contract: the `rel` stays constant while only the `href` varies, making the change non-breaking

## Details
The removed comment referenced specific platform behavior that may have changed or is better documented elsewhere. The core insight—that this is a non-breaking hypermedia change—is preserved and sufficient for understanding the type's purpose.

https://claude.ai/code/session_01Qt3W2Fkgeto9ntjL3urHEx