### PR TITLE
fix(save): route anonymous save-intent to signup, not the sign-in page

### DIFF
--- a/projects/hutch/src/e2e/queue-flow/action-catalog.ts
+++ b/projects/hutch/src/e2e/queue-flow/action-catalog.ts
@@ -3,7 +3,6 @@ export type ViewPageActionKey =
 	| 'anonymous-visit-view-page-crawl-fails'
 
 export type AuthActionKey =
-	| 'navigate-to-signup'
 	| 'submit-signup-form'
 	| 'click-logout'
 	| 'navigate-to-login'

--- a/projects/hutch/src/e2e/queue-flow/auth-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/auth-actions.ts
@@ -20,17 +20,6 @@ export function createAuthActions(
   passwordResetProgress: PasswordResetProgress,
 ): Record<AuthActionKey, PageAction> {
   return {
-    'navigate-to-signup': {
-      isAvailable: async (page) => {
-        if (progress.accountCreated) return false
-        if (await isOnPage(page, 'page-home')) return true
-        return isOnPage(page, 'page-login')
-      },
-      execute: async (page) => {
-        await page.locator('a[href^="/signup"]').first().click()
-      },
-    },
-
     'submit-signup-form': {
       isAvailable: async (page) => {
         if (progress.accountCreated) return false

--- a/projects/hutch/src/e2e/queue-flow/view-page-actions.ts
+++ b/projects/hutch/src/e2e/queue-flow/view-page-actions.ts
@@ -158,10 +158,11 @@ export function createAnonymousViewPageActions(
 				await page.waitForTimeout(1500)
 				await expect(shareWrap).not.toHaveClass(/share-balloon__wrap--open/)
 
-				// Click Save as anonymous — /save redirects to /login?return=/save?url=...
-				// so the regular navigate-to-signup action can pick up from page-login.
+				// Click Save as anonymous — /save redirects to /signup?return=/save?url=...
+				// (account creation converts an anonymous saver far better than the
+				// sign-in page), so submit-signup-form picks up directly from page-signup.
 				await clickAndWaitForPageReload(page, saveAction)
-				await expect(page.locator('body.page-login')).toHaveCount(1)
+				await expect(page.locator('body.page-signup')).toHaveCount(1)
 
 				progress.visitedAnonymously = true
 			},

--- a/projects/hutch/src/runtime/web/pages/save/save.page.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.page.ts
@@ -60,7 +60,7 @@ export function initSaveRoutes(deps: {
 					),
 				);
 			}
-			res.redirect(303, `/login?return=${encodeURIComponent(req.originalUrl)}`);
+			res.redirect(303, `/signup?return=${encodeURIComponent(req.originalUrl)}`);
 			return;
 		}
 

--- a/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/save/save.route.test.ts
@@ -123,13 +123,13 @@ describe("Save routes", () => {
 	});
 
 	describe("GET /save?url=https://example.com (unauthenticated)", () => {
-		it("should redirect to login with return URL", async () => {
+		it("should redirect to signup with return URL — an anonymous saver is almost always a new visitor, so the account-creation page converts the intent far better than the sign-in page", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const response = await request(harness.server).get("/save?url=https://example.com/article");
 
 			expect(response.status).toBe(303);
 			const location = response.headers.location;
-			expect(location).toContain("/login");
+			expect(location.startsWith("/signup")).toBe(true);
 			expect(location).toContain("return=");
 			const returnUrl = decodeURIComponent(location.split("return=")[1]);
 			expect(returnUrl).toBe("/save?url=https://example.com/article");
@@ -148,8 +148,8 @@ describe("Save routes", () => {
 		});
 	});
 
-	describe("login round-trip", () => {
-		it("should carry URL through login and redirect to queue with url", async () => {
+	describe("returning-user round-trip via login", () => {
+		it("still carries the URL back to the queue for an existing user who reaches sign-in from the signup page (the return param round-trips through login unchanged)", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const { auth } = harness;
 			await auth.createUser({ email: "test@example.com", password: "password123" });
@@ -157,11 +157,13 @@ describe("Save routes", () => {
 
 			const saveResponse = await agent.get("/save?url=https://example.com/article");
 			expect(saveResponse.status).toBe(303);
-			const loginRedirect = saveResponse.headers.location;
-			expect(loginRedirect).toContain("/login");
-			expect(loginRedirect).toContain("return=");
+			const signupRedirect = saveResponse.headers.location;
+			expect(signupRedirect.startsWith("/signup")).toBe(true);
+			expect(signupRedirect).toContain("return=");
 
-			const returnParam = decodeURIComponent(loginRedirect.split("return=")[1]);
+			// An existing user follows the "Already have an account? Sign in" link,
+			// which preserves the return param, then logs in.
+			const returnParam = decodeURIComponent(signupRedirect.split("return=")[1]);
 			await agent
 				.post(`/login?return=${encodeURIComponent(returnParam)}`)
 				.type("form")
@@ -200,21 +202,21 @@ describe("Save routes", () => {
 			expect(parsed.searchParams.get("utm_source")).toBe("twitter");
 		});
 
-		it("preserves the full originalUrl (utm included) in the /login return param", async () => {
+		it("preserves the full originalUrl (utm included) in the /signup return param", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const response = await request(harness.server).get("/save?url=https://example.com/article&utm_source=medium");
 
 			expect(response.status).toBe(303);
 			const location = response.headers.location;
-			expect(location.startsWith("/login")).toBe(true);
+			expect(location.startsWith("/signup")).toBe(true);
 			const returnParam = new URL(`http://localhost${location}`).searchParams.get("return");
 			expect(returnParam).toBe("/save?url=https://example.com/article&utm_source=medium");
 		});
 	});
 
 	describe("view_save_intent analytics emission", () => {
-		it("emits one view_save_intent for an anonymous save click before redirecting to /login — the warmest funnel moment that otherwise vanishes into the sign-in page", async () => {
+		it("emits one view_save_intent for an anonymous save click before redirecting to /signup — the warmest funnel moment, now routed to account creation instead of the sign-in page", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			const response = await request(harness.server).get("/save?url=https://example.com/article");


### PR DESCRIPTION
## Hypothesis

The single warmest moment in the acquisition funnel — an anonymous visitor clicking **"Save to My Queue"** on the public reader — currently redirects to **`/login`**, a page whose primary action is *sign in* (i.e. built for people who already have an account). A first-time visitor has to notice the secondary "Create one" link to convert. This PR sends them to **`/signup`** instead.

## Evidence (production, last 30 days, owner devices excluded)

| Funnel step | Distinct visitors |
|---|---|
| Anonymous reader opens (`view_opened`) | 7,778 |
| Anonymous save-intent (`view_save_intent`, reader surface) | 343 |
| …of those who later created an account (`user_created`) | **11 (3.2%)** |

- **332 visitors explicitly clicked "Save" and then vanished.** The save-intent → signup step is the funnel's biggest proportional leak.
- **`/login` drew ~4× the anonymous traffic of `/signup`** (768 vs 191 distinct anonymous visitors) — an inversion that only makes sense if new visitors are being funnelled to the sign-in door. The reader audience is overwhelmingly new (most hosts show ~1 view per visitor).
- The **import-commit flow already redirects anonymous users to `/signup`** (`redirectAnonymousToSignup`). `/save` was the inconsistent one.

## What this changes

`projects/hutch/src/runtime/web/pages/save/save.page.ts` — the anonymous redirect target flips from `/login?return=…` to `/signup?return=…`. Nothing else about the flow changes:

- The **`pending_save_id` cookie** is still minted before the redirect, so the blocked save still links to the eventual `user_created` conversion (attribution preserved).
- The **`return` URL** still round-trips: after signup the visitor lands back on `/save?url=…` → `/queue?url=…`, which auto-saves the article they wanted.
- **Returning users are covered**: the signup page's "Already have an account? Sign in" link preserves `return`, and the Google button is identical on both pages (a returning Google user just clicks it).
- Removes the now-dead `navigate-to-signup` E2E action (the anonymous save lands on the signup page directly).

## Estimated result

Recovering even a **fraction** of the 332 lost monthly save-intenders is material at current volume (35 signups/month). If the intent→signup rate moves from 3.2% toward a plausible 8–12% for a correctly-targeted account-creation page, that is on the order of **+15–30 signups/month (~1.5–2× total signups)** with no extra traffic. Directional, single-variable change; the measurement below quantifies the true lift.

## How to measure

1. **Primary — intent→signup conversion.** Join `view_save_intent` (`surface=reader_view`, `outcome=prompted_to_sign_up`, `is_authenticated=0`) `visitor_id`s to `user_created` `visitor_id`s over a fixed window before vs after merge. This is the existing "Try → Save-intent → Signup" dashboard funnel.
2. **Secondary — page rebalancing.** Anonymous pageviews of `/signup` vs `/login` should converge (the `/save` redirect stops feeding `/login`).
3. **Guardrail.** Watch `user_created` `method` split (email vs google) and total signups/day for a step change; watch for any rise in existing-user confusion (login attempts failing right after landing on signup).

```
# Logs Insights — intent→signup join (hutch-handler)
fields visitor_id
| filter (stream="analytics" and event="view_save_intent" and (surface="reader_view" or not ispresent(surface)) and is_authenticated=0)
      or (stream="conversions" and event="user_created")
| filter ispresent(visitor_id)
| stats count_distinct(visitor_id) as visitors by event
```

## Verification

`pnpm check` passes (all 36 projects: lint, types, 2,704 unit + integration tests, Playwright E2E, 100% coverage gate).

https://claude.ai/code/session_01En2uUiiwQoRQKWenCnkPi9
