### PR TITLE
fix(inbox): phrase the Articles report button as a statement, like its twin

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.test.ts
@@ -159,7 +159,7 @@ describe("toInboxLinkCardViewModel", () => {
 		expect(crawled.url).toBe("https://destination.test/article?ref=nodeweekly");
 		expect(crawled.actions.map((action) => action.ariaLabel)).toEqual([
 			"Save to queue: https://destination.test/article?ref=nodeweekly",
-			"Not an article? (report) https://destination.test/article?ref=nodeweekly",
+			"Not an article (report): https://destination.test/article?ref=nodeweekly",
 		]);
 	});
 

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts
@@ -90,8 +90,8 @@ function buildCardActions(input: {
 	}
 	actions.push({
 		key: "feedback-exclude",
-		label: "Not an article? (report)",
-		ariaLabel: `Not an article? (report) ${displayUrl}`,
+		label: "Not an article (report)",
+		ariaLabel: `Not an article (report): ${displayUrl}`,
 		buttonId: buttonId("feedback-exclude"),
 		href: buildInboxLinkFeedbackUrl({ emailId, ordinal: link.ordinal }),
 		method: "POST",


### PR DESCRIPTION
## What

The two inbox feedback buttons are the same mechanism pointing in opposite directions, but they were phrased in two different grammatical moods:

- **Articles card** asked it as a question — `Not an article? (report)`
- **Skipped panel** stated it — `This is an article (report)`

This settles the Articles button on the **statement** form to match its twin.

| | Before | After |
|---|---|---|
| Visible label | `Not an article? (report)` | `Not an article (report)` |
| `aria-label` | `Not an article? (report) <url>` | `Not an article (report): <url>` |

## Why

The statement form is already the product's own voice for this verdict: `inbox-email-detail.viewmodel.ts` declares `GENERIC_EXCLUDED_LABEL = "Not an article"`, rendered as the skipped-link reason a few lines from the button that was asking it as a question.

The aria change does two things: it drops the question mark **and** adds a colon separator, so it now matches both the excluded button's `aria-label` (`This is an article (report): <url>`) and the card's own sibling Save action (`Save to queue: <url>`), instead of running the label straight into the URL with a bare space.

`(report)` stays on both buttons — commit `4016a43a` added it deliberately to align the two labels, so this change preserves that.

## Changes

- `projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts` — updated the `feedback-exclude` action's `label` and `ariaLabel` in `buildCardActions`.
- `projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.test.ts` — updated the verbatim `ariaLabel` assertion (the only test carrying the string).

The Skipped button (`inbox-excluded-link.template.html`) was already the target phrasing and is untouched.

## Testing

- `pnpm nx run inbox:check` — passes, 100% coverage. Pure copy change on an already-covered viewmodel path (same branches, same lines), so coverage is unaffected.
- Full-repo pre-commit `pnpm check` passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdkvwinEaPiFRaNSLZu9xp)_