### PR TITLE
docs(blog): add war story on the share sheet that hid every PDF

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/save-pdf-from-iphone-share-sheet.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/save-pdf-from-iphone-share-sheet.md
@@ -1,0 +1,55 @@
+---
+title: "The Share Sheet That Left Out Every PDF"
+description: "Sharing a PDF from an iPhone used to skip Readplace, because the app was missing from the share sheet for any PDF. Fixing how the share extension declares what it accepts brings it back for Safari's viewer, Files, and mail attachments, and it uploads the file's bytes directly so a PDF behind a login still saves."
+slug: "save-pdf-from-iphone-share-sheet"
+date: "2026-07-03"
+author: "Fayner Brack"
+keywords: "save pdf from iphone, save pdf to read later iphone, share pdf to read it later, iphone share sheet pdf, save safari pdf ios, read pdf later app iphone, save pdf behind login, ios share extension pdf, save mail attachment pdf, readplace iphone"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+On an iPhone, a PDF was the one thing you could not hand to Readplace. Open a PDF in Safari, in Files, or as a mail attachment, tap share, and Readplace was missing from the row of apps. That was a bug in how the app told iOS what it accepts, not a choice. The share extension now declares PDFs too, so it shows up for them, and it uploads the file the share sheet already holds instead of fetching it again. That last part matters for a PDF behind a login: the app sends the bytes it was handed, so a file a crawler would be blocked from still saves. One limit stayed. A PDF shared straight from Files, with no web address behind it, reports no link to save, because Readplace files articles by their URL. The iPhone app is in beta on TestFlight.
+
+</div>
+</details>
+
+Every app in the iPhone share sheet has to declare what it accepts. Readplace's declaration named web pages and plain text. It left PDFs off, so sharing a PDF from Safari did not show Readplace in the list at all.
+
+I found the gap the way these gaps usually turn up. I opened a PDF in Safari, tapped share, and went looking for Readplace. It was not there. The web page in the next tab shared fine, so the extension itself worked. The PDF was the one thing it would not take.
+
+## Why iOS hid the app
+
+iOS decides which apps show in the share sheet by matching what you are handing it against a rule each app ships. Readplace's rule was a short list with two entries: a web address, and some text. A PDF is neither. It arrives as a file, tagged with the type `com.adobe.pdf`.
+
+The part that caught me out was the knock-on effect. iOS checks the whole of what you share against the rule, and if any piece of it is a type the app did not list, it drops that app from the sheet. So a PDF did not simply fail to match a slot. Its presence pulled Readplace out of the running for the share entirely.
+
+> **iOS hides an app that cannot name every part of what you are sharing.**
+
+## The rule that had to change
+
+The short-list form of the rule cannot say "take PDFs and web pages, and nothing else." Adding files to that form at all waves through every file type, which is worse than the gap I started with. So I moved the rule to the other shape iOS allows, a small query written as a predicate.
+
+The new rule names three things it will take: a web address that is not a file, text that is not a file, and a PDF. I checked it by running the real iOS predicate against 17 shapes of shared payload, the actual forms a share can arrive in, so a stray type could not push an icon into the sheet or out of it where it should not go.
+
+## Sending the file it already holds
+
+Showing up for a PDF was half of it. The other half was what to do once the share sheet handed one over.
+
+For a web page, the app loads the address in a hidden browser view and captures the cleaned page. A PDF needs none of that. It is already the finished document, and the share sheet passes the app its bytes directly. So the app uploads those bytes as they are and skips the browser view. No render, and no second trip to the site the file came from.
+
+That second trip is the one worth avoiding. The same idea runs in the [browser extension I wrote about when it started saving PDFs from your own tab](/blog/save-pdfs-straight-from-your-browser): a PDF behind a login or a bot check is one a crawler asks for and gets a block page instead of the file. The phone already has the bytes. Sending the ones it was handed means the save does not ride on a fresh request the site can refuse.
+
+> **The app sends the file it already has, so a PDF a crawler would be blocked from still lands in your queue.**
+
+Before it sends anything, the app reads the first few bytes for the marker every PDF opens with, so a mislabelled file does not go up as one. If that check fails, or the PDF runs past the 25 MiB the extension will carry, it falls back to sending the link alone and lets the server crawler fetch it, which allows far larger files.
+
+## The PDF with no link
+
+One case still comes back empty, and that one is on purpose. Share a PDF straight out of the Files app, with no web page behind it, and Readplace tells you it found no link to save.
+
+Readplace files every article under its web address. A loose PDF sitting in Files has none, so there is nothing to file it under. Open the same PDF from a web page and it carries that page's address, and it saves. The file with no origin is the edge that stays open, and closing it is a separate piece of work.
+
+So the share sheet now offers Readplace for a PDF wherever one shows up on the phone, from Safari's viewer to a mail attachment to a file that came off a web page. Share it, and the app sends the bytes it was already holding, which is what gets a login-guarded PDF into your queue. The iPhone app is in beta at [readplace.com/install](https://readplace.com/install?client=iphone). Put a PDF into it from your phone and open it back in the [in-app reader](/blog/read-saved-articles-in-the-iphone-app).

