### PR TITLE
fix(crawl): follow curl redirects (SSRF-guarded) + back off failing stale-checks

### DIFF
--- a/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.test.ts
+++ b/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.test.ts
@@ -284,11 +284,12 @@ describe("initStaleCheckHandler", () => {
 		expect(publishRefreshArticleContent).not.toHaveBeenCalled();
 	});
 
-	it("skips when crawl returns failed (no further effect)", async () => {
+	it("backs off when crawl returns failed: resets the freshness clock (carrying the bodyHash) so the next attempt waits a full TTL", async () => {
 		const findArticleFreshness: FindArticleFreshness = async () => ({
 			etag: undefined,
 			lastModified: undefined,
 			contentFetchedAt: "2026-04-01T00:00:00.000Z",
+			bodyHash: "h".repeat(64),
 		});
 		const crawlAndFinalizeArticle: CrawlAndFinalizeArticle = async () => ({ status: "failed", reason: "crawl-failed" });
 		const publishRefreshArticleContent: PublishRefreshArticleContent = jest
@@ -300,6 +301,7 @@ describe("initStaleCheckHandler", () => {
 		const emitSimpleCrawlUnsupported: EmitSimpleCrawlUnsupported = jest
 			.fn()
 			.mockResolvedValue(undefined);
+		const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
 
 		const handler = createHandler({
 			findArticleFreshness,
@@ -307,12 +309,21 @@ describe("initStaleCheckHandler", () => {
 			publishRefreshArticleContent,
 			publishUpdateFetchTimestamp,
 			emitSimpleCrawlUnsupported,
+			logger,
 		});
 
 		await handler(createSqsEvent({ url: URL_UNDER_TEST }), buildLambdaContext(), () => {});
 
+		expect(publishUpdateFetchTimestamp).toHaveBeenCalledTimes(1);
+		expect(publishUpdateFetchTimestamp).toHaveBeenCalledWith({
+			url: URL_UNDER_TEST,
+			contentFetchedAt: fixedNow().toISOString(),
+			bodyHash: "h".repeat(64),
+		});
+		expect(logger.info).toHaveBeenCalledWith("[StaleCheckRequested] backed off after refresh failure", {
+			url: URL_UNDER_TEST,
+		});
 		expect(publishRefreshArticleContent).not.toHaveBeenCalled();
-		expect(publishUpdateFetchTimestamp).not.toHaveBeenCalled();
 		expect(emitSimpleCrawlUnsupported).not.toHaveBeenCalled();
 	});
 

--- a/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.ts
+++ b/projects/save-link/src/runtime/domain/stale-check/stale-check-handler.ts
@@ -34,8 +34,12 @@ import type { CrawlAndFinalizeArticle } from "@packages/finalize-article";
  *
  * Action outcomes:
  *   - `"new"`             — row missing; re-published SaveAnonymousLinkCommand.
- *   - `"skip"`            — within TTL, terminal state, parse failure, or
- *                           simpleCrawl failure. No downstream effect.
+ *   - `"skip"`            — within TTL, terminal state, or parse failure. No
+ *                           downstream effect.
+ *   - `"backoff"`         — the refresh fetch failed (cert error, redirect,
+ *                           bot block); reset the freshness clock so the next
+ *                           attempt waits a full TTL instead of re-firing on
+ *                           every /view.
  *   - `"unchanged"`       — 304 Not Modified; published UpdateFetchTimestamp.
  *   - `"refreshed"`       — HTML refetched + parsed; published RefreshArticleContent.
  *   - `"tier-1-deferred"` — non-HTML body; emitted SimpleCrawlUnsupportedEvent
@@ -46,6 +50,7 @@ import type { CrawlAndFinalizeArticle } from "@packages/finalize-article";
 export type StaleCheckAction =
 	| "new"
 	| "skip"
+	| "backoff"
 	| "unchanged"
 	| "refreshed"
 	| "tier-1-deferred";
@@ -115,7 +120,18 @@ export function initStaleCheckHandler(deps: {
 			return "unchanged";
 		}
 
-		if (result.status === "failed") return "skip";
+		if (result.status === "failed") {
+			/* A permanently-failing origin (cert error, redirect, bot block) would
+			 * otherwise be re-crawled on every /view, since the failed branch never
+			 * advanced contentFetchedAt. Reset the freshness clock so the next
+			 * attempt waits a full TTL instead of firing on the next visit. */
+			await publishUpdateFetchTimestamp({
+				url,
+				contentFetchedAt: now().toISOString(),
+				bodyHash: freshness.bodyHash,
+			});
+			return "backoff";
+		}
 
 		if (result.status === "unsupported") {
 			/* Write the stage marker so the reader's progress bar advances
@@ -176,6 +192,8 @@ export function initStaleCheckHandler(deps: {
 						url: detail.url,
 						action,
 					});
+				} else if (action === "backoff") {
+					logger.info(`${logPrefix} backed off after refresh failure`, { url: detail.url });
 				} else {
 					logger.info(`${logPrefix} no-op`, { url: detail.url, action });
 				}

--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -125,7 +125,7 @@ describe("fetchCurl argument construction", () => {
 		const args = fake.calls[0].args;
 		expect(args).toContain("--http2");
 		expect(args).toContain("--compressed");
-		expect(args).toContain("--location");
+		expect(args).not.toContain("--location");
 		const sepIdx = args.indexOf("--");
 		expect(sepIdx).toBeGreaterThan(0);
 		expect(args[sepIdx + 1]).toBe("https://example.com/page?q=1");
@@ -268,6 +268,104 @@ describe("fetchCurl abort signal handling", () => {
 		expect(response.status).toBe(200);
 		controller.abort(new Error("late abort"));
 		expect(fake.kill).not.toHaveBeenCalled();
+	});
+});
+
+describe("fetchCurl redirect following (SSRF-guarded per hop)", () => {
+	function makeSequencedExec(stdouts: string[]): { execCurl: ExecCurl; calls: { args: readonly string[] }[] } {
+		const calls: { args: readonly string[] }[] = [];
+		let idx = 0;
+		const execCurl: ExecCurl = (args, _options, callback) => {
+			calls.push({ args });
+			const buf = Buffer.from(stdouts[Math.min(idx, stdouts.length - 1)]);
+			idx++;
+			setImmediate(() => callback(null, buf));
+			return { kill: () => {}, onClose: () => {} };
+		};
+		return { execCurl, calls };
+	}
+
+	it("follows a 301 to the final 200, re-validating each hop's host through the SSRF guard", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: https://example.com/final\r\n\r\n",
+			"HTTP/1.1 200 OK\r\ncontent-type: text/html\r\n\r\n<html>final</html>",
+		]);
+		const resolveSpy = jest.fn(async () => "93.184.216.34");
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress: resolveSpy });
+
+		const response = await fetchCurl("https://example.com/start");
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("<html>final</html>");
+		expect(seq.calls).toHaveLength(2);
+		expect(resolveSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("resolves a relative Location against the current url before following", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 302 Found\r\nlocation: /moved\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nok",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		await fetchCurl("https://example.com/a/b");
+
+		const secondArgs = seq.calls[1].args;
+		const sepIdx = secondArgs.indexOf("--");
+		expect(secondArgs[sepIdx + 1]).toBe("https://example.com/moved");
+	});
+
+	it("re-pins a cross-host redirect target through --resolve for the new host", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: https://other.example/dest\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nok",
+		]);
+		const resolveSpy = jest.fn(async ({ hostname }: { hostname: string }) =>
+			hostname === "other.example" ? "203.0.113.9" : "93.184.216.34",
+		);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress: resolveSpy });
+
+		await fetchCurl("https://example.com/start");
+
+		expect(resolveSpy).toHaveBeenCalledWith({ hostname: "other.example" });
+		const secondArgs = seq.calls[1].args;
+		expect(secondArgs[secondArgs.indexOf("--resolve") + 1]).toBe("other.example:443:203.0.113.9");
+	});
+
+	it("refuses a redirect whose target host is blocked by the SSRF guard (no curl spawned for it)", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: https://169.254.169.254/latest/meta-data\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nsecrets",
+		]);
+		const resolveSpy = jest.fn(async ({ hostname }: { hostname: string }) => {
+			if (hostname === "169.254.169.254") throw new Error("blocked address 169.254.169.254");
+			return "93.184.216.34";
+		});
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress: resolveSpy });
+
+		await expect(fetchCurl("https://example.com/start")).rejects.toThrow(/blocked address/);
+		expect(seq.calls).toHaveLength(1);
+	});
+
+	it("stops and fails after MAX_REDIRECTS consecutive redirects", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 302 Found\r\nlocation: https://example.com/loop\r\n\r\n",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		await expect(fetchCurl("https://example.com/start")).rejects.toThrow(/too many redirects/);
+	});
+
+	it("does not follow a non-redirect status even if a Location header is present", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 200 OK\r\nlocation: https://example.com/elsewhere\r\n\r\nbody",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		const response = await fetchCurl("https://example.com/start");
+
+		expect(response.status).toBe(200);
+		expect(seq.calls).toHaveLength(1);
 	});
 });
 

--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -7,7 +7,6 @@ const resolvePinnedAddress: ResolvePinnedAddress = async () => "93.184.216.34";
 
 type ExecCall = {
 	args: readonly string[];
-	options: { timeoutMs: number | undefined };
 };
 
 type FakeExec = {
@@ -22,8 +21,8 @@ function makeFakeExec(opts: { stdout?: Buffer | string; error?: Error; deferCall
 	const kill = jest.fn();
 	let closeListener: (() => void) | undefined;
 	let pendingCallback: (() => void) | undefined;
-	const execCurl: ExecCurl = (args, options, callback) => {
-		calls.push({ args, options });
+	const execCurl: ExecCurl = (args, callback) => {
+		calls.push({ args });
 		const buf = typeof opts.stdout === "string" ? Buffer.from(opts.stdout) : opts.stdout ?? Buffer.alloc(0);
 		const fire = () => {
 			callback(opts.error ?? null, buf);
@@ -213,18 +212,16 @@ describe("fetchCurl argument construction", () => {
 		expect(args).toContain("Accept: text/html");
 	});
 
-	it("uses the default 10s timeout when no signal is provided", async () => {
-		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
-		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl, resolvePinnedAddress });
-		await fetchCurl("https://example.com");
-		expect(fake.calls[0].options.timeoutMs).toBe(10000);
-	});
-
-	it("disables the internal timeout when a signal is provided so the caller controls timing", async () => {
-		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
-		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl, resolvePinnedAddress });
-		await fetchCurl("https://example.com", { signal: new AbortController().signal });
-		expect(fake.calls[0].options.timeoutMs).toBeUndefined();
+	it("uses the caller's signal instead of creating a timeout budget when one is provided", async () => {
+		const timeoutSpy = jest.spyOn(AbortSignal, "timeout");
+		try {
+			const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+			const fetchCurl = createCurlFetch({ execCurl: fake.execCurl, resolvePinnedAddress });
+			await fetchCurl("https://example.com", { signal: new AbortController().signal });
+			expect(timeoutSpy).not.toHaveBeenCalled();
+		} finally {
+			timeoutSpy.mockRestore();
+		}
 	});
 });
 
@@ -235,6 +232,15 @@ describe("fetchCurl error handling", () => {
 		await expect(fetchCurl("https://example.com/path")).rejects.toThrow(
 			/fetchCurl failed for https:\/\/example\.com\/path: spawn ENOENT/,
 		);
+	});
+
+	it("refuses a non-HTTP(S) entry URL before spawning curl", async () => {
+		const fake = makeFakeExec({ stdout: "HTTP/1.1 200 OK\r\n\r\n" });
+		const fetchCurl = createCurlFetch({ execCurl: fake.execCurl, resolvePinnedAddress });
+		await expect(fetchCurl("file:///etc/passwd")).rejects.toThrow(
+			/fetchCurl failed for file:\/\/\/etc\/passwd: refusing to fetch non-HTTP\(S\) scheme "file:"/,
+		);
+		expect(fake.calls).toHaveLength(0);
 	});
 });
 
@@ -275,7 +281,7 @@ describe("fetchCurl redirect following (SSRF-guarded per hop)", () => {
 	function makeSequencedExec(stdouts: string[]): { execCurl: ExecCurl; calls: { args: readonly string[] }[] } {
 		const calls: { args: readonly string[] }[] = [];
 		let idx = 0;
-		const execCurl: ExecCurl = (args, _options, callback) => {
+		const execCurl: ExecCurl = (args, callback) => {
 			calls.push({ args });
 			const buf = Buffer.from(stdouts[Math.min(idx, stdouts.length - 1)]);
 			idx++;
@@ -379,6 +385,78 @@ describe("fetchCurl redirect following (SSRF-guarded per hop)", () => {
 
 		expect(response.status).toBe(200);
 		expect(seq.calls).toHaveLength(1);
+	});
+
+	it("shares a single timeout budget across every hop when no signal is passed", async () => {
+		const timeoutSpy = jest.spyOn(AbortSignal, "timeout");
+		try {
+			const seq = makeSequencedExec([
+				"HTTP/1.1 301 Moved Permanently\r\nlocation: https://example.com/final\r\n\r\n",
+				"HTTP/1.1 200 OK\r\n\r\nok",
+			]);
+			const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+			await fetchCurl("https://example.com/start");
+
+			expect(timeoutSpy).toHaveBeenCalledTimes(1);
+			expect(timeoutSpy).toHaveBeenCalledWith(10000);
+		} finally {
+			timeoutSpy.mockRestore();
+		}
+	});
+
+	it("wraps a malformed redirect Location in the fetchCurl error convention (no second curl spawned)", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: https://exa mple.com/x\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nshould-not-be-reached",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		await expect(fetchCurl("https://example.com/start")).rejects.toThrow(
+			/fetchCurl failed for https:\/\/example\.com\/start: invalid redirect Location "https:\/\/exa mple\.com\/x"/,
+		);
+		expect(seq.calls).toHaveLength(1);
+	});
+
+	it("drops cookie/authorization/proxy-authorization when a redirect crosses origins", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: https://other.example/dest\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nok",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		await fetchCurl("https://example.com/start", {
+			headers: {
+				cookie: "session=secret",
+				authorization: "Bearer token",
+				"proxy-authorization": "Basic abc",
+				referer: "https://example.com/start",
+				"user-agent": "Persona/1.0",
+			},
+		});
+
+		const secondArgs = seq.calls[1].args;
+		expect(secondArgs).not.toContain("Cookie: session=secret");
+		expect(secondArgs).not.toContain("Authorization: Bearer token");
+		expect(secondArgs).not.toContain("Proxy-Authorization: Basic abc");
+		expect(secondArgs).toContain("Referer: https://example.com/start");
+		expect(secondArgs).toContain("User-Agent: Persona/1.0");
+	});
+
+	it("keeps sensitive headers when a redirect stays on the same origin", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: https://example.com/dest\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nok",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		await fetchCurl("https://example.com/start", {
+			headers: { cookie: "session=secret", "user-agent": "Persona/1.0" },
+		});
+
+		const secondArgs = seq.calls[1].args;
+		expect(secondArgs).toContain("Cookie: session=secret");
+		expect(secondArgs).toContain("User-Agent: Persona/1.0");
 	});
 });
 

--- a/src/packages/crawl-article/src/curl-fetch.test.ts
+++ b/src/packages/crawl-article/src/curl-fetch.test.ts
@@ -347,6 +347,19 @@ describe("fetchCurl redirect following (SSRF-guarded per hop)", () => {
 		expect(seq.calls).toHaveLength(1);
 	});
 
+	it("refuses to follow a redirect to a non-HTTP(S) scheme (no curl spawned for it)", async () => {
+		const seq = makeSequencedExec([
+			"HTTP/1.1 301 Moved Permanently\r\nlocation: gopher://example.com:70/1payload\r\n\r\n",
+			"HTTP/1.1 200 OK\r\n\r\nshould-not-be-reached",
+		]);
+		const fetchCurl = createCurlFetch({ execCurl: seq.execCurl, resolvePinnedAddress });
+
+		await expect(fetchCurl("https://example.com/start")).rejects.toThrow(
+			/refusing to follow redirect to non-HTTP.*gopher:/,
+		);
+		expect(seq.calls).toHaveLength(1);
+	});
+
 	it("stops and fails after MAX_REDIRECTS consecutive redirects", async () => {
 		const seq = makeSequencedExec([
 			"HTTP/1.1 302 Found\r\nlocation: https://example.com/loop\r\n\r\n",

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -12,7 +12,8 @@ const DEFAULT_TIMEOUT_MS = 10000;
 
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 const MAX_REDIRECTS = 5;
-const ALLOWED_REDIRECT_PROTOCOLS = new Set(["http:", "https:"]);
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+const CROSS_ORIGIN_SENSITIVE_HEADERS = new Set(["cookie", "authorization", "proxy-authorization"]);
 
 type CurlFetchInit = {
 	headers?: Record<string, string>;
@@ -26,7 +27,6 @@ type CurlChild = {
 
 export type ExecCurl = (
 	args: readonly string[],
-	options: { timeoutMs: number | undefined },
 	callback: (error: Error | null, stdout: Buffer) => void,
 ) => CurlChild;
 
@@ -39,11 +39,11 @@ export type CurlFetch = (url: string, init?: CurlFetchInit) => Promise<Response>
  */
 export const CURL_IMPERSONATE_BIN = "curl_chrome131";
 
-const defaultExecCurl: ExecCurl = (args, options, callback) => {
+const defaultExecCurl: ExecCurl = (args, callback) => {
 	const child = execFile(
 		CURL_IMPERSONATE_BIN,
 		args,
-		{ encoding: "buffer", maxBuffer: MAX_PDF_BYTES.bytes, timeout: options.timeoutMs },
+		{ encoding: "buffer", maxBuffer: MAX_PDF_BYTES.bytes },
 		callback,
 	);
 	return {
@@ -70,14 +70,16 @@ const defaultExecCurl: ExecCurl = (args, options, callback) => {
 export function createCurlFetch(deps: { execCurl: ExecCurl; resolvePinnedAddress: ResolvePinnedAddress }): CurlFetch {
 	const { execCurl, resolvePinnedAddress } = deps;
 
-	async function fetchOnce(url: string, init?: CurlFetchInit): Promise<Response> {
+	async function fetchOnce(
+		url: string,
+		init: { headers?: Record<string, string>; signal: AbortSignal },
+	): Promise<Response> {
 		const parsed = new URL(url);
 		const port = parsed.port ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80;
 		const pinnedAddress = await resolvePinnedAddress({ hostname: parsed.hostname });
 		return new Promise<Response>((resolve, reject) => {
-			const args = buildCurlArgs({ url, headers: init?.headers, hostname: parsed.hostname, port, pinnedAddress });
-			const timeoutMs = init?.signal ? undefined : DEFAULT_TIMEOUT_MS;
-			const child = execCurl(args, { timeoutMs }, (error, stdout) => {
+			const args = buildCurlArgs({ url, headers: init.headers, hostname: parsed.hostname, port, pinnedAddress });
+			const child = execCurl(args, (error, stdout) => {
 				if (error) {
 					reject(new Error(`fetchCurl failed for ${url}: ${error.message}`));
 					return;
@@ -85,27 +87,33 @@ export function createCurlFetch(deps: { execCurl: ExecCurl; resolvePinnedAddress
 				const { status, headers, body } = parseCurlOutput(stdout);
 				resolve(new Response(body.length === 0 ? null : body, { status, headers }));
 			});
-			const signal = init?.signal;
-			if (signal) {
-				if (signal.aborted) {
-					child.kill();
-					reject(signal.reason);
-					return;
-				}
-				const onAbort = () => {
-					child.kill();
-					reject(signal.reason);
-				};
-				signal.addEventListener("abort", onAbort, { once: true });
-				child.onClose(() => signal.removeEventListener("abort", onAbort));
+			const { signal } = init;
+			if (signal.aborted) {
+				child.kill();
+				reject(signal.reason);
+				return;
 			}
+			const onAbort = () => {
+				child.kill();
+				reject(signal.reason);
+			};
+			signal.addEventListener("abort", onAbort, { once: true });
+			child.onClose(() => signal.removeEventListener("abort", onAbort));
 		});
 	}
 
 	return async function fetchCurl(url, init) {
+		const entryUrl = new URL(url);
+		if (!ALLOWED_PROTOCOLS.has(entryUrl.protocol)) {
+			throw new Error(
+				`fetchCurl failed for ${url}: refusing to fetch non-HTTP(S) scheme "${entryUrl.protocol}"`,
+			);
+		}
+		const signal = init?.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
 		let currentUrl = url;
+		let headers = init?.headers;
 		for (let redirects = 0; ; redirects++) {
-			const response = await fetchOnce(currentUrl, init);
+			const response = await fetchOnce(currentUrl, { headers, signal });
 			const location = response.headers.get("location");
 			if (location === null || !REDIRECT_STATUS_CODES.has(response.status)) {
 				return response;
@@ -117,11 +125,19 @@ export function createCurlFetch(deps: { execCurl: ExecCurl; resolvePinnedAddress
 			// next fetchOnce re-runs resolvePinnedAddress on the target host — the
 			// per-hop SSRF re-validation that lets us follow a redirect curl itself
 			// (kept at --max-redirs 0) is not allowed to chase.
-			const nextUrl = new URL(location, currentUrl);
-			if (!ALLOWED_REDIRECT_PROTOCOLS.has(nextUrl.protocol)) {
+			let nextUrl: URL;
+			try {
+				nextUrl = new URL(location, currentUrl);
+			} catch {
+				throw new Error(`fetchCurl failed for ${url}: invalid redirect Location "${location}"`);
+			}
+			if (!ALLOWED_PROTOCOLS.has(nextUrl.protocol)) {
 				throw new Error(
 					`fetchCurl failed for ${url}: refusing to follow redirect to non-HTTP(S) scheme "${nextUrl.protocol}"`,
 				);
+			}
+			if (headers && nextUrl.origin !== new URL(currentUrl).origin) {
+				headers = stripCrossOriginSensitiveHeaders(headers);
 			}
 			currentUrl = nextUrl.href;
 		}
@@ -158,10 +174,13 @@ function buildCurlArgs(params: {
 		"--silent",
 		"--show-error",
 		// curl resolves DNS itself, bypassing the Node-level SSRF guard, so a
-		// redirect could reach an unchecked private IP. `--location` is deliberately
-		// omitted and `--max-redirs 0` stops curl following any redirect on its own;
-		// the 3xx is handed back to fetchCurl, which re-pins the target through the
-		// SSRF guard (resolvePinnedAddress) before following it.
+		// redirect could reach an unchecked private IP. Omitting `--location` is
+		// what stops curl from following redirects on its own — each 3xx is handed
+		// back to fetchCurl, which re-pins the target through the SSRF guard
+		// (resolvePinnedAddress) before following it. `--max-redirs 0` is inert
+		// without `--location` (curl consults it only under -L); it stays as a
+		// fail-closed backstop so that a re-added `--location` would make curl exit
+		// 47 instead of following a redirect unguarded.
 		"--max-redirs",
 		"0",
 		"--dump-header",
@@ -198,6 +217,16 @@ function toTitleCase(header: string): string {
 	return header.replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function stripCrossOriginSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(headers)) {
+		if (!CROSS_ORIGIN_SENSITIVE_HEADERS.has(key.toLowerCase())) {
+			out[key] = value;
+		}
+	}
+	return out;
+}
+
 type ParsedCurlOutput = {
 	status: number;
 	headers: Headers;
@@ -206,8 +235,9 @@ type ParsedCurlOutput = {
 
 /**
  * curl --dump-header - --output - writes headers then a blank line then body.
- * With --location, intermediate redirect headers appear before the final ones.
- * We parse the LAST header block (after the last HTTP status line).
+ * A single response can still carry more than one header block: an HTTP 1xx
+ * interim response (100 Continue, 103 Early Hints) precedes the final status,
+ * so we parse the LAST header block (after the last HTTP status line).
  */
 function parseCurlOutput(raw: Buffer): ParsedCurlOutput {
 	const crlfIndex = findLastHeaderBlock(raw);
@@ -234,8 +264,9 @@ function parseCurlOutput(raw: Buffer): ParsedCurlOutput {
 }
 
 /**
- * Finds the end of the last header block (\r\n\r\n boundary).
- * With --location, each redirect response has its own header block.
+ * Finds the end of the last header block (\r\n\r\n boundary). An HTTP 1xx
+ * interim response (100 Continue, 103 Early Hints) emits its own header block
+ * before the final one, so we skip past every interim block to the last.
  */
 function findLastHeaderBlock(raw: Buffer): number {
 	const separator = Buffer.from("\r\n\r\n");

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -10,6 +10,9 @@ import { MAX_PDF_BYTES } from "./pdf-page-limits";
 
 const DEFAULT_TIMEOUT_MS = 10000;
 
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 5;
+
 type CurlFetchInit = {
 	headers?: Record<string, string>;
 	signal?: AbortSignal;
@@ -65,7 +68,8 @@ const defaultExecCurl: ExecCurl = (args, options, callback) => {
  */
 export function createCurlFetch(deps: { execCurl: ExecCurl; resolvePinnedAddress: ResolvePinnedAddress }): CurlFetch {
 	const { execCurl, resolvePinnedAddress } = deps;
-	return async function fetchCurl(url, init) {
+
+	async function fetchOnce(url: string, init?: CurlFetchInit): Promise<Response> {
 		const parsed = new URL(url);
 		const port = parsed.port ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80;
 		const pinnedAddress = await resolvePinnedAddress({ hostname: parsed.hostname });
@@ -95,6 +99,25 @@ export function createCurlFetch(deps: { execCurl: ExecCurl; resolvePinnedAddress
 				child.onClose(() => signal.removeEventListener("abort", onAbort));
 			}
 		});
+	}
+
+	return async function fetchCurl(url, init) {
+		let currentUrl = url;
+		for (let redirects = 0; ; redirects++) {
+			const response = await fetchOnce(currentUrl, init);
+			const location = response.headers.get("location");
+			if (location === null || !REDIRECT_STATUS_CODES.has(response.status)) {
+				return response;
+			}
+			if (redirects >= MAX_REDIRECTS) {
+				throw new Error(`fetchCurl failed for ${url}: too many redirects (>${MAX_REDIRECTS})`);
+			}
+			// Resolve against the current hop so a relative Location works, then the
+			// next fetchOnce re-runs resolvePinnedAddress on the target host — the
+			// per-hop SSRF re-validation that lets us follow a redirect curl itself
+			// (kept at --max-redirs 0) is not allowed to chase.
+			currentUrl = new URL(location, currentUrl).href;
+		}
 	};
 }
 
@@ -127,12 +150,11 @@ function buildCurlArgs(params: {
 		"--globoff",
 		"--silent",
 		"--show-error",
-		"--location",
 		// curl resolves DNS itself, bypassing the Node-level SSRF guard, so a
-		// redirect could reach an unchecked private IP. Pin to the address we
-		// already verified (--resolve below) and refuse to follow any redirect:
-		// a 3xx exits non-zero and the crawl fails closed rather than chasing an
-		// unvalidated host.
+		// redirect could reach an unchecked private IP. `--location` is deliberately
+		// omitted and `--max-redirs 0` stops curl following any redirect on its own;
+		// the 3xx is handed back to fetchCurl, which re-pins the target through the
+		// SSRF guard (resolvePinnedAddress) before following it.
 		"--max-redirs",
 		"0",
 		"--dump-header",

--- a/src/packages/crawl-article/src/curl-fetch.ts
+++ b/src/packages/crawl-article/src/curl-fetch.ts
@@ -12,6 +12,7 @@ const DEFAULT_TIMEOUT_MS = 10000;
 
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 const MAX_REDIRECTS = 5;
+const ALLOWED_REDIRECT_PROTOCOLS = new Set(["http:", "https:"]);
 
 type CurlFetchInit = {
 	headers?: Record<string, string>;
@@ -116,7 +117,13 @@ export function createCurlFetch(deps: { execCurl: ExecCurl; resolvePinnedAddress
 			// next fetchOnce re-runs resolvePinnedAddress on the target host — the
 			// per-hop SSRF re-validation that lets us follow a redirect curl itself
 			// (kept at --max-redirs 0) is not allowed to chase.
-			currentUrl = new URL(location, currentUrl).href;
+			const nextUrl = new URL(location, currentUrl);
+			if (!ALLOWED_REDIRECT_PROTOCOLS.has(nextUrl.protocol)) {
+				throw new Error(
+					`fetchCurl failed for ${url}: refusing to follow redirect to non-HTTP(S) scheme "${nextUrl.protocol}"`,
+				);
+			}
+			currentUrl = nextUrl.href;
 		}
 	};
 }

--- a/src/packages/crawl-article/src/persona-fallback.test.ts
+++ b/src/packages/crawl-article/src/persona-fallback.test.ts
@@ -40,6 +40,7 @@ describe("isBlockClassError", () => {
 		"ERR_HTTP2_STREAM_ERROR: RST_STREAM",
 		"ERR_HTTP2_PROTOCOL_ERROR",
 		"UND_ERR_MAX_REDIRECTS: max_redirects exceeded",
+		"fetchCurl failed for https://example.com: too many redirects (>5)",
 	])("treats %j as block-class error", (message) => {
 		expect(isBlockClassError(new Error(message))).toBe(true);
 	});

--- a/src/packages/crawl-article/src/persona-fallback.test.ts
+++ b/src/packages/crawl-article/src/persona-fallback.test.ts
@@ -39,7 +39,6 @@ describe("isBlockClassError", () => {
 		"NGHTTP2_INTERNAL_ERROR",
 		"ERR_HTTP2_STREAM_ERROR: RST_STREAM",
 		"ERR_HTTP2_PROTOCOL_ERROR",
-		"fetchCurl failed for https://example.com: Maximum (5) redirects followed",
 		"UND_ERR_MAX_REDIRECTS: max_redirects exceeded",
 	])("treats %j as block-class error", (message) => {
 		expect(isBlockClassError(new Error(message))).toBe(true);

--- a/src/packages/crawl-article/src/persona-fallback.ts
+++ b/src/packages/crawl-article/src/persona-fallback.ts
@@ -29,7 +29,6 @@ const BLOCK_ERROR_SIGNATURES = [
 	"rst_stream", /* explicit ERR_HTTP2_STREAM_ERROR from undici / Node's http2 */
 	"not closed cleanly", /* curl exit 92 — server killed the h2 stream mid-request */
 	"err_http2_protocol_error", /* undici's mapping of generic h2 protocol errors */
-	"maximum (5) redirects followed", /* curl exit 47 — origin 302-loops AWS-range IPs */
 	"max_redirects", /* undici's mapping of redirect-loop failures */
 ];
 

--- a/src/packages/crawl-article/src/persona-fallback.ts
+++ b/src/packages/crawl-article/src/persona-fallback.ts
@@ -30,6 +30,7 @@ const BLOCK_ERROR_SIGNATURES = [
 	"not closed cleanly", /* curl exit 92 — server killed the h2 stream mid-request */
 	"err_http2_protocol_error", /* undici's mapping of generic h2 protocol errors */
 	"max_redirects", /* undici's mapping of redirect-loop failures */
+	"too many redirects",
 ];
 
 export function isBlockClassResponse(response: Response): boolean {

--- a/src/packages/crawl-article/src/persona-fallback.ts
+++ b/src/packages/crawl-article/src/persona-fallback.ts
@@ -30,7 +30,7 @@ const BLOCK_ERROR_SIGNATURES = [
 	"not closed cleanly", /* curl exit 92 — server killed the h2 stream mid-request */
 	"err_http2_protocol_error", /* undici's mapping of generic h2 protocol errors */
 	"max_redirects", /* undici's mapping of redirect-loop failures */
-	"too many redirects",
+	"too many redirects", /* fetchCurl/fetchH2 app-level redirect cap — mirrors undici's max_redirects */
 ];
 
 export function isBlockClassResponse(response: Response): boolean {


### PR DESCRIPTION
Two fixes for the `fetchCurl` error category (#3 in the 30-day dashboard audit). ENOENT is a documented follow-up (see bottom).

---

## Commit 1 — follow curl-impersonate redirects through the SSRF guard

**Why.** The curl fallback hardcoded `--location --max-redirs 0`, so any origin answering with a 3xx made curl exit 47 (`Maximum (0) redirects followed`) and the crawl failed. That was ~**59** of the fetchCurl failures over 30 days (archive.ph 46×, developer.android.com, dev.w3.org) — sites that block the Node/undici path (forcing the curl fallback) *and* redirect.

`--location` refused redirects deliberately: curl does its own DNS, so following a redirect could reach an unchecked private IP, bypassing the Node-level SSRF guard.

**How.** `fetchCurl` now follows redirects itself, re-applying the **same** guard per hop:
- `--location` dropped; `--max-redirs 0` kept so curl never chases anything on its own.
- A 3xx is returned to `fetchCurl`, which resolves the `Location` (relative against the current hop), runs `resolvePinnedAddress` on the **new host** (the existing SSRF guard — blocks private/❌ addresses), and re-pins curl to that validated address for the next hop.
- Bounded to 5 hops; a loop fails with `too many redirects`.

The SSRF invariant is preserved: every curl spawn still connects only to a `resolvePinnedAddress`-validated IP — now applied to each hop instead of only the first.

Also removes the dead persona-fallback signature `"maximum (5) redirects followed"` (it never matched the real `(0)` message, and curl no longer exits 47 for redirects). The undici `max_redirects` signature stays.

## Commit 2 — back off on refresh failure instead of re-crawling every /view

**Why.** A failed stale-check refresh returned `"skip"` **without** advancing `contentFetchedAt`, so a permanently-broken origin stayed past the 24h staleness gate and was re-crawled on **every** `/view`. That is what turned a handful of unfetchable URLs into the repeat storms: `www.ics.uci.edu` SSL-failed **73×**, `archive.ph` **46×** over 30 days — the same row hammered on each visit.

**How.** On `result.status === "failed"` the handler publishes `UpdateFetchTimestamp` (resets the freshness clock, carries the existing `bodyHash` forward) and returns a new `"backoff"` action. The next attempt waits a full TTL instead of firing on the next visit, collapsing the per-URL failure count to ~1 per TTL. Existing content on a ready row is untouched; only the redundant re-crawls stop.

## Combined effect on #3

- archive.ph (46×) and other redirecting origins now **crawl successfully** (commit 1) → they stop failing *and* stop being stale → drop off the dashboard.
- ics.uci.edu SSL (73×) and any still-failing origin are **re-crawled ~1×/TTL instead of every visit** (commit 2) → the storms collapse.

## Tests
- curl: follows 301→200, relative-Location resolution, cross-host re-pin via `--resolve`, **SSRF guard refuses a redirect to 169.254.169.254 (no curl spawned for it)**, MAX_REDIRECTS cap, and non-redirect-with-Location is not followed.
- stale-check: failed refresh now asserts the backoff timestamp + `bodyHash` carry-forward + the `backed off` log.
- `pnpm check` green (100% coverage).

## Follow-up NOT in this PR — `ENOENT` (curl binary missing on hutch-handler, ~5×/30d)

hutch-handler wires the same crawl fallback chain (`app.ts` `initCrawlFetch`) but the curl-impersonate **Lambda layer** is defined only in the **save-link** Pulumi stack (`projects/save-link/src/infra`), not attached to the hutch-handler Lambda (`projects/hutch/src/infra`). When a synchronous `/view` / `/import` / `/admin/recrawl` crawl escalates to curl, `execFile("curl_chrome131")` finds nothing → `spawn ENOENT`.

Fixing it means exporting the layer ARN from the save-link stack and consuming it via a **cross-stack StackReference** in the hutch stack (or building the layer in both) — a deploy-ordering-sensitive infra change I can't verify without deploying, so it is intentionally left out of this code PR. Recommend a dedicated infra PR.