### PR TITLE
fix(hutch,blog-site): stop promising an Export menu entry that never existed

### DIFF
--- a/projects/blog-site/src/runtime/web/pages/blog/posts/why-i-built-readplace.md
+++ b/projects/blog-site/src/runtime/web/pages/blog/posts/why-i-built-readplace.md
@@ -11,7 +11,7 @@ keywords: "Readplace founder, why I built Readplace, js-cookie, read-it-later ap
 <summary class="blog-tldr__toggle">Summary (TL;DR)</summary>
 <div class="blog-tldr__body">
 
-I wrote js-cookie, a tiny JavaScript library browsers download about 22 billion times a year, and for ten years I ran my own reading on Gmail filters, DynamoDB tables, and a stack of Reddit automations. That system taught me the bottleneck was never saving — it was deciding what *not* to read. When Pocket was acquired and abandoned, and Omnivore shut down overnight, the tool I needed didn't exist as a product anyone could use, so I turned my system into Readplace. It's a solo project, built in public. The part that matters most isn't a feature: if you ever stop paying, your account goes read-only rather than dark — you keep reading everything you saved, and Export stays in the menu. That behaviour is a few lines of code you can read on GitHub, not a promise on a page.
+I wrote js-cookie, a tiny JavaScript library browsers download about 22 billion times a year, and for ten years I ran my own reading on Gmail filters, DynamoDB tables, and a stack of Reddit automations. That system taught me the bottleneck was never saving — it was deciding what *not* to read. When Pocket was acquired and abandoned, and Omnivore shut down overnight, the tool I needed didn't exist as a product anyone could use, so I turned my system into Readplace. It's a solo project, built in public. The part that matters most isn't a feature: if you ever stop paying, your account goes read-only rather than dark — you keep reading everything you saved, and you can still export. That behaviour is a few lines of code you can read on GitHub, not a promise on a page.
 
 </div>
 </details>
@@ -36,7 +36,7 @@ So I started turning my personal system into Readplace — built in Australia, o
 
 Here's the part that matters most, and it isn't a feature.
 
-A sentence about "we'll always let you export your data" does not survive an acquisition. What survives is the code. So the behaviour is written in rather than promised: if you ever stop paying, your account goes **read-only, not dark**. Your queue, your saved articles, and the reader all keep working — you keep reading everything you saved. Only saving new links and importing pause. And Export stays in the menu whether or not you're paying, so you can pull everything out as JSON any time.
+A sentence about "we'll always let you export your data" does not survive an acquisition. What survives is the code. So the behaviour is written in rather than promised: if you ever stop paying, your account goes **read-only, not dark**. Your queue, your saved articles, and the reader all keep working — you keep reading everything you saved. Only saving new links and importing pause. And export carries no subscription gate, so you can pull everything out as JSON any time, paying or not.
 
 The infrastructure sits in Sydney under Australian privacy law. The codebase is [on GitHub](https://github.com/Readplace/readplace.com) — source-available, so the branch that decides what a cancelled account can still do is something you can go and read rather than take my word for.
 

--- a/projects/hutch/src/runtime/web/pages/home-b/home-b.content.ts
+++ b/projects/hutch/src/runtime/web/pages/home-b/home-b.content.ts
@@ -82,7 +82,7 @@ export const HOME_B_CONTENT = {
 	},
 	price: {
 		title: "$4.08 a month, and that's the whole business.",
-		body: "$49 a year, billed once. No ad path, no data resale, no investor whose timeline outlives yours. Fourteen days free first, and I don't ask for a card to start them. If you never subscribe, nothing is charged: the account drops to read-only, not dark — you keep reading every article you saved, and Export stays in the menu.",
+		body: "$49 a year, billed once. No ad path, no data resale, no investor whose timeline outlives yours. Fourteen days free first, and I don't ask for a card to start them. If you never subscribe, nothing is charged: the account drops to read-only, not dark — you keep reading every article you saved, and you can still export.",
 		note: "Google, Apple, or an email address. No card at any point in the trial.",
 	},
 	limits: {

--- a/projects/hutch/src/runtime/web/pages/home-b/home-b.content.ts
+++ b/projects/hutch/src/runtime/web/pages/home-b/home-b.content.ts
@@ -112,7 +112,7 @@ export const HOME_B_CONTENT = {
 		{
 			question: "What happens to my articles if I stop paying?",
 			answer:
-				"You keep reading every one of them. Saving new links and importing stop; the queue, the reader, and Export stay.",
+				"You keep reading every one of them. Saving new links and importing stop; the queue and the reader stay, and you can still export.",
 		},
 		{
 			question: "Can I bring my Pocket export?",


### PR DESCRIPTION
## What

The trial-first homepage arm (`home-b.content.ts`) and the founder-story blog post both tell readers that Export "stays in the menu" once an account lapses. Both now describe what the code actually does.

## Why it is wrong

`buildNavGroups` in `src/packages/web-shell/src/banner-state.ts` says it outright:

> Export is deliberately absent: it lives on the account page instead.

Export has never been a nav entry for anyone. And a read-only account loses the **Account** entry as well, so its nav is Queue + Sign out — the sentence describes a menu no reader has ever seen, whether or not they are paying.

## Why the promise underneath still holds

`app.use("/export", requireAuth, exportRouter)` carries no write gate, and the header's "Subscription not active" pill still links to `/account`, where Export lives. So a lapsed account really can pull everything out — the claim just needed to stop naming a menu.

## Scope

Found while correcting the same claim on the `/read-it-later-that-wont-die` landing page (`aa589cbf` on main). That page argues its case by inviting readers to verify it in the code, so a sentence that does not survive checking costs the most there. These two surfaces make the same promise to a wider audience, and ship separately because they are different pages.

`pnpm check` passes across all 46 projects.