### PR TITLE
docs(hutch): note homepage A/B noindex + canonical=/ is intentional defence-in-depth

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -73,9 +73,11 @@ export function HomePage(params: HomePageParams): PageBody {
 				"The read-it-later app and online reader for distraction-free reading — save any article or web page in one click and read it later in a clean reader view. A privacy-first Pocket alternative with real Tesseract OCR for scanned PDFs (no LLM hallucination). Read the Web, not the Slop.",
 			canonicalUrl: "https://readplace.com",
 			ogType: "website",
-			// The A/B arms are noindex so only the canonical `/` competes for SEO;
-			// the canonical above stays on `/` for all three renders.
-			// Defence-in-depth: the isbot gate already keeps crawlers off the arms, so pairing noindex with canonical=`/` here is deliberately redundant — don't remove either half.
+			// The A/B arms render `noindex` with canonical=`/`, so only the canonical `/` competes for
+			// SEO across all three renders. This is defence-in-depth, not redundancy: the isbot gate on
+			// `/` only keeps crawlers off the arms they'd reach via the client redirect. A direct hit to
+			// a `/landing-*` URL is not bot-gated and not disallowed in robots.txt, so on that path the
+			// arm's own noindex + canonical=`/` are the only guard. Don't remove either half.
 			robots: variant ? "noindex, follow" : "index, follow",
 			ogImage: `${staticBaseUrl}/og-image-1200x630.png`,
 			ogImageType: "image/png",

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -75,6 +75,7 @@ export function HomePage(params: HomePageParams): PageBody {
 			ogType: "website",
 			// The A/B arms are noindex so only the canonical `/` competes for SEO;
 			// the canonical above stays on `/` for all three renders.
+			// Defence-in-depth: the isbot gate already keeps crawlers off the arms, so pairing noindex with canonical=`/` here is deliberately redundant — don't remove either half.
 			robots: variant ? "noindex, follow" : "index, follow",
 			ogImage: `${staticBaseUrl}/og-image-1200x630.png`,
 			ogImageType: "image/png",


### PR DESCRIPTION
## What & why

Stacked on #908. Adds a single explanatory comment beside the homepage A/B `robots` line in `home.component.ts` — no behaviour change.

The A/B arms render `robots: noindex, follow` while keeping `canonical=/`. Because the server-side `isbot` gate already assigns bots the control `/` (so a crawler never follows the client redirect into an arm), that `noindex` + `canonical=/` pairing can read as redundant to a future maintainer. The comment records that the redundancy is deliberate defence-in-depth, so nobody strips one half on the assumption the other already covers it.

```ts
// The A/B arms are noindex so only the canonical `/` competes for SEO;
// the canonical above stays on `/` for all three renders.
// Defence-in-depth: the isbot gate already keeps crawlers off the arms, so pairing noindex with canonical=`/` here is deliberately redundant — don't remove either half.
robots: variant ? "noindex, follow" : "index, follow",
```

## Base

Targets `claude/homepage-ab-redirect-g6vdrs` (the #908 branch) because the `robots` line only exists there; the diff is a single comment line. GitHub will retarget this PR to `main` automatically once #908 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfj512E2zhVqMoHpwTewdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfj512E2zhVqMoHpwTewdg)_