### PR TITLE
fix(ios): guard coverage gate against same-basename source collisions

### DIFF
--- a/projects/ios-readplace/scripts/check-coverage.py
+++ b/projects/ios-readplace/scripts/check-coverage.py
@@ -37,9 +37,16 @@ def measured_files(report: dict) -> dict[str, float]:
     """Best line coverage per source basename across all non-test targets.
 
     A Shared file compiles into both the app and the extension target, so it
-    appears twice with identical coverage; keep the higher of the two.
+    appears twice at the SAME path with identical coverage; keep the higher of
+    the two. Two DIFFERENT files that share a basename (e.g. App/Foo.swift and
+    Shared/Foo.swift) cannot coexist under one basename key: the config
+    (floors/excluded) is basename-keyed, so max()-merging them would silently
+    hide the lower-coverage file behind its higher-coverage namesake. Assert the
+    basename maps to a single path so such a collision fails the gate loudly
+    instead of passing on the wrong number.
     """
     best: dict[str, float] = {}
+    path_of: dict[str, str] = {}
     for target in report.get("targets", []):
         if "Tests" in target.get("name", ""):
             continue
@@ -47,6 +54,13 @@ def measured_files(report: dict) -> dict[str, float]:
             name = f.get("name", "")
             if not name.endswith(".swift"):
                 continue
+            path = f.get("path", name)
+            seen = path_of.setdefault(name, path)
+            assert path == seen, (
+                f"basename {name!r} measured at two paths ({seen} and {path}); "
+                "the basename-keyed coverage config cannot represent both — "
+                "rename one file or key this gate by path"
+            )
             cov = float(f.get("lineCoverage", 0.0))
             best[name] = max(best.get(name, 0.0), cov)
     return best


### PR DESCRIPTION
## What

Harden `measured_files` in `projects/ios-readplace/scripts/check-coverage.py` against two different source files that share a basename in different directories being silently merged.

## Why

The iOS coverage gate keys line coverage by **basename** (matching the basename-keyed `coverage-baseline.json`) and merges duplicate entries with `max()`:

```python
best[name] = max(best.get(name, 0.0), cov)
```

That merge is legitimate for exactly one case: a `Shared/` file compiled into both the app and the extension target, which appears twice at the **same path** with identical coverage — keep the higher.

But it also silently merges two genuinely *different* files that happen to share a basename (e.g. `App/Foo.swift` and `Shared/Foo.swift`). Because `max()` keeps the higher number, a file that dropped below its floor could be hidden behind a high-coverage namesake, and the gate would **pass on the wrong number**. The config can't even represent per-file floors for a duplicated basename, so the collision is unrepresentable rather than merely inconvenient.

## How

Track the path each basename was measured at. A repeat basename at the **same** path (Shared file across two targets) merges via `max()` as before; a repeat at a **different** path fails the gate loudly with a message pointing at the fix (rename one file, or key the gate by path):

```
basename 'Foo.swift' measured at two paths (/x/App/Foo.swift and /x/Shared/Foo.swift);
the basename-keyed coverage config cannot represent both — rename one file or key this gate by path
```

No basename collisions exist in the tree today, so the guard is inert for the current sources and only fires if a future file introduces one.

## Verification

- Byte-compiled the script and ran the usage path.
- Smoke-tested `measured_files` against three fixtures: (1) same-path Shared file across two targets → merges to the higher value; (2) same basename at two paths → raises loudly instead of merging; (3) `Tests` targets and non-`.swift` files skipped with no false collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmmBvnwmjyehGYkZHhxFW2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmmBvnwmjyehGYkZHhxFW2)_