### PR TITLE
fix(hutch,ios-readplace): unify Back to queue on iOS chromeless sheets

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -195,6 +195,8 @@ import { PrivacyPage } from "./web/pages/privacy";
 import { SupportPage } from "./web/pages/support";
 import { TermsPage } from "./web/pages/terms";
 import { HelpAddLinksPage } from "./web/pages/help";
+import { isAppShell } from "./web/onboarding/ios-client";
+import { APP_BACK_LINK } from "./web/shared/ios-app-links";
 import { E2EFixturePage } from "./web/pages/e2e-fixture";
 import { createE2EFixturePdf } from "./web/pages/e2e-fixture-pdf";
 import { initInstallRoutes } from "./web/pages/install";
@@ -760,8 +762,17 @@ export function createApp(dependencies: AppDependencies): Express {
 	// holds this path client-side; the /queue collection still advertises it via the
 	// add-links-help rel so older installed clients resolve the help URL from there.
 	// Either way the copy ships via a hutch deploy rather than an App Store review.
+	//
+	// The app sheet appends ?shell=app, which earns the same chromeless "← Back to
+	// queue" deep link the account page renders — so both surfaces the sheet hosts
+	// return to the native list identically. A browser visitor (no marker) keeps the
+	// bare page, and an older store build that never sends the marker keeps the
+	// native toolbar it already ships.
 	app.get("/help/add-links", (req: Request, res: Response) => {
-		sendComponent(req, res, HelpAddLinksPage({ staticBaseUrl }));
+		const backLink = isAppShell(req)
+			? { href: APP_BACK_LINK.topHref, label: APP_BACK_LINK.label }
+			: undefined;
+		sendComponent(req, res, HelpAddLinksPage({ staticBaseUrl, backLink }));
 	});
 
 	// Path-uniqued article fixture for staging e2e tests. The :id segment is

--- a/projects/hutch/src/runtime/web/pages/help/add-links.component.ts
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.component.ts
@@ -128,9 +128,21 @@ function buildPinSteps(staticBaseUrl: string): PinStep[] {
 	}));
 }
 
