### PR TITLE
docs: reframe README security section around the guarantee, not the mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ The codebase has strong opinions on testing, typing, branded IDs, and comments t
 
 ## Security
 
-### Redirect de-duplication is pinned to the destination
+### Shared articles can't be hijacked through a redirect
 
-Saving a link follows its redirects and keys the article on where it lands, so `site.com/post.html` (saved from the web) and `site.com/post` (saved from the extension) collapse into one article instead of two. Articles are global — every user who saves the same destination attaches to the same shared row.
+Saving a link follows its redirects and keys the article on where it lands, so `site.com/post.html` (saved from the web) and `site.com/post` (saved from the extension) collapse into one shared article instead of two — every user who saves the same destination attaches to the same row.
 
-That sharing is the attack surface. Since the redirect terminal becomes an alias to whichever URL was saved first, an attacker could save `evil.com/x → victim.com/article` before anyone else claims it, let real users who save `victim.com/article` attach to *their* row, then swap `evil.com/x` to serve something malicious — and a later re-crawl of the stored identity would repaint the shared article for everyone, behind a URL they trust.
+That sharing is the attack surface: an attacker could save `evil.com/x → victim.com/article` before anyone else claims it, let real users who save `victim.com/article` attach to *their* row, then swap `evil.com/x` to serve something malicious — and a later re-crawl would repaint the shared article for everyone, behind a URL they trust.
 
-Two pins close this. Every re-crawl fetches the **destination** (`victim.com/article`), never the origin that redirected there, so the attacker's host is never the content source again; and the reader shows the destination, not the origin, so the origin can't be laundered behind trusted content. Same-host redirects skip both — an attacker only controls their own host — so the protection is scoped to the cross-host case that actually needs it.
+The defence is to stop trusting the origin once an article exists: re-crawls and the reader both work off the destination the article landed on, never the URL that redirected there, so the attacker's host can't launder content behind a trusted identity. Same-host redirects are exempt — an attacker only controls their own host — so the protection is scoped to the cross-host case that actually needs it.
 
 ---
 


### PR DESCRIPTION
## Summary

- The README's Security section led with "Redirect de-duplication is pinned to the destination" — implementation-detail phrasing that's too low-level for a README audience.
- Reworded the heading and body to lead with the security guarantee ("Shared articles can't be hijacked through a redirect") and the threat it defends against, with the destination-pinning mechanism now supporting that claim rather than being the headline.
- No behavior change — documentation only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KNowR4Vrrt5MAuY8ddP1ym)_