### PR TITLE
fix(hutch): gate URL unwrap on trimmed length to match the validator

### DIFF
--- a/projects/hutch/src/runtime/web/unwrap-preprocessors.test.ts
+++ b/projects/hutch/src/runtime/web/unwrap-preprocessors.test.ts
@@ -80,6 +80,17 @@ describe("withUnwrapPreprocessing — validator decorator", () => {
 		expect(seen()).toBe(oversized);
 	});
 
+	it("trims before measuring length, so a whitespace-padded over-length self-URL is still unwrapped", () => {
+		const { validate, seen } = captureValidator();
+		const selfUrl = "https://readplace.com/view/example.com/article";
+		const padded = `${selfUrl}${" ".repeat(MAX_SAVEABLE_URL_LENGTH)}`;
+		expect(padded.length).toBeGreaterThan(MAX_SAVEABLE_URL_LENGTH);
+		const unwrapSelfUrl: UnwrapPreprocessor = (url) =>
+			url === selfUrl ? "https://example.com/article" : url;
+		withUnwrapPreprocessing(validate, unwrapSelfUrl, CONTEXT)(padded);
+		expect(seen()).toBe("https://example.com/article");
+	});
+
 	it("returns the wrapped validator's result", () => {
 		const result: SaveableUrlResult = {
 			status: "ERROR",

--- a/projects/hutch/src/runtime/web/unwrap-preprocessors.ts
+++ b/projects/hutch/src/runtime/web/unwrap-preprocessors.ts
@@ -43,10 +43,11 @@ export function withUnwrapPreprocessing(
 	preprocess: UnwrapPreprocessor,
 	context: UnwrapContext,
 ): ValidateSaveableUrl {
-	return (value) =>
-		validate(
-			typeof value === "string" && value.length <= MAX_SAVEABLE_URL_LENGTH
-				? preprocess(value, context)
-				: value,
+	return (value) => {
+		if (typeof value !== "string") return validate(value);
+		const trimmed = value.trim();
+		return validate(
+			trimmed.length <= MAX_SAVEABLE_URL_LENGTH ? preprocess(trimmed, context) : trimmed,
 		);
+	};
 }


### PR DESCRIPTION
## What

`withUnwrapPreprocessing` (in `projects/hutch/src/runtime/web/unwrap-preprocessors.ts`) is the decorator that unwraps Readplace `/view/…` self-URLs down to the underlying article URL before the save-path validator runs. Its length gate measured the **raw** string length, while `validateSaveableUrl` measures the **trimmed** length.

That mismatch opened a gap: a self-URL padded past `MAX_SAVEABLE_URL_LENGTH` (8192) with whitespace that trims back under the cap would

1. fail the decorator's `value.length <= MAX` gate → **skip unwrapping**, then
2. be passed to the validator, which trims it back under the cap → **pass validation**,

so the self-referential `/view` wrapper was stored verbatim instead of the underlying article — exactly the self-referential record the unwrap step exists to prevent.

## Fix

Measure `value.trim().length` and hand the **trimmed** string to the preprocessor, so the gate agrees with the validator (which trims before it counts). Non-string input still passes straight through to the validator.

## Tests

Added a unit test in `unwrap-preprocessors.test.ts` covering a whitespace-padded, over-length self-URL: the padded string exceeds `MAX_SAVEABLE_URL_LENGTH`, yet the decorator now trims first, so the preprocessor is invoked with the trimmed self-URL and the validator receives the unwrapped article URL.

`pnpm nx run hutch:check` passes with `unwrap-preprocessors.ts` at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017yBX9Zzsbue4SnJdDy6sp1)_