### PR TITLE
feat(hutch): stop paywalling short /view reads and founder-blog referrals

### DIFF
--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
@@ -3,10 +3,12 @@ import { MinutesSchema } from "@packages/domain/article";
 import { UserIdSchema } from "@packages/domain/user";
 import {
 	PERMANENT_ARTICLE_DOMAINS,
+	PERMANENT_REFERRER_DOMAINS,
 	PUBLIC_VIEW_ACCESS_WINDOW_MS,
 	PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD,
 	computePublicViewExpiry,
 	formatSaveUtmContent,
+	isPermanentReferrer,
 	sharedUserIdFrom,
 	sharedUserIdFromQueryParams,
 } from "./view-expiry";
@@ -69,6 +71,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: longRead,
 		});
 		assert(result.expiresAt, "expiresAt must be set for organic visits");
@@ -82,6 +85,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "fagnerbrack.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: longRead,
 		});
 		assert.equal(result.expiresAt, null);
@@ -93,6 +97,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: true,
+			isPermanentReferrer: false,
 			estimatedReadTime: longRead,
 		});
 		assert.equal(result.expiresAt, null);
@@ -104,6 +109,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: longRead,
 		});
 		assert(result.expiresAt, "expiresAt must be set for non-sharer, non-permanent visits");
@@ -118,6 +124,7 @@ describe("computePublicViewExpiry", () => {
 				articleDomain: domain,
 				permanentArticleDomains: multiDomains,
 				isValidSharer: false,
+				isPermanentReferrer: false,
 				estimatedReadTime: longRead,
 			});
 			assert.equal(result.expiresAt, null, `expected permanent for ${domain}`);
@@ -130,6 +137,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "unknown.com",
 			permanentArticleDomains: ["first.com", "second.com", "third.com"],
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: longRead,
 		});
 		assert(result.expiresAt, "expiresAt must be set for non-permanent domain");
@@ -142,6 +150,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: MinutesSchema.parse(2),
 		});
 		assert.equal(result.expiresAt, null);
@@ -153,6 +162,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: MinutesSchema.parse(PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD),
 		});
 		assert.equal(result.expiresAt, null);
@@ -164,10 +174,105 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			isPermanentReferrer: false,
 			estimatedReadTime: MinutesSchema.parse(PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD + 1),
 		});
 		assert(result.expiresAt, "a read past the threshold must carry an expiry");
 		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
+	});
+
+	it("returns null when the referrer is a founder-blog host, even for a long read on a non-permanent domain", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			articleDomain: "example.com",
+			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
+			isValidSharer: false,
+			isPermanentReferrer: true,
+			estimatedReadTime: longRead,
+		});
+		assert.equal(result.expiresAt, null);
+	});
+});
+
+describe("isPermanentReferrer", () => {
+	it("returns true when the referrer host is a founder-blog domain", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "https://fagnerbrack.com/what-is-docker",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			true,
+		);
+	});
+
+	it("matches a subdomain of a founder-blog domain", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "https://www.fagnerbrack.com/",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			true,
+		);
+	});
+
+	it("matches when the browser sends only the origin (referrer policy stripped the path)", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "https://fagnerbrack.com",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			true,
+		);
+	});
+
+	it("is case-insensitive on the host", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "https://Fagnerbrack.COM/post",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			true,
+		);
+	});
+
+	it("returns false for a lookalike suffix that is not a subdomain", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "https://notfagnerbrack.com/post",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			false,
+		);
+	});
+
+	it("does not match bare medium.com — the bypass is the founder's readers, not all of Medium", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "https://medium.com/@fagnerbrack/what-is-docker",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			false,
+		);
+	});
+
+	it("returns false when there is no referrer", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: undefined,
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			false,
+		);
+	});
+
+	it("returns false for an unparseable referrer", () => {
+		assert.equal(
+			isPermanentReferrer({
+				referrer: "not a url",
+				permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+			}),
+			false,
+		);
 	});
 });
 

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { MinutesSchema } from "@packages/domain/article";
 import { UserIdSchema } from "@packages/domain/user";
 import {
 	PERMANENT_ARTICLE_DOMAINS,
 	PUBLIC_VIEW_ACCESS_WINDOW_MS,
+	PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD,
 	computePublicViewExpiry,
 	formatSaveUtmContent,
 	sharedUserIdFrom,
@@ -57,6 +59,9 @@ describe("sharedUserIdFromQueryParams", () => {
 
 describe("computePublicViewExpiry", () => {
 	const savedAt = new Date("2026-05-01T00:00:00.000Z");
+	// A read time comfortably past the threshold, so the expiry window engages
+	// for these cases and only the property under test decides the outcome.
+	const longRead = MinutesSchema.parse(PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD + 5);
 
 	it("returns savedAt + 3 days for organic visits", () => {
 		const result = computePublicViewExpiry({
@@ -64,6 +69,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			estimatedReadTime: longRead,
 		});
 		assert(result.expiresAt, "expiresAt must be set for organic visits");
 		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
@@ -76,6 +82,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "fagnerbrack.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			estimatedReadTime: longRead,
 		});
 		assert.equal(result.expiresAt, null);
 	});
@@ -86,6 +93,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: true,
+			estimatedReadTime: longRead,
 		});
 		assert.equal(result.expiresAt, null);
 	});
