### PR TITLE
feat(observability): instrument the checkout funnel with started/completed/failed events

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -110,6 +110,7 @@ import { createApp } from "./server";
 import { initChangelogBannerSource } from "./web/changelog-banner-source";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
 import type { ConversionEvent } from "./conversions";
+import type { SubscriptionLogEvent } from "./observability/subscription-events";
 import type { AnalyticsEvent } from "@packages/web-analytics";
 import { httpErrorMessageMapping } from "./web/pages/queue/queue.error";
 import { initFoundingAllocation } from "./web/shared/founding-progress/founding-allocation";
@@ -729,6 +730,7 @@ export function createHutchApp(deps?: {
 		now: () => new Date(),
 		botDefenseLogger: HutchLogger.fromJSON<BotDefenseEvent>(),
 		conversionLogger: HutchLogger.fromJSON<ConversionEvent>(),
+		subscriptionLogger: HutchLogger.fromJSON<SubscriptionLogEvent>(),
 		analytics: analyticsLogger,
 		salt,
 		foundingAllocation: initFoundingAllocation({ foundingMemberLimit }),

--- a/projects/hutch/src/runtime/domain/checkout-recovery/select-recipients.test.ts
+++ b/projects/hutch/src/runtime/domain/checkout-recovery/select-recipients.test.ts
@@ -17,6 +17,7 @@ function createRetrieve(
 	return async () => ({
 		ok: true,
 		paid: overrides.paid ?? false,
+		paymentStatus: "unpaid",
 		customerEmail: overrides.customerEmail ?? "buyer@example.com",
 		status: overrides.status ?? "open",
 		created: NOW_SECONDS - ageSeconds,
@@ -128,6 +129,7 @@ describe("selectRecipients", () => {
 			return {
 				ok: true,
 				paid: state.paid,
+				paymentStatus: "unpaid",
 				customerEmail: "x@example.com",
 				status: "open",
 				created: NOW_SECONDS - state.ageSeconds,

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -70,9 +70,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 32 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form, 2 checkout-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 33 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form, 2 checkout-funnel, 1 paid-conversions) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(32);
+		expect(body.widgets).toHaveLength(33);
 	});
 
 	it("the homepage A/B widget compares arms by distinct visitors (assignment is sticky per browser, so raw counts pile a returning visitor's landings onto one arm) with raw landings alongside, grouped by variant (utm_content)", () => {
@@ -232,17 +232,18 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 	});
 
 	it("queries spanning subscription Lambda log groups emit one `SOURCE '<name>'` per group joined by `|` — `logGroups(namePrefix: [...])` is a CLI-only form the dashboard renderer rejects", () => {
-		// Exempt the checkout widgets by their event set, not by log-group prefix:
-		// they are the only subscriptions-stream queries the web app sources, so any
+		// Exempt the web-app-emitted events by name, not by log-group prefix: these
+		// are the only subscriptions-stream events the hutch handler writes, so any
 		// OTHER subscriptions query must still fan out across the Lambda log groups.
-		const checkoutEvents = [
+		const webAppEvents = [
 			SUBSCRIPTION_EVENTS.checkoutStarted,
 			SUBSCRIPTION_EVENTS.checkoutCompleted,
 			SUBSCRIPTION_EVENTS.checkoutReturnFailed,
+			SUBSCRIPTION_EVENTS.resubscribeCompleted,
 		];
-		const isCheckoutQuery = (q: string) => checkoutEvents.some((e) => q.includes(e));
+		const isWebAppQuery = (q: string) => webAppEvents.some((e) => q.includes(e));
 		const subscriptionQueries = widgetQueries().filter(
-			(q) => q.includes(`"${STREAMS.subscriptions}"`) && !isCheckoutQuery(q),
+			(q) => q.includes(`"${STREAMS.subscriptions}"`) && !isWebAppQuery(q),
 		);
 		const expectedSourcePrefix = `${SUBSCRIPTION_DASHBOARD_LOG_GROUPS.map((name) => `SOURCE '${name}'`).join(" | ")} | `;
 		for (const q of subscriptionQueries) {
@@ -267,6 +268,15 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 		);
 		const detail = checkoutQueries.find((q) => q.includes("as detail"));
 		expect(detail).toContain(`stats count(*) as n by event, coalesce(variant, reason, "-") as detail`);
+	});
+
+	it("the conversions widget splits completed checkouts by paid_now (a $0 trial capture is not revenue) and counts saved-card resubscribes, which never pass through Checkout", () => {
+		const q = widgetQueries().find((x) => x.includes(SUBSCRIPTION_EVENTS.resubscribeCompleted));
+		expect(q).toBeDefined();
+		expect(q?.startsWith(`SOURCE '${LOG_GROUPS.hutchHandler}' | `)).toBe(true);
+		expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutCompleted);
+		expect(q).toContain("stats count_distinct(user_id) as users by bin(1d), event, paid_now");
+		expect(q).not.toContain(SUBSCRIPTION_EVENTS.checkoutStarted);
 	});
 
 	it("widget positions do not overlap so every chart is visible side-by-side, not stacked", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -70,9 +70,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 30 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 31 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form, 1 checkout-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(30);
+		expect(body.widgets).toHaveLength(31);
 	});
 
 	it("the homepage A/B widget compares arms by distinct visitors (assignment is sticky per browser, so raw counts pile a returning visitor's landings onto one arm) with raw landings alongside, grouped by variant (utm_content)", () => {
@@ -232,12 +232,24 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 	});
 
 	it("queries spanning subscription Lambda log groups emit one `SOURCE '<name>'` per group joined by `|` — `logGroups(namePrefix: [...])` is a CLI-only form the dashboard renderer rejects", () => {
-		const subscriptionQueries = widgetQueries().filter((q) => q.includes(`"${STREAMS.subscriptions}"`));
+		const hutchPrefix = `SOURCE '${LOG_GROUPS.hutchHandler}' | `;
+		const subscriptionQueries = widgetQueries().filter(
+			(q) => q.includes(`"${STREAMS.subscriptions}"`) && !q.startsWith(hutchPrefix),
+		);
 		const expectedSourcePrefix = `${SUBSCRIPTION_DASHBOARD_LOG_GROUPS.map((name) => `SOURCE '${name}'`).join(" | ")} | `;
 		for (const q of subscriptionQueries) {
 			expect(q.startsWith(expectedSourcePrefix)).toBe(true);
 		}
 		expect(subscriptionQueries.length).toBeGreaterThan(0);
+	});
+
+	it("the checkout-funnel widget sources the hutch handler log group — checkout events are emitted by the web app, not the subscription Lambdas", () => {
+		const q = widgetQueries().find((x) => x.includes(SUBSCRIPTION_EVENTS.checkoutStarted));
+		expect(q).toBeDefined();
+		expect(q?.startsWith(`SOURCE '${LOG_GROUPS.hutchHandler}' | `)).toBe(true);
+		expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutCompleted);
+		expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutReturnFailed);
+		expect(q).toContain("stats count(*) as checkouts by bin(1d), event");
 	});
 
 	it("widget positions do not overlap so every chart is visible side-by-side, not stacked", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -70,9 +70,9 @@ function collectReferencedEvents(): Set<string> {
 }
 
 describe("buildAnalyticsDashboardBody — drift prevention", () => {
-	it("emits 31 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form, 1 checkout-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
+	it("emits 32 widgets (7 traffic+audience, 3 conversions, 3 imports+medium, 3 subscriptions, 2 view-funnel, 1 internal-clicks, 3 save-funnel, 1 summary-engagement, 2 audience-device, 1 errors, 1 homepage-ab, 1 blog-traffic, 2 signup-form, 2 checkout-funnel) — adding or dropping one without updating this count is a deliberate signal to review the dashboard's scope", () => {
 		const body = buildBody();
-		expect(body.widgets).toHaveLength(31);
+		expect(body.widgets).toHaveLength(32);
 	});
 
 	it("the homepage A/B widget compares arms by distinct visitors (assignment is sticky per browser, so raw counts pile a returning visitor's landings onto one arm) with raw landings alongside, grouped by variant (utm_content)", () => {
@@ -232,9 +232,17 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 	});
 
 	it("queries spanning subscription Lambda log groups emit one `SOURCE '<name>'` per group joined by `|` — `logGroups(namePrefix: [...])` is a CLI-only form the dashboard renderer rejects", () => {
-		const hutchPrefix = `SOURCE '${LOG_GROUPS.hutchHandler}' | `;
+		// Exempt the checkout widgets by their event set, not by log-group prefix:
+		// they are the only subscriptions-stream queries the web app sources, so any
+		// OTHER subscriptions query must still fan out across the Lambda log groups.
+		const checkoutEvents = [
+			SUBSCRIPTION_EVENTS.checkoutStarted,
+			SUBSCRIPTION_EVENTS.checkoutCompleted,
+			SUBSCRIPTION_EVENTS.checkoutReturnFailed,
+		];
+		const isCheckoutQuery = (q: string) => checkoutEvents.some((e) => q.includes(e));
 		const subscriptionQueries = widgetQueries().filter(
-			(q) => q.includes(`"${STREAMS.subscriptions}"`) && !q.startsWith(hutchPrefix),
+			(q) => q.includes(`"${STREAMS.subscriptions}"`) && !isCheckoutQuery(q),
 		);
 		const expectedSourcePrefix = `${SUBSCRIPTION_DASHBOARD_LOG_GROUPS.map((name) => `SOURCE '${name}'`).join(" | ")} | `;
 		for (const q of subscriptionQueries) {
@@ -243,13 +251,22 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 		expect(subscriptionQueries.length).toBeGreaterThan(0);
 	});
 
-	it("the checkout-funnel widget sources the hutch handler log group — checkout events are emitted by the web app, not the subscription Lambdas", () => {
-		const q = widgetQueries().find((x) => x.includes(SUBSCRIPTION_EVENTS.checkoutStarted));
-		expect(q).toBeDefined();
-		expect(q?.startsWith(`SOURCE '${LOG_GROUPS.hutchHandler}' | `)).toBe(true);
-		expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutCompleted);
-		expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutReturnFailed);
-		expect(q).toContain("stats count(*) as checkouts by bin(1d), event");
+	it("both checkout-funnel widgets source the hutch handler log group — checkout events are emitted by the web app, not the subscription Lambdas", () => {
+		const checkoutQueries = widgetQueries().filter((x) =>
+			x.includes(SUBSCRIPTION_EVENTS.checkoutStarted),
+		);
+		expect(checkoutQueries).toHaveLength(2);
+		for (const q of checkoutQueries) {
+			expect(q.startsWith(`SOURCE '${LOG_GROUPS.hutchHandler}' | `)).toBe(true);
+			expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutCompleted);
+			expect(q).toContain(SUBSCRIPTION_EVENTS.checkoutReturnFailed);
+		}
+		const perDay = checkoutQueries.find((q) => q.includes("bin(1d)"));
+		expect(perDay).toContain(
+			"stats count_distinct(user_id) as users, count(*) as events by bin(1d), event",
+		);
+		const detail = checkoutQueries.find((q) => q.includes("as detail"));
+		expect(detail).toContain(`stats count(*) as n by event, coalesce(variant, reason, "-") as detail`);
 	});
 
 	it("widget positions do not overlap so every chart is visible side-by-side, not stacked", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -686,6 +686,23 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 			x: 12, y: 138, width: 12, height: 8,
 			view: "bar",
 		}),
+		logWidget({
+			region,
+			title: "Conversions per day — real charges vs $0 trial captures",
+			logGroupNames: [hutchLogGroupName],
+			// A completed checkout is not necessarily revenue: a trial-preserving
+			// checkout captures a card for $0 (paid_now:false). A saved-card
+			// resubscribe charges immediately and never touches Stripe Checkout, so it
+			// has no checkout_started/completed pair and is counted on its own event.
+			query: [
+				"fields @timestamp, event, paid_now",
+				`| filter stream = "${STREAMS.subscriptions}"`,
+				`| filter event in ["${SUBSCRIPTION_EVENTS.checkoutCompleted}", "${SUBSCRIPTION_EVENTS.resubscribeCompleted}"]`,
+				"| stats count_distinct(user_id) as users by bin(1d), event, paid_now",
+			].join(" "),
+			x: 0, y: 146, width: 12, height: 8,
+			view: "timeSeries",
+		}),
 	);
 
 	return { widgets };

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -653,19 +653,38 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 	// GET /auth/checkout/success), not the subscription Lambdas, so the widget
 	// sources the hutch handler log group.
 
+	const checkoutFunnelFilter = [
+		`| filter stream = "${STREAMS.subscriptions}"`,
+		`| filter event in ["${SUBSCRIPTION_EVENTS.checkoutStarted}", "${SUBSCRIPTION_EVENTS.checkoutCompleted}", "${SUBSCRIPTION_EVENTS.checkoutReturnFailed}"]`,
+	];
+
 	widgets.push(
 		logWidget({
 			region,
 			title: "Checkout funnel per day",
 			logGroupNames: [hutchLogGroupName],
+			// Distinct users, not raw counts: checkout_started fires once per Subscribe
+			// click, so abandon-and-retry would inflate the conversion denominator.
 			query: [
 				"fields @timestamp, event",
-				`| filter stream = "${STREAMS.subscriptions}"`,
-				`| filter event in ["${SUBSCRIPTION_EVENTS.checkoutStarted}", "${SUBSCRIPTION_EVENTS.checkoutCompleted}", "${SUBSCRIPTION_EVENTS.checkoutReturnFailed}"]`,
-				"| stats count(*) as checkouts by bin(1d), event",
+				...checkoutFunnelFilter,
+				"| stats count_distinct(user_id) as users, count(*) as events by bin(1d), event",
 			].join(" "),
 			x: 0, y: 138, width: 12, height: 8,
 			view: "timeSeries",
+		}),
+		logWidget({
+			region,
+			title: "Checkout funnel detail (variant / reason)",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields @timestamp, event, variant, reason",
+				...checkoutFunnelFilter,
+				`| stats count(*) as n by event, coalesce(variant, reason, "-") as detail`,
+				"| sort n desc",
+			].join(" "),
+			x: 12, y: 138, width: 12, height: 8,
+			view: "bar",
 		}),
 	);
 

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -648,6 +648,27 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 		}),
 	);
 
