### PR TITLE
docs(blog-site): post on saving newsletter links to the reading queue

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/save-newsletter-links-to-your-queue.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/save-newsletter-links-to-your-queue.md
@@ -13,24 +13,24 @@ banner: "I made newsletters drop their links straight into your reading queue"
 <summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
 <div class="blog-tldr__body">
 
-A newsletter issue arrives as one email, but only a few of its links are the articles you subscribed for. The rest is packaging: an unsubscribe line, a "view in browser" link, sponsor slots, a jobs board, section menus. Readplace now gives each newsletter its own forwarding address, shaped like tldr-a7b2c9@read.place, that you name after the source and point the newsletter at. When an issue lands, it pulls out the links, sets aside the ones that would unsubscribe or confirm on your behalf, and runs a pass that keeps only the articles. Those save to your reading queue like any other link, crawled and summarized, while the packaging is dropped. Each address is disposable, so a list that gets sold or noisy is one switch to cut off, and your real inbox is never in the loop. You can hold up to 25, one per newsletter.
+A newsletter issue arrives as one email, but only a few of its links are the articles you subscribed for. The rest is packaging: an unsubscribe line, a "view in browser" link, sponsor slots, a jobs board, section menus. Sorting that has always been yours to do by hand — until now. Readplace now gives each newsletter its own forwarding address, shaped like tldr-a7b2c9@read.place, that you name after the source and point the newsletter at. When an issue lands, it pulls out the links, sets aside the ones that would unsubscribe or confirm on your behalf, and runs a pass that keeps only the articles. Those save to your reading queue like any other link, crawled and summarized, while the packaging is dropped. Each address is disposable, so a list that gets sold or noisy is one switch to cut off, and your real inbox is never in the loop. You can hold up to 25, one per newsletter.
 
 </div>
 </details>
 
-tldr-a7b2c9@read.place is where I send one newsletter. Not my inbox and not a folder, just an address that belongs to TLDR and nothing else.
+As of this week, tldr-a7b2c9@read.place is where I send one newsletter. Not my inbox and not a folder, just an address that belongs to TLDR and nothing else.
 
-It exists because a newsletter is mostly not the thing I subscribed for.
+I wrote about [newsletter overload](/blog/newsletter-overload) a few months back and said I was building the fix. The plan then was a Gmail connection: hand Readplace your inbox, let it read your issues, pull the links out. What shipped doesn't reach into your inbox at all. Each newsletter gets an address of its own, and the issues come straight to Readplace instead of through your mail.
 
-Yesterday's issue carried 14 links. 3 of them were articles. The other 11 were an unsubscribe line, a "view in browser" link, 2 sponsor slots, a jobs board, and a strip of anchors that jump around inside the same email.
+The address earns its place because a newsletter is mostly not the thing I subscribed for.
+
+I've been running my own subscriptions through it while I built it. Yesterday's issue carried 14 links. 3 of them were articles. The other 11 were packaging — an unsubscribe line, a "view in browser" link, a couple of sponsor slots, a jobs board, and a run of section anchors that jump around inside the same email.
 
 Sorting that by hand is a small tax you pay every morning. Open the issue, find the 2 or 3 links worth reading, skip past the packaging, and either read them now or leave a tab open as a promise you might not keep.
 
 Run that across 10 subscriptions and the sorting is most of the work.
 
 > **A newsletter arrives as one email, but it reads like a folder someone else filled: a few articles inside a pile of packaging.**
-
-I wrote about the shape of this problem [a few months back](/blog/newsletter-overload), before there was anything built for it. There is now.
 
 ## An address you hand one newsletter
 
@@ -40,7 +40,7 @@ That address is the whole setup. Nothing to install, no account to connect, no i
 
 Each one stands alone. You can hold up to 25, one per newsletter, and a source only ever sees the address you handed it.
 
-## Most of an issue is not the article
+## What survives the sort
 
 When an issue arrives, Readplace pulls the links out and sorts them. A link that would unsubscribe or confirm gets set aside first. Then a pass reads what is left and labels each link an article, an ad, a menu, a subscription page, or noise.
 
@@ -70,6 +70,6 @@ Naming each address after its source earns its keep here too. When mail turns up
 
 ## Point a newsletter at it
 