@@ -96,6 +104,7 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "example.com",
 			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 			isValidSharer: false,
+			estimatedReadTime: longRead,
 		});
 		assert(result.expiresAt, "expiresAt must be set for non-sharer, non-permanent visits");
 		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
@@ -109,6 +118,7 @@ describe("computePublicViewExpiry", () => {
 				articleDomain: domain,
 				permanentArticleDomains: multiDomains,
 				isValidSharer: false,
+				estimatedReadTime: longRead,
 			});
 			assert.equal(result.expiresAt, null, `expected permanent for ${domain}`);
 		}
@@ -120,8 +130,43 @@ describe("computePublicViewExpiry", () => {
 			articleDomain: "unknown.com",
 			permanentArticleDomains: ["first.com", "second.com", "third.com"],
 			isValidSharer: false,
+			estimatedReadTime: longRead,
 		});
 		assert(result.expiresAt, "expiresAt must be set for non-permanent domain");
+		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
+	});
+
+	it("returns null for a short read even when the domain is not permanent and there is no sharer", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			articleDomain: "example.com",
+			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
+			isValidSharer: false,
+			estimatedReadTime: MinutesSchema.parse(2),
+		});
+		assert.equal(result.expiresAt, null);
+	});
+
+	it("keeps a read exactly at the threshold permanently public", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			articleDomain: "example.com",
+			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
+			isValidSharer: false,
+			estimatedReadTime: MinutesSchema.parse(PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD),
+		});
+		assert.equal(result.expiresAt, null);
+	});
+
+	it("applies the expiry one minute past the threshold", () => {
+		const result = computePublicViewExpiry({
+			savedAt,
+			articleDomain: "example.com",
+			permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
+			isValidSharer: false,
+			estimatedReadTime: MinutesSchema.parse(PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD + 1),
+		});
+		assert(result.expiresAt, "a read past the threshold must carry an expiry");
 		assert.equal(result.expiresAt.toISOString(), "2026-05-04T00:00:00.000Z");
 	});
 });

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
@@ -1,3 +1,4 @@
+import type { Minutes } from "@packages/domain/article";
 import type { UserId } from "@packages/domain/user";
 import type { UserIdPrefix } from "@packages/domain/user";
 import { userIdPrefixFrom, parseUserIdPrefix } from "@packages/domain/user";
@@ -10,6 +11,16 @@ export type ExpiryCountdown = "enabled" | "disabled";
  * disappears") while articles from permanent domains and validated sharers
  * bypass the expiry — see {@link computePublicViewExpiry}. */
 export const PUBLIC_VIEW_ACCESS_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** A short article read in one sitting — the reader lands on it from a link,