+	// --- Checkout funnel ---
+	// These events are emitted by the hutch web app (POST /account/subscribe and
+	// GET /auth/checkout/success), not the subscription Lambdas, so the widget
+	// sources the hutch handler log group.
+
+	widgets.push(
+		logWidget({
+			region,
+			title: "Checkout funnel per day",
+			logGroupNames: [hutchLogGroupName],
+			query: [
+				"fields @timestamp, event",
+				`| filter stream = "${STREAMS.subscriptions}"`,
+				`| filter event in ["${SUBSCRIPTION_EVENTS.checkoutStarted}", "${SUBSCRIPTION_EVENTS.checkoutCompleted}", "${SUBSCRIPTION_EVENTS.checkoutReturnFailed}"]`,
+				"| stats count(*) as checkouts by bin(1d), event",
+			].join(" "),
+			x: 0, y: 138, width: 12, height: 8,
+			view: "timeSeries",
+		}),
+	);
+
 	return { widgets };
 }
 

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -17,7 +17,28 @@ export const SUBSCRIPTION_EVENTS = {
 	chargeSucceeded: "charge_succeeded",
 	chargeFailed: "charge_failed",
 	cancelled: "cancelled",
+	checkoutStarted: "checkout_started",
+	checkoutCompleted: "checkout_completed",
+	checkoutReturnFailed: "checkout_return_failed",
 } as const;
+
+export const CHECKOUT_VARIANTS = {
+	trialCheckout: "trial_checkout",
+	cancelledResubscribe: "cancelled_resubscribe",
+	cardDeclineFallback: "card_decline_fallback",
+} as const;
+
+export type CheckoutVariant = (typeof CHECKOUT_VARIANTS)[keyof typeof CHECKOUT_VARIANTS];
+
+export const CHECKOUT_RETURN_FAILURE_REASONS = {
+	invalidQuery: "invalid_query",
+	sessionNotFound: "session_not_found",
+	notPaid: "not_paid",
+	replayed: "replayed",
+} as const;
+
+export type CheckoutReturnFailureReason =
+	(typeof CHECKOUT_RETURN_FAILURE_REASONS)[keyof typeof CHECKOUT_RETURN_FAILURE_REASONS];
 
 export const METRICS = {
 	importsCompleted: {

--- a/projects/hutch/src/runtime/observability/events.ts
+++ b/projects/hutch/src/runtime/observability/events.ts
@@ -1,3 +1,5 @@
+import type { CheckoutVariant } from "@packages/provider-contracts/hosted-checkout";
+
 export {
 	STREAMS,
 	ANALYTICS_EVENTS,
@@ -20,15 +22,18 @@ export const SUBSCRIPTION_EVENTS = {
 	checkoutStarted: "checkout_started",
 	checkoutCompleted: "checkout_completed",
 	checkoutReturnFailed: "checkout_return_failed",
+	resubscribeCompleted: "resubscribe_completed",
 } as const;
 
+// The variant union lives in provider-contracts because it is persisted on the
+// pending signup; `satisfies` keeps this lookup table from drifting off it.
 export const CHECKOUT_VARIANTS = {
 	trialCheckout: "trial_checkout",
 	cancelledResubscribe: "cancelled_resubscribe",
 	cardDeclineFallback: "card_decline_fallback",
-} as const;
+} as const satisfies Record<string, CheckoutVariant>;
 
-export type CheckoutVariant = (typeof CHECKOUT_VARIANTS)[keyof typeof CHECKOUT_VARIANTS];
+export type { CheckoutVariant };
 
 export const CHECKOUT_RETURN_FAILURE_REASONS = {
 	invalidQuery: "invalid_query",

--- a/projects/hutch/src/runtime/observability/subscription-events.test.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.test.ts
@@ -150,6 +150,46 @@ describe("initEmitSubscriptionEvent", () => {
 		}]);
 	});
 
+	it("carries the originating variant on checkout_completed so completions split by entry path without a self-join back to checkout_started", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.checkoutCompleted({
+			userId: USER_ID,
+			subscriptionId: "sub_123",
+			checkoutSessionId: "cs_test_1",
+			paidNow: true,
+			variant: CHECKOUT_VARIANTS.cancelledResubscribe,
+		});
+
+		expect(captured).toEqual([{
+			stream: "subscriptions",
+			event: "checkout_completed",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			user_id: USER_ID,
+			subscription_id: "sub_123",
+			checkout_session_id: "cs_test_1",
+			paid_now: true,
+			variant: "cancelled_resubscribe",
+		}]);
+	});
+
+	it("emits resubscribe_completed with paid_now:true — a saved-card resubscribe charges immediately and never passes through Stripe Checkout", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.resubscribeCompleted({ userId: USER_ID, subscriptionId: "sub_resub" });
+
+		expect(captured).toEqual([{
+			stream: "subscriptions",
+			event: "resubscribe_completed",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			user_id: USER_ID,
+			subscription_id: "sub_resub",
+			paid_now: true,
+		}]);
+	});
+
 	it("emits a checkout_return_failed event with user_id and checkout_session_id when both are known", () => {
 		const { logger, captured } = createCapturingLogger();
 		const emit = initEmitSubscriptionEvent({ logger, now: NOW });

--- a/projects/hutch/src/runtime/observability/subscription-events.test.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.test.ts
@@ -1,5 +1,6 @@
 import { UserIdSchema } from "@packages/domain/user";
 import type { HutchLogger } from "@packages/hutch-logger";
+import { CHECKOUT_RETURN_FAILURE_REASONS, CHECKOUT_VARIANTS } from "./events";
 import { initEmitSubscriptionEvent, type SubscriptionLogEvent } from "./subscription-events";
 
 function createCapturingLogger(): {
@@ -82,6 +83,80 @@ describe("initEmitSubscriptionEvent", () => {
 			timestamp: "2026-05-25T10:00:00.000Z",
 			user_id: USER_ID,
 			reason: "user_initiated_trial",
+		});
+	});
+
+	it("emits a checkout_started event carrying the variant and checkout session id so the funnel can attribute the click", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.checkoutStarted({
+			userId: USER_ID,
+			variant: CHECKOUT_VARIANTS.trialCheckout,
+			checkoutSessionId: "cs_test_1",
+		});
+
+		expect(captured).toEqual([{
+			stream: "subscriptions",
+			event: "checkout_started",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			user_id: USER_ID,
+			variant: "trial_checkout",
+			checkout_session_id: "cs_test_1",
+		}]);
+	});
+
+	it("emits a checkout_completed event with the subscription and checkout session ids — the missing paid-conversion signal", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.checkoutCompleted({
+			userId: USER_ID,
+			subscriptionId: "sub_123",
+			checkoutSessionId: "cs_test_1",
+		});
+
+		expect(captured).toEqual([{
+			stream: "subscriptions",
+			event: "checkout_completed",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			user_id: USER_ID,
+			subscription_id: "sub_123",
+			checkout_session_id: "cs_test_1",
+		}]);
+	});
+
+	it("emits a checkout_return_failed event with user_id and checkout_session_id when both are known", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.checkoutReturnFailed({
+			reason: CHECKOUT_RETURN_FAILURE_REASONS.notPaid,
+			userId: USER_ID,
+			checkoutSessionId: "cs_test_1",
+		});
+
+		expect(captured).toEqual([{
+			stream: "subscriptions",
+			event: "checkout_return_failed",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			reason: "not_paid",
+			user_id: USER_ID,
+			checkout_session_id: "cs_test_1",
+		}]);
+	});
+
+	it("omits user_id and checkout_session_id from checkout_return_failed when neither is known (anonymous return with no parseable session)", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.checkoutReturnFailed({ reason: CHECKOUT_RETURN_FAILURE_REASONS.invalidQuery });
+
+		expect(captured[0]).toEqual({
+			stream: "subscriptions",
+			event: "checkout_return_failed",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			reason: "invalid_query",
 		});
 	});
 });

--- a/projects/hutch/src/runtime/observability/subscription-events.test.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.test.ts
@@ -106,7 +106,7 @@ describe("initEmitSubscriptionEvent", () => {
 		}]);
 	});
 
