### PR TITLE
perf(hutch,@packages/test-fixtures): stop fetching article content blobs for queue listings

### DIFF
--- a/projects/hutch/src/runtime/web/pages/queue/my-readplace/my-readplace.placeholders.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/my-readplace/my-readplace.placeholders.ts
@@ -88,7 +88,6 @@ function toPlaceholderViewModel(
 			iso: new Date(now.getTime() - article.savedHoursAgo * HOUR_MS).toISOString(),
 			now,
 		}),
-		hasContent: true,
 		actions: PLACEHOLDER_ACTIONS,
 		deleteConfirm: {
 			articleId: article.id,

--- a/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue-card/queue-card.component.test.ts
@@ -20,7 +20,6 @@ function makeViewModel(
 		status: "unread",
 		isUnread: true,
 		saved: { iso: "2025-06-01T12:50:00.000Z", label: "10m ago", mode: "relative" },
-		hasContent: false,
 		actions: [],
 		deleteConfirm: {
 			articleId: "abc123",

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -14,6 +14,7 @@ import {
 import { initReadabilityParser } from "@packages/article-parser";
 
 import type { RefreshArticleIfStale } from "@packages/provider-contracts/article-freshness";
+import type { FindArticlesQuery } from "@packages/provider-contracts/article-store";
 
 const useApp = useTestServer();
 
@@ -91,6 +92,30 @@ describe("Queue routes", () => {
 					"Failed to batch-load article crawl statuses",
 				]),
 			);
+		});
+	});
+
+	describe("Listing content projection", () => {
+		it("asks the store to skip the article body when listing the queue", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const recorded: FindArticlesQuery[] = [];
+			const harness = useApp({
+				...fixture,
+				articleStore: {
+					...fixture.articleStore,
+					findArticlesByUser: async (query: FindArticlesQuery) => {
+						recorded.push(query);
+						return fixture.articleStore.findArticlesByUser(query);
+					},
+				},
+			});
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			await agent.get("/queue");
+
+			expect(recorded).toHaveLength(1);
+			expect(recorded[0]).toMatchObject({ excludeContent: true });
 		});
 	});
 

--- a/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.mutations.route.test.ts
@@ -4,6 +4,7 @@ import { JSDOM } from "jsdom";
 import { MinutesSchema } from "@packages/domain/article";
 import { useTestServer, loginAgent } from "../../../test-app";
 import type { ArticleReadEvent } from "@packages/web-analytics";