+ * skims a few screens, and is done — gains nothing from an expiry countdown but
+ * reads it as a paywall bolted onto content that needed no account (see the
+ * "sign in just to be redirected to a Jeff Atwood post" complaint). Only
+ * articles that take longer than this to read — the ones a reader is likely to
+ * want saved for later rather than finishing now — get the expiry window;
+ * anything at or under it stays permanently public. Compared against the
+ * estimated read time in whole minutes, so "5" keeps a five-minute read open. */
+export const PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD = 5;
 
 /** Articles crawled from any of these domains skip the expiry window.
  * Traffic from the founder's blog is a syndication channel we want to
@@ -31,11 +42,13 @@ export type ComputePublicViewExpiryInput = {
 	articleDomain: string;
 	permanentArticleDomains: readonly string[];
 	isValidSharer: boolean;
+	estimatedReadTime: Minutes;
 };
 
 export function computePublicViewExpiry(
 	input: ComputePublicViewExpiryInput,
 ): { expiresAt: Date | null } {
+	if (input.estimatedReadTime <= PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD) return { expiresAt: null };
 	if (input.permanentArticleDomains.includes(input.articleDomain)) return { expiresAt: null };
 	if (input.isValidSharer) return { expiresAt: null };
 	return {

--- a/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view-expiry.ts
@@ -27,6 +27,35 @@ export const PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD = 5;
  * encourage, not penalise. */
 export const PERMANENT_ARTICLE_DOMAINS: readonly string[] = ["fagnerbrack.com"];
 
+/** Hosts whose outbound links we treat as founder syndication by *referrer*:
+ * a reader who clicked a /view link from here never meets the paywall,
+ * whatever the article's length. The founder's fagnerbrack.com blog (a Medium
+ * publication on a custom domain) links out to /view pages, and those readers
+ * are the audience the syndication is courting — gating them is the exact
+ * friction the channel exists to avoid. Kept separate from
+ * {@link PERMANENT_ARTICLE_DOMAINS} because one is about where the article
+ * lives and this is about where the reader came from. Deliberately not
+ * `medium.com`: that would hand the bypass to all of Medium's traffic, not the
+ * founder's own readers. */
+export const PERMANENT_REFERRER_DOMAINS: readonly string[] = ["fagnerbrack.com"];
+
+/** True when the HTTP Referer names a founder-blog host (exact host or any
+ * subdomain, e.g. www.fagnerbrack.com). A missing or unparseable Referer — the
+ * common case once a referrer policy strips it — is simply not a founder
+ * referral, so the caller falls through to the normal expiry rules. */
+export function isPermanentReferrer(input: {
+	referrer: string | undefined;
+	permanentReferrerDomains: readonly string[];
+}): boolean {
+	if (input.referrer === undefined) return false;
+	const url = URL.parse(input.referrer);
+	if (url === null) return false;
+	const host = url.hostname.toLowerCase();
+	return input.permanentReferrerDomains.some(
+		(domain) => host === domain || host.endsWith(`.${domain}`),
+	);
+}
+
 export type SharedUserId = UserIdPrefix;
 
 export function sharedUserIdFrom(userId: UserId): SharedUserId {
@@ -42,12 +71,14 @@ export type ComputePublicViewExpiryInput = {
 	articleDomain: string;
 	permanentArticleDomains: readonly string[];
 	isValidSharer: boolean;
+	isPermanentReferrer: boolean;
 	estimatedReadTime: Minutes;
 };
 
 export function computePublicViewExpiry(
 	input: ComputePublicViewExpiryInput,
 ): { expiresAt: Date | null } {
+	if (input.isPermanentReferrer) return { expiresAt: null };
 	if (input.estimatedReadTime <= PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD) return { expiresAt: null };
 	if (input.permanentArticleDomains.includes(input.articleDomain)) return { expiresAt: null };
 	if (input.isValidSharer) return { expiresAt: null };

--- a/projects/hutch/src/runtime/web/pages/view/view-paywall.template.html
+++ b/projects/hutch/src/runtime/web/pages/view/view-paywall.template.html
@@ -2,7 +2,7 @@
   <div class="view__paywall-fade" aria-hidden="true"></div>
   <div class="view__paywall-modal">
     <h2 class="view__paywall-heading" id="view-paywall-heading">Public access expired</h2>
-    <p class="view__paywall-body">Save this link to your readplace queue and read every link without expiration.</p>
+    <p class="view__paywall-body">Sign in to save it to your queue and read the whole article in reader view.</p>
     <a class="view__paywall-save" href="{{saveHref}}" data-test-view-paywall-save>Save to My Queue</a>
   </div>
 </div>

--- a/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.component.test.ts
@@ -590,7 +590,7 @@ describe("ViewPage", () => {
 			assert(body, "paywall body must be rendered");
 			assert.equal(
 				body.textContent,
-				"Save this link to your readplace queue and read every link without expiration.",
+				"Sign in to save it to your queue and read the whole article in reader view.",
 			);
 
 			const save = paywall.querySelector("[data-test-view-paywall-save]");

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -53,7 +53,7 @@ import { collectUtmParams } from "../../shared/utm";
 import { SaveErrorPage } from "../save/save-error.component";
 import { NotFoundPage } from "../not-found";
 import type { ExistsUserByIdPrefix } from "@packages/provider-contracts/auth";
-import { PERMANENT_ARTICLE_DOMAINS, computePublicViewExpiry, formatSaveUtmContent, sharedUserIdFrom, sharedUserIdFromQueryParams, type ExpiryCountdown } from "./view-expiry";
+import { PERMANENT_ARTICLE_DOMAINS, PERMANENT_REFERRER_DOMAINS, computePublicViewExpiry, isPermanentReferrer, formatSaveUtmContent, sharedUserIdFrom, sharedUserIdFromQueryParams, type ExpiryCountdown } from "./view-expiry";
 import { parseViewPath, viewPathFor } from "./view-path";
 import { ViewPage, formatViewDocumentTitle, type ViewAction } from "./view.component";
 
@@ -276,6 +276,10 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				articleDomain,
 				permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 				isValidSharer,
+				isPermanentReferrer: isPermanentReferrer({
+					referrer: req.get("referer"),
+					permanentReferrerDomains: PERMANENT_REFERRER_DOMAINS,
+				}),
 				estimatedReadTime,
 			}));
 		}

