### PR TITLE
fix(article-store): consistent read-your-writes on save; pending /view fallback

### DIFF
--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.test.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.test.ts
@@ -309,6 +309,12 @@ describe("initDynamoDbArticleStore global writes", () => {
 		});
 
 		expect(commands.some((c) => c.name === "PutCommand")).toBe(true);
+		// Read-back-after-write must be strongly consistent, otherwise an
+		// eventually-consistent miss trips the "must exist immediately after save"
+		// asserts and 500s a healthy save (the readplace save-failure RCA).
+		const reads = commands.filter((c) => c.name === "GetCommand");
+		expect(reads).toHaveLength(2);
+		expect(reads.every((c) => c.input.ConsistentRead === true)).toBe(true);
 		expect(saved.id).toBeInstanceOf(ReaderArticleHashId);
 		expect(saved.url).toBe(URL);
 		expect(saved.status).toBe("read");

--- a/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
+++ b/projects/hutch/src/runtime/providers/article-store/dynamodb-article-store.ts
@@ -244,9 +244,12 @@ export function initDynamoDbArticleStore(deps: {
 			}),
 		]);
 
+		// Strongly-consistent read-your-writes: a default eventually-consistent read
+		// can miss the row we just wrote and trip the asserts below on an otherwise
+		// successful save. ConsistentRead makes both reflect the writes above.
 		const [article, userArticle] = await Promise.all([
-			articles.get({ url: articleResourceUniqueId.value }),
-			userArticles.get({ userId: params.userId, url: articleResourceUniqueId.value }),
+			articles.get({ url: articleResourceUniqueId.value }, { consistentRead: true }),
+			userArticles.get({ userId: params.userId, url: articleResourceUniqueId.value }, { consistentRead: true }),
 		]);
 		assertItem(article, "article must exist immediately after save");
 		assertItem(userArticle, "user article must exist immediately after save");

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -145,6 +145,9 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		// 5-30s). On first visit we still write a stub synchronously so the page
 		// has metadata to render and the existing summary/reader pollers see a row.
 		const existing = await deps.findArticleByUrl(articleUrl);
+		const hostname = articleHostFrom(articleUrl);
+		const stubMetadata: ArticleMetadata = { title: hostname, siteName: hostname, excerpt: "", wordCount: 0 };
+		const stubReadTime = calculateReadTime(0);
 		if (!existing) {
 			// First visit is the request that triggers the whole crawl cascade
 			// (stub save → crawl → summary → possibly OCR), each leg with real
@@ -159,16 +162,10 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				sendRateLimited(res, decision.retryAfterSeconds);
 				return;
 			}
-			const hostname = articleHostFrom(articleUrl);
 			await deps.saveArticleGlobally({
 				url: articleUrl,
-				metadata: {
-					title: hostname,
-					siteName: hostname,
-					excerpt: "",
-					wordCount: 0,
-				},
-				estimatedReadTime: calculateReadTime(0),
+				metadata: stubMetadata,
+				estimatedReadTime: stubReadTime,
 				savedAt: deps.now(),
 			});
 			await deps.markCrawlPending({ url: articleUrl });
@@ -180,11 +177,16 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 		// Re-read metadata after any first-visit save. In production this returns
 		// the stub we just wrote (the worker is async); in tests where the
 		// in-memory worker fixture runs synchronously inside the awaited dispatch,
-		// this picks up the parsed metadata the fixture wrote.
+		// this picks up the parsed metadata the fixture wrote. A just-written stub
+		// is not always visible on the immediately-following read (DynamoDB is
+		// eventually consistent), so a transient miss renders the row we already
+		// had or the stub we just wrote — pending, never a 500.
 		const articleSnapshot = await deps.findArticleByUrl(articleUrl);
