### PR TITLE
feat(hutch,@packages/web-analytics): emit signup_attempted to make the signup form measurable

### DIFF
--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -70,9 +70,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 28 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 30 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(28);
+		expect(body.widgets).toHaveLength(30);
 	});
 
 	it("the homepage A/B widget compares arms by distinct visitors (assignment is sticky per browser, so raw counts pile a returning visitor's landings onto one arm) with raw landings alongside, grouped by variant (utm_content)", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -618,14 +618,6 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 		}),
 	);
 
-	// --- Signup form funnel ---
-	// Driven by the signup_attempted event the POST /signup handler emits at each
-	// terminal outcome. Makes the email signup form's own conversion (submissions →
-	// accounts) measurable and separates the share lost to each rejection gate —
-	// notably disposable_email, a deliberate friction whose cost was invisible.
-	// Only the email form is counted (Google sign-in is a separate path), so this
-	// is the form's conversion, not total account creation.
-
 	widgets.push(
 		logWidget({
 			region,

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -620,14 +620,16 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 
 	// --- Signup form funnel ---
 	// Driven by the signup_attempted event the POST /signup handler emits at each
-	// terminal outcome. Makes the signup form's own conversion (submissions →
+	// terminal outcome. Makes the email signup form's own conversion (submissions →
 	// accounts) measurable and separates the share lost to each rejection gate —
 	// notably disposable_email, a deliberate friction whose cost was invisible.
+	// Only the email form is counted (Google sign-in is a separate path), so this
+	// is the form's conversion, not total account creation.
 
 	widgets.push(
 		logWidget({
 			region,
-			title: "Signup form outcomes",
+			title: "Email signup form outcomes",
 			logGroupNames: [hutchLogGroupName],
 			query: [
 				"fields @timestamp, outcome",
@@ -641,7 +643,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 		}),
 		logWidget({
 			region,
-			title: "Signup form outcomes per day",
+			title: "Email signup form outcomes per day",
 			logGroupNames: [hutchLogGroupName],
 			query: [
 				"fields @timestamp, outcome",

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -618,6 +618,42 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 		}),
 	);
 
+	// --- Signup form funnel ---
+	// Driven by the signup_attempted event the POST /signup handler emits at each
+	// terminal outcome. Makes the signup form's own conversion (submissions →
+	// accounts) measurable and separates the share lost to each rejection gate —
+	// notably disposable_email, a deliberate friction whose cost was invisible.
+
+	widgets.push(
+		logWidget({
+			region,
+			title: "Signup form outcomes",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields @timestamp, outcome",
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.signupAttempted}"`,
+				...exclude,
+				"| stats count(*) as attempts by outcome",
+				"| sort attempts desc",
+			].join(" "),
+			x: 0, y: 130, width: 12, height: 8,
+			view: "bar",
+		}),
+		logWidget({
+			region,
+			title: "Signup form outcomes per day",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields @timestamp, outcome",
+				`| filter stream = "${STREAMS.analytics}" and event = "${ANALYTICS_EVENTS.signupAttempted}"`,
+				...exclude,
+				"| stats count(*) as attempts by bin(1d), outcome",
+			].join(" "),
+			x: 12, y: 130, width: 12, height: 8,
+			view: "timeSeries",
+		}),
+	);
+
 	return { widgets };
 }
 

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -3,8 +3,10 @@ export {
 	ANALYTICS_EVENTS,
 	SAVE_SURFACES,
 	SAVE_OUTCOMES,
+	SIGNUP_OUTCOMES,
 	type SaveSurface,
 	type SaveOutcome,
+	type SignupOutcome,
 } from "@packages/web-analytics";
 
 export const CONVERSION_EVENTS = {

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -896,6 +896,8 @@ export function createApp(dependencies: AppDependencies): Express {
 		now: deps.now,
 		botDefenseLogger: deps.botDefenseLogger,
 		conversionLogger: deps.conversionLogger,
+		analytics: deps.analytics,
+		salt: deps.salt,
 		foundingAllocation,
 		buildBannerState,
 		consumeRateLimit: deps.consumeRateLimit,

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -307,6 +307,11 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					res.redirect(303, "/?signup=pending");
 					break;
 				case "field-errors":
+					/* A submission that is both disposable and otherwise invalid is
+					 * bucketed as disposable_email, not invalid_input: the disposable
+					 * gate takes precedence so its cost is measured in full rather than
+					 * hidden behind a co-occurring error. The outcome buckets are
+					 * therefore not mutually exclusive by input. */
 					logSignupAttempt(
 						result.errors.some((e) => e.message === DISPOSABLE_EMAIL_MESSAGE)
 							? SIGNUP_OUTCOMES.disposableEmail

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -69,6 +69,10 @@ import { readClickAttribution } from "@packages/web-analytics";
 import { consumePendingSaveId } from "../pending-save";
 import type { ConversionEvent } from "../../conversions";
 import { emitUserCreated } from "../../conversions";
+import type { AnalyticsEvent } from "@packages/web-analytics";
+import { buildSignupAttemptedEvent } from "@packages/web-analytics";
+import { SIGNUP_OUTCOMES, type SignupOutcome } from "../../observability/events";
+import { DISPOSABLE_EMAIL_MESSAGE } from "./disposable-email";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
 const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
@@ -112,6 +116,8 @@ interface AuthDependencies {
 	now: () => Date;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
 	conversionLogger: HutchLogger.Typed<ConversionEvent>;
+	analytics: HutchLogger.Typed<AnalyticsEvent>;
+	salt: string;
 	foundingAllocation: FoundingAllocation;
 	buildBannerState: BuildBannerState;
 	consumeRateLimit: ConsumeRateLimit;
@@ -254,6 +260,11 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const pendingSaveHost = pendingSaveHostFrom(returnUrl);
 		const body = (req.body ?? {}) as Record<string, unknown>;
 
+		const logSignupAttempt = (outcome: SignupOutcome) =>
+			deps.analytics.info(
+				buildSignupAttemptedEvent({ now: deps.now, salt: deps.salt }, { req, outcome }),
+			);
+
 		const renderFailure = async (email: string | undefined, errors: ComponentError[]) => {
 			const userCount = await fetchUserCount();
 			sendComponent(
@@ -296,9 +307,15 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					res.redirect(303, "/?signup=pending");
 					break;
 				case "field-errors":
+					logSignupAttempt(
+						result.errors.some((e) => e.message === DISPOSABLE_EMAIL_MESSAGE)
+							? SIGNUP_OUTCOMES.disposableEmail
+							: SIGNUP_OUTCOMES.invalidInput,
+					);
 					await renderFailure(result.email, result.errors);
 					break;
 				case "duplicate-email":
+					logSignupAttempt(SIGNUP_OUTCOMES.duplicateEmail);
 					await renderFailure(result.email, [{ message: "An account with this email already exists" }]);
 					break;
 			}
@@ -322,6 +339,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
 			res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 			sendVerificationEmail(created.userId, email);
+			logSignupAttempt(SIGNUP_OUTCOMES.created);
 			emitUserCreated(
 				{ logger: deps.conversionLogger, now: deps.now },
 				{
@@ -377,6 +395,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		const sessionId = await deps.createSession({ userId: created.userId, emailVerified: false });
 		res.cookie(SESSION_COOKIE_NAME, sessionId, sessionCookieOptions);
 		sendVerificationEmail(created.userId, email);
+		logSignupAttempt(SIGNUP_OUTCOMES.created);
 		emitUserCreated(
 			{ logger: deps.conversionLogger, now: deps.now },
 			{

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -297,6 +297,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 						now: deps.now(),
 					}));
 					if (result.reason === "submit_too_fast") {
+						logSignupAttempt(SIGNUP_OUTCOMES.tooFast);
 						await renderFailure(
 							typeof body.email === "string" ? body.email : undefined,
 							[{ message: "Please try again" }],
@@ -307,11 +308,6 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 					res.redirect(303, "/?signup=pending");
 					break;
 				case "field-errors":
-					/* A submission that is both disposable and otherwise invalid is
-					 * bucketed as disposable_email, not invalid_input: the disposable
-					 * gate takes precedence so its cost is measured in full rather than
-					 * hidden behind a co-occurring error. The outcome buckets are
-					 * therefore not mutually exclusive by input. */
 					logSignupAttempt(
 						result.errors.some((e) => e.message === DISPOSABLE_EMAIL_MESSAGE)
 							? SIGNUP_OUTCOMES.disposableEmail

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -332,6 +332,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 		if (!deps.foundingAllocation.isFoundingAllocationExhausted(userCount)) {
 			const created = await deps.createUserWithPasswordHash({ email, passwordHash, attribution });
 			if (!created.ok) {
+				logSignupAttempt(SIGNUP_OUTCOMES.duplicateEmail);
 				await renderFailure(email, [{ message: "An account with this email already exists" }]);
 				return;
 			}
@@ -358,6 +359,7 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 
 		const created = await deps.createUserWithPasswordHash({ email, passwordHash });
 		if (!created.ok) {
+			logSignupAttempt(SIGNUP_OUTCOMES.duplicateEmail);
 			await renderFailure(email, [{ message: "An account with this email already exists" }]);
 			return;
 		}

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -955,7 +955,34 @@ describe("Auth routes", () => {
 			expect(signupAttempts(harness)).toMatchObject([{ outcome: "duplicate_email" }]);
 		}, 30000);
 
-		it("does not emit signup_attempted for a bot-rejected submission — those are counted on the bot-defense stream", async () => {
+		it("emits outcome=too_fast when a submit inside the bot window is rejected — the visitor is shown the form again, so the rejection belongs in the signup funnel and not only on the bot-defense stream", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "autofill@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: String(Date.now() - 1000),
+			});
+
+			expect(response.status).toBe(422);
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "too_fast" }]);
+		});
+
+		it("emits outcome=disposable_email when the submission is both disposable and otherwise invalid — the disposable gate takes precedence, so the outcome buckets are not mutually exclusive by input", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "user@slmail.me",
+				password: "short",
+				confirmPassword: "short",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "disposable_email" }]);
+		});
+
+		it("does not emit signup_attempted for a honeypot trip — the visitor is silently fake-succeeded rather than shown a rejection, so it is counted on the bot-defense stream only", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 
 			await request(harness.server).post("/signup").type("form").send({
@@ -966,7 +993,19 @@ describe("Auth routes", () => {
 				loadedAt: freshLoadedAt(),
 			});
 
-			assert.equal(signupAttempts(harness).length, 0, "bot trips are not signup_attempted events");
+			assert.equal(signupAttempts(harness).length, 0, "honeypot trips are not signup_attempted events");
+		});
+
+		it("does not emit signup_attempted for a missing-timestamp trip — likewise fake-succeeded, so only the human-visible too-fast rejection reaches the signup funnel", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "bot@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+			});
+
+			assert.equal(signupAttempts(harness).length, 0, "missing-timestamp trips are not signup_attempted events");
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -810,6 +810,105 @@ describe("Auth routes", () => {
 
 	});
 
+	describe("POST /signup — signup_attempted analytics", () => {
+		function signupAttempts(harness: { analytics: { events: Array<{ event: string }> } }) {
+			return harness.analytics.events.filter((e) => e.event === "signup_attempted");
+		}
+
+		it("emits a single outcome=created event on a successful free signup", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "attempt-free@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			const attempts = signupAttempts(harness);
+			assert.equal(attempts.length, 1, "exactly one signup_attempted");
+			expect(attempts[0]).toMatchObject({
+				stream: "analytics",
+				event: "signup_attempted",
+				method: "email",
+				outcome: "created",
+				is_authenticated: 0,
+			});
+		});
+
+		it("emits outcome=created on a trial signup once the founding allocation is exhausted", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
+				await harness.auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "attempt-trial@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			const attempts = signupAttempts(harness);
+			assert.equal(attempts.length, 1, "exactly one signup_attempted");
+			expect(attempts[0]).toMatchObject({ outcome: "created" });
+		}, 30000);
+
+		it("emits outcome=disposable_email when a disposable domain is rejected — the deliberate friction whose signup cost was previously invisible", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "user@slmail.me",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "disposable_email" }]);
+		});
+
+		it("emits outcome=invalid_input for a generic validation failure (password too short)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "shortpw@gmail.com",
+				password: "short",
+				confirmPassword: "short",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "invalid_input" }]);
+		});
+
+		it("emits outcome=duplicate_email when the address already has an account", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			await harness.auth.createUser({ email: "dupe@gmail.com", password: "password123" });
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "dupe@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "duplicate_email" }]);
+		});
+
+		it("does not emit signup_attempted for a bot-rejected submission — those are counted on the bot-defense stream", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			await request(harness.server).post("/signup").type("form").send({
+				email: "bot@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				website: "http://spam.example",
+				loadedAt: freshLoadedAt(),
+			});
+
+			assert.equal(signupAttempts(harness).length, 0, "bot trips are not signup_attempted events");
+		});
+	});
+
 	describe("POST /signup — bot defense", () => {
 		it("returns a fake-success 303 to /?signup=pending and logs a 'honeypot' rejection when the hidden website field is filled", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));

--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -894,6 +894,67 @@ describe("Auth routes", () => {
 			expect(signupAttempts(harness)).toMatchObject([{ outcome: "duplicate_email" }]);
 		});
 
+		it("emits outcome=duplicate_email on the free path when the duplicate is caught at insert time (createUserWithPasswordHash race), not by validation", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			let raceFindCount = 0;
+			const harness = useApp({
+				...fixture,
+				auth: {
+					...fixture.auth,
+					findUserByEmail: async (email) => {
+						if (email === "race-free@gmail.com") {
+							raceFindCount++;
+							if (raceFindCount === 1) return null;
+						}
+						return fixture.auth.findUserByEmail(email);
+					},
+				},
+			});
+			await fixture.auth.createUser({ email: "race-free@gmail.com", password: "existing" });
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "race-free@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(422);
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "duplicate_email" }]);
+		});
+
+		it("emits outcome=duplicate_email on the trial path insert-time race once the founding allocation is exhausted", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			let raceFindCount = 0;
+			const harness = useApp({
+				...fixture,
+				auth: {
+					...fixture.auth,
+					findUserByEmail: async (email) => {
+						if (email === "race-trial@gmail.com") {
+							raceFindCount++;
+							if (raceFindCount === 1) return null;
+						}
+						return fixture.auth.findUserByEmail(email);
+					},
+				},
+			});
+			for (let i = 0; i < TEST_FOUNDING_MEMBER_LIMIT; i++) {
+				await fixture.auth.createUser({ email: `seed${i}@test.com`, password: "password123" });
+			}
+			await fixture.auth.createUser({ email: "race-trial@gmail.com", password: "existing" });
+
+			const response = await request(harness.server).post("/signup").type("form").send({
+				email: "race-trial@gmail.com",
+				password: "password123",
+				confirmPassword: "password123",
+				loadedAt: freshLoadedAt(),
+			});
+
+			expect(response.status).toBe(422);
+			expect(signupAttempts(harness)).toMatchObject([{ outcome: "duplicate_email" }]);
+		}, 30000);
+
 		it("does not emit signup_attempted for a bot-rejected submission — those are counted on the bot-defense stream", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 

--- a/src/packages/web-analytics/src/analytics.test.ts
+++ b/src/packages/web-analytics/src/analytics.test.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "node:events";
 import type { NextFunction, Request, Response } from "express";
 import type { HutchLogger } from "@packages/hutch-logger";
-import { type AnalyticsClick, type AnalyticsEvent, type AnalyticsPageview, buildSaveIntentEvent, classifyBrowser, classifyDeviceClass, createAnalyticsMiddleware, hashIp, suppressClickCount, type ViewSaveIntentEvent } from "./analytics";
-import { SAVE_OUTCOMES, SAVE_SURFACES } from "./events";
+import { type AnalyticsClick, type AnalyticsEvent, type AnalyticsPageview, buildSaveIntentEvent, buildSignupAttemptedEvent, classifyBrowser, classifyDeviceClass, createAnalyticsMiddleware, hashIp, type SignupAttemptedEvent, suppressClickCount, type ViewSaveIntentEvent } from "./analytics";
+import { SAVE_OUTCOMES, SAVE_SURFACES, SIGNUP_OUTCOMES } from "./events";
 
 function createCapturingLogger(): {
 	logger: HutchLogger.Typed<AnalyticsEvent>;
@@ -552,6 +552,43 @@ describe("buildSaveIntentEvent", () => {
 	it("throws when the visitor-id middleware has not run (req.visitorId unset) — a save surface must never emit view_save_intent without a visitor identity to join the conversion on", () => {
 		expect(() => buildIntent({ req: {} })).toThrow(
 			"visitor-id middleware must run before a save surface emits view_save_intent",
+		);
+	});
+});
+
+function buildSignup(overrides: { req?: MockReqOverrides; outcome?: SignupAttemptedEvent["outcome"] } = {}): SignupAttemptedEvent {
+	return buildSignupAttemptedEvent(
+		{ now: () => new Date("2026-04-21T10:00:00.000Z"), salt: "test-salt" },
+		{
+			req: createReq(overrides.req ?? { visitorId: VALID_VISITOR_ID }) as Request,
+			outcome: overrides.outcome ?? SIGNUP_OUTCOMES.created,
+		},
+	);
+}
+
+describe("buildSignupAttemptedEvent", () => {
+	it("builds a signup_attempted event carrying the terminal outcome, the visitor identity (hash + id) that joins to user_created, and is_authenticated=0 because the signup form is only shown to anonymous visitors", () => {
+		const event = buildSignup({ outcome: SIGNUP_OUTCOMES.disposableEmail });
+		expect(event).toEqual({
+			stream: "analytics",
+			event: "signup_attempted",
+			timestamp: "2026-04-21T10:00:00.000Z",
+			method: "email",
+			outcome: "disposable_email",
+			visitor_hash: expect.any(String),
+			visitor_id: VALID_VISITOR_ID,
+			is_authenticated: 0,
+		});
+	});
+
+	it("stamps visitor_hash as the salted hash of the request ip so the dashboard owner-exclusion filter can drop the maintainer's own attempts", () => {
+		const event = buildSignup({ req: { visitorId: VALID_VISITOR_ID, ip: "9.9.9.9" } });
+		expect(event.visitor_hash).toBe(hashIp({ ip: "9.9.9.9", salt: "test-salt" }));
+	});
+
+	it("throws when the visitor-id middleware has not run (req.visitorId unset) — POST /signup must never emit signup_attempted without a visitor identity to join user_created on", () => {
+		expect(() => buildSignup({ req: {} })).toThrow(
+			"visitor-id middleware must run before POST /signup emits signup_attempted",
 		);
 	});
 });

--- a/src/packages/web-analytics/src/analytics.ts
+++ b/src/packages/web-analytics/src/analytics.ts
@@ -257,12 +257,15 @@ export interface ViewSaveIntentEvent {
 }
 
 /**
- * Emitted at each terminal branch of the POST /signup handler so the signup
- * form's own conversion — submissions vs accounts created — is countable, and
- * so the share lost to each rejection gate (disposable email, duplicate,
- * generic validation) is separable. Carries `visitor_id` to join to
+ * Emitted at each terminal branch of the POST /signup handler so the email
+ * signup form's own conversion — submissions vs accounts created — is countable,
+ * and so the share lost to each rejection gate (disposable email, duplicate,
+ * generic validation) is separable. Only the email form is measured here; Google
+ * sign-in creates accounts through a separate path, so this is the form's
+ * conversion, not total account creation. Carries `visitor_id` to join to
  * `user_created` and to the anonymous reader funnel. Always `is_authenticated:
- * 0` (a signed-in visitor is redirected off /signup before the handler runs).
+ * 0` — the signup form is only ever shown to anonymous visitors, so a submission
+ * is never authenticated.
  */
 export interface SignupAttemptedEvent {
 	stream: typeof STREAMS.analytics;

--- a/src/packages/web-analytics/src/analytics.ts
+++ b/src/packages/web-analytics/src/analytics.ts
@@ -256,17 +256,6 @@ export interface ViewSaveIntentEvent {
 	is_authenticated: 0 | 1;
 }
 
-/**
- * Emitted at each terminal branch of the POST /signup handler so the email
- * signup form's own conversion — submissions vs accounts created — is countable,
- * and so the share lost to each rejection gate (disposable email, duplicate,
- * generic validation) is separable. Only the email form is measured here; Google
- * sign-in creates accounts through a separate path, so this is the form's
- * conversion, not total account creation. Carries `visitor_id` to join to
- * `user_created` and to the anonymous reader funnel. Always `is_authenticated:
- * 0` — the signup form is only ever shown to anonymous visitors, so a submission
- * is never authenticated.
- */
 export interface SignupAttemptedEvent {
 	stream: typeof STREAMS.analytics;
 	event: typeof ANALYTICS_EVENTS.signupAttempted;
@@ -423,12 +412,6 @@ export function buildSaveIntentEvent(
 	};
 }
 
-/**
- * Builds a `signup_attempted` event for a terminal outcome of the POST /signup
- * handler. Centralizes the `visitor_hash`/`visitor_id` derivation so signup
- * attempts carry the same join and dashboard-exclusion identifiers as the rest
- * of the analytics stream.
- */
 export function buildSignupAttemptedEvent(
 	deps: { now: () => Date; salt: string },
 	params: { req: Request; outcome: SignupOutcome },

--- a/src/packages/web-analytics/src/analytics.ts
+++ b/src/packages/web-analytics/src/analytics.ts
@@ -9,6 +9,7 @@ import {
 	INTERNAL_CLICK_MEDIUM,
 	type SaveOutcome,
 	type SaveSurface,
+	type SignupOutcome,
 	STREAMS,
 } from "./events";
 import {
@@ -255,6 +256,25 @@ export interface ViewSaveIntentEvent {
 	is_authenticated: 0 | 1;
 }
 
+/**
+ * Emitted at each terminal branch of the POST /signup handler so the signup
+ * form's own conversion — submissions vs accounts created — is countable, and
+ * so the share lost to each rejection gate (disposable email, duplicate,
+ * generic validation) is separable. Carries `visitor_id` to join to
+ * `user_created` and to the anonymous reader funnel. Always `is_authenticated:
+ * 0` (a signed-in visitor is redirected off /signup before the handler runs).
+ */
+export interface SignupAttemptedEvent {
+	stream: typeof STREAMS.analytics;
+	event: typeof ANALYTICS_EVENTS.signupAttempted;
+	timestamp: string;
+	method: "email";
+	outcome: SignupOutcome;
+	visitor_hash: string | null;
+	visitor_id: string | null;
+	is_authenticated: 0;
+}
+
 export type AnalyticsEvent =
 	| AnalyticsPageview
 	| AnalyticsClick
@@ -264,7 +284,8 @@ export type AnalyticsEvent =
 	| ArticleReadEvent
 	| SummaryToggledEvent
 	| ViewOpenedEvent
-	| ViewSaveIntentEvent;
+	| ViewSaveIntentEvent
+	| SignupAttemptedEvent;
 
 function shouldLog(params: { req: Request; path: string; statusCode: number }): boolean {
 	if (params.req.method !== "GET") return false;
@@ -396,6 +417,28 @@ export function buildSaveIntentEvent(
 		visitor_hash: hashIp({ ip: params.req.ip, salt: deps.salt }),
 		visitor_id: params.req.visitorId,
 		is_authenticated: params.req.userId ? 1 : 0,
+	};
+}
+
+/**
+ * Builds a `signup_attempted` event for a terminal outcome of the POST /signup
+ * handler. Centralizes the `visitor_hash`/`visitor_id` derivation so signup
+ * attempts carry the same join and dashboard-exclusion identifiers as the rest
+ * of the analytics stream.
+ */
+export function buildSignupAttemptedEvent(
+	deps: { now: () => Date; salt: string },
+	params: { req: Request; outcome: SignupOutcome },
+): SignupAttemptedEvent {
+	return {
+		stream: STREAMS.analytics,
+		event: ANALYTICS_EVENTS.signupAttempted,
+		timestamp: deps.now().toISOString(),
+		method: "email",
+		outcome: params.outcome,
+		visitor_hash: hashIp({ ip: params.req.ip, salt: deps.salt }),
+		visitor_id: params.req.visitorId ?? null,
+		is_authenticated: 0,
 	};
 }
 

--- a/src/packages/web-analytics/src/analytics.ts
+++ b/src/packages/web-analytics/src/analytics.ts
@@ -271,7 +271,7 @@ export interface SignupAttemptedEvent {
 	method: "email";
 	outcome: SignupOutcome;
 	visitor_hash: string | null;
-	visitor_id: string | null;
+	visitor_id: string;
 	is_authenticated: 0;
 }
 
@@ -430,6 +430,7 @@ export function buildSignupAttemptedEvent(
 	deps: { now: () => Date; salt: string },
 	params: { req: Request; outcome: SignupOutcome },
 ): SignupAttemptedEvent {
+	assert(params.req.visitorId, "visitor-id middleware must run before POST /signup emits signup_attempted");
 	return {
 		stream: STREAMS.analytics,
 		event: ANALYTICS_EVENTS.signupAttempted,
@@ -437,7 +438,7 @@ export function buildSignupAttemptedEvent(
 		method: "email",
 		outcome: params.outcome,
 		visitor_hash: hashIp({ ip: params.req.ip, salt: deps.salt }),
-		visitor_id: params.req.visitorId ?? null,
+		visitor_id: params.req.visitorId,
 		is_authenticated: 0,
 	};
 }

--- a/src/packages/web-analytics/src/events.ts
+++ b/src/packages/web-analytics/src/events.ts
@@ -29,14 +29,16 @@ export const ANALYTICS_EVENTS = {
 } as const;
 
 /**
- * Terminal outcomes of a POST /signup submission, emitted so the signup form's
- * own conversion (submissions → accounts) is measurable and the cost of each
- * rejection gate is separable. `disposable_email` is split out from generic
- * `invalid_input` because rejecting disposable-email domains is a deliberate
- * product friction whose signup cost was previously invisible. Bot-defense
- * trips are NOT counted here — they have their own bot-defense stream. The
- * per-IP rate-limit (429) short-circuits in middleware before the handler, so
- * it is likewise out of scope for this event.
+ * Terminal outcomes of a POST /signup submission, emitted so the email signup
+ * form's own conversion (submissions → accounts) is measurable and the cost of
+ * each rejection gate is separable. Only the email form is counted — Google
+ * sign-in creates accounts through a separate path — so this is the form's
+ * conversion, not total account creation. `disposable_email` is split out from
+ * generic `invalid_input` because rejecting disposable-email domains is a
+ * deliberate product friction whose signup cost was previously invisible.
+ * Bot-defense trips are NOT counted here — they have their own bot-defense
+ * stream. The per-IP rate-limit (429) short-circuits in middleware before the
+ * handler, so it is likewise out of scope for this event.
  */
 export const SIGNUP_OUTCOMES = {
 	created: "created",

--- a/src/packages/web-analytics/src/events.ts
+++ b/src/packages/web-analytics/src/events.ts
@@ -28,23 +28,12 @@ export const ANALYTICS_EVENTS = {
 	signupAttempted: "signup_attempted",
 } as const;
 
-/**
- * Terminal outcomes of a POST /signup submission, emitted so the email signup
- * form's own conversion (submissions → accounts) is measurable and the cost of
- * each rejection gate is separable. Only the email form is counted — Google
- * sign-in creates accounts through a separate path — so this is the form's
- * conversion, not total account creation. `disposable_email` is split out from
- * generic `invalid_input` because rejecting disposable-email domains is a
- * deliberate product friction whose signup cost was previously invisible.
- * Bot-defense trips are NOT counted here — they have their own bot-defense
- * stream. The per-IP rate-limit (429) short-circuits in middleware before the
- * handler, so it is likewise out of scope for this event.
- */
 export const SIGNUP_OUTCOMES = {
 	created: "created",
 	disposableEmail: "disposable_email",
 	invalidInput: "invalid_input",
 	duplicateEmail: "duplicate_email",
+	tooFast: "too_fast",
 } as const;
 
 export type SignupOutcome = (typeof SIGNUP_OUTCOMES)[keyof typeof SIGNUP_OUTCOMES];

--- a/src/packages/web-analytics/src/events.ts
+++ b/src/packages/web-analytics/src/events.ts
@@ -25,7 +25,27 @@ export const ANALYTICS_EVENTS = {
 	summaryToggled: "summary_toggled",
 	viewOpened: "view_opened",
 	viewSaveIntent: "view_save_intent",
+	signupAttempted: "signup_attempted",
 } as const;
+
+/**
+ * Terminal outcomes of a POST /signup submission, emitted so the signup form's
+ * own conversion (submissions → accounts) is measurable and the cost of each
+ * rejection gate is separable. `disposable_email` is split out from generic
+ * `invalid_input` because rejecting disposable-email domains is a deliberate
+ * product friction whose signup cost was previously invisible. Bot-defense
+ * trips are NOT counted here — they have their own bot-defense stream. The
+ * per-IP rate-limit (429) short-circuits in middleware before the handler, so
+ * it is likewise out of scope for this event.
+ */
+export const SIGNUP_OUTCOMES = {
+	created: "created",
+	disposableEmail: "disposable_email",
+	invalidInput: "invalid_input",
+	duplicateEmail: "duplicate_email",
+} as const;
+
+export type SignupOutcome = (typeof SIGNUP_OUTCOMES)[keyof typeof SIGNUP_OUTCOMES];
 
 /**
  * Dimensions of the `view_save_intent` event. Each is the single source of

--- a/src/packages/web-analytics/src/index.ts
+++ b/src/packages/web-analytics/src/index.ts
@@ -3,10 +3,12 @@ export {
 	ANALYTICS_EVENTS,
 	SAVE_SURFACES,
 	SAVE_OUTCOMES,
+	SIGNUP_OUTCOMES,
 	CONTENT_CLASSES,
 	INTERNAL_CLICK_MEDIUM,
 	type SaveSurface,
 	type SaveOutcome,
+	type SignupOutcome,
 } from "./events";
 export {
 	OWN_CONTENT_DOMAINS,
@@ -35,7 +37,9 @@ export {
 	classifyDeviceClass,
 	classifyBrowser,
 	buildSaveIntentEvent,
+	buildSignupAttemptedEvent,
 	type AnalyticsEvent,
+	type SignupAttemptedEvent,
 	type AnalyticsPageview,
 	type AnalyticsClick,
 	type ImportUploadedEvent,


### PR DESCRIPTION
## Hypothesis

The signup form is a black box. `POST /signup` emits nothing on any outcome except success (`user_created`), so a visitor who **submitted and was rejected** — disposable email, duplicate account, failed validation — is indistinguishable in analytics from one who bounced without ever submitting. In particular, **disposable-email blocking is a deliberate product friction whose signup cost has never been measured.** This PR emits a `signup_attempted` analytics event at every terminal branch of the handler so the form's own conversion — and the share lost to each gate — becomes countable.

## Evidence (production, last 30 days)

- **214 distinct anonymous visitors** hit `/signup`; **35** accounts were created. The ~180 who didn't convert are currently unattributable: bounce vs. rejected-submission is invisible.
- The repo rejects disposable-email domains at signup (commit `e87d530f`) — a real gate with an unmeasured cost. If a non-trivial share of those ~180 are being turned away at submit time, that's recoverable signup volume hiding in plain sight.
- Instrumentation audit flagged this as the #2 dark funnel stage (after the blog): "a visitor who submitted and was rejected is indistinguishable from one who bounced."

## What this changes

A new `signup_attempted` event (analytics stream) emitted at every terminal outcome of `POST /signup`:

| `outcome` | When |
|---|---|
| `created` | account created (free/founding or trial path) |
| `disposable_email` | rejected because the email domain is on the disposable blocklist |
| `invalid_input` | other schema failure (weak password, invalid email) |
| `duplicate_email` | address already has an account (validation, or the insert-time race) |
| `too_fast` | submitted inside the 2.5s bot window and shown the form again |

- Carries `visitor_id` (joins to `user_created` and the reader funnel) and `visitor_hash` (dashboard owner-exclusion).
- **`too_fast` is counted because the visitor sees the rejection.** Since `ab75c208` that branch re-renders the form with a 422 rather than the silent fake-success 303 the other bot reasons get — password-manager autofill routinely submits inside the window — so a hasty human who is told to retry and gives up is exactly the submitted-and-rejected cohort this event exists to surface. The genuinely silent trips (`honeypot`, `missing_timestamp`, `invalid_timestamp`) are fake-succeeded, never shown a rejection, and stay on the `bot-defense` stream only. The per-IP rate-limit 429 short-circuits in middleware before the handler, so it is out of scope. Each arm is pinned by a test.
- A submission that is **both** disposable and otherwise invalid is bucketed as `disposable_email` — the gate takes precedence, making its measured cost an upper bound, which is the conservative direction for the decision this informs. Also pinned by a test.
- Two dashboard widgets added: **"Email signup form outcomes"** (bar) and **"Email signup form outcomes per day"** (time series). Scope is the email form; Google and Apple sign-in create accounts through separate paths and are carried by the event's `method: "email"` type.

Files: `@packages/web-analytics` — `events.ts` (`ANALYTICS_EVENTS.signupAttempted` + `SIGNUP_OUTCOMES`), `analytics.ts` (`SignupAttemptedEvent` + `buildSignupAttemptedEvent`), `index.ts` (exports). `hutch` — `observability/events.ts` (re-export), `web/auth/auth.page.ts` (emit at every terminal branch), `server.ts` (thread the existing analytics logger + salt into the auth routes), `observability/analytics-dashboard.ts` (2 widgets).

## Estimated result

No direct conversion change — this is a **measurement enabler** for a suspected friction. Its payoff is a decision: once you can see `disposable_email` as a share of `signup_attempted`, you can quantify whether relaxing or refining the blocklist would recover signups, and compute the true **signup-page → account** conversion rate (impossible today). This is a prerequisite for optimizing the top of the funnel with data instead of guesses.

## How to measure

- **Signup-form conversion** = `count(outcome='created') / count(*)` over `signup_attempted`.
- **Cost of the disposable-email gate** = `count(outcome='disposable_email') / count(*)`.
- Both render on the new dashboard widgets; the raw query:

```
# Logs Insights (hutch-handler)
fields @timestamp, outcome
| filter stream="analytics" and event="signup_attempted"
| stats count(*) as attempts by outcome
| sort attempts desc
```

## Verification

`pnpm check` passes (all 42 projects; lint, types, knip, unit + integration + Playwright E2E, 100% coverage gate). Route tests assert exactly one event with the correct `outcome` for each terminal path — `created` (founding + trial), `disposable_email` (alone, and co-occurring with a weak password), `invalid_input`, `duplicate_email` (validation, plus the founding- and trial-path insert-time races), and `too_fast` — and that honeypot and missing-timestamp trips emit none.

https://claude.ai/code/session_01En2uUiiwQoRQKWenCnkPi9
