### PR TITLE
fix(hutch): keep the changelog NEW chip on the homepage A/B-split arms

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -180,6 +180,7 @@ import { E2EFixturePage } from "./web/pages/e2e-fixture";
 import { createE2EFixturePdf } from "./web/pages/e2e-fixture-pdf";
 import { initInstallRoutes } from "./web/pages/install";
 import { initLandingRoutes } from "./web/pages/landing";
+import { HOMEPAGE_SPLIT } from "./web/experiments/homepage-split";
 import { detectInstallBrowser } from "./web/onboarding/extension-install";
 import { NotFoundPage } from "./web/pages/not-found";
 import { initGetEffectiveAccess } from "./domain/access/effective-access";
@@ -687,10 +688,22 @@ export function createApp(dependencies: AppDependencies): Express {
 		// Gate the client A/B split redirect on humans: bots keep the canonical `/`
 		// (control) instead of following a client redirect into a noindex arm.
 		const abSplit = !isbot(req.get("user-agent"));
+		// Suppress this render's changelog seen-script only when the split script
+		// will actually replace `/` before it paints — a human guest AND the
+		// experiment active. That throwaway frame must not record the banner
+		// version as seen, or the landing arm the reader lands on would hide the
+		// one-shot NEW chip. When the split is off (kill switch) the emitted
+		// script no-ops and the guest stays on `/`, and a bot never runs it at
+		// all: in both cases `/` is the reader's real, persistent page, so it
+		// keeps its seen-script and the chip self-suppresses on the next visit.
+		const suppressChangelogSeenScript = abSplit && HOMEPAGE_SPLIT.active;
 		sendComponent(
 			req,
 			res,
-			Base(HomePage({ userCount, staticBaseUrl, browser, foundingAllocation, abSplit }), banner),
+			Base(HomePage({ userCount, staticBaseUrl, browser, foundingAllocation, abSplit }), {
+				...banner,
+				suppressChangelogSeenScript,
+			}),
 		);
 	});
 

--- a/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
@@ -48,4 +48,61 @@ describe("changelog banner on hutch pages", () => {
 		);
 		expect(banner?.classList.contains("changelog-banner--hidden")).toBe(true);
 	});
+
+	// The A/B-split launcher render of `/` is replaced client-side before it paints;
+	// keeping its seen-script would record the version as seen and hide the NEW chip
+	// on the arm the reader actually lands on. These three cases pin the boundary:
+	// the launcher suppresses the script, the arms and the bot control keep it.
+	it("suppresses the seen-script on the / launcher render for a human guest, keeping the banner visible", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN), {
+			getChangelogBanner: async () => BANNER,
+		});
+
+		const response = await request(app).get("/");
+
+		expect(response.status).toBe(200);
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		assert(banner, "changelog banner must render on the / launcher");
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner.getAttribute("data-changelog-version")).toBe(VERSION);
+		expect(banner.querySelector("script")).toBeNull();
+	});
+
+	it("keeps the seen-script on the landing arms so the reader's real page records the first impression", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN), {
+			getChangelogBanner: async () => BANNER,
+		});
+
+		for (const path of ["/landing-a", "/landing-b"]) {
+			const response = await request(app).get(path);
+
+			expect(response.status).toBe(200);
+			const banner = new JSDOM(response.text).window.document.querySelector(
+				"[data-test-changelog-banner]",
+			);
+			assert(banner, `changelog banner must render on ${path}`);
+			expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+			expect(banner.querySelector("script")?.textContent).toBe(CHANGELOG_SEEN_SCRIPT);
+		}
+	});
+
+	it("keeps the seen-script on / for a crawler, which stays on the control (no client redirect fires)", async () => {
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN), {
+			getChangelogBanner: async () => BANNER,
+		});
+
+		const response = await request(app)
+			.get("/")
+			.set("User-Agent", "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+
+		expect(response.status).toBe(200);
+		const banner = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-changelog-banner]",
+		);
+		assert(banner, "changelog banner must render on the control /");
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner.querySelector("script")?.textContent).toBe(CHANGELOG_SEEN_SCRIPT);
+	});
 });

--- a/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
@@ -8,6 +8,7 @@ import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fix
 import { JSDOM } from "jsdom";
 import request from "supertest";
 import { createTestApp } from "../test-app";
