### PR TITLE
feat(hutch): let users name each inbox forwarding address

### DIFF
--- a/projects/hutch/src/runtime/domain/inbox/receive-email-handler.test.ts
+++ b/projects/hutch/src/runtime/domain/inbox/receive-email-handler.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
-import { MessageIdSchema, type ParseEmailResult } from "@packages/domain/inbox";
+import {
+	DEFAULT_INBOX_ALIAS,
+	MessageIdSchema,
+	type ParseEmailResult,
+} from "@packages/domain/inbox";
 import { UserIdSchema } from "@packages/domain/user";
 import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { initInMemoryInboxAddress } from "@packages/test-fixtures/providers/inbox-address";
@@ -76,7 +80,11 @@ function makeHarness(opts?: {
 }
 
 async function mintAddress(addressStore: ReturnType<typeof initInMemoryInboxAddress>) {
-	const entry = await addressStore.createAddress({ userId: OWNER, domain: "read.place" });
+	const entry = await addressStore.createAddress({
+		userId: OWNER,
+		domain: "read.place",
+		name: DEFAULT_INBOX_ALIAS,
+	});
 	return entry.address;
 }
 
@@ -286,7 +294,11 @@ describe("initReceiveEmailHandler", () => {
 	it("stores a row and publishes for EVERY forwarding recipient in one envelope", async () => {
 		const { addressStore, emailStore, rawMap, published, runMany } = makeHarness();
 		const ownerAddress = await mintAddress(addressStore);
-		const second = await addressStore.createAddress({ userId: SECOND, domain: "read.place" });
+		const second = await addressStore.createAddress({
+			userId: SECOND,
+			domain: "read.place",
+			name: DEFAULT_INBOX_ALIAS,
+		});
 		rawMap.set(RAW_KEY, Buffer.from("raw"));
 
 		const result = await runMany([ownerAddress, second.address]);
@@ -308,6 +320,7 @@ describe("initReceiveEmailHandler", () => {
 		const { address: secondOfSameUser } = await addressStore.createAddress({
 			userId: OWNER,
 			domain: "read.place",
+			name: DEFAULT_INBOX_ALIAS,
 		});
 		rawMap.set(RAW_KEY, Buffer.from("raw"));
 

--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.test.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.test.ts
@@ -4,6 +4,7 @@ import {
 	type DynamoDBDocumentClient,
 } from "@packages/hutch-storage-client";
 import {
+	AliasNameSchema,
 	INBOX_ADDRESS_MAX_PER_USER,
 	InboxAddressLimitReachedError,
 	InboxAddressSchema,
@@ -36,6 +37,7 @@ interface CapturedCommand {
 const TABLE = "test-inbox-addresses";
 const USER = UserIdSchema.parse("user-1");
 const DOMAIN = "read.place";
+const NAME = AliasNameSchema.parse("netflix");
 const NOW = new Date("2026-06-23T00:00:00.000Z");
 
 function conditionalCheckFailed(): ConditionalCheckFailedException {
@@ -73,16 +75,18 @@ describe("initDynamoDbInboxAddress", () => {
 				now: () => NOW,
 			});
 
-			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
+			const entry = await store.createAddress({ userId: USER, domain: DOMAIN, name: NAME });
 
 			const puts = commands.filter((c) => c.input.Item);
 			expect(puts).toHaveLength(1);
 			expect(puts[0].input.ConditionExpression).toBe("attribute_not_exists(address)");
 			expect(puts[0].input.Item?.address).toBe(entry.address);
 			expect(puts[0].input.Item?.userId).toBe(USER);
+			expect(puts[0].input.Item?.name).toBe(NAME);
 			expect(puts[0].input.Item?.token).toBe(entry.token);
 			expect(puts[0].input.Item?.createdAt).toBe(NOW.toISOString());
-			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+			expect(entry.address).toMatch(/^netflix-[0-9a-z]{6}@read\.place$/);
+			expect(entry.name).toBe(NAME);
 			expect(entry.createdAt).toBe(NOW.toISOString());
 			expect(entry.disabledAt).toBeUndefined();
 		});
@@ -100,10 +104,10 @@ describe("initDynamoDbInboxAddress", () => {
 				now: () => NOW,
 			});
 
-			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
+			const entry = await store.createAddress({ userId: USER, domain: DOMAIN, name: NAME });
 
 			expect(puts).toBe(2);
-			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+			expect(entry.address).toMatch(/^netflix-[0-9a-z]{6}@read\.place$/);
 		});
 
 		it("throws after exhausting retries on persistent collisions", async () => {
@@ -116,7 +120,7 @@ describe("initDynamoDbInboxAddress", () => {
 				now: () => NOW,
 			});
 
-			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
+			await expect(store.createAddress({ userId: USER, domain: DOMAIN, name: NAME })).rejects.toThrow(
 				"Failed to mint a unique inbox address",
 			);
 		});
@@ -131,7 +135,7 @@ describe("initDynamoDbInboxAddress", () => {
 				now: () => NOW,
 			});
 
-			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
+			await expect(store.createAddress({ userId: USER, domain: DOMAIN, name: NAME })).rejects.toThrow(
 				"throttled",
 			);
 		});
@@ -151,7 +155,7 @@ describe("initDynamoDbInboxAddress", () => {
 				now: () => NOW,
 			});
 
-			await expect(store.createAddress({ userId: USER, domain: DOMAIN })).rejects.toThrow(
+			await expect(store.createAddress({ userId: USER, domain: DOMAIN, name: NAME })).rejects.toThrow(
 				InboxAddressLimitReachedError,
 			);
 			expect(commands.some((c) => c.input.Item)).toBe(false);
@@ -175,9 +179,9 @@ describe("initDynamoDbInboxAddress", () => {
 				now: () => NOW,
 			});
 
-			const entry = await store.createAddress({ userId: USER, domain: DOMAIN });
+			const entry = await store.createAddress({ userId: USER, domain: DOMAIN, name: NAME });
 
-			expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+			expect(entry.address).toMatch(/^netflix-[0-9a-z]{6}@read\.place$/);
 			expect(commands.some((c) => c.input.Item)).toBe(true);
 		});
 	});
@@ -191,9 +195,10 @@ describe("initDynamoDbInboxAddress", () => {
 					return {
 						Items: [
 							{
-								address: "in-3f9a2c@read.place",
+								address: "netflix-a7b2c9@read.place",
 								userId: "user-1",
-								token: "3f9a2c",
+								name: "netflix",
+								token: "a7b2c9",
 								createdAt: "2026-06-20T00:00:00.000Z",
 								disabledAt: null,
 							},
@@ -218,8 +223,11 @@ describe("initDynamoDbInboxAddress", () => {
 			expect(captured?.input.KeyConditionExpression).toBe("userId = :uid");
 			expect(captured?.input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
 			expect(result).toHaveLength(2);
-			expect(result[0].address).toBe("in-3f9a2c@read.place");
+			expect(result[0].address).toBe("netflix-a7b2c9@read.place");
+			expect(result[0].name).toBe("netflix");
 			expect(result[0].disabledAt).toBeUndefined();
+			// A legacy row predating the name column derives its label from the address.
+			expect(result[1].name).toBe("in");
 			expect(result[1].disabledAt).toBe("2026-06-22T00:00:00.000Z");
 		});
 	});
@@ -276,6 +284,8 @@ describe("initDynamoDbInboxAddress", () => {
 			assert(entry, "expected the row to be returned");
 			expect(entry.userId).toBe(USER);
 			expect(entry.address).toBe(address);
+			// The legacy row carries no name column, so the label is derived.
+			expect(entry.name).toBe("in");
 		});
 
 		it("returns undefined for an unknown address", async () => {

--- a/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
+++ b/projects/hutch/src/runtime/providers/inbox-address/dynamodb-inbox-address.ts
@@ -7,12 +7,15 @@ import {
 import { z } from "zod";
 import { UserIdSchema } from "@packages/domain/user";
 import {
+	aliasNameFromAddress,
+	AliasNameSchema,
 	buildInboxAddress,
 	countLiveAddresses,
 	generateInboxToken,
 	INBOX_ADDRESS_MAX_CREATE_ATTEMPTS,
 	INBOX_ADDRESS_MAX_PER_USER,
 	InboxAddressLimitReachedError,
+	type InboxAddressEntry,
 	InboxAddressSchema,
 	type InboxAddressStore,
 	InboxTokenSchema,
@@ -21,10 +24,28 @@ import {
 const InboxAddressRow = z.object({
 	address: InboxAddressSchema,
 	userId: UserIdSchema,
+	// Optional for read-compat with legacy `in-<token>` rows written before the
+	// column existed; always written on new creates. `toEntry` backfills a label
+	// from the address when it is absent.
+	name: dynamoField(AliasNameSchema),
 	token: InboxTokenSchema,
 	createdAt: z.string(),
 	disabledAt: dynamoField(z.string()),
 });
+
+/** The one seam that turns a stored row into a fully-populated entry, deriving
+ * the alias label for a legacy row that predates the `name` column so every
+ * caller sees a labelled address. */
+function toEntry(row: z.infer<typeof InboxAddressRow>): InboxAddressEntry {
+	return {
+		address: row.address,
+		userId: row.userId,
+		name: row.name ?? aliasNameFromAddress(row.address),
+		token: row.token,
+		createdAt: row.createdAt,
+		disabledAt: row.disabledAt,
+	};
+}
 
 export function initDynamoDbInboxAddress(deps: {
 	client: DynamoDBDocumentClient;
@@ -51,11 +72,11 @@ export function initDynamoDbInboxAddress(deps: {
 			KeyConditionExpression: "userId = :uid",
 			ExpressionAttributeValues: { ":uid": userId },
 		});
-		return items;
+		return items.map(toEntry);
 	};
 
 	return {
-		createAddress: async ({ userId, domain }) => {
+		createAddress: async ({ userId, domain, name }) => {
 			// Bound the live addresses a user can hold. disabledAt is not a key
 			// attribute, so the cap is counted in code over the GSI rows rather than
 			// pushed into a COUNT query. The GSI is eventually consistent, so this is a
@@ -69,13 +90,13 @@ export function initDynamoDbInboxAddress(deps: {
 			const createdAt = deps.now().toISOString();
 			for (let attempt = 0; attempt < INBOX_ADDRESS_MAX_CREATE_ATTEMPTS; attempt++) {
 				const token = generateInboxToken();
-				const address = buildInboxAddress({ token, domain });
+				const address = buildInboxAddress({ name, token, domain });
 				try {
 					await table.put({
-						Item: { address, userId, token, createdAt },
+						Item: { address, userId, name, token, createdAt },
 						ConditionExpression: "attribute_not_exists(address)",
 					});
-					return { address, userId, token, createdAt, disabledAt: undefined };
+					return { address, userId, name, token, createdAt, disabledAt: undefined };
 				} catch (error) {
 					if (error instanceof ConditionalCheckFailedException) continue;
 					throw error;
@@ -94,6 +115,9 @@ export function initDynamoDbInboxAddress(deps: {
 				ExpressionAttributeValues: { ":uid": userId, ":now": deps.now().toISOString() },
 			});
 		},
-		findByAddress: async (address) => table.get({ address }),
+		findByAddress: async (address) => {
+			const row = await table.get({ address });
+			return row === undefined ? undefined : toEntry(row);
+		},
 	};
 }

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -127,6 +127,7 @@ import {
 import { QUEUE_PATH } from "./web/pages/queue/queue.url";
 import { initImportSessionRoutes } from "./web/pages/import/import.page";
 import type { ImportSessionStore } from "@packages/domain/import-session";
+import { DEFAULT_INBOX_ALIAS } from "@packages/domain/inbox";
 import type { InboxAddressStore, InboxEmailLinkStore, InboxEmailStore } from "@packages/domain/inbox";
 import type { UserId } from "@packages/domain/user";
 import type { ExtractLinksFromPageUrl } from "@packages/extract-links-from-page";
@@ -750,7 +751,11 @@ export function createApp(dependencies: AppDependencies): Express {
 	 * signup — the inbox page's "Create Inbox Email" CTA is the recovery path. */
 	const provisionInboxAddressOnSignup = async (userId: UserId): Promise<void> => {
 		try {
-			await deps.inboxAddressStore.createAddress({ userId, domain: deps.inboxAddressDomain });
+			await deps.inboxAddressStore.createAddress({
+				userId,
+				domain: deps.inboxAddressDomain,
+				name: DEFAULT_INBOX_ALIAS,
+			});
 		} catch (error) {
 			deps.logError(
 				"[Inbox] Failed to provision a forwarding address at signup",

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import {
+	AliasNameSchema,
 	INBOX_ADDRESS_MAX_PER_USER,
 	type InboxAddressEntry,
 	InboxAddressSchema,
@@ -13,6 +14,7 @@ function entry(overrides: Partial<InboxAddressEntry> = {}): InboxAddressEntry {
 	return {
 		address: InboxAddressSchema.parse("in-3f9a2c@read.place"),
 		userId: UserIdSchema.parse("user-1"),
+		name: AliasNameSchema.parse("in"),
 		token: InboxTokenSchema.parse("3f9a2c"),
 		createdAt: "2026-06-23T00:00:00.000Z",
 		disabledAt: undefined,
@@ -124,6 +126,46 @@ describe("InboxPage", () => {
 			doc.querySelector(".inbox__disable")?.getAttribute("action"),
 			"/inbox/disable?feature=email",
 		);
+	});
+
+	it("renders the chosen alias name as a per-row label", () => {
+		const doc = parse(
+			InboxPage({
+				addresses: [entry({ name: AliasNameSchema.parse("netflix") })],
+				limitReached: false,
+			}).content.html,
+		);
+		const label = doc.querySelector("[data-test-inbox-name]");
+		assert.equal(label?.textContent, "netflix");
+	});
+
+	it("offers a required, length-capped name input on the create form", () => {
+		const doc = parse(InboxPage({ addresses: [], limitReached: false }).content.html);
+		const input = doc.querySelector("[data-test-inbox-name-input]");
+		assert.ok(input, "name input must render");
+		assert.equal(input.getAttribute("name"), "name");
+		assert.equal(input.hasAttribute("required"), true);
+		assert.equal(input.getAttribute("maxlength"), "24");
+	});
+
+	it("shows the invalid-name alert only when nameInvalid is set", () => {
+		const without = parse(InboxPage({ addresses: [], limitReached: false }).content.html);
+		assert.equal(without.querySelector("[data-test-inbox-name-error]"), null);
+
+		const withError = parse(
+			InboxPage({ addresses: [], limitReached: false, nameInvalid: true }).content.html,
+		);
+		assert.ok(withError.querySelector("[data-test-inbox-name-error]"), "invalid-name alert must render");
+	});
+
+	it("shows the duplicate-name alert only when nameTaken is set", () => {
+		const without = parse(InboxPage({ addresses: [], limitReached: false }).content.html);
+		assert.equal(without.querySelector("[data-test-inbox-name-taken]"), null);
+
+		const withError = parse(
+			InboxPage({ addresses: [], limitReached: false, nameTaken: true }).content.html,
+		);
+		assert.ok(withError.querySelector("[data-test-inbox-name-taken]"), "duplicate-name alert must render");
 	});
 
 	it("shows the per-user limit message naming the cap only when the limit is reached", () => {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
@@ -16,13 +16,18 @@ const INBOX_QUERY = `?feature=${EMAIL_FEATURE}`;
 export function InboxPage(params: {
 	addresses: InboxAddressEntry[];
 	createFailed?: boolean;
+	nameInvalid?: boolean;
+	nameTaken?: boolean;
 	limitReached: boolean;
 }): PageBody {
 	const content = render(INBOX_TEMPLATE, {
 		createFailed: params.createFailed === true,
+		nameInvalid: params.nameInvalid === true,
+		nameTaken: params.nameTaken === true,
 		hasAddresses: params.addresses.length > 0,
 		addresses: params.addresses.map((entry) => ({
 			address: entry.address,
+			name: entry.name,
 			enabled: entry.disabledAt === undefined,
 		})),
 		limitReached: params.limitReached,

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -9,6 +9,8 @@ import {
 	INBOX_ADDRESS_MAX_PER_USER,
 	InboxAddressLimitReachedError,
 	InboxAddressSchema,
+	isLiveAddress,
+	normalizeAliasName,
 } from "@packages/domain/inbox";
 import type {
 	InboxAddressStore,
@@ -55,6 +57,7 @@ interface InboxDependencies {
 }
 
 const DisableAddressSchema = z.object({ address: InboxAddressSchema });
+const CreateAddressSchema = z.object({ name: z.string() });
 
 export function initInboxRoutes(deps: InboxDependencies): Router {
 	const router = express.Router();
@@ -99,6 +102,8 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const addresses = await deps.inboxAddressStore.listAddressesByUserId(req.userId);
 		const createFailed = req.query.error === "create";
+		const nameInvalid = req.query.error === "name";
+		const nameTaken = req.query.error === "name-taken";
 		// Banner shows whenever the cap is genuinely reached, not only after a
 		// rejected create. &error=limit stays OR'd in so a just-rejected create
 		// still shows it even when the eventually-consistent live read
@@ -108,7 +113,10 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 		sendComponent(
 			req,
 			res,
-			Base(InboxPage({ addresses, createFailed, limitReached }), await deps.buildBannerState(req)),
+			Base(
+				InboxPage({ addresses, createFailed, nameInvalid, nameTaken, limitReached }),
+				await deps.buildBannerState(req),
+			),
 		);
 	});
 
@@ -228,10 +236,28 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 
 	router.post("/create", deps.requireNotLocked, deps.requireWriteAccess, async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
+		const userId = req.userId;
+		const parsed = CreateAddressSchema.safeParse(req.body);
+		const name = parsed.success ? normalizeAliasName(parsed.data.name) : undefined;
+		if (name === undefined) {
+			res.redirect(303, `${addressesPath}&error=name`);
+			return;
+		}
+		// Soft duplicate guard: reject a name the user already holds on a live
+		// address so two of their newsletters don't share a label. Best-effort like
+		// the per-user cap — the eventually-consistent list read can miss a
+		// just-minted row — so a rare racing pair may both land; harmless, since the
+		// random token still keeps the two addresses distinct.
+		const owned = await deps.inboxAddressStore.listAddressesByUserId(userId);
+		if (owned.some((entry) => isLiveAddress(entry) && entry.name === name)) {
+			res.redirect(303, `${addressesPath}&error=name-taken`);
+			return;
+		}
 		try {
 			await deps.inboxAddressStore.createAddress({
-				userId: req.userId,
+				userId,
 				domain: deps.inboxAddressDomain,
+				name,
 			});
 		} catch (error) {
 			// Hitting the per-user cap is expected user behaviour, not a fault — echo

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import request from "supertest";
-import { INBOX_ADDRESS_MAX_PER_USER } from "@packages/domain/inbox";
+import { AliasNameSchema, INBOX_ADDRESS_MAX_PER_USER } from "@packages/domain/inbox";
 import type { UserId } from "@packages/domain/user";
 import { loginAgent, useTestServer } from "../../../test-app";
 
@@ -34,13 +34,19 @@ function addressFieldValue(html: string): string | null | undefined {
 		?.getAttribute("value");
 }
 
+const SEED_NAME = AliasNameSchema.parse("inbox");
+
 /** Mints live addresses through the real store until the user sits exactly at the
  * per-user cap, so the next create is rejected the way production rejects it (the
  * in-memory fixture faithfully throws at the limit) instead of by stubbing the
  * throw. */
 async function seedAddressesToCap(fixture: TestAppFixture, userId: UserId): Promise<void> {
 	for (let i = 0; i < INBOX_ADDRESS_MAX_PER_USER; i++) {
-		await fixture.inboxAddress.inboxAddressStore.createAddress({ userId, domain: "read.place" });
+		await fixture.inboxAddress.inboxAddressStore.createAddress({
+			userId,
+			domain: "read.place",
+			name: SEED_NAME,
+		});
 	}
 }
 
@@ -104,16 +110,116 @@ describe("Inbox address routes", () => {
 	});
 
 	describe("POST /inbox/create", () => {
-		it("creates an address and surfaces it on the next visit to the addresses page", async () => {
+		it("creates a named address and surfaces it on the next visit to the addresses page", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
 
-			const created = await agent.post("/inbox/create?feature=email");
+			const created = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "Netflix" });
 			expect(created.status).toBe(303);
 			expect(created.headers.location).toBe("/inbox/addresses?feature=email");
 
 			const listed = await agent.get("/inbox/addresses?feature=email");
-			expect(addressFieldValue(listed.text)).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+			expect(addressFieldValue(listed.text)).toMatch(/^netflix-[0-9a-z]{6}@read\.place$/);
+			const doc = new JSDOM(listed.text).window.document;
+			expect(doc.querySelector("[data-test-inbox-name]")?.textContent).toBe("netflix");
+		});
+
+		it("redirects with error=name when the submitted name has no valid characters", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "🎉🎉" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses?feature=email&error=name");
+			const listed = await agent.get("/inbox/addresses?feature=email");
+			expect(addressFieldValue(listed.text)).toBeUndefined();
+		});
+
+		it("redirects with error=name when the name field is missing entirely", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.post("/inbox/create?feature=email");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses?feature=email&error=name");
+		});
+
+		it("surfaces the invalid-name alert on the redirect target", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const landing = await agent.get("/inbox/addresses?feature=email&error=name");
+
+			expect(
+				new JSDOM(landing.text).window.document.querySelector("[data-test-inbox-name-error]"),
+			).not.toBeNull();
+		});
+
+		it("rejects a name the user already holds on a live address with error=name-taken", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
+
+			const dup = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "Netflix" });
+
+			expect(dup.status).toBe(303);
+			expect(dup.headers.location).toBe("/inbox/addresses?feature=email&error=name-taken");
+			const doc = new JSDOM(
+				(await agent.get("/inbox/addresses?feature=email&error=name-taken")).text,
+			).window.document;
+			expect(doc.querySelector("[data-test-inbox-name-taken]")).not.toBeNull();
+			// Only the first address was minted — the duplicate did not create a second.
+			expect(doc.querySelectorAll("[data-test-inbox-item]")).toHaveLength(1);
+		});
+
+		it("allows a second live address under a different name", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
+
+			const second = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "gmail" });
+
+			expect(second.status).toBe(303);
+			expect(second.headers.location).toBe("/inbox/addresses?feature=email");
+			const names = Array.from(
+				new JSDOM(
+					(await agent.get("/inbox/addresses?feature=email")).text,
+				).window.document.querySelectorAll("[data-test-inbox-name]"),
+			).map((el) => el.textContent);
+			expect(names).toEqual(["netflix", "gmail"]);
+		});
+
+		it("allows reusing the name of a disabled address, since the guard only blocks live ones", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
+			const first = addressFieldValue((await agent.get("/inbox/addresses?feature=email")).text);
+			await agent
+				.post("/inbox/disable?feature=email")
+				.type("form")
+				.send({ address: first ?? "" });
+
+			const recreated = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "netflix" });
+
+			expect(recreated.status).toBe(303);
+			expect(recreated.headers.location).toBe("/inbox/addresses?feature=email");
 		});
 
 		it("returns 404 without the feature flag", async () => {
@@ -169,7 +275,12 @@ describe("Inbox address routes", () => {
 			assert(userId, "seeded login user must exist");
 			await seedAddressesToCap(fixture, userId);
 
-			const response = await agent.post("/inbox/create?feature=email");
+			// A fresh name (the seeded rows are all "inbox") so the cap — not the
+			// duplicate-name guard — is what rejects this create.
+			const response = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "overflow" });
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/inbox/addresses?feature=email&error=limit");
@@ -192,7 +303,10 @@ describe("Inbox address routes", () => {
 			const harness = useApp(fixture);
 			const agent = await loginAgent(harness.server, harness.auth);
 
-			const response = await agent.post("/inbox/create?feature=email");
+			const response = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "netflix" });
 
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/inbox/addresses?feature=email&error=create");
@@ -208,7 +322,10 @@ describe("Inbox address routes", () => {
 			const harness = useApp(fixture);
 			const agent = await loginAgent(harness.server, harness.auth);
 
-			const created = await agent.post("/inbox/create?feature=email");
+			const created = await agent
+				.post("/inbox/create?feature=email")
+				.type("form")
+				.send({ name: "netflix" });
 			const landing = await agent.get(created.headers.location);
 
 			expect(landing.status).toBe(200);
@@ -233,7 +350,7 @@ describe("Inbox address routes", () => {
 		it("disables an address the user owns", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
-			await agent.post("/inbox/create?feature=email");
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
 			const address = addressFieldValue(
 				(await agent.get("/inbox/addresses?feature=email")).text,
 			);
@@ -255,7 +372,7 @@ describe("Inbox address routes", () => {
 		it("ignores a request whose body is not a valid address", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
-			await agent.post("/inbox/create?feature=email");
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
 
 			const response = await agent
 				.post("/inbox/disable?feature=email")
@@ -272,7 +389,7 @@ describe("Inbox address routes", () => {
 		it("does not disable an address the user does not own", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const agent = await loginAgent(harness.server, harness.auth);
-			await agent.post("/inbox/create?feature=email");
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
 
 			const response = await agent
 				.post("/inbox/disable?feature=email")

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
@@ -51,6 +51,13 @@
   background: var(--card);
 }
 
+.inbox__name {
+  flex: 1 1 100%;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
 .inbox__address-field {
   flex: 1 1 200px;
   min-width: 0;
@@ -122,6 +129,32 @@
 
 .inbox__create {
   margin: 0 0 32px;
+}
+
+.inbox__create-label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--foreground);
+  margin: 0 0 8px;
+}
+
+.inbox__create-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.inbox__name-input {
+  flex: 1 1 200px;
+  min-width: 0;
+  padding: 8px 12px;
+  font-size: 0.95rem;
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 
 .inbox__create-btn {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
@@ -8,10 +8,19 @@
       <p class="inbox__error" role="alert" data-test-inbox-error>We couldn't create a forwarding address just now. Please try again in a moment.</p>
       {{/if}}
 
+      {{#if nameInvalid}}
+      <p class="inbox__error" role="alert" data-test-inbox-name-error>Give the address a name using letters and numbers — for example, netflix.</p>
+      {{/if}}
+
+      {{#if nameTaken}}
+      <p class="inbox__error" role="alert" data-test-inbox-name-taken>You already have an active address with that name. Pick a different one.</p>
+      {{/if}}
+
       {{#if hasAddresses}}
       <ul class="inbox__list" data-test-inbox-list>
         {{#each addresses}}
         <li class="inbox__item" data-test-inbox-item>
+          <span class="inbox__name" data-test-inbox-name>{{this.name}}</span>
           {{#if this.enabled}}
           <input class="inbox__address-field" type="text" value="{{this.address}}" readonly aria-label="Forwarding address" data-inbox-address="{{this.address}}" />
           <button type="button" class="inbox__copy-btn" data-inbox-copy data-inbox-address="{{this.address}}" hidden>Copy</button>
@@ -36,7 +45,11 @@
       {{/if}}
 
       <form action="{{createAction}}" method="POST" class="inbox__create">
-        <button type="submit" class="inbox__create-btn" data-test-inbox-create>Create Inbox Email</button>
+        <label class="inbox__create-label" for="inbox-name">Name this address</label>
+        <div class="inbox__create-row">
+          <input class="inbox__name-input" id="inbox-name" name="name" type="text" required maxlength="24" pattern="[A-Za-z0-9 -]+" placeholder="e.g. netflix" autocomplete="off" data-test-inbox-name-input />
+          <button type="submit" class="inbox__create-btn" data-test-inbox-create>Create Inbox Email</button>
+        </div>
       </form>
 
       <section class="inbox__instructions">

--- a/src/packages/domain/src/inbox/inbox-address.live.test.ts
+++ b/src/packages/domain/src/inbox/inbox-address.live.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
 import { UserIdSchema } from "../user";
 import { countLiveAddresses, isLiveAddress } from "./inbox-address.live";
-import { buildInboxAddress, generateInboxToken } from "./inbox-address.schema";
+import { AliasNameSchema, buildInboxAddress, generateInboxToken } from "./inbox-address.schema";
 import type { InboxAddressEntry } from "./inbox-address.types";
+
+const NAME = AliasNameSchema.parse("news");
 
 function makeEntry(disabledAt: string | undefined): InboxAddressEntry {
 	const token = generateInboxToken();
 	return {
-		address: buildInboxAddress({ token, domain: "read.place" }),
+		address: buildInboxAddress({ name: NAME, token, domain: "read.place" }),
 		userId: UserIdSchema.parse("user-1"),
+		name: NAME,
 		token,
 		createdAt: "2026-01-01T00:00:00.000Z",
 		disabledAt,

--- a/src/packages/domain/src/inbox/inbox-address.schema.ts
+++ b/src/packages/domain/src/inbox/inbox-address.schema.ts
@@ -13,11 +13,26 @@ export const InboxTokenSchema = z
 
 export type InboxToken = z.infer<typeof InboxTokenSchema>;
 
-/** A full forwarding address, `in-<token>@<domain>`. Branded so a raw string
- * can't stand in for one without passing through the parser. */
+/** The user-chosen label in a forwarding address — the human-readable prefix in
+ * `<alias>-<token>@<domain>` (e.g. `netflix` in `netflix-a7b2c9@read.place`).
+ * Lowercase alphanumerics with single internal hyphens (no leading, trailing, or
+ * doubled hyphen), 1–24 chars. Kept email-safe so it reads cleanly as a local
+ * part and can never smuggle a second `@` or `.` into the address. */
+export const AliasNameSchema = z
+	.string()
+	.regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+	.max(24)
+	.brand<"AliasName">();
+
+export type AliasName = z.infer<typeof AliasNameSchema>;
+
+/** A full forwarding address, `<alias>-<token>@<domain>`. Branded so a raw
+ * string can't stand in for one without passing through the parser. The trailing
+ * `-<token>` is the six-char random suffix by construction, so an address is a
+ * strict generalization of the legacy `in-<token>` form (alias = `in`). */
 export const InboxAddressSchema = z
 	.string()
-	.regex(/^in-[0-9a-z]{6}@[a-z0-9.-]+$/)
+	.regex(/^[a-z0-9]+(?:-[a-z0-9]+)*-[0-9a-z]{6}@[a-z0-9.-]+$/)
 	.brand<"InboxAddress">();
 
 export type InboxAddress = z.infer<typeof InboxAddressSchema>;
@@ -59,6 +74,40 @@ export function generateInboxToken(): InboxToken {
 	return InboxTokenSchema.parse(chars.join(""));
 }
 
-export function buildInboxAddress(input: { token: InboxToken; domain: string }): InboxAddress {
-	return InboxAddressSchema.parse(`in-${input.token}@${input.domain}`);
+export function buildInboxAddress(input: {
+	name: AliasName;
+	token: InboxToken;
+	domain: string;
+}): InboxAddress {
+	return InboxAddressSchema.parse(`${input.name}-${input.token}@${input.domain}`);
 }
+
+/** Recover the alias label from a stored address. Used to backfill a label for a
+ * legacy `in-<token>` row written before the `name` column existed. The address
+ * is `<alias>-<token>@…` by construction (guaranteed by {@link
+ * InboxAddressSchema}), so the label is the local part with the trailing
+ * `-<token>` removed. */
+export function aliasNameFromAddress(address: InboxAddress): AliasName {
+	const localPart = address.slice(0, address.indexOf("@"));
+	return AliasNameSchema.parse(localPart.slice(0, localPart.lastIndexOf("-")));
+}
+
+/** The single normalization seam for a user-typed alias. Lowercases, collapses
+ * every run of non-alphanumerics to one hyphen, truncates to the max length, and
+ * trims leading/trailing hyphens, then validates. Returns `undefined` when no
+ * valid label survives (empty, whitespace-only, or emoji-only input) so callers
+ * can reject rather than mint a nameless address. */
+export function normalizeAliasName(raw: string): AliasName | undefined {
+	const normalized = raw
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.slice(0, 24)
+		.replace(/^-+|-+$/g, "");
+	const parsed = AliasNameSchema.safeParse(normalized);
+	return parsed.success ? parsed.data : undefined;
+}
+
+/** The alias every account's first forwarding address is minted under at signup,
+ * so a brand-new user lands on `inbox-<token>@…` without having to name one. */
+export const DEFAULT_INBOX_ALIAS: AliasName = AliasNameSchema.parse("inbox");

--- a/src/packages/domain/src/inbox/inbox-address.test.ts
+++ b/src/packages/domain/src/inbox/inbox-address.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import {
+	aliasNameFromAddress,
+	AliasNameSchema,
 	buildInboxAddress,
+	DEFAULT_INBOX_ALIAS,
 	generateInboxToken,
 	INBOX_ADDRESS_MAX_PER_USER,
 	INBOX_TOKEN_LENGTH,
 	InboxAddressLimitReachedError,
+	InboxAddressSchema,
 	InboxTokenSchema,
+	normalizeAliasName,
 } from "./inbox-address.schema";
 
 describe("generateInboxToken", () => {
@@ -21,26 +26,125 @@ describe("generateInboxToken", () => {
 	});
 });
 
+describe("AliasNameSchema", () => {
+	it("accepts a lowercase alphanumeric label with single internal hyphens", () => {
+		for (const value of ["netflix", "in", "my-newsletter", "abc123", "a1-b2-c3"]) {
+			assert.equal(AliasNameSchema.parse(value), value);
+		}
+	});
+
+	it("rejects labels that break the local-part rules", () => {
+		for (const value of [
+			"", // empty
+			"-lead", // leading hyphen
+			"trail-", // trailing hyphen
+			"double--hyphen", // doubled hyphen
+			"Upper", // uppercase
+			"has space", // whitespace
+			"emoji🎉", // non-alphanumeric
+			"a".repeat(25), // over the 24-char cap
+		]) {
+			assert.equal(AliasNameSchema.safeParse(value).success, false, value);
+		}
+	});
+});
+
+describe("InboxAddressSchema", () => {
+	it("accepts the new <alias>-<token> shape", () => {
+		assert.equal(
+			InboxAddressSchema.parse("netflix-a7b2c9@read.place"),
+			"netflix-a7b2c9@read.place",
+		);
+		assert.equal(
+			InboxAddressSchema.parse("my-newsletter-a7b2c9@read.place"),
+			"my-newsletter-a7b2c9@read.place",
+		);
+	});
+
+	it("still accepts the legacy in-<token> shape (alias = in)", () => {
+		assert.equal(InboxAddressSchema.parse("in-3f9a2c@read.place"), "in-3f9a2c@read.place");
+	});
+
+	it("rejects an address without the trailing six-char token", () => {
+		assert.equal(InboxAddressSchema.safeParse("netflix@read.place").success, false);
+	});
+});
+
+describe("DEFAULT_INBOX_ALIAS", () => {
+	it("is a valid alias so signup can mint inbox-<token>@…", () => {
+		assert.equal(DEFAULT_INBOX_ALIAS, "inbox");
+		assert.equal(AliasNameSchema.safeParse(DEFAULT_INBOX_ALIAS).success, true);
+	});
+});
+
+describe("normalizeAliasName", () => {
+	it("lowercases and keeps an already-clean label", () => {
+		assert.equal(normalizeAliasName("Netflix"), "netflix");
+	});
+
+	it("collapses runs of non-alphanumerics to a single hyphen and trims the edges", () => {
+		assert.equal(normalizeAliasName("  My   Newsletter!!  "), "my-newsletter");
+		assert.equal(normalizeAliasName("--weird__name--"), "weird-name");
+	});
+
+	it("truncates to the 24-char cap without leaving a trailing hyphen", () => {
+		const result = normalizeAliasName("a".repeat(30));
+		assert.equal(result, "a".repeat(24));
+		// A run whose truncation boundary lands on a hyphen still yields a clean label.
+		assert.equal(normalizeAliasName(`${"a".repeat(23)} tail`), "a".repeat(23));
+	});
+
+	it("returns undefined when nothing valid survives", () => {
+		assert.equal(normalizeAliasName(""), undefined);
+		assert.equal(normalizeAliasName("   "), undefined);
+		assert.equal(normalizeAliasName("🎉🎉"), undefined);
+	});
+});
+
 describe("buildInboxAddress", () => {
-	it("composes the local-part prefix, token, and domain into an address", () => {
+	it("composes the alias name, token, and domain into an address", () => {
+		const name = AliasNameSchema.parse("netflix");
 		const token = InboxTokenSchema.parse("3f9a2c");
 		assert.equal(
-			buildInboxAddress({ token, domain: "read.place" }),
-			"in-3f9a2c@read.place",
+			buildInboxAddress({ name, token, domain: "read.place" }),
+			"netflix-3f9a2c@read.place",
 		);
 	});
 
 	it("uses the supplied domain so per-environment domains render correctly", () => {
+		const name = AliasNameSchema.parse("in");
 		const token = InboxTokenSchema.parse("abc123");
 		assert.equal(
-			buildInboxAddress({ token, domain: "staging.read.place" }),
+			buildInboxAddress({ name, token, domain: "staging.read.place" }),
 			"in-abc123@staging.read.place",
 		);
 	});
 
 	it("accepts a freshly generated token", () => {
-		const address = buildInboxAddress({ token: generateInboxToken(), domain: "read.place" });
-		assert.match(address, /^in-[0-9a-z]{6}@read\.place$/);
+		const address = buildInboxAddress({
+			name: DEFAULT_INBOX_ALIAS,
+			token: generateInboxToken(),
+			domain: "read.place",
+		});
+		assert.match(address, /^inbox-[0-9a-z]{6}@read\.place$/);
+	});
+});
+
+describe("aliasNameFromAddress", () => {
+	it("recovers the alias from a new multi-segment address", () => {
+		const address = InboxAddressSchema.parse("my-newsletter-a7b2c9@read.place");
+		assert.equal(aliasNameFromAddress(address), "my-newsletter");
+	});
+
+	it("recovers the label from a legacy in-<token> address", () => {
+		const address = InboxAddressSchema.parse("in-3f9a2c@read.place");
+		assert.equal(aliasNameFromAddress(address), "in");
+	});
+
+	it("round-trips with buildInboxAddress", () => {
+		const name = AliasNameSchema.parse("netflix");
+		const token = InboxTokenSchema.parse("3f9a2c");
+		assert.equal(aliasNameFromAddress(buildInboxAddress({ name, token, domain: "read.place" })), name);
 	});
 });
 

--- a/src/packages/domain/src/inbox/inbox-address.types.ts
+++ b/src/packages/domain/src/inbox/inbox-address.types.ts
@@ -1,25 +1,35 @@
 import type { UserId } from "../user";
-import type { InboxAddress, InboxToken } from "./inbox-address.schema";
+import type { AliasName, InboxAddress, InboxToken } from "./inbox-address.schema";
 
 /** One forwarding address owned by a user. Addresses are never deleted — a hash
  * that was once minted for one user must never be re-mintable for another, or
  * their forwarded mail could leak — so disabling sets `disabledAt` and the row
- * stays. `disabledAt === undefined` means the address is live. */
+ * stays. `disabledAt === undefined` means the address is live. `name` is the
+ * user-chosen label (the alias prefix); for a legacy `in-<token>` row minted
+ * before the column existed it is derived from the address on read. */
 export interface InboxAddressEntry {
 	address: InboxAddress;
 	userId: UserId;
+	name: AliasName;
 	token: InboxToken;
 	createdAt: string;
 	disabledAt: string | undefined;
 }
 
 export interface InboxAddressStore {
-	/** Mints a fresh address for the user. A user may hold many (one per
-	 * newsletter) up to `INBOX_ADDRESS_MAX_PER_USER`; at the cap it throws
-	 * `InboxAddressLimitReachedError` so callers can surface a friendly limit
-	 * message. Guards global uniqueness with a conditional put + bounded retry;
-	 * throws on retry exhaustion so the failure surfaces to alerting. */
-	createAddress: (input: { userId: UserId; domain: string }) => Promise<InboxAddressEntry>;
+	/** Mints a fresh address for the user under the chosen alias `name`. A user
+	 * may hold many (one per newsletter) up to `INBOX_ADDRESS_MAX_PER_USER`; at
+	 * the cap it throws `InboxAddressLimitReachedError` so callers can surface a
+	 * friendly limit message. Only the random token is regenerated on collision,
+	 * so global uniqueness of the full address is guarded with a conditional put +
+	 * bounded retry; throws on retry exhaustion so the failure surfaces to
+	 * alerting. Two users may hold the same `name` — the token keeps their
+	 * addresses distinct. */
+	createAddress: (input: {
+		userId: UserId;
+		domain: string;
+		name: AliasName;
+	}) => Promise<InboxAddressEntry>;
 	/** Every address the user owns (1:N). The production adapter reads a DynamoDB
 	 * GSI, which is eventually consistent — an address created moments earlier may
 	 * be absent from the result — so callers must not assume read-your-write. The

--- a/src/packages/domain/src/inbox/index.ts
+++ b/src/packages/domain/src/inbox/index.ts
@@ -3,14 +3,19 @@ export { countLiveAddresses, isLiveAddress } from "./inbox-address.live";
 export {
 	InboxTokenSchema,
 	type InboxToken,
+	AliasNameSchema,
+	type AliasName,
 	InboxAddressSchema,
 	type InboxAddress,
 	INBOX_TOKEN_LENGTH,
 	INBOX_ADDRESS_MAX_CREATE_ATTEMPTS,
 	INBOX_ADDRESS_MAX_PER_USER,
+	DEFAULT_INBOX_ALIAS,
 	InboxAddressLimitReachedError,
 	generateInboxToken,
 	buildInboxAddress,
+	aliasNameFromAddress,
+	normalizeAliasName,
 } from "./inbox-address.schema";
 export type { InboxEmailEntry, InboxEmailStore } from "./inbox-email.types";
 export {

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { ConditionalCheckFailedException } from "@packages/hutch-storage-client";
 import { UserIdSchema } from "@packages/domain/user";
 import {
+	AliasNameSchema,
 	INBOX_ADDRESS_MAX_PER_USER,
 	InboxAddressLimitReachedError,
 	InboxAddressSchema,
@@ -11,6 +12,7 @@ import { initInMemoryInboxAddress } from "./in-memory-inbox-address";
 const owner = UserIdSchema.parse("00000000000000000000000000000001");
 const otherUser = UserIdSchema.parse("00000000000000000000000000000002");
 const DOMAIN = "read.place";
+const NAME = AliasNameSchema.parse("news");
 
 describe("initInMemoryInboxAddress", () => {
 	it("creates an enabled address scoped to the owner", async () => {
@@ -18,19 +20,32 @@ describe("initInMemoryInboxAddress", () => {
 			now: () => new Date("2026-06-23T00:00:00.000Z"),
 		});
 
-		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 
-		expect(entry.address).toMatch(/^in-[0-9a-z]{6}@read\.place$/);
+		expect(entry.address).toMatch(/^news-[0-9a-z]{6}@read\.place$/);
 		expect(entry.userId).toBe(owner);
+		expect(entry.name).toBe(NAME);
 		expect(entry.createdAt).toBe("2026-06-23T00:00:00.000Z");
 		expect(entry.disabledAt).toBeUndefined();
 	});
 
+	it("persists the chosen name and surfaces it through list and find", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		const created = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
+
+		const [listed] = await store.listAddressesByUserId(owner);
+		const found = await store.findByAddress(created.address);
+
+		expect(listed.name).toBe(NAME);
+		assert(found, "expected the created address to resolve");
+		expect(found.name).toBe(NAME);
+	});
+
 	it("lists only the requesting user's addresses", async () => {
 		const store = initInMemoryInboxAddress({ now: () => new Date() });
-		await store.createAddress({ userId: owner, domain: DOMAIN });
-		await store.createAddress({ userId: owner, domain: DOMAIN });
-		await store.createAddress({ userId: otherUser, domain: DOMAIN });
+		await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
+		await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
+		await store.createAddress({ userId: otherUser, domain: DOMAIN, name: NAME });
 
 		const ownerAddresses = await store.listAddressesByUserId(owner);
 		const otherAddresses = await store.listAddressesByUserId(otherUser);
@@ -42,38 +57,38 @@ describe("initInMemoryInboxAddress", () => {
 	it("throws InboxAddressLimitReachedError once the user holds the per-user cap of live addresses", async () => {
 		const store = initInMemoryInboxAddress({ now: () => new Date() });
 		for (let i = 0; i < INBOX_ADDRESS_MAX_PER_USER; i++) {
-			await store.createAddress({ userId: owner, domain: DOMAIN });
+			await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 		}
 
-		await expect(store.createAddress({ userId: owner, domain: DOMAIN })).rejects.toThrow(
+		await expect(store.createAddress({ userId: owner, domain: DOMAIN, name: NAME })).rejects.toThrow(
 			InboxAddressLimitReachedError,
 		);
 		// The cap is per-user: a different user is unaffected.
 		await expect(
-			store.createAddress({ userId: otherUser, domain: DOMAIN }),
+			store.createAddress({ userId: otherUser, domain: DOMAIN, name: NAME }),
 		).resolves.toBeDefined();
 	});
 
 	it("frees a slot when a live address is disabled, since only live addresses count toward the cap", async () => {
 		const store = initInMemoryInboxAddress({ now: () => new Date() });
-		const first = await store.createAddress({ userId: owner, domain: DOMAIN });
+		const first = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 		for (let i = 1; i < INBOX_ADDRESS_MAX_PER_USER; i++) {
-			await store.createAddress({ userId: owner, domain: DOMAIN });
+			await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 		}
-		await expect(store.createAddress({ userId: owner, domain: DOMAIN })).rejects.toThrow(
+		await expect(store.createAddress({ userId: owner, domain: DOMAIN, name: NAME })).rejects.toThrow(
 			InboxAddressLimitReachedError,
 		);
 
 		await store.disableAddress({ userId: owner, address: first.address });
 
-		await expect(store.createAddress({ userId: owner, domain: DOMAIN })).resolves.toBeDefined();
+		await expect(store.createAddress({ userId: owner, domain: DOMAIN, name: NAME })).resolves.toBeDefined();
 	});
 
 	it("disables an owned address by stamping disabledAt", async () => {
 		const store = initInMemoryInboxAddress({
 			now: () => new Date("2026-06-23T12:00:00.000Z"),
 		});
-		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 
 		await store.disableAddress({ userId: owner, address: entry.address });
 
@@ -94,7 +109,7 @@ describe("initInMemoryInboxAddress", () => {
 
 	it("rejects a disable requested by a non-owner", async () => {
 		const store = initInMemoryInboxAddress({ now: () => new Date() });
-		const entry = await store.createAddress({ userId: owner, domain: DOMAIN });
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 
 		await expect(
 			store.disableAddress({ userId: otherUser, address: entry.address }),
@@ -108,7 +123,7 @@ describe("initInMemoryInboxAddress", () => {
 		const store = initInMemoryInboxAddress({
 			now: () => new Date("2026-06-23T00:00:00.000Z"),
 		});
-		const created = await store.createAddress({ userId: owner, domain: DOMAIN });
+		const created = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 
 		const found = await store.findByAddress(created.address);
 
@@ -128,7 +143,7 @@ describe("initInMemoryInboxAddress", () => {
 		const store = initInMemoryInboxAddress({
 			now: () => new Date("2026-06-23T12:00:00.000Z"),
 		});
-		const created = await store.createAddress({ userId: owner, domain: DOMAIN });
+		const created = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
 		await store.disableAddress({ userId: owner, address: created.address });
 
 		const found = await store.findByAddress(created.address);

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
@@ -13,7 +13,7 @@ export function initInMemoryInboxAddress(deps: { now: () => Date }): InboxAddres
 	const rows = new Map<string, InboxAddressEntry>();
 
 	return {
-		createAddress: async ({ userId, domain }) => {
+		createAddress: async ({ userId, domain, name }) => {
 			const live = [...rows.values()].filter(
 				(row) => row.userId === userId && isLiveAddress(row),
 			);
@@ -21,10 +21,11 @@ export function initInMemoryInboxAddress(deps: { now: () => Date }): InboxAddres
 				throw new InboxAddressLimitReachedError(INBOX_ADDRESS_MAX_PER_USER);
 			}
 			const token = generateInboxToken();
-			const address = buildInboxAddress({ token, domain });
+			const address = buildInboxAddress({ name, token, domain });
 			const entry: InboxAddressEntry = {
 				address,
 				userId,
+				name,
 				token,
 				createdAt: deps.now().toISOString(),
 				disabledAt: undefined,


### PR DESCRIPTION
## What & why

Forwarding addresses were an opaque `in-<token>@read.place`. This adds a **user-chosen alias** so each address reads like `netflix-a7b2c9@read.place` — hand a differently-named one to each newsletter, and disable any that starts getting spam. "Different address per newsletter" and one-way disable already existed; the only real gap was that the local part couldn't be named.

The address shape `<alias>-<token>@read.place` keeps the 6-char random token, so addresses stay **unguessable** (no spam harvesting) and **per-user** (two users can both hold `netflix-…`).

## Approach

The alias is a strict generalization of the legacy `in-<token>` format (alias = `in`), so nothing about routing changes:

- The **full address remains the DynamoDB partition key**; the receive path keeps doing an exact-match `findByAddress`. The alias is never parsed back out.
- The alias is stored as its own `name` attribute (a non-key column — no infra change; the `userId-index` GSI already projects `ALL`). It's optional on read so **legacy `in-<token>` rows still work**, with the label derived from the address when the column is absent.
- The create loop still regenerates **only the token** on collision — same conditional-put + bounded-retry uniqueness logic.
- Disable stays one-way; the feature stays behind the `email` flag.

## Changes

- **Domain** (`inbox-address.schema.ts`): `AliasNameSchema` + `normalizeAliasName` (the single normalization seam), `aliasNameFromAddress` (legacy back-fill), `DEFAULT_INBOX_ALIAS`. Widened `InboxAddressSchema` to `<alias>-<token>@…` (backward-compatible). `buildInboxAddress` and `InboxAddressEntry` gain a `name`.
- **Stores**: both adapters persist and return `name`; the DynamoDB adapter derives a label for rows predating the column via a single `toEntry` seam.
- **Web** (`inbox.page.ts` + component/template/styles): the create form takes a required, length-capped name input; `POST /create` zod-validates and normalizes it, redirecting `&error=name` for invalid input and `&error=name-taken` for a live duplicate (soft guard). Each row renders its alias label. The existing copy widget is reused unchanged.
- **Signup**: provisions each new account's first address under the `inbox` alias (`inbox-<token>@…`).

## Testing

- Domain unit tests: new + legacy address shapes, `normalizeAliasName` (incl. reject-to-`undefined`), `buildInboxAddress`, `aliasNameFromAddress` round-trip.
- Store tests: `name` persisted/returned; DynamoDB legacy-row label derivation.
- Web integration (`inbox.route.test.ts`): create-with-name renders `<name>-<token>@…` and shows the label; invalid → `error=name`; live duplicate → `error=name-taken`; disabled-name reuse allowed; distinct second name allowed; cap + locked/read-only gates still behave.
- Component tests: name label, name input, and both error alerts render.
- `pnpm check` passes across all projects at the 100% coverage gate. No E2E (alias CRUD belongs in route tests per `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Te2q1hP1jCGE5DnQFa4VYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te2q1hP1jCGE5DnQFa4VYT)_