### PR TITLE
refactor(infra): make HutchLambda own its Lambda log group

### DIFF
--- a/projects/hutch/src/infra/index.ts
+++ b/projects/hutch/src/infra/index.ts
@@ -18,7 +18,7 @@ import {
 	SubscriptionStartRequestCommand,
 } from "@packages/hutch-infra-components";
 import { EXPORT_DOWNLOAD_TTL_DAYS, EXPORT_S3_KEY_PREFIX } from "../runtime/web/pages/export/export-ttl";
-import { ANALYTICS_EVENTS, LAMBDA_NAMES, LOG_GROUPS, METRICS, STREAMS } from "../runtime/observability/events";
+import { ANALYTICS_EVENTS, LAMBDA_NAMES, METRICS, STREAMS } from "../runtime/observability/events";
 import {
 	buildAnalyticsDashboardBody,
 	SUBSCRIPTION_DASHBOARD_LOG_GROUPS,
@@ -202,11 +202,6 @@ const dynamodb = new HutchDynamoDBAccess("hutch-dynamodb-access", {
 	],
 });
 
-const logGroup = new aws.cloudwatch.LogGroup("hutch-log-analytics", {
-	name: LOG_GROUPS.hutchHandler,
-	retentionInDays: 30,
-}, { import: LOG_GROUPS.hutchHandler });
-
 const api = new aws.apigatewayv2.Api("hutch-api-gateway", {
 	name: "hutch-api-gateway",
 	protocolType: "HTTP",
@@ -299,6 +294,7 @@ const scheduleTrialFeedbackEmailSchedulerManagePolicy = {
 };
 
 const lambda = new HutchLambda(LAMBDA_NAMES.hutchHandler, {
+	priorLogGroupLogicalName: "hutch-log-analytics",
 	entryPoint: "./src/runtime/lambda.main.ts",
 	outputDir: ".lib/hutch-api",
 	assetDir: "./src/runtime",
@@ -1129,6 +1125,7 @@ const handleSubscriptionCancelledQueue = new HutchSQS("handle-subscription-cance
 });
 
 const handleSubscriptionCancelledLambda = new HutchLambda(LAMBDA_NAMES.handleSubscriptionCancelled, {
+	priorLogGroupLogicalName: "handle-subscription-cancelled-log-group",
 	entryPoint: "./src/runtime/handle-subscription-cancelled.main.ts",
 	outputDir: ".lib/handle-subscription-cancelled",
 	assetDir: "./src/runtime",
@@ -1178,6 +1175,7 @@ const cancelSubscriptionQueue = new HutchSQS("cancel-subscription", {
 });
 
 const cancelSubscriptionLambda = new HutchLambda(LAMBDA_NAMES.cancelSubscription, {
+	priorLogGroupLogicalName: "cancel-subscription-log-group",
 	entryPoint: "./src/runtime/cancel-subscription.main.ts",
 	outputDir: ".lib/cancel-subscription",
 	assetDir: "./src/runtime",
@@ -1283,6 +1281,7 @@ const subscriptionStartRequestQueue = new HutchSQS("subscription-start-request",
 });
 
 const subscriptionStartRequestLambda = new HutchLambda(LAMBDA_NAMES.subscriptionStartRequest, {
+	priorLogGroupLogicalName: "subscription-start-request-log-group",
 	entryPoint: "./src/runtime/subscription-start-request.main.ts",
 	outputDir: ".lib/subscription-start-request",
 	assetDir: "./src/runtime",
@@ -1321,6 +1320,7 @@ const subscriptionChargeSucceededQueue = new HutchSQS("subscription-charge-succe
 });
 
 const subscriptionChargeSucceededLambda = new HutchLambda(LAMBDA_NAMES.subscriptionChargeSucceeded, {
+	priorLogGroupLogicalName: "subscription-charge-succeeded-log-group",
 	entryPoint: "./src/runtime/subscription-charge-succeeded.main.ts",
 	outputDir: ".lib/subscription-charge-succeeded",
 	assetDir: "./src/runtime",
@@ -1349,6 +1349,7 @@ const subscriptionChargeFailedQueue = new HutchSQS("subscription-charge-failed",
 });
 
 const subscriptionChargeFailedLambda = new HutchLambda(LAMBDA_NAMES.subscriptionChargeFailed, {
+	priorLogGroupLogicalName: "subscription-charge-failed-log-group",
 	entryPoint: "./src/runtime/subscription-charge-failed.main.ts",
 	outputDir: ".lib/subscription-charge-failed",
 	assetDir: "./src/runtime",
@@ -1388,6 +1389,7 @@ const scheduleTrialFeedbackEmailQueue = new HutchSQS("schedule-trial-feedback-em
 const scheduleTrialFeedbackEmailLambda = new HutchLambda(
 	LAMBDA_NAMES.scheduleTrialFeedbackEmail,
 	{
+		priorLogGroupLogicalName: "schedule-trial-feedback-email-log-group",
 		entryPoint: "./src/runtime/schedule-trial-feedback-email.main.ts",
 		outputDir: ".lib/schedule-trial-feedback-email",
 		assetDir: "./src/runtime",
@@ -1452,6 +1454,7 @@ const sendTrialFeedbackEmailQueue = new HutchSQS("send-trial-feedback-email", {
 const sendTrialFeedbackEmailLambda = new HutchLambda(
 	LAMBDA_NAMES.sendTrialFeedbackEmail,
 	{
+		priorLogGroupLogicalName: "send-trial-feedback-email-log-group",
 		entryPoint: "./src/runtime/send-trial-feedback-email.main.ts",
 		outputDir: ".lib/send-trial-feedback-email",
 		assetDir: "./src/runtime",
@@ -1498,7 +1501,7 @@ for (const hash of excludedVisitorHashes) {
 
 new aws.cloudwatch.LogMetricFilter("imports-completed-filter", {
 	name: "imports-completed",
-	logGroupName: logGroup.name,
+	logGroupName: lambda.logGroupName,
 	pattern: `{ $.stream = "${STREAMS.analytics}" && $.event = "${ANALYTICS_EVENTS.importCommitted}" }`,
 	metricTransformation: {
 		name: METRICS.importsCompleted.name,
@@ -1509,46 +1512,15 @@ new aws.cloudwatch.LogMetricFilter("imports-completed-filter", {
 	},
 });
 
-// AWS auto-creates Lambda log groups on first invocation, but the subscription
+// Each subscription Lambda now owns its log group (HutchLambda), but those
 // Lambdas only run after a trial ends — so until the first trial-end charge
-// fires in a stack, none of these log groups exist and the analytics dashboard's
-// Logs Insights queries against them fail with `ResourceNotFoundException`.
-// Create them explicitly so the dashboard renders an empty result set instead
-// of erroring.
-const subscriptionLogGroups = [
-	new aws.cloudwatch.LogGroup("subscription-start-request-log-group", {
-		name: LOG_GROUPS.subscriptionStartRequest,
-		retentionInDays: 30,
-	}),
-	new aws.cloudwatch.LogGroup("subscription-charge-succeeded-log-group", {
-		name: LOG_GROUPS.subscriptionChargeSucceeded,
-		retentionInDays: 30,
-	}),
-	new aws.cloudwatch.LogGroup("subscription-charge-failed-log-group", {
-		name: LOG_GROUPS.subscriptionChargeFailed,
-		retentionInDays: 30,
-	}),
-	new aws.cloudwatch.LogGroup("cancel-subscription-log-group", {
-		name: LOG_GROUPS.cancelSubscription,
-		retentionInDays: 30,
-	}),
-	new aws.cloudwatch.LogGroup("handle-subscription-cancelled-log-group", {
-		name: LOG_GROUPS.handleSubscriptionCancelled,
-		retentionInDays: 30,
-	}),
-	new aws.cloudwatch.LogGroup("schedule-trial-feedback-email-log-group", {
-		name: LOG_GROUPS.scheduleTrialFeedbackEmail,
-		retentionInDays: 30,
-	}),
-	new aws.cloudwatch.LogGroup("send-trial-feedback-email-log-group", {
-		name: LOG_GROUPS.sendTrialFeedbackEmail,
-		retentionInDays: 30,
-	}),
-];
-
+// fires in a stack, AWS has never written to those groups. Depending on the
+// Lambdas orders their managed groups ahead of this dashboard, so its Logs
+// Insights queries render an empty result set instead of failing with
+// `ResourceNotFoundException`.
 new aws.cloudwatch.Dashboard("readplace-analytics", {
 	dashboardName: "readplace-analytics",
-	dashboardBody: pulumi.output(logGroup.name).apply((hutchLogGroupName) =>
+	dashboardBody: pulumi.output(lambda.logGroupName).apply((hutchLogGroupName) =>
 		JSON.stringify(buildAnalyticsDashboardBody({
 			region,
 			hutchLogGroupName,
@@ -1557,7 +1529,17 @@ new aws.cloudwatch.Dashboard("readplace-analytics", {
 			excludedVisitorHashes,
 		})),
 	),
-}, { dependsOn: subscriptionLogGroups });
+}, {
+	dependsOn: [
+		subscriptionStartRequestLambda,
+		subscriptionChargeSucceededLambda,
+		subscriptionChargeFailedLambda,
+		cancelSubscriptionLambda,
+		handleSubscriptionCancelledLambda,
+		scheduleTrialFeedbackEmailLambda,
+		sendTrialFeedbackEmailLambda,
+	],
+});
 
 
 // --- Exports ---

--- a/projects/save-link/src/infra/index.ts
+++ b/projects/save-link/src/infra/index.ts
@@ -34,7 +34,6 @@ import {
 	RecrawlContentExtractedEvent,
 	RefreshContentExtractedEvent,
 	SAVE_LINK_LAMBDA_NAMES,
-	SAVE_LINK_LOG_GROUPS,
 } from "@packages/hutch-infra-components";
 import { requireEnv } from "@packages/require-env";
 import { GENERATE_SUMMARY_TIMEOUTS } from "../runtime/domain/generate-summary/timeouts";
@@ -272,6 +271,7 @@ const saveLinkCommandDynamodb = new HutchDynamoDBAccess("save-link-command-dynam
 });
 
 const saveLinkCommandLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.saveLinkCommand, {
+	priorLogGroupLogicalName: "saveLinkCommand-log-group",
 	entryPoint: "./src/runtime/save-link-command.main.ts",
 	outputDir: ".lib/save-link-command",
 	assetDir: "./src",
@@ -329,6 +329,7 @@ const saveLinkRawHtmlCommandDynamodb = new HutchDynamoDBAccess("save-link-raw-ht
 });
 
 const saveLinkRawHtmlCommandLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.saveLinkRawHtmlCommand, {
+	priorLogGroupLogicalName: "saveLinkRawHtmlCommand-log-group",
 	entryPoint: "./src/runtime/save-link-raw-html-command.main.ts",
 	outputDir: ".lib/save-link-raw-html-command",
 	assetDir: "./src",
@@ -389,6 +390,7 @@ const saveAnonymousLinkCommandDynamodb = new HutchDynamoDBAccess("save-anonymous
 });
 
 const saveAnonymousLinkCommandLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.saveAnonymousLinkCommand, {
+	priorLogGroupLogicalName: "saveAnonymousLinkCommand-log-group",
 	entryPoint: "./src/runtime/save-anonymous-link-command.main.ts",
 	outputDir: ".lib/save-anonymous-link-command",
 	assetDir: "./src",
@@ -686,6 +688,7 @@ const comprehensiveCrawlCommandStagingDelete: LambdaPolicy = {
 };
 
 const comprehensiveCrawlCommandLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.comprehensiveCrawlCommand, {
+	priorLogGroupLogicalName: "comprehensiveCrawlCommand-log-group",
 	// Post-fan-out the orchestrator only runs pdfinfo, one S3 PutObject, up to
 	// 32 concurrent JSON Lambda responses, HTML join + sanitisation, and one
 	// tier-write — same workload shape as the simple-only save-link Lambdas at
@@ -803,6 +806,7 @@ const saveLinkRawPdfCommandStagingDelete: LambdaPolicy = {
 };
 
 const saveLinkRawPdfCommandLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.saveLinkRawPdfCommand, {
+	priorLogGroupLogicalName: "saveLinkRawPdfCommand-log-group",
 	// pdfinfo + one S3 PutObject + fan-out
 	// JSON Lambda invokes + HTML join + tier-write. 900s is the Lambda ceiling for
 	// a worst-case many-page document.
@@ -878,6 +882,7 @@ const staleCheckRequestedDynamodb = new HutchDynamoDBAccess("stale-check-request
 });
 
 const staleCheckRequestedLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.staleCheckRequested, {
+	priorLogGroupLogicalName: "staleCheckRequested-log-group",
 	entryPoint: "./src/runtime/stale-check.main.ts",
 	outputDir: ".lib/stale-check-requested",
 	assetDir: "./src",
@@ -935,6 +940,7 @@ const selectMostCompleteContentDynamodb = new HutchDynamoDBAccess(`${SAVE_LINK_L
 });
 
 const selectMostCompleteContentLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.selectMostCompleteContent, {
+	priorLogGroupLogicalName: "selectMostCompleteContent-log-group",
 			entryPoint: "./src/runtime/select-most-complete-content.main.ts",
 		outputDir: ".lib/select-most-complete-content",
 		assetDir: "./src",
@@ -1163,6 +1169,7 @@ const recrawlLinkInitiatedDynamodb = new HutchDynamoDBAccess("recrawl-link-initi
 });
 
 const recrawlLinkInitiatedLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.recrawlLinkInitiated, {
+	priorLogGroupLogicalName: "recrawlLinkInitiated-log-group",
 	entryPoint: "./src/runtime/recrawl-link-initiated.main.ts",
 	outputDir: ".lib/recrawl-link-initiated",
 	assetDir: "./src",
@@ -1295,6 +1302,7 @@ eventBus.subscribe(SummaryGeneratedEvent, summaryGeneratedLambdaWithSQS);
 // --- SummaryGenerationFailed handler ---
 
 const summaryGenerationFailedLambda = new HutchLambda(SAVE_LINK_LAMBDA_NAMES.summaryGenerationFailed, {
+	priorLogGroupLogicalName: "summaryGenerationFailed-log-group",
 	entryPoint: "./src/runtime/summary-generation-failed.main.ts",
 	outputDir: ".lib/summary-generation-failed",
 	assetDir: "./src",
@@ -1432,27 +1440,6 @@ const updateFetchTimestampWithSQS = new HutchSQSBackedLambda("update-fetch-times
 });
 
 eventBus.subscribe(UpdateFetchTimestampCommand, updateFetchTimestampWithSQS);
-
-// --- Worker log groups ---
-// AWS only auto-creates a Lambda's log group on its first invocation, but the
-// hutch analytics dashboard's "Recent errors" widget runs one Logs Insights
-// query spanning every save-link worker group (SAVE_LINK_LOG_GROUPS): a single
-// not-yet-created group fails that whole query with ResourceNotFoundException,
-// blanking the entire errors view — so a fresh stack, or a failure-path Lambda
-// (summary-generation-failed, recrawl-link-initiated, …) that has not fired
-// yet, would take the widget down. Provision them explicitly — mirroring the
-// subscription block in the hutch stack — so the widget renders an empty result
-// set instead of erroring, and the groups gain the 30-day retention the
-// auto-created ones lack. Names come from the shared SAVE_LINK_LOG_GROUPS
-// constant the dashboard reads, and iterating it means a worker later added to
-// SAVE_LINK_LAMBDA_NAMES is provisioned here automatically rather than silently
-// reopening the missing-group gap.
-for (const [name, logGroupName] of Object.entries(SAVE_LINK_LOG_GROUPS)) {
-	new aws.cloudwatch.LogGroup(`${name}-log-group`, {
-		name: logGroupName,
-		retentionInDays: 30,
-	});
-}
 
 // --- Exports ---
 

--- a/src/packages/hutch-infra-components/src/infra/hutch-lambda.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-lambda.ts
@@ -164,6 +164,8 @@ export class HutchLambda extends pulumi.ComponentResource {
 	public readonly functionName: pulumi.Output<string>;
 	public readonly arn: pulumi.Output<string>;
 	public readonly role: aws.iam.Role;
+	public readonly logGroupName: pulumi.Output<string>;
+	public readonly logGroupArn: pulumi.Output<string>;
 
 	constructor(
 		name: string,
@@ -201,6 +203,15 @@ export class HutchLambda extends pulumi.ComponentResource {
 			 * `outputDir`, and `assetDir` are ignored when this is set.
 			 */
 			containerImage?: { imageUri: pulumi.Input<string> };
+			/**
+			 * Logical name of the top-level `aws.cloudwatch.LogGroup` this call
+			 * site previously managed for the Lambda. Set only when migrating such
+			 * a site: the component now owns the group, and this drives an alias so
+			 * Pulumi re-parents the existing state resource instead of deleting the
+			 * live group and creating a new one. Omit for Lambdas whose group AWS
+			 * auto-created — those are adopted out-of-band via `pulumi import`.
+			 */
+			priorLogGroupLogicalName?: string;
 		},
 		opts?: pulumi.ComponentResourceOptions,
 	) {
@@ -242,6 +253,25 @@ export class HutchLambda extends pulumi.ComponentResource {
 			});
 		}
 
+		// Own the log group rather than letting the Lambda service auto-create it on
+		// first invocation. An auto-created group lives outside Pulumi state, so any
+		// later attempt to manage it by its fixed name collides with
+		// ResourceAlreadyExistsException. Creating it here — before the Function, via
+		// dependsOn — makes a group's existence imply Pulumi made it, so that
+		// collision is unrepresentable. `priorLogGroupLogicalName` aliases a group a
+		// call site previously managed as a top-level resource, so the migration
+		// re-parents the live group instead of deleting and recreating it.
+		const logGroup = new aws.cloudwatch.LogGroup(`${lambdaName}-log-group`, {
+			name: `/aws/lambda/${lambdaName}`,
+			retentionInDays: 30,
+		}, {
+			parent: this,
+			retainOnDelete: true,
+			aliases: args.priorLogGroupLogicalName
+				? [{ name: args.priorLogGroupLogicalName, parent: pulumi.rootStackResource }]
+				: [],
+		});
+
 		const hasEnvironment = Object.keys(args.environment).length > 0;
 		const environmentArg = hasEnvironment ? { environment: { variables: args.environment } } : {};
 
@@ -256,7 +286,7 @@ export class HutchLambda extends pulumi.ComponentResource {
 				memorySize: args.memorySize,
 				timeout: args.timeout,
 				...environmentArg,
-			}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+			}, { parent: this, dependsOn: [logGroup], aliases: [{ parent: pulumi.rootStackResource }] });
 		} else {
 			assert(args.entryPoint, "HutchLambda zip packaging requires 'entryPoint'");
 			assert(args.outputDir, "HutchLambda zip packaging requires 'outputDir'");
@@ -301,11 +331,13 @@ export class HutchLambda extends pulumi.ComponentResource {
 				timeout: args.timeout,
 				...environmentArg,
 				...layersArg,
-			}, { parent: this, aliases: [{ parent: pulumi.rootStackResource }] });
+			}, { parent: this, dependsOn: [logGroup], aliases: [{ parent: pulumi.rootStackResource }] });
 		}
 
 		this.functionName = lambdaFunction.name;
 		this.arn = lambdaFunction.arn;
+		this.logGroupName = logGroup.name;
+		this.logGroupArn = logGroup.arn;
 		this.registerOutputs();
 	}
 }

--- a/src/packages/hutch-infra-components/src/infra/hutch-lambda.ts
+++ b/src/packages/hutch-infra-components/src/infra/hutch-lambda.ts
@@ -165,7 +165,6 @@ export class HutchLambda extends pulumi.ComponentResource {
 	public readonly arn: pulumi.Output<string>;
 	public readonly role: aws.iam.Role;
 	public readonly logGroupName: pulumi.Output<string>;
-	public readonly logGroupArn: pulumi.Output<string>;
 
 	constructor(
 		name: string,
@@ -337,7 +336,6 @@ export class HutchLambda extends pulumi.ComponentResource {
 		this.functionName = lambdaFunction.name;
 		this.arn = lambdaFunction.arn;
 		this.logGroupName = logGroup.name;
-		this.logGroupArn = logGroup.arn;
 		this.registerOutputs();
 	}
 }


### PR DESCRIPTION
## Why

Every `HutchLambda` pins a fixed Function name and attaches `AWSLambdaBasicExecutionRole`, so the Lambda service auto-creates `/aws/lambda/<name>-handler` **outside Pulumi state** on first invocation. Any later attempt to manage that group by its fixed name then collides with `ResourceAlreadyExistsException` — the failure that broke `save-link/deploy-staging` when `select-most-complete-content` was enrolled into the log-group loop (adopted after the fact via `pulumi import` in `ca4bcd8`). That failure mode is latent for every worker not yet enrolled.

This change removes the capability that creates unmanaged groups, so the collision becomes **unrepresentable**: a log group can only exist because Pulumi made it.

## What

- **`HutchLambda` now owns its log group.** It creates `aws.cloudwatch.LogGroup` (`retentionInDays: 30`, `retainOnDelete: true`) **before** the Function (wired via `dependsOn`), and exposes a `logGroupName` output. `AWSLambdaBasicExecutionRole` is unchanged here — the IAM scope-down (dropping `logs:CreateLogGroup`) is a deliberately separate follow-up so a logging regression is a clean revert.
- **Deleted the three ad-hoc explicit-log-group blocks:** the `save-link` `SAVE_LINK_LOG_GROUPS` loop, the `hutch` 7-group subscription array, and `hutch-log-analytics`.
- **Repointed the two `hutch-log-analytics` consumers** — the `imports-completed` metric filter and the `readplace-analytics` dashboard — to the hutch lambda's exposed `logGroupName`; the dashboard now `dependsOn` the 7 subscription lambda components so their managed groups still precede it.
- **Migration aliases.** The 17 previously-managed groups pass a new optional `priorLogGroupLogicalName`, which drives a `{ name, parent: rootStackResource }` alias so Pulumi **re-parents** the existing state resource into the component instead of deleting and recreating the live group — the same alias idiom already used for the component's `Role` / `RolePolicyAttachment` / `RolePolicy`.

Every `/aws/lambda/*` group — the entire auto-create collision class — now originates from the single `aws.cloudwatch.LogGroup` inside the component. (One other `aws.cloudwatch.LogGroup` exists in the repo but is outside this class: the API Gateway *access-log* group `/aws/apigateway/<name>-access` created in `HutchAPIGateway`, already component-owned via `parent: this`. API Gateway only writes to a group you explicitly configure on the stage — it never auto-creates one — so it was never exposed to the collision this PR removes.)

## Rollout — required, per stack, out-of-band

The code alone is **not** safe to `pulumi up`. For each stack (`save-link`, `hutch`, `blog-site`, `web-embed` × staging + prod):

1. `pulumi import` the live-but-unmanaged groups — the group of every `HutchLambda` **without** a `priorLogGroupLogicalName` (the **36 no-alias groups enumerated under Verification**) that has already been invoked in the stack, since an invoked Lambda owns a `/aws/lambda/<name>-handler` group AWS auto-created outside state. The 17 aliased groups are re-parented by their aliases, never imported.
2. **Preview gate** — abort unless `pulumi preview` shows **zero LogGroup delete/replace** *and* **zero create against a name that already exists live**. The 17 managed groups must appear as re-parents (aliases), never deletes; a delete/replace means a broken alias. A missed step-1 import surfaces here as a create-against-an-existing-name and must be resolved (imported) before proceeding — it fails safe (the `up` would abort with `ResourceAlreadyExistsException`), never destructively.
3. `pulumi up`, then confirm a clean-preview no-op.

A wrong alias would permanently destroy production logs, so the preview gate — not the code — is the safety mechanism. Feature-branch CI runs `check`, not deploys, so the branch itself is safe.

## Verification

- Full-monorepo `pnpm check` passes via the pre-commit hook (all 36 projects, including `blog-site` / `web-embed`, which consume the component — the new arg and output are additive).
- Audited the diff: every removed managed-group logical name maps to exactly one `priorLogGroupLogicalName`, each attached to the lambda whose physical `/aws/lambda/<name>-handler` matches the removed group's physical name (a perfect bijection, true by construction). No orphaned or missed alias.
- **The no-alias set is *every* `HutchLambda` that is not one of the 17 migrated groups** — **36** groups (**53** managed groups total − 17 aliased), spanning every project, not only the DLQ/stripe/`blog-site`/`web-embed` handlers. None had a prior top-level managed group, so each correctly receives no alias; any already invoked in a stack owns an AWS-auto-created `/aws/lambda/<name>-handler` that the step-1 `pulumi import` sweep must adopt. Full breakdown:
  - **hutch — 10:** 9 top-level (`export-user-data`, `delete-account`, `receive-email`, `extract-email-links`, `crawl-email-link-preview`, `send-user-digest`, `digest-scan`, `reader-ready-fanout`, `handle-subscription-cancellation-scheduled`) + 1 nested `stripe-webhook-receiver`.
  - **save-link — 24:** 14 top-level (`simple-crawl-unsupported-policy`, `pdf-page-ocr`, `pdf-page-llm-cleanup`, `pdf-page-html-convert`, `pdf-document-diff-review`, `generate-summary`, `link-saved`, `anonymous-link-saved`, `canonical-content-changed`, `recrawl-content-extracted`, `summary-generated`, `refresh-article-content`, `refresh-content-extracted`, `update-fetch-timestamp`) + 10 nested DLQ handlers (`save-link-dlq`, `save-link-raw-html-dlq`, `save-anonymous-link-dlq`, `simple-crawl-unsupported-policy-dlq`, `comprehensive-crawl-dlq`, `save-link-raw-pdf-dlq`, `select-most-complete-content-dlq`, `generate-summary-dlq`, `recrawl-link-initiated-dlq`, `recrawl-content-extracted-dlq`).
  - **blog-site — 1**, **web-embed — 1**.

## Follow-ups

- **PR2** — scope the IAM policy: replace `AWSLambdaBasicExecutionRole` with an inline policy granting only `logs:CreateLogStream` + `logs:PutLogEvents` on the group. Must land after this deploys (the group is now always pre-created, so the runtime never needs `CreateLogGroup`).
- **PR3** — runbook: document the "adopt a pre-existing AWS resource into Pulumi state" procedure (import + preview gate), covering the full 36-group no-alias import set above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXFAXYapMGmX5YRT9vFTzM)_