+import { HOMEPAGE_SPLIT } from "./experiments/homepage-split";
 
 const VERSION = "a1b2c3d4";
 assert(isChangelogVersion(VERSION));
@@ -67,6 +68,10 @@ describe("changelog banner on hutch pages", () => {
 		assert(banner, "changelog banner must render on the / launcher");
 		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
 		expect(banner.getAttribute("data-changelog-version")).toBe(VERSION);
+		assert(
+			HOMEPAGE_SPLIT.active,
+			"the launcher only suppresses the seen-script while the split is active; with the kill switch off, / stays put and keeps its seen-script",
+		);
 		expect(banner.querySelector("script")).toBeNull();
 	});
 

--- a/src/packages/web-shell/src/banner-state.ts
+++ b/src/packages/web-shell/src/banner-state.ts
@@ -171,6 +171,13 @@ export interface BannerState {
 	 * the reader has dismissed the current one; the shell then renders the
 	 * hidden, empty banner shell. */
 	changelogBanner?: ChangelogBanner;
+	/** When true, the visible changelog banner omits its inline seen-script, so
+	 * this render does not record the version as seen. Set by a render that is
+	 * replaced client-side before it paints (the homepage A/B-split launcher) —
+	 * otherwise that throwaway frame burns the one-shot NEW chip before the
+	 * reader's real page renders. Undefined everywhere else, preserving current
+	 * behaviour on blog-site and every other hutch page. */
+	suppressChangelogSeenScript?: boolean;
 	/** Path (+ query) of the page this banner is rendered on, echoed into the
 	 * changelog dismiss form's hidden `returnTo` field so dismissing returns the
 	 * reader to where they were rather than the homepage. Undefined when the

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -330,6 +330,28 @@ describe("Base component", () => {
 		expect(seenScript.textContent).toBe(CHANGELOG_SEEN_SCRIPT);
 	});
 
+	it("omits the changelog seen-script when suppressChangelogSeenScript is set, keeping the banner and NEW chip visible", () => {
+		const page = createTestPageBody();
+		const result = Base(page, {
+			...GUEST_STATE,
+			suppressChangelogSeenScript: true,
+			changelogBanner: {
+				hook: "I added keyboard shortcuts to the reader",
+				href: "/blog/keyboard-shortcuts?utm_source=changelog-banner&utm_medium=internal&utm_content=read-more",
+				version: CHANGELOG_VERSION,
+			},
+		}).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const banner = doc.querySelector("[data-test-changelog-banner]");
+		assert(banner, "changelog banner must still render when the seen-script is suppressed");
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner.getAttribute("data-changelog-version")).toBe(CHANGELOG_VERSION);
+		expect(banner.querySelector(".changelog-banner__chip")?.textContent).toBe("NEW");
+		expect(banner.querySelector("script")).toBeNull();
+		expect(result.body).not.toContain(CHANGELOG_SEEN_SCRIPT);
+	});
+
 	it("threads currentPath into the changelog dismiss form so dismissing stays on the current page", () => {
 		const page = createTestPageBody();
 		const result = Base(page, {

--- a/src/packages/web-shell/src/base.component.ts
+++ b/src/packages/web-shell/src/base.component.ts
@@ -246,7 +246,9 @@ export function initBase(config: BaseConfig): RenderBase {
 			verifyBannerStyles: VERIFY_BANNER_STYLES,
 			trialCountdownStyles: TRIAL_COUNTDOWN_STYLES,
 			extensionSuggestionBannerStyles: EXTENSION_SUGGESTION_BANNER_STYLES,
-			changelogBanner: renderChangelogBannerShell(state.changelogBanner, state.currentPath),
+			changelogBanner: renderChangelogBannerShell(state.changelogBanner, state.currentPath, {
+				suppressSeenScript: state.suppressChangelogSeenScript,
+			}),
 			verifyBanner: renderVerifyBanner(state),
 			extensionSuggestionBanner: renderExtensionSuggestionBanner({
 				show: state.showExtensionSuggestionBanner ?? false,

--- a/src/packages/web-shell/src/changelog-banner.test.ts
+++ b/src/packages/web-shell/src/changelog-banner.test.ts
@@ -163,6 +163,20 @@ describe("renderChangelogBannerShell", () => {
 		expect(last.textContent).toBe(CHANGELOG_SEEN_SCRIPT);
 	});
 
+	it("omits the seen-script when suppressSeenScript is set, while still rendering the visible banner, version, and NEW chip", () => {
+		const html = renderChangelogBannerShell(BANNER, "/x", { suppressSeenScript: true });
+		const doc = parse(html);
+		const banner = doc.querySelector(".changelog-banner");
+		assert(banner, "the banner element must still render");
+		expect(banner.classList.contains("changelog-banner--visible")).toBe(true);
+		expect(banner.getAttribute("data-changelog-version")).toBe(VERSION);
+		const chip = banner.querySelector(".changelog-banner__chip");
+		assert(chip, "the NEW chip must still render when the seen-script is suppressed");
+		expect(chip.textContent).toBe("NEW");
+		expect(banner.querySelector("script")).toBeNull();
+		expect(html).not.toContain(CHANGELOG_SEEN_SCRIPT);
+	});
+
 	it("renders the hidden, empty banner when no banner is present", () => {
 		const doc = parse(renderChangelogBannerShell(undefined));
 		const banner = doc.querySelector(".changelog-banner");

--- a/src/packages/web-shell/src/changelog-banner.ts
+++ b/src/packages/web-shell/src/changelog-banner.ts
@@ -107,14 +107,19 @@ export const CHANGELOG_SEEN_SCRIPT = `(function(){var banner=document.querySelec
  * (so the dismiss route sends the reader back where they were rather than the
  * homepage — it cannot read `Referer`, which helmet's default `no-referrer`
  * policy strips from the POST). */
-const CHANGELOG_SHELL_TEMPLATE = `<div class="changelog-banner {{#if visible}}changelog-banner--visible{{else}}changelog-banner--hidden{{/if}}" role="status" aria-live="polite" data-test-changelog-banner{{#if visible}} data-changelog-version="{{version}}"{{/if}}>{{#if visible}}<div class="changelog-banner__inner"><span class="changelog-banner__chip" aria-hidden="true">NEW</span><span class="changelog-banner__hook">{{hook}}</span><a class="changelog-banner__link" href="{{href}}">Read more <span class="changelog-banner__arrow" aria-hidden="true">&rarr;</span></a><form class="changelog-banner__dismiss" method="POST" action="/banner/changelog/dismiss"><input type="hidden" name="version" value="{{version}}"><input type="hidden" name="returnTo" value="{{returnTo}}"><button type="submit" class="changelog-banner__close" aria-label="Dismiss changelog banner"><span aria-hidden="true">&times;</span></button></form></div><script>${CHANGELOG_SEEN_SCRIPT}</script>{{/if}}</div>`;
+const CHANGELOG_SHELL_TEMPLATE = `<div class="changelog-banner {{#if visible}}changelog-banner--visible{{else}}changelog-banner--hidden{{/if}}" role="status" aria-live="polite" data-test-changelog-banner{{#if visible}} data-changelog-version="{{version}}"{{/if}}>{{#if visible}}<div class="changelog-banner__inner"><span class="changelog-banner__chip" aria-hidden="true">NEW</span><span class="changelog-banner__hook">{{hook}}</span><a class="changelog-banner__link" href="{{href}}">Read more <span class="changelog-banner__arrow" aria-hidden="true">&rarr;</span></a><form class="changelog-banner__dismiss" method="POST" action="/banner/changelog/dismiss"><input type="hidden" name="version" value="{{version}}"><input type="hidden" name="returnTo" value="{{returnTo}}"><button type="submit" class="changelog-banner__close" aria-label="Dismiss changelog banner"><span aria-hidden="true">&times;</span></button></form></div>{{#if seenScript}}<script>${CHANGELOG_SEEN_SCRIPT}</script>{{/if}}{{/if}}</div>`;
 
-export function renderChangelogBannerShell(banner?: ChangelogBanner, returnTo?: string): string {
+export function renderChangelogBannerShell(
+	banner?: ChangelogBanner,
+	returnTo?: string,
+	options?: { suppressSeenScript?: boolean },
+): string {
 	return render(CHANGELOG_SHELL_TEMPLATE, {
 		visible: Boolean(banner),
 		hook: banner?.hook,
 		href: banner?.href,
 		version: banner?.version,
 		returnTo,
+		seenScript: Boolean(banner) && !options?.suppressSeenScript,
 	});
 }


### PR DESCRIPTION
## Problem

The changelog banner's **NEW** chip is a one-shot novelty signal. An inline, pre-paint script (`CHANGELOG_SEEN_SCRIPT`) records a banner version as "seen" in `localStorage['readplace.changelog-seen']` the first time any page carrying the banner renders; every later render finds the version already stored, adds `changelog-banner--seen`, and hides the chip.

The homepage A/B split (`homepage-split.client.ts`) is a **client-side `location.replace` redirect**, not a server 302. So a guest actually loads `/`, whose base shell renders the banner and its inline seen-script near the top of `<body>`. That script runs during parse — before the deferred split script — and writes the version to `localStorage`. Only *then* does the split script redirect to `/landing-a` / `/landing-b`. The arm re-renders the identical shell; the seen-script now finds the version already stored, adds `--seen`, and the chip is hidden. The throwaway `/` frame — which the visitor never actually sees — burns the one-shot NEW before the arm paints, so every redirected human guest loses NEW on a freshly announced feature.

## Fix

Thread an optional `suppressChangelogSeenScript` flag on `BannerState`, set only on the `/` launcher render. The seen-script has exactly one production render path (route → `Base(body, state)` → `renderBaseTemplate` → `renderChangelogBannerShell`), so the flag rides the already-threaded `BannerState` and leaves every other `Base(...)` call site untouched.

The **banner and NEW chip still render** (preserving the announcement for no-JS visitors, per the zero-client-JS principle) — only the inline version-marking script is omitted. The arm the visitor actually lands on then gets the genuine first impression and shows NEW once, then correctly self-suppresses on the next navigation.

### Suppress only when the render is genuinely thrown away

The launcher render is discarded **only when the split script actually replaces `/`** — a human guest **and** `HOMEPAGE_SPLIT.active`. The condition is `abSplit && HOMEPAGE_SPLIT.active`:

- **Kill switch off** (`HOMEPAGE_SPLIT.active = false`, the documented steady state once the experiment concludes): the split bundle is still emitted for human guests but early-returns without redirecting, so the guest stays on a real, persistent `/`. It must keep its seen-script — otherwise NEW would flash on every `/` visit and never self-suppress (the same regression, inverted).
- **Bots** (`abSplit` false): keep the control `/` and its seen-script; they never run the script anyway.
- **Landing arms** (`/landing-a`, `/landing-b`): render `HomePage` with `banner` as-is, so they keep the seen-script and record the genuine first impression on the reader's real page.

## Changes

- `src/packages/web-shell/src/changelog-banner.ts` — `renderChangelogBannerShell` takes an optional `{ suppressSeenScript }`; the inline seen-script is gated behind `{{#if seenScript}}` (nested inside `{{#if visible}}`). Chip, hook, link, and dismiss form stay unconditional.
- `src/packages/web-shell/src/banner-state.ts` — new optional `BannerState.suppressChangelogSeenScript` field, documented.
- `src/packages/web-shell/src/base.component.ts` — passes `{ suppressSeenScript: state.suppressChangelogSeenScript }` to the shell.
- `projects/hutch/src/runtime/server.ts` — the `/` handler sets `suppressChangelogSeenScript = abSplit && HOMEPAGE_SPLIT.active`.

## Tests

- `changelog-banner.test.ts` — `renderChangelogBannerShell(BANNER, "/x", { suppressSeenScript: true })` yields a visible banner with the NEW chip and `data-changelog-version` but **no** `<script>`.
- `base.component.test.ts` — a page with `changelogBanner` set and `suppressChangelogSeenScript: true` renders the visible banner with no seen-script.
- `changelog-banner.route.test.ts` — `GET /` (default human UA) suppresses the seen-script; `GET /landing-a` and `/landing-b` keep it; `GET /` with a Googlebot UA (control) keeps it.

## Verification

`pnpm check` passes across all 37 projects, including the 100% coverage gate on `@packages/web-shell` and `hutch`.

## Known limitation

If the split bundle fails to load (adblocker / CSP / a 404 during a deploy race), a human guest stays on `/` with the seen-script suppressed and NEW re-flashes — a cosmetic edge inherent to the existing client-redirect A/B architecture, not introduced here. Gating on `HOMEPAGE_SPLIT.active` handles the deliberate, documented kill-switch case, which is the real steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SenX5p52r8hyECDxVR7pt

---
_Generated by [Claude Code](https://claude.ai/code/session_012SenX5p52r8hyECDxVR7pt)_