### PR TITLE
test(hutch): guard return-URL round-trip through rendered auth forms

### DIFF
--- a/projects/hutch/src/runtime/web/auth/auth.route.test.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.route.test.ts
@@ -237,6 +237,34 @@ describe("Auth routes", () => {
 			expect(action).toContain("/login");
 			expect(action).toContain("return=");
 		});
+
+		it("round-trips a return URL with multiple query params through the rendered login form (trailing params survive the POST)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			await auth.createUser({ email: "login-round-trip@example.com", password: "password123" });
+
+			// The login action already carries `&`-joined UTM params, so the return
+			// URL's own `&` must be encoded to keep its trailing params from merging
+			// into the action's query string and being lost on POST.
+			const returnUrl = "/import/abc123?source=pocket&page=2";
+
+			const rendered = await request(harness.server).get(
+				`/login?return=${encodeURIComponent(returnUrl)}`,
+			);
+			expect(rendered.status).toBe(200);
+			const doc = new JSDOM(rendered.text).window.document;
+			const action = doc.querySelector('[data-test-form="login"]')?.getAttribute("action");
+			assert(action, "login form must render an action");
+			expect(action).toContain(`return=${encodeURIComponent(returnUrl)}`);
+
+			const submitted = await request(harness.server)
+				.post(action)
+				.type("form")
+				.send({ email: "login-round-trip@example.com", password: "password123" });
+
+			expect(submitted.status).toBe(303);
+			expect(submitted.headers.location).toBe(returnUrl);
+		});
 	});
 
 	describe("GET /signup", () => {
@@ -782,6 +810,40 @@ describe("Auth routes", () => {
 			const action = doc.querySelector('[data-test-form="signup"]')?.getAttribute("action");
 			expect(action).toContain("/signup");
 			expect(action).toContain("return=");
+		});
+
+		it("round-trips a return URL with multiple query params through the rendered signup form (trailing params survive the POST)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+			// The `&` between this return URL's own query params is exactly what a
+			// raw interpolation into the form action would swallow, dropping every
+			// param after the first once the browser POSTs the form.
+			const returnUrl = "/import/abc123?source=pocket&page=2";
+
+			const rendered = await request(harness.server).get(
+				`/signup?return=${encodeURIComponent(returnUrl)}`,
+			);
+			expect(rendered.status).toBe(200);
+			const doc = new JSDOM(rendered.text).window.document;
+			const action = doc.querySelector('[data-test-form="signup"]')?.getAttribute("action");
+			assert(action, "signup form must render an action");
+			expect(action).toBe(`/signup?return=${encodeURIComponent(returnUrl)}`);
+
+			// Replay exactly what the browser submits: POST to the action parsed off
+			// the rendered form, then assert the full return URL — trailing params
+			// included — reaches the redirect.
+			const submitted = await request(harness.server)
+				.post(action)
+				.type("form")
+				.send({
+					email: "signup-round-trip@example.com",
+					password: "password123",
+					confirmPassword: "password123",
+					loadedAt: freshLoadedAt(),
+				});
+
+			expect(submitted.status).toBe(303);
+			expect(submitted.headers.location).toBe(returnUrl);
 		});
 
 		it("should show error for short password", async () => {


### PR DESCRIPTION
## What & why

The signup and login form actions carry the return URL in their query string (`action="/signup?return=…"`, `action="/login?…&return=…"`). For that to survive a POST, the value must stay **percent-encoded end to end** — otherwise a return URL whose own query string contains `&` (e.g. `/import/abc123?source=pocket&page=2`) merges into the action's query string and the browser drops every param after the first when it submits.

While investigating, I confirmed the encoding is already in place: `SignupPage`/`LoginPage` in `auth.component.ts` pass `encodeURIComponent(data.returnUrl)` into the template, so the current round-trip is correct. What was **missing was coverage** — the existing return-URL tests only use single-param URLs (`/oauth/authorize?client_id=test`), which cannot detect a trailing-param drop, and none of them assert the value survives an actual POST.

This PR adds that missing regression coverage.

## Changes

Two route tests in `projects/hutch/src/runtime/web/auth/auth.route.test.ts`, one per form:

- Render the form (`GET /signup` / `GET /login`) with a multi-param return URL.
- Parse the `action` off the rendered form (exactly what the browser would submit to) and assert it carries the fully percent-encoded return value.
- Replay that action via `POST` and assert the **full** return URL — trailing params included — reaches the post-auth `303` redirect `Location`.

The login case additionally guards the trickier action that already carries `&`-joined UTM params.

## Verification

- Both tests pass on `main` as-is (encoding present).
- Temporarily removing `encodeURIComponent` from the component reproduces the described failure and makes both tests fail (rendered action becomes `/signup?return=/import/abc123?source=pocket&page=2`; the server parses only `/import/abc123?source=pocket`), confirming the tests are a genuine regression guard rather than passing vacuously.
- Full `pnpm nx run hutch:check` (lint + tests + coverage) passes; coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmAwU3aMYqao58fvjBWAQ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmAwU3aMYqao58fvjBWAQ3)_