### PR TITLE
perf: batch the per-card queue summary/crawl reads into two BatchGets

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -51,6 +51,7 @@ import { devSummariseInline } from "./providers/article-summary/dev-summarise-in
 import { initDynamoDbArticleCrawl } from "@packages/article-store";
 import { initInMemoryArticleCrawl } from "@packages/test-fixtures/providers/article-crawl";
 import { initInMemoryGeneratedSummary } from "@packages/test-fixtures/providers/article-summary";
+import { batchFromSingular } from "./batch-from-singular";
 import { S3Client } from "@aws-sdk/client-s3";
 import { SchedulerClient } from "@aws-sdk/client-scheduler";
 import { initS3ReadContent } from "@packages/article-store";
@@ -429,8 +430,10 @@ function initProviders(input: { appOrigin: string }) {
 			statPendingUpload,
 			readPendingUploadPrefix,
 			findGeneratedSummary: summaryStore.findGeneratedSummary,
+			findGeneratedSummaries: summaryStore.findGeneratedSummaries,
 			markSummaryPending: summaryStore.markSummaryPending,
 			findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
+			findArticleCrawlStatuses: crawlStore.findArticleCrawlStatuses,
 			findArticleFreshness: articleStore.findArticleFreshness,
 			findArticleCrawlVersions: articleStore.findArticleCrawlVersions,
 			markCrawlPending: crawlStore.markCrawlPending,
@@ -716,8 +719,10 @@ function initProviders(input: { appOrigin: string }) {
 		statPendingUpload,
 		readPendingUploadPrefix,
 		findGeneratedSummary: summaryStore.findGeneratedSummary,
+		findGeneratedSummaries: batchFromSingular(summaryStore.findGeneratedSummary),
 		markSummaryPending: summaryStore.markSummaryPending,
 		findArticleCrawlStatus: crawlStore.findArticleCrawlStatus,
+		findArticleCrawlStatuses: batchFromSingular(crawlStore.findArticleCrawlStatus),
 		findArticleFreshness: articleStore.findArticleFreshness,
 		findArticleCrawlVersions: articleStore.findArticleCrawlVersions,
 		markCrawlPending: crawlStore.markCrawlPending,

--- a/projects/hutch/src/runtime/batch-from-singular.test.ts
+++ b/projects/hutch/src/runtime/batch-from-singular.test.ts
@@ -1,0 +1,33 @@
+import { batchFromSingular } from "./batch-from-singular";
+
+describe("batchFromSingular", () => {
+	it("keys every input url to the singular's result, in one loop", async () => {
+		const seen: string[] = [];
+		const singular = async (url: string) => {
+			seen.push(url);
+			return url.endsWith("miss") ? undefined : `value:${url}`;
+		};
+
+		const batch = batchFromSingular(singular);
+		const result = await batch(["https://a", "https://b", "https://miss"]);
+
+		expect(seen).toEqual(["https://a", "https://b", "https://miss"]);
+		expect(result.get("https://a")).toBe("value:https://a");
+		expect(result.get("https://b")).toBe("value:https://b");
+		expect(result.has("https://miss")).toBe(true);
+		expect(result.get("https://miss")).toBeUndefined();
+	});
+
+	it("returns an empty map for empty input without calling the singular", async () => {
+		let calls = 0;
+		const batch = batchFromSingular(async () => {
+			calls += 1;
+			return "x";
+		});
+
+		const result = await batch([]);
+
+		expect(result.size).toBe(0);
+		expect(calls).toBe(0);
+	});
+});

--- a/projects/hutch/src/runtime/batch-from-singular.ts
+++ b/projects/hutch/src/runtime/batch-from-singular.ts
@@ -1,0 +1,15 @@
+/** Derives a batched read from a single-article read by looping it, keyed by the
+ * url as given. The in-memory dev/test providers only expose the singular
+ * contract, so the queue's batched loadSummaries/loadCrawls are fed a loop over
+ * it: one read per url, matching both the production DynamoDB batch's per-url
+ * result shape and the read count the singular path produced (which the
+ * summary-poll fake depends on to transition pending -> ready). Production wires
+ * the real BatchGet instead; this is only for the in-memory composition roots. */
+export function batchFromSingular<T>(
+	singular: (url: string) => Promise<T>,
+): (urls: readonly string[]) => Promise<ReadonlyMap<string, T>> {
+	return async (urls) =>
+		new Map(
+			await Promise.all(urls.map(async (url) => [url, await singular(url)] as const)),
+		);
+}

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -92,10 +92,12 @@ import type { ReadArticleContent } from "@packages/provider-contracts/article-st
 import type { RefreshArticleIfStale } from "@packages/provider-contracts/article-freshness";
 import type {
 	FindArticleCrawlStatus,
+	FindArticleCrawlStatuses,
 	ForceMarkCrawlPending,
 	MarkCrawlPending,
 } from "@packages/provider-contracts/article-crawl";
 import type {
+	FindGeneratedSummaries,
 	FindGeneratedSummary,
 	MarkSummaryPending,
 } from "@packages/provider-contracts/article-summary";
@@ -302,8 +304,10 @@ interface AppDependencies {
 	statPendingUpload: StatPendingUpload;
 	readPendingUploadPrefix: ReadPendingUploadPrefix;
 	findGeneratedSummary: FindGeneratedSummary;
+	findGeneratedSummaries: FindGeneratedSummaries;
 	markSummaryPending: MarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
+	findArticleCrawlStatuses: FindArticleCrawlStatuses;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;
 	refreshArticleIfStale: RefreshArticleIfStale;
@@ -1034,8 +1038,10 @@ export function createApp(dependencies: AppDependencies): Express {
 		statPendingUpload: deps.statPendingUpload,
 		readPendingUploadPrefix: deps.readPendingUploadPrefix,
 		findGeneratedSummary: deps.findGeneratedSummary,
+		findGeneratedSummaries: deps.findGeneratedSummaries,
 		markSummaryPending: deps.markSummaryPending,
 		findArticleCrawlStatus: deps.findArticleCrawlStatus,
+		findArticleCrawlStatuses: deps.findArticleCrawlStatuses,
 		markCrawlPending: deps.markCrawlPending,
 		refreshArticleIfStale: deps.refreshArticleIfStale,
 		resolveCanonicalIdentity: deps.resolveCanonicalIdentity,

--- a/projects/hutch/src/runtime/test-app.ts
+++ b/projects/hutch/src/runtime/test-app.ts
@@ -25,6 +25,7 @@ import type {
 } from "@packages/web-test-harness";
 import { useTestServer as useServerForFixture } from "@packages/web-test-harness";
 import { createApp } from "./server";
+import { batchFromSingular } from "./batch-from-singular";
 import { readplaceUnwrapPreprocessor } from "./web/pages/view/readplace-unwrap-preprocessor";
 import { unwrappedPreProcessors, withUnwrapPreprocessing } from "./web/unwrap-preprocessors";
 import type { GetChangelogBanner } from "./web/changelog-banner-source";
@@ -154,6 +155,7 @@ function flattenFixtureToAppDependencies(
 		markSummaryToggled: fixture.articleStore.markSummaryToggled,
 		readArticleContent: fixture.articleStore.readArticleContent,
 		findArticleCrawlStatus: fixture.articleCrawl.findArticleCrawlStatus,
+		findArticleCrawlStatuses: batchFromSingular(fixture.articleCrawl.findArticleCrawlStatus),
 		markCrawlPending: fixture.articleCrawl.markCrawlPending,
 		forceMarkCrawlPending: fixture.articleCrawl.forceMarkCrawlPending,
 		publishLinkSaved: fixture.events.publishLinkSaved,
@@ -174,6 +176,7 @@ function flattenFixtureToAppDependencies(
 		statPendingUpload: fixture.pendingUpload.statPendingUpload,
 		readPendingUploadPrefix: fixture.pendingUpload.readPendingUploadPrefix,
 		findGeneratedSummary: fixture.summary.findGeneratedSummary,
+		findGeneratedSummaries: batchFromSingular(fixture.summary.findGeneratedSummary),
 		markSummaryPending: fixture.summary.markSummaryPending,
 		refreshArticleIfStale: fixture.freshness.refreshArticleIfStale,
 		resolveCanonicalIdentity: async (url: string) => url,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -49,6 +49,51 @@ describe("Queue routes", () => {
 		});
 	});
 
+	describe("GET /queue — degraded batched summary/crawl reads", () => {
+		it("still renders the cards (minus chips) and logs when the batch reads reject", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const logged: string[] = [];
+			// The in-memory bundles expose only the singular read; test-app derives the
+			// batch by looping it, so a throwing singular makes the derived batch
+			// reject — exercising loadSummaries/loadCrawls' degradation path.
+			const harness = useApp({
+				...fixture,
+				summary: {
+					...fixture.summary,
+					findGeneratedSummary: async () => {
+						throw new Error("summary read unavailable");
+					},
+				},
+				articleCrawl: {
+					...fixture.articleCrawl,
+					findArticleCrawlStatus: async () => {
+						throw new Error("crawl read unavailable");
+					},
+				},
+				shared: {
+					...fixture.shared,
+					logError: (message: string) => {
+						logged.push(message);
+					},
+				},
+			});
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			await agent.post("/queue/save").type("form").send({ url: "https://example.com/degraded" });
+			const response = await agent.get("/queue");
+
+			expect(response.status).toBe(200);
+			const doc = new JSDOM(response.text).window.document;
+			expect(doc.querySelectorAll("[data-test-article-list] .queue-article").length).toBe(1);
+			expect(logged).toEqual(
+				expect.arrayContaining([
+					"Failed to batch-load article summaries",
+					"Failed to batch-load article crawl statuses",
+				]),
+			);
+		});
+	});
+
 	describe("Read status indicators", () => {
 		it("should show unread indicator on newly saved articles", async () => {
 			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -53,9 +53,11 @@ import type { ReadArticleContent } from "@packages/provider-contracts/article-st
 import type {
 	ArticleCrawl,
 	FindArticleCrawlStatus,
+	FindArticleCrawlStatuses,
 	MarkCrawlPending,
 } from "@packages/provider-contracts/article-crawl";
 import type {
+	FindGeneratedSummaries,
 	FindGeneratedSummary,
 	GeneratedSummary,
 	MarkSummaryPending,
@@ -221,8 +223,10 @@ interface QueueDependencies {
 	statPendingUpload: StatPendingUpload;
 	readPendingUploadPrefix: ReadPendingUploadPrefix;
 	findGeneratedSummary: FindGeneratedSummary;
+	findGeneratedSummaries: FindGeneratedSummaries;
 	markSummaryPending: MarkSummaryPending;
 	findArticleCrawlStatus: FindArticleCrawlStatus;
+	findArticleCrawlStatuses: FindArticleCrawlStatuses;
 	markCrawlPending: MarkCrawlPending;
 	refreshArticleIfStale: RefreshArticleIfStale;
 	resolveCanonicalIdentity: (url: string) => Promise<string>;
@@ -274,25 +278,36 @@ interface QueueDependencies {
 import type { SavedArticle } from "@packages/domain/article";
 
 async function loadSummaries(
-	findGeneratedSummary: FindGeneratedSummary,
+	findGeneratedSummaries: FindGeneratedSummaries,
 	articles: readonly SavedArticle[],
+	logError: (message: string, error?: Error) => void,
 ): Promise<Map<string, GeneratedSummary | undefined>> {
-	const results = await Promise.allSettled(articles.map((a) => findGeneratedSummary(a.url)));
-	return new Map(articles.map((a, i) => {
-		const r = results[i];
-		return [a.url, r.status === "fulfilled" ? r.value : undefined] as const;
-	}));
+	const urls = articles.map((a) => a.url);
+	try {
+		const byUrl = await findGeneratedSummaries(urls);
+		return new Map(urls.map((url) => [url, byUrl.get(url)] as const));
+	} catch (error) {
+		// A whole-batch transport failure degrades every card to "no summary chip"
+		// (the same visible outcome the old per-item allSettled produced), but log
+		// it — the previous silent swallow made this class of failure invisible.
+		logError("Failed to batch-load article summaries", error instanceof Error ? error : undefined);
+		return new Map(urls.map((url) => [url, undefined] as const));
+	}
 }
 
 async function loadCrawls(
-	findArticleCrawlStatus: FindArticleCrawlStatus,
+	findArticleCrawlStatuses: FindArticleCrawlStatuses,
 	articles: readonly SavedArticle[],
+	logError: (message: string, error?: Error) => void,
 ): Promise<Map<string, ArticleCrawl | undefined>> {
-	const results = await Promise.allSettled(articles.map((a) => findArticleCrawlStatus(a.url)));
-	return new Map(articles.map((a, i) => {
-		const r = results[i];
-		return [a.url, r.status === "fulfilled" ? r.value : undefined] as const;
-	}));
+	const urls = articles.map((a) => a.url);
+	try {
+		const byUrl = await findArticleCrawlStatuses(urls);
+		return new Map(urls.map((url) => [url, byUrl.get(url)] as const));
+	} catch (error) {
+		logError("Failed to batch-load article crawl statuses", error instanceof Error ? error : undefined);
+		return new Map(urls.map((url) => [url, undefined] as const));
+	}
 }
 
 const UNREAD_BADGE_COUNT_LIMIT = 100;
@@ -724,8 +739,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		const statusFlash = statusFlashMapping(req.query);
 		const importSkipped = readImportSkippedFlash(req, res);
 		const [summaryByUrl, crawlByUrl, effectiveAccess] = await Promise.all([
-			loadSummaries(deps.findGeneratedSummary, result.articles),
-			loadCrawls(deps.findArticleCrawlStatus, result.articles),
+			loadSummaries(deps.findGeneratedSummaries, result.articles, deps.logError),
+			loadCrawls(deps.findArticleCrawlStatuses, result.articles, deps.logError),
 			deps.getEffectiveAccess(userId),
 		]);
 		const vm = toQueueViewModel(result, urlState, {
@@ -1149,8 +1164,8 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			const urlState = parseQueueUrl({});
 			const result = await deps.findArticlesByUser({ userId });
 			const [summaryByUrl, crawlByUrl] = await Promise.all([
-				loadSummaries(deps.findGeneratedSummary, result.articles),
-				loadCrawls(deps.findArticleCrawlStatus, result.articles),
+				loadSummaries(deps.findGeneratedSummaries, result.articles, deps.logError),
+				loadCrawls(deps.findArticleCrawlStatuses, result.articles, deps.logError),
 			]);
 			const vm = toQueueViewModel(result, urlState, {
 				errors: [{ message: validation.error.message }],

--- a/src/packages/article-store/src/dynamodb-article-crawl.test.ts
+++ b/src/packages/article-store/src/dynamodb-article-crawl.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
@@ -26,6 +27,137 @@ const FROZEN_NOW = new Date("2026-07-17T10:00:00.000Z");
 const now = () => FROZEN_NOW;
 
 describe("initDynamoDbArticleCrawl", () => {
+	describe("findArticleCrawlStatuses (batch)", () => {
+		interface BatchRequest {
+			Keys: { url: string }[];
+			ProjectionExpression?: string;
+			ExpressionAttributeNames?: Record<string, string>;
+		}
+		interface Captured {
+			commands: { input: { RequestItems?: Record<string, BatchRequest> } }[];
+		}
+
+		function batchClient(
+			rows: Record<string, unknown>[],
+			captured: Captured,
+		): DynamoDBDocumentClient {
+			return createFakeClient((input) => {
+				const command = input as Captured["commands"][number];
+				captured.commands.push(command);
+				const tableName = Object.keys(command.input.RequestItems ?? {})[0] ?? TABLE;
+				return { Responses: { [tableName]: rows }, UnprocessedKeys: {} };
+			}) as DynamoDBDocumentClient;
+		}
+
+		function requestFor(captured: Captured): BatchRequest {
+			const req = captured.commands[0]?.input.RequestItems?.[TABLE];
+			assert(req, "a BatchGet must have been issued against the table");
+			return req;
+		}
+
+		it("issues one BatchGet with normalized, deduped keys and a projection that excludes content", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient([{ url: "example.com/a", crawlStatus: "ready" }], captured);
+			const { findArticleCrawlStatuses } = initDynamoDbArticleCrawl({ client, tableName: TABLE, now });
+
+			const map = await findArticleCrawlStatuses([
+				"https://example.com/a",
+				"https://example.com/a#heading",
+			]);
+
+			expect(captured.commands).toHaveLength(1);
+			const req = requestFor(captured);
+			expect(req.Keys).toEqual([{ url: "example.com/a" }]);
+			const projectedNames = Object.values(req.ExpressionAttributeNames ?? {});
+			expect(projectedNames).not.toContain("content");
+			expect(projectedNames).toEqual(
+				expect.arrayContaining(["url", "crawlStatus", "crawlStage"]),
+			);
+			expect(req.ProjectionExpression).not.toContain("content");
+			expect(map.get("https://example.com/a")).toEqual({ status: "ready" });
+			expect(map.get("https://example.com/a#heading")).toEqual({ status: "ready" });
+		});
+
+		it("keys every input url, mapping a missing row to undefined", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient([{ url: "example.com/present", crawlStatus: "ready" }], captured);
+			const { findArticleCrawlStatuses } = initDynamoDbArticleCrawl({ client, tableName: TABLE, now });
+
+			const map = await findArticleCrawlStatuses([
+				"https://example.com/present",
+				"https://example.com/absent",
+			]);
+
+			expect(map.has("https://example.com/absent")).toBe(true);
+			expect(map.get("https://example.com/absent")).toBeUndefined();
+			expect(map.get("https://example.com/present")).toEqual({ status: "ready" });
+		});
+
+		it("degrades only the poisoned row (unknown status enum), mapping its siblings", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[
+					{ url: "example.com/good", crawlStatus: "ready" },
+					{ url: "example.com/poison", crawlStatus: "not-a-real-status" },
+				],
+				captured,
+			);
+			const { findArticleCrawlStatuses } = initDynamoDbArticleCrawl({ client, tableName: TABLE, now });
+
+			const map = await findArticleCrawlStatuses([
+				"https://example.com/good",
+				"https://example.com/poison",
+			]);
+
+			expect(map.get("https://example.com/poison")).toBeUndefined();
+			expect(map.get("https://example.com/good")).toEqual({ status: "ready" });
+		});
+
+		it("degrades a row that trips a mapper assert (failed without a reason) without throwing the batch", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[
+					{ url: "example.com/ok", crawlStatus: "ready" },
+					{ url: "example.com/broken", crawlStatus: "failed" },
+				],
+				captured,
+			);
+			const { findArticleCrawlStatuses } = initDynamoDbArticleCrawl({ client, tableName: TABLE, now });
+
+			const map = await findArticleCrawlStatuses([
+				"https://example.com/ok",
+				"https://example.com/broken",
+			]);
+
+			expect(map.get("https://example.com/broken")).toBeUndefined();
+			expect(map.get("https://example.com/ok")).toEqual({ status: "ready" });
+		});
+
+		it("maps an unparseable input url to undefined and never sends its key", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient([{ url: "example.com/valid", crawlStatus: "pending" }], captured);
+			const { findArticleCrawlStatuses } = initDynamoDbArticleCrawl({ client, tableName: TABLE, now });
+
+			const map = await findArticleCrawlStatuses(["https://example.com/valid", "not a url"]);
+
+			expect(map.has("not a url")).toBe(true);
+			expect(map.get("not a url")).toBeUndefined();
+			expect(map.get("https://example.com/valid")).toEqual({ status: "pending" });
+			expect(requestFor(captured).Keys).toEqual([{ url: "example.com/valid" }]);
+		});
+
+		it("sends no request for empty input", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient([], captured);
+			const { findArticleCrawlStatuses } = initDynamoDbArticleCrawl({ client, tableName: TABLE, now });
+
+			const map = await findArticleCrawlStatuses([]);
+
+			expect(map.size).toBe(0);
+			expect(captured.commands).toHaveLength(0);
+		});
+	});
+
 	describe("findArticleCrawlStatus", () => {
 		it("returns undefined when no row exists", async () => {
 			const { findArticleCrawlStatus } = initDynamoDbArticleCrawl({

--- a/src/packages/article-store/src/dynamodb-article-crawl.ts
+++ b/src/packages/article-store/src/dynamodb-article-crawl.ts
@@ -3,6 +3,7 @@ import { CrawlStatusSchema } from "@packages/article-state-types";
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
+	batchGetFromTable,
 	defineDynamoTable,
 	dynamoField,
 } from "@packages/hutch-storage-client";
@@ -11,6 +12,7 @@ import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import type {
 	ArticleCrawl,
 	FindArticleCrawlStatus,
+	FindArticleCrawlStatuses,
 	ForceMarkCrawlPending,
 	MarkCrawlPending,
 } from "@packages/provider-contracts/article-crawl";
@@ -75,12 +77,18 @@ function rowToArticleCrawl(
 	return undefined;
 }
 
+// Loose schema for the batch read: batchGetFromTable runs `schema.parse` on
+// every returned item, so a strict schema would discard the whole batch on one
+// malformed row. Each row is re-validated strictly below, per row.
+const LooseArticleCrawlRow = z.looseObject({ url: z.string() });
+
 export function initDynamoDbArticleCrawl(deps: {
 	client: DynamoDBDocumentClient;
 	tableName: string;
 	now: () => Date;
 }): {
 	findArticleCrawlStatus: FindArticleCrawlStatus;
+	findArticleCrawlStatuses: FindArticleCrawlStatuses;
 	markCrawlPending: MarkCrawlPending;
 	forceMarkCrawlPending: ForceMarkCrawlPending;
 } {
@@ -94,6 +102,51 @@ export function initDynamoDbArticleCrawl(deps: {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
 		const row = await table.get({ url: articleResourceUniqueId.value });
 		return rowToArticleCrawl(row);
+	};
+
+	const findArticleCrawlStatuses: FindArticleCrawlStatuses = async (urls) => {
+		const result = new Map<string, ArticleCrawl | undefined>();
+		const keyToUrls = new Map<string, string[]>();
+		for (const url of urls) {
+			let normalizedKey: string;
+			try {
+				normalizedKey = ArticleResourceUniqueId.parse(url).value;
+			} catch {
+				result.set(url, undefined);
+				continue;
+			}
+			const group = keyToUrls.get(normalizedKey);
+			if (group) group.push(url);
+			else keyToUrls.set(normalizedKey, [url]);
+		}
+		if (keyToUrls.size === 0) return result;
+
+		const rows = await batchGetFromTable({
+			client: deps.client,
+			tableName: deps.tableName,
+			schema: LooseArticleCrawlRow,
+			keys: [...keyToUrls.keys()].map((url) => ({ url })),
+			projection: ArticleCrawlRow.keyof().options,
+		});
+
+		const valueByKey = new Map<string, ArticleCrawl | undefined>();
+		for (const row of rows) {
+			const parsed = ArticleCrawlRow.safeParse(row);
+			let value: ArticleCrawl | undefined;
+			if (parsed.success) {
+				try {
+					value = rowToArticleCrawl(parsed.data);
+				} catch {
+					value = undefined;
+				}
+			}
+			valueByKey.set(row.url, value);
+		}
+		for (const [key, groupUrls] of keyToUrls) {
+			const value = valueByKey.get(key);
+			for (const url of groupUrls) result.set(url, value);
+		}
+		return result;
 	};
 
 	const markCrawlPending: MarkCrawlPending = async ({ url }) => {
@@ -131,6 +184,7 @@ export function initDynamoDbArticleCrawl(deps: {
 
 	return {
 		findArticleCrawlStatus,
+		findArticleCrawlStatuses,
 		markCrawlPending,
 		forceMarkCrawlPending,
 	};

--- a/src/packages/article-store/src/dynamodb-generated-summary.test.ts
+++ b/src/packages/article-store/src/dynamodb-generated-summary.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
@@ -215,6 +216,146 @@ describe("initDynamoDbGeneratedSummary", () => {
 		const result = await findGeneratedSummary("https://example.com/article");
 
 		expect(result).toEqual({ status: "skipped", reason: "content-too-short" });
+	});
+
+	describe("findGeneratedSummaries (batch)", () => {
+		interface BatchRequest {
+			Keys: { url: string }[];
+			ProjectionExpression?: string;
+			ExpressionAttributeNames?: Record<string, string>;
+		}
+		interface Captured {
+			commands: { input: { RequestItems?: Record<string, BatchRequest> } }[];
+		}
+
+		function batchClient(
+			rows: Record<string, unknown>[],
+			captured: Captured,
+		): DynamoDBDocumentClient {
+			return createSendingClient((input) => {
+				const command = input as Captured["commands"][number];
+				captured.commands.push(command);
+				const tableName = Object.keys(command.input.RequestItems ?? {})[0] ?? "test-table";
+				return { Responses: { [tableName]: rows }, UnprocessedKeys: {} };
+			});
+		}
+
+		function requestFor(captured: Captured): BatchRequest {
+			const req = captured.commands[0]?.input.RequestItems?.["test-table"];
+			assert(req, "a BatchGet must have been issued against test-table");
+			return req;
+		}
+
+		it("issues one BatchGet with normalized, deduped keys and a projection that excludes content", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[{ url: "example.com/a", summaryStatus: "ready", summary: "A" }],
+				captured,
+			);
+			const { findGeneratedSummaries } = initDynamoDbGeneratedSummary({ client, tableName: "test-table" });
+
+			const map = await findGeneratedSummaries([
+				"https://example.com/a",
+				"https://example.com/a#heading", // strips to the same table key
+			]);
+
+			expect(captured.commands).toHaveLength(1);
+			const req = requestFor(captured);
+			expect(req.Keys).toEqual([{ url: "example.com/a" }]);
+			const projectedNames = Object.values(req.ExpressionAttributeNames ?? {});
+			expect(projectedNames).not.toContain("content");
+			expect(projectedNames).toEqual(
+				expect.arrayContaining(["url", "summaryStatus", "summary", "summaryExcerpt"]),
+			);
+			expect(req.ProjectionExpression).not.toContain("content");
+			expect(map.get("https://example.com/a")).toEqual({ status: "ready", summary: "A" });
+			expect(map.get("https://example.com/a#heading")).toEqual({ status: "ready", summary: "A" });
+		});
+
+		it("keys every input url, mapping a missing row to undefined", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[{ url: "example.com/present", summaryStatus: "ready", summary: "Here" }],
+				captured,
+			);
+			const { findGeneratedSummaries } = initDynamoDbGeneratedSummary({ client, tableName: "test-table" });
+
+			const map = await findGeneratedSummaries([
+				"https://example.com/present",
+				"https://example.com/absent",
+			]);
+
+			expect(map.has("https://example.com/absent")).toBe(true);
+			expect(map.get("https://example.com/absent")).toBeUndefined();
+			expect(map.get("https://example.com/present")).toEqual({ status: "ready", summary: "Here" });
+		});
+
+		it("degrades only the poisoned row (unknown status enum), mapping its siblings", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[
+					{ url: "example.com/good", summaryStatus: "ready", summary: "Good" },
+					{ url: "example.com/poison", summaryStatus: "not-a-real-status" },
+				],
+				captured,
+			);
+			const { findGeneratedSummaries } = initDynamoDbGeneratedSummary({ client, tableName: "test-table" });
+
+			const map = await findGeneratedSummaries([
+				"https://example.com/good",
+				"https://example.com/poison",
+			]);
+
+			expect(map.get("https://example.com/poison")).toBeUndefined();
+			expect(map.get("https://example.com/good")).toEqual({ status: "ready", summary: "Good" });
+		});
+
+		it("degrades a row that trips a mapper assert (ready without summary text) without throwing the batch", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[
+					{ url: "example.com/ok", summaryStatus: "ready", summary: "OK" },
+					{ url: "example.com/broken", summaryStatus: "ready" },
+				],
+				captured,
+			);
+			const { findGeneratedSummaries } = initDynamoDbGeneratedSummary({ client, tableName: "test-table" });
+
+			const map = await findGeneratedSummaries([
+				"https://example.com/ok",
+				"https://example.com/broken",
+			]);
+
+			expect(map.get("https://example.com/broken")).toBeUndefined();
+			expect(map.get("https://example.com/ok")).toEqual({ status: "ready", summary: "OK" });
+		});
+
+		it("maps an unparseable input url to undefined and never sends its key", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient(
+				[{ url: "example.com/valid", summaryStatus: "pending" }],
+				captured,
+			);
+			const { findGeneratedSummaries } = initDynamoDbGeneratedSummary({ client, tableName: "test-table" });
+
+			const map = await findGeneratedSummaries(["https://example.com/valid", "not a url"]);
+
+			expect(map.has("not a url")).toBe(true);
+			expect(map.get("not a url")).toBeUndefined();
+			expect(map.get("https://example.com/valid")).toEqual({ status: "pending" });
+			expect(requestFor(captured).Keys).toEqual([{ url: "example.com/valid" }]);
+		});
+
+		it("sends no request for empty input", async () => {
+			const captured: Captured = { commands: [] };
+			const client = batchClient([], captured);
+			const { findGeneratedSummaries } = initDynamoDbGeneratedSummary({ client, tableName: "test-table" });
+
+			const map = await findGeneratedSummaries([]);
+
+			expect(map.size).toBe(0);
+			expect(captured.commands).toHaveLength(0);
+		});
 	});
 
 	describe("markSummaryPending", () => {

--- a/src/packages/article-store/src/dynamodb-generated-summary.ts
+++ b/src/packages/article-store/src/dynamodb-generated-summary.ts
@@ -3,6 +3,7 @@ import { SummaryStatusSchema } from "@packages/article-state-types";
 import {
 	ConditionalCheckFailedException,
 	type DynamoDBDocumentClient,
+	batchGetFromTable,
 	defineDynamoTable,
 	dynamoField,
 } from "@packages/hutch-storage-client";
@@ -10,6 +11,7 @@ import { z } from "zod";
 import { ArticleResourceUniqueId } from "@packages/article-resource-unique-id";
 import type {
 	GeneratedSummary,
+	FindGeneratedSummaries,
 	FindGeneratedSummary,
 	MarkSummaryPending,
 } from "@packages/provider-contracts/article-summary";
@@ -76,11 +78,17 @@ function rowToGeneratedSummary(
 	return readyFromRow(row.summary, row.summaryExcerpt);
 }
 
+// Loose schema for the batch read: batchGetFromTable runs `schema.parse` on
+// every returned item, so a strict schema would discard the whole batch on one
+// malformed row. Each row is re-validated strictly below, per row.
+const LooseArticleSummaryRow = z.looseObject({ url: z.string() });
+
 export function initDynamoDbGeneratedSummary(deps: {
 	client: DynamoDBDocumentClient;
 	tableName: string;
 }): {
 	findGeneratedSummary: FindGeneratedSummary;
+	findGeneratedSummaries: FindGeneratedSummaries;
 	markSummaryPending: MarkSummaryPending;
 } {
 	const table = defineDynamoTable({
@@ -93,6 +101,51 @@ export function initDynamoDbGeneratedSummary(deps: {
 		const articleResourceUniqueId = ArticleResourceUniqueId.parse(url);
 		const row = await table.get({ url: articleResourceUniqueId.value });
 		return rowToGeneratedSummary(row);
+	};
+
+	const findGeneratedSummaries: FindGeneratedSummaries = async (urls) => {
+		const result = new Map<string, GeneratedSummary | undefined>();
+		const keyToUrls = new Map<string, string[]>();
+		for (const url of urls) {
+			let normalizedKey: string;
+			try {
+				normalizedKey = ArticleResourceUniqueId.parse(url).value;
+			} catch {
+				result.set(url, undefined);
+				continue;
+			}
+			const group = keyToUrls.get(normalizedKey);
+			if (group) group.push(url);
+			else keyToUrls.set(normalizedKey, [url]);
+		}
+		if (keyToUrls.size === 0) return result;
+
+		const rows = await batchGetFromTable({
+			client: deps.client,
+			tableName: deps.tableName,
+			schema: LooseArticleSummaryRow,
+			keys: [...keyToUrls.keys()].map((url) => ({ url })),
+			projection: ArticleSummaryRow.keyof().options,
+		});
+
+		const valueByKey = new Map<string, GeneratedSummary | undefined>();
+		for (const row of rows) {
+			const parsed = ArticleSummaryRow.safeParse(row);
+			let value: GeneratedSummary | undefined;
+			if (parsed.success) {
+				try {
+					value = rowToGeneratedSummary(parsed.data);
+				} catch {
+					value = undefined;
+				}
+			}
+			valueByKey.set(row.url, value);
+		}
+		for (const [key, groupUrls] of keyToUrls) {
+			const value = valueByKey.get(key);
+			for (const url of groupUrls) result.set(url, value);
+		}
+		return result;
 	};
 
 	const markSummaryPending: MarkSummaryPending = async ({ url }) => {
@@ -113,5 +166,5 @@ export function initDynamoDbGeneratedSummary(deps: {
 		}
 	};
 
-	return { findGeneratedSummary, markSummaryPending };
+	return { findGeneratedSummary, findGeneratedSummaries, markSummaryPending };
 }

--- a/src/packages/provider-contracts/src/article-crawl.ts
+++ b/src/packages/provider-contracts/src/article-crawl.ts
@@ -15,6 +15,14 @@ export type FindArticleCrawlStatus = (
 	url: string,
 ) => Promise<ArticleCrawl | undefined>;
 
+/** Batched form of {@link FindArticleCrawlStatus}. Every input url has an entry
+ * in the returned map (value possibly `undefined`), keyed by the url as given. A
+ * row missing, unparseable, or failing the strict row schema degrades to
+ * `undefined` for that url only; a transport failure rejects the whole call. */
+export type FindArticleCrawlStatuses = (
+	urls: readonly string[],
+) => Promise<ReadonlyMap<string, ArticleCrawl | undefined>>;
+
 export type MarkCrawlPending = (params: { url: string }) => Promise<void>;
 
 /**

--- a/src/packages/provider-contracts/src/article-summary.ts
+++ b/src/packages/provider-contracts/src/article-summary.ts
@@ -8,6 +8,14 @@ export type GeneratedSummary =
 
 export type FindGeneratedSummary = (url: string) => Promise<GeneratedSummary | undefined>;
 
+/** Batched form of {@link FindGeneratedSummary}. Every input url has an entry in
+ * the returned map (value possibly `undefined`), keyed by the url as given. A row
+ * missing, unparseable, or failing the strict row schema degrades to `undefined`
+ * for that url only; a transport failure rejects the whole call. */
+export type FindGeneratedSummaries = (
+	urls: readonly string[],
+) => Promise<ReadonlyMap<string, GeneratedSummary | undefined>>;
+
 export type MarkSummaryPending = (params: { url: string }) => Promise<void>;
 
 export const MAX_SUMMARY_LENGTH = 750;


### PR DESCRIPTION
## Summary

The `/queue` render fired **2N individual DynamoDB GetItems** — one `findGeneratedSummary` and one `findArticleCrawlStatus` per card (40 at pageSize 20) — each issued **without a projection**, so every one hauled the full article row including legacy inline `content` blobs (up to 400 KB/item).

This adds two batched read contracts implemented over the existing `batchGetFromTable` helper with a **content-excluding projection**, collapsing the 2N GetItems into **2 BatchGets** of projected metadata.

```ts
export type FindGeneratedSummaries = (urls: readonly string[]) => Promise<ReadonlyMap<string, GeneratedSummary | undefined>>;
export type FindArticleCrawlStatuses = (urls: readonly string[]) => Promise<ReadonlyMap<string, ArticleCrawl | undefined>>;
```

## Contract semantics (match today's per-item `allSettled`)
- Every input url is keyed (value possibly `undefined`), keyed by the url as given.
- A **missing**, **unparseable**, or **schema-poisoned** row degrades to `undefined` for **that url only** — a loose batch schema is fed to `batchGetFromTable` (so one malformed row doesn't throw the whole batch), then each row is re-validated with strict `safeParse` + the existing mapper inside `try/catch`.
- Duplicate-normalizing urls dedupe to one BatchGet key and fan the result back out.
- A whole-batch **transport failure rejects** and is now logged via `deps.logError` (previously swallowed silently by `allSettled`).
- Empty input → empty map, no network call.

## What win this is (honest)
The 40 GetItems already ran in parallel, so wall-clock ≈ 1 in-region RTT today. The gains are: **2 SDK request cycles instead of 40**, **~2 × 20 × ~1 KB projected bytes instead of 40 × full rows (incl. content blobs)**, and **2 tail-latency samples instead of 40**. RCU is unchanged. Expect ~20–80 ms of serial serialize/parse think-time off the `/queue` render on a 512 MB Lambda — to be measured post-deploy.

## Scope preserved
- The **singular** contracts (`findGeneratedSummary` / `findArticleCrawlStatus`) stay for the reader, `GET /queue/:id/card`, `/view`, admin recrawl, MCP, and digest paths.
- The Siren `GET /queue` branch returns before the batch call — untouched.
- Production wires the real BatchGet; **dev and tests compose the batch by looping the in-memory singular** (`batchFromSingular`), preserving the one-read-per-url count the summary-poll fake depends on for its pending → ready transition.

## Testing
- `pnpm check` green across all 45 projects, **100% coverage** on the new code (the batch impls, `batch-from-singular`, and the degraded-render route test).
- New unit tests (fake-client capturing the `BatchGetCommand`): single BatchGet per store, normalized + deduped keys, `ProjectionExpression` excludes `content`, missing row → `undefined`, poisoned row (unknown status enum) degrades only its url, mapper-assert trip degrades without throwing the batch, unparseable url never reaches Dynamo, empty input sends nothing.
- New route test: a whole-batch rejection still renders `/queue` 200 with the cards (minus chips) and logs both failures.
- Existing queue/reader/view route suites and E2E pins pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMZviBeuMsmp3JsocavnUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMZviBeuMsmp3JsocavnUE)_