-Pick the newsletter you open the least and trust the most, the one whose links you keep meaning to get to. Make an address for it, subscribe with that address, and let the next issue sort itself into your queue while the sponsor blocks and the unsubscribe footer stay behind.
+It's live now, so you can set the first one up today. Pick the newsletter you open the least and trust the most, the one whose links you keep meaning to get to. Make an address for it, subscribe with that address, and let the next issue sort itself into your queue while the sponsor blocks and the unsubscribe footer stay behind.
 
 Start at [readplace.com](/) to set up the first address, or bring an issue you already have by forwarding it in. The next newsletter you read can be 3 links waiting in a queue instead of 14 sitting in an email.

--- a/projects/blog-site/src/runtime/web/pages/blog/posts/save-newsletter-links-to-your-queue.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/save-newsletter-links-to-your-queue.md
@@ -1,0 +1,75 @@
+---
+title: "Most of a Newsletter Isn't the Article"
+description: "Give each newsletter its own Readplace address and the article links inside it land in your reading queue, crawled and summarized. The unsubscribe footers, ads, and menus get dropped, so only the few links worth reading survive, and you can switch off any one address without unsubscribing."
+slug: "save-newsletter-links-to-your-queue"
+date: "2026-07-20"
+author: "Fayner Brack"
+keywords: "save newsletter links to read later, read newsletters later, newsletter reading list, email newsletter to read it later, newsletter inbox reader, forward newsletters to read later, dedicated email for newsletters, newsletter read it later app, save links from newsletters, cut a newsletter without unsubscribing"
+tags: ["changelog"]
+banner: "I made newsletters drop their links straight into your reading queue"
+---
+
+<details class="blog-tldr">
+<summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
+<div class="blog-tldr__body">
+
+A newsletter issue arrives as one email, but only a few of its links are the articles you subscribed for. The rest is packaging: an unsubscribe line, a "view in browser" link, sponsor slots, a jobs board, section menus. Readplace now gives each newsletter its own forwarding address, shaped like tldr-a7b2c9@read.place, that you name after the source and point the newsletter at. When an issue lands, it pulls out the links, sets aside the ones that would unsubscribe or confirm on your behalf, and runs a pass that keeps only the articles. Those save to your reading queue like any other link, crawled and summarized, while the packaging is dropped. Each address is disposable, so a list that gets sold or noisy is one switch to cut off, and your real inbox is never in the loop. You can hold up to 25, one per newsletter.
+
+</div>
+</details>
+
+tldr-a7b2c9@read.place is where I send one newsletter. Not my inbox and not a folder, just an address that belongs to TLDR and nothing else.
+
+It exists because a newsletter is mostly not the thing I subscribed for.
+
+Yesterday's issue carried 14 links. 3 of them were articles. The other 11 were an unsubscribe line, a "view in browser" link, 2 sponsor slots, a jobs board, and a strip of anchors that jump around inside the same email.
+
+Sorting that by hand is a small tax you pay every morning. Open the issue, find the 2 or 3 links worth reading, skip past the packaging, and either read them now or leave a tab open as a promise you might not keep.
+
+Run that across 10 subscriptions and the sorting is most of the work.
+
+> **A newsletter arrives as one email, but it reads like a folder someone else filled: a few articles inside a pile of packaging.**
+
+I wrote about the shape of this problem [a few months back](/blog/newsletter-overload), before there was anything built for it. There is now.
+
+## An address you hand one newsletter
+
+In Readplace you make an address for each newsletter you follow. You name it after the source, so TLDR turns into something like tldr-a7b2c9@read.place, and the 6 random characters on the end keep it yours. Then you point the newsletter at it, either by subscribing with the address or forwarding the issues you already get.
+
+That address is the whole setup. Nothing to install, no account to connect, no inbox to grant anyone access to.
+
+Each one stands alone. You can hold up to 25, one per newsletter, and a source only ever sees the address you handed it.
+
+## Most of an issue is not the article
+
+When an issue arrives, Readplace pulls the links out and sorts them. A link that would unsubscribe or confirm gets set aside first. Then a pass reads what is left and labels each link an article, an ad, a menu, a subscription page, or noise.
+
+Only the articles come through.
+
+They don't stop at a preview. Each one saves to your reading queue the same way a link you paste in yourself would, crawled for a clean copy and given an AI summary. By the time you look, the 3 articles from a 14-link issue are in your queue, ready to read, and the other 11 links are gone.
+
+> **You subscribed for the articles, and the articles are what reach your queue.**
+
+They also show as cards under the newsletter itself, so you can see what a source has been sending and save an older one by hand if the pass set it aside.
+
+## The links it will not open
+
+A link in an email is not always a page. Some of them act. Follow an unsubscribe link and you're unsubscribed. Follow a confirm link and you've confirmed something. A tool that fetched every link in your mail to find out what it was would do both for you, without meaning to.
+
+So Readplace doesn't fetch those. An unsubscribe or confirm link is recognised for what it is and marked done, with no request ever sent to it. Only a link that reads like an article gets opened, and opening it saves a copy rather than setting anything off.
+
+That line matters more than it looks. The cost of crossing it isn't a weak summary. It's a subscription cancelled, or a signup confirmed, by a machine reading your mail.
+
+## Disposable on purpose
+
+Each newsletter gets its own address, rather than one shared one, because lists leak. A newsletter changes hands, gets sold, or starts arriving twice a week when it used to come once.
+
+When one does, you switch off the single address you gave it and the other 24 keep working. You never handed over your real inbox, so there is nothing to take back.
+
+Naming each address after its source earns its keep here too. When mail turns up at an address you only ever gave to one newsletter, you know exactly who let it out.
+
+## Point a newsletter at it
+
+Pick the newsletter you open the least and trust the most, the one whose links you keep meaning to get to. Make an address for it, subscribe with that address, and let the next issue sort itself into your queue while the sponsor blocks and the unsubscribe footer stay behind.
+
+Start at [readplace.com](/) to set up the first address, or bring an issue you already have by forwarding it in. The next newsletter you read can be 3 links waiting in a queue instead of 14 sitting in an email.