-export function HelpAddLinksPage(params: { staticBaseUrl: string }): Component {
+export function HelpAddLinksPage(params: {
+	staticBaseUrl: string;
+	/** The app-shell "Back to queue" deep link, rendered only when the page is
+	 * hosted in the iOS web sheet (`?shell=app`). A browser visitor gets no link —
+	 * the `readplace://` scheme would be a dead end there — so the page keeps its
+	 * bare public shape by default. Mirrors the account page, the other chromeless
+	 * surface the same sheet hosts, so both read "← Back to queue". */
+	backLink?: { href: string; label: string };
+}): Component {
 	return HtmlPage(
 		render(HELP_ADD_LINKS_TEMPLATE, {
+			backLink: params.backLink,
+			// The chromeless sheet ignores the safe area, so the app variant hard-codes
+			// the bottom pad that clears the home indicator (see the stylesheet).
+			mainClass: params.backLink ? "help help--app" : "help",
 			pinSteps: buildPinSteps(params.staticBaseUrl),
 			trackSlides: buildTrackSlides(params.staticBaseUrl),
 			dots: buildDots(),

--- a/projects/hutch/src/runtime/web/pages/help/add-links.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.route.test.ts
@@ -137,6 +137,30 @@ describe("GET /help/add-links", () => {
 		]);
 	});
 
+	it("renders a Back to queue deep link when hosted in the app web sheet", async () => {
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(server).get("/help/add-links?shell=app");
+
+		expect(response.status).toBe(200);
+		const doc = new JSDOM(response.text).window.document;
+		const back = doc.querySelector("[data-test-help-back-link]");
+		expect(back?.getAttribute("href")).toBe("readplace://reader/close");
+		expect(back?.textContent).toBe("← Back to queue");
+		// The chromeless variant hard-codes the home-indicator pad the app sheet needs.
+		expect(doc.querySelector("main")?.className).toBe("help help--app");
+	});
+
+	it("omits the deep link for an ordinary browser visitor", async () => {
+		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+
+		const response = await request(server).get("/help/add-links");
+
+		const doc = new JSDOM(response.text).window.document;
+		expect(doc.querySelector("[data-test-help-back-link]")).toBeNull();
+		expect(doc.querySelector("main")?.className).toBe("help");
+	});
+
 	it("falls through to HTML when text/markdown is requested", async () => {
 		const { server } = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 

--- a/projects/hutch/src/runtime/web/pages/help/add-links.template.html
+++ b/projects/hutch/src/runtime/web/pages/help/add-links.template.html
@@ -46,6 +46,29 @@
         padding: 2.5rem 1.5rem;
       }
 
+      /* The app sheet is presented ignoring the safe area and this WKWebView's
+       * viewport sets no viewport-fit=cover, so env(safe-area-inset-bottom)
+       * resolves to 0 — the pad clearing the home indicator has to be hard-coded,
+       * the same reason the chromeless reader and account page hard-code theirs. */
+      .help--app {
+        padding-bottom: 4rem;
+      }
+
+      /* The app sheet's only way back to the native list, matching the account
+       * page's back affordance so the two chromeless surfaces read identically. */
+      .help__back {
+        display: inline-block;
+        margin: 0 0 1rem;
+        font-size: 0.9375rem;
+        font-weight: 600;
+        color: var(--help-text);
+        text-decoration: none;
+      }
+
+      .help__back:hover {
+        text-decoration: underline;
+      }
+
       .help__title {
         margin: 0 0 1.5rem;
         font-size: 1.5rem;
@@ -339,7 +362,10 @@
     </style>
   </head>
   <body>
-    <main class="help">
+    <main class="{{mainClass}}">
+      {{#if backLink}}
+      <a class="help__back" href="{{backLink.href}}" data-test-help-back-link>{{backLink.label}}</a>
+      {{/if}}
       <h1 class="help__title" data-test-help-title>Add links with Share</h1>
       <ol class="help__steps">
         <li class="help__step" data-test-help-step>Open a link in any app.</li>

--- a/projects/hutch/src/runtime/web/shared/ios-app-links.ts
+++ b/projects/hutch/src/runtime/web/shared/ios-app-links.ts
@@ -4,7 +4,8 @@
  * here silently strips the control from every installed build. */
 
 /** Closes the in-app web sheet, returning the user to the native reading list.
- * The chromeless reader's and the chromeless account page's back link point here. */
+ * The chromeless reader's, account page's and add-links help page's back links all
+ * point here — one close contract every in-app sheet shares. */
 const READER_CLOSE_HREF = "readplace://reader/close";
 
 export const APP_BACK_LINK = {

--- a/projects/ios-readplace/App/AddLinkInstructionsView.swift
+++ b/projects/ios-readplace/App/AddLinkInstructionsView.swift
@@ -5,9 +5,14 @@ import SwiftUI
 /// menu by rendering the server's help page in a webview, so the copy ships via
 /// a hutch deploy rather than an App Store release. The help URL is a client-held
 /// path resolved against the API base (`AppConfig.addLinksHelpPath`), not a link
-/// discovered from the server; if it can't be resolved or the page fails to load,
-/// the sheet shows a local fallback that still teaches Share rather than a blank
-/// or dead-end page.
+/// discovered from the server.
+///
+/// Chromeless, like the reader and account sheets: the page renders its own
+/// "← Back to queue" deep link, which the webview intercepts to dismiss, so all
+/// three in-app sheets return to the native list the same way rather than this
+/// one alone wearing a native nav bar. If the URL can't be resolved or the page
+/// fails to load, a local fallback still teaches Share — and carries its own
+/// native back button, since there is no page to render one.
 struct AddLinkInstructionsView: View {
 	let helpURL: URL?
 	let onClose: () -> Void
@@ -16,24 +21,11 @@ struct AddLinkInstructionsView: View {
 	@State private var loadFailed = false
 
 	var body: some View {
-		NavigationStack {
-			content
-				.navigationTitle("Add a link")
-				.navigationBarTitleDisplayMode(.inline)
-				.toolbar {
-					ToolbarItem(placement: .navigationBarLeading) {
-						Button("Back to Queue", action: onClose)
-					}
-				}
-		}
-	}
-
-	@ViewBuilder
-	private var content: some View {
 		if let helpURL, !loadFailed {
 			ZStack {
 				WebPageView(
 					url: helpURL,
+					onClose: onClose,
 					onFinish: { isLoading = false },
 					onFail: {
 						isLoading = false
@@ -51,7 +43,9 @@ struct AddLinkInstructionsView: View {
 
 	/// A self-contained native version of the help page, shown when the webview
 	/// can't be displayed. It still delivers the core instruction so the feature
-	/// degrades gracefully; "Back to Queue" lives in the toolbar above.
+	/// degrades gracefully, and — unlike the happy path, whose back link the page
+	/// renders — carries its own native "Back to queue" button, mirroring the
+	/// reader sheet's native unavailable view.
 	private var fallback: some View {
 		VStack(spacing: 12) {
 			Image(systemName: "square.and.arrow.up")
@@ -63,6 +57,8 @@ struct AddLinkInstructionsView: View {
 				.font(.subheadline)
 				.foregroundStyle(.secondary)
 				.multilineTextAlignment(.center)
+			Button("← Back to queue", action: onClose)
+				.padding(.top, 4)
 		}
 		.padding(40)
 		.frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/projects/ios-readplace/App/ReadingListView.swift
+++ b/projects/ios-readplace/App/ReadingListView.swift
@@ -93,10 +93,13 @@ struct ReadingListView: View {
 					.ignoresSafeArea()
 				}
 				.sheet(isPresented: $showingAddInstructions) {
+					// Edge-to-edge like the reader/account sheet: the help page is now
+					// chromeless and renders its own back link, so it owns the full sheet.
 					AddLinkInstructionsView(
 						helpURL: viewModel.addLinksHelpURL,
 						onClose: { showingAddInstructions = false }
 					)
+					.ignoresSafeArea()
 				}
 				.confirmationDialog(
 					pendingDestructive?.affordance.label ?? "Are you sure?",

--- a/projects/ios-readplace/App/ReadingListViewModel.swift
+++ b/projects/ios-readplace/App/ReadingListViewModel.swift
@@ -17,7 +17,9 @@ final class ReadingListViewModel: ObservableObject {
 	/// The "add links via Share" help page the reading list's + control opens in a
 	/// webview. A client-owned path resolved against the API base — the client holds
 	/// it itself rather than reading it from the server's add-links-help link — so the
-	/// + control works before (and regardless of) a queue load.
+	/// + control works before (and regardless of) a queue load. It carries the
+	/// app-shell marker so the server renders the page chromeless with a "← Back to
+	/// queue" deep link, the same way the account page does inside this sheet.
 	let addLinksHelpURL: URL?
 
 	/// The collection-level controls the toolbar renders. The server's own collection
@@ -62,7 +64,12 @@ final class ReadingListViewModel: ObservableObject {
 	init(api: ReadplaceAPI, onSessionExpired: @escaping () -> Void) {
 		self.api = api
 		self.onSessionExpired = onSessionExpired
+		// Append the same app-shell marker `open(link:)` puts on the account href, so
+		// the help page is served chromeless with a deep-link back to the native list.
+		// A URL that can't take the marker resolves to nil — the + control then shows
+		// its native fallback rather than opening a marker-less page.
 		addLinksHelpURL = Href.resolve(AppConfig.addLinksHelpPath, baseURL: api.baseURL)
+			.flatMap { Href.appending(AppConfig.appShellQueryItem, to: $0) }
 	}
 
 	func loadIfNeeded() async {

--- a/projects/ios-readplace/App/WebPageView.swift
+++ b/projects/ios-readplace/App/WebPageView.swift
@@ -5,16 +5,20 @@ import WebKit
 /// injection and no JS bridge, unlike the reader-specific `ReaderWebView`. A
 /// navigation delegate reports first-load completion, and failure — a transport
 /// error or an HTTP error status — through closures so the presenting view can
-/// drive its loading and error overlays. Per the `ReaderWebView`/web-auth
-/// precedent, this WKWebView glue is an OS boundary left untested; the URL it
-/// loads is discovered by the view model, which is.
+/// drive its loading and error overlays, and intercepts the page's own
+/// `readplace://reader/close` back link to dismiss the sheet. Per the
+/// `ReaderWebView`/web-auth precedent, this WKWebView glue is an OS boundary left
+/// untested; the URL it loads is discovered by the view model, which is.
 struct WebPageView: UIViewControllerRepresentable {
 	let url: URL
+	/// Invoked when the hosted page activates its "Back to queue" deep link, so the
+	/// caller dismisses the sheet — the page renders no chrome of its own.
+	let onClose: () -> Void
 	let onFinish: () -> Void
 	let onFail: () -> Void
 
 	func makeCoordinator() -> Coordinator {
-		Coordinator(onFinish: onFinish, onFail: onFail)
+		Coordinator(onClose: onClose, onFinish: onFinish, onFail: onFail)
 	}
 
 	func makeUIViewController(context: Context) -> UIViewController {
@@ -33,12 +37,41 @@ struct WebPageView: UIViewControllerRepresentable {
 	func updateUIViewController(_ controller: UIViewController, context: Context) {}
 
 	final class Coordinator: NSObject, WKNavigationDelegate {
+		private let onClose: () -> Void
 		private let onFinish: () -> Void
 		private let onFail: () -> Void
 
-		init(onFinish: @escaping () -> Void, onFail: @escaping () -> Void) {
+		init(onClose: @escaping () -> Void, onFinish: @escaping () -> Void, onFail: @escaping () -> Void) {
+			self.onClose = onClose
 			self.onFinish = onFinish
 			self.onFail = onFail
+		}
+
+		/// The chromeless help page's only navigation is its "Back to queue" deep
+		/// link; intercept it to dismiss, reusing the reader's `readplace://reader/close`
+		/// contract so the one close link lives in one decision. The page links out
+		/// nowhere else, so `ReaderNavigation`'s external/logout branches never fire
+		/// here — every other navigation (the initial load) is allowed through.
+		func webView(
+			_ webView: WKWebView,
+			decidePolicyFor navigationAction: WKNavigationAction,
+			decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+		) {
+			guard let url = navigationAction.request.url else {
+				decisionHandler(.allow)
+				return
+			}
+			switch ReaderNavigation.decide(
+				url: url,
+				navigationType: navigationAction.navigationType,
+				currentURL: webView.url
+			) {
+			case .close:
+				decisionHandler(.cancel)
+				onClose()
+			default:
+				decisionHandler(.allow)
+			}
 		}
 
 		/// WKWebView delivers a 4xx/5xx through `didFinish`, not `didFail`, so without

--- a/projects/ios-readplace/README.md
+++ b/projects/ios-readplace/README.md
@@ -122,10 +122,14 @@ That produces `build/Readplace-unsigned.ipa` (the app + its share extension).
   ignoring (deduping) any the server also advertises. It opens a sheet whose
   `WKWebView` renders the server's help page at a client-held path
   (`AppConfig.addLinksHelpPath`), so the instructions ship via a hutch deploy
-  rather than an App Store release. A **Back to Queue** button
-  dismisses it. There is no in-app paste box; capturing a page is the Share
-  Extension's job, and the server's `save-article` URL-only action is reached only
-  through that Share flow, never the toolbar.
+  rather than an App Store release. The sheet is chromeless like the reader and
+  account: it carries the `?shell=app` marker, so the page renders its own
+  **← Back to queue** deep link, which the webview intercepts to dismiss — all
+  three in-app sheets return to the list identically, instead of this one wearing
+  a native nav bar. If the page can't load, a native fallback still teaches Share
+  and carries its own back button. There is no in-app paste box; capturing a page
+  is the Share Extension's job, and the server's `save-article` URL-only action is
+  reached only through that Share flow, never the toolbar.
 
 It speaks `application/vnd.siren+json`, sends `Authorization: Bearer <token>` on
 every request, and refreshes the token once on a `401` — the same contract the

--- a/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
+++ b/projects/ios-readplace/Tests/ReadingListViewModelTests.swift
@@ -22,15 +22,17 @@ final class ReadingListViewModelTests: XCTestCase {
 
 	// MARK: - Add-links help (client-side)
 
-	func testAddLinksHelpURLIsTheClientHeldHelpPath() {
+	func testAddLinksHelpURLIsTheClientHeldHelpPathWithTheAppShellMarker() {
 		// The + control opens the help page at a path the client holds, resolved
 		// against the API base — not a link discovered from the server — so it is
-		// available before (and regardless of) any queue load.
+		// available before (and regardless of) any queue load. It carries the
+		// app-shell marker so the server serves it chromeless, with the deep-link
+		// back to the native list this sheet intercepts.
 		let viewModel = makeViewModel(store: TestSupport.loggedInStore())
 
 		XCTAssertEqual(
 			viewModel.addLinksHelpURL?.absoluteString,
-			"\(AppConfig.serverBaseURL)/help/add-links"
+			"\(AppConfig.serverBaseURL)/help/add-links?shell=app"
 		)
 	}
 


### PR DESCRIPTION
## Problem

The "back to queue" affordance was inconsistent across the iOS app's in-app sheets:

| Sheet | Back affordance |
|-------|-----------------|
| Reader | web-rendered `← Back to queue` deep link (chromeless) |
| Account | web-rendered `← Back to queue` deep link (chromeless) |
| **Add link** | **native nav bar + `Back to Queue` toolbar button** |

Two of the three sheets already shared the chromeless web-rendered affordance — the reader is the shared anchor (it needs web-rendered actions), and the account page was aligned to it in the previous commit. The add-links help sheet was the lone outlier, differing in label, casing (`Back to Queue` vs `← Back to queue`), and mechanism (native toolbar vs web link).

## Change

Bring the add-links sheet into the same chromeless pattern so all three in-app sheets return to the native list identically.

**Server (hutch)**
- `/help/add-links` renders the same chromeless `← Back to queue` deep link `/account` renders, gated on the `?shell=app` marker. A browser visitor (no marker) keeps the bare public page — the `readplace://` scheme would be a dead end there — and an older store build that never sends the marker keeps the native toolbar it already ships. The app variant also hard-codes the home-indicator bottom pad, matching the account/reader rationale (the WKWebView viewport sets no `viewport-fit=cover`, so `env(safe-area-inset-bottom)` is 0).

**iOS**
- The app appends `?shell=app` to its client-held help URL (the same marker `open(link:)` puts on the account href).
- `AddLinkInstructionsView` drops its `NavigationStack`/toolbar and hosts the page edge-to-edge like the reader/account sheet.
- `WebPageView` intercepts the `readplace://reader/close` back link — reusing `ReaderNavigation`'s single close contract — to dismiss.
- The native fallback shown when the page can't load keeps its own native back button, mirroring the reader's unavailable view.
- The close deep link now has one shared source of truth documented in `ios-app-links.ts`.

## Testing

- `pnpm check` passes across all 42 projects with 100% coverage thresholds met.
- Added route tests: the help page renders the `← Back to queue` deep link (href `readplace://reader/close`, `main.help--app`) under `?shell=app`, and omits it for an ordinary browser visitor.
- Updated the iOS view-model test to expect the `?shell=app` marker on the help URL.
- iOS Swift build/tests run in CI on macOS (no Swift toolchain in this environment); the changed Swift files are the coverage-excluded OS-boundary/layout files plus a one-line view-model change covered by the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCsqbgF5BeS4jq6k5HJAn7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCsqbgF5BeS4jq6k5HJAn7)_