+import type { FindArticlesQuery } from "@packages/provider-contracts/article-store";
 import {
 	TEST_APP_ORIGIN,
 	createDefaultTestAppFixture,
@@ -46,6 +47,32 @@ describe("Queue routes", () => {
 			expect(response.status).toBe(422);
 			const doc = new JSDOM(response.text).window.document;
 			expect(doc.querySelector("[data-test-save-error]")?.textContent).toBe("Please enter a valid URL");
+		});
+
+		it("skips the article body when re-rendering the queue after an invalid save", async () => {
+			const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+			const recorded: FindArticlesQuery[] = [];
+			const harness = useApp({
+				...fixture,
+				articleStore: {
+					...fixture.articleStore,
+					findArticlesByUser: async (query: FindArticlesQuery) => {
+						recorded.push(query);
+						return fixture.articleStore.findArticlesByUser(query);
+					},
+				},
+			});
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			const response = await agent
+				.post("/queue/save")
+				.type("form")
+				.send({ url: "not-a-url" });
+
+			expect(response.status).toBe(422);
+			expect(recorded).toHaveLength(1);
+			expect(recorded[0]).toMatchObject({ excludeContent: true });
 		});
 
 		it("rejects a chrome:// URL with an unsupported-scheme message and never saves", async () => {

--- a/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.page.ts
@@ -748,6 +748,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 			page: urlState.page,
 			pageSize: queuePageSizeForClient(req.oauthClientId),
 			includeTotal: siren,
+			excludeContent: true,
 		});
 
 		if (siren) {
@@ -904,6 +905,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 				userId,
 				includeTotal: true,
 				pageSize: queuePageSizeForClient(req.oauthClientId),
+				excludeContent: true,
 			});
 			const crawlByUrl = await loadCrawls(
 				deps.findArticleCrawlStatuses,
@@ -1241,7 +1243,7 @@ export function initQueueRoutes(deps: QueueDependencies): Router {
 		if (validation.status === "ERROR") {
 			emitSaveIntent({ req, url: submittedUrl, path: SAVE_INTENT_PATH.save, surface: SAVE_SURFACES.queueSaveBar, outcome: SAVE_OUTCOMES.error });
 			const urlState = parseQueueUrl({});
-			const result = await deps.findArticlesByUser({ userId });
+			const result = await deps.findArticlesByUser({ userId, excludeContent: true });
 			const [summaryByUrl, crawlByUrl] = await Promise.all([
 				loadSummaries(deps.findGeneratedSummaries, result.articles, deps.logError),
 				loadCrawls(deps.findArticleCrawlStatuses, result.articles, deps.logError),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.test.ts
@@ -270,24 +270,6 @@ describe("toQueueViewModel", () => {
 		expect(vm.errors?.[0]?.message).toBe("Could not parse article: Invalid URL");
 	});
 
-	it("should set hasContent to true when article has content", () => {
-		const article = makeArticle({ content: "<p>Some content</p>" });
-		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, {
-			now: NOW,
-		});
-
-		expect(vm.articles[0].hasContent).toBe(true);
-	});
-
-	it("should set hasContent to false when article has no content", () => {
-		const article = makeArticle({ content: undefined });
-		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, {
-			now: NOW,
-		});
-
-		expect(vm.articles[0].hasContent).toBe(false);
-	});
-
 	it("should generate mark-read and delete actions for unread article", () => {
 		const article = makeArticle({ status: "unread" });
 		const vm = toQueueViewModel(makeResult([article]), DEFAULT_FILTERS, { now: NOW });

--- a/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.viewmodel.ts
@@ -51,7 +51,6 @@ export interface QueueArticleViewModel {
 	isUnread: boolean;
 	saved: LocalTime;
 	imageUrl?: string;
-	hasContent: boolean;
 	actions: ArticleAction[];
 	deleteConfirm: DeleteConfirmViewModel;
 	/**
@@ -198,7 +197,6 @@ export function toQueueArticleViewModel(params: {
 		isUnread: article.status === "unread",
 		saved: toRelativeOrDate({ iso: article.savedAt.toISOString(), now }),
 		imageUrl: article.metadata.imageUrl,
-		hasContent: Boolean(article.content),
 		actions: [...toStatusActions({ id, status: article.status }, returnQuery), deleteAction],
 		deleteConfirm: {
 			articleId: id,


### PR DESCRIPTION
## Summary

Every `/queue` render BatchGets the **full** article row for all 20 cards — including the `content` body, which a legacy row can carry up to ~400KB of — even though no listing surface renders a byte of it. This narrows those reads to metadata only.

## What changed

- **`excludeContent: true`** at the three queue `findArticlesByUser` call sites in `queue.page.ts`:
  - `GET /queue` (shared by the HTML render and the Siren branch)
  - the Siren 422 unreachable-scheme collection re-render
  - the save-bar 422 invalid-URL re-render

  The store already supports metadata-only projection (`ArticleMetadataFields = ArticleRow.omit({ content: true })`), and every other list-shaped caller (MCP, export, trial-feedback) already passes this flag — the queue router was the last full-row lister.

- **Deleted the dead `hasContent` view-model field.** Its last consumer was removed in April 2026 (cards now always link to the reader view), and it is already `false` for every article saved after the S3 content migration — production content lives in S3, not the DynamoDB `content` attribute — so nothing rendered depended on it.

- **Made the in-memory test store honour `excludeContent`** — it now returns `content: undefined` (key present, not absent) to match production's DynamoDB projection, closing the fidelity gap that would otherwise let a future content-consuming template pass route tests while silently breaking in production.

## Why it's safe

- Rendered queue HTML is byte-identical — `hasContent` never reached any template, links already all point at the reader, and the card ETag hashes metadata only.
- Siren JSON is byte-identical — `toArticleSubEntity` never read content; `total`/`totalPages` are untouched.
- `ArticleRow.content` is already optional, so projected rows parse with the existing Zod schema (the same path MCP/export exercise in production today).
- No schema change, no infra change, no backfill.

## Effect

The wins are **wire bytes and Lambda CPU** (SDK unmarshalling + Zod parsing), not RCUs — DynamoDB bills reads on the full stored item size regardless of `ProjectionExpression`. The largest wins go to legacy/import-heavy accounts whose rows still carry a DynamoDB `content` attribute; the change is strictly non-negative for every account.

## Testing

- `pnpm check` green across all 45 projects.
- Added: a `GET /queue` wiring spy test and a save-bar 422 wiring spy test (each asserts `excludeContent: true` reaches the store), plus an in-memory-store unit test asserting the body is stripped (key still present) with the flag and returned without it.
- Removed the two dead `hasContent` view-model tests and the `hasContent` fixture field.

## Out of scope

Removing the now-universal `excludeContent` option and making the metadata projection unconditional, the `/queue/:id/card` poll / `findArticleById` full-row reads, and purging legacy DynamoDB `content` attributes — all follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTcM5FsS2Aa6hs9Ao8DdY2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTcM5FsS2Aa6hs9Ao8DdY2)_