### PR TITLE
fix(inbox): use --input-font-size token to avoid iOS focus-zoom

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
@@ -76,7 +76,7 @@
   flex: 1 1 200px;
   min-width: 0;
   padding: 8px 12px;
-  font-size: 0.95rem;
+  font-size: var(--input-font-size);
   color: var(--foreground);
   background: var(--background);
   border: 1px solid var(--border);
@@ -210,7 +210,7 @@
   flex: 1 1 200px;
   min-width: 0;
   padding: 8px 12px;
-  font-size: 0.95rem;
+  font-size: var(--input-font-size);
   color: var(--foreground);
   background: var(--background);
   border: 1px solid var(--border);


### PR DESCRIPTION
## What

Point both inbox text inputs at the `--input-font-size` design-system token instead of the hard-coded `0.95rem`:

- `.inbox__name-input` (`inbox.styles.css:213`) — the editable "name your inbox email" `<input>`. This is the load-bearing fix.
- `.inbox__address-field` (`inbox.styles.css:79`) — the readonly / disabled address input. Consistency-only.

Both now read `font-size: var(--input-font-size)` (16px) instead of `0.95rem` (15.2px).

## Why

iOS Safari force-zooms the viewport when a focused input renders under 16px, and does **not** zoom back out on blur. `.inbox__name-input` rendered at 15.2px, so naming a new inbox email on an iPhone stranded the user at a zoomed-in viewport.

The `--input-font-size: 16px` token already exists (`src/packages/web-shell/src/base.styles.ts:58`) for exactly this purpose, `BRAND_GUIDELINES.md:257` mandates it, and every hutch input already uses it (`auth.styles.css`, `queue.styles.css`, `account.styles.css`, `landing-pages.styles.css`). The two inbox inputs were the only ones that didn't.

`.inbox__address-field` is readonly/disabled, so it doesn't trigger focus-zoom — it moves to the token purely for visual consistency, keeping the create row and the address rows matched (the visual delta is 0.8px, and `flex: 1 1 200px; min-width: 0` absorbs any width change).

Non-input `0.95rem` uses on the page (`.inbox__steps`, email/detail body text) are intentionally left alone.

## Testing

`pnpm nx run inbox:check` passes (lint, type-check, tests, unused-css, 100% coverage). No tests added: this is a CSS value swap with zero behavioural or DOM surface, and the repo's conventions target state rendering rather than stylesheet literals. The full-monorepo `pnpm check` ran green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016a14gtgP9NrkGviD9Tmn8t)_