### PR DESCRIPTION
## What

New blog post: **"Most of a Newsletter Isn't the Article"** (`save-newsletter-links-to-your-queue.md`), announcing the per-newsletter forwarding-address feature that shipped after the last published post.

The post covers, from the reader's side:
- Creating a named, disposable forwarding address per newsletter (`tldr-a7b2c9@read.place`), up to 25.
- Article links inside an issue landing in the reading queue, crawled and summarized, the same as any other save.
- The classification/triage that keeps only articles and drops the unsubscribe footer, "view in browser" line, ads, menus, and sponsor links.
- The safety line that unsubscribe/confirm links are recognised and never fetched, so a crawl can't act on the reader's behalf.
- Cutting off one noisy or sold list by disabling its single address, without touching the real inbox.

## Why this topic

Reviewed the 19 commits on `main` after the last post (`your-first-article-is-already-saved`, 2026-07-19). The dominant user-facing theme is the inbox → queue work (`feat(inbox): save kept newsletter links to the reader's queue`, the submit-link Lambda, and the per-card save button). Heavy newsletter readers are a strong paid-conversion audience, and this is the shipped, concrete follow-up to the earlier aspirational `newsletter-overload` post, which is cross-linked.

## Notes for review

- Tagged `changelog` with banner copy, so this becomes the site-wide banner (dated 2026-07-20 to sit newest). Adjust the date if a different publish slot is preferred.
- Matched the existing corpus format (frontmatter → TL;DR → body → closing CTA). The published posts do not use the generic cover-image block or the "Want to come back later" / "If you liked this" footers, so those are omitted for consistency.
- Ran the Structural Variety lookback against the last 8 posts: opens on a literal address (no recent post does), TL;DR opens on the reader's situation rather than "Readplace…", and the section headers and closing CTA avoid the worn "Why this matters" / "Try it" / extension sign-off shapes.
- No pricing or time-bound promo copy.
- `pnpm nx run blog-site:check` passes (73 tests, 100% coverage, lint, knip); the full monorepo pre-commit `check` passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r9nJBQiBdxiptQAQG7h3G

---
_Generated by [Claude Code](https://claude.ai/code/session_012r9nJBQiBdxiptQAQG7h3G)_