### PR TITLE
Strip email marker from owner reader permalink after login

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/owner-reader-link.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/owner-reader-link.ts
@@ -4,8 +4,14 @@ import type { Request } from "express";
 const MARKER_KEY = "from";
 const MARKER_VALUE = "reader-ready-email";
 
+/** The clean, shareable reader permalink — no email marker. This is what
+ * the owner's address bar should settle on after authentication. */
+export function readerPermalinkPath(articleId: ReaderArticleHashId): string {
+	return `/queue/${articleId.value}/view`;
+}
+
 export function buildOwnerReaderPath(articleId: ReaderArticleHashId): string {
-	return `/queue/${articleId.value}/view?${MARKER_KEY}=${MARKER_VALUE}`;
+	return `${readerPermalinkPath(articleId)}?${MARKER_KEY}=${MARKER_VALUE}`;
 }
 
 export function wantsOwnerLogin(query: Request["query"]): boolean {

--- a/projects/hutch/src/runtime/web/pages/queue/owner-reader-link.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/owner-reader-link.ts
@@ -4,14 +4,29 @@ import type { Request } from "express";
 const MARKER_KEY = "from";
 const MARKER_VALUE = "reader-ready-email";
 
-/** The clean, shareable reader permalink — no email marker. This is what
- * the owner's address bar should settle on after authentication. */
-export function readerPermalinkPath(articleId: ReaderArticleHashId): string {
+/** The clean, shareable reader permalink — no email marker. */
+function readerPermalinkPath(articleId: ReaderArticleHashId): string {
 	return `/queue/${articleId.value}/view`;
 }
 
 export function buildOwnerReaderPath(articleId: ReaderArticleHashId): string {
 	return `${readerPermalinkPath(articleId)}?${MARKER_KEY}=${MARKER_VALUE}`;
+}
+
+export function readerPermalinkPathWithoutMarker(
+	articleId: ReaderArticleHashId,
+	query: Request["query"],
+): string {
+	const params = new URLSearchParams(
+		Object.entries(query).filter(
+			(entry): entry is [string, string] =>
+				entry[0] !== MARKER_KEY && typeof entry[1] === "string",
+		),
+	);
+	const queryString = params.toString();
+	return queryString
+		? `${readerPermalinkPath(articleId)}?${queryString}`
+		: readerPermalinkPath(articleId);
 }
 
 export function wantsOwnerLogin(query: Request["query"]): boolean {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader-platform.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader-platform.route.test.ts
@@ -173,6 +173,32 @@ describe("Queue reader chromeless switch (GET /queue/:id/view?platform=ios)", ()
 		);
 	});
 
+	it("strips the reader-ready email marker but keeps platform=ios so the owner's in-app open still renders chromeless", async () => {
+		const harness = buildHarness();
+		const agent = await loginAgent(harness.server, harness.auth);
+		const articleId = await saveAndGetArticleId(agent, "https://example.com/app-email-marker");
+
+		const redirect = await agent
+			.get(`/queue/${articleId}/view`)
+			.query({ from: "reader-ready-email", platform: "ios" });
+
+		expect(redirect.status).toBe(303);
+		const location = new URL(redirect.headers.location, TEST_APP_ORIGIN);
+		expect(location.pathname).toBe(`/queue/${articleId}/view`);
+		expect(location.searchParams.get("platform")).toBe("ios");
+		expect(location.searchParams.has("from")).toBe(false);
+
+		const doc = new JSDOM(
+			(await agent.get(`${location.pathname}${location.search}`)).text,
+		).window.document;
+		assert(
+			doc.querySelector("[data-test-back-link]"),
+			"the chromeless reader must render after the marker strip",
+		);
+		expect(doc.querySelector(".header")).toBe(null);
+		expect(doc.querySelector(".footer")).toBe(null);
+	});
+
 	it("redirects an anonymous visitor to the public /view permalink, exactly like /view", async () => {
 		const harness = buildHarness();
 		const ownerAgent = await loginAgent(harness.server, harness.auth);

--- a/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.reader.route.test.ts
@@ -581,14 +581,19 @@ describe("Queue routes", () => {
 				.type("form")
 				.send({ email: "test@example.com", password: "password123" });
 
-			const readerResponse = await loggedOutAgent.get(returnPath);
+			const markerResponse = await loggedOutAgent.get(returnPath);
+
+			expect(markerResponse.status).toBe(303);
+			expect(markerResponse.headers.location).toBe(`/queue/${articleId}/view`);
+
+			const readerResponse = await loggedOutAgent.get(`/queue/${articleId}/view`);
 
 			expect(readerResponse.status).toBe(200);
 			const doc = new JSDOM(readerResponse.text).window.document;
 			assert(doc.querySelector("iframe[data-reader-iframe]"), "private reader iframe must be rendered after login");
 		});
 
-		it("renders the private reader for a logged-in owner even when the reader-ready email marker is present", async () => {
+		it("strips the reader-ready email marker for a logged-in owner, redirecting to the clean permalink that renders the private reader", async () => {
 			const articleHtml = `
 			<html><head><title>Email Reader Post</title></head>
 			<body><article>
@@ -632,9 +637,14 @@ describe("Queue routes", () => {
 				?.getAttribute("data-test-article");
 			assert.ok(articleId, "owner must see the saved article in their queue");
 
-			const readerResponse = await agent
+			const markerResponse = await agent
 				.get(`/queue/${articleId}/view`)
 				.query({ from: "reader-ready-email" });
+
+			expect(markerResponse.status).toBe(303);
+			expect(markerResponse.headers.location).toBe(`/queue/${articleId}/view`);
+
+			const readerResponse = await agent.get(`/queue/${articleId}/view`);
 
 			expect(readerResponse.status).toBe(200);
 			const doc = new JSDOM(readerResponse.text).window.document;

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
@@ -186,7 +186,23 @@ describe("resolveReaderPermalink", () => {
 		});
 	});
 
-	it("ignores the reader-ready email marker for a logged-in owner and renders the reader directly", async () => {
+	it("renders the reader directly for a logged-in owner when no email marker is present", async () => {
+		const owned = savedArticleFor(OWNER_ID);
+		const resolve = initReaderPermalink(createDeps({
+			findArticleById: async (id, userId) =>
+				id.value === ARTICLE_ID.value && userId === OWNER_ID ? owned : null,
+		}));
+
+		const result = await resolve({
+			rawId: ARTICLE_ID.value,
+			requesterId: OWNER_ID,
+			query: {},
+		});
+
+		expect(result).toEqual({ kind: "article", article: owned });
+	});
+
+	it("strips the reader-ready email marker for a logged-in owner by redirecting to the clean shareable permalink", async () => {
 		const owned = savedArticleFor(OWNER_ID);
 		const resolve = initReaderPermalink(createDeps({
 			findArticleById: async (id, userId) =>
@@ -199,7 +215,10 @@ describe("resolveReaderPermalink", () => {
 			query: { from: "reader-ready-email" },
 		});
 
-		expect(result).toEqual({ kind: "article", article: owned });
+		expect(result).toEqual({
+			kind: "redirect",
+			redirect: { statusCode: 303, location: `/queue/${ARTICLE_ID.value}/view` },
+		});
 	});
 
 	it("ignores the reader-ready email marker for a logged-in non-owner and keeps the public /view share redirect", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.test.ts
@@ -221,6 +221,34 @@ describe("resolveReaderPermalink", () => {
 		});
 	});
 
+	it("strips only the email marker for a logged-in owner, carrying scalar params (platform=ios, utm_*) onto the clean permalink while dropping array-valued params", async () => {
+		const owned = savedArticleFor(OWNER_ID);
+		const resolve = initReaderPermalink(createDeps({
+			findArticleById: async (id, userId) =>
+				id.value === ARTICLE_ID.value && userId === OWNER_ID ? owned : null,
+		}));
+
+		const result = await resolve({
+			rawId: ARTICLE_ID.value,
+			requesterId: OWNER_ID,
+			query: {
+				from: "reader-ready-email",
+				platform: "ios",
+				utm_source: "newsletter",
+				tags: ["a", "b"],
+			},
+		});
+
+		assert(result.kind === "redirect");
+		expect(result.redirect.statusCode).toBe(303);
+		const location = new URL(result.redirect.location, "https://example.test");
+		expect(location.pathname).toBe(`/queue/${ARTICLE_ID.value}/view`);
+		expect(location.searchParams.get("platform")).toBe("ios");
+		expect(location.searchParams.get("utm_source")).toBe("newsletter");
+		expect(location.searchParams.has("tags")).toBe(false);
+		expect(location.searchParams.has("from")).toBe(false);
+	});
+
 	it("ignores the reader-ready email marker for a logged-in non-owner and keeps the public /view share redirect", async () => {
 		const resolve = initReaderPermalink(createDeps({
 			findArticleById: async () => null,

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
@@ -10,7 +10,7 @@ import type { Redirect } from "../../redirect.component";
 import { shareUserIdPrefix } from "../../shared/share-user-id";
 import { collectUtmParams } from "../../shared/utm";
 import { viewPathFor } from "../view/view-path";
-import { buildOwnerReaderPath, wantsOwnerLogin } from "./owner-reader-link";
+import { buildOwnerReaderPath, readerPermalinkPath, wantsOwnerLogin } from "./owner-reader-link";
 
 export interface ReaderPermalinkDeps {
 	findArticleById: FindArticleById;
@@ -80,7 +80,19 @@ export function initReaderPermalink(deps: ReaderPermalinkDeps) {
 		const ownedArticle = input.requesterId
 			? await deps.findArticleById(parsedId.data, input.requesterId)
 			: null;
-		if (ownedArticle) return { kind: "article", article: ownedArticle };
+		if (ownedArticle) {
+			/** The email marker only gates the logged-out → /login hop; once the
+			 * owner is authenticated it is inert. Redirect to strip it so the
+			 * address bar settles on the clean shareable permalink instead of the
+			 * `?from=reader-ready-email` link the owner clicked from their inbox. */
+			if (wantsOwnerLogin(input.query)) {
+				return {
+					kind: "redirect",
+					redirect: { statusCode: 303, location: readerPermalinkPath(parsedId.data) },
+				};
+			}
+			return { kind: "article", article: ownedArticle };
+		}
 
 		const articleUrl = await deps.findArticleUrlById(parsedId.data);
 		if (!articleUrl) return REDIRECT_TO_QUEUE;

--- a/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/reader-permalink.ts
@@ -10,7 +10,11 @@ import type { Redirect } from "../../redirect.component";
 import { shareUserIdPrefix } from "../../shared/share-user-id";
 import { collectUtmParams } from "../../shared/utm";
 import { viewPathFor } from "../view/view-path";
-import { buildOwnerReaderPath, readerPermalinkPath, wantsOwnerLogin } from "./owner-reader-link";
+import {
+	buildOwnerReaderPath,
+	readerPermalinkPathWithoutMarker,
+	wantsOwnerLogin,
+} from "./owner-reader-link";
 
 export interface ReaderPermalinkDeps {
 	findArticleById: FindArticleById;
@@ -88,7 +92,10 @@ export function initReaderPermalink(deps: ReaderPermalinkDeps) {
 			if (wantsOwnerLogin(input.query)) {
 				return {
 					kind: "redirect",
-					redirect: { statusCode: 303, location: readerPermalinkPath(parsedId.data) },
+					redirect: {
+						statusCode: 303,
+						location: readerPermalinkPathWithoutMarker(parsedId.data, input.query),
+					},
 				};
 			}
 			return { kind: "article", article: ownedArticle };


### PR DESCRIPTION
## Summary

When a logged-in article owner accesses the reader via an email link containing the `?from=reader-ready-email` marker, the app now redirects to the clean shareable permalink instead of rendering directly. This ensures the address bar settles on the canonical URL without the transient email marker.

## Changes

- **reader-permalink.ts**: Added redirect logic that detects the email marker on authenticated owner requests and issues a 303 redirect to the clean permalink path
- **owner-reader-link.ts**: Extracted `readerPermalinkPath()` helper to define the canonical reader URL (`/queue/{id}/view`) separately from the email-marked variant
- **Tests**: Updated test descriptions and assertions to reflect the new redirect behavior; added integration test verifying the 303 redirect strips the marker before rendering the reader

## Implementation Details

The email marker (`?from=reader-ready-email`) serves only to gate the logged-out → `/login` flow. Once the owner is authenticated, the marker becomes inert and should be stripped from the address bar. The redirect uses HTTP 303 (See Other) to ensure the browser performs a clean GET to the canonical URL, matching the semantics of post-login redirects.

https://claude.ai/code/session_01CN5nSfE6K8hZXaAop9xWR9