### PR TITLE
docs(blog): post on the reader's dated crawl-version history

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/saved-article-version-history.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/saved-article-version-history.md
@@ -1,0 +1,63 @@
+---
+title: "A Saved Article Can Hold More Than One Version"
+description: "Readplace re-fetches a page you kept, and when the text comes back changed it stores that version too, dated. The reader bookmark now lists those dates newest first, with the copy you're reading marked current, and every version is held in storage that keeps them."
+slug: "saved-article-version-history"
+date: "2026-07-13"
+author: "Fayner Brack"
+keywords: "keep versions of a saved article, web page changed after I saved it, article version history read it later, save a dated copy of a page, read it later that keeps snapshots, track when a saved page changed, saved copy vs live page changes, page revision history reader, wayback machine for your reading list, read it later version log"
+tags: ["changelog"]
+banner: "I made the reader bookmark log each version of your copy"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+Pages you save keep changing on the live web. Readplace stores your copy the moment it fetches the page, and it now stores more than one. Each time it re-fetches a saved page and the article text comes back different, it snapshots that version and stamps it with the minute it changed, then keeps every one. The reader bookmark, the small tab down the right edge that used to show a single "last crawled at" date, now lists those versions newest first. The copy you're reading sits on top with a "current" badge, and the dates under it mark the earlier versions the page moved through. A version is cut only when the words actually change, so a re-fetch that brings back the same text adds nothing to the list. The older dates are shown and their snapshots are held, one per minute, in storage with no cap. Reading a past version back from the tab isn't wired up yet, so the reader still opens on the current copy. For now the list is a record of what the page has done since you saved it.
+
+</div>
+</details>
+
+Fetching a saved page a second time usually brings back the same words. When it comes back changed, Readplace keeps that version too, dated, and holds on to the one it had before.
+
+So a copy you saved is one version of a page that keeps moving. The reader shows that now, as a short stack of dates down the right edge, the copy you're reading sitting on top.
+
+## A version only when the words change
+
+Readplace fetches a saved page more than once. It fetches when you first save it, when a first try comes back thin and it retries, and when you save the same address again to pull a fresher copy. Most of those fetches land on the same article, unchanged since the last look.
+
+The app compares each fetch to the copy it already holds. It hashes the cleaned article text and checks the new hash against the stored one. Same hash, same words, and nothing is recorded. A new version goes in the log only when the text is genuinely different, or when a better source wins and takes over from the one before it.
+
+That gate is what keeps the list worth reading. Without it, every retry and re-save would stamp a fresh date on a page that never moved, and the stack would fill with copies of one version.
+
+> **A new version is recorded only when the words come back different, not every time Readplace looks.**
+
+## A page that reads differently in March
+
+Say you save a framework's getting-started page in January. It lists the install steps you followed, and the copy in your queue holds them.
+
+In March the framework ships a new major version and someone rewrites that page. The commands change. The old steps are gone from the live web, with no note that they were ever there. Anyone who opens the address today gets the March version.
+
+Your January copy still reads the January steps. Open it in Readplace and save the same address again, or let a recrawl reach it, and the fetch comes back with the March text. The hash differs, so Readplace records a second version and stamps it March. The bookmark shows two dates now, January under March, the newer one marked current.
+
+Neither version wrote over the other. The page you followed in January is still the copy you followed, and the record shows the day the live page left it behind.
+
+## Every version, nothing pruned
+
+Each date on the bookmark points at a stored snapshot of the article as it read at that minute. Those snapshots are not pruned. The log they hang off is append-only and has no ceiling, so a page you re-save across a year builds a version for each time its text changed, and every one stays.
+
+The bookmark draws the newest 10. That is a display limit, not a storage one. This is close to what [the Internet Archive does for a public page](/view/web.archive.org), with one difference: it keeps versions of the page for everyone, and Readplace keeps versions of the copy tied to your queue, [the copy built to outlast the original](/blog/saved-articles-outlast-the-original-page).
+
+> **Nothing past the tenth version is thrown away. The bookmark just stops drawing it.**
+
+## What you can't do with them yet
+
+There's something worth being straight about. The older dates on the bookmark are listed, but they don't open yet. TBH... right now they sit there disabled, a record you can read but not click into. The reader still shows the current version, the one on top.
+
+So today the feature is a log, not a way back. It tells you how many times your copy has changed and when, and it holds each version in storage against the day you can open one. That day isn't here. What is here is the record, and the snapshots behind it that make the rest possible later.
+
+## Where the dates show up
+
+Open an article you saved a while back and look to the right edge of the reader. If the page has changed since, and Readplace has fetched it again, more than one date sits there, the current one badged on top. If it hasn't, a single date holds, [the way it has since the bookmark first showed a capture time](/blog/saved-article-shows-when-it-was-captured).
+
+To watch a second version land, save a page that updates often, then save the same address again once it changes, or [follow a save as it retries](/blog/watch-your-article-save-step-by-step) and comes back with different text. The bookmark grows a row. Start a queue that keeps its own versions at [readplace.com](/), or add [the browser extension](https://readplace.com/install) and save the first page you want to hold on to.


### PR DESCRIPTION
## What

Adds one blog post, `saved-article-version-history.md`, covering the crawl-version tabs shipped in #953. It's the first substantive user-facing feature to land on `main` since the last post (`switch-accounts-when-connecting-an-app`, 2026-07-12).

The reader bookmark that used to show a single "last crawled at" date now lists a dated version for every time a saved page's canonical text changed, newest first, with the copy you're reading badged **current**. The post explains:

- **The gate.** A version is recorded only when the cleaned article text hash changes (or a better source wins), so retries and no-op re-fetches don't pollute the list.
- **What's kept.** The version log is append-only and unbounded, each entry backed by a per-minute S3 snapshot that's never pruned; the bookmark draws the newest 10 as a display cap over unbounded storage.
- **The honest limit.** Older versions are listed and preserved but not yet openable from the tab, so the reader still opens on the current copy. The post states this plainly rather than implying a working time machine.

## Why this topic

Picked over the other post-worthy commit (adding Gemini to the AI assistants) because content permanence and versioning is a competitive differentiator for paid conversions, and it reads well for search/GEO (people search "web page changed after I saved it", "keep versions of a saved article"). The Gemini addition is more incremental and two recent posts already cover AI-assistant integration.

## Editorial choices

- **Voice:** Principle Voice (single claim proven by one example).
- **Structural variety:** ran the lookback against the last 8 posts. Opens mechanism-first ("Fetching a saved page a second time…") to avoid the recent flat-declarative and belly-invert openers; TL;DR opens on "Pages…" not the product name; section headers and the closing CTA sentence are distinct from the recent set.
- **No time-bound pricing/promo copy.**

## Changelog banner

Tagged `changelog` with `banner: "I made the reader bookmark log each version of your copy"`. Dated 2026-07-13, so it becomes the newest changelog post and drives the site-wide banner.

## Validation

- No installed toolchain in this fresh clone, so I validated the frontmatter and the slug↔filename invariant directly (required fields present, date format, `changelog`⇒`banner`, `slug == basename`).
- Prose audited: no em dashes, no semicolons (the only `;` is the fixed "TL;DR" boilerplate), no banned words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4CU8SsurkyDRfcjZaBp4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4CU8SsurkyDRfcjZaBp4v)_