### PR TITLE
fix(ios-auth): reliably reuse Chrome web session on login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ Workflow for a canary failure:
 3. Re-run the canary locally until the failing source passes — never commit until it does.
 4. Only then push and watch CI.
 
+### iOS login is Chrome-first
+
+When the iOS app opens the browser to log in, it must reuse the user's existing **Chrome** web session — most users browse in Chrome but never change the iOS default-browser setting, so their OS default stays **Safari**, where they are not signed in. The app therefore opens the authorize URL via Chrome's `googlechromes://` scheme ([`openAuthorizeURLChromeFirst`](./projects/ios-readplace/App/WebAuthOpeners.swift)) and must **not** fall back to the OS default browser when Chrome is installed — the fallback fires only when the system reports Chrome can't be opened (not installed). Do not reintroduce a `canOpenURL` pre-check to decide the browser (a false-negative probe silently routes login into Safari and regresses session reuse); let the actual open result decide. Reuse also depends on the `hutch_sid` session cookie being **persistent** — it carries `maxAge: SESSION_COOKIE_MAX_AGE_MS` (bounded by the server session TTL) so a Chrome login survives Chrome fully closing; do not downgrade it back to a bare session cookie.
+
 ## Architecture Guidelines
 
 ### Brand & Design Guidelines

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -51,7 +51,7 @@ import { LoginSchema } from "./auth.schema";
 import { LoginPage, SignupPage, VerifyEmailPage } from "./auth.component";
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
 import { baseCookieOptions } from "../cookie-options";
-import { SESSION_COOKIE_NAME } from "@packages/web-session";
+import { SESSION_COOKIE_MAX_AGE_MS, SESSION_COOKIE_NAME } from "@packages/web-session";
 import { buildVerificationEmailHtml } from "./verification-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 import { initFetchUserCount } from "./fetch-user-count";
