### PR TITLE
fix(@packages/web-shell,hutch,inbox): announce toasts via a persistent shell live region

### DIFF
--- a/projects/hutch/src/runtime/web/shared/toast/toast.client.test.ts
+++ b/projects/hutch/src/runtime/web/shared/toast/toast.client.test.ts
@@ -7,12 +7,18 @@ interface ScheduledTimer {
 	ms: number;
 }
 
-function initWithDom(bodyHtml: string): {
+function initWithDom(
+	bodyHtml: string,
+	opts: { withRegion?: boolean } = {},
+): {
 	document: Document;
 	timers: ScheduledTimer[];
 	triggerSwap: () => void;
 } {
-	const dom = new JSDOM(`<!DOCTYPE html><html><body>${bodyHtml}</body></html>`);
+	const region = opts.withRegion
+		? `<div class="sr-only" id="toast-live-region" role="status" aria-live="polite"></div>`
+		: "";
+	const dom = new JSDOM(`<!DOCTYPE html><html><body>${bodyHtml}${region}</body></html>`);
 	const timers: ScheduledTimer[] = [];
 	let swapListener: (() => void) | undefined;
 	initToastDismiss({
@@ -79,5 +85,98 @@ describe("initToastDismiss", () => {
 			`<div class="toast" data-dismiss="abc">bad</div><div class="toast" data-dismiss="0">zero</div>`,
 		);
 		expect(timers.length).toBe(0);
+	});
+
+	const toastWithMessage = (message: string, ms = 6000) =>
+		`<div class="toast" data-dismiss="${ms}"><span class="toast__message">${message}</span></div>`;
+
+	it("announces a scanned toast by writing its message into the live region only after the settle delay fires", () => {
+		const { document, timers } = initWithDom(toastWithMessage("Saved"), {
+			withRegion: true,
+		});
+		const region = document.getElementById("toast-live-region");
+		assert(region, "the persistent live region must be present");
+
+		expect(region.textContent).toBe("");
+		const settle = timers.find((timer) => timer.ms === 150);
+		assert(settle, "a settle timer must be scheduled for the announcement");
+
+		settle.callback();
+		expect(region.textContent).toBe("Saved");
+	});
+
+	it("clears the live region when the toast is dismissed, so an unchanged region does not keep the last message", () => {
+		const { document, timers } = initWithDom(toastWithMessage("Saved"), {
+			withRegion: true,
+		});
+		const region = document.getElementById("toast-live-region");
+		assert(region, "the persistent live region must be present");
+
+		const settle = timers.find((timer) => timer.ms === 150);
+		assert(settle, "a settle timer must be scheduled");
+		settle.callback();
+		expect(region.textContent).toBe("Saved");
+
+		const dismissTimer = timers.find((timer) => timer.ms === 6000);
+		assert(dismissTimer, "a dismiss timer must be scheduled");
+		dismissTimer.callback();
+		expect(region.textContent).toBe("");
+	});
+
+	it("re-announces a second identical toast after the first was dismissed and cleared", () => {
+		const { document, timers, triggerSwap } = initWithDom(toastWithMessage("Saved"), {
+			withRegion: true,
+		});
+		const region = document.getElementById("toast-live-region");
+		assert(region, "the persistent live region must be present");
+
+		timers.find((timer) => timer.ms === 150)?.callback();
+		timers.find((timer) => timer.ms === 6000)?.callback();
+		expect(region.textContent).toBe("");
+
+		document.body.querySelector(".toast")?.remove();
+		const before = timers.length;
+		document.body.insertAdjacentHTML("afterbegin", toastWithMessage("Saved"));
+		triggerSwap();
+
+		const settle = timers.slice(before).find((timer) => timer.ms === 150);
+		assert(settle, "the second toast must schedule its own settle timer");
+		settle.callback();
+		expect(region.textContent).toBe("Saved");
+	});
+
+	it("announces a toast that arrives via an htmx swap", () => {
+		const { document, timers, triggerSwap } = initWithDom("", { withRegion: true });
+		const region = document.getElementById("toast-live-region");
+		assert(region, "the persistent live region must be present");
+
+		document.body.insertAdjacentHTML("afterbegin", toastWithMessage("Updated", 5000));
+		triggerSwap();
+
+		const settle = timers.find((timer) => timer.ms === 150);
+		assert(settle, "the swapped-in toast must schedule a settle timer");
+		settle.callback();
+		expect(region.textContent).toBe("Updated");
+	});
+
+	it("still schedules dismissal, without announcing or throwing, when no live region is present", () => {
+		const { timers } = initWithDom(toastWithMessage("Saved"));
+
+		expect(timers.length).toBe(1);
+		expect(timers[0].ms).toBe(6000);
+		expect(() => timers[0].callback()).not.toThrow();
+	});
+
+	it("throws if a scanned toast has no message span to announce, since a well-formed toast always carries one", () => {
+		const dom = new JSDOM(
+			`<!DOCTYPE html><html><body><div class="toast" data-dismiss="6000"></div><div id="toast-live-region"></div></body></html>`,
+		);
+		expect(() =>
+			initToastDismiss({
+				document: dom.window.document,
+				setTimeoutFn: () => {},
+				addSwapListener: () => {},
+			}),
+		).toThrow(/toast__message/);
 	});
 });

--- a/projects/hutch/src/runtime/web/shared/toast/toast.client.ts
+++ b/projects/hutch/src/runtime/web/shared/toast/toast.client.ts
@@ -12,15 +12,33 @@ export interface ToastDismissDeps {
 	addSwapListener: (listener: () => void) => void;
 }
 
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
 /** Matches the CSS fade-out transition duration: the toast
  * fades for this long before it is removed from the DOM. */
 const FADE_OUT_MS = 300;
 
+const LIVE_REGION_SETTLE_MS = 150;
+
 export function initToastDismiss(deps: ToastDismissDeps): void {
 	const scheduled = new WeakSet<Element>();
+	const region = deps.document.getElementById("toast-live-region");
+
+	function announce(toast: Element): void {
+		if (!region) return;
+		const messageEl = toast.querySelector(".toast__message");
+		assert(messageEl, "a toast must carry a .toast__message to announce");
+		const message = messageEl.textContent;
+		deps.setTimeoutFn(() => {
+			region.textContent = message;
+		}, LIVE_REGION_SETTLE_MS);
+	}
 
 	function dismiss(toast: Element): void {
 		toast.classList.add("toast--dismissing");
+		if (region) region.textContent = "";
 		deps.setTimeoutFn(() => toast.remove(), FADE_OUT_MS);
 	}
 
@@ -31,6 +49,7 @@ export function initToastDismiss(deps: ToastDismissDeps): void {
 		if (ms <= 0) return;
 		scheduled.add(toast);
 		deps.setTimeoutFn(() => dismiss(toast), ms);
+		announce(toast);
 	}
 
 	function dismissPending(): void {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.route.test.ts
@@ -1060,6 +1060,29 @@ describe("Inbox link feedback route", () => {
 		expect(errors).toHaveLength(1);
 	});
 
+	it("renders the confirmation toast ahead of the active tab panel, so a no-JS reader meets it before the panel instead of last in the page", async () => {
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		fixture.shared.logError = () => {};
+		const harness = useApp(fixture);
+		const agent = await loginAgent(harness.server, harness.auth);
+		await seed(fixture, "received");
+		await seedLinks(fixture, [{ status: "crawled", title: "Kept article" }]);
+
+		const response = await agent.post(`${feedbackPath}`).type("form").send({
+			verdict: "should-be-excluded",
+		});
+		const confirmation = await agent.get(response.headers.location);
+		const doc = parseDoc(confirmation.text);
+
+		const toast = doc.querySelector("[data-test-toast]");
+		const panel = doc.querySelector("[data-test-tab-panel]");
+		assert(toast, "the confirmation toast must render");
+		assert(panel, "the active tab panel must render");
+		expect(toast.compareDocumentPosition(panel) & toast.DOCUMENT_POSITION_FOLLOWING).toBe(
+			toast.DOCUMENT_POSITION_FOLLOWING,
+		);
+	});
+
 	it("picks the tab from the link's status, not from the verdict", async () => {
 		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
 		fixture.shared.logError = () => {};

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.template.html
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.template.html
@@ -9,11 +9,11 @@
     </p>
   </header>
 
+  {{{statusToastHtml}}}
+
   {{{tabsHtml}}}
 
   {{{liveStatusHtml}}}
 
   {{{panelHtml}}}
-
-  {{{statusToastHtml}}}
 </main>

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-link-save.route.test.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-link-save.route.test.ts
@@ -96,10 +96,10 @@ describe("Inbox link save route", () => {
 		expect(doc.querySelector("[data-test-toast-message]")?.textContent?.trim()).toBe(
 			"Adding to your queue…",
 		);
-		// role/aria-live carry the announcement; data-dismiss is what the global
-		// toast script reads to fade it out, so a stale flag can't pin it on screen.
-		expect(toast.getAttribute("role")).toBe("status");
-		expect(toast.getAttribute("aria-live")).toBe("polite");
+		// data-dismiss is what the global toast script reads to fade the toast out,
+		// so a stale flag can't pin it on screen.
+		expect(toast.getAttribute("role")).toBeNull();
+		expect(toast.getAttribute("aria-live")).toBeNull();
 		expect(toast.getAttribute("data-dismiss")).toBe("6000");
 	});
 

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -249,6 +249,20 @@ describe("Base component", () => {
 		expect(footer?.textContent).toContain("Readplace");
 	});
 
+	it("renders one empty persistent live region for toast announcements, outside <main> so a main-targeted swap never replaces it", () => {
+		const page = createTestPageBody();
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const regions = doc.querySelectorAll("#toast-live-region");
+		expect(regions.length).toBe(1);
+		const region = regions[0];
+		expect(region.getAttribute("role")).toBe("status");
+		expect(region.getAttribute("aria-live")).toBe("polite");
+		expect(region.textContent).toBe("");
+		expect(region.closest("main")).toBeNull();
+	});
+
 	it("should include the offline banner", () => {
 		const page = createTestPageBody();
 		const result = Base(page, GUEST_STATE).to("text/html");

--- a/src/packages/web-shell/src/base.template.ts
+++ b/src/packages/web-shell/src/base.template.ts
@@ -125,7 +125,7 @@ export const BASE_TEMPLATE = `<!DOCTYPE html>
 		})();
 	</script>
 	{{{content}}}
-	<div class="sr-only" id="toast-live-region" role="status" aria-live="polite" data-test-toast-live-region></div>
+	<div class="sr-only" id="toast-live-region" role="status" aria-live="polite"></div>
 	{{{footer}}}
 	{{{navScript}}}
 	{{{offlineScript}}}

--- a/src/packages/web-shell/src/base.template.ts
+++ b/src/packages/web-shell/src/base.template.ts
@@ -125,6 +125,7 @@ export const BASE_TEMPLATE = `<!DOCTYPE html>
 		})();
 	</script>
 	{{{content}}}
+	<div class="sr-only" id="toast-live-region" role="status" aria-live="polite" data-test-toast-live-region></div>
 	{{{footer}}}
 	{{{navScript}}}
 	{{{offlineScript}}}

--- a/src/packages/web-shell/src/shared/toast/toast.component.test.ts
+++ b/src/packages/web-shell/src/shared/toast/toast.component.test.ts
@@ -19,6 +19,16 @@ describe("renderToast", () => {
 		);
 	});
 
+	it("carries no live-region attributes: the shell's persistent #toast-live-region announces, so a self-announcing toast would double-speak", () => {
+		const doc = parse(
+			renderToast({ message: "Marked as read", dismissMs: 10000, actions: [] }),
+		);
+		const toast = doc.querySelector("[data-test-toast]");
+		assert(toast, "toast must render");
+		expect(toast.getAttribute("role")).toBeNull();
+		expect(toast.getAttribute("aria-live")).toBeNull();
+	});
+
 	it("renders each action as a boosted form posting its hidden fields", () => {
 		const doc = parse(
 			renderToast({

--- a/src/packages/web-shell/src/shared/toast/toast.template.ts
+++ b/src/packages/web-shell/src/shared/toast/toast.template.ts
@@ -1,4 +1,4 @@
-export const TOAST_TEMPLATE = `<div class="toast" role="status" aria-live="polite" data-dismiss="{{dismissMs}}" data-test-toast>
+export const TOAST_TEMPLATE = `<div class="toast" data-dismiss="{{dismissMs}}" data-test-toast>
 	<span class="toast__message" data-test-toast-message>{{message}}</span>
 	{{#each actions}}
 	<form class="toast__action-form" method="{{method}}" action="{{url}}" hx-boost="true" hx-target="main" hx-select="main" hx-swap="outerHTML show:none" hx-disabled-elt="find button">


### PR DESCRIPTION
## Why

The save/report toast was a live region (`role="status"`) rendered **already populated**, which is the unreliable case for screen readers:

- On a **full document load**, a live region populated at parse time is never announced — universally.
- Inside an **htmx-swapped `<main>`**, a toast is announced by NVDA/JAWS in many configurations but not dependably by VoiceOver/Safari.
- On the **inbox detail page** the toast was also the *last* child of `<main>`, so a no-JS reader met the save/report confirmation dead last in reading order.

## What changed

- **`base.template.ts`** — adds one persistent, parse-time-**empty** `#toast-live-region` (`role="status"`, `aria-live="polite"`, `.sr-only`) between `{{{content}}}` and `{{{footer}}}`, i.e. **outside `<main>`** so no `hx-target="main"` swap ever replaces the node the screen reader is watching.
- **`toast.template.ts`** — removes `role="status" aria-live="polite"` from `.toast`. Announcement now flows through one reliable channel; keeping both would double-announce on NVDA.
- **`toast.client.ts`** — the already-global toast client (scans `[data-dismiss]` on load and every `htmx:afterSwap`) now, on first sight of a toast, writes its `.toast__message` text into the region after a short **150ms settle delay** (a region mutated in the same task as the insertion is the unreliable case being fixed), and **clears** the region on dismiss so a second identical save re-announces. If the region is absent, announcement is skipped and dismissal is unchanged.
- **`inbox-email-detail.template.html`** — moves `{{{statusToastHtml}}}` to directly after `</header>` (before the tab strip), matching the queue's early placement. `.toast` is `position: fixed`, so the visual is unchanged; only the no-JS reading order improves.

No new client script and no inbox wiring changes — this rides the existing global `toast.client.js` bundle, which hutch already serves on every page.

## Decisions

- **Removed `role`/`aria-live` from `.toast`** rather than keeping it: the region announces on every path the toast ever did, plus the ones it didn't, and a self-announcing toast would double-speak once the region ships.
- **150ms settle delay** over a zero-delay same-tick write: the same-tick write is the unreliability being fixed, and 150ms is imperceptible next to the 6000ms dismiss.

## Tests

- `toast.component.test.ts` — the rendered `.toast` carries no `role`/`aria-live`.
- `base.component.test.ts` — every page renders exactly one empty `#toast-live-region` with `role="status"` / `aria-live="polite"`, outside `<main>`.
- `toast.client.test.ts` — message lands in the region only after the settle callback fires; dismiss clears it; a second identical toast re-announces; a swapped-in toast announces; a page with no region still schedules dismissal without throwing.
- `inbox-email-detail.route.test.ts` — DOM-order assertion (`compareDocumentPosition`) that the confirmation toast precedes the active tab panel.
- `inbox-link-save.route.test.ts` — swept: the confirmation toast now carries no `role`/`aria-live`.

The queue surface (hutch) picks up the same shell behaviour with no template change. `pnpm nx run` `@packages/web-shell:check`, `hutch:check`, `inbox:check` (plus `blog-site`/`web-embed`, which share the shell) all pass at 100% coverage, and the pre-commit full `pnpm check` is green.

## Follow-up not included

The plan flagged widening the `toast.client.ts` module-header comment and the build-script footer comment; per the repo comment policy those are left for explicit human approval. The existing comments remain accurate (the defer/swap wiring is unchanged), just narrower in scope. Happy to add them on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mxZ6RFTY5fLfXnPYxHBMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012mxZ6RFTY5fLfXnPYxHBMJ)_