### PR TITLE
Type owner reader path with ReaderArticleHashId

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/owner-reader-link.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/owner-reader-link.ts
@@ -1,9 +1,10 @@
+import type { ReaderArticleHashId } from "@packages/domain/article";
 import type { Request } from "express";
 
 const MARKER_KEY = "from";
 const MARKER_VALUE = "reader-ready-email";
 
-export function buildOwnerReaderPath(articleId: { value: string }): string {
+export function buildOwnerReaderPath(articleId: ReaderArticleHashId): string {
 	return `/queue/${articleId.value}/view?${MARKER_KEY}=${MARKER_VALUE}`;
 }
 


### PR DESCRIPTION
## Summary
Improves type safety in the owner-reader link builder by replacing a generic object type with the specific `ReaderArticleHashId` domain type.

## Changes
- Updated `buildOwnerReaderPath` parameter type from `{ value: string }` to `ReaderArticleHashId`
- Added import of `ReaderArticleHashId` type from `@packages/domain/article`

## Details
This change strengthens the type contract of the function by using the domain type that represents article hash IDs, rather than accepting any object with a `value` property. This makes the intent clearer and prevents accidental misuse with incompatible types.

https://claude.ai/code/session_01DWqG5SK6p6C1pCigNW9FRS