@@ -112,7 +112,7 @@ interface AuthDependencies {
 
 export function initAuthRoutes(deps: AuthDependencies): Router {
 	const router = express.Router();
-	const sessionCookieOptions = baseCookieOptions(deps.secureCookies);
+	const sessionCookieOptions = { ...baseCookieOptions(deps.secureCookies), maxAge: SESSION_COOKIE_MAX_AGE_MS };
 
 	const fetchUserCount = initFetchUserCount({
 		countUsers: deps.countUsers,

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -12,7 +12,7 @@ import { initInMemoryRateLimit } from "@packages/test-fixtures/providers/rate-li
 import { completeStripeSignup } from "./test-helpers/complete-stripe-signup";
 import { createAccessToken, saveAccessTokenForUser } from "../test-helpers/oauth-token";
 import { DISPOSABLE_EMAIL_MESSAGE } from "./disposable-email";
-import { SESSION_COOKIE_NAME } from "@packages/web-session";
+import { SESSION_COOKIE_NAME, SESSION_TTL_SECONDS } from "@packages/web-session";
 
 const TEST_FOUNDING_MEMBER_LIMIT = 3;
 
@@ -117,6 +117,9 @@ describe("Auth routes", () => {
 			expect(response.status).toBe(303);
 			expect(response.headers.location).toBe("/queue");
 			expect(response.headers["set-cookie"].length).toBeGreaterThan(0);
+			// Persistent (not a bare session cookie) so an already-signed-in browser —
+			// e.g. iOS Chrome-first login — still carries it after the browser closes.
+			expect(sessionCookie(response)).toContain(`Max-Age=${SESSION_TTL_SECONDS}`);
 		});
 
 		it("should show error on invalid credentials", async () => {

--- a/projects/hutch/src/runtime/web/auth/google-auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/google-auth.page.ts
@@ -23,7 +23,7 @@ import { bannerStateFromRequest, sendComponent } from "@packages/web-shell";
 
 import { extractReturnUrl, parseReturnUrl } from "./parse-return-url";
 import { baseCookieOptions } from "../cookie-options";
-import { SESSION_COOKIE_NAME } from "@packages/web-session";
+import { SESSION_COOKIE_MAX_AGE_MS, SESSION_COOKIE_NAME } from "@packages/web-session";
 import { LoginPage } from "./auth.component";
 import { initFetchUserCount } from "./fetch-user-count";
 import { readClickAttribution } from "../click-attribution.middleware";
@@ -85,7 +85,7 @@ const verifyState = (signed: string, secret: string): string | null => {
 
 export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 	const router = express.Router();
-	const sessionCookieOptions = baseCookieOptions(deps.secureCookies);
+	const sessionCookieOptions = { ...baseCookieOptions(deps.secureCookies), maxAge: SESSION_COOKIE_MAX_AGE_MS };
 	const redirectUri = `${deps.appOrigin}/auth/google/callback`;
 	const fetchUserCount = initFetchUserCount({
 		countUsers: deps.countUsers,
@@ -107,7 +107,7 @@ export const initGoogleAuthRoutes = (deps: GoogleAuthDependencies): Router => {
 		const signedState = signState(statePayload, deps.googleClientSecret);
 
 		res.cookie(STATE_COOKIE, signedState, {
-			...sessionCookieOptions,
+			...baseCookieOptions(deps.secureCookies),
 			maxAge: STATE_TTL_MS,
 		});
 

--- a/projects/ios-readplace/App/ReaderWebView.swift
+++ b/projects/ios-readplace/App/ReaderWebView.swift
@@ -104,7 +104,7 @@ struct ReaderWebView: UIViewControllerRepresentable {
 				onClose()
 			case let .openExternally(target):
 				decisionHandler(.cancel)
-				externalBrowser.open(target)
+				externalBrowser.open(target) { _ in }
 			}
 		}
 	}

--- a/projects/ios-readplace/App/WebAuthOpeners.swift
+++ b/projects/ios-readplace/App/WebAuthOpeners.swift
@@ -1,20 +1,30 @@
 import UIKit
 
-/// The browser seam the UI-free `WebAuthFlow` core opens through, kept in the App
-/// target so the tested core stays free of UIKit. `.system` uses the live
-/// `UIApplication`; tests inject their own closures.
-///
-/// `canOpen` needs the queried schemes (`googlechrome`/`googlechromes`) declared
-/// in `Info.plist`'s `LSApplicationQueriesSchemes`, or it silently returns false
-/// and the flow always falls back to the default browser.
+/// The browser seam the app opens external URLs through, kept in the App target so
+/// the tested cores stay free of UIKit. `.system` uses the live `UIApplication`;
+/// tests inject their own closure. `open` mirrors
+/// `UIApplication.open(_:options:completionHandler:)` — its `Bool` reports whether
+/// the system accepted the URL, which the Chrome-first flow needs to decide
+/// whether to fall back; the reader's plain "open externally" ignores it.
 struct ExternalBrowser {
-	let canOpen: (URL) -> Bool
-	let open: (URL) -> Void
+	let open: (_ url: URL, _ completion: @escaping (Bool) -> Void) -> Void
 
 	static let system = ExternalBrowser(
-		canOpen: { UIApplication.shared.canOpenURL($0) },
-		open: { UIApplication.shared.open($0) }
+		open: { url, completion in UIApplication.shared.open(url, options: [:], completionHandler: completion) }
 	)
+}
+
+/// Opens the OAuth authorize URL Chrome-first: it rewrites the https URL to
+/// `googlechromes://` and opens Chrome, so login lands in the browser where the
+/// user already has a Readplace web session. Only when the system reports Chrome
+/// could not be opened (Chrome not installed) does it fall back to the original
+/// https URL in the default browser — never as the default path, because most
+/// users keep Safari as the iOS default yet are signed in only in Chrome.
+func openAuthorizeURLChromeFirst(_ httpsURL: URL, browser: ExternalBrowser) {
+	browser.open(chromeURLForHTTPS(httpsURL)) { openedInChrome in
+		guard !openedInChrome else { return }
+		browser.open(httpsURL) { _ in }
+	}
 }
 
 /// Composition root for the external-browser auth flow shared by Login and Sign
@@ -32,8 +42,7 @@ func makeWebAuthFlow(session: AppSession) -> WebAuthFlow {
 	let browser = ExternalBrowser.system
 	return initWebAuthFlow(deps: WebAuthFlowDependencies(
 		pendingStore: store,
-		canOpenURL: browser.canOpen,
-		openURL: browser.open,
+		openAuthorizeURL: { httpsURL in openAuthorizeURLChromeFirst(httpsURL, browser: browser) },
 		exchange: { callbackURL, pending in
 			await session.completeSignIn(
 				callbackURL: callbackURL,

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -65,9 +65,12 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
   in the **external browser** via the same flow as **Sign up** (below), carrying
   `screen_hint=login` so a logged-out user lands on the web `/login` page and
   returns authenticated through the native `readplace://oauth-callback` deep link.
-- **Sign up** by opening `/oauth/authorize` in the **external browser** — Chrome
-  if installed (`googlechromes://`), else the default — so an existing Chrome
-  session is reused. The redirect is a native `readplace://oauth-callback` deep
+- **Sign up** by opening `/oauth/authorize` in the **external browser**,
+  Chrome-first: it rewrites to `googlechromes://` and opens Chrome, falling back to
+  the default browser only if the system reports Chrome can't be opened (not
+  installed) — so an existing Chrome session is reused rather than the app landing
+  in the default browser (usually Safari), where the user isn't signed in. The
+  redirect is a native `readplace://oauth-callback` deep
   link and the request carries `screen_hint=signup`: an already-logged-in Chrome
   passes straight to consent, while a new/logged-out user lands on the web
   `/signup` page and returns authenticated. This mirrors the browser extension's
@@ -273,11 +276,12 @@ cases:
 - **Web-auth flow (shared by Login & Sign up)**: the native authorize requests
   (`readplace://oauth-callback` redirect + `screen_hint=login`/`signup`), the
   deep-link callback exchanging the code with the native `redirect_uri` and
-  flipping the session logged-in, the Chrome-scheme selection (rewrite to
-  `googlechromes://` when Chrome is available, byte-equal HTTPS fallback
-  otherwise), the `PendingAuthStore` save/load/clear round-trip, and the flow
-  persisting the PKCE secrets before opening the browser (so a kill mid-hop can't
-  lose them).
+  flipping the session logged-in, the Chrome-first open (unconditional rewrite to
+  `googlechromes://`, opening Chrome, with the default-browser fallback taken only
+  when the system reports Chrome can't be opened), the core handing the raw https
+  authorize URL to its open seam, the `PendingAuthStore` save/load/clear
+  round-trip, and the flow persisting the PKCE secrets before opening the browser
+  (so a kill mid-hop can't lose them).
 
 `make test` then runs a **staging smoke pass** (`make test-staging`): it
 recompiles the app, extension and tests with the `STAGING` condition and runs

--- a/projects/ios-readplace/Shared/WebAuthFlow.swift
+++ b/projects/ios-readplace/Shared/WebAuthFlow.swift
@@ -1,15 +1,16 @@
 import Foundation
 
-/// Rewrites an `https` authorize URL to Chrome's `googlechromes` scheme so the
-/// OS opens it in Chrome (reusing the user's Chrome session) when Chrome is
-/// installed; otherwise returns the URL unchanged so the default browser opens
-/// it. Host, path and query are preserved either way.
-///
-/// `canOpen` is injected (it wraps `UIApplication.canOpenURL` in the app, a stub
-/// in tests). Chrome documents `googlechrome://` for http and `googlechromes://`
+/// Rewrites an `https` authorize URL to Chrome's `googlechromes` scheme so the OS
+/// opens it in Chrome, which shares one cookie jar across scheme-opened tabs and
+/// so reuses the user's existing Chrome web session. Host, path and query are
+/// preserved. Chrome documents `googlechrome://` for http and `googlechromes://`
 /// for https; the authorize URL is always https, so we use `googlechromes`.
-func chromeURLForHTTPS(_ httpsURL: URL, canOpen: (URL) -> Bool) -> URL {
-	guard canOpen(URL(string: "googlechromes://")!) else { return httpsURL }
+///
+/// The rewrite is unconditional: whether Chrome can actually be opened is left to
+/// the system when the App seam opens the URL (via the open completion handler),
+/// not to a `canOpenURL` pre-check — a false-negative probe must never silently
+/// route login into the default browser (Safari), where the user isn't signed in.
+func chromeURLForHTTPS(_ httpsURL: URL) -> URL {
 	var components = URLComponents(url: httpsURL, resolvingAgainstBaseURL: false)
 	components?.scheme = "googlechromes"
 	return components?.url ?? httpsURL
@@ -17,11 +18,12 @@ func chromeURLForHTTPS(_ httpsURL: URL, canOpen: (URL) -> Bool) -> URL {
 
 /// The seams the UI-free web-auth core needs, injected so tests never launch a
 /// browser or hit the network: where to persist the in-flight secrets, how to
-/// detect/open the browser, and how to exchange the returned code.
+/// open the authorize URL, and how to exchange the returned code. `openAuthorizeURL`
+/// receives the raw https authorize URL; the Chrome-first rewrite and the
+/// open-failure fallback live behind this seam in the App layer.
 struct WebAuthFlowDependencies {
 	let pendingStore: PendingAuthStore
-	let canOpenURL: (URL) -> Bool
-	let openURL: (URL) -> Void
+	let openAuthorizeURL: (URL) -> Void
 	let exchange: (_ callbackURL: URL, _ pending: PendingAuth) async -> Result<Void, Error>
 }
 
@@ -49,7 +51,7 @@ func initWebAuthFlow(deps: WebAuthFlowDependencies) -> WebAuthFlow {
 				state: request.state,
 				redirectURI: request.redirectURI
 			))
-			deps.openURL(chromeURLForHTTPS(request.url, canOpen: deps.canOpenURL))
+			deps.openAuthorizeURL(request.url)
 		},
 		complete: { callbackURL in
 			guard let pending = deps.pendingStore.load() else { return nil }

--- a/projects/ios-readplace/Tests/SignupFlowTests.swift
+++ b/projects/ios-readplace/Tests/SignupFlowTests.swift
@@ -48,8 +48,7 @@ final class SignupFlowTests: XCTestCase {
 
 		let flow = initWebAuthFlow(deps: WebAuthFlowDependencies(
 			pendingStore: pendingStore,
-			canOpenURL: { _ in false },
-			openURL: { _ in },
+			openAuthorizeURL: { _ in },
 			exchange: { callbackURL, pending in
 				await session.completeSignIn(
 					callbackURL: callbackURL,
@@ -75,25 +74,45 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(body["redirect_uri"], AppConfig.nativeCallbackURL)
 	}
 
-	func testChromeURLForHTTPSRewritesSchemeWhenChromeAvailable() {
+	func testChromeURLForHTTPSRewritesSchemeToGoogleChrome() {
 		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=ios-app&state=abc")!
-		var probed: URL?
-		let chrome = chromeURLForHTTPS(https, canOpen: { probed = $0; return true })
+		let chrome = chromeURLForHTTPS(https)
 
-		XCTAssertEqual(probed?.scheme, "googlechromes", "Chrome availability is probed with the https scheme variant")
 		let components = URLComponents(url: chrome, resolvingAgainstBaseURL: false)!
-		XCTAssertEqual(components.scheme, "googlechromes")
+		XCTAssertEqual(components.scheme, "googlechromes", "https is rewritten to Chrome's https scheme variant")
 		XCTAssertEqual(components.host, "readplace.com")
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		XCTAssertEqual(components.percentEncodedQuery, "client_id=ios-app&state=abc")
 	}
 
-	func testChromeURLForHTTPSReturnsHTTPSUnchangedWhenChromeUnavailable() {
+	func testOpenAuthorizeURLOpensChromeAndNeverFallsBackWhenChromeOpens() {
 		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=ios-app&state=abc")!
-		let fallback = chromeURLForHTTPS(https, canOpen: { _ in false })
+		var opened: [URL] = []
+		let browser = ExternalBrowser(open: { url, completion in
+			opened.append(url)
+			completion(true)
+		})
 
-		XCTAssertEqual(fallback, https)
-		XCTAssertEqual(fallback.absoluteString, https.absoluteString)
+		openAuthorizeURLChromeFirst(https, browser: browser)
+
+		// The requirement: when Chrome opens, login must never touch the default
+		// browser (Safari), where the user isn't signed in.
+		XCTAssertEqual(opened.map(\.scheme), ["googlechromes"])
+	}
+
+	func testOpenAuthorizeURLFallsBackToHTTPSOnlyWhenChromeCannotOpen() {
+		let https = URL(string: "https://readplace.com/oauth/authorize?client_id=ios-app&state=abc")!
+		var opened: [URL] = []
+		let browser = ExternalBrowser(open: { url, completion in
+			opened.append(url)
+			completion(url.scheme == "https") // Chrome (googlechromes) can't open; https can
+		})
+
+		openAuthorizeURLChromeFirst(https, browser: browser)
+
+		// Only a genuine Chrome-open failure (Chrome not installed) falls through to
+		// the default browser with the original https URL.
+		XCTAssertEqual(opened.map(\.scheme), ["googlechromes", "https"])
 	}
 
 	func testPendingAuthStoreRoundTrip() {
@@ -116,8 +135,7 @@ final class SignupFlowTests: XCTestCase {
 		var pendingWhenOpened: PendingAuth?
 		let flow = initWebAuthFlow(deps: WebAuthFlowDependencies(
 			pendingStore: store,
-			canOpenURL: { _ in false },
-			openURL: { url in
+			openAuthorizeURL: { url in
 				openedURL = url
 				pendingWhenOpened = store.load()
 			},
@@ -131,6 +149,7 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(pending.redirectURI, AppConfig.nativeCallbackURL)
 
 		let opened = try XCTUnwrap(openedURL)
+		XCTAssertEqual(opened.scheme, "https", "the core hands the raw https authorize URL to the seam; the Chrome rewrite lives in the App layer")
 		let items = Dictionary(uniqueKeysWithValues: (URLComponents(url: opened, resolvingAgainstBaseURL: false)?.queryItems ?? []).map { ($0.name, $0.value ?? "") })
 		XCTAssertEqual(items["state"], pending.state, "the opened authorize URL carries the persisted state")
 		XCTAssertEqual(items["redirect_uri"], AppConfig.nativeCallbackURL)

--- a/src/packages/web-session/src/index.ts
+++ b/src/packages/web-session/src/index.ts
@@ -1,4 +1,4 @@
-export { SESSION_COOKIE_NAME } from "./session-cookie";
+export { SESSION_COOKIE_NAME, SESSION_COOKIE_MAX_AGE_MS } from "./session-cookie";
 export { readCookie } from "./cookie";
 export { SESSION_TTL_SECONDS, SessionRow } from "./session-row";
 export { initGetSessionUserId } from "./get-session-user-id";

--- a/src/packages/web-session/src/session-cookie.ts
+++ b/src/packages/web-session/src/session-cookie.ts
@@ -1,5 +1,15 @@
+import { SESSION_TTL_SECONDS } from "./session-row";
+
 /** The session cookie hutch sets on login. Host-only (path "/", no domain), so
  * the browser sends it to every same-origin surface — hutch, /blog, /embed —
  * even though only hutch writes it. Single-sourced here so every deployable that
  * reads or writes the cookie agrees on the name. */
 export const SESSION_COOKIE_NAME = "hutch_sid";
+
+/** Persist the session cookie for the full server-side session lifetime instead
+ * of leaving it a bare session cookie, which the browser drops the moment it
+ * fully closes (why iOS Chrome-first login stopped reusing an existing web
+ * session across a Chrome restart). Bounded by — never outliving — the same TTL
+ * that evicts the session row, so a cookie sent past it resolves to no session.
+ * `res.cookie`'s `maxAge` is milliseconds; `SESSION_TTL_SECONDS` is seconds. */
+export const SESSION_COOKIE_MAX_AGE_MS = SESSION_TTL_SECONDS * 1000;


### PR DESCRIPTION
## Problem

When the Readplace iOS app opens a browser to log in, a user already signed in to `readplace.com` **in Chrome** is forced to log in again. Two things defeated the existing session-reuse mechanism:

1. **Client fallback fired into the wrong browser.** `chromeURLForHTTPS` rewrote the authorize URL to `googlechromes://` only when a `canOpenURL` pre-check passed; a false-negative probe silently routed login into the **OS default browser (Safari)**, where the user isn't signed in. Login is required to be **Chrome-first** — most users browse in Chrome but never change the iOS default-browser setting.
2. **The session cookie didn't survive a browser restart.** `hutch_sid` was a bare session cookie (no `maxAge`/`expires`), so Chrome dropped it the moment it fully closed — even though the server-side session record lives for `SESSION_TTL_SECONDS`.

## Changes

### Client — land login in Chrome, never Safari (`projects/ios-readplace`)
- `chromeURLForHTTPS` now rewrites `https` → `googlechromes://` **unconditionally**; whether Chrome can actually be opened is decided by the system at open time, not by a weak `canOpenURL` pre-check.
- New App-seam `openAuthorizeURLChromeFirst` opens the Chrome URL via `UIApplication.open(_:options:completionHandler:)` and falls back to the original https URL in the default browser **only** when the completion handler reports the open failed (Chrome not installed) — never as the default path.
- The UI-free `WebAuthFlow` core now exposes a single `openAuthorizeURL` seam handed the **raw https** authorize URL; the Chrome rewrite + open-failure fallback live in the App layer, matching the existing live-`UIApplication` pattern.
- `ExternalBrowser.open` gains a completion flag (mirrors `UIApplication.open`); the reader's plain "open externally" call ignores it.

### Server — persist the web session (`hutch` + `@packages/web-session`)
- Add `SESSION_COOKIE_MAX_AGE_MS` (`= SESSION_TTL_SECONDS * 1000`) and give the `hutch_sid` cookie a `maxAge` at every set-cookie site in `auth.page.ts` and `google-auth.page.ts`, so a Chrome login survives Chrome closing. Bounded by — never outliving — the same server TTL that evicts the session row. The Google `hutch_gstate` state cookie keeps its own short TTL (built from `baseCookieOptions` directly); `baseCookieOptions` (shared by visitor/click cookies) is untouched.

### Docs
- New "iOS login is Chrome-first" Product Constraint in `CLAUDE.md` and updated `projects/ios-readplace/README.md` so the requirement isn't re-broken.

## Testing
- `pnpm check` — green across all 36 projects, 100% coverage thresholds met.
- Added server test asserting the session cookie carries `Max-Age=SESSION_TTL_SECONDS`.
- Added iOS unit tests for the Chrome-first open: Chrome-opens → no fallback; Chrome-can't-open → falls back to https; and the core hands the raw https URL to the seam. (iOS suite runs via `make test` on macOS/simulator — not executable in this Linux CI environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSa5oav1spo7JN4uTqThDQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSa5oav1spo7JN4uTqThDQ)_