### PR TITLE
test(ios-readplace): assert exact values instead of existence/negatives

### DIFF
--- a/projects/ios-readplace/Tests/LoginFlowTests.swift
+++ b/projects/ios-readplace/Tests/LoginFlowTests.swift
@@ -23,7 +23,7 @@ final class LoginFlowTests: XCTestCase {
 		let request = makeService(store: TestSupport.loggedInStore()).makeNativeLoginAuthorizationRequest()
 
 		let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false)!
-		XCTAssertEqual(components.host, "readplace.com")
+		XCTAssertEqual(components.host, URL(string: AppConfig.serverBaseURL)?.host)
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
 		XCTAssertEqual(items["client_id"], "ios-app")

--- a/projects/ios-readplace/Tests/PKCETests.swift
+++ b/projects/ios-readplace/Tests/PKCETests.swift
@@ -23,11 +23,14 @@ final class PKCETests: XCTestCase {
 		XCTAssertNotEqual(PKCE.makeCodeVerifier(), PKCE.makeCodeVerifier())
 	}
 
-	func testChallengeIsURLSafe() {
+	func testChallengeIsBase64URLAndCorrectLength() {
 		let challenge = PKCE.challenge(for: PKCE.makeCodeVerifier())
-		XCTAssertFalse(challenge.contains("+"))
-		XCTAssertFalse(challenge.contains("/"))
-		XCTAssertFalse(challenge.contains("="))
-		XCTAssertFalse(challenge.isEmpty)
+		XCTAssertEqual(challenge.count, 43, "a SHA-256 digest base64url-encodes to 43 chars")
+		let allowed = CharacterSet(charactersIn:
+			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+		XCTAssertTrue(
+			challenge.unicodeScalars.allSatisfy(allowed.contains),
+			"every character is in the base64url alphabet (no +, /, or =)"
+		)
 	}
 }

--- a/projects/ios-readplace/Tests/SignupFlowTests.swift
+++ b/projects/ios-readplace/Tests/SignupFlowTests.swift
@@ -21,7 +21,7 @@ final class SignupFlowTests: XCTestCase {
 		let request = makeService(store: TestSupport.loggedInStore()).makeSignupAuthorizationRequest()
 
 		let components = URLComponents(url: request.url, resolvingAgainstBaseURL: false)!
-		XCTAssertEqual(components.host, "readplace.com")
+		XCTAssertEqual(components.host, URL(string: AppConfig.serverBaseURL)?.host)
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
 		XCTAssertEqual(items["client_id"], "ios-app")
@@ -83,7 +83,7 @@ final class SignupFlowTests: XCTestCase {
 		XCTAssertEqual(probed?.scheme, "googlechromes", "Chrome availability is probed with the https scheme variant")
 		let components = URLComponents(url: chrome, resolvingAgainstBaseURL: false)!
 		XCTAssertEqual(components.scheme, "googlechromes")
-		XCTAssertEqual(components.host, "readplace.com")
+		XCTAssertEqual(components.host, URL(string: AppConfig.serverBaseURL)?.host)
 		XCTAssertEqual(components.path, "/oauth/authorize")
 		XCTAssertEqual(components.percentEncodedQuery, "client_id=ios-app&state=abc")
 	}

--- a/projects/ios-readplace/Tests/SirenDecodingTests.swift
+++ b/projects/ios-readplace/Tests/SirenDecodingTests.swift
@@ -2,6 +2,16 @@ import XCTest
 @testable import Readplace
 
 final class SirenDecodingTests: XCTestCase {
+	/// A fixed UTC instant, for asserting a parsed date equals a known point in
+	/// time rather than merely being non-nil.
+	static func utc(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int, _ second: Int) -> Date {
+		var calendar = Calendar(identifier: .gregorian)
+		calendar.timeZone = TimeZone(identifier: "UTC")!
+		return calendar.date(from: DateComponents(
+			year: year, month: month, day: day, hour: hour, minute: minute, second: second
+		))!
+	}
+
 	private func decodeCollection(_ json: String) throws -> SirenCollection {
 		try JSONDecoder().decode(SirenCollection.self, from: Data(json.utf8))
 	}
@@ -27,7 +37,8 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertEqual(updateStatus.type, "application/x-www-form-urlencoded")
 		XCTAssertEqual(updateStatus.fields?.first?.name, "status")
 		XCTAssertEqual(article.readHref, "/queue/a1/view")
-		XCTAssertNotNil(article.savedAt)
+		XCTAssertEqual(article.savedAt, SirenDecodingTests.utc(2026, 5, 30, 10, 0, 0),
+			"the fixture's savedAt (2026-05-30T10:00:00.000Z) parses to that exact instant")
 	}
 
 	func testArticleAffordancesIterateAdvertisedActionsInWireOrder() throws {
@@ -315,9 +326,12 @@ final class SirenDecodingTests: XCTestCase {
 		XCTAssertEqual(page.warning?.message, "Cannot save that link.")
 	}
 
-	func testSirenDateParsesWithAndWithoutFractionalSeconds() {
-		XCTAssertNotNil(SirenDate.parse("2026-05-30T10:00:00.123Z"))
-		XCTAssertNotNil(SirenDate.parse("2026-05-30T10:00:00Z"))
+	func testSirenDateParsesWithAndWithoutFractionalSeconds() throws {
+		let base = SirenDecodingTests.utc(2026, 5, 30, 10, 0, 0)
+		XCTAssertEqual(try XCTUnwrap(SirenDate.parse("2026-05-30T10:00:00Z")), base)
+		let fractional = try XCTUnwrap(SirenDate.parse("2026-05-30T10:00:00.123Z"))
+		XCTAssertEqual(fractional.timeIntervalSince(base), 0.123, accuracy: 0.0005,
+			"the fractional variant is 123 ms after the whole-second instant")
 		XCTAssertNil(SirenDate.parse("not-a-date"))
 		XCTAssertNil(SirenDate.parse(""))
 	}


### PR DESCRIPTION
> Stacked on #922 (base = `ios/untested-seams`). Review/merge after it. Test-only, no production changes.

## Purpose

Three tests passed **for the wrong reason** — an existence check or a negative assertion that a buggy implementation would still satisfy. This replaces them with assertions that pin the actual value, per the repo's test-driven-design conventions ("Test Behavior, Not Element Existence" / "Avoid Negative Test Assertions").

## What changed & why it matters

- **`SirenDate` parsing** — `XCTAssertNotNil(SirenDate.parse(…))` passed even if the parser returned the *wrong instant* (dropped the fractional part, misread the zone). Now it asserts the parsed value equals a known UTC instant, and that the fractional variant is exactly 123 ms later. Same fix for the fixture's `savedAt` (was `XCTAssertNotNil`).
- **PKCE challenge** — `testChallengeIsURLSafe` proved the challenge only by what it *didn't* contain (`+`, `/`, `=`), so a wrong-length or wrong-alphabet challenge passed. Now it asserts the exact length (43) and a positive base64url-alphabet check, mirroring the verifier test.
- **Login/Signup authorize** — the tests pinned the literal host `"readplace.com"`, which is *why* the full suite can't run under the STAGING build. They now derive the expected host from `AppConfig.serverBaseURL` (the same config the code uses), making them environment-agnostic — a prerequisite for a later widening of `make test-staging`.

## Testing
Full suite green (**242 tests**), coverage gate passes, STAGING smoke passes.