--- a/projects/hutch/src/runtime/web/pages/view/view.page.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.page.ts
@@ -276,6 +276,7 @@ function handleViewArticle(deps: ViewDependencies, reader: ReturnType<typeof ini
 				articleDomain,
 				permanentArticleDomains: PERMANENT_ARTICLE_DOMAINS,
 				isValidSharer,
+				estimatedReadTime,
 			}));
 		}
 

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -2089,6 +2089,44 @@ describe("View routes", () => {
 			const iframe = doc.querySelector("iframe[data-reader-iframe]");
 			assert(iframe, "a short read must show the full article, unblurred");
 		});
+
+		it("never blurs or counts down when the reader arrived from the founder's blog, even a long expired read", async () => {
+			const now = new Date("2026-05-10T00:00:00.000Z");
+			const { fixture, harness } = makeHarness(now);
+			// A long read on a non-permanent domain whose save window has elapsed —
+			// normally the expired paywall — but the reader clicked through from the
+			// founder's fagnerbrack.com blog, so it stays open (no login wall).
+			await seedReadyArticle(fixture, new Date("2026-05-01T00:00:00.000Z"));
+
+			const response = await request(harness.server)
+				.get(`/view/${CANONICAL_PATH}`)
+				.set("Referer", "https://fagnerbrack.com/what-is-docker");
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("permanent");
+			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(0);
+
+			const iframe = doc.querySelector("iframe[data-reader-iframe]");
+			assert(iframe, "a founder-blog referral must show the full article, unblurred");
+		});
+
+		it("still counts down a long read arriving from an unrelated referrer", async () => {
+			const now = new Date("2026-05-04T00:00:00.000Z");
+			const { fixture, harness } = makeHarness(now);
+			await seedReadyArticle(fixture, new Date("2026-05-03T13:54:27.000Z"));
+
+			const response = await request(harness.server)
+				.get(`/view/${CANONICAL_PATH}`)
+				.set("Referer", "https://news.ycombinator.com/");
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("counting");
+			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(1);
+		});
 	});
 
 	describe("anonymous crawl-trigger rate limiting", () => {

--- a/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/view/view.route.test.ts
@@ -23,6 +23,10 @@ import type { ViewOpenedEvent } from "@packages/web-analytics";
 
 const GOOGLEBOT = "Googlebot/2.1 (+http://www.google.com/bot.html)";
 
+// A word count whose estimated read time clears the paywall's read-minutes
+// threshold, so seeds using it still exercise the expiry window and paywall.
+// Short reads stay permanently public — see PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD.
+const LONG_ARTICLE_WORD_COUNT = 1500;
 const ARTICLE_URL = "https://example.com/post";
 const ENCODED = encodeURIComponent(ARTICLE_URL);
 const CANONICAL_PATH = "example.com/post";
@@ -1754,8 +1758,8 @@ describe("View routes", () => {
 			const { fixture, harness } = makeHarness(now);
 			await fixture.articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
-				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: 0 },
-				estimatedReadTime: calculateReadTime(0),
+				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: LONG_ARTICLE_WORD_COUNT },
+				estimatedReadTime: calculateReadTime(LONG_ARTICLE_WORD_COUNT),
 				savedAt: new Date("2026-05-03T13:54:27.000Z"),
 			});
 
