### PR TITLE
chore(check-failed-articles): exclude 2018-03-22 wayback ABU capture

### DIFF
--- a/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.test.ts
@@ -595,6 +595,16 @@ describe("EXCLUDE_PATTERNS — permanently-unreachable saves", () => {
 			label: "wayback ABU press-page capture (collapsed scheme)",
 		},
 		{
+			url: "https://web.archive.org/web/20180322015139/http://www.abu.org.my/Latest_News-@-CNA_to_launch_satellite_studio_in_Malaysia.aspx",
+			excluded: true,
+			label: "wayback ABU press-page 2018-03-22 capture, uncollapsed embedded scheme (http://)",
+		},
+		{
+			url: "https://web.archive.org/web/20180322015139/http:/www.abu.org.my/Latest_News-@-CNA_to_launch_satellite_studio_in_Malaysia.aspx",
+			excluded: true,
+			label: "wayback ABU press-page 2018-03-22 capture, collapsed embedded scheme (http:/)",
+		},
+		{
 			url: "https://web.archive.org/web/20200101000000/https://www.abu.org.my/Latest_News-@-CNA_to_launch_satellite_studio_in_Malaysia.aspx",
 			excluded: false,
 			label: "different-timestamp ABU capture — must NOT be hidden",

--- a/src/packages/check-failed-articles/scripts/exclude-patterns.ts
+++ b/src/packages/check-failed-articles/scripts/exclude-patterns.ts
@@ -226,6 +226,10 @@ export const EXCLUDE_PATTERNS: readonly RegExp[] = [
 	// successfully) but exhausts retries whenever wayback throttles, so it
 	// recurs as canary noise on bulk imports.
 	/^https:\/\/web\.archive\.org\/web\/20180630081250\/https:\/{1,2}www\.abu\.org\.my\/Latest_News-@-CNA_to_launch_satellite_studio_in_Malaysia\.aspx$/i,
+	// An earlier capture of the same ABU press page (2018-03-22, embedded
+	// `http://` scheme) — same wayback-throttling failure mode as the June
+	// capture above. Anchored per timestamp so other snapshots still surface.
+	/^https:\/\/web\.archive\.org\/web\/20180322015139\/http:\/{1,2}www\.abu\.org\.my\/Latest_News-@-CNA_to_launch_satellite_studio_in_Malaysia\.aspx$/i,
 ];
 
 export function isExcluded(url: string, patterns: readonly RegExp[]): boolean {


### PR DESCRIPTION
## What

Adds one operator-curated entry to the failed-articles canary ignore list (`EXCLUDE_PATTERNS` in `src/packages/check-failed-articles/scripts/exclude-patterns.ts`):

```
https://web.archive.org/web/20180322015139/http://www.abu.org.my/Latest_News-@-CNA_to_launch_satellite_studio_in_Malaysia.aspx
```

## Why

This is a `web.archive.org` capture, which falls under the file's existing category (i) ("web.archive.org captures behind datacenter throttling"). archive.org throttles/429s datacenter (AWS-range) egress, so saved captures intermittently exhaust their crawl retries and recur as canary noise with nothing the operator can act on.

It is a **different capture of the same ABU press page** already excluded at the entry above it — the June 2018 capture (`20180630081250`). The new entry differs by timestamp (`20180322015139`) and by embedded scheme (`http://` rather than the June capture's `https://`). The underlying "CNA to launch satellite studio in Malaysia" article shares the delisted-origin story as the TODAY page already covered by category (h).

## How

- New regex is anchored per-timestamp (`^…$`) so **other** snapshots of the same page still surface as real failures. The existing `keeps: different-timestamp ABU capture` test (`20200101000000`) confirms this and still passes.
- `\/{1,2}` after `http:` tolerates the embedded scheme whether upstream normalization collapsed `//` to `/`, matching the convention of the sibling entries.

## Tests

Added two cases to `exclude-patterns.test.ts` (uncollapsed `http://` and collapsed `http:/` forms of the new capture). Full `pnpm check` passes locally: 215 tests, 100% coverage across all thresholds, lint/type-check/knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6LKg2W4XZoVRAckxwozrw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6LKg2W4XZoVRAckxwozrw)_