### PR TITLE
fix(web-shell): pin the site footer to the viewport bottom on short pages

### DIFF
--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -249,6 +249,19 @@ describe("Base component", () => {
 		expect(footer?.textContent).toContain("Readplace");
 	});
 
+	it("ships both halves of the sticky-footer pattern together — a body flex column plus .footer margin-top:auto — so the footer pins to the viewport bottom instead of floating mid-screen", () => {
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const headStyle = doc.querySelector("head style");
+		assert(headStyle?.textContent, "the base shell must inline its CSS in a <head> <style>");
+		const styleText = headStyle.textContent;
+
+		expect(styleText).toMatch(/body\s*\{[^}]*display:\s*flex[^}]*flex-direction:\s*column[^}]*\}/);
+		expect(styleText).toContain("margin-top: auto");
+	});
+
 	it("should include the offline banner", () => {
 		const page = createTestPageBody();
 		const result = Base(page, GUEST_STATE).to("text/html");

--- a/src/packages/web-shell/src/base.styles.ts
+++ b/src/packages/web-shell/src/base.styles.ts
@@ -221,6 +221,11 @@ export const HEADER_STYLES = `
 `;
 
 export const FOOTER_STYLES = `
+	body {
+		display: flex;
+		flex-direction: column;
+	}
+
 	.footer {
 		background: var(--footer-bg);
 		color: var(--footer-text);


### PR DESCRIPTION
## What & why

The shared web shell shipped **half** a sticky-footer pattern: `.footer` in `FOOTER_STYLES` carried `margin-top: auto`, but `body` was a plain block box, so on an in-flow block child that auto margin resolves to `0` and does nothing. On any page shorter than the viewport the footer floated mid-screen over dead whitespace instead of sitting at the bottom.

The inbox exhibits it worst — its most common states (few emails, few links, both empty states) are exactly the short-content states, so the first-run surface reads unfinished. But the defect is in the shared shell (`@packages/web-shell`), so it affects every full-chrome page across **hutch, blog-site, web-embed, and inbox**.

## The fix

Complete the pattern by making `body` a flex column. `body` already carries `min-height: 100vh`, so `display: flex; flex-direction: column` lets the footer's existing `margin-top: auto` absorb the free space and pin it to the viewport bottom.

```css
export const FOOTER_STYLES = `
  body {
    display: flex;
    flex-direction: column;
  }

  .footer { … margin-top: auto; }
  …
```

Why the rule lives in `FOOTER_STYLES` rather than the base reset:
- It keeps **both halves** of the sticky-footer pattern co-located in one exported constant.
- It **scopes** the layout change to shells that actually render a footer. The chromeless shell (`initChromelessPage`, used by the iOS in-app reader) imports `BASE_RESET_STYLES` but **not** `FOOTER_STYLES` and renders no footer, so it stays a normal block — the reader's own bottom-sticky action bar is untouched.

No other CSS changes. Deliberately no `main { flex: 1 }`: the footer's auto margin absorbs the free space on its own, and leaving `<main>`'s height untouched means in-`main` sticky elements (the reader mark-read toolbar, the `/view` and `/import` bars) and its background box behave exactly as before.

## Cross-surface safety

`display: flex; flex-direction: column` on `body` only affects the shell's own direct body children — `.banner-area` (`position: fixed`, out of flow), the two inline `display:none` scripts (not flex items), the sticky `header`, `<main>`, and the `footer`. All were full-width block boxes and remain full-width flex items (`align-items: stretch` on the cross axis = width). Verified against the flagged surfaces:

- No page style in hutch / inbox / blog-site / web-embed sets a `body` display rule, so nothing conflicts with or overrides the new rule; page content lives inside `<main>`.
- All `position: sticky` / `fixed` / `absolute` elements are component-scoped inside `<main>` (view CTA, import commit bar, reader mark-read toolbar, paywall, auth logos, hero measurers). Their offsets resolve against the viewport scrollport / positioned ancestors — a body-level flex context does not change that, so the sticky header slide and in-`main` toolbars still track together.
- `.header--transparent` (landing hero) is `position: absolute` — out of flow under both block and flex — so the full-bleed hero is unaffected.

## Tests

- Added a pairing test in `base.component.test.ts` next to the existing footer test: it renders a page and asserts the shipped shell CSS carries **both** a `body { display: flex; flex-direction: column }` rule **and** `.footer`'s `margin-top: auto`, so the two halves of the pattern can't drift apart. (JSDOM does no layout, so a presence assertion on shipped state is the honest string-level check.)
- The change is inside a template-literal constant — no new branches/functions, coverage thresholds unaffected.

## Verification

- `pnpm nx run @packages/web-shell:check` — green, 100% coverage on `base.styles.ts` and `base.component.ts`.
- `pnpm check` — green across all 45 projects / 63 tasks, including `hutch:check`, `blog-site:check`, `web-embed:check`, and `inbox:check` (their route tests snapshot rendered pages). No infra touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013PyKHudy5AWkR4UqffYwab)_