### PR TITLE
fix(inbox): use straight apostrophes to match product-wide copy

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
@@ -905,7 +905,7 @@ describe("Inbox Articles panel poll route", () => {
 		const failed = doc.querySelector("[data-test-articles-failed]");
 		assert(failed, "the failed notice must render");
 		expect(failed.textContent).toBe(
-			"I couldn’t scan this email for links. The original message is still on the View tab.",
+			"I couldn't scan this email for links. The original message is still on the View tab.",
 		);
 		// Counts stay withheld — a scan that never ran has no zero to report — so the
 		// tick ships the panel and an empty count badge, and no tab strip to rebuild.

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.ts
@@ -40,7 +40,7 @@ const NOTHING_SKIPPED_MESSAGE = "Nothing was skipped in this email.";
 // than about the panel showing it.
 const EXTRACTING_MESSAGE = "Looking for links…";
 const STALE_MESSAGE =
-	"I couldn’t scan this email for links. The original message is still on the View tab.";
+	"I couldn't scan this email for links. The original message is still on the View tab.";
 
 // Present tense on purpose: the save route only publishes SubmitLinkCommand, and
 // the queue write happens in a downstream subscriber. Claiming "Saved" would
@@ -328,7 +328,7 @@ export function toInboxEmailDetailViewModel(input: {
 		bodyHtml: input.bodyHtml ?? "",
 		imagesCdnBaseUrl: input.imagesCdnBaseUrl,
 		unavailableMessage:
-			"This message couldn’t be displayed here; the original email is preserved.",
+			"This message couldn't be displayed here; the original email is preserved.",
 		// Suppressed until extraction writes its barrier so the header never claims a
 		// count the panel can't back — this covers both the live spinner and the
 		// terminal give-up, neither of which has a trustworthy count.

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.viewmodel.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.viewmodel.test.ts
@@ -76,7 +76,7 @@ describe("toInboxEmailsViewModel", () => {
 		const { empty } = build([], []);
 
 		expect(empty?.key).toBe("no-address");
-		expect(empty?.text).toContain("don’t have an inbox email address");
+		expect(empty?.text).toContain("don't have an inbox email address");
 		expect(empty?.cta).toEqual({
 			href: "/inbox/addresses",
 			label: "Create my first inbox address",
@@ -103,7 +103,7 @@ describe("toInboxEmailsViewModel", () => {
 	it("badges non-received statuses with a label, leaving received unbadged", () => {
 		const cases: { status: InboxEmailStatus; needsBadge: boolean; label: string }[] = [
 			{ status: "received", needsBadge: false, label: "Received" },
-			{ status: "unparsed", needsBadge: true, label: "Couldn’t render" },
+			{ status: "unparsed", needsBadge: true, label: "Couldn't render" },
 			{ status: "rejected", needsBadge: true, label: "Rejected" },
 		];
 		for (const { status, needsBadge, label } of cases) {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.viewmodel.ts
@@ -66,13 +66,13 @@ export interface InboxEmailsViewModel {
 const EMPTY_STATES: Record<InboxEmptyStateKey, InboxEmailsEmptyViewModel> = {
 	"no-address": {
 		key: "no-address",
-		text: "No forwarded emails yet — you don’t have an inbox email address to send them to.",
+		text: "No forwarded emails yet — you don't have an inbox email address to send them to.",
 		cta: { href: INBOX_ADDRESSES_PATH, label: "Create my first inbox address" },
 		addresses: [],
 	},
 	"no-mail": {
 		key: "no-mail",
-		text: "No forwarded emails yet — forward a newsletter to one of your addresses and it’ll appear here.",
+		text: "No forwarded emails yet — forward a newsletter to one of your addresses and it'll appear here.",
 		cta: undefined,
 		addresses: [],
 	},
@@ -81,7 +81,7 @@ const EMPTY_STATES: Record<InboxEmptyStateKey, InboxEmailsEmptyViewModel> = {
 const STATUS_LABEL: Record<InboxEmailStatus, string> = {
 	received: "Received",
 	rejected: "Rejected",
-	unparsed: "Couldn’t render",
+	unparsed: "Couldn't render",
 };
 
 /** Empty rather than absent for a row with nothing to count — the element always

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-excluded-panel.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-excluded-panel.template.html
@@ -22,7 +22,7 @@
   {{else}}
   <div class="inbox-email-detail__excluded" data-test-inbox-excluded>
     <p class="inbox-email-detail__excluded-note">
-      These looked like unsubscribe, ad, or menu links — not articles — so they weren’t fetched
+      These looked like unsubscribe, ad, or menu links — not articles — so they weren't fetched
       or added.
     </p>
     {{#each excludedHtmls}}{{{this}}}{{/each}}

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts
@@ -47,7 +47,7 @@ type CardStatusState = "working" | "stalled" | "failed" | "none";
 
 const CARD_STATUS_LABELS: Record<CardStatusState, string> = {
 	working: "Fetching preview…",
-	stalled: "Preview didn’t arrive",
+	stalled: "Preview didn't arrive",
 	failed: "No preview available",
 	none: "",
 };


### PR DESCRIPTION
## What

The inbox project was the only surface in the product using curly apostrophes (`’`, U+2019) in user-facing copy. Every other surface — hutch, web-shell, blog-site — uses the straight `'`. This produced near-duplicate sentences in two typographic registers, e.g. `/inbox` empty state "you **don't** have an inbox email address" (curly) next to `/inbox/addresses` "You **don't** have an inbox email yet" (straight).

This converts the seven curly-apostrophe strings in `projects/inbox/src` to straight apostrophes, making straight the single standard, and updates the two test assertions that pin the affected copy verbatim.

## Changes

Seven user-facing strings converted `’` → `'`:

- `inbox-email-detail.viewmodel.ts` — "I couldn't scan this email…" and "This message couldn't be displayed here…"
- `inbox-emails.viewmodel.ts` — "you don't have an inbox email address…", "…it'll appear here." and the `unparsed: "Couldn't render"` badge
- `inbox-link-card.viewmodel.ts` — `stalled: "Preview didn't arrive"`
- `inbox-excluded-panel.template.html` — "…so they weren't fetched or added."

Two verbatim test assertions updated to the straight glyph:

- `inbox-emails.viewmodel.test.ts` — the empty-state text and the `unparsed` badge label

## Scope / non-goals

- Pure copy substitution — no markup, class, viewmodel-shape, or template-structure changes.
- Em dashes (`—`) and ellipses (`…`) are used consistently product-wide and are deliberately left untouched.
- The two curly hits under `src/packages/article-parser/` are content-parsing site rules, not UI copy, and are out of scope.
- The four straight apostrophes already in `inbox.template.html` are the standard — they were **not** converted to curly.

## Verification

- `grep -rn "’" projects/inbox/src` returns zero hits.
- `pnpm nx run inbox:check` passes; the full-workspace `pnpm check` (all 45 projects) runs clean via the pre-commit hook at 100% coverage.
- No coverage consequences — string literals only, no branches added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RaCmnVNg93YAJRgsotCy9