-	it("emits a checkout_completed event with the subscription and checkout session ids — the missing paid-conversion signal", () => {
+	it("emits a checkout_completed event carrying paid_now:true when Stripe collected a real charge", () => {
 		const { logger, captured } = createCapturingLogger();
 		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
 
@@ -114,6 +114,7 @@ describe("initEmitSubscriptionEvent", () => {
 			userId: USER_ID,
 			subscriptionId: "sub_123",
 			checkoutSessionId: "cs_test_1",
+			paidNow: true,
 		});
 
 		expect(captured).toEqual([{
@@ -123,6 +124,29 @@ describe("initEmitSubscriptionEvent", () => {
 			user_id: USER_ID,
 			subscription_id: "sub_123",
 			checkout_session_id: "cs_test_1",
+			paid_now: true,
+		}]);
+	});
+
+	it("emits a checkout_completed event carrying paid_now:false for a $0 trial-preserving checkout (card captured, no charge)", () => {
+		const { logger, captured } = createCapturingLogger();
+		const emit = initEmitSubscriptionEvent({ logger, now: NOW });
+
+		emit.checkoutCompleted({
+			userId: USER_ID,
+			subscriptionId: "sub_123",
+			checkoutSessionId: "cs_test_1",
+			paidNow: false,
+		});
+
+		expect(captured).toEqual([{
+			stream: "subscriptions",
+			event: "checkout_completed",
+			timestamp: "2026-05-25T10:00:00.000Z",
+			user_id: USER_ID,
+			subscription_id: "sub_123",
+			checkout_session_id: "cs_test_1",
+			paid_now: false,
 		}]);
 	});
 

--- a/projects/hutch/src/runtime/observability/subscription-events.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.ts
@@ -37,12 +37,19 @@ export type SubscriptionLogEvent =
 			subscription_id: string;
 			checkout_session_id: string;
 			paid_now: boolean;
+			variant?: CheckoutVariant;
 	  })
 	| (SubscriptionEventBase & {
 			event: typeof SUBSCRIPTION_EVENTS.checkoutReturnFailed;
 			reason: CheckoutReturnFailureReason;
 			user_id?: UserId;
 			checkout_session_id?: string;
+	  })
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.resubscribeCompleted;
+			user_id: UserId;
+			subscription_id: string;
+			paid_now: boolean;
 	  });
 
 // Emitters build the strict union above so user_id is omissible only on
@@ -74,12 +81,17 @@ export interface EmitSubscriptionEvent {
 		subscriptionId: string;
 		checkoutSessionId: string;
 		paidNow: boolean;
+		variant?: CheckoutVariant;
 	}) => void;
 	checkoutReturnFailed: (params: {
 		reason: CheckoutReturnFailureReason;
 		userId?: UserId;
 		checkoutSessionId?: string;
 	}) => void;