-		assert(articleSnapshot, "article row must exist after saveArticleGlobally");
-		const metadata: ArticleMetadata = articleSnapshot.metadata;
-		const estimatedReadTime: Minutes = articleSnapshot.estimatedReadTime;
+		const pendingSnapshot: { metadata: ArticleMetadata; estimatedReadTime: Minutes; savedAt: Date } =
+			existing ?? { metadata: stubMetadata, estimatedReadTime: stubReadTime, savedAt: deps.now() };
+		const snapshot = articleSnapshot ?? pendingSnapshot;
+		const metadata: ArticleMetadata = snapshot.metadata;
+		const estimatedReadTime: Minutes = snapshot.estimatedReadTime;
 
 		const pollUrlBuilder = pollUrlBuilderFor(articleUrl);
 		const state = await reader.resolveReaderState({
@@ -227,7 +229,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 			const isValidSharer = sharerPrefix !== null && await deps.existsUserByIdPrefix(sharerPrefix);
 			const articleDomain = new URL(articleUrl).hostname;
 			({ expiresAt } = computePublicViewExpiry({
-				savedAt: articleSnapshot.savedAt,
+				savedAt: snapshot.savedAt,
 				articleDomain,
 				permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 				isValidSharer,

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -549,6 +549,47 @@ describe("View routes", () => {
 		});
 	});
 
+	describe("GET /view when the just-saved row is not yet readable", () => {
+		it("renders the pending stub (200), not a 500, when the post-save read misses (eventual consistency)", async () => {
+			const parseArticle: ParseArticle = async () => buildParseResult();
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const applyParseResult = createFakeApplyParseResult({
+				articleStore: fixture.articleStore,
+				articleCrawl: fixture.articleCrawl,
+				parseArticle,
+			});
+			// Simulate DynamoDB eventual consistency: the row is never visible on
+			// read, so both the first-visit probe and the post-save re-read miss.
+			const missingReadStore = {
+				...fixture.articleStore,
+				findArticleByUrl: async () => null,
+			};
+			const harness = useApp({
+				...fixture,
+				articleStore: missingReadStore,
+				parser: { parseArticle, crawlArticle: fixture.parser.crawlArticle },
+				events: {
+					publishLinkSaved: createFakePublishLinkSaved(applyParseResult),
+					publishRecrawlLinkInitiated: createFakePublishRecrawlLinkInitiated(applyParseResult),
+					publishSaveAnonymousLink: createFakePublishSaveAnonymousLink(applyParseResult),
+					publishSaveLinkRawHtmlCommand: fixture.events.publishSaveLinkRawHtmlCommand,
+					publishSaveLinkRawPdfCommand: fixture.events.publishSaveLinkRawPdfCommand,
+					publishStaleCheckRequested: fixture.events.publishStaleCheckRequested,
+					publishUpdateFetchTimestamp: fixture.events.publishUpdateFetchTimestamp,
+					publishExportUserDataCommand: fixture.events.publishExportUserDataCommand,
+					publishCancelSubscriptionCommand: fixture.events.publishCancelSubscriptionCommand,
+					publishSubscriptionReactivated: fixture.events.publishSubscriptionReactivated,
+				},
+			});
+
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelector("[data-test-view-cta-action]")).not.toBeNull();
+		});
+	});
+
 	describe("view_opened analytics emission", () => {
 		it("emits one view_opened with the article host and a joinable visitor_id when an anonymous visitor opens the reader", async () => {
 			const harness = buildReaderHarness();

--- a/src/packages/hutch-storage-client/src/define-table.ts
+++ b/src/packages/hutch-storage-client/src/define-table.ts
@@ -34,7 +34,13 @@ export type DynamoTable<TSchema extends z.ZodObject> = {
 	 */
 	get: (
 		key: Key,
-		options?: { projection?: readonly (keyof z.infer<TSchema>)[] },
+		options?: {
+			projection?: readonly (keyof z.infer<TSchema>)[];
+			/** Strongly-consistent read for a read-your-writes that must reflect a
+			 * just-completed write; default reads are eventually consistent and may
+			 * still return the pre-write state. Only valid on base-table gets. */
+			consistentRead?: boolean;
+		},
 	) => Promise<z.infer<TSchema> | undefined>;
 
 	/** Raw Put passthrough. Item is not parsed — writes bypass the read-side schema. */
@@ -111,6 +117,7 @@ export function defineDynamoTable<TSchema extends z.ZodObject>(config: {
 					TableName: tableName,
 					Key: key,
 					...projectionOptions,
+					...(options?.consistentRead ? { ConsistentRead: true } : {}),
 				}),
 			);
 			if (!result.Item) return undefined;


### PR DESCRIPTION
## Why

Saving a link intermittently 500'd. The failure is a **read-your-writes race on an eventually-consistent DynamoDB read, hard-gated by an `assert`.**

`saveArticle` writes the global + per-user rows, then **immediately re-reads both and asserts they exist**:

```ts
// dynamodb-article-store.ts (before)
await Promise.all([ upsertGlobal(), userArticles.update({...}) ]); // writes succeed
const [article, userArticle] = await Promise.all([
  articles.get({ url }),                       // default read = eventually consistent
  userArticles.get({ userId, url }),
]);
assertItem(article, "article must exist immediately after save");        // ← throws
assertItem(userArticle, "user article must exist immediately after save"); // ← throws
```

`get()` (hutch-storage-client `define-table.ts`) issued `GetCommand` with **no `ConsistentRead`**, so a `GetItem` fired microseconds after the `Put`/`Update` can be served by a stale replica and return `undefined`. The code treated that *transient* invisibility as a *fatal invariant*, so a normal consistency lag became a hard 500.

### Evidence it was real (not theoretical)
- **Production logs** (`/aws/lambda/hutch-handler`) — this exact assert fired **3× in 14 days** (latest 2026-06-28):
  ```
  message: "Failed to save article"
  AssertionError [ERR_ASSERTION]: user article must exist immediately after save
      at Object.saveArticle (…)
  ```
  Both variants have fired (the global-row read at line 250 *and* the user-row read at line 251).
- The article behind the reported failing card (`routeId 47437208…`) had **no row** in `hutch-articles-cda0a08` — consistent with the save aborting at the assert before the row became reliably readable.

## What changed

**1. `saveArticle` read-back is now strongly consistent (the confirmed fix).**
`saveArticle` is an upsert (the global row may pre-exist with richer crawled data; `status` uses `if_not_exists`), so the read-back returns *merged* state I can't reconstruct locally — reconstructing from written values would return stale `status`. Instead the two **base-table** read-backs pass `consistentRead: true`, which guarantees read-your-writes. The asserts stay and become true invariants (they now only fire if a write genuinely failed).
- `hutch-storage-client` `get()` gains an optional `consistentRead` flag → `ConsistentRead: true`. Purely additive/backward-compatible; base-table only (GSIs can't be strongly consistent).

**2. `GET /view` first-visit had the same anti-pattern (latent twin, uncaught → generic 500).**
`view.page.ts` stub-saves on first visit, re-reads via the shared `FindArticleByUrl`, then `assert(articleSnapshot, …)`. `FindArticleByUrl` is used in ~8 modules and faked in 4+ tests, so threading `consistentRead` through it would be a wide, risky ripple. Instead the fatal assert is replaced with a **pending fallback** — render the row we already had (`existing`) or the stub we just wrote — so a transient miss renders `200`, never a 500. (Matches "treat not-yet-visible as pending, not a fatal invariant.")

## Out of scope
- The `curl-impersonate 0.8.0 → 1.5.6` change (already committed separately as `fix(crawl): impersonate Chrome 131…`) is unrelated — crawl failures fail closed / are caught as Siren `save-failed`, never this assert.

## How to reverify (for another agent)
1. **Root cause**: read `dynamodb-article-store.ts` `saveArticle` (~246–251) and `hutch-storage-client/src/define-table.ts` `get()`; confirm base-table gets are eventually consistent by default and the assert converts a stale read into a throw.
2. **Prod evidence** (needs read access to account `572337278115`, `ap-southeast-2`):
   ```
   aws logs filter-log-events --log-group-name /aws/lambda/hutch-handler \
     --filter-pattern '"immediately after save"' --start-time <ms>
   ```
3. **Fix 1**: `articles.get`/`userArticles.get` in `saveArticle` now pass `{ consistentRead: true }`; `get()` maps it to `ConsistentRead: true`. Test `dynamodb-article-store.test.ts` asserts both read-backs set `ConsistentRead === true`.
4. **Fix 2**: `view.page.ts` no longer `assert`s the re-read; it falls back to `existing`/stub. Test `view.route.test.ts` → "renders the pending stub (200) … when the post-save read misses" drives `findArticleByUrl: async () => null` and asserts `200` + reader CTA present (was a 500 before).
5. **Gate**: `pnpm nx run hutch:check` and `pnpm nx run @packages/hutch-storage-client:check` are green (types, lint, unit + integration tests, 100% coverage, knip, unused-css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
