### PR TITLE
fix(inbox): give each address row's controls a per-row accessible name

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.component.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.component.test.ts
@@ -94,6 +94,45 @@ describe("InboxPage", () => {
 		);
 	});
 
+	it("gives each control in a row a per-row accessible name so screen-reader users can tell rows apart", () => {
+		const doc = parse(
+			InboxPage({
+				addresses: [
+					entry({
+						name: AliasNameSchema.parse("netflix"),
+						address: InboxAddressSchema.parse("netflix-def456@read.place"),
+						token: InboxTokenSchema.parse("def456"),
+					}),
+					entry({
+						name: AliasNameSchema.parse("stratechery"),
+						address: InboxAddressSchema.parse("stratechery-abc123@read.place"),
+						token: InboxTokenSchema.parse("abc123"),
+						disabledAt: "2026-06-22T00:00:00.000Z",
+					}),
+				],
+				limitReached: false,
+			}).content.html,
+		);
+
+		assert.equal(
+			doc.querySelector("[data-inbox-copy]")?.getAttribute("aria-label"),
+			"Copy inbox email: netflix",
+		);
+		assert.equal(
+			doc.querySelector("[data-test-inbox-disable]")?.getAttribute("aria-label"),
+			"Disable inbox email: netflix",
+		);
+
+		const [active, disabled] = Array.from(doc.querySelectorAll(".inbox__address-field"));
+		assert.equal(active.getAttribute("aria-label"), "Inbox email: netflix");
+		assert.equal(disabled.getAttribute("aria-label"), "Inbox email: stratechery");
+		assert.notEqual(
+			active.getAttribute("aria-label"),
+			disabled.getAttribute("aria-label"),
+			"each row's field carries a distinct accessible name",
+		);
+	});
+
 	it("shows a Disable action for enabled addresses and a Disabled marker (no action) for disabled ones", () => {
 		const doc = parse(
 			InboxPage({

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
@@ -45,13 +45,13 @@
           {{#each activeAddresses}}
           <li class="inbox__item" data-test-inbox-item>
             <span class="inbox__name" data-test-inbox-name>{{this.name}}</span>
-            <button type="button" class="inbox__copy-btn" data-inbox-copy data-inbox-address="{{this.address}}" hidden>Copy</button>
-            <input class="inbox__address-field" type="text" value="{{this.address}}" readonly aria-label="Inbox email" data-inbox-address="{{this.address}}" />
+            <button type="button" class="inbox__copy-btn" data-inbox-copy data-inbox-address="{{this.address}}" aria-label="{{this.copyAriaLabel}}" hidden>Copy</button>
+            <input class="inbox__address-field" type="text" value="{{this.address}}" readonly aria-label="{{this.addressAriaLabel}}" data-inbox-address="{{this.address}}" />
             <div class="inbox__controls">
               <span class="inbox__status inbox__status--enabled" data-test-inbox-status="enabled">Active</span>
               <form action="{{../disableAction}}" method="POST" class="inbox__disable">
                 <input type="hidden" name="address" value="{{this.address}}" />
-                <button type="submit" class="inbox__disable-btn" data-test-inbox-disable>Disable</button>
+                <button type="submit" class="inbox__disable-btn" data-test-inbox-disable aria-label="{{this.disableAriaLabel}}">Disable</button>
               </form>
             </div>
           </li>
@@ -63,7 +63,7 @@
             {{#each disabledAddresses}}
             <li class="inbox__item" data-test-inbox-item>
               <span class="inbox__name" data-test-inbox-name>{{this.name}}</span>
-              <input class="inbox__address-field inbox__address-field--disabled" type="text" value="{{this.address}}" disabled aria-label="Inbox email" />
+              <input class="inbox__address-field inbox__address-field--disabled" type="text" value="{{this.address}}" disabled aria-label="{{this.addressAriaLabel}}" />
               <div class="inbox__controls">
                 <span class="inbox__status inbox__status--disabled" data-test-inbox-status="disabled">Disabled</span>
               </div>

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.viewmodel.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.viewmodel.test.ts
@@ -40,11 +40,29 @@ describe("toInboxAddressesViewModel", () => {
 
 		expect(vm.hasAddresses).toBe(true);
 		expect(vm.activeAddresses).toEqual([
-			{ name: "netflix", address: "netflix-bbb222@read.place" },
+			{
+				name: "netflix",
+				address: "netflix-bbb222@read.place",
+				addressAriaLabel: "Inbox email: netflix",
+				copyAriaLabel: "Copy inbox email: netflix",
+				disableAriaLabel: "Disable inbox email: netflix",
+			},
 		]);
 		expect(vm.disabledAddresses).toEqual([
-			{ name: "gmail", address: "gmail-aaa111@read.place" },
-			{ name: "substack", address: "substack-ccc333@read.place" },
+			{
+				name: "gmail",
+				address: "gmail-aaa111@read.place",
+				addressAriaLabel: "Inbox email: gmail",
+				copyAriaLabel: "Copy inbox email: gmail",
+				disableAriaLabel: "Disable inbox email: gmail",
+			},
+			{
+				name: "substack",
+				address: "substack-ccc333@read.place",
+				addressAriaLabel: "Inbox email: substack",
+				copyAriaLabel: "Copy inbox email: substack",
+				disableAriaLabel: "Disable inbox email: substack",
+			},
 		]);
 		expect(vm.hasDisabled).toBe(true);
 		expect(vm.disabledCount).toBe(2);
@@ -58,8 +76,20 @@ describe("toInboxAddressesViewModel", () => {
 
 		expect(vm.hasAddresses).toBe(true);
 		expect(vm.activeAddresses).toEqual([
-			{ name: "netflix", address: "netflix-bbb222@read.place" },
-			{ name: "gmail", address: "gmail-aaa111@read.place" },
+			{
+				name: "netflix",
+				address: "netflix-bbb222@read.place",
+				addressAriaLabel: "Inbox email: netflix",
+				copyAriaLabel: "Copy inbox email: netflix",
+				disableAriaLabel: "Disable inbox email: netflix",
+			},
+			{
+				name: "gmail",
+				address: "gmail-aaa111@read.place",
+				addressAriaLabel: "Inbox email: gmail",
+				copyAriaLabel: "Copy inbox email: gmail",
+				disableAriaLabel: "Disable inbox email: gmail",
+			},
 		]);
 		expect(vm.disabledAddresses).toEqual([]);
 		expect(vm.hasDisabled).toBe(false);

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.viewmodel.ts
@@ -3,6 +3,9 @@ import { type InboxAddressEntry, isLiveAddress } from "@packages/domain/inbox";
 export interface InboxAddressRowViewModel {
 	address: string;
 	name: string;
+	addressAriaLabel: string;
+	copyAriaLabel: string;
+	disableAriaLabel: string;
 }
 
 export interface InboxAddressesViewModel {
@@ -14,7 +17,13 @@ export interface InboxAddressesViewModel {
 }
 
 function toRow(entry: InboxAddressEntry): InboxAddressRowViewModel {
-	return { address: entry.address, name: entry.name };
+	return {
+		address: entry.address,
+		name: entry.name,
+		addressAriaLabel: `Inbox email: ${entry.name}`,
+		copyAriaLabel: `Copy inbox email: ${entry.name}`,
+		disableAriaLabel: `Disable inbox email: ${entry.name}`,
+	};
 }
 
 export function toInboxAddressesViewModel(entries: InboxAddressEntry[]): InboxAddressesViewModel {


### PR DESCRIPTION
## What & why

Every inbox address row exposed **identical accessible names** to assistive tech: the readonly address input was labelled `Inbox email`, the copy button `Copy`, and the disable button `Disable` — the same for all up to `INBOX_ADDRESS_MAX_PER_USER` (25) rows. A screen-reader user tabbing or listing form controls heard "Inbox email, edit text / Copy, button / Disable, button" repeated with nothing distinguishing `netflix` from `stratechery`, and Disable is destructive to a live forwarding pipeline. This fails **WCAG 2.4.6 (Headings and Labels)**.

The link cards on the same page already get this right (`ariaLabel: \`Save to queue: ${displayUrl}\``), so this change mirrors that pattern: labels are built in TS and bound in the template, rather than hardcoded per control in Handlebars.

## Changes

- **`inbox.viewmodel.ts`** — `InboxAddressRowViewModel` gains three required fields, populated in `toRow`:
  - `addressAriaLabel` → `Inbox email: <name>`
  - `copyAriaLabel` → `Copy inbox email: <name>`
  - `disableAriaLabel` → `Disable inbox email: <name>`
- **`inbox.template.html`** — attribute-only edits: the active input, copy button, disable button, and the disabled-group input now bind their per-row `aria-label`. Visible button text (`Copy`, `Disable`) is unchanged.
- No styles, colours, client JS, or route changes.

Each `aria-label` starts with the visible text, so **WCAG 2.5.3 (Label in Name)** is also satisfied. The `<name>` follows the existing "inbox email" noun and the card viewmodel's `<action>: <subject>` shape.

## Tests

- `inbox.viewmodel.test.ts` — existing `toRow` cases now assert the three new label fields on both active and disabled entries.
- `inbox.component.test.ts` — new test asserts `aria-label` on the copy button, disable button, and both address fields, and that two rows carry **distinct** field labels (the per-row distinctness is the point of the finding).
- Pure additive fields in an already fully covered function — coverage stays at 100%; `pnpm nx run inbox:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014VcBSg36U3ub6trZRjHgVJ)_