### PR TITLE
fix(inbox): keep the email detail tab strip on one line below ~344px

### DIFF
--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-email-detail.styles.css
@@ -64,17 +64,21 @@
 .inbox-email-detail__tabs {
   display: flex;
   gap: 16px;
-  border-bottom: 1px solid var(--border);
   margin-bottom: 16px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  box-shadow: inset 0 -1px var(--border);
 }
 
 .inbox-email-detail__tab {
+  flex-shrink: 0;
   padding: 12px 8px;
-  margin: 0 -6px -1px;
+  margin: 0 -6px;
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--muted-foreground);
   text-decoration: none;
+  white-space: nowrap;
   border-bottom: 2px solid transparent;
   transition: color 0.15s ease, border-color 0.15s ease;
 }


### PR DESCRIPTION
## What

The three-tab strip on the inbox email detail page (`View` / `Extracted Articles (N)` / `Skipped`) is a flex row with no `white-space` or shrink guard. Between ~320px and ~344px the middle label soft-wraps to two lines (`Extracted / Articles (12)`), growing the strip from one line (~43px) to two (~59px) — a cosmetic reflow at the 320px WCAG 1.4.10 test width, on the detail page's primary navigation and the only route to the Skipped list.

## Change

All changes are pure CSS inside existing selectors in `inbox-email-detail.styles.css` — no template, TS, or token changes; no colours touched.

- **`.inbox-email-detail__tab`** — add `white-space: nowrap` (the label never soft-wraps) and `flex-shrink: 0` (each anchor keeps its intrinsic width instead of compressing), so the strip's `scrollWidth` exceeds its box below ~344px.
- **`.inbox-email-detail__tabs`** — add `overflow-x: auto` so the strip becomes its own scroll container and pans below ~344px instead of wrapping (per the web-shell convention: wide content scrolls inside its container, never the page body), plus `scrollbar-width: none` so no permanent bar shows at the ≥360px widths where nothing overflows. Where the strip does pan, the cut-off third tab is itself the affordance.
- **Border joint** — `overflow-x: auto` clips the tab's old `-1px` bottom-margin overlap, which would shave the active tab's 2px underline. Fixed by dropping that `-1px` margin and moving the divider hairline off the strip's `border-bottom` onto `box-shadow: inset 0 -1px var(--border)`, which paints inside the padding box (never clipped) and behind the child tabs' borders — so the active underline paints over it and still meets the divider line.

## Verification

- `pnpm nx run inbox:check` and the full-monorepo `pnpm check` pass (100% coverage maintained; no new selectors, so the unused-css check is unaffected).
- Rendered the exact edited CSS + template markup in headless Chromium at 320 / 344 / 360 / 375px, with worst-case `(99+)` counts:
  - **320px & 344px** — strip pans (single-row 43px height, no wrap), page body has **no** horizontal scroll, active 2px underline meets the divider (**0px gap**).
  - **≥360px** — no panning, no scrollbar, strip identical to before.
  - Control render with the pre-fix CSS wraps to 59px at 320px, confirming the harness exercised the real bug and the fix eliminates it.

The nav is an `hx-swap-oob` target; a pure-CSS fix survives the OOB swap by construction.

## Out of scope

Renaming `Extracted Articles` → `Articles` (raised in the finding) is a separate copy decision touching the label constant and ~17 assertions, and would ship as its own PR. The CSS guard is needed either way — it protects against any future longer label or locale.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tDwrggb9u2DwbVmW22T23

---
_Generated by [Claude Code](https://claude.ai/code/session_013tDwrggb9u2DwbVmW22T23)_