### PR TITLE
docs(blog): add war story on defeating aged-out TLS fingerprint blocks

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/save-articles-from-sites-that-block-bots.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/save-articles-from-sites-that-block-bots.md
@@ -1,0 +1,59 @@
+---
+title: "The 403 That Only the Crawler Got"
+description: "A saved link from a normally reliable site came back empty while the same page opened in a browser. Readplace's crawler impersonated Chrome 116, whose TLS fingerprint had aged off the list of current browsers that anti-bot edges allow, so it read as a bot. Switching the persona to Chrome 131 turned those sites from 403 back to 200."
+slug: "save-articles-from-sites-that-block-bots"
+date: "2026-07-02"
+author: "Fayner Brack"
+keywords: "save article blocked by bot protection, read it later 403 error, couldn't pull the article text, TLS fingerprint JA3, curl-impersonate chrome 131, crawler blocked by Fastly, read it later that saves protected sites, save link that will not load, anti-bot 403, Readplace crawler"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Some sites hand a full page to a browser and a 403 to a crawler, even when both run from the same machine. That is what started happening to saved links Readplace pulled from The Hill, StackOverflow, and other sites behind anti-bot edges. The crawler impersonated Chrome 116, and that browser's TLS fingerprint had aged off the allowlist those edges check, so the fetch read as a bot instead of a browser. Bumping the crawler to pose as Chrome 131 turned those sites from 403 back to 200, checked against every source in the crawler's health canary with no regressions. One site, The Hill, still blocks the datacenter address itself, which no fingerprint change reaches.
+
+</div>
+</details>
+
+StackOverflow returned the full page to a browser and a 403 to our crawler. The two requests left the same machine on the same network, seconds apart. The reader showed the message it puts up when a save comes back empty: We couldn't pull the article text.
+
+That message had started appearing on sites that saved fine for months. The Hill was the one that tipped me off, because a reader tried to keep a piece from it and got the empty version instead of the article.
+
+The confusing part was that nothing about the request had changed on our side.
+
+## Not the IP, and not the headers
+
+My first guess was the address. Cloud crawlers run from datacenter IP ranges, and some sites block those on sight. But this crawl ran from a residential address, and a browser on that same address loaded the page. So the block was not about where the request came from.
+
+Headers were the next guess. The crawler sent a normal Chrome user-agent and the usual accept headers. I copied them into a browser and the page still loaded. I stripped them back and the crawler still got 403. The 403 did not care what the request said it was.
+
+> **The block was not on who we were. It was on what we looked like.**
+
+## A fingerprint that aged out
+
+The block keyed on the TLS handshake. Before any HTTP header is sent, the client and the server negotiate encryption, and the exact shape of that negotiation, the cipher list and the extensions and the order they arrive in, is specific enough to name the software making the request. The fingerprint of that handshake has a name, [JA3](/view/github.com/salesforce/ja3). Anti-bot services like Fastly read it, compare it against the handshakes that current browsers produce, and drop the ones that do not match.
+
+Our crawler used [curl-impersonate](/view/github.com/lexiforest/curl-impersonate), a build of curl that copies a real browser's handshake so a server sees a browser and not a script. It was pinned to a persona of Chrome 116. Chrome 116 shipped in 2023. Three years on, an edge that gates on current-browser fingerprints reads a Chrome 116 handshake as one no shipping browser produces, which is to say a bot.
+
+> **Chrome 116 shipped in 2023. To a 2026 anti-bot edge, a client that still fingerprints as Chrome 116 reads as a bot.**
+
+## Posing as a browser people still run
+
+The fix was to move the impersonation forward. curl-impersonate had gone from the version we pinned, 0.8.0, to 1.5.6, and the newer release carries a Chrome 131 persona. That release also renamed the binary, from curl-impersonate-chrome to curl-impersonate, so the layer build and the Dockerfile that ship it to our crawler Lambda had to track the rename along with the version.
+
+I built the real Linux 1.5.6 binary into the Lambda image and ran the same URLs through it. From one residential address, Chrome 116 got 403 and Chrome 131 got 200 on The Hill, on StackOverflow, and on LinkedIn.
+
+## What Chrome 131 fixed, and what it did not
+
+Before shipping, I ran the new fingerprint against every source in the crawler's health canary, the list of URL shapes that each broke a real save at some point. Chrome 131 passed all of them and regressed none. It is a straight upgrade over 116.
+
+Then production drew the line of what a fingerprint can do. StackOverflow, which had been 403 from the Lambda on Chrome 116, crawled cleanly on Chrome 131. The Hill did not. From a residential address the same binary loaded it, but from the Lambda's datacenter address it still returned 403. The Hill blocks the AWS egress range on top of the fingerprint check, and no handshake change reaches that. Getting past it needs a residential or mobile proxy, which is separate work. So the fingerprint fix shipped and The Hill came off the canary until that egress piece lands, because a canary that fails every run is noise.
+
+## Saving the links a bare fetch bounces off
+
+A read-it-later tool is only as good as the saves it completes. The sites most worth keeping, the news and reference and discussion ones, are also the sites most likely to sit behind an anti-bot edge. A plain download gets a 403 there, and the reader gets an apology instead of the article. Matching a current browser's handshake is what turns that 403 into the text.
+
+Fingerprints age. A browser persona that clears every edge today reads as stale a year or two on, which is why the canary now sweeps the fingerprint across every source and trips CI before a reader ever meets the empty version.
+
+Point it at a link a plain download would bounce off: [install the browser extension](https://readplace.com/install), or paste the link at [readplace.com](/), and see whether it comes back as clean reading.


### PR DESCRIPTION
## What

Adds one new blog post: **"The 403 That Only the Crawler Got"** (`save-articles-from-sites-that-block-bots.md`, dated 2026-07-02).

It reconstructs the incident behind commit `9833156` (`fix(crawl): impersonate Chrome 131 to defeat aged-out JA3 fingerprint blocks`): a saved link started returning "We couldn't pull the article text" from sites behind anti-bot edges (The Hill, StackOverflow) while the same page opened fine in a browser. Root cause was the crawler impersonating Chrome 116, whose JA3/TLS fingerprint had aged off the current-browser allowlists that edges like Fastly gate on, so the fetch read as a bot. The fix bumped curl-impersonate `0.8.0 → 1.5.6` and switched the persona to Chrome 131, flipping those sites from 403 to 200.

## Why this topic

Reviewed every commit to `main` after the last published post (2026-06-24). The strongest SEO/conversion-relevant, durable topic was the crawler anti-blocking work — a technical differentiator that matters directly to paying customers: a read-it-later tool is only as good as the saves it completes, and the sites most worth keeping are the ones most likely to block a naive fetch. The post keeps the honest limit intact (The Hill also blocks the datacenter egress IP, which no fingerprint change reaches — separate proxy-egress work, per the follow-up revert `4ada054`), so nothing in it overstates the shipped state.

## Editorial

- **Voice:** War Story. Ran the Structural Variety lookback against the last 8 posts and differ on every shared axis: opening on a proper-noun/status-code declarative (not the corpus's saturated "You"/gerund/scene openers), TL;DR opening on "Some" (not "Readplace…"), fresh section headers (no "Why this matters"/"Try it"), and a rewritten closing CTA around the install links.
- External references (`JA3`, `curl-impersonate`) are rendered as `/view/` links per the view-path logic.
- No pricing/promotion copy that could go stale.

## Verification

- `pnpm nx run blog-site:test` → 63 passed. Confirmed `getAllPosts()` returns 40 posts with the new post sorted first and reachable via `findPostBySlug`; rendered `/view/` and CTA anchors verified.
- Full `pnpm check` pre-commit hook ran clean (all 36 projects, coverage thresholds met).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbVELJ2hVgMFpAokLcLKvk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbVELJ2hVgMFpAokLcLKvk)_