### PR TITLE
feat(inbox): let users re-enable a disabled inbox email

### DIFF
--- a/projects/inbox/src/runtime/domain/inbox/receive-email-handler.test.ts
+++ b/projects/inbox/src/runtime/domain/inbox/receive-email-handler.test.ts
@@ -212,6 +212,22 @@ describe("initReceiveEmailHandler", () => {
 		expect(published).toHaveLength(0);
 	});
 
+	it("delivers again to an address that was disabled and then re-enabled", async () => {
+		const { addressStore, emailStore, rawMap, published, run } = makeHarness();
+		const address = await mintAddress(addressStore);
+		await addressStore.disableAddress({ userId: OWNER, address });
+		await addressStore.enableAddress({ userId: OWNER, address });
+		rawMap.set(RAW_KEY, Buffer.from("raw"));
+
+		const result = await run(address);
+
+		assert(result);
+		expect(result.batchItemFailures).toHaveLength(0);
+		const [row] = await listEmails(emailStore, OWNER);
+		expect(row.status).toBe("received");
+		expect(published).toHaveLength(1);
+	});
+
 	it("records an unparseable email as status=unparsed and fails to the DLQ", async () => {
 		const { addressStore, emailStore, rawMap, published, run } = makeHarness({
 			parseEmail: async () => ({ ok: false, reason: "unparseable" }),

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.component.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.component.ts
@@ -27,6 +27,7 @@ export function InboxPage(params: {
 		}),
 		createAction: "/inbox/create",
 		disableAction: "/inbox/disable",
+		enableAction: "/inbox/enable",
 	});
 
 	return {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.page.ts
@@ -71,9 +71,9 @@ interface InboxDependencies {
 	logError: (message: string, error?: Error) => void;
 	buildBannerState: BuildBannerState;
 	publishSubmitLink: (input: { userId: UserId; url: string }) => Promise<void>;
-	/** Save gates applied to the write actions — /create (a forwarding address is
-	 * a save-flow input) and the per-link save (it lands an article in the
-	 * reader's queue). Both gates run: `requireNotLocked` blocks a
+	/** Save gates applied to the write actions — /create and /enable (each opens
+	 * a mail-receiving save-flow input) and the per-link save (it lands an article
+	 * in the reader's queue). Both gates run: `requireNotLocked` blocks a
 	 * locked (unverified-past-window) account, `requireWriteAccess` blocks a
 	 * read-only (trial-expired / cancelled) account. Viewing and disabling existing
 	 * addresses stay open — disabling reduces footprint and is harmless. */
@@ -95,7 +95,7 @@ const POLL_PANEL_RENDERERS: Record<
 	excluded: (vm) => renderInboxExcludedPanel(vm.excluded),
 };
 
-const DisableAddressSchema = z.object({ address: InboxAddressSchema });
+const AddressActionSchema = z.object({ address: InboxAddressSchema });
 const CreateAddressSchema = z.object({ name: z.string() });
 const LinkFeedbackSchema = z.object({
 	verdict: z.enum(["should-be-included", "should-be-excluded"]),
@@ -492,7 +492,7 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 	router.post("/disable", async (req: Request, res: Response) => {
 		assert(req.userId, "userId required - route must be protected by requireAuth");
 		const userId = req.userId;
-		const parsed = DisableAddressSchema.safeParse(req.body);
+		const parsed = AddressActionSchema.safeParse(req.body);
 		if (parsed.success) {
 			// Confirm ownership before disabling so a forged address for someone
 			// else's row never reaches the (also ownership-guarded) store write.
@@ -503,6 +503,29 @@ export function initInboxRoutes(deps: InboxDependencies): Router {
 		}
 		res.redirect(303, addressesPath);
 	});
+
+	router.post(
+		"/enable",
+		deps.requireNotLocked,
+		deps.requireWriteAccess,
+		async (req: Request, res: Response) => {
+			assert(req.userId, "userId required - route must be protected by requireAuth");
+			const userId = req.userId;
+			const parsed = AddressActionSchema.safeParse(req.body);
+			if (parsed.success) {
+				const owned = await deps.inboxAddressStore.listAddressesByUserId(userId);
+				const target = owned.find((entry) => entry.address === parsed.data.address);
+				if (target !== undefined && !isLiveAddress(target)) {
+					if (countLiveAddresses(owned) >= INBOX_ADDRESS_MAX_PER_USER) {
+						res.redirect(303, `${addressesPath}?error=limit`);
+						return;
+					}
+					await deps.inboxAddressStore.enableAddress({ userId, address: parsed.data.address });
+				}
+			}
+			res.redirect(303, addressesPath);
+		},
+	);
 
 	return router;
 }

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.route.test.ts
@@ -439,4 +439,205 @@ describe("Inbox address routes", () => {
 			expect(after.querySelector('[data-test-inbox-status="enabled"]')).not.toBeNull();
 		});
 	});
+
+	describe("POST /inbox/enable", () => {
+		it("re-enables a disabled address and returns it to the active list", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create").type("form").send({ name: "netflix" });
+			const address = addressFieldValue((await agent.get("/inbox/addresses")).text);
+			assert(address, "the created address must render");
+			await agent.post("/inbox/disable").type("form").send({ address });
+
+			const response = await agent.post("/inbox/enable").type("form").send({ address });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			const statuses = Array.from(after.querySelectorAll("[data-test-inbox-status]")).map(
+				(el) => el.getAttribute("data-test-inbox-status"),
+			);
+			expect(statuses).toEqual(["enabled"]);
+			expect(after.querySelector(".inbox__disabled-summary")?.textContent).toBe(
+				"Disabled inbox emails (0)",
+			);
+			expect(
+				after
+					.querySelector("[data-test-inbox-disabled-group]")
+					?.classList.contains("inbox__disabled-group--hidden"),
+			).toBe(true);
+		});
+
+		it("renders an enable control on each disabled row pointing at the enable route", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create").type("form").send({ name: "netflix" });
+			const address = addressFieldValue((await agent.get("/inbox/addresses")).text);
+			assert(address, "the created address must render");
+			await agent.post("/inbox/disable").type("form").send({ address });
+
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			const enable = after.querySelector(
+				"[data-test-inbox-disabled-group] [data-test-inbox-enable]",
+			);
+			assert(enable, "the disabled row must render an enable control");
+			expect(enable.closest("form")?.getAttribute("action")).toBe("/inbox/enable");
+		});
+
+		it("leaves an already-live address unchanged and issues no error param", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create").type("form").send({ name: "netflix" });
+			const address = addressFieldValue((await agent.get("/inbox/addresses")).text);
+			assert(address, "the created address must render");
+
+			const response = await agent.post("/inbox/enable").type("form").send({ address });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			const statuses = Array.from(after.querySelectorAll("[data-test-inbox-status]")).map(
+				(el) => el.getAttribute("data-test-inbox-status"),
+			);
+			expect(statuses).toEqual(["enabled"]);
+		});
+
+		it("ignores a request whose body is not a valid address", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create").type("form").send({ name: "netflix" });
+
+			const response = await agent
+				.post("/inbox/enable")
+				.type("form")
+				.send({ address: "not-an-address" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			expect(after.querySelector('[data-test-inbox-status="enabled"]')).not.toBeNull();
+		});
+
+		it("does not enable an address the user does not own", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			await agent.post("/inbox/create").type("form").send({ name: "netflix" });
+
+			const response = await agent
+				.post("/inbox/enable")
+				.type("form")
+				.send({ address: "in-zzzzzz@read.place" });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			const statuses = Array.from(after.querySelectorAll("[data-test-inbox-status]")).map(
+				(el) => el.getAttribute("data-test-inbox-status"),
+			);
+			expect(statuses).toEqual(["enabled"]);
+		});
+
+		it("refuses to enable when it would exceed the cap, leaving the row disabled", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+			const userId = (await harness.auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "seeded login user must exist");
+			const store = fixture.inboxAddress.inboxAddressStore;
+			for (let i = 0; i < INBOX_ADDRESS_MAX_PER_USER - 1; i++) {
+				await store.createAddress({ userId, domain: "read.place", name: SEED_NAME });
+			}
+			const target = await store.createAddress({
+				userId,
+				domain: "read.place",
+				name: SEED_NAME,
+			});
+			await store.disableAddress({ userId, address: target.address });
+			await store.createAddress({ userId, domain: "read.place", name: SEED_NAME });
+
+			const response = await agent
+				.post("/inbox/enable")
+				.type("form")
+				.send({ address: target.address });
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/inbox/addresses?error=limit");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			const disabledField = after.querySelector(
+				"[data-test-inbox-disabled-group] .inbox__address-field",
+			);
+			expect(disabledField?.getAttribute("value")).toBe(target.address);
+		});
+
+		it("redirects a read-only user to /queue?inactive=1 and re-enables nothing", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const agent = await loginAgent(harness.server, harness.auth);
+			const userId = (await harness.auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "seeded login user must exist");
+			await agent.post("/inbox/create").type("form").send({ name: "netflix" });
+			const address = addressFieldValue((await agent.get("/inbox/addresses")).text);
+			assert(address, "the created address must render");
+			await agent.post("/inbox/disable").type("form").send({ address });
+			await harness.subscriptionProviders.upsertTrialing({
+				userId,
+				trialEndsAt: new Date(Date.now() - ONE_DAY_MS).toISOString(),
+			});
+
+			const response = await agent
+				.post("/inbox/enable")
+				.type("form")
+				.send({ address })
+				.set("Accept", "text/html");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/queue?inactive=1");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			expect(after.querySelector('[data-test-inbox-status="disabled"]')).not.toBeNull();
+			expect(after.querySelector('[data-test-inbox-status="enabled"]')).toBeNull();
+		});
+
+		it("blocks a locked user with the account-locked screen and re-enables nothing", async () => {
+			const fixture = fixtureClockedDaysAhead(8);
+			const harness = useApp(fixture);
+			const agent = await loginAgent(harness.server, harness.auth);
+			const userId = (await harness.auth.findUserByEmail("test@example.com"))?.userId;
+			assert(userId, "seeded login user must exist");
+			const store = fixture.inboxAddress.inboxAddressStore;
+			const entry = await store.createAddress({
+				userId,
+				domain: "read.place",
+				name: SEED_NAME,
+			});
+			await store.disableAddress({ userId, address: entry.address });
+
+			const response = await agent
+				.post("/inbox/enable")
+				.type("form")
+				.send({ address: entry.address })
+				.set("Accept", "text/html");
+
+			expect(response.status).toBe(403);
+			expect(
+				new JSDOM(response.text).window.document.querySelector("h1")?.textContent,
+			).toBe("Your account is locked");
+			const after = new JSDOM(
+				(await agent.get("/inbox/addresses")).text,
+			).window.document;
+			expect(after.querySelector('[data-test-inbox-status="disabled"]')).not.toBeNull();
+		});
+	});
 });

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.styles.css
@@ -136,11 +136,13 @@
   color: var(--muted-foreground);
 }
 
