### PR TITLE
perf(hutch): return card-scoped fragments for queue card mutations

### DIFF
--- a/.claude/skills/web/SKILL.md
+++ b/.claude/skills/web/SKILL.md
@@ -138,6 +138,15 @@ No custom `*.client.js` is needed when htmx covers the interaction. Reserve `*.c
 
 IMPORTANT: Ask for human intervention whenever a deviation from htmx is needed away from this basic pattern for SPA navigation.
 
+#### Sanctioned deviation: card-scoped mutation fragments
+
+The boosted-`<main>` pattern above re-renders and re-ships the whole listing for every mutation. Where a mutation's visible effect is just "this one row disappears" — the queue's card **Mark as read / unread / Delete** — the maintainer has approved a narrower response. **This deviation is already decided; implement or extend it, don't re-litigate or revert it back to a full-`<main>` swap.** The shape:
+
+- **A URL marker selects the representation, not the behaviour.** The card affordance's action URL carries a `swap=card` query param (see `withCardSwapMarker` in `queue.viewmodel.ts`); the handler opts into the fragment response only when `req.get("HX-Request") === "true"` **and** `req.query.swap === "card"`. A no-JS submit (no `HX-Request`) and every other POST to the shared route (the toast Undo, the reader's mark-read, Siren clients) keep the byte-identical 303 baseline. The marker is a hint about the wanted response, never trusted state.
+- **The server decides sync vs. re-render — never the client.** The common case swaps the card out (`hx-target="closest .queue-article" hx-swap="outerHTML"`, empty primary body) and delivers toast/counts out-of-band. After the write the handler re-reads the page itself and, when a card-removal would desync the DOM (the page emptied, the mutation was a no-op, or — for delete — the page refilled from the next page), answers with the full listing plus `HX-Retarget: main` / `HX-Reswap` / `HX-Reselect` headers so it lands exactly where the 303 → GET swap would. Do **not** trust a client-reported count of visible rows to make this decision.
+
+See `respondToCardMutation` and `renderQueueListing` in `queue.page.ts` for the reference implementation.
+
 ### No Side Effects on GET
 
 Never mutate state on a GET — proxies cache them, prefetchers fire them, crawlers hit them. For URLs that need to trigger a mutation (e.g., a share-able permalink), render a page with an auto-submitting `<form method="POST">`:

--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -421,12 +421,14 @@ const BUNDLES = [
     globalName: "QueueFocus",
     footer: [
       // htmx:beforeSwap fires on the element about to be swapped; the queue's
-      // card mutations remove the card the user acted on, so this re-homes
-      // focus after the swap settles. Both listeners live on body so they
-      // survive the target's own removal.
+      // card mutations (POST) remove the card the user acted on, so this
+      // re-homes focus after the swap settles. The request verb rides along so
+      // the script can ignore a pending card's 3s self-poll (GET), which
+      // re-renders the card in place rather than removing it. Both listeners
+      // live on body so they survive the target's own removal.
       "QueueFocus.initQueueFocus({",
       "  document: window.document,",
-      "  addBeforeSwapListener: function (cb) { window.document.body.addEventListener('htmx:beforeSwap', function (e) { cb(e.target); }); },",
+      "  addBeforeSwapListener: function (cb) { window.document.body.addEventListener('htmx:beforeSwap', function (e) { cb({ target: e.target, verb: e.detail.requestConfig.verb }); }); },",
       "  addAfterSettleListener: function (cb) { window.document.body.addEventListener('htmx:afterSettle', cb); }",
       "});",
     ].join("\n"),

--- a/projects/hutch/scripts/build-client-bundles.js
+++ b/projects/hutch/scripts/build-client-bundles.js
@@ -415,18 +415,40 @@ const BUNDLES = [
   {
     entry: path.join(
       PROJECT_ROOT,
+      "src/runtime/web/pages/queue/queue-focus.client.ts",
+    ),
+    outfile: path.join(OUT_DIR, "queue-focus.client.js"),
+    globalName: "QueueFocus",
+    footer: [
+      // htmx:beforeSwap fires on the element about to be swapped; the queue's
+      // card mutations remove the card the user acted on, so this re-homes
+      // focus after the swap settles. Both listeners live on body so they
+      // survive the target's own removal.
+      "QueueFocus.initQueueFocus({",
+      "  document: window.document,",
+      "  addBeforeSwapListener: function (cb) { window.document.body.addEventListener('htmx:beforeSwap', function (e) { cb(e.target); }); },",
+      "  addAfterSettleListener: function (cb) { window.document.body.addEventListener('htmx:afterSettle', cb); }",
+      "});",
+    ].join("\n"),
+  },
+  {
+    entry: path.join(
+      PROJECT_ROOT,
       "src/runtime/web/shared/toast/toast.client.ts",
     ),
     outfile: path.join(OUT_DIR, "toast.client.js"),
     globalName: "Toast",
     footer: [
       // Loaded with `defer`, so the DOM is parsed before this runs and the
-      // initial scan sees any toast already in the document. The swap
-      // listener catches toasts that arrive inside a swapped <main>.
+      // initial scan sees any toast already in the document. afterSwap catches
+      // a toast that arrives inside a swapped <main>; oobAfterSwap catches one
+      // delivered out-of-band (the card-scoped status mutation), whose primary
+      // target is removed so afterSwap may fire on a detached node and never
+      // reach body.
       "Toast.initToastDismiss({",
       "  document: window.document,",
       "  setTimeoutFn: function (cb, ms) { return window.setTimeout(cb, ms); },",
-      "  addSwapListener: function (cb) { document.body.addEventListener('htmx:afterSwap', cb); }",
+      "  addSwapListener: function (cb) { document.body.addEventListener('htmx:afterSwap', cb); document.body.addEventListener('htmx:oobAfterSwap', cb); }",
       "});",
     ].join("\n"),
   },

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
@@ -302,7 +302,7 @@ describe("renderQueueCard", () => {
 		expect(statusForm.getAttribute("hx-disabled-elt")).toBe("find button");
 	});
 
-	it("leaves the delete control as a bare icon with no loader or request-disable", () => {
+	it("leaves the delete control a bare icon (no loader) but still disables it during its request", () => {
 		const html = renderQueueCard(
 			display(makeViewModel({ actions: [MARK_READ_ACTION, DELETE_ACTION] }), {
 				isFirst: false,
@@ -312,11 +312,14 @@ describe("renderQueueCard", () => {
 		const deleteButton = doc.querySelector("[data-test-action='delete']");
 		assert(deleteButton, "delete button must be present");
 		expect(deleteButton.textContent).toBe("×");
-		// The with-loader shape wraps its text in label + loader spans and its
-		// form carries hx-disabled-elt — both gated on affordance === "with-loader".
-		// Zero element children is the positive proof the delete control ("bare")
-		// opted out; a selector typo can't make it pass for the wrong reason.
+		// The with-loader shape wraps its text in label + loader spans; zero element
+		// children is the positive proof the delete control ("bare") opted out of the
+		// loader markup — a selector typo can't make it pass for the wrong reason.
 		expect(deleteButton.children.length).toBe(0);
+		// hx-disabled-elt now sits on the form of both affordances: under a
+		// card-scoped swap an un-disabled delete could double-submit against a card
+		// the first response is removing.
+		expect(deleteButton.closest("form")?.getAttribute("hx-disabled-elt")).toBe("find button");
 	});
 
 	it("shows a processing state and disables the status action while the card is still being fetched", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.ts
@@ -14,9 +14,8 @@ export interface ActionDisplayModel extends ArticleAction {
 	buttonClass: string;
 	disabled: boolean;
 	/** "with-loader" for the mark-read/unread toggle — it renders the in-flight
-	 * loader affordance and hx-disabled-elt so the button behaves like the
-	 * reader's mark-read control during the htmx <main> swap. "bare" for the
-	 * delete action, a static icon that opts out of the loader treatment. */
+	 * loader affordance (the three animated dots). "bare" for the delete action,
+	 * a static icon that opts out of the loader treatment. */
 	affordance: "with-loader" | "bare";
 }
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.template.html
@@ -7,7 +7,7 @@
     </div>
     <div class="queue-article__actions">
       {{#each actions}}
-      <form method="{{method}}" action="{{url}}" class="queue-article__action-form" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none"{{#if (eq affordance "with-loader")}} hx-disabled-elt="find button"{{/if}}>
+      <form method="{{method}}" action="{{url}}" class="queue-article__action-form" hx-boost="true" hx-target="closest .queue-article" hx-swap="outerHTML" hx-push-url="false" hx-disabled-elt="find button">
         {{#each fields}}<input type="hidden" name="{{name}}" value="{{value}}">{{/each}}
         <button class="{{buttonClass}}" type="submit" title="{{title}}" data-test-action="{{testAction}}"{{#if disabled}} disabled{{/if}}>{{#if (eq affordance "with-loader")}}<span class="queue-article__action-btn-label">{{text}}</span><span class="queue-article__action-btn-loader" aria-hidden="true"><span></span><span></span><span></span></span>{{else}}{{text}}{{/if}}</button>
       </form>

--- a/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.test.ts
@@ -4,16 +4,18 @@ import { initQueueFocus } from "./queue-focus.client";
 
 interface Harness {
 	document: Document;
-	fireBeforeSwap: (target: Element) => void;
+	fireBeforeSwap: (target: Element, verb?: string) => void;
 	fireAfterSettle: () => void;
 }
 
 /** Wires initQueueFocus to a jsdom document, capturing the htmx listeners so a
- * test can drive a beforeSwap → (DOM mutation) → afterSettle cycle by hand. */
+ * test can drive a beforeSwap → (DOM mutation) → afterSettle cycle by hand. The
+ * verb defaults to "post" — the card mutations that remove a card — so only the
+ * self-poll case has to name the "get" verb. */
 function harness(bodyHtml: string): Harness {
 	const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`);
 	const document = dom.window.document;
