### PR TITLE
perf(@packages/article-store): drop the redundant existence GetItem from status toggles and deletes

### DIFF
--- a/src/packages/article-store/src/dynamodb-saved-article-store.test.ts
+++ b/src/packages/article-store/src/dynamodb-saved-article-store.test.ts
@@ -730,12 +730,13 @@ describe("initDynamoDbSavedArticleStore deleteArticle", () => {
 	it("deletes the user row and reports success", async () => {
 		const { client, commands } = createFakeClient({
 			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
-			GetCommand: { default: { Item: userArticleItem() } },
 		});
 
 		const deleted = await initStore(client).deleteArticle(ReaderArticleHashId.fromHash(ROUTE_ID), USER);
 
-		expect(commands.some((c) => c.name === "DeleteCommand")).toBe(true);
+		const del = commands.find((c) => c.name === "DeleteCommand");
+		expect(del?.input.ConditionExpression).toBe("attribute_exists(savedAt)");
+		expect(commands.some((c) => c.name === "GetCommand")).toBe(false);
 		expect(deleted).toBe(true);
 	});
 
@@ -750,12 +751,31 @@ describe("initDynamoDbSavedArticleStore deleteArticle", () => {
 	it("reports false when the user never saved the article", async () => {
 		const { client } = createFakeClient({
 			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
-			GetCommand: { default: { Item: undefined } },
+			DeleteCommand: {
+				default: () => {
+					throw new ConditionalCheckFailedException({ $metadata: {}, message: "row deleted" });
+				},
+			},
 		});
 
 		const deleted = await initStore(client).deleteArticle(ReaderArticleHashId.fromHash(ROUTE_ID), USER);
 
 		expect(deleted).toBe(false);
+	});
+
+	it("rethrows non-conditional errors", async () => {
+		const { client } = createFakeClient({
+			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
+			DeleteCommand: {
+				default: () => {
+					throw new Error("throttled");
+				},
+			},
+		});
+
+		await expect(
+			initStore(client).deleteArticle(ReaderArticleHashId.fromHash(ROUTE_ID), USER),
+		).rejects.toThrow("throttled");
 	});
 });
 
@@ -848,20 +868,20 @@ describe("initDynamoDbSavedArticleStore updateArticleStatus", () => {
 	it("stamps readAt when marking an article read", async () => {
 		const { client, commands } = createFakeClient({
 			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
-			GetCommand: { default: { Item: userArticleItem() } },
 		});
 
 		const updated = await initStore(client).updateArticleStatus(ReaderArticleHashId.fromHash(ROUTE_ID), USER, "read");
 
 		const update = commands.find((c) => c.name === "UpdateCommand");
 		expect(update?.input.UpdateExpression).toBe("SET #status = :status, readAt = :readAt");
+		expect(update?.input.ConditionExpression).toBe("attribute_exists(savedAt)");
+		expect(commands.some((c) => c.name === "GetCommand")).toBe(false);
 		expect(updated).toBe(true);
 	});
 
 	it("removes readAt when marking an article unread", async () => {
 		const { client, commands } = createFakeClient({
 			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
-			GetCommand: { default: { Item: userArticleItem({ status: "read", readAt: "2026-05-30T11:00:00.000Z" }) } },
 		});
 
 		const updated = await initStore(client).updateArticleStatus(ReaderArticleHashId.fromHash(ROUTE_ID), USER, "unread");
@@ -882,12 +902,31 @@ describe("initDynamoDbSavedArticleStore updateArticleStatus", () => {
 	it("reports false when the user never saved the article", async () => {
 		const { client } = createFakeClient({
 			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
-			GetCommand: { default: { Item: undefined } },
+			UpdateCommand: {
+				default: () => {
+					throw new ConditionalCheckFailedException({ $metadata: {}, message: "row deleted" });
+				},
+			},
 		});
 
 		const updated = await initStore(client).updateArticleStatus(ReaderArticleHashId.fromHash(ROUTE_ID), USER, "read");
 
 		expect(updated).toBe(false);
+	});
+
+	it("rethrows non-conditional errors", async () => {
+		const { client } = createFakeClient({
+			QueryCommand: { default: { Items: [articleItem()], Count: 1 } },
+			UpdateCommand: {
+				default: () => {
+					throw new Error("throttled");
+				},
+			},
+		});
+
+		await expect(
+			initStore(client).updateArticleStatus(ReaderArticleHashId.fromHash(ROUTE_ID), USER, "read"),
+		).rejects.toThrow("throttled");
 	});
 });
 

--- a/src/packages/article-store/src/dynamodb-saved-article-store.ts
+++ b/src/packages/article-store/src/dynamodb-saved-article-store.ts
@@ -435,10 +435,15 @@ export function initDynamoDbSavedArticleStore(deps: {
 		const article = await findArticleByRouteId(routeId);
 		if (!article) return false;
 
-		const ua = await findUserArticle(userId, article.url);
-		if (!ua) return false;
-
-		await userArticles.delete({ Key: { userId, url: article.url } });
+		try {
+			await userArticles.delete({
+				Key: { userId, url: article.url },
+				ConditionExpression: "attribute_exists(savedAt)",
+			});
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) return false;
+			throw error;
+		}
 		return true;
 	};
 
@@ -491,28 +496,28 @@ export function initDynamoDbSavedArticleStore(deps: {
 		const article = await findArticleByRouteId(routeId);
 		if (!article) return false;
 
-		const ua = await findUserArticle(userId, article.url);
-		if (!ua) return false;
+		const expression =
+			status === "read"
+				? {
+						UpdateExpression: "SET #status = :status, readAt = :readAt",
+						ExpressionAttributeValues: { ":status": status, ":readAt": new Date().toISOString() },
+					}
+				: {
+						UpdateExpression: "SET #status = :status REMOVE readAt",
+						ExpressionAttributeValues: { ":status": status },
+					};
 
-		if (status === "read") {
+		try {
 			await userArticles.update({
 				Key: { userId, url: article.url },
-				UpdateExpression: "SET #status = :status, readAt = :readAt",
+				ConditionExpression: "attribute_exists(savedAt)",
 				ExpressionAttributeNames: { "#status": "status" },
-				ExpressionAttributeValues: {
-					":status": status,
-					":readAt": new Date().toISOString(),
-				},
+				...expression,
 			});
-		} else {
-			await userArticles.update({
-				Key: { userId, url: article.url },
-				UpdateExpression: "SET #status = :status REMOVE readAt",
-				ExpressionAttributeNames: { "#status": "status" },
-				ExpressionAttributeValues: { ":status": status },
-			});
+		} catch (error) {
+			if (error instanceof ConditionalCheckFailedException) return false;
+			throw error;
 		}
-
 		return true;
 	};
 


### PR DESCRIPTION
## What

`updateArticleStatus` and `deleteArticle` in `dynamodb-saved-article-store.ts` each ran a sequential three-hop DynamoDB chain on the queue's hottest mutations:

`findArticleByRouteId` (routeId GSI Query) → `findUserArticle` (**GetItem**) → `UpdateItem` / `DeleteItem`

The middle **GetItem** existed only to answer "does this user have this article?" for the boolean return — the row's contents were never read. This replaces it with `ConditionExpression: "attribute_exists(savedAt)"` on the write itself, mapping `ConditionalCheckFailedException` to the existing `false` return.

## Why

- **Latency** — removes one sequential in-region round trip (~5–15ms) from the POST leg of every "Mark as read/unread" and "Delete", cutting the store calls on that leg from 3 to 2. One increment of the CTA-latency programme, not its resolution (the dominant cost remains the 303 → full `/queue` re-render).
- **Race correctness** — previously, if the row was deleted between the GetItem and the UpdateItem, DynamoDB's upsert semantics re-created a phantom `{userId, url, status, readAt?}` row with no `savedAt`. That phantom is invisible to the queue (the `userId-savedAt-index` GSI is sparse on `savedAt`) but surfaces in `url-index`, where `UserArticleRow.parse` throws on the missing required `savedAt` — breaking `findUserArticlesByUrl` and `findArticleById`. The condition turns that race into a clean `false`.

`attribute_exists(savedAt)` is the file's established row-exists idiom (`stampUserArticleIfStillSaved`, `markReaderReadyEmailSent`); `savedAt` is required by `UserArticleRow` on every read path, so the condition cannot newly exclude any functioning row.

## Contracts unchanged

`DeleteArticle` / `UpdateArticleStatus` stay `(…) => Promise<boolean>` — only how the boolean is computed changes. No provider-contract, caller, or Siren-shape edits. `findUserArticle` is retained (still used by `findArticleById`). The in-memory store already had these exact semantics, so its integration tests are untouched.

**Contract note:** the loser of a concurrent double-`deleteArticle` now returns `false` (was `true`). Strictly more truthful, and both HTML callers ignore the boolean.

## Tests

- Rewrote the "reports false when the user never saved the article" tests for both functions to drive the conditional-failure path via the fake client's error-injection seam.
- Added a `rethrows non-conditional errors` test to each `describe` block (covers the `throw error` branch).
- Read/unread tests now assert the new `ConditionExpression` and that no `GetCommand` is sent.
- `@packages/article-store:check` green with 100% statements/branches/functions/lines; full `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ri7Byha9DajrK7u6sDyHdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ri7Byha9DajrK7u6sDyHdt)_