### PR TITLE
fix(inbox): design-system focus rings on inputs and the disabled summary

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
@@ -185,6 +185,11 @@
   display: none;
 }
 
+.inbox__disabled-summary:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
 .inbox__disabled-caret {
   display: inline-flex;
   color: var(--muted-foreground);
@@ -242,6 +247,13 @@
   background: var(--background);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+}
+
+.inbox__name-input:focus,
+.inbox__address-field:focus {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px var(--ring-shadow);
 }
 
 .inbox__create-btn {


### PR DESCRIPTION
## What & why

The inbox pages were the only surfaces where keyboard users got **bare UA-default focus rendering**. The design-system focus ring in `web-shell`'s `base.styles.ts` is scoped to `button:focus-visible, a:focus-visible`, and the inbox project carried no input- or summary-focus rule of its own. Three focusable elements were affected:

- `.inbox__name-input` — the create-form text input
- `.inbox__address-field` — the `readonly` inbox-email field users click to copy
- `.inbox__disabled-summary` — the "Disabled inbox emails (N)" `<summary>`, which suppresses both its list marker and `::-webkit-details-marker`, so it fell back to the UA ring alone

Every hutch equivalent already styles these states (`queue.styles.css`, `auth.styles.css`, `import.styles.css` for inputs; `article-body.styles.css` for a marker-suppressed summary). This brings inbox in line.

## Change

Two additive rules in `projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css`, reusing the live `--ring` / `--ring-shadow` tokens (defined in both light and dark themes):

- A shared `.inbox__name-input:focus, .inbox__address-field:focus` rule using the hutch text-input idiom (`outline: none; border-color: var(--ring); box-shadow: 0 0 0 3px var(--ring-shadow);`). `:focus` (not `:focus-visible`) matches the established input idiom — text fields correctly show focus on click too, including the readonly field users click to select-all before copying. The `--disabled` variant carries `disabled` and can never match, so no override is needed.
- A `.inbox__disabled-summary:focus-visible` rule mirroring the article-body summary idiom (`outline: 2px solid var(--ring); outline-offset: -2px;`). The inset offset keeps the ring inside the card bounds, same rationale as `.inbox-emails__link:focus-visible`.

No template, TypeScript, or `base.styles.ts` changes — a base `input, summary` rule would compete with existing component `outline: none` rules.

## Accessibility

Both meet WCAG 1.4.11 (non-text contrast, ≥3:1) against the actual token values:

- Light `--ring` `hsl(27 65% 47%)` vs `#FFFFFF` surfaces: **3.65:1**
- Dark `--ring` `hsl(27 65% 52%)` vs `--background` `#121212`: **6.04:1**; vs `--card` `#222222`: **5.13:1**

## Testing

- `pnpm nx run inbox:check` — green (lint, type-check, tests, 100% coverage, and `unused-css` confirming the reused selectors still match the templates).
- Full-monorepo `pnpm check` — green (45 projects), matching the pre-commit hook.

CSS-only change: no unit tests exist for stylesheet content in this project and none are added; existing `inbox.route.test.ts` assertions are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6K3E1DrxbErZb97VnUy42)_