### PR TITLE
fix(inbox): rename "Manage addresses" link to "My Emails"

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.template.html
@@ -5,7 +5,7 @@
 			class="inbox-emails__manage"
 			href="/inbox/addresses?feature=email"
 			data-test-inbox-manage-addresses
-			>Manage addresses</a
+			>My Emails</a
 		>
 	</header>
 


### PR DESCRIPTION
## Summary
- Renamed the inbox emails page header link from "Manage addresses" to "My Emails" in `inbox-emails.template.html`

## Test plan
- [x] `pnpm nx run inbox:check` passes (lint, type-check, tests, 100% coverage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QYD7cKpR4LFC6gWCutTx1y)_