### PR TITLE
feat(inbox): persist saved-card state so a sent link stays distinct

### DIFF
--- a/projects/hutch/src/runtime/delete-account/delete-account-handler.test.ts
+++ b/projects/hutch/src/runtime/delete-account/delete-account-handler.test.ts
@@ -357,6 +357,7 @@ async function seedAccount(
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 	});
 	await s.inboxLink.putLinksMeta({
 		userId,

--- a/projects/inbox/src/runtime/domain/inbox/crawl-email-link-preview-handler.test.ts
+++ b/projects/inbox/src/runtime/domain/inbox/crawl-email-link-preview-handler.test.ts
@@ -64,6 +64,7 @@ async function seedPending(
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 	});
 }
 

--- a/projects/inbox/src/runtime/domain/inbox/extract-email-links-handler.ts
+++ b/projects/inbox/src/runtime/domain/inbox/extract-email-links-handler.ts
@@ -196,6 +196,7 @@ export function initExtractEmailLinksHandler(deps: {
 						siteName: undefined,
 						imageUrl: undefined,
 						failureReason: undefined,
+						submittedAt: undefined,
 					};
 					if (classification.action === "skip") {
 						// Terminal at birth: a skipped link is never crawled, so no

--- a/projects/inbox/src/runtime/server.main.ts
+++ b/projects/inbox/src/runtime/server.main.ts
@@ -89,6 +89,7 @@ async function main(): Promise<void> {
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 	});
 	await fixture.inboxEmail.inboxEmailLinkStore.putLink({
 		userId,
@@ -103,6 +104,7 @@ async function main(): Promise<void> {
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 	});
 	await fixture.inboxEmail.inboxEmailLinkStore.putLink({
 		userId,
@@ -117,6 +119,7 @@ async function main(): Promise<void> {
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: "list-unsubscribe",
+		submittedAt: undefined,
 	});
 	await fixture.inboxEmail.inboxEmailStore.setEmailLinkCounts({
 		userId,

--- a/projects/inbox/src/runtime/test-app.ts
+++ b/projects/inbox/src/runtime/test-app.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import type { Express } from "express";
 import request from "supertest";
 import { HutchLogger, noopLogger } from "@packages/hutch-logger";
+import type { UserId } from "@packages/domain/user";
 import type {
 	AuthBundle,
 	RunningServer,
@@ -27,10 +28,15 @@ export const TEST_IMAGES_CDN_BASE_URL = "https://cdn.test.readplace.com";
 
 /** `overrides` lets a test swap a single dependency without rebuilding the whole
  * fixture — `getChangelogBanner` defaults to "no banner" so it stays hidden in
- * every other route test. */
+ * every other route test; `publishSubmitLink` defaults to recording into
+ * `submittedLinks` and is overridden to a throwing stub only by the save route's
+ * publish-failure test, which asserts the link is left unmarked. */
 export function createInboxTestApp(
 	fixture: TestAppFixture,
-	overrides?: { getChangelogBanner?: GetChangelogBanner },
+	overrides?: {
+		getChangelogBanner?: GetChangelogBanner;
+		publishSubmitLink?: (input: { userId: UserId; url: string }) => Promise<void>;
+	},
 ): TestAppResult {
 	const resolveLogin = initResolveLogin({
 		getSessionUserId: fixture.auth.getSessionUserId,
@@ -55,9 +61,11 @@ export function createInboxTestApp(
 			inboxEmailStore: fixture.inboxEmail.inboxEmailStore,
 			inboxEmailLinkStore: fixture.inboxEmail.inboxEmailLinkStore,
 			readEmailContent: fixture.inboxEmail.readEmailContent,
-			publishSubmitLink: async (input) => {
-				submittedLinks.push(input);
-			},
+			publishSubmitLink:
+				overrides?.publishSubmitLink ??
+				(async (input) => {
+					submittedLinks.push(input);
+				}),
 			logError: fixture.shared.logError,
 			now: fixture.shared.now,
 		},
@@ -72,8 +80,10 @@ export function createInboxTestApp(
 
 export interface TestAppHarness extends TestAppResult, RunningServer {}
 
-export function useTestServer(): (fixture: TestAppFixture) => TestAppHarness {
-	return useServerForFixture(createInboxTestApp);
+export function useTestServer(
+	overrides?: Parameters<typeof createInboxTestApp>[1],
+): (fixture: TestAppFixture) => TestAppHarness {
+	return useServerForFixture((fixture) => createInboxTestApp(fixture, overrides));
 }
 
 /** Logs a fresh user in without a /login route: this deployable never mounts

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-article-card.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-article-card.route.test.ts
@@ -25,6 +25,7 @@ function link(userId: UserId, overrides: Partial<InboxEmailLinkEntry> = {}): Inb
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }
@@ -247,6 +248,54 @@ describe("Inbox link card route", () => {
 		const bare = card.querySelector("[data-test-inbox-article-url]");
 		assert(bare, "the bare URL anchor must render");
 		expect(bare.getAttribute("href")).toBe("https://localhost/private");
+	});
+
+	it("renders a submitted link as sent, drops its Save button, and survives the poll swap", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		await seed(fixture, {
+			status: "crawled",
+			title: "A saved post",
+			submittedAt: "2026-07-01T00:00:00.000Z",
+		});
+
+		const response = await agent.get(cardPath);
+
+		expect(response.status).toBe(200);
+		const card = new JSDOM(response.text).window.document.querySelector(
+			"[data-test-inbox-article-card]",
+		);
+		assert(card, "the card fragment must render");
+		const saved = card.querySelector("[data-test-card-saved]");
+		assert(saved, "the saved marker must render on every card");
+		expect(saved.getAttribute("data-test-card-saved")).toBe("sent");
+		expect(saved.textContent).toBe("Sent to your queue");
+		expect(saved.classList.contains("inbox-article-card__saved--sent")).toBe(true);
+		expect(cardActions(card)).toEqual(["feedback-exclude"]);
+	});
+
+	it("differs the ETag between a submitted and an unsubmitted row", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		await seed(fixture, { status: "crawled", title: "T" });
+
+		const beforeSave = await agent.get(cardPath);
+		const beforeEtag = beforeSave.headers.etag;
+		assert(beforeEtag, "the card response must carry an ETag");
+
+		const user = await fixture.auth.findUserByEmail("test@example.com");
+		assert(user, "the seeded user must exist");
+		await fixture.inboxEmail.inboxEmailLinkStore.markLinkSubmitted({
+			userId: user.userId,
+			receivedAtMessageId: SK,
+			ordinal: EmailLinkOrdinalSchema.parse("0000"),
+			submittedAt: "2026-07-01T00:00:00.000Z",
+		});
+
+		const afterSave = await agent.get(cardPath);
+		expect(afterSave.headers.etag).not.toBe(beforeEtag);
 	});
 
 	it("revalidates with a 304 when the link has not changed", async () => {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-article-card.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-article-card.template.html
@@ -6,6 +6,7 @@
   <a class="inbox-article-card__title inbox-article-card__title--bare" href="{{url}}" target="_blank" rel="noopener noreferrer" data-test-inbox-article-url>{{url}}</a>
   {{/if}}
   <span class="inbox-article-card__status inbox-article-card__status--{{statusState}}" data-test-card-status="{{statusState}}">{{statusLabel}}</span>
+  <span class="inbox-article-card__saved inbox-article-card__saved--{{savedState}}" data-test-card-saved="{{savedState}}">{{savedLabel}}</span>
   <ul class="inbox-article-card__actions">
     {{#each actions}}
     <li class="inbox-article-card__action">

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-articles-more.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-articles-more.route.test.ts
@@ -45,6 +45,7 @@ function linkEntry(userId: UserId, overrides: Partial<InboxEmailLinkEntry>): Inb
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
@@ -62,6 +62,7 @@ function linkEntry(userId: UserId, overrides: Partial<InboxEmailLinkEntry>): Inb
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
@@ -174,6 +174,16 @@
   display: none;
 }
 
+.inbox-article-card__saved {
+  font-size: 0.75rem;
+  margin-top: 2px;
+  color: var(--success-text);
+}
+
+.inbox-article-card__saved--none {
+  display: none;
+}
+
 .inbox-article-card__actions {
   display: flex;
   align-items: center;

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.viewmodel.test.ts
@@ -49,6 +49,7 @@ function link(overrides: Partial<InboxEmailLinkEntry> = {}): InboxEmailLinkEntry
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.etag.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.etag.test.ts
@@ -16,6 +16,7 @@ function link(overrides: Partial<InboxEmailLinkEntry> = {}): InboxEmailLinkEntry
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }
@@ -62,5 +63,13 @@ describe("computeInboxLinkCardEtag", () => {
 			link({ status: "crawled", title: "T", resolvedUrl: "https://destination.test/a" }),
 		);
 		expect(unresolved).not.toBe(resolved);
+	});
+
+	it("changes once the link is submitted, so a save from another tab invalidates a mid-poll card", () => {
+		const unsaved = computeInboxLinkCardEtag(link({ status: "crawled", title: "T" }));
+		const saved = computeInboxLinkCardEtag(
+			link({ status: "crawled", title: "T", submittedAt: "2026-07-01T00:00:00.000Z" }),
+		);
+		expect(unsaved).not.toBe(saved);
 	});
 });

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.etag.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.etag.ts
@@ -3,7 +3,7 @@ import type { InboxEmailLinkEntry } from "@packages/domain/inbox";
 
 export function computeInboxLinkCardEtag(link: InboxEmailLinkEntry): string {
 	const hash = createHash("sha256");
-	for (const part of [link.status, link.title ?? "", link.resolvedUrl ?? ""]) {
+	for (const part of [link.status, link.title ?? "", link.resolvedUrl ?? "", link.submittedAt ?? ""]) {
 		hash.update(part);
 		hash.update("|");
 	}

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.test.ts
@@ -19,6 +19,7 @@ function link(overrides: Partial<InboxEmailLinkEntry> = {}): InboxEmailLinkEntry
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }
@@ -277,6 +278,36 @@ describe("toInboxLinkCardViewModel", () => {
 
 		expect(vm.statusState).toBe("none");
 		expect(vm.statusLabel).toBe("");
+	});
+
+	it("marks a submitted link as sent and drops its Save action", () => {
+		const vm = toInboxLinkCardViewModel({
+			link: link({ status: "crawled", title: "T", submittedAt: "2026-07-01T00:00:00.000Z" }),
+			emailId: EMAIL_ID,
+			pollCount: 1,
+			maxPolls: 300,
+			shown: SHOWN,
+		});
+
+		expect(vm.savedState).toBe("sent");
+		expect(vm.savedLabel).toBe("Sent to your queue");
+		// Re-saving is harmless as dedupe but resurrects a finished article, so a sent
+		// card offers only the report action — never a second Save.
+		expect(vm.actions.map((action) => action.key)).toEqual(["feedback-exclude"]);
+	});
+
+	it("leaves an unsubmitted link savable and shows no sent marker", () => {
+		const vm = toInboxLinkCardViewModel({
+			link: link({ status: "crawled", title: "T", submittedAt: undefined }),
+			emailId: EMAIL_ID,
+			pollCount: 1,
+			maxPolls: 300,
+			shown: SHOWN,
+		});
+
+		expect(vm.savedState).toBe("none");
+		expect(vm.savedLabel).toBe("");
+		expect(vm.actions.map((action) => action.key)).toEqual(["save", "feedback-exclude"]);
 	});
 
 	it("keeps the card and action ids identical across a poll swap so focus can be restored", () => {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-card.viewmodel.ts
@@ -32,6 +32,12 @@ export interface InboxLinkCardViewModel {
 	statusState: CardStatusState;
 	/** Empty for `crawled`, where the title the crawl produced is the signal. */
 	statusLabel: string;
+	/** `sent` once the link has been submitted to the queue, otherwise `none`.
+	 * Renders the durable "Sent to your queue" marker so a saved card stays visibly
+	 * distinct from an unsaved one after the toast fades, a reload, or a poll swap. */
+	savedState: CardSavedState;
+	/** Empty for `none`; the marker copy for `sent`. */
+	savedLabel: string;
 	actions: InboxCardAction[];
 }
 
@@ -43,6 +49,20 @@ const CARD_STATUS_LABELS: Record<CardStatusState, string> = {
 	working: "Fetching preview…",
 	stalled: "Preview didn’t arrive",
 	failed: "No preview available",
+	none: "",
+};
+
+/** Mirrors {@link CardStatusState}: `none` still renders, hidden by its modifier,
+ * so a test asserts the state rather than an element's absence. */
+type CardSavedState = "sent" | "none";
+
+// Past tense, and "Sent" not "In": the save route only publishes SubmitLinkCommand
+// — the queue row lands in a downstream subscriber — so claiming "In your queue"
+// would over-promise a row a reader jumping to /queue might not find yet. Kept in
+// step with the transient toast ("Adding to your queue…"): present and past tense
+// of the same publish.
+const CARD_SAVED_LABELS: Record<CardSavedState, string> = {
+	sent: "Sent to your queue",
 	none: "",
 };
 
@@ -76,8 +96,11 @@ function buildCardActions(input: {
 	const shownParam = { shown: String(shown) };
 	const actions: InboxCardAction[] = [];
 	// Crawl state does not gate saving: the queue save runs its own crawl, so a
-	// link whose preview is still pending or failed is still worth saving.
-	if (validateSaveableUrl(link.url).status === "SUCCESS") {
+	// link whose preview is still pending or failed is still worth saving. An
+	// already-submitted link drops Save entirely: re-submitting is harmless as
+	// dedupe but resurrects a finished article (markUnreadIfRead), and a live Save
+	// next to "Sent to your queue" reads as a contradiction.
+	if (link.submittedAt === undefined && validateSaveableUrl(link.url).status === "SUCCESS") {
 		actions.push({
 			key: "save",
 			label: "Save to queue",
@@ -125,6 +148,7 @@ export function toInboxLinkCardViewModel(input: {
 		status: link.status,
 		isPolling: cardPollUrl !== undefined,
 	});
+	const savedState: CardSavedState = link.submittedAt !== undefined ? "sent" : "none";
 	return {
 		ordinal: link.ordinal,
 		url,
@@ -134,6 +158,8 @@ export function toInboxLinkCardViewModel(input: {
 		domId: cardDomId(link.ordinal),
 		statusState,
 		statusLabel: CARD_STATUS_LABELS[statusState],
+		savedState,
+		savedLabel: CARD_SAVED_LABELS[savedState],
 		actions: buildCardActions({ link, emailId, displayUrl: url, shown }),
 	};
 }

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-save.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-save.route.test.ts
@@ -181,6 +181,22 @@ describe("Inbox link save route", () => {
 		expect(card.querySelector('[data-test-card-action="save"]')).toBe(null);
 	});
 
+	it("does not re-publish an already-submitted link, so a stale second-tab save can't resurrect it", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		const userId = await seed(fixture);
+
+		await agent.post(savePath);
+		const second = await agent.post(savePath);
+
+		expect(second.status).toBe(303);
+		expect(second.headers.location).toBe(
+			`/inbox/${encodeURIComponent(SK)}?tab=articles&saved=1`,
+		);
+		expect(harness.submittedLinks).toEqual([{ userId, url: "https://example.com/post" }]);
+	});
+
 	it("leaves the link unmarked when the publish fails, so a saved card never over-promises", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		const harness = usePublishFailsApp(fixture);

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-save.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-save.route.test.ts
@@ -12,6 +12,14 @@ import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fix
 import { loginAgent, useTestServer } from "../../../test-app";
 
 const useApp = useTestServer();
+// A second harness whose publish always rejects, to prove the mark runs after the
+// publish: a failed publish must leave the link unmarked (under-promise) rather
+// than marking a save that never happened (over-promise).
+const usePublishFailsApp = useTestServer({
+	publishSubmitLink: async () => {
+		throw new Error("submit publish failed");
+	},
+});
 const SK = "2026-06-24T09:00:00.000Z#<save@x>";
 
 function link(userId: UserId, overrides: Partial<InboxEmailLinkEntry> = {}): InboxEmailLinkEntry {
@@ -28,6 +36,7 @@ function link(userId: UserId, overrides: Partial<InboxEmailLinkEntry> = {}): Inb
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }
@@ -101,6 +110,93 @@ describe("Inbox link save route", () => {
 		expect(toast.getAttribute("role")).toBe("status");
 		expect(toast.getAttribute("aria-live")).toBe("polite");
 		expect(toast.getAttribute("data-dismiss")).toBe("6000");
+	});
+
+	it("marks the link submitted so the saved card stays distinct after the toast fades", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		const userId = await seed(fixture);
+
+		await agent.post(savePath);
+
+		const saved = await fixture.inboxEmail.inboxEmailLinkStore.getLink({
+			userId,
+			receivedAtMessageId: SK,
+			ordinal: EmailLinkOrdinalSchema.parse("0000"),
+		});
+		assert(saved, "the saved link must still exist");
+		expect(saved.submittedAt).toBeDefined();
+	});
+
+	it("shows the durable sent marker on the followed redirect, not just the toast", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		const userId = await seed(fixture);
+		// The meta barrier makes the Articles panel terminal, so it renders cards
+		// rather than the "Looking for links…" extracting notice.
+		await fixture.inboxEmail.inboxEmailLinkStore.putLinksMeta({
+			userId,
+			receivedAtMessageId: SK,
+			meta: { truncated: false },
+		});
+
+		const response = await agent.post(savePath);
+		const confirmation = await agent.get(response.headers.location);
+
+		const card = new JSDOM(confirmation.text).window.document.querySelector(
+			'[data-test-inbox-article-card="0000"]',
+		);
+		assert(card, "the saved card must render on the redirect target");
+		const marker = card.querySelector("[data-test-card-saved]");
+		assert(marker, "the saved card must carry its sent marker");
+		expect(marker.getAttribute("data-test-card-saved")).toBe("sent");
+		expect(marker.classList.contains("inbox-article-card__saved--sent")).toBe(true);
+		expect(marker.textContent).toBe("Sent to your queue");
+		// The Save button is gone once sent — only the report action remains.
+		expect(card.querySelector('[data-test-card-action="save"]')).toBe(null);
+	});
+
+	it("keeps the sent marker on a plain reload, where a card is byte-identical to its poll swap", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		const userId = await seed(fixture, { submittedAt: "2026-07-01T00:00:00.000Z" });
+		await fixture.inboxEmail.inboxEmailLinkStore.putLinksMeta({
+			userId,
+			receivedAtMessageId: SK,
+			meta: { truncated: false },
+		});
+
+		const plain = await agent.get(`/inbox/${encodeURIComponent(SK)}?tab=articles`);
+
+		const card = new JSDOM(plain.text).window.document.querySelector(
+			'[data-test-inbox-article-card="0000"]',
+		);
+		assert(card, "the pre-submitted card must render on a plain GET");
+		expect(card.querySelector("[data-test-card-saved]")?.getAttribute("data-test-card-saved")).toBe(
+			"sent",
+		);
+		expect(card.querySelector('[data-test-card-action="save"]')).toBe(null);
+	});
+
+	it("leaves the link unmarked when the publish fails, so a saved card never over-promises", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness = usePublishFailsApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		const userId = await seed(fixture);
+
+		const response = await agent.post(savePath);
+
+		expect(response.status).toBe(500);
+		const link = await fixture.inboxEmail.inboxEmailLinkStore.getLink({
+			userId,
+			receivedAtMessageId: SK,
+			ordinal: EmailLinkOrdinalSchema.parse("0000"),
+		});
+		assert(link, "the seeded link must still exist");
+		expect(link.submittedAt).toBeUndefined();
 	});
 
 	it("renders no toast on a plain view of the same page", async () => {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
@@ -404,6 +404,16 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 				userId,
 				url: link.status === "pending" ? link.url : stripUtmParams(link.url),
 			});
+			// Publish first, then mark: a failed mark under-promises (no marker, but the
+			// command is out) where a failed publish after marking would over-promise a
+			// save that never happened. The marker is what makes the saved card durable —
+			// otherwise it reverts to an unsaved-looking card the moment the toast fades.
+			await deps.inboxEmailLinkStore.markLinkSubmitted({
+				userId,
+				receivedAtMessageId,
+				ordinal: link.ordinal,
+				submittedAt: deps.now().toISOString(),
+			});
 			res.redirect(
 				303,
 				`${buildInboxEmailDetailUrl({

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
@@ -387,8 +387,8 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 						ordinal: parsedOrdinal.data,
 					})
 				: undefined;
-			// The card only renders Save for a non-skipped, saveable link, so any
-			// other shape is an out-of-band request, not a user path.
+			// A missing, skipped, or unsaveable link never renders Save, so a POST for
+			// one is an out-of-band request, not a user path.
 			if (
 				link === undefined ||
 				link.status === "skipped" ||
@@ -397,23 +397,30 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 				res.status(404).type("html").send("");
 				return;
 			}
-			// Submits the stored URL, never the resolved one — the save pipeline owns
-			// redirects. Stripping runs after the saveable gate above and only shortens,
-			// so the validated URL cannot grow back past its length cap.
-			await deps.publishSubmitLink({
-				userId,
-				url: link.status === "pending" ? link.url : stripUtmParams(link.url),
-			});
-			// Publish first, then mark: a failed mark under-promises (no marker, but the
-			// command is out) where a failed publish after marking would over-promise a
-			// save that never happened. The marker is what makes the saved card durable —
-			// otherwise it reverts to an unsaved-looking card the moment the toast fades.
-			await deps.inboxEmailLinkStore.markLinkSubmitted({
-				userId,
-				receivedAtMessageId,
-				ordinal: link.ordinal,
-				submittedAt: deps.now().toISOString(),
-			});
+			// A submitted link no longer renders Save either, but a stale second-tab
+			// button or a replay can still POST it. Re-publishing would resurrect a
+			// finished article (the downstream save runs markUnreadIfRead), so an
+			// already-submitted save is answered idempotently — the publish and mark
+			// skipped, the &saved=1 redirect not.
+			if (link.submittedAt === undefined) {
+				// Submits the stored URL, never the resolved one — the save pipeline owns
+				// redirects. Stripping runs after the saveable gate above and only shortens,
+				// so the validated URL cannot grow back past its length cap.
+				await deps.publishSubmitLink({
+					userId,
+					url: link.status === "pending" ? link.url : stripUtmParams(link.url),
+				});
+				// Publish first, then mark: a failed mark under-promises (no marker, but the
+				// command is out) where a failed publish after marking would over-promise a
+				// save that never happened. The marker is what makes the saved card durable —
+				// otherwise it reverts to an unsaved-looking card the moment the toast fades.
+				await deps.inboxEmailLinkStore.markLinkSubmitted({
+					userId,
+					receivedAtMessageId,
+					ordinal: link.ordinal,
+					submittedAt: deps.now().toISOString(),
+				});
+			}
 			res.redirect(
 				303,
 				`${buildInboxEmailDetailUrl({

--- a/src/packages/domain/src/inbox/inbox-email-link.types.ts
+++ b/src/packages/domain/src/inbox/inbox-email-link.types.ts
@@ -25,6 +25,13 @@ export interface InboxEmailLinkEntry {
 	imageUrl: string | undefined;
 	failureReason: string | undefined;
 	skipReason: EmailLinkSkipReason | undefined;
+	/** ISO timestamp of the last `SubmitLinkCommand` publish for this link, or
+	 * `undefined` if never saved. Named for the act the save route performs — it
+	 * only publishes; the queue row lands in a downstream subscriber — so the card
+	 * can show a durable "Sent to your queue" marker that survives a reload, a poll
+	 * swap, or a device switch, where before a saved card was byte-identical to an
+	 * unsaved one once the toast faded. */
+	submittedAt: string | undefined;
 }
 
 /** A small per-email summary co-located in the links partition under a reserved
@@ -59,6 +66,15 @@ export interface InboxEmailLinkStore {
 		receivedAtMessageId: string;
 		ordinal: EmailLinkOrdinal;
 		outcome: EmailLinkOutcome;
+	}) => Promise<void>;
+	/** Stamp the last-submitted timestamp onto an existing link when the reader
+	 * saves it. Conditional on the row existing (fail closed like {@link
+	 * setLinkOutcome}), so a save on a deleted link never upserts a partial row. */
+	markLinkSubmitted: (input: {
+		userId: UserId;
+		receivedAtMessageId: string;
+		ordinal: EmailLinkOrdinal;
+		submittedAt: string;
 	}) => Promise<void>;
 	/** Write the per-email truncated meta item (reserved sort key) under the
 	 * email's partition. Idempotent PutItem. */

--- a/src/packages/inbox-store/src/dynamodb-inbox-email-link.test.ts
+++ b/src/packages/inbox-store/src/dynamodb-inbox-email-link.test.ts
@@ -105,6 +105,7 @@ describe("initDynamoDbInboxEmailLink", () => {
 				imageUrl: undefined,
 				failureReason: undefined,
 				skipReason: undefined,
+				submittedAt: undefined,
 			});
 
 			expect(result).toBe("stored");
@@ -134,6 +135,7 @@ describe("initDynamoDbInboxEmailLink", () => {
 				imageUrl: undefined,
 				failureReason: undefined,
 				skipReason: "list-unsubscribe",
+				submittedAt: undefined,
 			});
 
 			expect(result).toBe("stored");
@@ -157,6 +159,7 @@ describe("initDynamoDbInboxEmailLink", () => {
 				imageUrl: undefined,
 				failureReason: undefined,
 				skipReason: undefined,
+				submittedAt: undefined,
 			});
 
 			expect(result).toBe("duplicate");
@@ -179,6 +182,7 @@ describe("initDynamoDbInboxEmailLink", () => {
 					imageUrl: undefined,
 					failureReason: undefined,
 					skipReason: undefined,
+					submittedAt: undefined,
 				}),
 			).rejects.toThrow("throttled");
 		});
@@ -259,6 +263,76 @@ describe("initDynamoDbInboxEmailLink", () => {
 				"SET #status = :status, #failureReason = :failureReason REMOVE #title, #excerpt, #siteName, #imageUrl, #resolvedUrl, #skipReason",
 			);
 			expect(captured?.input.ExpressionAttributeValues?.[":failureReason"]).toBe("unsafe-url");
+		});
+	});
+
+	describe("markLinkSubmitted", () => {
+		it("sets the submitted timestamp on an existing row, conditional on the row's presence", async () => {
+			let captured: CapturedCommand | undefined;
+			await store((cmd) => {
+				captured = cmd as CapturedCommand;
+				return {};
+			}).markLinkSubmitted({
+				userId: USER,
+				receivedAtMessageId: RAM,
+				ordinal: ORDINAL,
+				submittedAt: "2026-07-01T00:00:00.000Z",
+			});
+
+			expect(captured?.input.Key).toEqual({ userLinkGroup: GROUP, ordinal: "0003" });
+			expect(captured?.input.ConditionExpression).toBe("attribute_exists(ordinal)");
+			expect(captured?.input.UpdateExpression).toBe("SET #submittedAt = :submittedAt");
+			expect(captured?.input.ExpressionAttributeNames?.["#submittedAt"]).toBe("submittedAt");
+			expect(captured?.input.ExpressionAttributeValues?.[":submittedAt"]).toBe(
+				"2026-07-01T00:00:00.000Z",
+			);
+		});
+
+		it("surfaces a conditional-check failure when the row is gone rather than upserting it", async () => {
+			await expect(
+				store(() => {
+					throw conditionalCheckFailed();
+				}).markLinkSubmitted({
+					userId: USER,
+					receivedAtMessageId: RAM,
+					ordinal: ORDINAL,
+					submittedAt: "2026-07-01T00:00:00.000Z",
+				}),
+			).rejects.toBeInstanceOf(ConditionalCheckFailedException);
+		});
+
+		it("is never undone by a later crawl outcome — setLinkOutcome removes only preview fields", async () => {
+			const removeExpressions: string[] = [];
+			const s = store((cmd) => {
+				const update = (cmd as CapturedCommand).input.UpdateExpression;
+				if (update !== undefined) removeExpressions.push(update);
+				return {};
+			});
+
+			await s.setLinkOutcome({
+				userId: USER,
+				receivedAtMessageId: RAM,
+				ordinal: ORDINAL,
+				outcome: {
+					status: "crawled",
+					title: "T",
+					excerpt: "E",
+					siteName: "S",
+					imageUrl: undefined,
+					resolvedUrl: undefined,
+				},
+			});
+			await s.setLinkOutcome({
+				userId: USER,
+				receivedAtMessageId: RAM,
+				ordinal: ORDINAL,
+				outcome: { status: "failed", failureReason: "crawl-failed" },
+			});
+
+			expect(removeExpressions).toHaveLength(2);
+			for (const expression of removeExpressions) {
+				expect(expression).not.toContain("submittedAt");
+			}
 		});
 	});
 
@@ -384,6 +458,7 @@ describe("initDynamoDbInboxEmailLink", () => {
 						title: "Title",
 						excerpt: "Excerpt",
 						siteName: "Site",
+						submittedAt: "2026-07-01T00:00:00.000Z",
 					},
 				};
 			}).getLink({ userId: USER, receivedAtMessageId: RAM, ordinal: ORDINAL });
@@ -392,6 +467,7 @@ describe("initDynamoDbInboxEmailLink", () => {
 			assert(found, "expected the link to be returned");
 			expect(found.title).toBe("Title");
 			expect(found.imageUrl).toBeUndefined();
+			expect(found.submittedAt).toBe("2026-07-01T00:00:00.000Z");
 		});
 
 		it("returns undefined for an unknown link", async () => {

--- a/src/packages/inbox-store/src/dynamodb-inbox-email-link.ts
+++ b/src/packages/inbox-store/src/dynamodb-inbox-email-link.ts
@@ -47,6 +47,7 @@ const InboxEmailLinkRow = z.object({
 	imageUrl: dynamoField(z.string()),
 	failureReason: dynamoField(z.string()),
 	skipReason: dynamoField(EmailLinkSkipReasonSchema),
+	submittedAt: dynamoField(z.string()),
 	truncated: dynamoField(z.boolean()),
 });
 
@@ -68,6 +69,7 @@ function toEntry(row: InboxEmailLinkRowType): InboxEmailLinkEntry {
 		imageUrl: row.imageUrl,
 		failureReason: row.failureReason,
 		skipReason: row.skipReason,
+		submittedAt: row.submittedAt,
 	};
 }
 
@@ -184,6 +186,19 @@ export function initDynamoDbInboxEmailLink(deps: {
 					"#skipReason": "skipReason",
 				},
 				ExpressionAttributeValues: { ":status": "failed", ":failureReason": outcome.failureReason },
+			});
+		},
+		markLinkSubmitted: async ({ userId, receivedAtMessageId, ordinal, submittedAt }) => {
+			await table.update({
+				Key: { userLinkGroup: groupKey({ userId, receivedAtMessageId }), ordinal },
+				// Fail closed if the row is gone (same reason as setLinkOutcome): a bare
+				// UpdateItem would upsert a partial item with no url/status. A crawl
+				// outcome that lands after this only REMOVEs preview fields, never
+				// submittedAt, so the marker survives a save-then-crawl race.
+				ConditionExpression: "attribute_exists(ordinal)",
+				UpdateExpression: "SET #submittedAt = :submittedAt",
+				ExpressionAttributeNames: { "#submittedAt": "submittedAt" },
+				ExpressionAttributeValues: { ":submittedAt": submittedAt },
 			});
 		},
 		putLinksMeta: async ({ userId, receivedAtMessageId, meta }) => {

--- a/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email-link.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email-link.test.ts
@@ -24,6 +24,7 @@ function makeLink(overrides: Partial<InboxEmailLinkEntry> = {}): InboxEmailLinkE
 		imageUrl: undefined,
 		failureReason: undefined,
 		skipReason: undefined,
+		submittedAt: undefined,
 		...overrides,
 	};
 }
@@ -168,6 +169,75 @@ describe("initInMemoryInboxEmailLink", () => {
 		expect(found.failureReason).toBe("crawl-failed");
 		expect(found.title).toBeUndefined();
 		expect(found.resolvedUrl).toBeUndefined();
+	});
+
+	describe("markLinkSubmitted", () => {
+		it("stamps the submitted timestamp onto an existing link", async () => {
+			const store = initInMemoryInboxEmailLink();
+			await store.putLink(makeLink());
+
+			await store.markLinkSubmitted({
+				userId: owner,
+				receivedAtMessageId: RAM,
+				ordinal: EmailLinkOrdinalSchema.parse("0000"),
+				submittedAt: "2026-07-01T00:00:00.000Z",
+			});
+
+			const found = await store.getLink({
+				userId: owner,
+				receivedAtMessageId: RAM,
+				ordinal: EmailLinkOrdinalSchema.parse("0000"),
+			});
+			assert(found);
+			expect(found.submittedAt).toBe("2026-07-01T00:00:00.000Z");
+		});
+
+		it("asserts when the link was never stored, rather than upserting a partial row", async () => {
+			const store = initInMemoryInboxEmailLink();
+
+			await expect(
+				store.markLinkSubmitted({
+					userId: owner,
+					receivedAtMessageId: RAM,
+					ordinal: EmailLinkOrdinalSchema.parse("0000"),
+					submittedAt: "2026-07-01T00:00:00.000Z",
+				}),
+			).rejects.toThrow("never stored");
+		});
+
+		it("keeps the submitted marker when a crawl outcome lands afterwards", async () => {
+			const store = initInMemoryInboxEmailLink();
+			await store.putLink(makeLink());
+			await store.markLinkSubmitted({
+				userId: owner,
+				receivedAtMessageId: RAM,
+				ordinal: EmailLinkOrdinalSchema.parse("0000"),
+				submittedAt: "2026-07-01T00:00:00.000Z",
+			});
+
+			await store.setLinkOutcome({
+				userId: owner,
+				receivedAtMessageId: RAM,
+				ordinal: EmailLinkOrdinalSchema.parse("0000"),
+				outcome: {
+					status: "crawled",
+					title: "T",
+					excerpt: "E",
+					siteName: "S",
+					imageUrl: undefined,
+					resolvedUrl: undefined,
+				},
+			});
+
+			const found = await store.getLink({
+				userId: owner,
+				receivedAtMessageId: RAM,
+				ordinal: EmailLinkOrdinalSchema.parse("0000"),
+			});
+			assert(found);
+			expect(found.status).toBe("crawled");
+			expect(found.submittedAt).toBe("2026-07-01T00:00:00.000Z");
+		});
 	});
 
 	describe("deleteLinksByEmail", () => {

--- a/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email-link.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-email/in-memory-inbox-email-link.ts
@@ -62,6 +62,12 @@ export function initInMemoryInboxEmailLink(): InboxEmailLinkStore {
 						},
 			);
 		},
+		markLinkSubmitted: async ({ userId, receivedAtMessageId, ordinal, submittedAt }) => {
+			const key = linkKey(groupKey({ userId, receivedAtMessageId }), ordinal);
+			const existing = links.get(key);
+			assert(existing, "markLinkSubmitted on a link that was never stored");
+			links.set(key, { ...existing, submittedAt });
+		},
 		putLinksMeta: async ({ userId, receivedAtMessageId, meta }) => {
 			metas.set(groupKey({ userId, receivedAtMessageId }), meta);
 		},


### PR DESCRIPTION
## Problem

A saved inbox link card looked byte-identical to an unsaved one the moment the confirmation toast faded — and again after a reload, a tab switch, or the 3s poll swap. The save route (`inbox.page.ts`) only published `SubmitLinkCommand` and redirected to `&saved=1`; it wrote nothing to the link row, and the card view model carried no saved field. The sole feedback was the self-dismissing toast.

Working a 15-link newsletter one card at a time, nothing recorded which links were already sent. Re-saving doesn't duplicate, but it *does* resurrect: `markUnreadIfRead` flips a finished article back to `unread` and clears `readAt` on every re-submit.

## Change

Persist the save on the link row and render a durable marker:

- **Domain contract** (`@packages/domain`): add `submittedAt: string | undefined` to `InboxEmailLinkEntry` and a `markLinkSubmitted` method to `InboxEmailLinkStore`. Named for the act the route performs — it only *publishes*; the queue row lands downstream — matching the honesty of the existing "Adding to your queue…" toast copy.
- **Stores** (`inbox-store` DynamoDB + in-memory fixture): implement `markLinkSubmitted` as a conditional `UpdateItem` (`attribute_exists(ordinal)`, fail closed like `setLinkOutcome`); map `submittedAt` through `toEntry`. `setLinkOutcome`'s REMOVE lists name only preview fields, so a crawl completing after a save preserves the marker.
- **Save route**: after `publishSubmitLink`, call `markLinkSubmitted` with `now()`. Order is deliberate — publish first, so a failed mark under-promises rather than a failed publish over-promising.
- **View model / template / styles**: derive a `savedState` (`"sent"`/`"none"`) and `savedLabel`. A sent card renders "Sent to your queue" (using the established `--success-text` variable) and drops the Save action — leaving only the report action, since re-saving is harmful to a finished article. Mirrors the existing render-always-plus-modifier pattern used by `statusState`.
- **ETag**: hash `submittedAt` so a save from another tab/device invalidates a mid-poll card instead of 304ing stale markup.

## Marker wording & Save affordance

"Sent to your queue" (past tense, "Sent" not "In") is honest about the publish-only path; "In your queue" / "Added to queue" would over-promise a downstream write. Save is replaced by the marker rather than shown alongside it: the aggregate makes re-submits harmless as dedupe, but `markUnreadIfRead` makes them harmful, and a live Save button next to "Sent to your queue" reads as a contradiction.

## Tests

- Store tests (DynamoDB + in-memory): `markLinkSubmitted` sets the attribute; conditional-check failure on a missing row; a later `setLinkOutcome` preserves `submittedAt`; `toEntry` round-trips it.
- View model: `submittedAt` set → `sent` / "Sent to your queue" / actions `["feedback-exclude"]`; unset → `none` / `""` / `["save", "feedback-exclude"]`.
- Save route: POST leaves `submittedAt` defined; the followed redirect and a plain reload both render the `--sent` marker with the Save button gone (durability); when `publishSubmitLink` rejects, the row stays unmarked (publish-order guard).
- Card route: the poll fragment renders `--sent` (survives the swap); the ETag differs between submitted and unsubmitted rows.

Verified with `pnpm nx run inbox:check`, `@packages/domain:check`, `inbox-store:check`, `test-fixtures:check`, and the full `pnpm check` (all projects) via the pre-commit hook — 100% coverage on the touched inbox/domain/store files, unused-css green. No infrastructure diff (DynamoDB items are schemaless; no attribute-definition change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwrdqNgyVAxYHxxdV7qaVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwrdqNgyVAxYHxxdV7qaVg)_