### PR TITLE
fix(inbox): center the skipped-link row and stack it on narrow screens

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
@@ -255,7 +255,7 @@
 
 .inbox-excluded-link {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 6px 0;
@@ -281,4 +281,12 @@
 
 .inbox-excluded-link__feedback {
   flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+  .inbox-excluded-link {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+  }
 }


### PR DESCRIPTION
## What

Two CSS-only fixes to the inbox email-detail **skipped-link** row (`.inbox-excluded-link` in `inbox-email-detail.styles.css`):

1. **Baseline → center alignment.** The row used `align-items: baseline`. Because the report button is a 44px `inline-flex` control, its first baseline sits well below its own box top, so the button's tall above-baseline distance defined the flex line's top edge and pushed the info block (URL + reason) down ~10px — leaving unexplained dead space above the URL and detaching the URL text from the "This is an article (report)" label. Switching to `align-items: center` centers the info block against the button and removes the dead space, matching the sibling `.inbox-article-card__actions` row which already uses `center`.

2. **Stack the row below 480px.** At narrow widths the fixed-width feedback form left the URL column ~120px wide, where `word-break: break-all` shredded a long UTM-laden unsubscribe URL into an unreadable single-character column. A new `@media (max-width: 480px)` block sets the row to `flex-direction: column` so the URL takes full width and the button sits beneath it, left-aligned. `gap: 0` because the button's 44px min-height already supplies vertical breathing room and tap separation. 480px is the breakpoint web-shell's base styles already use; this is the first media query in the inbox project and sets that precedent.

## Diff

```css
 .inbox-excluded-link {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   padding: 6px 0;
 }

+@media (max-width: 480px) {
+  .inbox-excluded-link {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+  }
+}
```

No markup, template, TypeScript, or color changes. No new class names, so the unused-css check sees the same selector set.

## Verification

- `pnpm nx run inbox:check` and the full-monorepo `pnpm check` pass (100% coverage unchanged; `.css` files are not instrumented, and the JSDOM route tests assert rendered HTML, not computed layout, so no test surface changes).
- Visually verified against the dev server (`server.main.ts`, digest email → excluded tab) with the seed URL temporarily lengthened to ~120 chars of UTM query string, via Playwright at both viewports:
  - **481px**: row is side-by-side, info block vertically centered against the button (measured center-to-center delta 0px, vs. the previous baseline offset); URL starts at the row top with no dead space.
  - **320px**: row stacks — URL wraps full-width and readable, button directly below it left-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016GoQqHhg4RtCZYwKcXNTd6)_