--- a/projects/blog-site/src/runtime/web/pages/blog/posts/save-pdf-from-iphone-share-sheet.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/save-pdf-from-iphone-share-sheet.md
@@ -32,7 +32,7 @@ The part that caught me out was the knock-on effect. iOS checks the whole of wha
 
 The short-list form of the rule cannot say "take PDFs and web pages, and nothing else." Adding files to that form at all waves through every file type, which is worse than the gap I started with. So I moved the rule to the other shape iOS allows, a small query written as a predicate.
 
-The new rule names three things it will take: a web address that is not a file, text that is not a file, and a PDF. I checked it by running the real iOS predicate against 17 shapes of shared payload, the actual forms a share can arrive in, so a stray type could not push an icon into the sheet or out of it where it should not go.
+The new rule names three things it will take: a web address that is not a file, text that is not a file, and a PDF. I checked it by running the real iOS predicate against 16 shapes of shared payload, the actual forms a share can arrive in, so a stray type could not push an icon into the sheet or out of it where it should not go.
 
 ## Sending the file it already holds
 


### PR DESCRIPTION
## What

A new blog post: **"The Share Sheet That Left Out Every PDF"** (`save-pdf-from-iphone-share-sheet.md`).

It covers the iOS share-extension change that landed on main after the last published post (2026-07-02):

- Readplace was missing from the iPhone share sheet for any PDF, because the extension's `NSExtensionActivationRule` declared only web pages and text, and iOS drops an app when any part of the shared payload is an undeclared type.
- The fix moves the rule to a SUBQUERY predicate that accepts web URLs, plain text, and `com.adobe.pdf`, validated against 16 payload shapes.
- Once shown, the app uploads the share-sheet-delivered bytes directly (gated on the `%PDF-` header, `save-content`) with no `WKWebView` render and no refetch, so a login-guarded PDF a crawler would be blocked from still saves.
- Honest limit: a PDF shared straight from Files with no web address reports "no link to save", because articles are keyed by URL.

## Why this topic

Reviewed all commits to main after the last post. The strongest SEO/conversion-relevant, genuinely-shipped, not-yet-covered story was the iOS PDF share extension (#856, follow-up #3cb1bb8). The inbox-address-naming feature (#907) is still behind a 404 feature flag ("reading forwarded mail is coming next"), so it was set aside as not shippable news.

## Editorial notes

- **Voice:** War Story — matches the material and adds variety against the explainer-heavy recent corpus.
- **Structural variety:** ran the lookback against the last 8 posts. Opening leads on the iOS mechanism (not "You"/"I"/"A user"/a cold scene); TL;DR opens on "On an iPhone…" (not the product name); section headers and the closing CTA are reworded away from the worn "Why this matters" / "Try it" / "Install the browser extension or start at readplace.com" templates; no "The lesson I took from this…" closer.
- No pricing or time-bound promo copy.
- Hard-rule scan clean: no semicolons in prose, no em dashes, no exclamation marks, no banned words; 828-word body, 2 pull-quotes.

## Verification

- `pnpm nx run blog-site:compile` + `blog-site:test` — 63/63 pass.
- Exercised the discovery module: post loads as the newest entry, resolves at `/blog/save-pdf-from-iphone-share-sheet`, renders HTML, and leaves the changelog banner unchanged.
- Full-monorepo pre-commit `pnpm check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HR5DWpP2mGcK1G7hAPzRov

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5DWpP2mGcK1G7hAPzRov)_
