### PR TITLE
[DUMMY] broken-toolchain visibility probe — do not merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nx": "22.7.5",
     "typescript": "6.0.3"
   },
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@99.99.99",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
Deliberately unresolvable packageManager (pnpm@99.99.99) so the listener fails at Setup pnpm. Verifies the failure now gets reported on the PR instead of dying silently, and that crash-retry no longer re-runs it. Will be closed after verification.