-.inbox__disable {
+.inbox__disable,
+.inbox__enable {
   margin: 0;
 }
 
-.inbox__disable-btn {
+.inbox__disable-btn,
+.inbox__enable-btn {
   padding: var(--button-padding-sm);
   font-size: 0.85rem;
   color: var(--muted-foreground);
@@ -150,7 +152,8 @@
   cursor: pointer;
 }
 
-.inbox__disable-btn:hover {
+.inbox__disable-btn:hover,
+.inbox__enable-btn:hover {
   color: var(--foreground);
 }
 

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.template.html
@@ -53,6 +53,10 @@
               <input class="inbox__address-field inbox__address-field--disabled" type="text" value="{{this.address}}" disabled aria-label="{{this.addressAriaLabel}}" />
               <div class="inbox__controls">
                 <span class="inbox__status inbox__status--disabled" data-test-inbox-status="disabled">Disabled</span>
+                <form action="{{../enableAction}}" method="POST" class="inbox__enable">
+                  <input type="hidden" name="address" value="{{this.address}}" />
+                  <button type="submit" class="inbox__enable-btn" data-test-inbox-enable>Enable</button>
+                </form>
               </div>
             </li>
             {{/each}}

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox.viewmodel.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox.viewmodel.ts
@@ -35,7 +35,7 @@ const ALERT_MESSAGES: Record<InboxAlertKey, string> = {
 	"name-invalid":
 		"Give the inbox email a name using letters and numbers — for example, netflix.",
 	"name-taken": "You already have an active inbox email with that name. Pick a different one.",
-	limit: `You've reached the maximum of ${INBOX_ADDRESS_MAX_PER_USER} inbox emails. Disable any you no longer need before creating more.`,
+	limit: `You've reached the maximum of ${INBOX_ADDRESS_MAX_PER_USER} inbox emails. Disable any you no longer need before enabling or creating more.`,
 };
 
 /** The alerts the page is showing, in the order they render. Built here rather

--- a/src/packages/domain/src/inbox/inbox-address.types.ts
+++ b/src/packages/domain/src/inbox/inbox-address.types.ts
@@ -47,6 +47,11 @@ export interface InboxAddressStore {
 	 * another user throws `ConditionalCheckFailedException` rather than silently
 	 * succeeding, so a forged address can never reach a foreign row. */
 	disableAddress: (input: { userId: UserId; address: InboxAddress }) => Promise<void>;
+	/** Clears `disabledAt`, returning an address the user owns to live. Guarded
+	 * exactly like {@link disableAddress}: a tombstoned row's sentinel `userId`
+	 * fails the ownership condition, so a deleted-account address can never be
+	 * resurrected and a forged address can never reach a foreign row. */
+	enableAddress: (input: { userId: UserId; address: InboxAddress }) => Promise<void>;
 	/** Resolve a forwarding address to its owner. A single strongly-consistent
 	 * GetItem on the `address` partition key — not the eventually-consistent GSI
 	 * that `listAddressesByUserId` reads — so the receive path never races a

--- a/src/packages/inbox-store/src/dynamodb-inbox-address.test.ts
+++ b/src/packages/inbox-store/src/dynamodb-inbox-address.test.ts
@@ -259,6 +259,43 @@ describe("initDynamoDbInboxAddress", () => {
 		});
 	});
 
+	describe("enableAddress", () => {
+		it("clears disabledAt with an ownership-guarded REMOVE update", async () => {
+			let captured: CapturedCommand | undefined;
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient((cmd) => {
+					captured = cmd as CapturedCommand;
+					return {};
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+			const address = InboxAddressSchema.parse("in-3f9a2c@read.place");
+
+			await store.enableAddress({ userId: USER, address });
+
+			expect(captured?.input.Key).toEqual({ address });
+			expect(captured?.input.ConditionExpression).toBe("userId = :uid");
+			expect(captured?.input.UpdateExpression).toBe("REMOVE disabledAt");
+			expect(captured?.input.ExpressionAttributeValues?.[":uid"]).toBe(USER);
+		});
+
+		it("propagates the conditional-check failure when the caller does not own the row", async () => {
+			const store = initDynamoDbInboxAddress({
+				client: createFakeClient(() => {
+					throw conditionalCheckFailed();
+				}) as DynamoDBDocumentClient,
+				tableName: TABLE,
+				now: () => NOW,
+			});
+			const address = InboxAddressSchema.parse("in-3f9a2c@read.place");
+
+			await expect(store.enableAddress({ userId: USER, address })).rejects.toThrow(
+				ConditionalCheckFailedException,
+			);
+		});
+	});
+
 	describe("findByAddress", () => {
 		it("resolves an address with a single GetItem on the address key", async () => {
 			let captured: CapturedCommand | undefined;

--- a/src/packages/inbox-store/src/dynamodb-inbox-address.ts
+++ b/src/packages/inbox-store/src/dynamodb-inbox-address.ts
@@ -137,6 +137,14 @@ export function initDynamoDbInboxAddress(deps: {
 				ExpressionAttributeValues: { ":uid": userId, ":now": deps.now().toISOString() },
 			});
 		},
+		enableAddress: async ({ userId, address }) => {
+			await table.update({
+				Key: { address },
+				ConditionExpression: "userId = :uid",
+				UpdateExpression: "REMOVE disabledAt",
+				ExpressionAttributeValues: { ":uid": userId },
+			});
+		},
 		findByAddress: async (address) => {
 			const row = await table.get({ address });
 			return row === undefined ? undefined : toEntry(row);

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.test.ts
@@ -153,6 +153,43 @@ describe("initInMemoryInboxAddress", () => {
 		expect(found.disabledAt).toBe("2026-06-23T12:00:00.000Z");
 	});
 
+	it("enables an owned address by clearing disabledAt", async () => {
+		const store = initInMemoryInboxAddress({
+			now: () => new Date("2026-06-23T12:00:00.000Z"),
+		});
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
+		await store.disableAddress({ userId: owner, address: entry.address });
+
+		await store.enableAddress({ userId: owner, address: entry.address });
+
+		const [refreshed] = await store.listAddressesByUserId(owner);
+		expect(refreshed.disabledAt).toBeUndefined();
+	});
+
+	it("rejects an enable for an address that does not exist", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		const missing = InboxAddressSchema.parse("in-3f9a2c@read.place");
+
+		await expect(
+			store.enableAddress({ userId: owner, address: missing }),
+		).rejects.toThrow(ConditionalCheckFailedException);
+
+		expect(await store.listAddressesByUserId(owner)).toHaveLength(0);
+	});
+
+	it("rejects an enable requested by a non-owner", async () => {
+		const store = initInMemoryInboxAddress({ now: () => new Date() });
+		const entry = await store.createAddress({ userId: owner, domain: DOMAIN, name: NAME });
+		await store.disableAddress({ userId: owner, address: entry.address });
+
+		await expect(
+			store.enableAddress({ userId: otherUser, address: entry.address }),
+		).rejects.toThrow(ConditionalCheckFailedException);
+
+		const [refreshed] = await store.listAddressesByUserId(owner);
+		expect(refreshed.disabledAt).not.toBeUndefined();
+	});
+
 	describe("tombstoneUserAddresses", () => {
 		it("unlinks the owner's addresses to the reserved owner, keeps every row, and stamps disabledAt only when unset", async () => {
 			let clock = new Date("2026-06-01T00:00:00.000Z");

--- a/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
+++ b/src/packages/test-fixtures/src/providers/inbox-address/in-memory-inbox-address.ts
@@ -47,6 +47,16 @@ export function initInMemoryInboxAddress(deps: { now: () => Date }): InboxAddres
 			}
 			rows.set(address, { ...row, disabledAt: deps.now().toISOString() });
 		},
+		enableAddress: async ({ userId, address }) => {
+			const row = rows.get(address);
+			if (row === undefined || row.userId !== userId) {
+				throw new ConditionalCheckFailedException({
+					$metadata: {},
+					message: "The conditional request failed",
+				});
+			}
+			rows.set(address, { ...row, disabledAt: undefined });
+		},
 		findByAddress: async (address) => rows.get(address),
 		tombstoneUserAddresses: async (userId) => {
 			for (const [address, entry] of rows) {


### PR DESCRIPTION
## What & why

Disabling an inbox forwarding address was a one-click, one-way door. The random token in `netflix-<token>@read.place` is not reproducible, so recreating the same name mints a *different* address — every newsletter subscription and Gmail filter pointed at the old one silently breaks, with nothing in the product able to bring it back. The limit banner even steers at-cap users (the ones with the most subscriptions) straight at that unconfirmed button.

The fix is **undo instead of confirm**: disable stays one click (it is reversible and frees its cap slot instantly), and every disabled row now carries a first-class **Enable** action. No JS confirm dialog — the surface serves no client JS, and reversibility makes interruption unnecessary.

## Changes

- **`@packages/domain` — `InboxAddressStore`**: new required `enableAddress`, the ownership-guarded inverse of `disableAddress`. It clears `disabledAt`; a tombstoned row's sentinel `userId` fails the `userId = :uid` guard, so a deleted-account address can never be resurrected and a forged address can never reach a foreign row.
- **`@packages/inbox-store` (DynamoDB)**: `enableAddress` issues an ownership-guarded `REMOVE disabledAt` update (idempotent on an already-live row).
- **`@packages/test-fixtures` (in-memory)**: mirrors `disableAddress`'s semantics — throws `ConditionalCheckFailedException` when the row is missing or foreign-owned, else clears `disabledAt`.
- **`inbox.page.ts`**: new `POST /inbox/enable`, gated by `requireNotLocked` + `requireWriteAccess` like `/create` (it re-opens a mail-receiving input). It acts only on an owned, currently-disabled address; if re-enabling would exceed `INBOX_ADDRESS_MAX_PER_USER` live it redirects `?error=limit` and leaves the row disabled; invalid body / foreign / already-live fall through to a plain 303, matching `/disable`. `DisableAddressSchema` → `AddressActionSchema` (shared by both routes).
- **Template / component / CSS**: an Enable `<form>` on each disabled row, sharing the Disable button's muted `--muted-foreground`-on-`--card` styling via grouped selectors — a recovery action, deliberately not the amber primary treatment.

## Tests

- **`inbox.route.test.ts`** — new `POST /inbox/enable` suite: happy path (row returns to the active list, disabled group collapses), Enable control renders in the disabled row pointing at `/inbox/enable`, foreign address, invalid body, already-live no-op, at-cap refusal (`?error=limit`, row stays disabled), and both save gates (read-only → `/queue?inactive=1`, locked → account-locked screen; store untouched).
- **`dynamodb-inbox-address.test.ts`** — `enableAddress` issues the ownership-guarded `REMOVE`; propagates the conditional-check failure for a non-owner.
- **`in-memory-inbox-address.test.ts`** — clears `disabledAt`; rejects missing / foreign.
- **`receive-email-handler.test.ts`** — mail to a disabled-then-re-enabled address is delivered again (the "no way back" reversed).

## Verification

`pnpm check` — green across all 45 projects / 63 tasks, **100% coverage** on every changed inbox file (`inbox.page.ts`, `inbox.component.ts`, `receive-email-handler.ts`) and 100% on `@packages/domain`, `@packages/inbox-store`, and `@packages/test-fixtures`. No infrastructure touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMopAS6SXNiSaKVXjgmBDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMopAS6SXNiSaKVXjgmBDB)_