### PR TITLE
fix(inbox): add base CSS reset to email View-tab srcdoc so wide images fit the frame

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.test.ts
@@ -19,6 +19,27 @@ describe("buildInboxEmailIframeSrcdoc", () => {
 		expect(srcdoc).toContain('<base target="_top">');
 	});
 
+	it("injects a base <style> reset so a rehosted wide image cannot overflow the frame", () => {
+		const srcdoc = buildInboxEmailIframeSrcdoc({
+			bodyHtml: '<img width="600" height="400" alt="hero">',
+			imagesCdnBaseUrl: CDN,
+		});
+
+		// Caps a surviving `width="600"` attribute at the frame width, keeping the
+		// aspect ratio via `height:auto` (the `height` attribute also survives).
+		expect(srcdoc).toContain("img{max-width:100%;height:auto}");
+		// Deliberate padding over the UA 8px margin; `overflow-wrap:anywhere` breaks
+		// long unbroken tracking URLs rendered as bare text; `font-family` lifts
+		// near-plaintext forwards out of the iframe UA default (Times).
+		expect(srcdoc).toContain(
+			"body{margin:0;padding:12px;overflow-wrap:anywhere;font-family:system-ui,-apple-system,sans-serif}",
+		);
+		// `pre` is the one other allowlisted tag that can force horizontal overflow.
+		expect(srcdoc).toContain("pre{white-space:pre-wrap}");
+		// The reset must live in the head, never inside the sanitized body.
+		expect(srcdoc.indexOf("<style>")).toBeLessThan(srcdoc.indexOf("<body>"));
+	});
+
 	it("refuses a CDN base URL that is not a bare https origin", () => {
 		// A path, query, or semicolon could smuggle extra CSP source expressions or
 		// directives into the policy string.

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.test.ts
@@ -34,6 +34,11 @@ describe("buildInboxEmailIframeSrcdoc", () => {
 		expect(srcdoc).toContain(
 			"body{margin:0;padding:12px;overflow-wrap:anywhere;font-family:system-ui,-apple-system,sans-serif}",
 		);
+		// An explicit table width never survives the sanitizer, but auto table
+		// layout is content-driven: side-by-side cells of wide rehosted images
+		// expand to intrinsic width, so the img cap alone measures against the
+		// widened cell rather than the frame.
+		expect(srcdoc).toContain("table{max-width:100%}");
 		// `pre` is the one other allowlisted tag that can force horizontal overflow.
 		expect(srcdoc).toContain("pre{white-space:pre-wrap}");
 		// The reset must live in the head, never inside the sanitized body.

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.ts
@@ -14,8 +14,13 @@ import assert from "node:assert";
  * rewrote to `data:` URIs and the remote images the receive path rehosted to
  * our CDN — the host pin is what keeps "no tracking beacon can fire" true even
  * against a future sanitizer regression; `style-src 'unsafe-inline'` keeps the
- * email's own inline styling. `<base target="_top">` makes any surviving link
- * open the top tab. `bodyHtml` is already allowlist-sanitized.
+ * email's own inline styling AND legitimizes the base `<style>` reset below, so
+ * do not tighten it to nonce-only — that reset is the only thing that caps a
+ * rehosted `width="600"` hero image to the frame width (the sanitizer's `style=`
+ * allowlist has no `width`/`max-width`, so a surviving `width` attribute would
+ * otherwise force a horizontal scrollbar inside the ~350px frame on a phone).
+ * `<base target="_top">` makes any surviving link open the top tab. `bodyHtml`
+ * is already allowlist-sanitized.
  */
 export function buildInboxEmailIframeSrcdoc(input: {
 	bodyHtml: string;
@@ -31,6 +36,7 @@ export function buildInboxEmailIframeSrcdoc(input: {
 		"<!doctype html><html><head>",
 		'<meta charset="utf-8">',
 		`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: ${input.imagesCdnBaseUrl}; style-src 'unsafe-inline';">`,
+		"<style>img{max-width:100%;height:auto}body{margin:0;padding:12px;overflow-wrap:anywhere;font-family:system-ui,-apple-system,sans-serif}pre{white-space:pre-wrap}</style>",
 		'<base target="_top">',
 		"</head><body>",
 		input.bodyHtml,

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.ts
@@ -36,7 +36,7 @@ export function buildInboxEmailIframeSrcdoc(input: {
 		"<!doctype html><html><head>",
 		'<meta charset="utf-8">',
 		`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: ${input.imagesCdnBaseUrl}; style-src 'unsafe-inline';">`,
-		"<style>img{max-width:100%;height:auto}body{margin:0;padding:12px;overflow-wrap:anywhere;font-family:system-ui,-apple-system,sans-serif}pre{white-space:pre-wrap}</style>",
+		"<style>img{max-width:100%;height:auto}table{max-width:100%}body{margin:0;padding:12px;overflow-wrap:anywhere;font-family:system-ui,-apple-system,sans-serif}pre{white-space:pre-wrap}</style>",
 		'<base target="_top">',
 		"</head><body>",
 		input.bodyHtml,


### PR DESCRIPTION
## Problem

The email **View** tab renders forwarded newsletter HTML inside a sandboxed iframe via `srcdoc`, but that srcdoc emitted **no base stylesheet** — only a charset meta, a CSP meta, and `<base target="_top">`. Forwarded marketing HTML almost always leads with a hero image, and the receive path rehosts remote images to our CDN while the sanitizer keeps the `<img>` `width`/`height` **attributes** (`sanitize-email-html.ts`). So a rehosted `<img width="600">` kept its 600px pixel width inside a `width: 100%` frame that is only ~350px wide on a 390px phone, producing a **horizontal scrollbar inside the iframe** that clipped the right third of the image until the user dragged sideways.

The iframe's `sandbox` has no `allow-scripts`, so nothing can repair this client-side after the fact — the fix has to live in the srcdoc itself.

## Fix

`projects/inbox/src/runtime/web/pages/inbox/inbox-email-iframe-srcdoc.ts` now injects one `<style>` block into the srcdoc head. The existing CSP already carries `style-src 'unsafe-inline'`, so no policy change was needed:

```css
img{max-width:100%;height:auto}
body{margin:0;padding:12px;overflow-wrap:anywhere;font-family:system-ui,-apple-system,sans-serif}
pre{white-space:pre-wrap}
```

- `img{max-width:100%;height:auto}` — caps the surviving `width` attribute at the frame width; `height:auto` is load-bearing because the `height` attribute also survives the sanitizer and would otherwise squash the aspect ratio once width is capped.
- `body{margin:0;padding:12px;overflow-wrap:anywhere;…}` — replaces the UA 8px margin with deliberate padding, breaks long unbroken tracking URLs rendered as bare text, and lifts near-plaintext forwards out of the iframe UA default (Times) into `system-ui`.
- `pre{white-space:pre-wrap}` — `pre` is the one other allowlisted tag that can force horizontal overflow.

Sender inline styles cannot set `width`/`max-width`/`height`/`font-family` (none are in the sanitizer's `allowedStyles`), so a plain CSS property beats the surviving attributes without needing `!important`. `video`/viewport rules were deliberately skipped — a `video` tag can't survive the sanitizer, and an iframe's viewport is its own element box. `table{max-width:100%}` is included: an explicit table width can't survive the sanitizer, but auto table layout is content-driven, so side-by-side cells of wide rehosted images would otherwise widen past the frame.

The builder's JSDoc was extended to record that `style-src 'unsafe-inline'` now legitimizes this base reset, so a future reader doesn't tighten the CSP to nonce-only and silently reintroduce the overflow.

## Tests

- Extended `inbox-email-iframe-srcdoc.test.ts` with a new case asserting the three reset rules are present and an order guard that `<style>` precedes `<body>` (the reset can never end up inside sanitized content). The existing `style-src 'unsafe-inline'` assertion that makes the block legal is kept.
- The change is one new element in an unconditional array join — no new branches.
- Verified with `pnpm nx run inbox:check`: all tasks pass, 100% statement/branch/function/line coverage on the srcdoc builder. The full-workspace `pnpm check` pre-commit hook also passed.

## Scope

Layout-only changes inside an always-white document (`background: #ffffff` on the frame) — no colour token, contrast ratio, CSS file, template, or component changes. `@packages/domain` and `web-shell` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFnzpYw2tebzWB2s3UK9Mo)_
