### PR TITLE
fix(inbox): tint the inbox failure badge red instead of muted grey

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.styles.css
@@ -132,8 +132,8 @@
   flex: none;
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--muted-foreground);
-  border: 1px solid var(--border);
+  color: var(--error-text);
+  border: 1px solid var(--error-text);
   border-radius: var(--radius-sm);
   padding: 2px 8px;
   white-space: nowrap;


### PR DESCRIPTION
## What

The inbox failure badge (`.inbox-emails__badge`) now uses the `--error-text` token for its text and border instead of the muted grey (`--muted-foreground` / `--border`) it shared with every other piece of row metadata.

## Why

The badge only ever renders for a **failure** state — it carries `"Rejected"` or `"Couldn't render"`, gated by `needsBadge: entry.status !== "received"` in the viewmodel and `{{#if needsBadge}}` in the template. `"Received"` mail never gets a badge. Yet it sat in the same `.inbox-emails__meta-line` flex row as the `.inbox-emails__subject`, in the identical `--muted-foreground` grey, so a failure read as ordinary metadata rather than as something that went wrong.

## Approach

Because every rendered badge is a failure badge by construction, no new viewmodel field, template change, or per-status modifier class is needed — the base class is tinted directly:

- `color: var(--muted-foreground)` → `color: var(--error-text)`
- `border: 1px solid var(--border)` → `border: 1px solid var(--error-text)`

`--error-text` is the accessible-contrast error token minted for exactly this class of problem (light `hsl(0 43% 50%)`, dark `--color-error` `#D46B6B`). Contrast passes the 4.5:1 threshold for 0.75rem text in both themes, on both the card (`--card`) and row-hover (`--muted`) backgrounds.

Both `"Rejected"` and `"Couldn't render"` are terminal failures from the list's perspective, so they share one red treatment; no `--warning-tier` token is minted.

## Testing

- `pnpm nx run inbox:check` — passes, 100% coverage maintained.
- Full-workspace `pnpm check` ran green via the pre-commit hook.

This is a CSS-only change: no behaviour, viewmodel, or template delta, so no new test assertions are possible in the JSDOM route tests (external-stylesheet colours are not computed there). Existing coverage already pins the state this styling hangs off — `inbox-emails.route.test.ts` asserts the per-status badge renders (and that a received row carries none), and `inbox-emails.viewmodel.test.ts` pins the `needsBadge` invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Yei9a1yvz3kNhnmSMeANt)_