### PR TITLE
fix(inbox): announce the address-creation success

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.component.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.component.test.ts
@@ -360,7 +360,7 @@ describe("InboxPage", () => {
 		]);
 	});
 
-	it("keeps the explainer first and the create form last in the create section, with the limit error between them", () => {
+	it("keeps the explainer first and the create form last in the create section, with the limit error and create confirmation between them", () => {
 		const shape = (el: Element) => `${el.tagName.toLowerCase()}.${el.classList[0]}`;
 
 		const withoutErrors = parse(InboxPage({ addresses: [], limitReached: false }).content.html);
@@ -368,6 +368,7 @@ describe("InboxPage", () => {
 		assert.ok(section, "create section must render");
 		assert.deepEqual(Array.from(section.children).map(shape), [
 			"section.inbox__instructions",
+			"p.inbox__success",
 			"form.inbox__create",
 		]);
 
@@ -377,6 +378,7 @@ describe("InboxPage", () => {
 		assert.deepEqual(Array.from(limitedSection.children).map(shape), [
 			"section.inbox__instructions",
 			"p.inbox__error",
+			"p.inbox__success",
 			"form.inbox__create",
 		]);
 	});

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.component.ts
@@ -16,8 +16,11 @@ export function InboxPage(params: {
 	nameInvalid?: boolean;
 	nameTaken?: boolean;
 	limitReached: boolean;
+	createdName?: string;
 }): PageBody {
 	const content = render(INBOX_TEMPLATE, {
+		created: params.createdName !== undefined,
+		createdName: params.createdName ?? "",
 		...toInboxAddressesViewModel(params.addresses),
 		alerts: toInboxAlerts({
 			createFailed: params.createFailed === true,

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
@@ -4,6 +4,7 @@ import express from "express";
 import { z } from "zod";
 import { sendComponent } from "@packages/web-shell";
 import {
+	AliasNameSchema,
 	countLiveAddresses,
 	EmailLinkOrdinalSchema,
 	INBOX_ADDRESS_MAX_PER_USER,
@@ -146,6 +147,7 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 		const createFailed = req.query.error === "create";
 		const nameInvalid = req.query.error === "name";
 		const nameTaken = req.query.error === "name-taken";
+		const createdName = AliasNameSchema.safeParse(req.query.created);
 		// Banner shows whenever the cap is genuinely reached, not only after a
 		// rejected create. error=limit stays OR'd in so a just-rejected create
 		// still shows it even when the eventually-consistent live read
@@ -156,7 +158,14 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 			req,
 			res,
 			Base(
-				InboxPage({ addresses, createFailed, nameInvalid, nameTaken, limitReached }),
+				InboxPage({
+					addresses,
+					createFailed,
+					nameInvalid,
+					nameTaken,
+					limitReached,
+					createdName: createdName.success ? createdName.data : undefined,
+				}),
 				await deps.buildBannerState(req),
 			),
 		);
@@ -486,7 +495,7 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 			res.redirect(303, addressesCreateFailedPath);
 			return;
 		}
-		res.redirect(303, addressesPath);
+		res.redirect(303, `${addressesPath}?created=${encodeURIComponent(name)}`);
 	});
 
 	router.post("/disable", async (req: Request, res: Response) => {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -113,12 +113,17 @@ describe("Inbox address routes", () => {
 				.type("form")
 				.send({ name: "Netflix" });
 			expect(created.status).toBe(303);
-			expect(created.headers.location).toBe("/inbox/addresses");
+			expect(created.headers.location).toBe("/inbox/addresses?created=netflix");
 
-			const listed = await agent.get("/inbox/addresses");
+			const listed = await agent.get(created.headers.location);
 			expect(addressFieldValue(listed.text)).toMatch(/^netflix-[0-9a-z]{6}@read\.place$/);
 			const doc = new JSDOM(listed.text).window.document;
 			expect(doc.querySelector("[data-test-inbox-name]")?.textContent).toBe("netflix");
+			const confirmation = doc.querySelector("[data-test-inbox-created]");
+			assert(confirmation, "the create confirmation must render on the redirect target");
+			expect(confirmation.classList.contains("inbox__success--visible")).toBe(true);
+			expect(confirmation.getAttribute("role")).toBe("status");
+			expect(confirmation.textContent).toContain("netflix");
 		});
 
 		it("redirects with error=name when the submitted name has no valid characters", async () => {
@@ -186,7 +191,7 @@ describe("Inbox address routes", () => {
 				.send({ name: "gmail" });
 
 			expect(second.status).toBe(303);
-			expect(second.headers.location).toBe("/inbox/addresses");
+			expect(second.headers.location).toBe("/inbox/addresses?created=gmail");
 			const names = Array.from(
 				new JSDOM(
 					(await agent.get("/inbox/addresses")).text,
@@ -211,7 +216,7 @@ describe("Inbox address routes", () => {
 				.send({ name: "netflix" });
 
 			expect(recreated.status).toBe(303);
-			expect(recreated.headers.location).toBe("/inbox/addresses");
+			expect(recreated.headers.location).toBe("/inbox/addresses?created=netflix");
 		});
 
 		it("redirects a read-only user to /queue?inactive=1 and mints nothing", async () => {
@@ -345,6 +350,48 @@ describe("Inbox address routes", () => {
 			const response = await agent.get("/inbox/addresses");
 
 			expect(alertKeys(new JSDOM(response.text).window.document)).toEqual([]);
+		});
+
+		it("renders the visible create confirmation on the redirect target", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox/addresses?created=netflix");
+
+			const confirmation = new JSDOM(response.text).window.document.querySelector(
+				"[data-test-inbox-created]",
+			);
+			assert(confirmation, "the create confirmation element must render");
+			expect(confirmation.classList.contains("inbox__success--visible")).toBe(true);
+			expect(confirmation.getAttribute("role")).toBe("status");
+			expect(confirmation.textContent).toContain("netflix");
+		});
+
+		it("keeps the create confirmation hidden and empty on a normal visit", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox/addresses");
+
+			const confirmation = new JSDOM(response.text).window.document.querySelector(
+				"[data-test-inbox-created]",
+			);
+			assert(confirmation, "the create confirmation element must render");
+			expect(confirmation.classList.contains("inbox__success--hidden")).toBe(true);
+			expect(confirmation.textContent).toBe("");
+		});
+
+		it("keeps the create confirmation hidden when the created param is not a valid name", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+
+			const response = await agent.get("/inbox/addresses?created=NOT%20a%20name!");
+
+			const confirmation = new JSDOM(response.text).window.document.querySelector(
+				"[data-test-inbox-created]",
+			);
+			assert(confirmation, "the create confirmation element must render");
+			expect(confirmation.classList.contains("inbox__success--hidden")).toBe(true);
 		});
 	});
 

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
@@ -32,6 +32,24 @@
   font-size: 0.95rem;
 }
 
+.inbox__success {
+  margin: 0 0 24px;
+  padding: 12px 16px;
+  color: var(--success-text);
+  background: var(--card);
+  border: 1px solid var(--success);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+}
+
+.inbox__success--visible {
+  display: block;
+}
+
+.inbox__success--hidden {
+  display: none;
+}
+
 .inbox__create-section {
   border-bottom: 1px solid var(--border);
   padding-bottom: 24px;

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
@@ -18,6 +18,8 @@
         <p class="inbox__error" role="alert" data-test-inbox-alert="{{key}}">{{message}}</p>
         {{/each}}
 
+        <p class="inbox__success {{#if created}}inbox__success--visible{{else}}inbox__success--hidden{{/if}}" role="status" data-test-inbox-created>{{#if created}}Created the inbox email "{{createdName}}" — it's live in the list below.{{/if}}</p>
+
         <form action="{{createAction}}" method="POST" class="inbox__create">
           <label class="inbox__create-label" for="inbox-name">Name this inbox email</label>
           <div class="inbox__create-row">


### PR DESCRIPTION
## What & why

Creating an inbox email was the only outcome of `POST /inbox/create` with no announced result. Every failure path already carries a flag — `error=name`, `error=name-taken`, `error=limit`, `error=create` — each rendering a `role="alert"` block. The success path redirected with `res.redirect(303, addressesPath)` and nothing else, so after the POST-redirect-GET the page reloaded with focus at the top and a screen-reader user got no confirmation the new address was live.

This was the last write on the inbox surface whose success was silent: the sibling detail page already confirms its own writes (`saved=1` / `feedback=sent`). This change gives the create form the same courtesy.

## Changes

- **`inbox.page.ts`** — carry the already-normalized alias name on the success redirect (`?created=<name>`), and on the `/addresses` GET parse it back with `AliasNameSchema.safeParse` (query strings are external input, so a hand-typed junk value renders the hidden state rather than 500ing).
- **`inbox.component.ts`** — accept an optional `createdName` and forward `created` / `createdName` to the template.
- **`inbox.template.html`** — render a `role="status"` line above the create form, always present and toggled by `--visible`/`--hidden` modifiers (the same render-both idiom the disabled group uses), so there's no client-JS dependency. The copy names the new address and points at the list without repeating the "How it works" steps.
- **`inbox.styles.css`** — style `.inbox__success` mirroring `.inbox__error`, using the established `--success` (surface) / `--success-text` (text, 4.98:1 on the card surface) token split. No new colours.

## Tests

`inbox.route.test.ts` (supertest + JSDOM):
- Updated the three success-redirect `Location` assertions to carry the `?created=<name>` flag.
- The full-flow create test now follows the redirect and asserts the confirmation renders visible, `role="status"`, and names the address — proving the POST and GET agree on the param.
- Added: confirmation is visible on `?created=netflix`; hidden and empty on a normal visit; hidden when `created` is not a valid alias name (covers the `safeParse` failure branch).

`inbox.component.test.ts` — updated the create-section child-order test to include the always-present `p.inbox__success`.

`pnpm nx run inbox:check` passes at 100% coverage, and the full-monorepo pre-commit `pnpm check` passed on commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_016mCfd2NmSJqEKj9HNdXind)_