-	let beforeSwap: ((target: Element) => void) | undefined;
+	let beforeSwap: ((swap: { target: Element; verb: string }) => void) | undefined;
 	let afterSettle: (() => void) | undefined;
 	initQueueFocus({
 		document,
@@ -26,9 +28,10 @@ function harness(bodyHtml: string): Harness {
 	});
 	assert(beforeSwap, "beforeSwap listener must be registered");
 	assert(afterSettle, "afterSettle listener must be registered");
+	const fireBeforeSwap = beforeSwap;
 	return {
 		document,
-		fireBeforeSwap: beforeSwap,
+		fireBeforeSwap: (target, verb = "post") => fireBeforeSwap({ target, verb }),
 		fireAfterSettle: afterSettle,
 	};
 }
@@ -169,6 +172,25 @@ describe("initQueueFocus", () => {
 		h.fireAfterSettle();
 
 		expect(h.document.activeElement).toBe(h.document.querySelector(".queue__save-input"));
+	});
+
+	it("leaves focus alone when a focused pending card re-renders itself in place via the 3s poll (GET)", () => {
+		const h = harness(LIST(CARD("c1") + CARD("c2")));
+		focus(h.document, "#btn-c1");
+		const c1 = h.document.getElementById("c1");
+		assert(c1);
+
+		// The 3s self-poll is a GET that swaps the card with a fresh copy in place
+		// (hx-target="this" hx-swap="outerHTML") — the old node detaches exactly as
+		// a removal would, so only the verb tells them apart.
+		h.fireBeforeSwap(c1, "get");
+		c1.remove();
+		h.document.querySelector(".queue__list")?.insertAdjacentHTML("afterbegin", CARD("c1"));
+		h.fireAfterSettle();
+
+		// Focus must not jump to the neighbour: the card was re-rendered, not
+		// removed, so the script stays out of it and focus falls to <body>.
+		expect(h.document.activeElement).toBe(h.document.body);
 	});
 
 	it("ignores a swap whose target is not a queue card (counts / poll swaps)", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { initQueueFocus } from "./queue-focus.client";
+
+interface Harness {
+	document: Document;
+	fireBeforeSwap: (target: Element) => void;
+	fireAfterSettle: () => void;
+}
+
+/** Wires initQueueFocus to a jsdom document, capturing the htmx listeners so a
+ * test can drive a beforeSwap → (DOM mutation) → afterSettle cycle by hand. */
+function harness(bodyHtml: string): Harness {
+	const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`);
+	const document = dom.window.document;
+	let beforeSwap: ((target: Element) => void) | undefined;
+	let afterSettle: (() => void) | undefined;
+	initQueueFocus({
+		document,
+		addBeforeSwapListener: (listener) => {
+			beforeSwap = listener;
+		},
+		addAfterSettleListener: (listener) => {
+			afterSettle = listener;
+		},
+	});
+	assert(beforeSwap, "beforeSwap listener must be registered");
+	assert(afterSettle, "afterSettle listener must be registered");
+	return {
+		document,
+		fireBeforeSwap: beforeSwap,
+		fireAfterSettle: afterSettle,
+	};
+}
+
+const LIST = (cards: string) => `
+	<input class="queue__save-input" type="url">
+	<div class="queue__list">${cards}</div>
+`;
+
+const CARD = (id: string) =>
+	`<div class="queue-article" id="${id}"><button class="queue-article__action-btn" id="btn-${id}">act</button></div>`;
+
+function focus(document: Document, selector: string): void {
+	const el = document.querySelector<HTMLElement>(selector);
+	assert(el, `fixture must contain ${selector}`);
+	el.focus();
+}
+
+function activeId(document: Document): string | null {
+	return document.activeElement?.id ?? null;
+}
+
+describe("initQueueFocus", () => {
+	it("moves focus to the toast Undo after a focused status card is removed", () => {
+		const h = harness(LIST(CARD("c1") + CARD("c2")));
+		focus(h.document, "#btn-c1");
+		const c1 = h.document.getElementById("c1");
+		assert(c1);
+
+		h.fireBeforeSwap(c1);
+		c1.remove();
+		// The status response OOB-mounts the toast before settle.
+		h.document.querySelector(".queue__list")?.insertAdjacentHTML(
+			"beforebegin",
+			`<div class="toast"><button class="toast__action" id="undo">Undo</button></div>`,
+		);
+		h.fireAfterSettle();
+
+		expect(activeId(h.document)).toBe("undo");
+	});
+
+	it("falls to the adjacent (next) card when a focused delete card is removed and there is no toast", () => {
+		const h = harness(LIST(CARD("c1") + CARD("c2")));
+		focus(h.document, "#btn-c1");
+		const c1 = h.document.getElementById("c1");
+		assert(c1);
+
+		h.fireBeforeSwap(c1);
+		c1.remove();
+		h.fireAfterSettle();
+
+		expect(activeId(h.document)).toBe("btn-c2");
+	});
+
+	it("falls to the previous card when the removed focused card was the last in the list", () => {
+		const h = harness(LIST(CARD("c1") + CARD("c2")));
+		focus(h.document, "#btn-c2");
+		const c2 = h.document.getElementById("c2");
+		assert(c2);
+
+		h.fireBeforeSwap(c2);
+		c2.remove();
+		h.fireAfterSettle();
+
+		expect(activeId(h.document)).toBe("btn-c1");
+	});
+
+	it("falls to the save input when the removed card had no sibling card", () => {
+		const h = harness(LIST(CARD("only")));
+		focus(h.document, "#btn-only");
+		const only = h.document.getElementById("only");
+		assert(only);
+
+		h.fireBeforeSwap(only);
+		only.remove();
+		h.fireAfterSettle();
+
+		expect(h.document.activeElement).toBe(h.document.querySelector(".queue__save-input"));
+	});
+
+	it("falls to the save input when the remembered adjacent card was itself replaced (detached)", () => {
+		const h = harness(LIST(CARD("c1") + CARD("c2")));
+		focus(h.document, "#btn-c1");
+		const c1 = h.document.getElementById("c1");
+		const c2 = h.document.getElementById("c2");
+		assert(c1 && c2);
+
+		h.fireBeforeSwap(c1);
+		// A full-listing fallback replaces the whole list, detaching the remembered
+		// adjacent reference.
+		c1.remove();
+		c2.remove();
+		h.fireAfterSettle();
+
+		expect(h.document.activeElement).toBe(h.document.querySelector(".queue__save-input"));
+	});
+
+	it("falls to the save input when the adjacent card carries no action button", () => {
+		const h = harness(
+			LIST(
+				`<div class="queue-article" id="c1"><button class="queue-article__action-btn" id="btn-c1">act</button></div>` +
+					`<div class="queue-article" id="c2"></div>`,
+			),
+		);
+		focus(h.document, "#btn-c1");
+		const c1 = h.document.getElementById("c1");
+		assert(c1);
+
+		h.fireBeforeSwap(c1);
+		c1.remove();
+		h.fireAfterSettle();
+
+		expect(h.document.activeElement).toBe(h.document.querySelector(".queue__save-input"));
+	});
+
+	it("does nothing when nothing focusable remains (no toast, no adjacent, no save input)", () => {
+		const h = harness(`<div class="queue__list">${CARD("only")}</div>`);
+		focus(h.document, "#btn-only");
+		const only = h.document.getElementById("only");
+		assert(only);
+
+		h.fireBeforeSwap(only);
+		only.remove();
+		h.fireAfterSettle();
+
+		// activeElement falls back to <body> once the focused button is gone.
+		expect(h.document.activeElement).toBe(h.document.body);
+	});
+
+	it("leaves focus alone when it was outside the swapped card (mouse user)", () => {
+		const h = harness(LIST(CARD("c1") + CARD("c2")));
+		focus(h.document, ".queue__save-input");
+		const c1 = h.document.getElementById("c1");
+		assert(c1);
+
+		h.fireBeforeSwap(c1);
+		c1.remove();
+		h.fireAfterSettle();
+
+		expect(h.document.activeElement).toBe(h.document.querySelector(".queue__save-input"));
+	});
+
+	it("ignores a swap whose target is not a queue card (counts / poll swaps)", () => {
+		const h = harness(`${LIST(CARD("c1"))}<span id="queue-counts"></span>`);
+		focus(h.document, "#btn-c1");
+		const counts = h.document.getElementById("queue-counts");
+		assert(counts);
+
+		h.fireBeforeSwap(counts);
+		h.fireAfterSettle();
+
+		// Focus stays put: the settle handler was never armed.
+		expect(activeId(h.document)).toBe("btn-c1");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.ts
@@ -1,0 +1,64 @@
+/**
+ * Keeps the keyboard focus somewhere useful when a card-scoped mutation removes
+ * the card the user just acted on. Without this, activating "Mark as read" or
+ * Delete with the keyboard would drop focus to the document body once the card
+ * (and the button inside it) leaves the DOM. Only fires when focus was inside
+ * the removed card, so a mouse user sees no focus jump. Dependencies are
+ * injected so the browser wiring stays out of this module and it stays
+ * unit-testable.
+ */
+export interface QueueFocusDeps {
+	document: Document;
+	/** Fires with the element htmx is about to swap, for every swap. */
+	addBeforeSwapListener: (listener: (target: Element) => void) => void;
+	/** Fires after htmx settles a swap (main and out-of-band both done). */
+	addAfterSettleListener: (listener: () => void) => void;
+}
+
+function isQueueArticle(element: Element | null): element is Element {
+	return element?.matches(".queue-article") ?? false;
+}
+
+function adjacentCard(card: Element): Element | null {
+	const next = card.nextElementSibling;
+	if (isQueueArticle(next)) return next;
+	const prev = card.previousElementSibling;
+	return isQueueArticle(prev) ? prev : null;
+}
+
+/** Priority order once a focused card is removed: the toast's Undo (a status
+ * change puts keyboard users one keypress from reversing it), else the adjacent
+ * card's first action, else the always-present save input. */
+function firstFocusTarget(document: Document, adjacent: Element | null): HTMLElement | null {
+	const toastAction = document.querySelector<HTMLElement>(".toast__action");
+	if (toastAction) return toastAction;
+	if (adjacent?.isConnected) {
+		const btn = adjacent.querySelector<HTMLElement>(".queue-article__action-btn");
+		if (btn) return btn;
+	}
+	return document.querySelector<HTMLElement>(".queue__save-input");
+}
+
+export function initQueueFocus(deps: QueueFocusDeps): void {
+	/** The card adjacent to the one being removed, remembered on beforeSwap and
+	 * focused after the swap settles. `armed` gates the settle handler so it acts
+	 * only for a swap that removed the focused card, not for counts/poll swaps. */
+	let adjacentToRemoved: Element | null = null;
+	let armed = false;
+
+	deps.addBeforeSwapListener((target) => {
+		if (!isQueueArticle(target)) return;
+		if (!target.contains(deps.document.activeElement)) return;
+		adjacentToRemoved = adjacentCard(target);
+		armed = true;
+	});
+
+	deps.addAfterSettleListener(() => {
+		if (!armed) return;
+		const adjacent = adjacentToRemoved;
+		armed = false;
+		adjacentToRemoved = null;
+		const target = firstFocusTarget(deps.document, adjacent);
+		if (target) target.focus();
+	});
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-focus.client.ts
@@ -9,8 +9,11 @@
  */
 export interface QueueFocusDeps {
 	document: Document;
-	/** Fires with the element htmx is about to swap, for every swap. */
-	addBeforeSwapListener: (listener: (target: Element) => void) => void;
+	/** Fires with the element htmx is about to swap and the swap request's HTTP
+	 * verb (lowercased), for every swap. */
+	addBeforeSwapListener: (
+		listener: (swap: { target: Element; verb: string }) => void,
+	) => void;
 	/** Fires after htmx settles a swap (main and out-of-band both done). */
 	addAfterSettleListener: (listener: () => void) => void;
 }
@@ -46,8 +49,13 @@ export function initQueueFocus(deps: QueueFocusDeps): void {
 	let adjacentToRemoved: Element | null = null;
 	let armed = false;
 
-	deps.addBeforeSwapListener((target) => {
+	deps.addBeforeSwapListener(({ target, verb }) => {
 		if (!isQueueArticle(target)) return;
+		// Only a POST mutation (mark read/unread, delete) removes the card. A
+		// pending card also self-polls every 3s with GET and re-renders itself in
+		// place (hx-target="this" hx-swap="outerHTML"); relocating on that would
+		// yank a keyboard user's focus to a neighbour every 3s, so ignore it.
+		if (verb !== "post") return;
 		if (!target.contains(deps.document.activeElement)) return;
 		adjacentToRemoved = adjacentCard(target);
 		armed = true;

--- a/projects/hutch/src/runtime/web/pages/queue/queue-mutation-fragment.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-mutation-fragment.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+	QUEUE_COUNTS_ID,
+	STATUS_TOAST_DISMISS_MS,
+	STATUS_TOAST_MOUNT_ID,
+	renderDeleteMutationFragment,
+	renderQueueCountsTrigger,
+	renderQueueStatusToast,
+	renderStatusMutationFragment,
+} from "./queue-mutation-fragment";
+
+function parse(html: string): Document {
+	return new JSDOM(`<main>${html}</main>`).window.document;
+}
+
+describe("renderQueueStatusToast", () => {
+	it("renders the message, the dismiss window, and a working tracked Undo", () => {
+		const html = renderQueueStatusToast({
+			message: "Marked as read",
+			undoUrl: "/queue/abc/status?order=asc",
+			undoStatus: "unread",
+		});
+		const doc = parse(html);
+
+		const toast = doc.querySelector("[data-test-toast]");
+		assert(toast, "toast must render");
+		expect(toast.getAttribute("data-dismiss")).toBe(String(STATUS_TOAST_DISMISS_MS));
+		expect(doc.querySelector("[data-test-toast-message]")?.textContent).toBe("Marked as read");
+
+		const undoForm = doc.querySelector("[data-test-toast-action]")?.closest("form");
+		expect(undoForm?.getAttribute("action")).toBe(
+			"/queue/abc/status?order=asc&utm_source=queue-toast&utm_medium=internal&utm_content=undo",
+		);
+		expect(undoForm?.querySelector("input[name='status']")?.getAttribute("value")).toBe("unread");
+	});
+});
+
+describe("renderQueueCountsTrigger", () => {
+	it("renders the inert loader span with the stable id when oob is false", () => {
+		const html = renderQueueCountsTrigger({ countsUrl: "/queue/counts?tab=done", oob: false });
+		const span = parse(html).querySelector("[data-test-queue-counts]");
+		assert(span, "counts trigger span must render");
+		expect(span.getAttribute("id")).toBe(QUEUE_COUNTS_ID);
+		expect(span.getAttribute("hx-get")).toBe("/queue/counts?tab=done");
+		expect(span.getAttribute("hx-trigger")).toBe("load");
+		expect(span.getAttribute("hx-swap")).toBe("none");
+		expect(span.hasAttribute("hx-swap-oob")).toBe(false);
+	});
+
+	it("adds the out-of-band swap marker when oob is true, keeping the load trigger", () => {
+		const html = renderQueueCountsTrigger({ countsUrl: "/queue/counts", oob: true });
+		const span = parse(html).querySelector("[data-test-queue-counts]");
+		assert(span, "counts trigger span must render");
+		expect(span.getAttribute("id")).toBe(QUEUE_COUNTS_ID);
+		expect(span.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(span.getAttribute("hx-trigger")).toBe("load");
+	});
+});
+
+describe("renderStatusMutationFragment", () => {
+	it("wraps the toast in the stable OOB mount and re-arms the counts loader", () => {
+		const html = renderStatusMutationFragment({
+			flash: { message: "Marked as unread", undoUrl: "/queue/abc/status", undoStatus: "read" },
+			countsUrl: "/queue/counts",
+		});
+		const doc = parse(html);
+
+		const mount = doc.getElementById(STATUS_TOAST_MOUNT_ID);
+		assert(mount, "toast mount must be present");
+		expect(mount.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(mount.querySelector("[data-test-toast-message]")?.textContent).toBe("Marked as unread");
+
+		const counts = doc.getElementById(QUEUE_COUNTS_ID);
+		assert(counts, "counts re-arm span must be present");
+		expect(counts.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(counts.getAttribute("hx-trigger")).toBe("load");
+
+		// Both fragments are out-of-band, so the primary swap content is empty and
+		// removes the card htmx targeted.
+		const oobIds = Array.from(doc.querySelectorAll("[hx-swap-oob]"), (el) => el.id).sort();
+		expect(oobIds).toEqual([QUEUE_COUNTS_ID, STATUS_TOAST_MOUNT_ID].sort());
+	});
+});
+
+describe("renderDeleteMutationFragment", () => {
+	it("re-arms the counts loader only, carrying no toast", () => {
+		const html = renderDeleteMutationFragment({ countsUrl: "/queue/counts?tab=done" });
+		const doc = parse(html);
+
+		// The only out-of-band element is the counts re-arm — delete has no toast,
+		// so the status-toast mount is positively absent from the fragment's ids.
+		const oobIds = Array.from(doc.querySelectorAll("[hx-swap-oob]"), (el) => el.id);
+		expect(oobIds).toEqual([QUEUE_COUNTS_ID]);
+
+		const counts = doc.getElementById(QUEUE_COUNTS_ID);
+		assert(counts, "counts re-arm span must be present");
+		expect(counts.getAttribute("hx-swap-oob")).toBe("outerHTML");
+		expect(counts.getAttribute("hx-get")).toBe("/queue/counts?tab=done");
+	});
+});

--- a/projects/hutch/src/runtime/web/pages/queue/queue-mutation-fragment.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-mutation-fragment.ts
@@ -1,0 +1,72 @@
+import { render, renderToast, withInternalTracking } from "@packages/web-shell";
+
+/** Long enough to read the message and reach for Undo, short enough not to
+ * linger; the global toast.client script removes it after this delay. */
+export const STATUS_TOAST_DISMISS_MS = 6000;
+
+/** Stable-id mount the queue template wraps around the toast and the mutation
+ * response replaces out-of-band, so a card-scoped status POST can deliver its
+ * confirmation toast without re-rendering the listing. */
+export const STATUS_TOAST_MOUNT_ID = "status-toast";
+
+/** Stable id of the counts loader span. The template renders it inert; a card
+ * mutation OOB-replaces it with an identical span so its `hx-trigger="load"`
+ * re-fires and the badge/page-count refresh off the mutation's critical path. */
+export const QUEUE_COUNTS_ID = "queue-counts";
+
+export interface QueueStatusFlashView {
+	message: string;
+	undoUrl: string;
+	undoStatus: "read" | "unread";
+}
+
+/** The confirmation toast for a status change, with a working Undo that posts
+ * the opposite status back. Shared by the full listing render (queue.component)
+ * and the card-scoped mutation response so the two can't drift. */
+export function renderQueueStatusToast(flash: QueueStatusFlashView): string {
+	return renderToast({
+		message: flash.message,
+		dismissMs: STATUS_TOAST_DISMISS_MS,
+		actions: [
+			{
+				method: "POST",
+				url: withInternalTracking(flash.undoUrl, { source: "queue-toast", content: "undo" }),
+				label: "Undo",
+				fields: [{ name: "status", value: flash.undoStatus }],
+			},
+		],
+	});
+}
+
+const COUNTS_TRIGGER_TEMPLATE = `<span id="${QUEUE_COUNTS_ID}" hx-get="{{countsUrl}}" hx-trigger="load" hx-swap="none" data-test-queue-counts{{#if oob}} hx-swap-oob="outerHTML"{{/if}}></span>`;
+
+/** The counts loader span. `oob:false` renders the inert span the template
+ * mounts; `oob:true` renders the identical span the mutation response swaps
+ * over it, re-arming the `hx-trigger="load"` so GET /queue/counts re-runs. */
+export function renderQueueCountsTrigger(input: { countsUrl: string; oob: boolean }): string {
+	return render(COUNTS_TRIGGER_TEMPLATE, input);
+}
+
+/** OOB toast wrapped in its stable mount, for the card-scoped status response. */
+export function renderStatusToastOob(flash: QueueStatusFlashView): string {
+	return `<div id="${STATUS_TOAST_MOUNT_ID}" hx-swap-oob="outerHTML">${renderQueueStatusToast(flash)}</div>`;
+}
+
+/** Body of a card-scoped status mutation response: the primary content is empty
+ * (an outerHTML swap of empty content removes the card htmx targeted), and the
+ * out-of-band toast + counts re-arm ride alongside it. */
+export function renderStatusMutationFragment(input: {
+	flash: QueueStatusFlashView;
+	countsUrl: string;
+}): string {
+	return (
+		renderStatusToastOob(input.flash) +
+		renderQueueCountsTrigger({ countsUrl: input.countsUrl, oob: true })
+	);
+}
+
+/** Body of a card-scoped delete mutation response: empty primary content (card
+ * removed) plus the counts re-arm. Delete carries no toast, matching today. */
+export function renderDeleteMutationFragment(input: { countsUrl: string }): string {
+	return renderQueueCountsTrigger({ countsUrl: input.countsUrl, oob: true });
+}

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -7,7 +7,6 @@ import type { DeviceClass } from "@packages/web-analytics";
 import {
 	formatTabCountLabel,
 	render,
-	renderToast,
 	withInternalTracking,
 	SUBSCRIBE_CTA_LABEL,
 } from "@packages/web-shell";
@@ -15,6 +14,7 @@ import type { LocalTime, PageBody } from "@packages/web-shell";
 
 import { QUEUE_STYLES } from "./queue.styles";
 import { renderQueueCard, toQueueCardDisplayModel } from "./queue-card/queue-card.component";
+import { renderQueueCountsTrigger, renderQueueStatusToast } from "./queue-mutation-fragment";
 import { SAVE_SURFACES_SHORT_PHRASE } from "../../shared/client-surface-phrases";
 import type { QueueViewModel, SubscriptionBannerState } from "./queue.viewmodel";
 import { buildQueueUrl } from "./queue.url";
@@ -22,9 +22,7 @@ import { tabQuery, type TabId } from "./queue.tabs";
 
 const QUEUE_TEMPLATE = readFileSync(join(__dirname, "queue.template.html"), "utf-8");
 
-/** Long enough to read the message and reach for Undo, short enough not to
- * linger; the global toast.client script removes it after this delay. */
-const STATUS_TOAST_DISMISS_MS = 6000;
+const QUEUE_FOCUS_SCRIPT = `<script src="/client-dist/queue-focus.client.js" defer></script>`;
 
 interface QueueDisplayModel {
 	saveError?: string;
@@ -53,7 +51,7 @@ interface QueueDisplayModel {
 	prevUrl?: string;
 	nextUrl?: string;
 	currentPage: number;
-	countsUrl: string;
+	countsTriggerHtml: string;
 	subscriptionBannerStateClass: string;
 	subscriptionBannerIsTrialCountdown: boolean;
 	subscriptionBannerIsCancellationScheduled: boolean;
@@ -112,20 +110,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { installed: boolean; 
 		saveError: vm.errors?.[0]?.message,
 		saveErrorCode: vm.saveErrorCode,
 		importFlash: vm.importFlash,
-		statusToastHtml: vm.statusFlash
-			? renderToast({
-				message: vm.statusFlash.message,
-				dismissMs: STATUS_TOAST_DISMISS_MS,
-				actions: [
-					{
-						method: "POST",
-						url: withInternalTracking(vm.statusFlash.undoUrl, { source: "queue-toast", content: "undo" }),
-						label: "Undo",
-						fields: [{ name: "status", value: vm.statusFlash.undoStatus }],
-					},
-				],
-			})
-			: "",
+		statusToastHtml: vm.statusFlash ? renderQueueStatusToast(vm.statusFlash) : "",
 		hasImportSkipped: Boolean(vm.importSkipped && vm.importSkipped.entries.length > 0),
 		importSkippedEntries: vm.importSkipped?.entries ?? [],
 		importSkippedAndMore: vm.importSkipped?.andMore,
@@ -147,7 +132,7 @@ function toQueueDisplayModel(vm: QueueViewModel, options: { installed: boolean; 
 		filterReadClass: filterLinkClass(activeTab === "done"),
 		filterUnreadUrl: withInternalTracking(vm.filterUrls.unread, { source: "queue-filters", content: "filter-unread" }),
 		filterReadUrl: withInternalTracking(vm.filterUrls.read, { source: "queue-filters", content: "filter-read" }),
-		countsUrl: vm.countsUrl,
+		countsTriggerHtml: renderQueueCountsTrigger({ countsUrl: vm.countsUrl, oob: false }),
 		sortUrl,
 		sortLabel,
 		showPagination: Boolean(vm.paginationUrls.prev || vm.paginationUrls.next),
@@ -194,7 +179,7 @@ export function QueuePage(vm: QueueViewModel, options: { deviceClass: DeviceClas
 	const displayModel = toQueueDisplayModel(vm, { installed: options.installed ?? false, savedArticle: options.savedArticle ?? false, platform: options.platform ?? "other", hasInstallableClient: options.hasInstallableClient ?? false, onboardingDismissed: options.onboardingDismissed ?? false, deviceClass: options.deviceClass });
 	const content = render(QUEUE_TEMPLATE, { ...displayModel, saveUrl });
 
-	const scriptParts: string[] = [NAV_HIDE_SCRIPT];
+	const scriptParts: string[] = [NAV_HIDE_SCRIPT, QUEUE_FOCUS_SCRIPT];
 	if (saveUrl) scriptParts.push(AUTO_SUBMIT_SCRIPT);
 
 	return {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.error.ts
@@ -17,6 +17,21 @@ export interface StatusFlash {
 	undoStatus: "read" | "unread";
 }
 
+/** Builds the confirmation flash for a status change: the message the toast
+ * shows and the opposite status its Undo posts back. Shared by the redirect
+ * query-param path (`statusFlashMapping`) and the card-scoped mutation handler,
+ * which builds it in-process, so the two message strings can't drift. */
+export function statusFlashFor(input: {
+	status: "read" | "unread";
+	articleId: string;
+}): StatusFlash {
+	return {
+		message: input.status === "read" ? "Marked as read" : "Marked as unread",
+		undoArticleId: input.articleId,
+		undoStatus: input.status === "read" ? "unread" : "read",
+	};
+}
+
 /** Reads the one-shot params the POST /:id/status redirect appends so the
  * queue page can confirm the change with a toast and offer a working Undo
  * that posts the opposite status back. */
@@ -27,11 +42,7 @@ export const statusFlashMapping = (
 	const articleId = query.status_article;
 	if (changed !== "read" && changed !== "unread") return undefined;
 	if (typeof articleId !== "string" || articleId.length === 0) return undefined;
-	return {
-		message: changed === "read" ? "Marked as read" : "Marked as unread",
-		undoArticleId: articleId,
-		undoStatus: changed === "read" ? "unread" : "read",
-	};
+	return statusFlashFor({ status: changed, articleId });
 };
 
 /** Pulls the one-shot status flash params off the query so an intervening

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -240,7 +240,7 @@ describe("Queue routes", () => {
 			expect(doc.querySelector("[data-test-action='delete']")?.textContent).toBe("×");
 		});
 
-		it("should enable htmx boost on the mark-read action form", async () => {
+		it("boosts the mark-read action form and scopes its swap to the card", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 			const { auth } = harness;
 			const agent = await loginAgent(harness.server, auth);
@@ -255,9 +255,16 @@ describe("Queue routes", () => {
 			const readForm = doc.querySelector("[data-test-action='mark-read']")?.closest("form");
 
 			expect(readForm?.getAttribute("hx-boost")).toBe("true");
-			expect(readForm?.getAttribute("hx-target")).toBe("main");
-			expect(readForm?.getAttribute("hx-select")).toBe("main");
-			expect(readForm?.getAttribute("hx-swap")).toBe("outerHTML show:none");
+			expect(readForm?.getAttribute("hx-target")).toBe("closest .queue-article");
+			// hx-select is dropped so htmx keeps the empty primary body (which removes
+			// the card) and the out-of-band toast/counts fragments; the full-listing
+			// fallback re-establishes selection with an HX-Reselect header instead.
+			expect(readForm?.hasAttribute("hx-select")).toBe(false);
+			expect(readForm?.getAttribute("hx-swap")).toBe("outerHTML");
+			// Boosted forms push history by default; the POST action URL must not
+			// become a history entry a refresh would re-GET.
+			expect(readForm?.getAttribute("hx-push-url")).toBe("false");
+			expect(readForm?.getAttribute("hx-disabled-elt")).toBe("find button");
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -514,6 +514,239 @@ describe("Queue routes", () => {
 		});
 	});
 
+	describe("card-scoped mutations (HX-Request + swap=card)", () => {
+		type Agent = Awaited<ReturnType<typeof loginAgent>>;
+
+		async function saveMany(agent: Agent, count: number): Promise<void> {
+			for (let i = 0; i < count; i++) {
+				await agent.post("/queue/save").type("form").send({ url: `https://example.com/card-${i}` });
+			}
+		}
+
+		async function firstCardId(agent: Agent, path = "/queue"): Promise<string> {
+			const doc = new JSDOM((await agent.get(path)).text).window.document;
+			const id = doc.querySelector("[data-test-article-list] .queue-article")?.getAttribute("data-test-article");
+			assert(id, "a card must be listed");
+			return id;
+		}
+
+		function fragment(text: string): Document {
+			return new JSDOM(`<main>${text}</main>`).window.document;
+		}
+
+		it("marks a card read on a multi-row page: 200, no redirect, empty primary, OOB toast + counts", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 2);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/status?swap=card`)
+				.set("HX-Request", "true")
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.location, undefined);
+			const doc = fragment(response.text);
+			// The primary swap body is empty — no card markup — so htmx removes the card.
+			assert.equal(doc.querySelectorAll(".queue-article").length, 0);
+
+			const toastMount = doc.getElementById("status-toast");
+			assert(toastMount, "status toast must arrive out-of-band");
+			assert.equal(toastMount.getAttribute("hx-swap-oob"), "outerHTML");
+			assert.equal(toastMount.querySelector("[data-test-toast-message]")?.textContent, "Marked as read");
+			const undoForm = toastMount.querySelector("[data-test-toast-action]")?.closest("form");
+			assert.equal(
+				undoForm?.getAttribute("action"),
+				`/queue/${id}/status?utm_source=queue-toast&utm_medium=internal&utm_content=undo`,
+			);
+			assert.equal(undoForm?.querySelector("input[name='status']")?.getAttribute("value"), "unread");
+
+			const counts = doc.getElementById("queue-counts");
+			assert(counts, "counts loader must re-arm out-of-band");
+			assert.equal(counts.getAttribute("hx-swap-oob"), "outerHTML");
+			assert.equal(counts.getAttribute("hx-trigger"), "load");
+		});
+
+		it("deletes a card on a multi-row page: 200, empty primary, OOB counts, no toast", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 2);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/delete?swap=card`)
+				.set("HX-Request", "true");
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.location, undefined);
+			const doc = fragment(response.text);
+			assert.equal(doc.querySelectorAll(".queue-article").length, 0);
+			// Delete carries no flash today, so the only out-of-band element is counts.
+			assert.deepEqual(
+				Array.from(doc.querySelectorAll("[hx-swap-oob]"), (el) => el.id),
+				["queue-counts"],
+			);
+		});
+
+		it("marks the last unread card read: full-listing fallback retargeted to main with the confirmation toast", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 1);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/status?swap=card`)
+				.set("HX-Request", "true")
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers.location, undefined);
+			assert.equal(response.headers["hx-retarget"], "main");
+			assert.equal(response.headers["hx-reswap"], "outerHTML show:none");
+			assert.equal(response.headers["hx-reselect"], "main");
+			const doc = new JSDOM(response.text).window.document;
+			assert(doc.querySelector("[data-test-empty-queue]"), "the emptied unread tab shows its empty state");
+			assert.equal(doc.querySelector("[data-test-toast-message]")?.textContent, "Marked as read");
+		});
+
+		it("deletes the last card: full-listing fallback with the empty state and no toast", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 1);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/delete?swap=card`)
+				.set("HX-Request", "true");
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers["hx-retarget"], "main");
+			const doc = new JSDOM(response.text).window.document;
+			assert(doc.querySelector("[data-test-empty-queue]"), "the emptied tab shows its empty state");
+			assert.equal(doc.querySelector("[data-test-toast]"), null);
+		});
+
+		it("marks the last card on page 2 read: fallback clamped to the last valid page", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 21);
+			const id = await firstCardId(agent, "/queue?page=2");
+
+			const response = await agent
+				.post(`/queue/${id}/status?page=2&swap=card`)
+				.set("HX-Request", "true")
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers["hx-retarget"], "main");
+			const doc = new JSDOM(response.text).window.document;
+			const cards = doc.querySelectorAll("[data-test-article-list] .queue-article");
+			assert.equal(cards.length, 20, "the clamped page 1 shows the full 20 remaining unread items");
+			assert.ok(
+				!Array.from(cards).some((el) => el.getAttribute("data-test-article") === id),
+				"the just-read item is no longer listed",
+			);
+			assert.equal(doc.querySelector("[data-test-toast-message]")?.textContent, "Marked as read");
+		});
+
+		it("deletes from a still-full page: fallback re-renders the refilled page", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 21);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/delete?swap=card`)
+				.set("HX-Request", "true");
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers["hx-retarget"], "main");
+			const doc = new JSDOM(response.text).window.document;
+			assert.equal(
+				doc.querySelectorAll("[data-test-article-list] .queue-article").length,
+				20,
+				"the page refilled from page 2 and re-rendered full",
+			);
+		});
+
+		it("marks a card read on a still-full page: card removal, drift accepted (no fallback)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 21);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/status?swap=card`)
+				.set("HX-Request", "true")
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers["hx-retarget"], undefined);
+			const doc = fragment(response.text);
+			assert.equal(doc.querySelectorAll(".queue-article").length, 0, "just the card is removed");
+			assert(doc.getElementById("status-toast"), "status still confirms with a toast");
+		});
+
+		it("resyncs with the full listing when the mutation did not apply", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 1);
+
+			// Well-formed hash id that resolves to no owned article → updateArticleStatus false.
+			const response = await agent
+				.post("/queue/00000000000000000000000000000000/status?swap=card")
+				.set("HX-Request", "true")
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 200);
+			assert.equal(response.headers["hx-retarget"], "main");
+			const doc = new JSDOM(response.text).window.document;
+			assert.equal(
+				doc.querySelectorAll("[data-test-article-list] .queue-article").length,
+				1,
+				"the DOM resyncs to the untouched listing rather than removing a card",
+			);
+			assert.equal(doc.querySelector("[data-test-toast]"), null, "a no-op mutation shows no toast");
+		});
+
+		it("keeps the 303 baseline for a no-JS submit that carries the marker but no HX-Request", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 2);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/status?swap=card`)
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 303);
+			assert.equal(response.headers.location, `/queue?status_changed=read&status_article=${id}`);
+		});
+
+		it("keeps the 303 baseline for an htmx request without the card marker (the toast Undo shape)", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await saveMany(agent, 2);
+			const id = await firstCardId(agent);
+
+			const response = await agent
+				.post(`/queue/${id}/status`)
+				.set("HX-Request", "true")
+				.type("form")
+				.send({ status: "read" });
+
+			assert.equal(response.status, 303);
+			assert.equal(response.headers.location, `/queue?status_changed=read&status_article=${id}`);
+		});
+	});
+
 	describe("POST /queue/:id/summary-toggle", () => {
 		async function saveAndGetArticleId(agent: Awaited<ReturnType<typeof loginAgent>>): Promise<string> {
 			await agent.post("/queue/save").type("form").send({ url: "https://example.com/article" });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -30,6 +30,7 @@ import type {
 	FindArticleFreshness,
 	FindArticleUrlById,
 	FindArticlesByUser,
+	FindArticlesResult,
 	MarkArticleViewed,
 	MarkSummaryToggled,
 	SaveArticle,
@@ -86,11 +87,15 @@ import { toArticleCollectionEntity } from "../../api/collection-siren";
 import { toBulkSaveResultEntity } from "../../api/bulk-save-siren";
 import { toArticleEntity } from "../../api/article-siren";
 import { toUploadSlotEntity } from "../../api/upload-slot-siren";
-import { parseQueueUrl, buildQueueUrl, QUEUE_PATH, canonicalQueuePageRedirect } from "./queue.url";
+import { parseQueueUrl, buildQueueUrl, buildQueueCountsUrl, QUEUE_PATH, canonicalQueuePageRedirect, type QueueUrlState } from "./queue.url";
 import { collectUtmParams } from "../../shared/utm";
 import { tabQuery } from "./queue.tabs";
-import type { HttpErrorMessageMapping } from "./queue.error";
-import { collectStatusFlashParams, importFlashMapping, statusFlashMapping } from "./queue.error";
+import type { HttpErrorMessageMapping, StatusFlash } from "./queue.error";
+import { collectStatusFlashParams, importFlashMapping, statusFlashFor, statusFlashMapping } from "./queue.error";
+import {
+	renderDeleteMutationFragment,
+	renderStatusMutationFragment,
+} from "./queue-mutation-fragment";
 import { MAX_POLLS } from "@packages/web-shell";
 import { parsePollParam } from "@packages/web-shell";
 import { toQueueArticleViewModel, toQueueViewModel } from "./queue.viewmodel";
@@ -365,6 +370,17 @@ const READER_MARK_READ_BRIDGE_SCRIPT = `<script>
  * predating the query param — which cannot deploy in lockstep with the server —
  * still resolves to its chromeless reader. */
 const isIosPlatform = (req: Request): boolean => isIosSurface(req);
+
+/** True when a queue POST wants the card-scoped fragment response rather than
+ * the full-listing 303 redirect. Both conditions are required: the `HX-Request`
+ * header proves htmx is driving the swap (a no-JS submit gets the 303 baseline),
+ * and the `swap=card` marker — appended only to the card affordance's action URL
+ * (`withCardSwapMarker` in queue.viewmodel) — proves this POST is the card form,
+ * not the toast Undo, the reader's mark-read, or a Siren client sharing the same
+ * route. The marker only *selects the response representation*; the handler
+ * still computes the resulting page state from the store, never from the client. */
+const wantsCardSwap = (req: Request): boolean =>
+	req.get("HX-Request") === "true" && req.query.swap === "card";
 
 export function initQueueRoutes(deps: QueueDependencies): Router {
 	const router = express.Router();
@@ -649,6 +665,137 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		return { platform, installed, savedArticle, hasInstallableClient: hasClient, onboardingDismissed };
 	};
 
+	/** Renders the full `<main>` queue listing for an already-fetched page of
+	 * rows. Shared by the top-of-page GET and the card-mutation fallback so the
+	 * fallback returns byte-identical HTML to the 303 → GET path. Flash options
+	 * are passed explicitly (the GET parses them from the query; the mutation
+	 * fallback builds its status flash in-process), keeping this helper free of
+	 * query-param knowledge. */
+	const renderQueueListing = async (
+		req: Request,
+		res: Response,
+		input: {
+			userId: UserId;
+			urlState: QueueUrlState;
+			result: FindArticlesResult;
+			saveError?: string;
+			importFlash?: string;
+			statusFlash?: StatusFlash;
+			importSkipped?: ImportSkippedViewModel;
+			filterUrl?: string;
+		},
+	): Promise<void> => {
+		const [summaryByUrl, crawlByUrl, effectiveAccess] = await Promise.all([
+			loadSummaries(deps.findGeneratedSummary, input.result.articles),
+			loadCrawls(deps.findArticleCrawlStatus, input.result.articles),
+			deps.getEffectiveAccess(input.userId),
+		]);
+		const vm = toQueueViewModel(input.result, input.urlState, {
+			errors: input.saveError ? [{ message: input.saveError }] : undefined,
+			importFlash: input.importFlash,
+			statusFlash: input.statusFlash,
+			importSkipped: input.importSkipped,
+			summaryByUrl,
+			crawlByUrl,
+			effectiveAccess,
+			now: deps.now(),
+		});
+		const onboarding = await resolveOnboardingSignals(req, input.userId);
+		sendComponent(
+			req, res,
+			Base(
+				QueuePage(vm, { ...onboarding, saveUrl: input.filterUrl, deviceClass: classifyDeviceClass(req.get("user-agent")) }),
+				await deps.buildBannerState(req, { preFetchedAccess: effectiveAccess }),
+			),
+		);
+	};
+
+	/** Answers a card-scoped status/delete POST (see {@link wantsCardSwap}). The
+	 * common case removes just the acted-on card and re-arms counts (plus a toast
+	 * for status) out-of-band. The server — never the client — decides when that
+	 * would leave the DOM out of sync and instead re-renders the whole listing,
+	 * retargeted to `<main>` via response headers so it lands exactly where the
+	 * 303 → GET swap would. `fallbackOnFullPage` is the one status/delete
+	 * asymmetry: a delete off a still-full page means the next page refilled it,
+	 * and the delete-loop journeys depend on seeing that refill; status accepts
+	 * the "list holds its place" drift instead. */
+	const respondToCardMutation = async (
+		req: Request,
+		res: Response,
+		input: {
+			userId: UserId;
+			applied: boolean;
+			fallbackOnFullPage: boolean;
+			statusFlash?: StatusFlash;
+		},
+	): Promise<void> => {
+		const urlState = parseQueueUrl(req.query);
+		const tab = tabQuery(urlState.tab);
+		const order = urlState.order ?? tab.defaultOrder;
+
+		const pageCheck = await deps.findArticlesByUser({
+			userId: input.userId,
+			status: tab.status,
+			sort: tab.sort,
+			order,
+			page: urlState.page,
+			pageSize: QUEUE_PAGE_SIZE,
+			excludeContent: true,
+		});
+		const rows = pageCheck.articles.length;
+		const shouldFallback =
+			!input.applied ||
+			rows === 0 ||
+			(input.fallbackOnFullPage && rows === QUEUE_PAGE_SIZE);
+
+		if (shouldFallback) {
+			let renderState = urlState;
+			if (rows === 0 && urlState.page > 1) {
+				const total = await deps.countArticlesByUser({ userId: input.userId, status: tab.status });
+				const totalPages = Math.max(1, Math.ceil(total / QUEUE_PAGE_SIZE));
+				renderState = { ...urlState, page: Math.min(urlState.page, totalPages) };
+			}
+			const result = await deps.findArticlesByUser({
+				userId: input.userId,
+				status: tab.status,
+				sort: tab.sort,
+				order,
+				page: renderState.page,
+				pageSize: QUEUE_PAGE_SIZE,
+			});
+			res.set("HX-Retarget", "main");
+			res.set("HX-Reswap", "outerHTML show:none");
+			res.set("HX-Reselect", "main");
+			await renderQueueListing(req, res, {
+				userId: input.userId,
+				urlState: renderState,
+				result,
+				statusFlash: input.statusFlash,
+			});
+			return;
+		}
+
+		const countsUrl = buildQueueCountsUrl(urlState);
+		if (input.statusFlash) {
+			const queueUrl = buildQueueUrl(urlState);
+			const queryIndex = queueUrl.indexOf("?");
+			const returnQuery = queryIndex !== -1 ? queueUrl.slice(queryIndex) : "";
+			res.status(200).type("html").send(
+				renderStatusMutationFragment({
+					flash: {
+						message: input.statusFlash.message,
+						undoUrl: `${QUEUE_PATH}/${input.statusFlash.undoArticleId}/status${returnQuery}`,
+						undoStatus: input.statusFlash.undoStatus,
+					},
+					countsUrl,
+				}),
+			);
+			return;
+		}
+
+		res.status(200).type("html").send(renderDeleteMutationFragment({ countsUrl }));
+	};
+
 	router.get("/", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
@@ -719,33 +866,16 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			}
 		}
 
-		const saveError = deps.httpErrorMessageMapping(req.query);
-		const importFlash = importFlashMapping(req.query);
-		const statusFlash = statusFlashMapping(req.query);
-		const importSkipped = readImportSkippedFlash(req, res);
-		const [summaryByUrl, crawlByUrl, effectiveAccess] = await Promise.all([
-			loadSummaries(deps.findGeneratedSummary, result.articles),
-			loadCrawls(deps.findArticleCrawlStatus, result.articles),
-			deps.getEffectiveAccess(userId),
-		]);
-		const vm = toQueueViewModel(result, urlState, {
-			errors: saveError ? [{ message: saveError }] : undefined,
-			importFlash,
-			statusFlash,
-			importSkipped,
-			summaryByUrl,
-			crawlByUrl,
-			effectiveAccess,
-			now: deps.now(),
+		await renderQueueListing(req, res, {
+			userId,
+			urlState,
+			result,
+			saveError: deps.httpErrorMessageMapping(req.query),
+			importFlash: importFlashMapping(req.query),
+			statusFlash: statusFlashMapping(req.query),
+			importSkipped: readImportSkippedFlash(req, res),
+			filterUrl,
 		});
-		const onboarding = await resolveOnboardingSignals(req, userId);
-		sendComponent(
-			req, res,
-			Base(
-				QueuePage(vm, { ...onboarding, saveUrl: filterUrl, deviceClass: classifyDeviceClass(req.get("user-agent")) }),
-				await deps.buildBannerState(req, { preFetchedAccess: effectiveAccess }),
-			),
-		);
 	});
 
 	router.get("/counts", async (req: Request, res: Response) => {
@@ -1330,25 +1460,42 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
 		const parsedStatus = ArticleStatusSchema.safeParse(req.body.status);
 
-		const flashParams: [string, string][] = [];
+		let appliedStatus: "read" | "unread" | undefined;
 		if (parsedId.success && parsedStatus.success) {
 			const updated = await deps.updateArticleStatus(parsedId.data, userId, parsedStatus.data);
 			if (updated) {
-				flashParams.push(["status_changed", parsedStatus.data]);
-				flashParams.push(["status_article", req.params.id]);
-			}
-			if (updated && parsedStatus.data === "read") {
-				deps.analytics.info({
-					stream: STREAMS.analytics,
-					event: ANALYTICS_EVENTS.articleRead,
-					timestamp: deps.now().toISOString(),
-					user_id: userId,
-					visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
-					device_class: classifyDeviceClass(req.get("user-agent")),
-				});
+				appliedStatus = parsedStatus.data;
+				if (parsedStatus.data === "read") {
+					deps.analytics.info({
+						stream: STREAMS.analytics,
+						event: ANALYTICS_EVENTS.articleRead,
+						timestamp: deps.now().toISOString(),
+						user_id: userId,
+						visitor_hash: hashIp({ ip: req.ip, salt: deps.salt }),
+						device_class: classifyDeviceClass(req.get("user-agent")),
+					});
+				}
 			}
 		}
 
+		if (wantsCardSwap(req)) {
+			await respondToCardMutation(req, res, {
+				userId,
+				applied: appliedStatus !== undefined,
+				// A page that is still full after marking one card read means a row slid
+				// up from the next page; status accepts that drift (the list holds its
+				// place, matching the iOS app) rather than re-render.
+				fallbackOnFullPage: false,
+				statusFlash: appliedStatus
+					? statusFlashFor({ status: appliedStatus, articleId: req.params.id })
+					: undefined,
+			});
+			return;
+		}
+
+		const flashParams: [string, string][] = appliedStatus
+			? [["status_changed", appliedStatus], ["status_article", req.params.id]]
+			: [];
 		res.redirect(303, buildQueueUrl(parseQueueUrl(req.query), [...collectUtmParams(req.query), ...flashParams]));
 	});
 
@@ -1357,8 +1504,21 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const userId = req.userId;
 		const parsedId = ReaderArticleHashIdSchema.safeParse(req.params.id);
 
+		let applied = false;
 		if (parsedId.success) {
-			await deps.deleteArticle(parsedId.data, userId);
+			applied = await deps.deleteArticle(parsedId.data, userId);
+		}
+
+		if (wantsCardSwap(req)) {
+			await respondToCardMutation(req, res, {
+				userId,
+				applied,
+				// A still-full page after a delete means the next page refilled it; the
+				// delete-loop journeys assert the exact survivors, so re-render the
+				// refilled page rather than card-swap and strand a row off-screen.
+				fallbackOnFullPage: true,
+			});
+			return;
 		}
 
 		res.redirect(303, buildQueueUrl(parseQueueUrl(req.query)));

--- a/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.styles.css
@@ -563,8 +563,8 @@
 
 /**
  * Mark-read/unread in-flight loader — mirrors the reader's mark-read control so
- * the status toggle shows the same three animated dots while htmx re-swaps the
- * <main> fragment, covering the slight round-trip delay.
+ * the status toggle shows the same three animated dots, covering the slight
+ * round-trip delay.
  *
  * 1. Scoped to the submitting form's own htmx-request, NOT an ambient
  *    descendant match: the card polls itself (hx-get on the root every 3s),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.template.html
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.template.html
@@ -17,7 +17,7 @@
         <a class="queue-banner__cta" href="{{track '/account' source='queue-banner' content='resubscribe'}}" data-test-action="resubscribe">{{subscribeCtaLabel}}</a>
         {{/if}}
       </aside>
-      {{{statusToastHtml}}}
+      <div id="status-toast">{{{statusToastHtml}}}</div>
       <form class="{{saveFormClass}}" method="POST" action="{{track '/queue/save' source='queue' content='save'}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:#latest-saved:top" hx-disabled-elt=".queue__save-btn" data-test-form="save-article"{{#if saveUrl}} data-auto-submit{{/if}}>
         <input class="queue__save-input" type="url" name="url" placeholder="Paste a URL to save an article…" required value="{{saveUrl}}"{{#if accessIsReadOnly}} disabled{{/if}}>
         <button class="queue__save-btn" type="submit"{{#if accessIsReadOnly}} disabled{{/if}}><span class="queue__save-btn-label">Save</span><span class="queue__save-btn-saving">Saving…</span></button>
@@ -42,7 +42,7 @@
         <a class="{{filterUnreadClass}}" id="queue-filter-unread" href="{{filterUnreadUrl}}" data-test-filter="unread">{{filterUnreadLabel}}</a>
         <a class="{{filterReadClass}}" href="{{filterReadUrl}}" data-test-filter="read">Read</a>
       </nav>
-      <span hx-get="{{countsUrl}}" hx-trigger="load" hx-swap="none" data-test-queue-counts></span>
+      {{{countsTriggerHtml}}}
       <div class="queue__sort" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none">
         <a class="queue__sort-link" href="{{sortUrl}}" data-test-sort>{{sortLabel}}</a>
       </div>

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -311,50 +311,50 @@ describe("toQueueViewModel", () => {
 		expect(actions.map(a => a.testAction)).toEqual(["mark-unread", "delete"]);
 	});
 
-	it("should include return query in action URLs for non-default view", () => {
+	it("should include return query and the card-swap marker in action URLs for non-default view", () => {
 		const article = makeArticle({ status: "read" });
 		const filters = { order: "asc" as const, page: 1, tab: "done" as const };
 		const vm = toQueueViewModel(makeResult([article]), filters, { now: NOW });
 
 		const deleteAction = vm.articles[0].actions.find(a => a.testAction === "delete");
-		expect(deleteAction?.url).toBe(`/queue/${ARTICLE_ID}/delete?tab=done&order=asc`);
+		expect(deleteAction?.url).toBe(`/queue/${ARTICLE_ID}/delete?tab=done&order=asc&swap=card`);
 	});
 
-	it("should not include query string in action URLs for default view", () => {
+	it("should carry the card-swap marker even in the default view", () => {
 		const article = makeArticle({ status: "unread" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, { now: NOW });
 
 		const deleteAction = vm.articles[0].actions.find(a => a.testAction === "delete");
-		expect(deleteAction?.url).toBe(`/queue/${ARTICLE_ID}/delete`);
+		expect(deleteAction?.url).toBe(`/queue/${ARTICLE_ID}/delete?swap=card`);
 	});
 
-	it("should use POST method and /status URL for mark-unread action", () => {
+	it("should use POST method and /status URL (with the card-swap marker) for mark-unread action", () => {
 		const article = makeArticle({ status: "read" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, { now: NOW });
 
 		const markUnreadAction = vm.articles[0].actions.find(a => a.testAction === "mark-unread");
 		expect(markUnreadAction?.method).toBe("POST");
-		expect(markUnreadAction?.url).toBe(`/queue/${ARTICLE_ID}/status`);
+		expect(markUnreadAction?.url).toBe(`/queue/${ARTICLE_ID}/status?swap=card`);
 		expect(markUnreadAction?.fields).toEqual([{ name: "status", value: "unread" }]);
 	});
 
-	it("should use POST method and /status URL for mark-read action", () => {
+	it("should use POST method and /status URL (with the card-swap marker) for mark-read action", () => {
 		const article = makeArticle({ status: "unread" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, { now: NOW });
 
 		const markReadAction = vm.articles[0].actions.find(a => a.testAction === "mark-read");
 		expect(markReadAction?.method).toBe("POST");
-		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/status`);
+		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/status?swap=card`);
 		expect(markReadAction?.fields).toEqual([{ name: "status", value: "read" }]);
 	});
 
-	it("should include return query in mark-read URL for non-default view", () => {
+	it("should include return query and the card-swap marker in mark-read URL for non-default view", () => {
 		const article = makeArticle({ status: "unread" });
 		const filters = { order: "asc" as const, page: 1, tab: "queue" as const };
 		const vm = toQueueViewModel(makeResult([article]), filters, { now: NOW });
 
 		const markReadAction = vm.articles[0].actions.find(a => a.testAction === "mark-read");
-		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/status?order=asc`);
+		expect(markReadAction?.url).toBe(`/queue/${ARTICLE_ID}/status?order=asc&swap=card`);
 	});
 
 	it("should have no hidden fields in delete action", () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -118,16 +118,27 @@ function toSubscriptionBannerState(access: EffectiveAccess, now: Date): Subscrip
 	}
 }
 
+/** Appends the `swap=card` marker to a card action URL. It tells the status and
+ * delete handlers that this POST came from the card affordance (not the toast
+ * Undo, the reader's mark-read, or a Siren client, all of which share the same
+ * routes), so — and only so — an htmx request may get the card-scoped fragment
+ * response instead of the full-listing 303. The marker is a response-shape hint,
+ * never trusted state: the handler still computes the resulting page itself. */
+function withCardSwapMarker(returnQuery: string): string {
+	return returnQuery ? `${returnQuery}&swap=card` : "?swap=card";
+}
+
 function toArticleActions(
 	article: { id: string; status: string },
 	returnQuery: string,
 ): ArticleAction[] {
 	const actions: ArticleAction[] = [];
+	const cardQuery = withCardSwapMarker(returnQuery);
 
 	if (article.status !== "read") {
 		actions.push({
 			method: "POST",
-			url: `/queue/${article.id}/status${returnQuery}`,
+			url: `/queue/${article.id}/status${cardQuery}`,
 			text: "Mark as read",
 			title: "Mark as read",
 			testAction: "mark-read",
@@ -138,7 +149,7 @@ function toArticleActions(
 	if (article.status !== "unread") {
 		actions.push({
 			method: "POST",
-			url: `/queue/${article.id}/status${returnQuery}`,
+			url: `/queue/${article.id}/status${cardQuery}`,
 			text: "Mark as unread",
 			title: "Mark as unread",
 			testAction: "mark-unread",
@@ -148,7 +159,7 @@ function toArticleActions(
 
 	actions.push({
 		method: "POST",
-		url: `/queue/${article.id}/delete${returnQuery}`,
+		url: `/queue/${article.id}/delete${cardQuery}`,
 		text: "×",
 		title: "Delete",
 		testAction: "delete",


### PR DESCRIPTION
## Summary

Queue card **Mark as read / unread / Delete** re-rendered and re-shipped the whole `<main>` (~131 KB) after a 303 → GET round trip, even though the visible effect is just "this one card disappears". This retargets the htmx swap to the card itself.

- **Common case** removes just the acted-on card (`hx-target="closest .queue-article"`, empty primary body) and delivers the toast + counts refresh **out-of-band** (~2 KB).
- **Server-determined fallback**: after the write, the handler re-reads the page itself and — when a card removal would desync the DOM — re-renders the full listing retargeted to `<main>` (`HX-Retarget`/`HX-Reswap`/`HX-Reselect`). This fires when the page emptied, the mutation was a no-op, or a **delete** came off a still-full page the next page refilled (the delete-loop journeys assert exact survivors and depend on that refill). **Status** accepts the "list holds its place" drift, matching the iOS app.
- A `swap=card` marker on the card action URL **plus** the `HX-Request` header gate the fragment response, so the no-JS 303 baseline, the toast Undo, the reader's mark-read, and Siren clients stay byte-identical. The marker only selects the response *representation* — the server always computes the resulting page from the store, never from client-reported state.

## Behaviour preserved
- No `HX-Request` → identical 303-with-flash baseline (progressive enhancement).
- Reader mark-as-read keeps its full-`<main>` swap (the iOS bridge observes that request shape).
- Toast Undo keeps `hx-target="main"`.

## Client
- New bundled `queue-focus.client.ts` re-homes keyboard focus (toast Undo → adjacent card → save input) only when focus was inside the removed card, so mouse users see no jump.
- Toast auto-dismiss now also listens for `htmx:oobAfterSwap` so the out-of-band toast dismisses (its primary target is removed, so `afterSwap` can fire on a detached node).

## Testing
- `pnpm check` green: lint, typecheck, all unit/integration/route tests, **100% coverage**, knip, unused-css. New route tests cover every branch of the fallback table (card removal, empty-page fallback, page-2 clamp, delete-refill vs status-drift, no-op resync, and both 303-baseline negatives).
- New unit tests for the fragment builders and the focus script (jsdom, DI).
- **queue-flow E2E** journey passes unmodified (delete-pagination loop, cleanup-delete-all, mark-read, pagination, sort) — real htmx in a browser.

## Notes
- The sanctioned card-fragment mutation pattern is recorded in `.claude/skills/web/SKILL.md` so it isn't re-litigated back to a full-`<main>` swap.
- Some `<main>`-swap comments were trimmed where the card swap made them stale; the `swap=card` marker, `wantsCardSwap`, the toast footer, and the focus script carry short "why" comments — flagged here for reviewer visibility per the code-comments policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMZviBeuMsmp3JsocavnUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMZviBeuMsmp3JsocavnUE)_