@@ -1803,8 +1807,8 @@ describe("View routes", () => {
 			const { fixture, harness } = makeHarness(now);
 			await fixture.articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
-				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: 0 },
-				estimatedReadTime: calculateReadTime(0),
+				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: LONG_ARTICLE_WORD_COUNT },
+				estimatedReadTime: calculateReadTime(LONG_ARTICLE_WORD_COUNT),
 				savedAt: new Date("2026-05-03T13:54:27.000Z"),
 			});
 
@@ -1823,8 +1827,8 @@ describe("View routes", () => {
 			const { fixture, harness } = makeHarness(now);
 			await fixture.articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
-				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: 0 },
-				estimatedReadTime: calculateReadTime(0),
+				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: LONG_ARTICLE_WORD_COUNT },
+				estimatedReadTime: calculateReadTime(LONG_ARTICLE_WORD_COUNT),
 				savedAt: new Date("2026-05-01T00:00:00.000Z"),
 			});
 
@@ -1842,8 +1846,8 @@ describe("View routes", () => {
 			const { fixture, harness } = makeHarness(now);
 			await fixture.articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
-				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: 0 },
-				estimatedReadTime: calculateReadTime(0),
+				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: LONG_ARTICLE_WORD_COUNT },
+				estimatedReadTime: calculateReadTime(LONG_ARTICLE_WORD_COUNT),
 				savedAt: new Date("2026-05-03T13:00:00.000Z"),
 			});
 
@@ -1878,8 +1882,8 @@ describe("View routes", () => {
 			const { fixture, harness } = makeHarness(now);
 			await fixture.articleStore.saveArticleGlobally({
 				url: ARTICLE_URL,
-				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: 0 },
-				estimatedReadTime: calculateReadTime(0),
+				metadata: { title: "stub", siteName: "example.com", excerpt: "", wordCount: LONG_ARTICLE_WORD_COUNT },
+				estimatedReadTime: calculateReadTime(LONG_ARTICLE_WORD_COUNT),
 				savedAt: new Date("2026-05-01T00:00:00.000Z"),
 			});
 
@@ -1949,9 +1953,9 @@ describe("View routes", () => {
 					title: "Hello World",
 					siteName: "example.com",
 					excerpt: "A lovely article.",
-					wordCount: 500,
+					wordCount: LONG_ARTICLE_WORD_COUNT,
 				},
-				estimatedReadTime: calculateReadTime(500),
+				estimatedReadTime: calculateReadTime(LONG_ARTICLE_WORD_COUNT),
 				savedAt,
 			});
 			await fixture.articleStore.writeContent({
@@ -2057,6 +2061,33 @@ describe("View routes", () => {
 			expect(counter.getAttribute("data-expiry-state")).toBe("permanent");
 
 			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(0);
+		});
+
+		it("never blurs or counts down a short read, even when the save window has elapsed", async () => {
+			const now = new Date("2026-05-10T00:00:00.000Z");
+			const { fixture, harness } = makeHarness(now);
+			// A ready article on a non-permanent domain, saved well over 3 days ago —
+			// long enough that a lengthy read would have expired — but short enough to
+			// finish in one sitting, so no login wall (the Jeff Atwood-post case).
+			await fixture.articleStore.saveArticleGlobally({
+				url: ARTICLE_URL,
+				metadata: { title: "Short one", siteName: "example.com", excerpt: "Quick read.", wordCount: 300 },
+				estimatedReadTime: calculateReadTime(300),
+				savedAt: new Date("2026-05-01T00:00:00.000Z"),
+			});
+			await fixture.articleStore.writeContent({ url: ARTICLE_URL, content: "<p>Body copy.</p>" });
+			await fixture.articleCrawl.markCrawlReady({ url: ARTICLE_URL });
+
+			const response = await request(harness.server).get(`/view/${CANONICAL_PATH}`);
+
+			const doc = new JSDOM(response.text).window.document;
+			const counter = doc.querySelector("[data-test-view-expiry]");
+			assert(counter, "expiry element must be rendered");
+			expect(counter.getAttribute("data-expiry-state")).toBe("permanent");
+			expect(doc.querySelectorAll("[data-test-view-paywall]").length).toBe(0);
+
+			const iframe = doc.querySelector("iframe[data-reader-iframe]");
+			assert(iframe, "a short read must show the full article, unblurred");
 		});
 	});
 


