### PR TITLE
fix(inbox): update newsletter forwarding subtitle copy

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
@@ -1,7 +1,7 @@
     <main class="inbox">
       <div class="inbox__header">
         <h1 class="inbox__title">Your forwarding addresses</h1>
-        <p class="inbox__subtitle">Forward any newsletter to one of these addresses and it lands in Readplace. I'll pull out the links and queue them up for you to read later.</p>
+        <p class="inbox__subtitle">Sign any newsletter with one of these addresses (or use them to email links to your inbox) and it lands in your Readplace queue. It'll pull out the links and queue them up for you to read later.</p>
       </div>
 
       <section class="inbox__create-section" data-test-inbox-section="create">

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
@@ -1,7 +1,7 @@
     <main class="inbox">
       <div class="inbox__header">
         <h1 class="inbox__title">Your forwarding addresses</h1>
-        <p class="inbox__subtitle">Sign any newsletter with one of these addresses (or use them to email links to your inbox) and it lands in your Readplace queue. It'll pull out the links and queue them up for you to read later.</p>
+        <p class="inbox__subtitle">Sign up for any newsletter with one of these addresses (or use them to email links to your inbox) and it lands in your Readplace queue. I'll pull out the links and queue them up for you to read later.</p>
       </div>
 
       <section class="inbox__create-section" data-test-inbox-section="create">


### PR DESCRIPTION
## Summary
- Update the `/inbox` page subtitle copy to clarify the forwarding addresses can be used to sign up newsletters directly (or to forward links), and that saves land in the reader's own Readplace queue.

## Test plan
- [x] `pnpm nx run inbox:check` (lint, type-check, tests, 100% coverage) — passing
- [x] `pnpm check` (full monorepo check, run via pre-commit hook) — passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01JsKYL8HfHUGVUAdYQPXkqG)_