+	/** A cancelled subscriber resubscribed with a saved card: Stripe charges
+	 * immediately, so this never passes through Stripe Checkout and has no
+	 * checkout_started to pair with. Always revenue. */
+	resubscribeCompleted: (params: { userId: UserId; subscriptionId: string }) => void;
 }
 
 export function initEmitSubscriptionEvent(deps: {
@@ -125,7 +137,7 @@ export function initEmitSubscriptionEvent(deps: {
 				checkout_session_id: checkoutSessionId,
 			});
 		},
-		checkoutCompleted: ({ userId, subscriptionId, checkoutSessionId, paidNow }) => {
+		checkoutCompleted: ({ userId, subscriptionId, checkoutSessionId, paidNow, variant }) => {
 			deps.logger.info({
 				stream: STREAMS.subscriptions,
 				event: SUBSCRIPTION_EVENTS.checkoutCompleted,
@@ -134,6 +146,17 @@ export function initEmitSubscriptionEvent(deps: {
 				subscription_id: subscriptionId,
 				checkout_session_id: checkoutSessionId,
 				paid_now: paidNow,
+				...(variant ? { variant } : {}),
+			});
+		},
+		resubscribeCompleted: ({ userId, subscriptionId }) => {
+			deps.logger.info({
+				stream: STREAMS.subscriptions,
+				event: SUBSCRIPTION_EVENTS.resubscribeCompleted,
+				timestamp: deps.now().toISOString(),
+				user_id: userId,
+				subscription_id: subscriptionId,
+				paid_now: true,
 			});
 		},
 		checkoutReturnFailed: ({ reason, userId, checkoutSessionId }) => {

--- a/projects/hutch/src/runtime/observability/subscription-events.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.ts
@@ -3,7 +3,52 @@ import type { HutchLogger } from "@packages/hutch-logger";
 import { STREAMS, SUBSCRIPTION_EVENTS } from "./events";
 import type { CheckoutReturnFailureReason, CheckoutVariant } from "./events";
 
-export interface SubscriptionLogEvent {
+interface SubscriptionEventBase {
+	stream: typeof STREAMS.subscriptions;
+	timestamp: string;
+}
+
+export type SubscriptionLogEvent =
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.chargeSucceeded;
+			user_id: UserId;
+			subscription_id: string;
+	  })
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.chargeFailed;
+			user_id: UserId;
+			reason: string;
+	  })
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.cancelled;
+			user_id: UserId;
+			reason: string;
+			subscription_id?: string;
+	  })
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.checkoutStarted;
+			user_id: UserId;
+			variant: CheckoutVariant;
+			checkout_session_id: string;
+	  })
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.checkoutCompleted;
+			user_id: UserId;
+			subscription_id: string;
+			checkout_session_id: string;
+			paid_now: boolean;
+	  })
+	| (SubscriptionEventBase & {
+			event: typeof SUBSCRIPTION_EVENTS.checkoutReturnFailed;
+			reason: CheckoutReturnFailureReason;
+			user_id?: UserId;
+			checkout_session_id?: string;
+	  });
+
+// Emitters build the strict union above so user_id is omissible only on
+// checkout_return_failed (the pre-auth return). Consumers that read a captured
+// event without narrowing on `event` see this widened superset instead.
+export interface SubscriptionLogEventView {
 	stream: typeof STREAMS.subscriptions;
 	event: (typeof SUBSCRIPTION_EVENTS)[keyof typeof SUBSCRIPTION_EVENTS];
 	timestamp: string;
@@ -12,6 +57,7 @@ export interface SubscriptionLogEvent {
 	reason?: string;
 	variant?: CheckoutVariant;
 	checkout_session_id?: string;
+	paid_now?: boolean;
 }
 
 export interface EmitSubscriptionEvent {
@@ -27,6 +73,7 @@ export interface EmitSubscriptionEvent {
 		userId: UserId;
 		subscriptionId: string;
 		checkoutSessionId: string;
+		paidNow: boolean;
 	}) => void;
 	checkoutReturnFailed: (params: {
 		reason: CheckoutReturnFailureReason;
@@ -78,7 +125,7 @@ export function initEmitSubscriptionEvent(deps: {
 				checkout_session_id: checkoutSessionId,
 			});
 		},
-		checkoutCompleted: ({ userId, subscriptionId, checkoutSessionId }) => {
+		checkoutCompleted: ({ userId, subscriptionId, checkoutSessionId, paidNow }) => {
 			deps.logger.info({
 				stream: STREAMS.subscriptions,
 				event: SUBSCRIPTION_EVENTS.checkoutCompleted,
@@ -86,6 +133,7 @@ export function initEmitSubscriptionEvent(deps: {
 				user_id: userId,
 				subscription_id: subscriptionId,
 				checkout_session_id: checkoutSessionId,
+				paid_now: paidNow,
 			});
 		},
 		checkoutReturnFailed: ({ reason, userId, checkoutSessionId }) => {

--- a/projects/hutch/src/runtime/observability/subscription-events.ts
+++ b/projects/hutch/src/runtime/observability/subscription-events.ts
@@ -1,20 +1,38 @@
 import type { UserId } from "@packages/domain/user";
 import type { HutchLogger } from "@packages/hutch-logger";
 import { STREAMS, SUBSCRIPTION_EVENTS } from "./events";
+import type { CheckoutReturnFailureReason, CheckoutVariant } from "./events";
 
 export interface SubscriptionLogEvent {
 	stream: typeof STREAMS.subscriptions;
 	event: (typeof SUBSCRIPTION_EVENTS)[keyof typeof SUBSCRIPTION_EVENTS];
 	timestamp: string;
-	user_id: UserId;
+	user_id?: UserId;
 	subscription_id?: string;
 	reason?: string;
+	variant?: CheckoutVariant;
+	checkout_session_id?: string;
 }
 
 export interface EmitSubscriptionEvent {
 	chargeSucceeded: (params: { userId: UserId; subscriptionId: string }) => void;
 	chargeFailed: (params: { userId: UserId; reason: string }) => void;
 	cancelled: (params: { userId: UserId; reason: string; subscriptionId?: string }) => void;
+	checkoutStarted: (params: {
+		userId: UserId;
+		variant: CheckoutVariant;
+		checkoutSessionId: string;
+	}) => void;
+	checkoutCompleted: (params: {
+		userId: UserId;
+		subscriptionId: string;
+		checkoutSessionId: string;
+	}) => void;
+	checkoutReturnFailed: (params: {
+		reason: CheckoutReturnFailureReason;
+		userId?: UserId;
+		checkoutSessionId?: string;
+	}) => void;
 }
 
 export function initEmitSubscriptionEvent(deps: {
@@ -48,6 +66,36 @@ export function initEmitSubscriptionEvent(deps: {
 				user_id: userId,
 				reason,
 				...(subscriptionId ? { subscription_id: subscriptionId } : {}),
+			});
+		},
+		checkoutStarted: ({ userId, variant, checkoutSessionId }) => {
+			deps.logger.info({
+				stream: STREAMS.subscriptions,
+				event: SUBSCRIPTION_EVENTS.checkoutStarted,
+				timestamp: deps.now().toISOString(),
+				user_id: userId,
+				variant,
+				checkout_session_id: checkoutSessionId,
+			});
+		},
+		checkoutCompleted: ({ userId, subscriptionId, checkoutSessionId }) => {
+			deps.logger.info({
+				stream: STREAMS.subscriptions,
+				event: SUBSCRIPTION_EVENTS.checkoutCompleted,
+				timestamp: deps.now().toISOString(),
+				user_id: userId,
+				subscription_id: subscriptionId,
+				checkout_session_id: checkoutSessionId,
+			});
+		},
+		checkoutReturnFailed: ({ reason, userId, checkoutSessionId }) => {
+			deps.logger.info({
+				stream: STREAMS.subscriptions,
+				event: SUBSCRIPTION_EVENTS.checkoutReturnFailed,
+				timestamp: deps.now().toISOString(),
+				reason,
+				...(userId ? { user_id: userId } : {}),
+				...(checkoutSessionId ? { checkout_session_id: checkoutSessionId } : {}),
 			});
 		},
 	};

--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.test.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.test.ts
@@ -97,6 +97,35 @@ describe("initDynamoDbPendingSignup", () => {
 			});
 		});
 
+		it("persists the checkout variant so the completion can be attributed to its entry path", async () => {
+			const { client, inputs } = createClient(() => ({}));
+			const { storePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+				logger: noopLogger,
+			});
+
+			await storePendingSignup({
+				checkoutSessionId: SESSION_ID,
+				signup: {
+					method: "existing-user-subscribe",
+					email: "e@b.com",
+					userId: USER_ID,
+					variant: "cancelled_resubscribe",
+				},
+				createdAt: 300,
+			});
+
+			expect(inputs[0]?.Item).toEqual({
+				checkoutSessionId: SESSION_ID,
+				method: "existing-user-subscribe",
+				email: "e@b.com",
+				createdAt: 300,
+				userId: USER_ID,
+				variant: "cancelled_resubscribe",
+			});
+		});
+
 		it("omits returnUrl when absent", async () => {
 			const { client, inputs } = createClient(() => ({}));
 			const { storePendingSignup } = initDynamoDbPendingSignup({
@@ -212,6 +241,57 @@ describe("initDynamoDbPendingSignup", () => {
 				email: "e@b.com",
 				userId: USER_ID,
 				trialEndsAt: "2026-07-24T00:00:00.000Z",
+			});
+		});
+
+		it("reconstructs the checkout variant of an instrumented row", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "existing-user-subscribe",
+					email: "e@b.com",
+					userId: USER_ID,
+					variant: "trial_checkout",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+				logger: noopLogger,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toEqual({
+				method: "existing-user-subscribe",
+				email: "e@b.com",
+				userId: USER_ID,
+				variant: "trial_checkout",
+			});
+		});
+
+		it("drops an unrecognised variant instead of throwing — the row is already deleted by then, so a parse failure would destroy a paying customer's signup", async () => {
+			const { client } = createClient(() => ({
+				Attributes: {
+					checkoutSessionId: SESSION_ID,
+					method: "existing-user-subscribe",
+					email: "e@b.com",
+					userId: USER_ID,
+					variant: "a_variant_from_the_future",
+				},
+			}));
+			const { consumePendingSignup } = initDynamoDbPendingSignup({
+				client,
+				tableName: TABLE,
+				logger: noopLogger,
+			});
+
+			const result = await consumePendingSignup(SESSION_ID);
+
+			expect(result).toEqual({
+				method: "existing-user-subscribe",
+				email: "e@b.com",
+				userId: USER_ID,
 			});
 		});
 

--- a/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
+++ b/projects/hutch/src/runtime/providers/pending-signup/dynamodb-pending-signup.ts
@@ -6,7 +6,10 @@ import {
 import type { HutchLogger } from "@packages/hutch-logger";
 import { z } from "zod";
 import { UserIdSchema, normalizeEmail } from "@packages/domain/user";
-import { CheckoutSessionIdSchema } from "@packages/provider-contracts/hosted-checkout";
+import {
+	CheckoutSessionIdSchema,
+	CheckoutVariantSchema,
+} from "@packages/provider-contracts/hosted-checkout";
 import type {
 	ConsumePendingSignup,
 	DeletePendingSignupsByUser,
@@ -28,6 +31,9 @@ const PendingSignupRow = z.object({
 	userId: dynamoField(UserIdSchema),
 	returnUrl: dynamoField(z.string()),
 	trialEndsAt: dynamoField(z.string()),
+	/** z.string() for the same reason as `method`: an unrecognised variant on a
+	 * leftover row must not throw during the post-delete parse. Narrowed on read. */
+	variant: dynamoField(z.string()),
 	createdAt: dynamoField(z.number()),
 	checkoutRecoveryEmailSentAt: dynamoField(z.number()),
 });
@@ -86,7 +92,8 @@ export function initDynamoDbPendingSignup(deps: {
 				createdAt,
 				userId: signup.userId,
 				...(signup.returnUrl ? { returnUrl: signup.returnUrl } : {}),
-				...(signup.trialEndsAt ? { trialEndsAt: signup.trialEndsAt } : {})
+				...(signup.trialEndsAt ? { trialEndsAt: signup.trialEndsAt } : {}),
+				...(signup.variant ? { variant: signup.variant } : {})
 			},
 		});
 	};
@@ -109,12 +116,14 @@ export function initDynamoDbPendingSignup(deps: {
 		if (!userId) return null;
 		const returnUrl = Attributes.returnUrl ?? undefined;
 		const trialEndsAt = Attributes.trialEndsAt ?? undefined;
+		const variant = CheckoutVariantSchema.safeParse(Attributes.variant);
 		const signup: PendingSignup = {
 			method: "existing-user-subscribe",
 			email: Attributes.email,
 			userId,
 			...(returnUrl ? { returnUrl } : {}),
 			...(trialEndsAt ? { trialEndsAt } : {}),
+			...(variant.success ? { variant: variant.data } : {}),
 		};
 		return signup;
 	};

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.test.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.test.ts
@@ -178,6 +178,7 @@ describe("initStripeCheckout", () => {
 			assert.deepEqual(result, {
 				ok: true,
 				paid: true,
+				paymentStatus: "paid",
 				customerEmail: "paid@example.com",
 				status: "complete",
 				created: 1735000000,
@@ -241,6 +242,7 @@ describe("initStripeCheckout", () => {
 			assert.deepEqual(result, {
 				ok: true,
 				paid: true,
+				paymentStatus: "no_payment_required",
 				customerEmail: "fallback@example.com",
 				status: "complete",
 				created: 1735000001,
@@ -269,6 +271,7 @@ describe("initStripeCheckout", () => {
 			assert.deepEqual(result, {
 				ok: true,
 				paid: false,
+				paymentStatus: "unpaid",
 				customerEmail: "open@example.com",
 				status: "open",
 				created: 1735000002,

--- a/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
+++ b/projects/hutch/src/runtime/providers/stripe-checkout/stripe-checkout.ts
@@ -118,6 +118,7 @@ export function initStripeCheckout(deps: {
 		return {
 			ok: true,
 			paid: parsed.payment_status === "paid" || parsed.payment_status === "no_payment_required",
+			paymentStatus: parsed.payment_status,
 			customerEmail,
 			status: parsed.status,
 			created: parsed.created,

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -137,6 +137,10 @@ import {
 import { initAuthRoutes } from "./web/auth/auth.page";
 import type { BotDefenseEvent } from "./web/auth/auth.page";
 import type { ConversionEvent } from "./conversions";
+import {
+	initEmitSubscriptionEvent,
+	type SubscriptionLogEvent,
+} from "./observability/subscription-events";
 import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { initAppleAuthRoutes } from "./web/auth/apple-auth.page";
 import { initResolveLogin } from "@packages/web-session";
@@ -328,6 +332,7 @@ interface AppDependencies {
 	stripePublishableKey: string | undefined;
 	botDefenseLogger: HutchLogger.Typed<BotDefenseEvent>;
 	conversionLogger: HutchLogger.Typed<ConversionEvent>;
+	subscriptionLogger: HutchLogger.Typed<SubscriptionLogEvent>;
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
 	salt: string;
 	foundingAllocation: FoundingAllocation;
@@ -857,6 +862,11 @@ export function createApp(dependencies: AppDependencies): Express {
 
 	const featureToggle = new QuerystringFeatureToggle();
 
+	const emitSubscriptionEvent = initEmitSubscriptionEvent({
+		logger: deps.subscriptionLogger,
+		now: deps.now,
+	});
+
 	const authRouter = initAuthRoutes({
 		hashPassword: deps.hashPassword,
 		createUserWithPasswordHash,
@@ -893,6 +903,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		conversionLogger: deps.conversionLogger,
 		analytics: deps.analytics,
 		salt: deps.salt,
+		emitSubscriptionEvent,
 		foundingAllocation,
 		buildBannerState,
 		consumeRateLimit: deps.consumeRateLimit,
@@ -1149,6 +1160,7 @@ export function createApp(dependencies: AppDependencies): Express {
 		}),
 		now: deps.now,
 		buildBannerState,
+		emitSubscriptionEvent,
 	});
 	app.use("/account", requireAuth, accountRouter);
 

--- a/projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts
+++ b/projects/hutch/src/runtime/subscription-charge-failed/subscription-charge-failed-handler.test.ts
@@ -5,12 +5,15 @@ import { HutchLogger, noopLogger } from "@packages/hutch-logger";
 import type { PublishCancelSubscriptionCommand } from "@packages/test-fixtures/providers/events";
 import { buildSqsEvent } from "@packages/test-fixtures/sqs";
 import { initSubscriptionChargeFailedHandler } from "./subscription-charge-failed-handler";
-import { initEmitSubscriptionEvent, type SubscriptionLogEvent } from "../observability/subscription-events";
+import {
+	initEmitSubscriptionEvent,
+	type SubscriptionLogEventView,
+} from "../observability/subscription-events";
 
 const USER_ID = UserIdSchema.parse("3".repeat(32));
 
-function makeEmit(): { emit: ReturnType<typeof initEmitSubscriptionEvent>; captured: SubscriptionLogEvent[] } {
-	const captured: SubscriptionLogEvent[] = [];
+function makeEmit(): { emit: ReturnType<typeof initEmitSubscriptionEvent>; captured: SubscriptionLogEventView[] } {
+	const captured: SubscriptionLogEventView[] = [];
 	const emit = initEmitSubscriptionEvent({
 		logger: {
 			info: (data) => { captured.push(data); },

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -29,7 +29,10 @@ import { initFoundingAllocation } from "./web/shared/founding-progress/founding-
 import { type AnalyticsEvent, createAnalyticsMiddleware } from "@packages/web-analytics";
 import { DEFAULT_INBOX_ALIAS } from "@packages/domain/inbox";
 import type { UserId } from "@packages/domain/user";
-import type { SubscriptionLogEvent } from "./observability/subscription-events";
+import type {
+	SubscriptionLogEvent,
+	SubscriptionLogEventView,
+} from "./observability/subscription-events";
 
 export type {
 	AdminBundle,
@@ -69,7 +72,7 @@ export interface AnalyticsBundle {
 
 export interface SubscriptionEventsBundle {
 	logger: HutchLogger.Typed<SubscriptionLogEvent>;
-	events: SubscriptionLogEvent[];
+	events: SubscriptionLogEventView[];
 }
 
 export interface TestAppResult {
@@ -253,7 +256,7 @@ export function createTestApp(
 		logger: { info: captureAnalytics, error: captureAnalytics, warn: captureAnalytics, debug: captureAnalytics },
 		events: analyticsEvents,
 	};
-	const subscriptionLogEvents: SubscriptionLogEvent[] = [];
+	const subscriptionLogEvents: SubscriptionLogEventView[] = [];
 	const captureSubscription = (data: SubscriptionLogEvent) => { subscriptionLogEvents.push(data); };
 	const subscriptionBundle: SubscriptionEventsBundle = {
 		logger: { info: captureSubscription, error: captureSubscription, warn: captureSubscription, debug: captureSubscription },

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -29,6 +29,7 @@ import { initFoundingAllocation } from "./web/shared/founding-progress/founding-
 import { type AnalyticsEvent, createAnalyticsMiddleware } from "@packages/web-analytics";
 import { DEFAULT_INBOX_ALIAS } from "@packages/domain/inbox";
 import type { UserId } from "@packages/domain/user";
+import type { SubscriptionLogEvent } from "./observability/subscription-events";
 
 export type {
 	AdminBundle,
@@ -66,6 +67,11 @@ export interface AnalyticsBundle {
 	events: AnalyticsEvent[];
 }
 
+export interface SubscriptionEventsBundle {
+	logger: HutchLogger.Typed<SubscriptionLogEvent>;
+	events: SubscriptionLogEvent[];
+}
+
 export interface TestAppResult {
 	app: Express;
 	auth: AuthBundle;
@@ -86,11 +92,13 @@ export interface TestAppResult {
 	botDefense: BotDefenseBundle;
 	conversions: ConversionsBundle;
 	analytics: AnalyticsBundle;
+	subscriptionEvents: SubscriptionEventsBundle;
 }
 
 function flattenFixtureToAppDependencies(
 	fixture: TestAppFixture,
 	analyticsBundle: AnalyticsBundle,
+	subscriptionBundle: SubscriptionEventsBundle,
 ): Parameters<typeof createApp>[0] {
 	return {
 		validateSaveableUrl: fixture.shared.validateSaveableUrl,
@@ -218,6 +226,7 @@ function flattenFixtureToAppDependencies(
 		stripePublishableKey: fixture.stripePublishableKey,
 		botDefenseLogger: fixture.botDefense.logger,
 		conversionLogger: fixture.conversions.logger,
+		subscriptionLogger: subscriptionBundle.logger,
 		analytics: analyticsBundle.logger,
 		salt: "test-analytics-salt",
 		foundingAllocation: initFoundingAllocation({
@@ -244,13 +253,19 @@ export function createTestApp(
 		logger: { info: captureAnalytics, error: captureAnalytics, warn: captureAnalytics, debug: captureAnalytics },
 		events: analyticsEvents,
 	};
+	const subscriptionLogEvents: SubscriptionLogEvent[] = [];
+	const captureSubscription = (data: SubscriptionLogEvent) => { subscriptionLogEvents.push(data); };
+	const subscriptionBundle: SubscriptionEventsBundle = {
+		logger: { info: captureSubscription, error: captureSubscription, warn: captureSubscription, debug: captureSubscription },
+		events: subscriptionLogEvents,
+	};
 	const app = express()
 		.use(createAnalyticsMiddleware({
 			logger: analyticsBundle.logger,
 			salt: "test-analytics-salt",
 			now: fixture.shared.now,
 		}))
-		.use(createApp({ ...flattenFixtureToAppDependencies(fixture, analyticsBundle), ...overrides }));
+		.use(createApp({ ...flattenFixtureToAppDependencies(fixture, analyticsBundle, subscriptionBundle), ...overrides }));
 	return {
 		app,
 		auth: fixture.auth,
@@ -271,6 +286,7 @@ export function createTestApp(
 		botDefense: fixture.botDefense,
 		conversions: fixture.conversions,
 		analytics: analyticsBundle,
+		subscriptionEvents: subscriptionBundle,
 	};
 }
 

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -36,6 +36,7 @@ import type {
 } from "@packages/provider-contracts/trial-scheduler";
 import {
 	CheckoutSessionIdSchema,
+	type CheckoutSessionId,
 	type RetrieveCheckoutSession,
 } from "@packages/provider-contracts/hosted-checkout";
 import type {
@@ -74,6 +75,11 @@ import { emitUserCreated } from "../../conversions";
 import type { AnalyticsEvent } from "@packages/web-analytics";
 import { buildSignupAttemptedEvent } from "@packages/web-analytics";
 import { SIGNUP_OUTCOMES, type SignupOutcome } from "../../observability/events";
+import {
+	CHECKOUT_RETURN_FAILURE_REASONS,
+	type CheckoutReturnFailureReason,
+} from "../../observability/events";
+import type { EmitSubscriptionEvent } from "../../observability/subscription-events";
 import { DISPOSABLE_EMAIL_MESSAGE } from "./disposable-email";
 
 const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
@@ -121,6 +127,10 @@ interface AuthDependencies {
 	conversionLogger: HutchLogger.Typed<ConversionEvent>;
 	analytics: HutchLogger.Typed<AnalyticsEvent>;
 	salt: string;
+	emitSubscriptionEvent: Pick<
+		EmitSubscriptionEvent,
+		"checkoutCompleted" | "checkoutReturnFailed"
+	>;
 	foundingAllocation: FoundingAllocation;
 	buildBannerState: BuildBannerState;
 	consumeRateLimit: ConsumeRateLimit;
@@ -418,42 +428,54 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 	});
 
 	router.get("/auth/checkout/success", async (req: Request, res: Response) => {
-		const parsedQuery = CheckoutSuccessQuerySchema.safeParse(req.query);
-		if (!parsedQuery.success) {
+		const renderFailure = async (params: {
+			statusCode: number;
+			message: string;
+			reason: CheckoutReturnFailureReason;
+			checkoutSessionId?: CheckoutSessionId;
+		}) => {
+			deps.emitSubscriptionEvent.checkoutReturnFailed({
+				reason: params.reason,
+				userId: req.userId,
+				checkoutSessionId: params.checkoutSessionId,
+			});
 			const userCount = await fetchUserCount();
 			sendComponent(
 				req, res,
-				Base(SignupPage(
-					{
-						userCount,
-						foundingAllocation: deps.foundingAllocation,
-						loadedAt: deps.now().getTime(),
-						errors: [{ message: "Missing checkout session — please start again." }],
-					},
-					{ statusCode: 400 },
-				), bannerStateFromRequest(req)),
+				Base(SignupPage({ userCount, foundingAllocation: deps.foundingAllocation, loadedAt: deps.now().getTime(), errors: [{ message: params.message }] }, { statusCode: params.statusCode }), bannerStateFromRequest(req)),
 			);
+		};
+
+		const parsedQuery = CheckoutSuccessQuerySchema.safeParse(req.query);
+		if (!parsedQuery.success) {
+			await renderFailure({
+				statusCode: 400,
+				message: "Missing checkout session — please start again.",
+				reason: CHECKOUT_RETURN_FAILURE_REASONS.invalidQuery,
+			});
 			return;
 		}
 
 		const checkoutSessionId = CheckoutSessionIdSchema.parse(parsedQuery.data.session_id);
 		const session = await deps.retrieveCheckoutSession(checkoutSessionId);
 
-		const renderFailure = async (statusCode: number, message: string) => {
-			const userCount = await fetchUserCount();
-			sendComponent(
-				req, res,
-				Base(SignupPage({ userCount, foundingAllocation: deps.foundingAllocation, loadedAt: deps.now().getTime(), errors: [{ message }] }, { statusCode }), bannerStateFromRequest(req)),
-			);
-		};
-
 		if (!session.ok) {
-			await renderFailure(404, "Checkout session not found — please start again.");
+			await renderFailure({
+				statusCode: 404,
+				message: "Checkout session not found — please start again.",
+				reason: CHECKOUT_RETURN_FAILURE_REASONS.sessionNotFound,
+				checkoutSessionId,
+			});
 			return;
 		}
 
 		if (!session.paid || session.status !== "complete") {
-			await renderFailure(402, "Payment was not completed. Please try again.");
+			await renderFailure({
+				statusCode: 402,
+				message: "Payment was not completed. Please try again.",
+				reason: CHECKOUT_RETURN_FAILURE_REASONS.notPaid,
+				checkoutSessionId,
+			});
 			return;
 		}
 
@@ -463,7 +485,12 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 
 		const pending = await deps.consumePendingSignup(checkoutSessionId);
 		if (!pending) {
-			await renderFailure(409, "This checkout link has already been used.");
+			await renderFailure({
+				statusCode: 409,
+				message: "This checkout link has already been used.",
+				reason: CHECKOUT_RETURN_FAILURE_REASONS.replayed,
+				checkoutSessionId,
+			});
 			return;
 		}
 
@@ -491,6 +518,11 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				);
 			}
 		}
+		deps.emitSubscriptionEvent.checkoutCompleted({
+			userId: pending.userId,
+			subscriptionId,
+			checkoutSessionId,
+		});
 		res.redirect(303, parseReturnUrl({ return: pending.returnUrl }));
 	});
 

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -507,9 +507,17 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			subscriptionId,
 			checkoutSessionId,
 			paidNow: session.paymentStatus === "paid",
+			variant: pending.variant,
 		});
-		await deps.trialScheduler.deleteTrialEndSchedule({ userId: pending.userId });
-		await deps.trialScheduler.deleteTrialReminderSchedule({ userId: pending.userId });
+		try {
+			await deps.trialScheduler.deleteTrialEndSchedule({ userId: pending.userId });
+			await deps.trialScheduler.deleteTrialReminderSchedule({ userId: pending.userId });
+		} catch (err) {
+			deps.logError(
+				"[checkout/success] Clearing the trial schedules failed — continuing; the user has already paid and is active",
+				err instanceof Error ? err : new Error(String(err)),
+			);
+		}
 		if (pending.trialEndsAt) {
 			try {
 				await deps.trialScheduler.createChargeReminderSchedule({

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -499,6 +499,15 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 			subscriptionId,
 			customerId,
 		});
+		// paid_now separates a real charge from a $0 trial capture: Stripe reports
+		// no_payment_required for a trial-preserving checkout, which still counts as
+		// a completed checkout but not revenue.
+		deps.emitSubscriptionEvent.checkoutCompleted({
+			userId: pending.userId,
+			subscriptionId,
+			checkoutSessionId,
+			paidNow: session.paymentStatus === "paid",
+		});
 		await deps.trialScheduler.deleteTrialEndSchedule({ userId: pending.userId });
 		await deps.trialScheduler.deleteTrialReminderSchedule({ userId: pending.userId });
 		if (pending.trialEndsAt) {
@@ -518,11 +527,6 @@ export function initAuthRoutes(deps: AuthDependencies): Router {
 				);
 			}
 		}
-		deps.emitSubscriptionEvent.checkoutCompleted({
-			userId: pending.userId,
-			subscriptionId,
-			checkoutSessionId,
-		});
 		res.redirect(303, parseReturnUrl({ return: pending.returnUrl }));
 	});
 

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -114,7 +114,6 @@ describe("GET /auth/checkout/success", () => {
 		const doc = new JSDOM(replay.text).window.document;
 		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("already been used");
 
-		// First visit emitted checkout_completed; the replay emits checkout_return_failed.
 		const events = harness.subscriptionEvents.events;
 		expect(events).toHaveLength(2);
 		expect(events[0].event).toBe("checkout_completed");
@@ -151,7 +150,45 @@ describe("GET /auth/checkout/success", () => {
 		expect(evt.user_id).toBe(lookup.userId);
 		expect(evt.checkout_session_id).toBe(checkoutSessionId);
 		expect(evt.subscription_id).toMatch(/^sub_test_/);
+		expect(evt.paid_now).toBe(true);
 		expect(typeof evt.timestamp).toBe("string");
+	});
+
+	it("records paid_now:false on checkout_completed when Stripe collected nothing now (a $0 trial-preserving checkout returns no_payment_required)", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, hostedCheckout, pendingSignup } = harness;
+
+		const created = await auth.createUser({
+			email: "trial-capture@example.com",
+			password: "password123",
+		});
+		assert(created.ok, "user must be created before driving Stripe success");
+		const checkout = await hostedCheckout.createCheckoutSession({
+			customerEmail: "trial-capture@example.com",
+			successUrl: "http://localhost:3000/auth/checkout/success?session_id={CHECKOUT_SESSION_ID}",
+			cancelUrl: "http://localhost:3000/signup",
+		});
+		await pendingSignup.storePendingSignup({
+			checkoutSessionId: checkout.id,
+			signup: {
+				method: "existing-user-subscribe",
+				email: "trial-capture@example.com",
+				userId: created.userId,
+				trialEndsAt: new Date(Date.now() + 10 * 86_400_000).toISOString(),
+			},
+			createdAt: 1735000000,
+		});
+		hostedCheckout.markPaid(checkout.id, { paymentStatus: "no_payment_required" });
+
+		const response = await request
+			.agent(harness.server)
+			.get(`/auth/checkout/success?session_id=${encodeURIComponent(checkout.id)}`);
+
+		expect(response.status).toBe(303);
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		const evt = harness.subscriptionEvents.events[0];
+		expect(evt.event).toBe("checkout_completed");
+		expect(evt.paid_now).toBe(false);
 	});
 
 	it("writes an active subscription_providers row with the Stripe ids on first paid visit", async () => {

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -154,6 +154,77 @@ describe("GET /auth/checkout/success", () => {
 		expect(typeof evt.timestamp).toBe("string");
 	});
 
+	it("carries the originating variant on checkout_completed, so a completion attributes to its entry path without a self-join", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth, hostedCheckout, pendingSignup } = harness;
+
+		await completeCheckoutSignup({
+			server: harness.server,
+			auth,
+			hostedCheckout,
+			pendingSignup,
+			email: "variant-carried@example.com",
+			password: "password123",
+			variant: "card_decline_fallback",
+		});
+
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		const evt = harness.subscriptionEvents.events[0];
+		expect(evt.event).toBe("checkout_completed");
+		expect(evt.variant).toBe("card_decline_fallback");
+	});
+
+	it("still completes the checkout when clearing the trial schedules throws — the user has already paid, so a scheduler fault must not 500 them or lose the conversion", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		fixture.trialScheduler.deleteTrialEndSchedule = async () => {
+			throw new Error("EventBridge Scheduler unavailable");
+		};
+		const harness = useApp(fixture);
+		const { auth, hostedCheckout, pendingSignup, subscriptionProviders } = harness;
+
+		const { successResponse } = await completeCheckoutSignup({
+			server: harness.server,
+			auth,
+			hostedCheckout,
+			pendingSignup,
+			email: "schedule-delete-down@example.com",
+			password: "password123",
+		});
+
+		expect(successResponse.status).toBe(303);
+		expect(successResponse.headers.location).toBe("/queue");
+		const lookup = await auth.findUserByEmail("schedule-delete-down@example.com");
+		assert(lookup, "user must exist after paid signup");
+		const row = await subscriptionProviders.findByUserId(lookup.userId);
+		assert(row, "subscription row must exist");
+		expect(row.status).toBe("active");
+
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		expect(harness.subscriptionEvents.events[0].event).toBe("checkout_completed");
+	});
+
+	it("still completes the checkout when the trial-schedule cleanup rejects with a non-Error value", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		fixture.trialScheduler.deleteTrialReminderSchedule = async () => {
+			throw "scheduler exploded";
+		};
+		const harness = useApp(fixture);
+		const { auth, hostedCheckout, pendingSignup } = harness;
+
+		const { successResponse } = await completeCheckoutSignup({
+			server: harness.server,
+			auth,
+			hostedCheckout,
+			pendingSignup,
+			email: "schedule-delete-non-error@example.com",
+			password: "password123",
+		});
+
+		expect(successResponse.status).toBe(303);
+		expect(successResponse.headers.location).toBe("/queue");
+		expect(harness.subscriptionEvents.events[0].event).toBe("checkout_completed");
+	});
+
 	it("records paid_now:false on checkout_completed when Stripe collected nothing now (a $0 trial-preserving checkout returns no_payment_required)", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { auth, hostedCheckout, pendingSignup } = harness;

--- a/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/checkout-success.route.test.ts
@@ -3,6 +3,7 @@ import { JSDOM } from "jsdom";
 import request from "supertest";
 import { useTestServer } from "../../test-app";
 import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
+import { CHECKOUT_RETURN_FAILURE_REASONS } from "../../observability/events";
 import { completeCheckoutSignup } from "./test-helpers/complete-checkout-signup";
 
 const useApp = useTestServer();
@@ -17,6 +18,13 @@ describe("GET /auth/checkout/success", () => {
 		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain(
 			"Missing checkout session",
 		);
+
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		const evt = harness.subscriptionEvents.events[0];
+		expect(evt.event).toBe("checkout_return_failed");
+		expect(evt.reason).toBe(CHECKOUT_RETURN_FAILURE_REASONS.invalidQuery);
+		expect(evt.user_id).toBeUndefined();
+		expect(evt.checkout_session_id).toBeUndefined();
 	});
 
 	it("renders 404 when Stripe says the session does not exist", async () => {
@@ -26,6 +34,12 @@ describe("GET /auth/checkout/success", () => {
 		expect(response.status).toBe(404);
 		const doc = new JSDOM(response.text).window.document;
 		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not found");
+
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		const evt = harness.subscriptionEvents.events[0];
+		expect(evt.event).toBe("checkout_return_failed");
+		expect(evt.reason).toBe(CHECKOUT_RETURN_FAILURE_REASONS.sessionNotFound);
+		expect(evt.checkout_session_id).toBe("cs_test_unknown");
 	});
 
 	it("renders 402 when the checkout has not been paid yet", async () => {
@@ -45,6 +59,12 @@ describe("GET /auth/checkout/success", () => {
 		expect(response.status).toBe(402);
 		const doc = new JSDOM(response.text).window.document;
 		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("not completed");
+
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		const evt = harness.subscriptionEvents.events[0];
+		expect(evt.event).toBe("checkout_return_failed");
+		expect(evt.reason).toBe(CHECKOUT_RETURN_FAILURE_REASONS.notPaid);
+		expect(evt.checkout_session_id).toBe(checkout.id);
 	});
 
 	it("renders 402 for a still-open session even when Stripe reports no payment is required (trial checkout visited before completion)", async () => {
@@ -93,13 +113,21 @@ describe("GET /auth/checkout/success", () => {
 		expect(replay.status).toBe(409);
 		const doc = new JSDOM(replay.text).window.document;
 		expect(doc.querySelector("[data-test-global-error]")?.textContent).toContain("already been used");
+
+		// First visit emitted checkout_completed; the replay emits checkout_return_failed.
+		const events = harness.subscriptionEvents.events;
+		expect(events).toHaveLength(2);
+		expect(events[0].event).toBe("checkout_completed");
+		expect(events[1].event).toBe("checkout_return_failed");
+		expect(events[1].reason).toBe(CHECKOUT_RETURN_FAILURE_REASONS.replayed);
+		expect(events[1].checkout_session_id).toBe(checkoutSessionId);
 	});
 
 	it("marks the pre-existing user active and redirects to /queue on first paid visit", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { auth, hostedCheckout, subscriptionProviders, pendingSignup } = harness;
 
-		const { successResponse } = await completeCheckoutSignup({
+		const { successResponse, checkoutSessionId } = await completeCheckoutSignup({
 			server: harness.server,
 			auth,
 			hostedCheckout,
@@ -116,6 +144,14 @@ describe("GET /auth/checkout/success", () => {
 		const subRow = await subscriptionProviders.findByUserId(lookup.userId);
 		assert(subRow, "subscription row must exist after paid checkout");
 		expect(subRow.status).toBe("active");
+
+		expect(harness.subscriptionEvents.events).toHaveLength(1);
+		const evt = harness.subscriptionEvents.events[0];
+		expect(evt.event).toBe("checkout_completed");
+		expect(evt.user_id).toBe(lookup.userId);
+		expect(evt.checkout_session_id).toBe(checkoutSessionId);
+		expect(evt.subscription_id).toMatch(/^sub_test_/);
+		expect(typeof evt.timestamp).toBe("string");
 	});
 
 	it("writes an active subscription_providers row with the Stripe ids on first paid visit", async () => {

--- a/projects/hutch/src/runtime/web/auth/test-helpers/complete-checkout-signup.ts
+++ b/projects/hutch/src/runtime/web/auth/test-helpers/complete-checkout-signup.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import type { Server } from "node:http";
 import type { SuperTest, Test } from "supertest";
 import request from "supertest";
-import type { CheckoutSessionId } from "@packages/provider-contracts/hosted-checkout";
+import type {
+	CheckoutSessionId,
+	CheckoutVariant,
+} from "@packages/provider-contracts/hosted-checkout";
 import type { AuthBundle, PendingSignupBundle } from "../../../test-app";
 
 interface HostedCheckoutLike {
@@ -32,6 +35,7 @@ export async function completeCheckoutSignup(params: {
 	password: string;
 	returnUrl?: string;
 	trialEndsAt?: string;
+	variant?: CheckoutVariant;
 	agent?: SuperTest<Test>;
 }): Promise<{
 	successResponse: import("supertest").Response;
@@ -56,6 +60,7 @@ export async function completeCheckoutSignup(params: {
 			userId: created.userId,
 			...(params.returnUrl ? { returnUrl: params.returnUrl } : {}),
 			...(params.trialEndsAt ? { trialEndsAt: params.trialEndsAt } : {}),
+			...(params.variant ? { variant: params.variant } : {}),
 		},
 		createdAt: 1735000000,
 	});

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -577,14 +577,6 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					userId,
 				}));
 			} catch (err) {
-				/** Only a *charge* failure reaches this catch — the upsert below is
-				 * deliberately outside the try. Stripe rejected the saved card
-				 * (declined, expired, fingerprint mismatch, etc.), so fall through to
-				 * Checkout for a new card and label the funnel event
-				 * `card_decline_fallback`, which now means what it says. A post-charge
-				 * upsert failure is NOT a decline — the card was already charged — so it
-				 * must not start a second checkout on an already-charged customer; it
-				 * propagates to the route-level catch (payment-method error) instead. */
 				deps.logger.warn(
 					"[subscribe/cancelled] saved-card charge failed — falling back to checkout",
 					{ userId, error: err instanceof Error ? err.message : String(err) },

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -108,7 +108,7 @@ interface AccountDependencies {
 	logger: HutchLogger;
 	now: () => Date;
 	buildBannerState: BuildBannerState;
-	emitSubscriptionEvent: Pick<EmitSubscriptionEvent, "checkoutStarted">;
+	emitSubscriptionEvent: Pick<EmitSubscriptionEvent, "checkoutStarted" | "resubscribeCompleted">;
 }
 
 type SubscribeBranchKey = "trialing" | "cancelled" | "noop" | "forbidden";
@@ -508,6 +508,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 				userId,
 				returnUrl: "/queue",
 				trialEndsAt: params.trialEndsAt,
+				variant: params.variant,
 			},
 			createdAt: deps.now().getTime(),
 		});
@@ -593,6 +594,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 				subscriptionId,
 				customerId: row.customerId,
 			});
+			deps.emitSubscriptionEvent.resubscribeCompleted({ userId, subscriptionId });
 			res.redirect(303, buildAccountUrl());
 		},
 		noop: async (_req, res) => {

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -569,25 +569,24 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 				redirectFullPage(req, res, checkout.url);
 				return;
 			}
+			let subscriptionId: string;
 			try {
-				const { subscriptionId } = await deps.createSubscriptionOnExistingCustomer({
+				({ subscriptionId } = await deps.createSubscriptionOnExistingCustomer({
 					customerId: row.customerId,
 					priceId: deps.stripePriceId,
 					userId,
-				});
-				await deps.upsertActiveSubscription({
-					userId,
-					subscriptionId,
-					customerId: row.customerId,
-				});
-				res.redirect(303, buildAccountUrl());
+				}));
 			} catch (err) {
-									/** Stripe rejected the saved card (declined, expired, fingerprint
-					 * mismatch, etc.). Rather than parking the user on a dead-end
-					 * error page, fall through to Stripe Checkout so they can enter
-					 * a new card. */
+				/** Only a *charge* failure reaches this catch — the upsert below is
+				 * deliberately outside the try. Stripe rejected the saved card
+				 * (declined, expired, fingerprint mismatch, etc.), so fall through to
+				 * Checkout for a new card and label the funnel event
+				 * `card_decline_fallback`, which now means what it says. A post-charge
+				 * upsert failure is NOT a decline — the card was already charged — so it
+				 * must not start a second checkout on an already-charged customer; it
+				 * propagates to the route-level catch (payment-method error) instead. */
 				deps.logger.warn(
-					"[subscribe/cancelled] one-click resub failed — falling back to checkout",
+					"[subscribe/cancelled] saved-card charge failed — falling back to checkout",
 					{ userId, error: err instanceof Error ? err.message : String(err) },
 				);
 				const checkout = await startCheckout(req, {
@@ -595,7 +594,14 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					variant: CHECKOUT_VARIANTS.cardDeclineFallback,
 				});
 				redirectFullPage(req, res, checkout.url);
+				return;
 			}
+			await deps.upsertActiveSubscription({
+				userId,
+				subscriptionId,
+				customerId: row.customerId,
+			});
+			res.redirect(303, buildAccountUrl());
 		},
 		noop: async (_req, res) => {
 			res.redirect(303, buildAccountUrl());

--- a/projects/hutch/src/runtime/web/pages/account/account.page.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.page.ts
@@ -46,6 +46,8 @@ import {
 	chargeReminderFiresAt,
 	trialReminderFiresAt,
 } from "../../../domain/stripe/stripe-trial-config";
+import { CHECKOUT_VARIANTS, type CheckoutVariant } from "../../../observability/events";
+import type { EmitSubscriptionEvent } from "../../../observability/subscription-events";
 import { Base } from "../../base.component";
 import type { BuildBannerState } from "../../banner-state";
 import { HxRedirectPage } from "../../hx-redirect-page";
@@ -106,6 +108,7 @@ interface AccountDependencies {
 	logger: HutchLogger;
 	now: () => Date;
 	buildBannerState: BuildBannerState;
+	emitSubscriptionEvent: Pick<EmitSubscriptionEvent, "checkoutStarted">;
 }
 
 type SubscribeBranchKey = "trialing" | "cancelled" | "noop" | "forbidden";
@@ -483,7 +486,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 
 	async function startCheckout(
 		req: Request,
-		opts: { trialEndsAt: string | undefined },
+		params: { trialEndsAt: string | undefined; variant: CheckoutVariant },
 	): Promise<{ id: CheckoutSessionId; url: string }> {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
@@ -494,7 +497,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 			customerEmail: email,
 			successUrl: deps.buildCheckoutSuccessUrl("{CHECKOUT_SESSION_ID}"),
 			cancelUrl: `${deps.appOrigin}${buildAccountUrl()}`,
-			trialEndsAt: opts.trialEndsAt,
+			trialEndsAt: params.trialEndsAt,
 		});
 
 		await deps.storePendingSignup({
@@ -504,9 +507,15 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 				email,
 				userId,
 				returnUrl: "/queue",
-				trialEndsAt: opts.trialEndsAt,
+				trialEndsAt: params.trialEndsAt,
 			},
 			createdAt: deps.now().getTime(),
+		});
+
+		deps.emitSubscriptionEvent.checkoutStarted({
+			userId,
+			variant: params.variant,
+			checkoutSessionId: checkout.id,
 		});
 
 		return checkout;
@@ -540,6 +549,7 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					trialRemainingMs >= STRIPE_CHECKOUT_MIN_TRIAL_END_LEAD_MS
 						? row.trialEndsAt
 						: undefined,
+				variant: CHECKOUT_VARIANTS.trialCheckout,
 			});
 			redirectFullPage(req, res, checkout.url);
 		},
@@ -552,7 +562,10 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					"[subscribe] cancelled row without customerId — falling back to checkout",
 					{ userId },
 				);
-				const checkout = await startCheckout(req, { trialEndsAt: undefined });
+				const checkout = await startCheckout(req, {
+					trialEndsAt: undefined,
+					variant: CHECKOUT_VARIANTS.cancelledResubscribe,
+				});
 				redirectFullPage(req, res, checkout.url);
 				return;
 			}
@@ -577,7 +590,10 @@ export function initAccountRoutes(deps: AccountDependencies): Router {
 					"[subscribe/cancelled] one-click resub failed — falling back to checkout",
 					{ userId, error: err instanceof Error ? err.message : String(err) },
 				);
-				const checkout = await startCheckout(req, { trialEndsAt: undefined });
+				const checkout = await startCheckout(req, {
+					trialEndsAt: undefined,
+					variant: CHECKOUT_VARIANTS.cardDeclineFallback,
+				});
 				redirectFullPage(req, res, checkout.url);
 			}
 		},

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -634,6 +634,41 @@ describe("POST /account/subscribe", () => {
 		expect(started[0].user_id).toBe(userId);
 	});
 
+	it("cancelled user — saved-card charge SUCCEEDS but the active-row upsert throws → 303 /account?error=payment_method, and NOT a card_decline_fallback checkout (the card was already charged, so it is not a decline)", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		// Fail only the post-charge DB write. createSubscriptionOnExistingCustomer
+		// still succeeds, so this is NOT a decline: the funnel must not record
+		// card_decline_fallback, and the user must not be sent to a second checkout
+		// on an already-charged customer.
+		fixture.subscriptionProviders.upsertActive = async () => {
+			throw new Error("dynamo down");
+		};
+		const harness = useApp(fixture);
+		const { subscriptionProviders, subscriptionBilling } = harness;
+		const { agent, userId } = await loginUser(harness, "resub-upsert-fails@example.com");
+		// Seed the cancelled-after-paid row directly — upsertActive is rigged to throw.
+		subscriptionProviders.seedRow({
+			userId,
+			provider: "stripe",
+			status: "cancelled",
+			subscriptionId: "sub_was_paid",
+			customerId: "cus_was_paid",
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		});
+
+		const response = await agent.post("/account/subscribe");
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/account?error=payment_method");
+		// The saved-card charge went through...
+		expect(subscriptionBilling.createdSubscriptions()).toHaveLength(1);
+		// ...so no checkout is started at all — in particular no card_decline_fallback.
+		expect(
+			harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started"),
+		).toHaveLength(0);
+	});
+
 	it("trialing user via HTMX (hx-boost) — 200 with HX-Redirect to Stripe, not 303 Location (HTMX would XHR-follow cross-origin and fail to navigate)", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const { subscriptionProviders } = harness;

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -593,6 +593,14 @@ describe("POST /account/subscribe", () => {
 		expect(row.customerId).toBe("cus_was_paid");
 
 		expect(harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started")).toHaveLength(0);
+
+		const resubscribed = harness.subscriptionEvents.events.filter(
+			(e) => e.event === "resubscribe_completed",
+		);
+		expect(resubscribed).toHaveLength(1);
+		expect(resubscribed[0].user_id).toBe(userId);
+		expect(resubscribed[0].subscription_id).toBe(created[0].subscriptionId);
+		expect(resubscribed[0].paid_now).toBe(true);
 	});
 
 	it("cancelled user with customerId — saved-card Stripe call throws → fall back to Stripe Checkout (not the dead-end error page), row stays cancelled until the new checkout completes", async () => {
@@ -659,6 +667,9 @@ describe("POST /account/subscribe", () => {
 		expect(subscriptionBilling.createdSubscriptions()).toHaveLength(1);
 		expect(
 			harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started"),
+		).toHaveLength(0);
+		expect(
+			harness.subscriptionEvents.events.filter((e) => e.event === "resubscribe_completed"),
 		).toHaveLength(0);
 	});
 

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -8,6 +8,7 @@ import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
 } from "@packages/test-fixtures";
+import { CHECKOUT_VARIANTS } from "../../../observability/events";
 
 function card(id: string, isPrimary: boolean, last4: string): SavedCard {
 	return {
@@ -457,6 +458,12 @@ describe("POST /account/subscribe", () => {
 		expect(response.status).toBe(303);
 		const location = response.headers.location;
 		assert(typeof location === "string" && location.includes("checkout.stripe.test"));
+
+		const started = harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started");
+		expect(started).toHaveLength(1);
+		expect(started[0].variant).toBe(CHECKOUT_VARIANTS.trialCheckout);
+		expect(started[0].user_id).toBe(userId);
+		expect(started[0].checkout_session_id).toMatch(/^cs_test_/);
 	});
 
 	it("creates a Stripe checkout session for a trial-expired user (no second free trial)", async () => {
@@ -584,6 +591,9 @@ describe("POST /account/subscribe", () => {
 		expect(row.status).toBe("active");
 		expect(row.subscriptionId).toBe(created[0].subscriptionId);
 		expect(row.customerId).toBe("cus_was_paid");
+
+		// One-click resub bypasses Stripe Checkout, so no checkout_started fires.
+		expect(harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started")).toHaveLength(0);
 	});
 
 	it("cancelled user with customerId — saved-card Stripe call throws → fall back to Stripe Checkout (not the dead-end error page), row stays cancelled until the new checkout completes", async () => {
@@ -617,6 +627,11 @@ describe("POST /account/subscribe", () => {
 		const row = await subscriptionProviders.findByUserId(userId);
 		assert(row, "row must still exist");
 		expect(row.status).toBe("cancelled");
+
+		const started = harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started");
+		expect(started).toHaveLength(1);
+		expect(started[0].variant).toBe(CHECKOUT_VARIANTS.cardDeclineFallback);
+		expect(started[0].user_id).toBe(userId);
 	});
 
 	it("trialing user via HTMX (hx-boost) — 200 with HX-Redirect to Stripe, not 303 Location (HTMX would XHR-follow cross-origin and fail to navigate)", async () => {
@@ -675,6 +690,9 @@ describe("POST /account/subscribe", () => {
 
 		expect(response.status).toBe(303);
 		expect(response.headers.location).toBe("/account?error=payment_method");
+
+		// The throw happens before the pending-signup write and the emit.
+		expect(harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started")).toHaveLength(0);
 	});
 
 	it("cancelled user without customerId — Stripe Checkout fallback throws → 303 to /account?error=payment_method (no 500)", async () => {
@@ -716,6 +734,11 @@ describe("POST /account/subscribe", () => {
 		expect(response.status).toBe(303);
 		const location = response.headers.location;
 		assert(typeof location === "string" && location.includes("checkout.stripe.test"));
+
+		const started = harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started");
+		expect(started).toHaveLength(1);
+		expect(started[0].variant).toBe(CHECKOUT_VARIANTS.cancelledResubscribe);
+		expect(started[0].user_id).toBe(userId);
 	});
 
 	it("redirects active users back to /account instead of creating a Stripe checkout session", async () => {
@@ -732,6 +755,8 @@ describe("POST /account/subscribe", () => {
 
 		expect(response.status).toBe(303);
 		expect(response.headers.location).toBe("/account");
+
+		expect(harness.subscriptionEvents.events).toHaveLength(0);
 	});
 
 	it("returns 400 for a founding member (no row) trying to subscribe", async () => {
@@ -741,6 +766,8 @@ describe("POST /account/subscribe", () => {
 		const response = await agent.post("/account/subscribe");
 
 		expect(response.status).toBe(400);
+
+		expect(harness.subscriptionEvents.events).toHaveLength(0);
 	});
 
 	it("redirects unauthenticated POST /account/subscribe to /login", async () => {

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -592,7 +592,6 @@ describe("POST /account/subscribe", () => {
 		expect(row.subscriptionId).toBe(created[0].subscriptionId);
 		expect(row.customerId).toBe("cus_was_paid");
 
-		// One-click resub bypasses Stripe Checkout, so no checkout_started fires.
 		expect(harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started")).toHaveLength(0);
 	});
 
@@ -636,10 +635,6 @@ describe("POST /account/subscribe", () => {
 
 	it("cancelled user — saved-card charge SUCCEEDS but the active-row upsert throws → 303 /account?error=payment_method, and NOT a card_decline_fallback checkout (the card was already charged, so it is not a decline)", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
-		// Fail only the post-charge DB write. createSubscriptionOnExistingCustomer
-		// still succeeds, so this is NOT a decline: the funnel must not record
-		// card_decline_fallback, and the user must not be sent to a second checkout
-		// on an already-charged customer.
 		fixture.subscriptionProviders.upsertActive = async () => {
 			throw new Error("dynamo down");
 		};
@@ -661,9 +656,7 @@ describe("POST /account/subscribe", () => {
 
 		expect(response.status).toBe(303);
 		expect(response.headers.location).toBe("/account?error=payment_method");
-		// The saved-card charge went through...
 		expect(subscriptionBilling.createdSubscriptions()).toHaveLength(1);
-		// ...so no checkout is started at all — in particular no card_decline_fallback.
 		expect(
 			harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started"),
 		).toHaveLength(0);
@@ -726,7 +719,6 @@ describe("POST /account/subscribe", () => {
 		expect(response.status).toBe(303);
 		expect(response.headers.location).toBe("/account?error=payment_method");
 
-		// The throw happens before the pending-signup write and the emit.
 		expect(harness.subscriptionEvents.events.filter((e) => e.event === "checkout_started")).toHaveLength(0);
 	});
 

--- a/src/packages/provider-contracts/src/hosted-checkout.ts
+++ b/src/packages/provider-contracts/src/hosted-checkout.ts
@@ -20,6 +20,17 @@ export type CheckoutSessionStatus = "open" | "complete" | "expired";
 
 export type CheckoutPaymentStatus = "paid" | "unpaid" | "no_payment_required";
 
+/** Which entry path sent the user to Stripe Checkout. Persisted on the pending
+ * signup because the subscription row it was derived from has moved on by the
+ * time the user returns from Stripe. */
+export const CheckoutVariantSchema = z.enum([
+	"trial_checkout",
+	"cancelled_resubscribe",
+	"card_decline_fallback",
+]);
+
+export type CheckoutVariant = z.infer<typeof CheckoutVariantSchema>;
+
 export type RetrieveCheckoutSession = (id: CheckoutSessionId) => Promise<
 	| {
 			ok: true;

--- a/src/packages/provider-contracts/src/hosted-checkout.ts
+++ b/src/packages/provider-contracts/src/hosted-checkout.ts
@@ -18,10 +18,13 @@ export type CreateCheckoutSession = (params: {
 
 export type CheckoutSessionStatus = "open" | "complete" | "expired";
 
+export type CheckoutPaymentStatus = "paid" | "unpaid" | "no_payment_required";
+
 export type RetrieveCheckoutSession = (id: CheckoutSessionId) => Promise<
 	| {
 			ok: true;
 			paid: boolean;
+			paymentStatus: CheckoutPaymentStatus;
 			customerEmail: string;
 			status: CheckoutSessionStatus;
 			created: number;

--- a/src/packages/provider-contracts/src/pending-signup.ts
+++ b/src/packages/provider-contracts/src/pending-signup.ts
@@ -1,5 +1,5 @@
 import type { UserId } from "@packages/domain/user";
-import type { CheckoutSessionId } from "./hosted-checkout";
+import type { CheckoutSessionId, CheckoutVariant } from "./hosted-checkout";
 
 /** An already-signed-in user clicked Subscribe on /account. There is no
  * account to create — just upsertActive on the existing userId once the
@@ -10,6 +10,8 @@ export type PendingSignup = {
 	userId: UserId;
 	returnUrl?: string;
 	trialEndsAt?: string;
+	/** Optional: rows written before the funnel was instrumented carry no variant. */
+	variant?: CheckoutVariant;
 };
 
 export interface PendingSignupSummary {

--- a/src/packages/test-fixtures/src/providers/hosted-checkout/in-memory-hosted-checkout.ts
+++ b/src/packages/test-fixtures/src/providers/hosted-checkout/in-memory-hosted-checkout.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { CheckoutSessionIdSchema } from "./hosted-checkout.schema";
 import type {
+	CheckoutPaymentStatus,
 	CheckoutSessionId,
 	CheckoutSessionStatus,
 	CreateCheckoutSession,
@@ -10,6 +11,7 @@ import type {
 interface StoredSession {
 	customerEmail: string;
 	paid: boolean;
+	paymentStatus: CheckoutPaymentStatus;
 	status: CheckoutSessionStatus;
 	created: number;
 	subscriptionId: string;
@@ -22,7 +24,7 @@ export function initInMemoryHostedCheckout(opts: {
 }): {
 	createCheckoutSession: CreateCheckoutSession;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
-	markPaid: (id: CheckoutSessionId) => void;
+	markPaid: (id: CheckoutSessionId, opts?: { paymentStatus?: CheckoutPaymentStatus }) => void;
 	markExpired: (id: CheckoutSessionId) => void;
 	getCheckoutUrl: (id: CheckoutSessionId) => string;
 } {
@@ -35,6 +37,7 @@ export function initInMemoryHostedCheckout(opts: {
 		sessions.set(id, {
 			customerEmail,
 			paid: false,
+			paymentStatus: "unpaid",
 			status: "open",
 			created: Math.floor(opts.now().getTime() / 1000),
 			subscriptionId: `sub_test_${sessionSuffix}`,
@@ -51,6 +54,7 @@ export function initInMemoryHostedCheckout(opts: {
 		return {
 			ok: true,
 			paid: session.paid,
+			paymentStatus: session.paymentStatus,
 			customerEmail: session.customerEmail,
 			status: session.status,
 			created: session.created,
@@ -59,10 +63,11 @@ export function initInMemoryHostedCheckout(opts: {
 		};
 	};
 
-	const markPaid = (id: CheckoutSessionId) => {
+	const markPaid = (id: CheckoutSessionId, markOpts?: { paymentStatus?: CheckoutPaymentStatus }) => {
 		const session = sessions.get(id);
 		if (!session) throw new Error(`No checkout session: ${id}`);
 		session.paid = true;
+		session.paymentStatus = markOpts?.paymentStatus ?? "paid";
 		session.status = "complete";
 	};
 

--- a/src/packages/web-test-harness/src/bundle.types.ts
+++ b/src/packages/web-test-harness/src/bundle.types.ts
@@ -9,6 +9,7 @@ import type { ParseArticle } from "@packages/article-parser";
 import type {
 	BotDefenseEvent,
 	BumpArticleSavedAt,
+	CheckoutPaymentStatus,
 	CheckoutSessionId,
 	ConsumePendingSignup,
 	ConsumeRateLimit,
@@ -161,7 +162,7 @@ export interface AuthBundle {
 export interface HostedCheckoutBundle {
 	createCheckoutSession: CreateCheckoutSession;
 	retrieveCheckoutSession: RetrieveCheckoutSession;
-	markPaid: (id: CheckoutSessionId) => void;
+	markPaid: (id: CheckoutSessionId, opts?: { paymentStatus?: CheckoutPaymentStatus }) => void;
 	getCheckoutUrl: (id: CheckoutSessionId) => string;
 }
 


### PR DESCRIPTION
## Checkout funnel instrumentation (R2)

### Hypothesis
The stage between the /account Subscribe click and revenue is dark. If we emit structured events at checkout start, checkout completion, and every checkout-return failure, we can see where the 0% trial→paid conversion is leaking — and measure any future fix instead of guessing.

### Evidence (30d, Jun 4 – Jul 4 2026)
- 35 signups, 28 trials reached end-of-trial: **28× charge_failed (no_card_on_file) → 28× cancelled**. Trial→paid = **0%**.
- Upgrade funnel: 54 header trial-countdown clicks / 40 visitors → 22 /account views / 11 visitors → **4 subscribe clicks / 4 users → 2 /auth/checkout/success returns → 0 recorded conversion events**. Checkout success emitted nothing (`upsertActive` directly), so the two known conversions (3e9c7e5c Jun 21, af194ac4 Jun 23) were invisible to every dashboard.
- The only Stripe webhook in 30 days was dropped ("no subscription row found — skipping event emission"), so there is no backstop signal. Only 3 of 45 subscription rows ever carried a Stripe subscriptionId.

### What this changes
Four new events on the existing `subscriptions` stream, emitted by the hutch web app (not the subscription Lambdas):

| Event | Where | Fields |
|---|---|---|
| `checkout_started` | `POST /account/subscribe`, after the Stripe Checkout session + pending-signup write | `user_id`, `variant` ∈ `trial_checkout` \| `cancelled_resubscribe` \| `card_decline_fallback`, `checkout_session_id` |
| `checkout_completed` | `GET /auth/checkout/success` completed path | `user_id`, `subscription_id`, `checkout_session_id`, **`paid_now`**, `variant` |
| `checkout_return_failed` | each failure branch of `GET /auth/checkout/success` | `reason` ∈ `invalid_query` (400) \| `session_not_found` (404) \| `not_paid` (402) \| `replayed` (409), optional `user_id` / `checkout_session_id` |
| `resubscribe_completed` | `POST /account/subscribe`, saved-card one-click resubscribe (charges immediately, never touches Stripe Checkout, so it has no `checkout_started` to pair with) | `user_id`, `subscription_id`, `paid_now` (always true) |

Plumbing reuses the existing `initEmitSubscriptionEvent` factory and `SUBSCRIPTION_EVENTS` constants; the composition root supplies `HutchLogger.fromJSON<SubscriptionLogEvent>()` like the conversion logger.

**`checkout_completed` is a completed-checkout event, not a revenue event.** A trial-preserving checkout collects a card and charges **$0** now; Stripe reports `payment_status: no_payment_required`, which the app maps to `paid: true`. So the completion fires for **card captures** as well as real charges. To keep the two apart, the event carries **`paid_now`** (`payment_status === "paid"`), surfaced through the `RetrieveCheckoutSession` contract. Read `paid_now = true` for revenue and `paid_now = false` for a $0 trial capture. Nothing in the system currently observes the later trial-end charge (no `invoice.payment_succeeded` webhook is wired, and the internal `charge_succeeded` path is unreachable in production) — a true revenue signal is a separate follow-up.

Three dashboard widgets on the hutch handler log group: **"Checkout funnel per day"** (distinct users + raw events per event, `timeSeries`), **"Checkout funnel detail (variant / reason)"** (`count(*) by event, coalesce(variant, reason)`, `bar`), and **"Conversions per day — real charges vs $0 trial captures"** (`count_distinct(user_id) by bin(1d), event, paid_now` over `checkout_completed` + `resubscribe_completed`, `timeSeries`). Widget count **30 → 33**.

### Behaviour change (not pure instrumentation)
This PR is instrumentation **plus** one payment-flow fix. The cancelled-user one-click resubscribe previously wrapped the Stripe charge and the active-row upsert in one try/catch and fell back to a second Checkout on **any** throw — so a post-charge upsert failure both mislabeled the funnel event `card_decline_fallback` and started a second Checkout on an already-charged customer. The try is now narrowed to the charge alone: only a genuine charge failure falls back to `card_decline_fallback` Checkout; a post-charge upsert failure surfaces `/account?error=payment_method` instead. This is a reachable, user-visible change on the resubscribe path (safer, and covered by a regression test).

### Known gaps (follow-ups, not addressed here)
- **No revenue observability.** `checkout_completed{paid_now:true}` is the only revenue-ish signal; the trial-end auto-charge (`charge_succeeded`) is structurally unreachable in production (a `{trialing, customerId}` row can never be written), and no `invoice.payment_succeeded` webhook exists. Wiring one is the highest-value next ticket.
- **Charged-but-cancelled row is not reconciled.** If the one-click charge succeeds but the upsert throws, Stripe bills a live subscription while the local row stays `cancelled` (and a manual retry can create a second subscription — `createSubscriptionOnExistingCustomer` sends no idempotency key). Pre-existing; not introduced here.

### How to measure
CloudWatch Logs Insights against `/aws/lambda/hutch-handler`:

```
fields @timestamp, event, user_id, variant, reason, paid_now, checkout_session_id
| filter stream = "subscriptions"
| filter event in ["checkout_started", "checkout_completed", "checkout_return_failed", "resubscribe_completed"]
| stats count(*) as n, count_distinct(user_id) as users by event, coalesce(variant, reason, "-") as detail
| sort n desc
```

Paid conversion rate = distinct `user_id` on `checkout_completed{paid_now=true}` / distinct `user_id` on `checkout_started`. Total revenue events = `checkout_completed{paid_now=true}` + `resubscribe_completed`. The three dashboard widgets show the funnel, its variant/reason breakdown, and the real-charge vs $0-capture split.