### PR DESCRIPTION
## Why

A reader who follows a blog hyperlink to a public `/view/<url>` page hit an expiry countdown and a scroll-gated blur paywall once the 3-day access window elapsed — even on a short piece, and even when they came straight from the founder's own blog. A reader called it out on fagnerbrack.com:

> What the hell is this "readplace" link that wants you to sign in just to be redirected to a Jeff Atwood post from 2007?

The wall exists to nudge readers to save the **long reads they won't finish now**. On a quick read, and on the founder's own syndication audience, it's pure friction — and when it does appear, it never said what signing in actually buys you.

## What changed

Expiry decisions live in `computePublicViewExpiry` ([`view-expiry.ts`](projects/hutch/src/runtime/web/pages/view/view-expiry.ts)) — a permanent (`null`) expiry means no countdown and no paywall — and only apply to logged-out readers (the only ones the window ever gated).

**1. Read-time threshold.** Any article estimated at **5 minutes or less** stays permanently public. Longer reads keep the existing 3-day window. The threshold is one named constant, `PUBLIC_VIEW_PAYWALL_READ_MINUTES_THRESHOLD`. (Read time is only known after crawl, and the paywall only renders on a `ready` crawl, so a short article settles to "no wall" exactly when its length becomes known.)

**2. Founder-blog referrer bypass.** When the HTTP `Referer` names a founder-blog host — `fagnerbrack.com` or a subdomain — the paywall never appears, **whatever the article's length**. Scoped to `fagnerbrack.com` deliberately (`PERMANENT_REFERRER_DOMAINS`): bare `medium.com` would hand the bypass to all of Medium's traffic rather than the founder's own readers. A missing or unparseable `Referer` (stripped by a referrer policy) falls through to the normal rules.

**3. Clearer paywall copy.** When the wall *does* appear, its body now states the payoff for signing in instead of pitching a queue feature:

> _before:_ "Save this link to your readplace queue and read every link without expiration."
> _after:_ "Sign in to save it to your queue and read the whole article in reader view."

These compose with the existing bypasses (article hosted on a permanent domain, valid authenticated sharer).

## Tests

- Unit tests for `computePublicViewExpiry`: short/at-threshold → permanent, one minute past → the standard expiry, founder referrer → permanent even for a long read; existing domain/sharer cases pass a long read so only the property under test decides.
- Unit tests for `isPermanentReferrer`: host + subdomain + origin-only + case-insensitive match; lookalike suffix, bare `medium.com`, missing, and unparseable all reject.
- Route tests: a short expired read and a founder-blog-referred long expired read both render `permanent` state with no `[data-test-view-paywall]` and the full unblurred article; a long read from an unrelated referrer still counts down and blurs.
- Component test updated to assert the new paywall body copy.
- Existing expiry/paywall route seeds bumped to a `LONG_ARTICLE_WORD_COUNT` so they keep exercising the expiry path.
- `pnpm nx run hutch:check` passes (lint, types, 3303 tests, 100% coverage thresholds met); the full monorepo pre-commit `check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxsWRSsXDLp2dAbegYT29V