### PR TITLE
feat(hutch): paginate the inbox email list and rework Manage addresses

### DIFF
--- a/projects/hutch/src/runtime/delete-account/delete-account-handler.test.ts
+++ b/projects/hutch/src/runtime/delete-account/delete-account-handler.test.ts
@@ -386,7 +386,11 @@ describe("delete-account handler", () => {
 			savedArticle: false,
 		});
 		assert.equal(await s.subs.findByUserId(victim.userId), undefined);
-		assert.equal((await s.inboxEmail.listEmailsByUserId(victim.userId)).length, 0);
+		assert.equal(
+			(await s.inboxEmail.listEmailsByUserId({ userId: victim.userId, page: 1, pageSize: 20 }))
+				.total,
+			0,
+		);
 		const victimLinks = await s.inboxLink.listLinksByEmail({
 			userId: victim.userId,
 			receivedAtMessageId: victim.ramA,
@@ -441,7 +445,16 @@ describe("delete-account handler", () => {
 		const bystanderSub = await s.subs.findByUserId(bystander.userId);
 		assert(bystanderSub, "expected the bystander subscription to survive");
 		assert.equal(bystanderSub.status, "active");
-		assert.equal((await s.inboxEmail.listEmailsByUserId(bystander.userId)).length, 2);
+		assert.equal(
+			(
+				await s.inboxEmail.listEmailsByUserId({
+					userId: bystander.userId,
+					page: 1,
+					pageSize: 20,
+				})
+			).total,
+			2,
+		);
 		assert.equal(
 			(
 				await s.inboxLink.listLinksByEmail({
@@ -647,7 +660,11 @@ describe("delete-account handler", () => {
 		// were the rows removed.
 		assert.equal(s.rawEmailDeleteArgs.length, 1);
 		assert.deepEqual(sorted(s.rawEmailDeleteArgs[0]), sorted(account.rawKeys));
-		assert.equal((await s.inboxEmail.listEmailsByUserId(account.userId)).length, 0);
+		assert.equal(
+			(await s.inboxEmail.listEmailsByUserId({ userId: account.userId, page: 1, pageSize: 20 }))
+				.total,
+			0,
+		);
 
 		// The per-user schedule deletes run before the injected S3 failure, so the
 		// pre-expiry trial-reminder schedule delete fired on both the failed first

--- a/projects/hutch/src/runtime/domain/inbox/receive-email-handler.test.ts
+++ b/projects/hutch/src/runtime/domain/inbox/receive-email-handler.test.ts
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import {
 	DEFAULT_INBOX_ALIAS,
+	type InboxEmailStore,
 	MessageIdSchema,
 	type ParseEmailResult,
 } from "@packages/domain/inbox";
-import { UserIdSchema } from "@packages/domain/user";
+import { type UserId, UserIdSchema } from "@packages/domain/user";
 import { buildLambdaContext } from "@packages/test-fixtures/lambda-context";
 import { initInMemoryInboxAddress } from "@packages/test-fixtures/providers/inbox-address";
 import { initInMemoryInboxEmail } from "@packages/test-fixtures/providers/inbox-email";
@@ -79,6 +80,11 @@ function makeHarness(opts?: {
 	return { addressStore, emailStore, rawMap, published, handler, run, runMany };
 }
 
+async function listEmails(emailStore: InboxEmailStore, userId: UserId) {
+	const { emails } = await emailStore.listEmailsByUserId({ userId, page: 1, pageSize: 100 });
+	return emails;
+}
+
 async function mintAddress(addressStore: ReturnType<typeof initInMemoryInboxAddress>) {
 	const entry = await addressStore.createAddress({
 		userId: OWNER,
@@ -100,7 +106,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(1);
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(0);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(0);
 		expect(published).toHaveLength(0);
 	});
 
@@ -112,7 +118,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(1);
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(0);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(0);
 		expect(published).toHaveLength(0);
 	});
 
@@ -125,7 +131,7 @@ describe("initReceiveEmailHandler", () => {
 		assert(result);
 		// Expected on a public catch-all MX — ACK rather than page the operator.
 		expect(result.batchItemFailures).toHaveLength(0);
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(0);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(0);
 		expect(published).toHaveLength(0);
 	});
 
@@ -138,7 +144,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(1);
-		const [row] = await emailStore.listEmailsByUserId(OWNER);
+		const [row] = await listEmails(emailStore, OWNER);
 		expect(row.status).toBe("rejected");
 		expect(row.bodyS3Key).toBeUndefined();
 		expect(published).toHaveLength(0);
@@ -154,7 +160,7 @@ describe("initReceiveEmailHandler", () => {
 		// Oversize spam to a guessed address on the public MX has no victim — audit
 		// under the unrouted partition and ACK rather than page the operator.
 		expect(result.batchItemFailures).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(UNROUTED);
+		const [row] = await listEmails(emailStore, UNROUTED);
 		expect(row.status).toBe("rejected");
 		expect(published).toHaveLength(0);
 	});
@@ -168,8 +174,8 @@ describe("initReceiveEmailHandler", () => {
 		assert(result);
 		// A guessed/mistyped address is expected on a public MX — audit, don't page.
 		expect(result.batchItemFailures).toHaveLength(0);
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(UNROUTED);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(0);
+		const [row] = await listEmails(emailStore, UNROUTED);
 		expect(row.status).toBe("rejected");
 		expect(published).toHaveLength(0);
 	});
@@ -187,8 +193,8 @@ describe("initReceiveEmailHandler", () => {
 		// don't page. The owner opted out, so the row lands under the unrouted
 		// partition rather than cluttering their list with "Rejected" rows.
 		expect(result.batchItemFailures).toHaveLength(0);
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(UNROUTED);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(0);
+		const [row] = await listEmails(emailStore, UNROUTED);
 		expect(row.status).toBe("rejected");
 		expect(row.recipientAddress).toBe(address);
 		expect(published).toHaveLength(0);
@@ -205,7 +211,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(1);
-		const [row] = await emailStore.listEmailsByUserId(OWNER);
+		const [row] = await listEmails(emailStore, OWNER);
 		expect(row.status).toBe("unparsed");
 		expect(row.bodyS3Key).toBeUndefined();
 		expect(published).toHaveLength(0);
@@ -223,7 +229,7 @@ describe("initReceiveEmailHandler", () => {
 		// Malformed spam to a guessed address is not a parser gap worth paging on —
 		// audit under the unrouted partition and ACK.
 		expect(result.batchItemFailures).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(UNROUTED);
+		const [row] = await listEmails(emailStore, UNROUTED);
 		expect(row.status).toBe("unparsed");
 		expect(published).toHaveLength(0);
 	});
@@ -239,7 +245,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(OWNER);
+		const [row] = await listEmails(emailStore, OWNER);
 		expect(row.status).toBe("received");
 		expect(row.bodyS3Key).toBe("content/email/content.html");
 		expect(row.senderEmail).toBe("news@example.com");
@@ -259,7 +265,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(OWNER);
+		const [row] = await listEmails(emailStore, OWNER);
 		expect(row.status).toBe("received");
 		expect(published).toHaveLength(1);
 	});
@@ -279,7 +285,7 @@ describe("initReceiveEmailHandler", () => {
 		// The sanitizer did its job (nothing renderable survived) — not a fault, so
 		// ACK rather than page; the immutable raw .eml stays the record.
 		expect(result.batchItemFailures).toHaveLength(0);
-		const [row] = await emailStore.listEmailsByUserId(OWNER);
+		const [row] = await listEmails(emailStore, OWNER);
 		// `unparsed` (not `received`) so the list shows the "Couldn't render" badge and
 		// the detail page shows the unavailable panel, never a blank iframe.
 		expect(row.status).toBe("unparsed");
@@ -307,8 +313,8 @@ describe("initReceiveEmailHandler", () => {
 		expect(result.batchItemFailures).toHaveLength(0);
 		// Both addressees get their own row under their own partition — neither is
 		// silently dropped, and each gets its own delivered event.
-		const [ownerRow] = await emailStore.listEmailsByUserId(OWNER);
-		const [secondRow] = await emailStore.listEmailsByUserId(SECOND);
+		const [ownerRow] = await listEmails(emailStore, OWNER);
+		const [secondRow] = await listEmails(emailStore, SECOND);
 		expect(ownerRow.status).toBe("received");
 		expect(secondRow.status).toBe("received");
 		expect(published).toHaveLength(2);
@@ -331,7 +337,7 @@ describe("initReceiveEmailHandler", () => {
 		// One physical email = one row: the sort key is the (recipient-independent)
 		// message id, so the second address's put is a no-op duplicate under the same
 		// partition. The event is re-published, which the consumer absorbs idempotently.
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(1);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(1);
 		expect(published).toHaveLength(2);
 	});
 
@@ -344,9 +350,9 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(result);
 		expect(result.batchItemFailures).toHaveLength(0);
-		const [ownerRow] = await emailStore.listEmailsByUserId(OWNER);
+		const [ownerRow] = await listEmails(emailStore, OWNER);
 		expect(ownerRow.status).toBe("received");
-		const [unrouted] = await emailStore.listEmailsByUserId(UNROUTED);
+		const [unrouted] = await listEmails(emailStore, UNROUTED);
 		expect(unrouted.status).toBe("rejected");
 		// Only the deliverable recipient produces an event.
 		expect(published).toHaveLength(1);
@@ -362,7 +368,7 @@ describe("initReceiveEmailHandler", () => {
 
 		assert(second);
 		expect(second.batchItemFailures).toHaveLength(0);
-		expect(await emailStore.listEmailsByUserId(OWNER)).toHaveLength(1);
+		expect(await listEmails(emailStore, OWNER)).toHaveLength(1);
 		expect(published).toHaveLength(2);
 	});
 

--- a/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.test.ts
+++ b/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.test.ts
@@ -71,6 +71,7 @@ interface CapturedCommand {
 		ConditionExpression?: string;
 		ScanIndexForward?: boolean;
 		ExpressionAttributeValues?: Record<string, unknown>;
+		ExclusiveStartKey?: Record<string, unknown>;
 	};
 }
 
@@ -95,6 +96,21 @@ function makeEntry(overrides: Partial<InboxEmailEntry> = {}): InboxEmailEntry {
 
 function conditionalCheckFailed(): ConditionalCheckFailedException {
 	return new ConditionalCheckFailedException({ $metadata: {}, message: "exists" });
+}
+
+function rawRow(input: { hour: string; messageId: string }): Record<string, unknown> {
+	return {
+		userId: "user-1",
+		receivedAtMessageId: `2026-06-23T${input.hour}:00:00.000Z#${input.messageId}`,
+		messageId: input.messageId,
+		recipientAddress: "in-3f9a2c@read.place",
+		senderEmail: "news@example.com",
+		subject: `At ${input.hour}`,
+		status: "received",
+		receivedAt: `2026-06-23T${input.hour}:00:00.000Z`,
+		rawEmailS3Key: `inbound/${input.hour}`,
+		bodyS3Key: `content/${input.hour}/content.html`,
+	};
 }
 
 describe("initDynamoDbInboxEmail", () => {
@@ -205,15 +221,82 @@ describe("initDynamoDbInboxEmail", () => {
 				tableName: TABLE,
 			});
 
-			const result = await store.listEmailsByUserId(USER);
+			const result = await store.listEmailsByUserId({ userId: USER, page: 1, pageSize: 20 });
 
 			expect(captured?.input.KeyConditionExpression).toBe("userId = :uid");
 			expect(captured?.input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
 			expect(captured?.input.ScanIndexForward).toBe(false);
-			expect(result).toHaveLength(2);
-			expect(result[0].subject).toBe("Newer");
-			expect(result[0].bodyS3Key).toBe("content/b/content.html");
-			expect(result[1].bodyS3Key).toBeUndefined();
+			expect(result.emails).toHaveLength(2);
+			expect(result.total).toBe(2);
+			expect(result.emails[0].subject).toBe("Newer");
+			expect(result.emails[0].bodyS3Key).toBe("content/b/content.html");
+			expect(result.emails[1].bodyS3Key).toBeUndefined();
+		});
+
+		it("walks LastEvaluatedKey to exhaustion so a partition over 1 MB is not truncated", async () => {
+			const captured: CapturedCommand[] = [];
+			const lastEvaluatedKey = {
+				userId: "user-1",
+				receivedAtMessageId: "2026-06-23T09:00:00.000Z#<b@x>",
+			};
+			const store = initDynamoDbInboxEmail({
+				client: createFakeClient((cmd) => {
+					captured.push(cmd as CapturedCommand);
+					if (captured.length === 1) {
+						return {
+							Items: [
+								rawRow({ hour: "10", messageId: "<c@x>" }),
+								rawRow({ hour: "09", messageId: "<b@x>" }),
+							],
+							Count: 2,
+							LastEvaluatedKey: lastEvaluatedKey,
+						};
+					}
+					return { Items: [rawRow({ hour: "08", messageId: "<a@x>" })], Count: 1 };
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			const result = await store.listEmailsByUserId({ userId: USER, page: 1, pageSize: 20 });
+
+			expect(captured).toHaveLength(2);
+			expect(captured[1].input.ExclusiveStartKey).toEqual(lastEvaluatedKey);
+			expect(result.emails.map((e) => e.subject)).toEqual(["At 10", "At 09", "At 08"]);
+			expect(result.total).toBe(3);
+		});
+
+		it("slices out the requested page while reporting the unpaged total", async () => {
+			const store = initDynamoDbInboxEmail({
+				client: createFakeClient(() => ({
+					Items: [
+						rawRow({ hour: "10", messageId: "<c@x>" }),
+						rawRow({ hour: "09", messageId: "<b@x>" }),
+						rawRow({ hour: "08", messageId: "<a@x>" }),
+					],
+					Count: 3,
+				})) as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			const result = await store.listEmailsByUserId({ userId: USER, page: 2, pageSize: 2 });
+
+			expect(result.emails.map((e) => e.subject)).toEqual(["At 08"]);
+			expect(result).toMatchObject({ total: 3, page: 2, pageSize: 2 });
+		});
+
+		it("returns no emails but the correct total for a page beyond the data", async () => {
+			const store = initDynamoDbInboxEmail({
+				client: createFakeClient(() => ({
+					Items: [rawRow({ hour: "10", messageId: "<c@x>" })],
+					Count: 1,
+				})) as DynamoDBDocumentClient,
+				tableName: TABLE,
+			});
+
+			const result = await store.listEmailsByUserId({ userId: USER, page: 5, pageSize: 2 });
+
+			expect(result.emails).toEqual([]);
+			expect(result.total).toBe(1);
 		});
 	});
 

--- a/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.test.ts
+++ b/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.test.ts
@@ -70,9 +70,25 @@ interface CapturedCommand {
 		KeyConditionExpression?: string;
 		ConditionExpression?: string;
 		ScanIndexForward?: boolean;
+		Select?: string;
+		Limit?: number;
 		ExpressionAttributeValues?: Record<string, unknown>;
 		ExclusiveStartKey?: Record<string, unknown>;
 	};
+}
+
+function createOrderedClient(responses: Record<string, unknown>[]): {
+	client: DynamoDBDocumentClient;
+	captured: CapturedCommand[];
+} {
+	const captured: CapturedCommand[] = [];
+	let index = 0;
+	const client = createFakeClient((cmd) => {
+		captured.push(cmd as CapturedCommand);
+		assert(index < responses.length, "ordered client received an unexpected extra query");
+		return responses[index++];
+	}) as DynamoDBDocumentClient;
+	return { client, captured };
 }
 
 const TABLE = "test-inbox-emails";
@@ -183,49 +199,48 @@ describe("initDynamoDbInboxEmail", () => {
 	});
 
 	describe("listEmailsByUserId", () => {
-		it("queries the base table newest-first, normalizing a missing body pointer", async () => {
-			let captured: CapturedCommand | undefined;
-			const store = initDynamoDbInboxEmail({
-				client: createFakeClient((cmd) => {
-					captured = cmd as CapturedCommand;
-					return {
-						Items: [
-							{
-								userId: "user-1",
-								receivedAtMessageId: "2026-06-23T09:00:00.000Z#<b@x>",
-								messageId: "<b@x>",
-								recipientAddress: "in-3f9a2c@read.place",
-								senderEmail: "b@x",
-								subject: "Newer",
-								status: "received",
-								receivedAt: "2026-06-23T09:00:00.000Z",
-								rawEmailS3Key: "inbound/b",
-								bodyS3Key: "content/b/content.html",
-							},
-							{
-								userId: "user-1",
-								receivedAtMessageId: "2026-06-23T08:00:00.000Z#<a@x>",
-								messageId: "<a@x>",
-								recipientAddress: "in-3f9a2c@read.place",
-								senderEmail: "a@x",
-								subject: "",
-								status: "rejected",
-								receivedAt: "2026-06-23T08:00:00.000Z",
-								rawEmailS3Key: "inbound/a",
-								bodyS3Key: null,
-							},
-						],
-						Count: 2,
-					};
-				}) as DynamoDBDocumentClient,
-				tableName: TABLE,
-			});
+		it("counts the mailbox, then fetches only the first page newest-first, normalizing a missing body pointer", async () => {
+			const { client, captured } = createOrderedClient([
+				{ Count: 2 },
+				{
+					Items: [
+						{
+							userId: "user-1",
+							receivedAtMessageId: "2026-06-23T09:00:00.000Z#<b@x>",
+							messageId: "<b@x>",
+							recipientAddress: "in-3f9a2c@read.place",
+							senderEmail: "b@x",
+							subject: "Newer",
+							status: "received",
+							receivedAt: "2026-06-23T09:00:00.000Z",
+							rawEmailS3Key: "inbound/b",
+							bodyS3Key: "content/b/content.html",
+						},
+						{
+							userId: "user-1",
+							receivedAtMessageId: "2026-06-23T08:00:00.000Z#<a@x>",
+							messageId: "<a@x>",
+							recipientAddress: "in-3f9a2c@read.place",
+							senderEmail: "a@x",
+							subject: "",
+							status: "rejected",
+							receivedAt: "2026-06-23T08:00:00.000Z",
+							rawEmailS3Key: "inbound/a",
+							bodyS3Key: null,
+						},
+					],
+				},
+			]);
+			const store = initDynamoDbInboxEmail({ client, tableName: TABLE });
 
 			const result = await store.listEmailsByUserId({ userId: USER, page: 1, pageSize: 20 });
 
-			expect(captured?.input.KeyConditionExpression).toBe("userId = :uid");
-			expect(captured?.input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
-			expect(captured?.input.ScanIndexForward).toBe(false);
+			expect(captured[0].input.Select).toBe("COUNT");
+			expect(captured[1].input.KeyConditionExpression).toBe("userId = :uid");
+			expect(captured[1].input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
+			expect(captured[1].input.ScanIndexForward).toBe(false);
+			expect(captured[1].input.Limit).toBe(20);
+			expect(captured[1].input.Select).toBeUndefined();
 			expect(result.emails).toHaveLength(2);
 			expect(result.total).toBe(2);
 			expect(result.emails[0].subject).toBe("Newer");
@@ -233,70 +248,97 @@ describe("initDynamoDbInboxEmail", () => {
 			expect(result.emails[1].bodyS3Key).toBeUndefined();
 		});
 
-		it("walks LastEvaluatedKey to exhaustion so a partition over 1 MB is not truncated", async () => {
-			const captured: CapturedCommand[] = [];
-			const lastEvaluatedKey = {
+		it("sums COUNT pages so a total spanning more than 1 MB is not truncated", async () => {
+			const countStartKey = {
 				userId: "user-1",
 				receivedAtMessageId: "2026-06-23T09:00:00.000Z#<b@x>",
 			};
-			const store = initDynamoDbInboxEmail({
-				client: createFakeClient((cmd) => {
-					captured.push(cmd as CapturedCommand);
-					if (captured.length === 1) {
-						return {
-							Items: [
-								rawRow({ hour: "10", messageId: "<c@x>" }),
-								rawRow({ hour: "09", messageId: "<b@x>" }),
-							],
-							Count: 2,
-							LastEvaluatedKey: lastEvaluatedKey,
-						};
-					}
-					return { Items: [rawRow({ hour: "08", messageId: "<a@x>" })], Count: 1 };
-				}) as DynamoDBDocumentClient,
-				tableName: TABLE,
-			});
+			const { client, captured } = createOrderedClient([
+				{ Count: 2, LastEvaluatedKey: countStartKey },
+				{ Count: 1 },
+				{ Items: [rawRow({ hour: "10", messageId: "<c@x>" })] },
+			]);
+			const store = initDynamoDbInboxEmail({ client, tableName: TABLE });
 
 			const result = await store.listEmailsByUserId({ userId: USER, page: 1, pageSize: 20 });
 
-			expect(captured).toHaveLength(2);
-			expect(captured[1].input.ExclusiveStartKey).toEqual(lastEvaluatedKey);
-			expect(result.emails.map((e) => e.subject)).toEqual(["At 10", "At 09", "At 08"]);
+			expect(captured[0].input.Select).toBe("COUNT");
+			expect(captured[1].input.Select).toBe("COUNT");
+			expect(captured[1].input.ExclusiveStartKey).toEqual(countStartKey);
+			expect(captured[2].input.Select).toBeUndefined();
 			expect(result.total).toBe(3);
+			expect(result.emails.map((e) => e.subject)).toEqual(["At 10"]);
 		});
 
-		it("slices out the requested page while reporting the unpaged total", async () => {
-			const store = initDynamoDbInboxEmail({
-				client: createFakeClient(() => ({
-					Items: [
-						rawRow({ hour: "10", messageId: "<c@x>" }),
-						rawRow({ hour: "09", messageId: "<b@x>" }),
-						rawRow({ hour: "08", messageId: "<a@x>" }),
-					],
-					Count: 3,
-				})) as DynamoDBDocumentClient,
-				tableName: TABLE,
-			});
+		it("stops after filling the page even when earlier pages and more rows remain", async () => {
+			const firstItemKey = {
+				userId: "user-1",
+				receivedAtMessageId: "2026-06-23T10:00:00.000Z#<c@x>",
+			};
+			const secondItemKey = {
+				userId: "user-1",
+				receivedAtMessageId: "2026-06-23T09:00:00.000Z#<b@x>",
+			};
+			const { client, captured } = createOrderedClient([
+				{ Count: 3 },
+				{ Items: [rawRow({ hour: "10", messageId: "<c@x>" })], LastEvaluatedKey: firstItemKey },
+				{ Items: [rawRow({ hour: "09", messageId: "<b@x>" })], LastEvaluatedKey: secondItemKey },
+			]);
+			const store = initDynamoDbInboxEmail({ client, tableName: TABLE });
 
-			const result = await store.listEmailsByUserId({ userId: USER, page: 2, pageSize: 2 });
+			const result = await store.listEmailsByUserId({ userId: USER, page: 2, pageSize: 1 });
 
-			expect(result.emails.map((e) => e.subject)).toEqual(["At 08"]);
-			expect(result).toMatchObject({ total: 3, page: 2, pageSize: 2 });
+			expect(captured).toHaveLength(3);
+			expect(captured[2].input.ExclusiveStartKey).toEqual(firstItemKey);
+			expect(result.emails.map((e) => e.subject)).toEqual(["At 09"]);
+			expect(result).toMatchObject({ total: 3, page: 2, pageSize: 1 });
 		});
 
 		it("returns no emails but the correct total for a page beyond the data", async () => {
-			const store = initDynamoDbInboxEmail({
-				client: createFakeClient(() => ({
-					Items: [rawRow({ hour: "10", messageId: "<c@x>" })],
-					Count: 1,
-				})) as DynamoDBDocumentClient,
-				tableName: TABLE,
-			});
+			const { client } = createOrderedClient([
+				{ Count: 1 },
+				{ Items: [rawRow({ hour: "10", messageId: "<c@x>" })] },
+			]);
+			const store = initDynamoDbInboxEmail({ client, tableName: TABLE });
 
 			const result = await store.listEmailsByUserId({ userId: USER, page: 5, pageSize: 2 });
 
 			expect(result.emails).toEqual([]);
 			expect(result.total).toBe(1);
+		});
+
+		it("drops overflow rows when a 1 MB split misaligns the page boundary", async () => {
+			const firstItemKey = {
+				userId: "user-1",
+				receivedAtMessageId: "2026-06-23T05:00:00.000Z#<e@x>",
+			};
+			const secondItemKey = {
+				userId: "user-1",
+				receivedAtMessageId: "2026-06-23T03:00:00.000Z#<c@x>",
+			};
+			const { client } = createOrderedClient([
+				{ Count: 5 },
+				{ Items: [rawRow({ hour: "05", messageId: "<e@x>" })], LastEvaluatedKey: firstItemKey },
+				{
+					Items: [
+						rawRow({ hour: "04", messageId: "<d@x>" }),
+						rawRow({ hour: "03", messageId: "<c@x>" }),
+					],
+					LastEvaluatedKey: secondItemKey,
+				},
+				{
+					Items: [
+						rawRow({ hour: "02", messageId: "<b@x>" }),
+						rawRow({ hour: "01", messageId: "<a@x>" }),
+					],
+				},
+			]);
+			const store = initDynamoDbInboxEmail({ client, tableName: TABLE });
+
+			const result = await store.listEmailsByUserId({ userId: USER, page: 2, pageSize: 2 });
+
+			expect(result.emails.map((e) => e.subject)).toEqual(["At 03", "At 02"]);
+			expect(result.total).toBe(5);
 		});
 	});
 

--- a/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.ts
+++ b/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
@@ -8,6 +9,7 @@ import {
 import { z } from "zod";
 import {
 	InboxAddressSchema,
+	type InboxEmailEntry,
 	InboxEmailStatusSchema,
 	type InboxEmailStore,
 	MessageIdSchema,
@@ -55,13 +57,29 @@ export function initDynamoDbInboxEmail(deps: {
 				throw error;
 			}
 		},
-		listEmailsByUserId: async (userId) => {
-			const { items } = await table.query({
-				KeyConditionExpression: "userId = :uid",
-				ExpressionAttributeValues: { ":uid": userId },
-				ScanIndexForward: false,
-			});
-			return items;
+		listEmailsByUserId: async ({ userId, page, pageSize }) => {
+			assert(Number.isInteger(page), "page must be an integer");
+			assert(page >= 1, "page must be >= 1");
+			assert(Number.isInteger(pageSize), "pageSize must be an integer");
+			assert(pageSize >= 1, "pageSize must be >= 1");
+			const all: InboxEmailEntry[] = [];
+			await forEachQueryPage(
+				table,
+				{
+					KeyConditionExpression: "userId = :uid",
+					ExpressionAttributeValues: { ":uid": userId },
+					ScanIndexForward: false,
+				},
+				async (items) => {
+					all.push(...items);
+				},
+			);
+			return {
+				emails: all.slice((page - 1) * pageSize, page * pageSize),
+				total: all.length,
+				page,
+				pageSize,
+			};
 		},
 		getEmail: async ({ userId, receivedAtMessageId }) =>
 			table.get({ userId, receivedAtMessageId }),

--- a/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.ts
+++ b/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.ts
@@ -4,6 +4,7 @@ import {
 	type DynamoDBDocumentClient,
 	defineDynamoTable,
 	dynamoField,
+	forEachQueryPage,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import {

--- a/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.ts
+++ b/projects/hutch/src/runtime/providers/inbox-email/dynamodb-inbox-email.ts
@@ -4,7 +4,6 @@ import {
 	type DynamoDBDocumentClient,
 	defineDynamoTable,
 	dynamoField,
-	forEachQueryPage,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
 import {
@@ -62,24 +61,46 @@ export function initDynamoDbInboxEmail(deps: {
 			assert(page >= 1, "page must be >= 1");
 			assert(Number.isInteger(pageSize), "pageSize must be an integer");
 			assert(pageSize >= 1, "pageSize must be >= 1");
-			const all: InboxEmailEntry[] = [];
-			await forEachQueryPage(
-				table,
-				{
+
+			let total = 0;
+			let countStartKey: Record<string, unknown> | undefined;
+			do {
+				const { count, lastEvaluatedKey } = await table.query({
+					KeyConditionExpression: "userId = :uid",
+					ExpressionAttributeValues: { ":uid": userId },
+					Select: "COUNT",
+					ExclusiveStartKey: countStartKey,
+				});
+				total += count;
+				countStartKey = lastEvaluatedKey;
+			} while (countStartKey);
+
+			const itemsToSkip = (page - 1) * pageSize;
+			const emails: InboxEmailEntry[] = [];
+			let skippedCount = 0;
+			let exclusiveStartKey: Record<string, unknown> | undefined;
+			do {
+				const { items, lastEvaluatedKey } = await table.query({
 					KeyConditionExpression: "userId = :uid",
 					ExpressionAttributeValues: { ":uid": userId },
 					ScanIndexForward: false,
-				},
-				async (items) => {
-					all.push(...items);
-				},
+					Limit: pageSize,
+					ExclusiveStartKey: exclusiveStartKey,
+				});
+				for (const item of items) {
+					if (skippedCount < itemsToSkip) {
+						skippedCount++;
+					} else if (emails.length < pageSize) {
+						emails.push(item);
+					}
+				}
+				exclusiveStartKey = lastEvaluatedKey;
+			} while (
+				exclusiveStartKey &&
+				(skippedCount < itemsToSkip || emails.length < pageSize)
 			);
-			return {
-				emails: all.slice((page - 1) * pageSize, page * pageSize),
-				total: all.length,
-				page,
-				pageSize,
-			};
+
+			return { emails, total, page, pageSize };
 		},
 		getEmail: async ({ userId, receivedAtMessageId }) =>
 			table.get({ userId, receivedAtMessageId }),

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.route.test.ts
@@ -212,4 +212,118 @@ describe("Inbox emails list route", () => {
 		expect(rows[0].querySelector("[data-test-inbox-email-link-count]")?.textContent).toBe("2 links");
 		expect(rows[1].querySelector("[data-test-inbox-email-link-count]")).toBeNull();
 	});
+
+	describe("Pagination", () => {
+		function ascendingEmails(userId: UserId, count: number): InboxEmailEntry[] {
+			return Array.from({ length: count }, (_, i) =>
+				emailEntry(userId, {
+					messageId: `<m-${i}@x>`,
+					receivedAt: new Date(Date.UTC(2026, 5, 24, 0, i)).toISOString(),
+					senderEmail: `sender-${i}@example.com`,
+				}),
+			);
+		}
+
+		it("renders page 1 of 2 with a boosted nav and only a next link", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+			await seedEmails(fixture, (userId) => ascendingEmails(userId, 21));
+
+			const response = await agent.get("/inbox?feature=email");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelectorAll("[data-test-inbox-emails-row]")).toHaveLength(20);
+			const pagination = doc.querySelector("[data-test-pagination]");
+			assert(pagination, "pagination nav must render");
+			expect(pagination.getAttribute("hx-boost")).toBe("true");
+			expect(pagination.getAttribute("hx-target")).toBe("main");
+			expect(pagination.getAttribute("hx-select")).toBe("main");
+			expect(pagination.getAttribute("hx-swap")).toBe("outerHTML show:none");
+			const links = Array.from(pagination.querySelectorAll(".inbox-emails__pagination-link"));
+			expect(links.map((link) => link.getAttribute("href"))).toEqual([
+				"/inbox?feature=email&page=2",
+			]);
+			const next = pagination.querySelector("[data-test-pagination-next]");
+			assert(next, "next link must render on page 1 of 2");
+			expect(next.getAttribute("href")).toBe("/inbox?feature=email&page=2");
+			expect(
+				pagination.querySelector("[data-test-pagination-info]")?.textContent,
+			).toBe("Page 1 of 2");
+		});
+
+		it("renders the oldest email alone on page 2 with only a previous link", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+			await seedEmails(fixture, (userId) => ascendingEmails(userId, 21));
+
+			const response = await agent.get("/inbox?feature=email&page=2");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			const rows = Array.from(doc.querySelectorAll("[data-test-inbox-emails-row]"));
+			expect(rows).toHaveLength(1);
+			expect(rows[0].querySelector("[data-test-inbox-email-sender]")?.textContent).toBe(
+				"sender-0@example.com",
+			);
+			const pagination = doc.querySelector("[data-test-pagination]");
+			assert(pagination, "pagination nav must render");
+			const links = Array.from(pagination.querySelectorAll(".inbox-emails__pagination-link"));
+			expect(links.map((link) => link.getAttribute("href"))).toEqual([
+				"/inbox?feature=email",
+			]);
+			const prev = pagination.querySelector("[data-test-pagination-prev]");
+			assert(prev, "previous link must render on the last page");
+			expect(prev.getAttribute("href")).toBe("/inbox?feature=email");
+			expect(
+				pagination.querySelector("[data-test-pagination-info]")?.textContent,
+			).toBe("Page 2 of 2");
+		});
+
+		it("redirects an out-of-bounds page (stale bookmark / manual URL) to the last valid page", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+			await seedEmails(fixture, (userId) => ascendingEmails(userId, 21));
+
+			const response = await agent.get("/inbox?feature=email&page=99");
+
+			expect(response.status).toBe(302);
+			expect(response.headers.location).toBe("/inbox?feature=email&page=2");
+			const followed = await agent.get(response.headers.location);
+			expect(followed.status).toBe(200);
+		});
+
+		it("renders a full single page without a pagination nav", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+			await seedEmails(fixture, (userId) => ascendingEmails(userId, 20));
+
+			const response = await agent.get("/inbox?feature=email");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelectorAll("[data-test-inbox-emails-row]")).toHaveLength(20);
+			expect(doc.querySelector("[data-test-pagination]")).toBeNull();
+		});
+
+		it("clamps a paged URL on an empty inbox back to the empty state", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox?feature=email&page=2");
+
+			expect(response.status).toBe(302);
+			expect(response.headers.location).toBe("/inbox?feature=email");
+			const followed = await agent.get(response.headers.location);
+			expect(followed.status).toBe(200);
+			const doc = new JSDOM(followed.text).window.document;
+			const empty = doc.querySelector("[data-test-inbox-emails-empty]");
+			assert(empty, "empty state must render after the clamp");
+			expect(empty.textContent).toContain("No forwarded emails yet");
+		});
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.styles.css
@@ -92,3 +92,30 @@
   font-size: 0.85rem;
   color: var(--muted-foreground);
 }
+
+.inbox-emails__pagination {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.inbox-emails__pagination-link {
+  padding: var(--button-padding-sm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.inbox-emails__pagination-link:hover {
+  background: var(--muted);
+}
+
+.inbox-emails__pagination-info {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.template.html
@@ -35,5 +35,12 @@
 		</li>
 		{{/each}}
 	</ul>
+	{{#if showPagination}}
+	<nav class="inbox-emails__pagination" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" data-test-pagination>
+		{{#if hasPrev}}<a class="inbox-emails__pagination-link" href="{{prevUrl}}" data-test-pagination-prev>← Previous</a>{{/if}}
+		<span class="inbox-emails__pagination-info" data-test-pagination-info>Page {{currentPage}} of {{totalPages}}</span>
+		{{#if hasNext}}<a class="inbox-emails__pagination-link" href="{{nextUrl}}" data-test-pagination-next>Next →</a>{{/if}}
+	</nav>
+	{{/if}}
 	{{/if}}
 </main>

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.url.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.url.test.ts
@@ -1,0 +1,62 @@
+import {
+	buildInboxEmailsUrl,
+	canonicalInboxEmailsPageRedirect,
+	parseInboxEmailsUrl,
+} from "./inbox-emails.url";
+
+describe("parseInboxEmailsUrl", () => {
+	it("defaults to page 1 for an empty query", () => {
+		expect(parseInboxEmailsUrl({})).toEqual({ page: 1 });
+	});
+
+	it("parses a valid page number", () => {
+		expect(parseInboxEmailsUrl({ page: "3" }).page).toBe(3);
+	});
+
+	it("defaults to page 1 for junk values", () => {
+		expect(parseInboxEmailsUrl({ page: "abc" }).page).toBe(1);
+		expect(parseInboxEmailsUrl({ page: "0" }).page).toBe(1);
+		expect(parseInboxEmailsUrl({ page: "-1" }).page).toBe(1);
+		expect(parseInboxEmailsUrl({ page: "1.5" }).page).toBe(1);
+	});
+});
+
+describe("buildInboxEmailsUrl", () => {
+	it("always carries the email feature flag", () => {
+		expect(buildInboxEmailsUrl({})).toBe("/inbox?feature=email");
+	});
+
+	it("omits page 1", () => {
+		expect(buildInboxEmailsUrl({ page: 1 })).toBe("/inbox?feature=email");
+	});
+
+	it("appends page > 1 after the flag", () => {
+		expect(buildInboxEmailsUrl({ page: 2 })).toBe("/inbox?feature=email&page=2");
+	});
+});
+
+describe("canonicalInboxEmailsPageRedirect", () => {
+	it("returns undefined for an in-bounds page", () => {
+		expect(
+			canonicalInboxEmailsPageRedirect({ page: 1, total: 20, pageSize: 20 }),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for the last valid page", () => {
+		expect(
+			canonicalInboxEmailsPageRedirect({ page: 3, total: 60, pageSize: 20 }),
+		).toBeUndefined();
+	});
+
+	it("clamps a page beyond the last to the last valid page", () => {
+		expect(
+			canonicalInboxEmailsPageRedirect({ page: 4, total: 60, pageSize: 20 }),
+		).toBe("/inbox?feature=email&page=3");
+	});
+
+	it("clamps a page beyond an empty inbox to page 1", () => {
+		expect(
+			canonicalInboxEmailsPageRedirect({ page: 2, total: 0, pageSize: 20 }),
+		).toBe("/inbox?feature=email");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.url.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.url.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { EMAIL_FEATURE } from "@packages/web-shell";
+
+export const INBOX_PATH = "/inbox";
+
+export const INBOX_EMAILS_PAGE_SIZE = 20;
+
+const InboxEmailsQuerySchema = z.object({
+	page: z.coerce.number().int().min(1).optional().catch(undefined),
+}).passthrough();
+
+export function parseInboxEmailsUrl(query: Record<string, unknown>): { page: number } {
+	const parsed = InboxEmailsQuerySchema.parse(query);
+	return { page: parsed.page ?? 1 };
+}
+
+/** Every built URL carries feature=email — the whole inbox surface 404s
+ * without the flag, so a link that dropped it would dead-end. */
+export function buildInboxEmailsUrl(state: { page?: number }): string {
+	const params = new URLSearchParams();
+	params.set("feature", EMAIL_FEATURE);
+	if (state.page && state.page > 1) {
+		params.set("page", String(state.page));
+	}
+	return `${INBOX_PATH}?${params.toString()}`;
+}
+
+/** This read-boundary clamp must compute the last page the same way the
+ * rendered pagination does, so they agree on where the list ends and can't
+ * diverge. */
+export function canonicalInboxEmailsPageRedirect(input: {
+	page: number;
+	total: number;
+	pageSize: number;
+}): string | undefined {
+	const totalPages = Math.max(1, Math.ceil(input.total / input.pageSize));
+	if (input.page <= totalPages) return undefined;
+	return buildInboxEmailsUrl({ page: totalPages });
+}

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.test.ts
@@ -34,10 +34,20 @@ function build(
 	entries: InboxEmailEntry[],
 	summaries: Record<string, InboxEmailLinkSummary> = {},
 ) {
-	return toInboxEmailsViewModel(entries, {
-		now: NOW,
-		linkSummaries: new Map(Object.entries(summaries)),
-	});
+	return toInboxEmailsViewModel(
+		{ emails: entries, total: entries.length, page: 1, pageSize: 20 },
+		{
+			now: NOW,
+			linkSummaries: new Map(Object.entries(summaries)),
+		},
+	);
+}
+
+function buildPage(input: { page: number; total: number; pageSize: number }) {
+	return toInboxEmailsViewModel(
+		{ emails: [entry()], ...input },
+		{ now: NOW, linkSummaries: new Map() },
+	);
 }
 
 function ago(ms: number): string {
@@ -116,6 +126,39 @@ describe("toInboxEmailsViewModel", () => {
 			"2d ago",
 		]);
 		expect(rows.every((row) => row.received.mode === "relative")).toBe(true);
+	});
+
+	it("hides pagination when everything fits on one page", () => {
+		const vm = buildPage({ page: 1, total: 20, pageSize: 20 });
+
+		expect(vm.showPagination).toBe(false);
+		expect(vm.totalPages).toBe(1);
+		expect(vm.currentPage).toBe(1);
+		expect(vm.hasPrev).toBe(false);
+		expect(vm.hasNext).toBe(false);
+		expect(vm.prevUrl).toBeUndefined();
+		expect(vm.nextUrl).toBeUndefined();
+	});
+
+	it("links forward from page 1 of 2", () => {
+		const vm = buildPage({ page: 1, total: 21, pageSize: 20 });
+
+		expect(vm.showPagination).toBe(true);
+		expect(vm.totalPages).toBe(2);
+		expect(vm.hasPrev).toBe(false);
+		expect(vm.hasNext).toBe(true);
+		expect(vm.prevUrl).toBeUndefined();
+		expect(vm.nextUrl).toBe("/inbox?feature=email&page=2");
+	});
+
+	it("links back from the last page", () => {
+		const vm = buildPage({ page: 2, total: 21, pageSize: 20 });
+
+		expect(vm.currentPage).toBe(2);
+		expect(vm.hasPrev).toBe(true);
+		expect(vm.hasNext).toBe(false);
+		expect(vm.prevUrl).toBe("/inbox?feature=email");
+		expect(vm.nextUrl).toBeUndefined();
 	});
 
 	it("falls back to a UTC-baselined absolute date past the 30-day cutoff", () => {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox-emails.viewmodel.ts
@@ -1,6 +1,7 @@
 import { EMAIL_FEATURE, type LocalTime, toRelativeOrDate } from "@packages/web-shell";
-import type { InboxEmailEntry, InboxEmailStatus } from "@packages/domain/inbox";
+import type { InboxEmailStatus, ListInboxEmailsResult } from "@packages/domain/inbox";
 import { buildLinkCountLabel } from "./inbox-link-count-label";
+import { buildInboxEmailsUrl } from "./inbox-emails.url";
 
 /** Per-email link tally, derived by the route from a single per-email Query
  * (no parent-row denormalisation). */
@@ -28,6 +29,13 @@ export interface InboxEmailRowViewModel {
 export interface InboxEmailsViewModel {
 	isEmpty: boolean;
 	rows: InboxEmailRowViewModel[];
+	currentPage: number;
+	totalPages: number;
+	showPagination: boolean;
+	hasPrev: boolean;
+	hasNext: boolean;
+	prevUrl: string | undefined;
+	nextUrl: string | undefined;
 }
 
 const STATUS_LABEL: Record<InboxEmailStatus, string> = {
@@ -37,12 +45,24 @@ const STATUS_LABEL: Record<InboxEmailStatus, string> = {
 };
 
 export function toInboxEmailsViewModel(
-	entries: InboxEmailEntry[],
+	result: ListInboxEmailsResult,
 	options: { now: Date; linkSummaries: Map<string, InboxEmailLinkSummary> },
 ): InboxEmailsViewModel {
+	const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize));
 	return {
-		isEmpty: entries.length === 0,
-		rows: entries.map((entry) => {
+		isEmpty: result.total === 0,
+		currentPage: result.page,
+		totalPages,
+		showPagination: totalPages > 1,
+		hasPrev: result.page > 1,
+		hasNext: result.page < totalPages,
+		prevUrl:
+			result.page > 1 ? buildInboxEmailsUrl({ page: result.page - 1 }) : undefined,
+		nextUrl:
+			result.page < totalPages
+				? buildInboxEmailsUrl({ page: result.page + 1 })
+				: undefined,
+		rows: result.emails.map((entry) => {
 			const summary = options.linkSummaries.get(entry.receivedAtMessageId);
 			return {
 				href: `/inbox/${encodeURIComponent(entry.receivedAtMessageId)}?feature=${EMAIL_FEATURE}`,

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.test.ts
@@ -177,4 +177,145 @@ describe("InboxPage", () => {
 		assert.ok(message, "limit message must render when the cap is reached");
 		assert.match(message.textContent ?? "", new RegExp(String(INBOX_ADDRESS_MAX_PER_USER)));
 	});
+
+	it("orders active addresses before disabled ones regardless of creation order", () => {
+		const doc = parse(
+			InboxPage({
+				addresses: [
+					entry({
+						name: AliasNameSchema.parse("gmail"),
+						address: InboxAddressSchema.parse("gmail-abc123@read.place"),
+						token: InboxTokenSchema.parse("abc123"),
+						disabledAt: "2026-06-22T00:00:00.000Z",
+					}),
+					entry({
+						name: AliasNameSchema.parse("netflix"),
+						address: InboxAddressSchema.parse("netflix-def456@read.place"),
+						token: InboxTokenSchema.parse("def456"),
+					}),
+				],
+				limitReached: false,
+			}).content.html,
+		);
+
+		const statuses = Array.from(doc.querySelectorAll("[data-test-inbox-status]")).map((el) =>
+			el.getAttribute("data-test-inbox-status"),
+		);
+		assert.deepEqual(statuses, ["enabled", "disabled"]);
+		const names = Array.from(doc.querySelectorAll("[data-test-inbox-name]")).map(
+			(el) => el.textContent,
+		);
+		assert.deepEqual(names, ["netflix", "gmail"]);
+	});
+
+	it("collapses every disabled address into a closed details group holding the disabled rows", () => {
+		const doc = parse(
+			InboxPage({
+				addresses: [
+					entry(),
+					entry({
+						name: AliasNameSchema.parse("gmail"),
+						address: InboxAddressSchema.parse("gmail-abc123@read.place"),
+						token: InboxTokenSchema.parse("abc123"),
+						disabledAt: "2026-06-21T00:00:00.000Z",
+					}),
+					entry({
+						name: AliasNameSchema.parse("substack"),
+						address: InboxAddressSchema.parse("substack-def456@read.place"),
+						token: InboxTokenSchema.parse("def456"),
+						disabledAt: "2026-06-22T00:00:00.000Z",
+					}),
+				],
+				limitReached: false,
+			}).content.html,
+		);
+
+		const group = doc.querySelector("[data-test-inbox-disabled-group]");
+		assert.ok(group, "disabled group must render");
+		assert.equal(group.tagName, "DETAILS");
+		assert.equal(group.hasAttribute("open"), false);
+		assert.equal(
+			group.querySelector(".inbox__disabled-summary")?.textContent,
+			"Disabled addresses (2)",
+		);
+		const namesInside = Array.from(group.querySelectorAll("[data-test-inbox-name]")).map(
+			(el) => el.textContent,
+		);
+		assert.deepEqual(namesInside, ["gmail", "substack"]);
+	});
+
+	it("keeps the details group rendered but hidden when no address is disabled", () => {
+		const doc = parse(InboxPage({ addresses: [entry()], limitReached: false }).content.html);
+
+		const group = doc.querySelector("[data-test-inbox-disabled-group]");
+		assert.ok(group, "disabled group must render");
+		assert.equal(group.classList.contains("inbox__disabled-group--hidden"), true);
+		assert.equal(
+			group.querySelector(".inbox__disabled-summary")?.textContent,
+			"Disabled addresses (0)",
+		);
+	});
+
+	it("marks the details group visible when a disabled address exists", () => {
+		const doc = parse(
+			InboxPage({
+				addresses: [
+					entry({
+						address: InboxAddressSchema.parse("in-abc123@read.place"),
+						token: InboxTokenSchema.parse("abc123"),
+						disabledAt: "2026-06-22T00:00:00.000Z",
+					}),
+				],
+				limitReached: false,
+			}).content.html,
+		);
+
+		const group = doc.querySelector("[data-test-inbox-disabled-group]");
+		assert.ok(group, "disabled group must render");
+		assert.equal(group.classList.contains("inbox__disabled-group--visible"), true);
+	});
+
+	it("lays out the page as create, then active, then disabled sections", () => {
+		const doc = parse(InboxPage({ addresses: [entry()], limitReached: false }).content.html);
+
+		const sections = Array.from(doc.querySelectorAll("[data-test-inbox-section]")).map((el) =>
+			el.getAttribute("data-test-inbox-section"),
+		);
+		assert.deepEqual(sections, ["create", "active", "disabled"]);
+	});
+
+	it("orders an active row as name, copy button, address field, then right-edge controls", () => {
+		const doc = parse(InboxPage({ addresses: [entry()], limitReached: false }).content.html);
+
+		const row = doc.querySelector('[data-test-inbox-section="active"] [data-test-inbox-item]');
+		assert.ok(row, "active row must render");
+		const childClasses = Array.from(row.children).map((el) => el.classList[0]);
+		assert.deepEqual(childClasses, [
+			"inbox__name",
+			"inbox__copy-btn",
+			"inbox__address-field",
+			"inbox__controls",
+		]);
+	});
+
+	it("keeps the explainer first and the create form last in the create section, with the limit error between them", () => {
+		const shape = (el: Element) => `${el.tagName.toLowerCase()}.${el.classList[0]}`;
+
+		const withoutErrors = parse(InboxPage({ addresses: [], limitReached: false }).content.html);
+		const section = withoutErrors.querySelector('[data-test-inbox-section="create"]');
+		assert.ok(section, "create section must render");
+		assert.deepEqual(Array.from(section.children).map(shape), [
+			"section.inbox__instructions",
+			"form.inbox__create",
+		]);
+
+		const withLimit = parse(InboxPage({ addresses: [], limitReached: true }).content.html);
+		const limitedSection = withLimit.querySelector('[data-test-inbox-section="create"]');
+		assert.ok(limitedSection, "create section must render");
+		assert.deepEqual(Array.from(limitedSection.children).map(shape), [
+			"section.inbox__instructions",
+			"p.inbox__error",
+			"form.inbox__create",
+		]);
+	});
 });

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.component.ts
@@ -4,6 +4,7 @@ import { EMAIL_FEATURE, render } from "@packages/web-shell";
 import type { PageBody } from "@packages/web-shell";
 import { INBOX_ADDRESS_MAX_PER_USER, type InboxAddressEntry } from "@packages/domain/inbox";
 import { INBOX_STYLES } from "./inbox.styles";
+import { toInboxAddressesViewModel } from "./inbox.viewmodel";
 
 const INBOX_TEMPLATE = readFileSync(join(__dirname, "inbox.template.html"), "utf-8");
 
@@ -24,12 +25,7 @@ export function InboxPage(params: {
 		createFailed: params.createFailed === true,
 		nameInvalid: params.nameInvalid === true,
 		nameTaken: params.nameTaken === true,
-		hasAddresses: params.addresses.length > 0,
-		addresses: params.addresses.map((entry) => ({
-			address: entry.address,
-			name: entry.name,
-			enabled: entry.disabledAt === undefined,
-		})),
+		...toInboxAddressesViewModel(params.addresses),
 		limitReached: params.limitReached,
 		maxAddresses: INBOX_ADDRESS_MAX_PER_USER,
 		createAction: `/inbox/create${INBOX_QUERY}`,

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.page.ts
@@ -30,6 +30,11 @@ import { InboxEmailDetailPage } from "./inbox-email-detail.component";
 import { renderInboxLinkCount } from "./inbox-link-count.component";
 import { toInboxEmailDetailViewModel } from "./inbox-email-detail.viewmodel";
 import { InboxEmailsPage } from "./inbox-emails.component";
+import {
+	INBOX_EMAILS_PAGE_SIZE,
+	canonicalInboxEmailsPageRedirect,
+	parseInboxEmailsUrl,
+} from "./inbox-emails.url";
 import { type InboxEmailLinkSummary, toInboxEmailsViewModel } from "./inbox-emails.viewmodel";
 import { computeInboxLinkCardEtag } from "./inbox-link-card.etag";
 import { toInboxLinkCardViewModel } from "./inbox-link-card.viewmodel";
@@ -77,12 +82,26 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 	router.get("/", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
-		const emails = await deps.inboxEmailStore.listEmailsByUserId(userId);
+		const { page } = parseInboxEmailsUrl(req.query);
+		const result = await deps.inboxEmailStore.listEmailsByUserId({
+			userId,
+			page,
+			pageSize: INBOX_EMAILS_PAGE_SIZE,
+		});
+		const pageRedirect = canonicalInboxEmailsPageRedirect({
+			page,
+			total: result.total,
+			pageSize: result.pageSize,
+		});
+		if (pageRedirect) {
+			res.redirect(302, pageRedirect);
+			return;
+		}
 		// One cheap per-email partition Query each (no GSI, no scan) — the accepted
 		// cost of deriving the count instead of denormalising it onto the email row.
 		// Fired concurrently so a heavy-newsletter user pays one round-trip, not N.
 		const summaries = await Promise.all(
-			emails.map(async (email): Promise<[string, InboxEmailLinkSummary]> => {
+			result.emails.map(async (email): Promise<[string, InboxEmailLinkSummary]> => {
 				const { links, meta } = await deps.inboxEmailLinkStore.listLinksByEmail({
 					userId,
 					receivedAtMessageId: email.receivedAtMessageId,
@@ -94,7 +113,7 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 			}),
 		);
 		const linkSummaries = new Map<string, InboxEmailLinkSummary>(summaries);
-		const vm = toInboxEmailsViewModel(emails, { now: deps.now(), linkSummaries });
+		const vm = toInboxEmailsViewModel(result, { now: deps.now(), linkSummaries });
 		sendComponent(req, res, Base(InboxEmailsPage(vm), await deps.buildBannerState(req)));
 	});
 

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -365,8 +365,42 @@ describe("Inbox address routes", () => {
 			const after = new JSDOM(
 				(await agent.get("/inbox/addresses?feature=email")).text,
 			).window.document;
-			expect(after.querySelector('[data-test-inbox-status="disabled"]')).not.toBeNull();
-			expect(after.querySelector("[data-test-inbox-disable]")).toBeNull();
+			const statuses = Array.from(after.querySelectorAll("[data-test-inbox-status]")).map(
+				(el) => el.getAttribute("data-test-inbox-status"),
+			);
+			expect(statuses).toEqual(["disabled"]);
+			expect(after.querySelector(".inbox__disabled-summary")?.textContent).toBe(
+				"Disabled addresses (1)",
+			);
+		});
+
+		it("moves a disabled address into the collapsed group behind the remaining active ones", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "netflix" });
+			await agent.post("/inbox/create?feature=email").type("form").send({ name: "gmail" });
+			const netflixAddress = addressFieldValue(
+				(await agent.get("/inbox/addresses?feature=email")).text,
+			);
+			assert(netflixAddress, "the created netflix address must render");
+			expect(netflixAddress).toMatch(/^netflix-/);
+
+			await agent
+				.post("/inbox/disable?feature=email")
+				.type("form")
+				.send({ address: netflixAddress });
+
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses?feature=email")).text,
+			).window.document;
+			const names = Array.from(after.querySelectorAll("[data-test-inbox-name]")).map(
+				(el) => el.textContent,
+			);
+			expect(names).toEqual(["gmail", "netflix"]);
+			expect(
+				after.querySelector("[data-test-inbox-disabled-group] [data-test-inbox-name]")
+					?.textContent,
+			).toBe("netflix");
 		});
 
 		it("ignores a request whose body is not a valid address", async () => {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.styles.css
@@ -31,13 +31,27 @@
   font-size: 0.95rem;
 }
 
+.inbox__create-section {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 24px;
+  margin-bottom: 32px;
+}
+
+.inbox__addresses {
+  margin: 0 0 24px;
+}
+
 .inbox__list {
   list-style: none;
-  margin: 0 0 24px;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.inbox__list--nested {
+  margin-top: 12px;
 }
 
 .inbox__item {
@@ -91,6 +105,13 @@
   opacity: 0.9;
 }
 
+.inbox__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
 .inbox__status {
   font-size: 0.85rem;
   font-weight: 600;
@@ -122,13 +143,52 @@
   color: var(--foreground);
 }
 
+.inbox__disabled-group {
+  margin-top: 12px;
+}
+
+.inbox__disabled-group--visible {
+  display: block;
+}
+
+.inbox__disabled-group--hidden {
+  display: none;
+}
+
+.inbox__disabled-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--muted-foreground);
+  list-style: none;
+  user-select: none;
+}
+
+.inbox__disabled-summary::-webkit-details-marker {
+  display: none;
+}
+
+.inbox__disabled-summary::after {
+  content: "\25BE";
+  font-size: 1.2em;
+  color: var(--muted-foreground);
+  transition: transform 0.2s ease;
+}
+
+.inbox__disabled-group[open] .inbox__disabled-summary::after {
+  transform: rotate(180deg);
+}
+
 .inbox__empty {
   color: var(--muted-foreground);
   margin: 0 0 24px;
 }
 
 .inbox__create {
-  margin: 0 0 32px;
+  margin: 0;
 }
 
 .inbox__create-label {
@@ -174,8 +234,7 @@
 }
 
 .inbox__instructions {
-  border-top: 1px solid var(--border);
-  padding-top: 24px;
+  margin-bottom: 24px;
 }
 
 .inbox__instructions-title {

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.template.html
@@ -4,61 +4,76 @@
         <p class="inbox__subtitle">Forward any newsletter to one of these addresses and it lands in Readplace. I'll pull out the links and queue them up for you to read later.</p>
       </div>
 
-      {{#if createFailed}}
-      <p class="inbox__error" role="alert" data-test-inbox-error>We couldn't create a forwarding address just now. Please try again in a moment.</p>
-      {{/if}}
+      <section class="inbox__create-section" data-test-inbox-section="create">
+        <section class="inbox__instructions">
+          <h2 class="inbox__instructions-title">How it works</h2>
+          <ol class="inbox__steps">
+            <li>Create a forwarding address and copy it.</li>
+            <li>In your email app, forward a newsletter (or set up forwarding) to it.</li>
+            <li>New issues show up here automatically.</li>
+          </ol>
+          <p class="inbox__note">This is new — right now it just gives you the address. Reading forwarded mail in Readplace is coming next.</p>
+        </section>
 
-      {{#if nameInvalid}}
-      <p class="inbox__error" role="alert" data-test-inbox-name-error>Give the address a name using letters and numbers — for example, netflix.</p>
-      {{/if}}
+        {{#if createFailed}}
+        <p class="inbox__error" role="alert" data-test-inbox-error>We couldn't create a forwarding address just now. Please try again in a moment.</p>
+        {{/if}}
 
-      {{#if nameTaken}}
-      <p class="inbox__error" role="alert" data-test-inbox-name-taken>You already have an active address with that name. Pick a different one.</p>
-      {{/if}}
+        {{#if nameInvalid}}
+        <p class="inbox__error" role="alert" data-test-inbox-name-error>Give the address a name using letters and numbers — for example, netflix.</p>
+        {{/if}}
+
+        {{#if nameTaken}}
+        <p class="inbox__error" role="alert" data-test-inbox-name-taken>You already have an active address with that name. Pick a different one.</p>
+        {{/if}}
+
+        {{#if limitReached}}
+        <p class="inbox__error" data-test-inbox-limit role="alert">You've reached the maximum of {{maxAddresses}} forwarding addresses. Disable any you no longer need before creating more.</p>
+        {{/if}}
+
+        <form action="{{createAction}}" method="POST" class="inbox__create">
+          <label class="inbox__create-label" for="inbox-name">Name this address</label>
+          <div class="inbox__create-row">
+            <input class="inbox__name-input" id="inbox-name" name="name" type="text" required maxlength="24" pattern="[A-Za-z0-9 -]+" placeholder="e.g. netflix" autocomplete="off" data-test-inbox-name-input />
+            <button type="submit" class="inbox__create-btn" data-test-inbox-create>Create Inbox Email</button>
+          </div>
+        </form>
+      </section>
 
       {{#if hasAddresses}}
-      <ul class="inbox__list" data-test-inbox-list>
-        {{#each addresses}}
-        <li class="inbox__item" data-test-inbox-item>
-          <span class="inbox__name" data-test-inbox-name>{{this.name}}</span>
-          {{#if this.enabled}}
-          <input class="inbox__address-field" type="text" value="{{this.address}}" readonly aria-label="Forwarding address" data-inbox-address="{{this.address}}" />
-          <button type="button" class="inbox__copy-btn" data-inbox-copy data-inbox-address="{{this.address}}" hidden>Copy</button>
-          <span class="inbox__status inbox__status--enabled" data-test-inbox-status="enabled">Active</span>
-          <form action="{{../disableAction}}" method="POST" class="inbox__disable">
-            <input type="hidden" name="address" value="{{this.address}}" />
-            <button type="submit" class="inbox__disable-btn" data-test-inbox-disable>Disable</button>
-          </form>
-          {{else}}
-          <input class="inbox__address-field inbox__address-field--disabled" type="text" value="{{this.address}}" disabled aria-label="Forwarding address" />
-          <span class="inbox__status inbox__status--disabled" data-test-inbox-status="disabled">Disabled</span>
-          {{/if}}
-        </li>
-        {{/each}}
-      </ul>
+      <div class="inbox__addresses" data-test-inbox-list>
+        <ul class="inbox__list" data-test-inbox-section="active">
+          {{#each activeAddresses}}
+          <li class="inbox__item" data-test-inbox-item>
+            <span class="inbox__name" data-test-inbox-name>{{this.name}}</span>
+            <button type="button" class="inbox__copy-btn" data-inbox-copy data-inbox-address="{{this.address}}" hidden>Copy</button>
+            <input class="inbox__address-field" type="text" value="{{this.address}}" readonly aria-label="Forwarding address" data-inbox-address="{{this.address}}" />
+            <div class="inbox__controls">
+              <span class="inbox__status inbox__status--enabled" data-test-inbox-status="enabled">Active</span>
+              <form action="{{../disableAction}}" method="POST" class="inbox__disable">
+                <input type="hidden" name="address" value="{{this.address}}" />
+                <button type="submit" class="inbox__disable-btn" data-test-inbox-disable>Disable</button>
+              </form>
+            </div>
+          </li>
+          {{/each}}
+        </ul>
+        <details class="inbox__disabled-group {{#if hasDisabled}}inbox__disabled-group--visible{{else}}inbox__disabled-group--hidden{{/if}}" data-test-inbox-section="disabled" data-test-inbox-disabled-group>
+          <summary class="inbox__disabled-summary">Disabled addresses ({{disabledCount}})</summary>
+          <ul class="inbox__list inbox__list--nested">
+            {{#each disabledAddresses}}
+            <li class="inbox__item" data-test-inbox-item>
+              <span class="inbox__name" data-test-inbox-name>{{this.name}}</span>
+              <input class="inbox__address-field inbox__address-field--disabled" type="text" value="{{this.address}}" disabled aria-label="Forwarding address" />
+              <div class="inbox__controls">
+                <span class="inbox__status inbox__status--disabled" data-test-inbox-status="disabled">Disabled</span>
+              </div>
+            </li>
+            {{/each}}
+          </ul>
+        </details>
+      </div>
       {{else}}
       <p class="inbox__empty" data-test-inbox-empty>You don't have a forwarding address yet. Create one to get started.</p>
       {{/if}}
-
-      {{#if limitReached}}
-      <p class="inbox__error" data-test-inbox-limit role="alert">You've reached the maximum of {{maxAddresses}} forwarding addresses. Disable any you no longer need before creating more.</p>
-      {{/if}}
-
-      <form action="{{createAction}}" method="POST" class="inbox__create">
-        <label class="inbox__create-label" for="inbox-name">Name this address</label>
-        <div class="inbox__create-row">
-          <input class="inbox__name-input" id="inbox-name" name="name" type="text" required maxlength="24" pattern="[A-Za-z0-9 -]+" placeholder="e.g. netflix" autocomplete="off" data-test-inbox-name-input />
-          <button type="submit" class="inbox__create-btn" data-test-inbox-create>Create Inbox Email</button>
-        </div>
-      </form>
-
-      <section class="inbox__instructions">
-        <h2 class="inbox__instructions-title">How it works</h2>
-        <ol class="inbox__steps">
-          <li>Create a forwarding address and copy it.</li>
-          <li>In your email app, forward a newsletter (or set up forwarding) to it.</li>
-          <li>New issues show up here automatically.</li>
-        </ol>
-        <p class="inbox__note">This is new — right now it just gives you the address. Reading forwarded mail in Readplace is coming next.</p>
-      </section>
     </main>

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.viewmodel.test.ts
@@ -1,0 +1,78 @@
+import {
+	AliasNameSchema,
+	type InboxAddressEntry,
+	InboxAddressSchema,
+	InboxTokenSchema,
+} from "@packages/domain/inbox";
+import { UserIdSchema } from "@packages/domain/user";
+import { toInboxAddressesViewModel } from "./inbox.viewmodel";
+
+function entry(input: {
+	name: string;
+	address: string;
+	disabledAt?: string;
+}): InboxAddressEntry {
+	return {
+		address: InboxAddressSchema.parse(input.address),
+		userId: UserIdSchema.parse("user-1"),
+		name: AliasNameSchema.parse(input.name),
+		token: InboxTokenSchema.parse("3f9a2c"),
+		createdAt: "2026-06-23T00:00:00.000Z",
+		disabledAt: input.disabledAt,
+	};
+}
+
+describe("toInboxAddressesViewModel", () => {
+	it("partitions interleaved entries into active-first lists, keeping creation order inside each partition", () => {
+		const vm = toInboxAddressesViewModel([
+			entry({
+				name: "gmail",
+				address: "gmail-aaa111@read.place",
+				disabledAt: "2026-06-20T00:00:00.000Z",
+			}),
+			entry({ name: "netflix", address: "netflix-bbb222@read.place" }),
+			entry({
+				name: "substack",
+				address: "substack-ccc333@read.place",
+				disabledAt: "2026-06-22T00:00:00.000Z",
+			}),
+		]);
+
+		expect(vm.hasAddresses).toBe(true);
+		expect(vm.activeAddresses).toEqual([
+			{ name: "netflix", address: "netflix-bbb222@read.place" },
+		]);
+		expect(vm.disabledAddresses).toEqual([
+			{ name: "gmail", address: "gmail-aaa111@read.place" },
+			{ name: "substack", address: "substack-ccc333@read.place" },
+		]);
+		expect(vm.hasDisabled).toBe(true);
+		expect(vm.disabledCount).toBe(2);
+	});
+
+	it("leaves the disabled partition empty when every address is live", () => {
+		const vm = toInboxAddressesViewModel([
+			entry({ name: "netflix", address: "netflix-bbb222@read.place" }),
+			entry({ name: "gmail", address: "gmail-aaa111@read.place" }),
+		]);
+
+		expect(vm.hasAddresses).toBe(true);
+		expect(vm.activeAddresses).toEqual([
+			{ name: "netflix", address: "netflix-bbb222@read.place" },
+			{ name: "gmail", address: "gmail-aaa111@read.place" },
+		]);
+		expect(vm.disabledAddresses).toEqual([]);
+		expect(vm.hasDisabled).toBe(false);
+		expect(vm.disabledCount).toBe(0);
+	});
+
+	it("reports no addresses for an empty list", () => {
+		const vm = toInboxAddressesViewModel([]);
+
+		expect(vm.hasAddresses).toBe(false);
+		expect(vm.activeAddresses).toEqual([]);
+		expect(vm.disabledAddresses).toEqual([]);
+		expect(vm.hasDisabled).toBe(false);
+		expect(vm.disabledCount).toBe(0);
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/inbox/inbox.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/inbox/inbox.viewmodel.ts
@@ -1,0 +1,30 @@
+import { type InboxAddressEntry, isLiveAddress } from "@packages/domain/inbox";
+
+export interface InboxAddressRowViewModel {
+	address: string;
+	name: string;
+}
+
+export interface InboxAddressesViewModel {
+	hasAddresses: boolean;
+	activeAddresses: InboxAddressRowViewModel[];
+	disabledAddresses: InboxAddressRowViewModel[];
+	hasDisabled: boolean;
+	disabledCount: number;
+}
+
+function toRow(entry: InboxAddressEntry): InboxAddressRowViewModel {
+	return { address: entry.address, name: entry.name };
+}
+
+export function toInboxAddressesViewModel(entries: InboxAddressEntry[]): InboxAddressesViewModel {
+	const activeAddresses = entries.filter(isLiveAddress).map(toRow);
+	const disabledAddresses = entries.filter((entry) => !isLiveAddress(entry)).map(toRow);
+	return {
+		hasAddresses: entries.length > 0,
+		activeAddresses,
+		disabledAddresses,
+		hasDisabled: disabledAddresses.length > 0,
+		disabledCount: disabledAddresses.length,
+	};
+}

--- a/src/packages/domain/src/inbox/inbox-email.types.ts
+++ b/src/packages/domain/src/inbox/inbox-email.types.ts
@@ -22,15 +22,27 @@ export interface InboxEmailEntry {
 	bodyS3Key: string | undefined;
 }
 
+export interface ListInboxEmailsResult {
+	emails: InboxEmailEntry[];
+	total: number;
+	page: number;
+	pageSize: number;
+}
+
 export interface InboxEmailStore {
 	/** Conditional put on the sort key — an at-least-once redelivery collapses
 	 * to one row. Returns `"duplicate"` when the row already exists so the caller
 	 * can skip re-publishing side effects. */
 	putEmail: (email: InboxEmailEntry) => Promise<"stored" | "duplicate">;
-	/** Every email the user owns, newest first (descending sort key). Answered by
-	 * the base table — no GSI, no scan. Strongly consistent in the in-memory
-	 * fixture; the production adapter reads the base table so it is too. */
-	listEmailsByUserId: (userId: UserId) => Promise<InboxEmailEntry[]>;
+	/** One 1-based page of the user's emails, newest first (descending sort
+	 * key), plus the total across all pages. Answered by the base table — no
+	 * GSI, no scan. Strongly consistent in the in-memory fixture; the
+	 * production adapter reads the base table so it is too. */
+	listEmailsByUserId: (input: {
+		userId: UserId;
+		page: number;
+		pageSize: number;
+	}) => Promise<ListInboxEmailsResult>;
 	getEmail: (input: {
 		userId: UserId;
 		receivedAtMessageId: string;

--- a/src/packages/domain/src/inbox/index.ts
+++ b/src/packages/domain/src/inbox/index.ts
@@ -22,7 +22,11 @@ export {
 	aliasNameFromAddress,
 	normalizeAliasName,
 } from "./inbox-address.schema";
-export type { InboxEmailEntry, InboxEmailStore } from "./inbox-email.types";
+export type {
+	InboxEmailEntry,
+	InboxEmailStore,
+	ListInboxEmailsResult,
+} from "./inbox-email.types";
 export {
 	MessageIdSchema,
 	type MessageId,

--- a/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email.test.ts
@@ -170,7 +170,12 @@ describe("initInMemoryInboxEmail", () => {
 			expect(refs.rawEmailS3Keys).toEqual(["inbound/a", "inbound/b"]);
 			expect(refs.bodyS3Keys).toEqual(["content/a/content.html"]);
 			// The read pass leaves every row in place so a redrive re-derives the keys.
-			expect(await store.listEmailsByUserId(owner)).toHaveLength(2);
+			const remaining = await store.listEmailsByUserId({
+				userId: owner,
+				page: 1,
+				pageSize: 20,
+			});
+			expect(remaining.total).toBe(2);
 		});
 
 		it("scopes the references to the owner, ignoring another user's emails", async () => {
@@ -212,7 +217,12 @@ describe("initInMemoryInboxEmail", () => {
 
 			await store.deleteAllEmailsByUserId(owner);
 
-			expect(await store.listEmailsByUserId(owner)).toHaveLength(0);
+			const remaining = await store.listEmailsByUserId({
+				userId: owner,
+				page: 1,
+				pageSize: 20,
+			});
+			expect(remaining.total).toBe(0);
 		});
 
 		it("leaves another user's emails intact", async () => {
@@ -227,8 +237,18 @@ describe("initInMemoryInboxEmail", () => {
 
 			await store.deleteAllEmailsByUserId(owner);
 
-			expect(await store.listEmailsByUserId(owner)).toHaveLength(0);
-			expect(await store.listEmailsByUserId(otherUser)).toHaveLength(1);
+			const ownerRemaining = await store.listEmailsByUserId({
+				userId: owner,
+				page: 1,
+				pageSize: 20,
+			});
+			const otherRemaining = await store.listEmailsByUserId({
+				userId: otherUser,
+				page: 1,
+				pageSize: 20,
+			});
+			expect(ownerRemaining.total).toBe(0);
+			expect(otherRemaining.total).toBe(1);
 		});
 
 		it("is a no-op for a user with no emails", async () => {
@@ -236,7 +256,12 @@ describe("initInMemoryInboxEmail", () => {
 
 			await store.deleteAllEmailsByUserId(owner);
 
-			expect(await store.listEmailsByUserId(owner)).toHaveLength(0);
+			const remaining = await store.listEmailsByUserId({
+				userId: owner,
+				page: 1,
+				pageSize: 20,
+			});
+			expect(remaining.total).toBe(0);
 		});
 	});
 });

--- a/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email.test.ts
@@ -81,9 +81,57 @@ describe("initInMemoryInboxEmail", () => {
 			}),
 		);
 
-		const ownerEmails = await store.listEmailsByUserId(owner);
+		const ownerEmails = await store.listEmailsByUserId({
+			userId: owner,
+			page: 1,
+			pageSize: 20,
+		});
 
-		expect(ownerEmails.map((e) => e.subject)).toEqual(["Newer", "Older"]);
+		expect(ownerEmails.emails.map((e) => e.subject)).toEqual(["Newer", "Older"]);
+		expect(ownerEmails.total).toBe(2);
+	});
+
+	it("slices pages newest-first while reporting the unpaged total", async () => {
+		const store = initInMemoryInboxEmail();
+		for (const hour of ["08", "09", "10"]) {
+			await store.putEmail(
+				makeEntry({
+					messageId: MessageIdSchema.parse(`<m-${hour}@x>`),
+					receivedAtMessageId: `2026-06-23T${hour}:00:00.000Z#<m-${hour}@x>`,
+					subject: `At ${hour}`,
+				}),
+			);
+		}
+
+		const pageOne = await store.listEmailsByUserId({
+			userId: owner,
+			page: 1,
+			pageSize: 2,
+		});
+		const pageTwo = await store.listEmailsByUserId({
+			userId: owner,
+			page: 2,
+			pageSize: 2,
+		});
+
+		expect(pageOne.emails.map((e) => e.subject)).toEqual(["At 10", "At 09"]);
+		expect(pageOne).toMatchObject({ total: 3, page: 1, pageSize: 2 });
+		expect(pageTwo.emails.map((e) => e.subject)).toEqual(["At 08"]);
+		expect(pageTwo).toMatchObject({ total: 3, page: 2, pageSize: 2 });
+	});
+
+	it("returns no emails but the correct total for a page beyond the data", async () => {
+		const store = initInMemoryInboxEmail();
+		await store.putEmail(makeEntry());
+
+		const result = await store.listEmailsByUserId({
+			userId: owner,
+			page: 3,
+			pageSize: 2,
+		});
+
+		expect(result.emails).toEqual([]);
+		expect(result.total).toBe(1);
 	});
 
 	it("returns undefined for an unknown email", async () => {

--- a/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import type { InboxEmailEntry, InboxEmailStore } from "@packages/domain/inbox";
 import type { UserId } from "@packages/domain/user";
 
@@ -13,12 +14,23 @@ export function initInMemoryInboxEmail(): InboxEmailStore {
 			rows.set(key, email);
 			return "stored";
 		},
-		listEmailsByUserId: async (userId) =>
-			[...rows.values()]
+		listEmailsByUserId: async ({ userId, page, pageSize }) => {
+			assert(Number.isInteger(page), "page must be an integer");
+			assert(page >= 1, "page must be >= 1");
+			assert(Number.isInteger(pageSize), "pageSize must be an integer");
+			assert(pageSize >= 1, "pageSize must be >= 1");
+			const matching = [...rows.values()]
 				.filter((row) => row.userId === userId)
 				.sort((a, b) =>
 					a.receivedAtMessageId < b.receivedAtMessageId ? 1 : -1,
-				),
+				);
+			return {
+				emails: matching.slice((page - 1) * pageSize, page * pageSize),
+				total: matching.length,
+				page,
+				pageSize,
+			};
+		},
 		getEmail: async ({ userId, receivedAtMessageId }) =>
 			rows.get(keyOf(userId, receivedAtMessageId)),
 		listDeletionReferencesByUserId: async (userId) => {


### PR DESCRIPTION
Four UX changes to the email inbox feature (behind the `?feature=email` flag). Both pages are HTML-only — no Siren/extension/iOS/MCP client is affected.

## Inbox email list — pagination (`GET /inbox`)

The list previously fetched and rendered **every** email with no pagination. It's now paginated the same way `/queue` is:

- 1-based `?page=` param, 20 emails per page, newest-first across the page boundary
- htmx-boosted **Previous / Next** nav with "Page X of Y"
- a **302 clamp** that redirects an out-of-range page (stale bookmark / hand-typed URL) to the last valid page
- the per-email link-count fan-out is now naturally bounded to the page size instead of the whole mailbox

**Incidental fix:** the DynamoDB adapter's old single, un-looped `Query` silently **truncated any email partition larger than 1 MB**. It now walks `ExclusiveStartKey` to exhaustion (via the existing `forEachQueryPage` helper), so both `total` and the page slice are computed over the full partition.

The store contract `listEmailsByUserId` changes from `(userId) => InboxEmailEntry[]` to `({ userId, page, pageSize }) => { emails, total, page, pageSize }`. It's an internal, unversioned contract; the only production caller is the `GET /inbox` route (the in-memory fixture, the DynamoDB adapter, and test call sites all move to the new shape in the same change).

## Manage addresses — layout rework (`GET /inbox/addresses`)

- **Section order** (top → bottom): the create-address form **and its "How it works" explainer** move to the top, then active addresses, then disabled.
- **Grouping:** active addresses render first; **all disabled addresses collapse into a native `<details>` group** as the last item, closed by default. The group renders unconditionally with a `--visible` / `--hidden` state class (no `open` attribute) rather than being conditionally rendered.
- **Row layout:** the **Copy** control moves to the **left** of the address field; the **Active / Disable** controls sit at the **right edge** of the row.

A new `toInboxAddressesViewModel` partitions entries with the canonical `isLiveAddress` predicate, so list membership encodes active/disabled state instead of a per-row `enabled` flag.

## Verification

- `pnpm nx run hutch:check` and the repo-wide pre-commit `pnpm check` pass (lint, types, unit + integration tests, 100% coverage, knip, unused-CSS).
- Driven end-to-end in the running app with the flag on: 21 seeded emails → page 1 shows 20 rows + "Page 1 of 2" + Next; page 2 shows the single oldest email + Previous; `?page=99` → 302 to the last page. On the addresses page: create form + "How it works" at the top, active list with Copy-left / Active-Disable-right, and disabling an address moves it into the collapsed "Disabled addresses (N)" group (which expands natively).

## Notes / out of scope

- No re-enable action for disabled addresses exists today (disable is permanent); this only regroups them.
- Queue's own pagination internals are untouched — the inbox replicates the pattern rather than importing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfH8LL8NeuuSde6WtcbkuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfH8LL8NeuuSde6WtcbkuZ)_