### PR TITLE
fix(hutch): make the Reader Opens widget match the real reader permalink

### DIFF
--- a/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.test.ts
@@ -1,9 +1,11 @@
+import assert from "node:assert/strict";
 import {
 	BLOG_SITE_LOG_GROUP,
 	FORWARD_ANALYTICS_FUNCTION_NAME,
 	SAVE_LINK_LOG_GROUPS,
 } from "@packages/hutch-infra-components";
 import { campaignTag, HOMEPAGE_SPLIT } from "../web/experiments/homepage-split";
+import { QUEUE_PATH } from "../web/pages/queue/queue.url";
 import {
 	ANALYTICS_EVENTS,
 	ANALYTICS_LOG_GROUP,
@@ -160,12 +162,23 @@ describe("buildAnalyticsDashboardBody — drift prevention", () => {
 		expect(readers).toContain("count_distinct(user_id)");
 	});
 
-	it("the opens widget counts distinct authenticated visitors on the reader view path /<id>/view — funnel companion to the readers widget", () => {
+	it("the opens widget counts distinct authenticated visitors on the reader view path — funnel companion to the readers widget", () => {
 		const queries = widgetQueries();
 		const opens = queries.find((q) => q.includes("reader_opens"));
 		expect(opens).toBeDefined();
 		expect(opens).toContain(`event = "${ANALYTICS_EVENTS.pageview}"`);
 		expect(opens).toContain("\\/view$");
+	});
+
+	it("the opens widget's path pattern actually matches a real authenticated reader permalink — asserting only that the query mentions \\/view$ let a pattern one path segment short ship and plot nothing for weeks", () => {
+		const opens = widgetQueries().find((q) => q.includes("reader_opens"));
+		assert(opens, "the reader_opens widget must exist");
+		const source = opens.match(/\| filter path like \/(\S+)\/ \|/)?.[1];
+		assert(source, "the opens widget must filter on a regex literal");
+		const pattern = new RegExp(source);
+		expect(pattern.test(`${QUEUE_PATH}/58b83c9aad6a5c0a32f6d8caa3a69bbc/view`)).toBe(true);
+		expect(pattern.test("/view/example.com/some-article")).toBe(false);
+		expect(pattern.test(QUEUE_PATH)).toBe(false);
 	});
 
 	it("the device-mix widget slices pageviews by the composite device_class / browser key so the audience's device+browser usage is visible at pageview scale (not just the authenticated-reader cohort), excluding pageviews logged before the field shipped and the no-signal \"other\" (no-User-Agent) bucket so the pie reads as real devices", () => {

--- a/projects/hutch/src/runtime/observability/analytics-dashboard.ts
+++ b/projects/hutch/src/runtime/observability/analytics-dashboard.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { BLOG_SITE_LOG_GROUP } from "@packages/hutch-infra-components";
 import { campaignTag, HOMEPAGE_SPLIT } from "../web/experiments/homepage-split";
+import { QUEUE_PATH } from "../web/pages/queue/queue.url";
 import {
 	ANALYTICS_EVENTS,
 	CONVERSION_EVENTS,
@@ -110,6 +111,14 @@ function anyOriginClause(logGroupNames: readonly string[]): string {
 	const legs = logGroupNames.map((name) => `@logStream like "${name}/"`).join(" or ");
 	return `| filter (${legs})`;
 }
+
+/**
+ * The authenticated reader permalink, as a Logs Insights regex literal. Derived
+ * from QUEUE_PATH so it cannot drift from the mount point the path is built
+ * from — the previous hand-written pattern matched `/<id>/view`, one segment
+ * short of the real `/queue/<id>/view`, so the widget silently plotted nothing.
+ */
+const READER_VIEW_PATH_PATTERN = `/^${QUEUE_PATH.replaceAll("/", "\\/")}\\/[^\\/]+\\/view$/`;
 
 function excludeVisitorHashesClause(excludedVisitorHashes: readonly string[]): string[] {
 	if (excludedVisitorHashes.length === 0) return [];
@@ -247,7 +256,7 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 				"| filter ispresent(visitor_hash)",
 				...exclude,
 				"| filter is_authenticated",
-				"| filter path like /^\\/[^\\/]+\\/view$/",
+				`| filter path like ${READER_VIEW_PATH_PATTERN}`,
 				"| stats count_distinct(visitor_hash) as reader_opens by bin(1d)",
 			].join(" "),
 			x: 12, y: 16, width: 12, height: 8,
@@ -427,10 +436,9 @@ export function buildAnalyticsDashboardBody(deps: BuildAnalyticsDashboardDeps): 
 	);
 
 	// --- View ("try the reader") funnel ---
-	// The pageview middleware cannot see /view (hx-request + redirect chain), so
-	// these widgets are driven by the explicit view_opened / view_save_intent
-	// events. Counting distinct visitor_id makes the funnel joinable to
-	// user_created, which also carries visitor_id.
+	// Driven by the explicit view_opened / view_save_intent events. Counting
+	// distinct visitor_id makes the funnel joinable to user_created, which also
+	// carries visitor_id.
 
 	widgets.push(
 		logWidget({


### PR DESCRIPTION
The "Reader Opens per Day" widget has never plotted a point.

Its filter is `path like /^\/[^\/]+\/view$/` — a **two-segment** pattern — but the authenticated reader permalink is `/queue/<id>/view`, **three** segments. It could never match.

## Evidence

Run against prod `/readplace/analytics` over 40 days:

| Query | Matched records |
|---|---|
| the widget's current filter | **0** |
| same query, pattern corrected | **120** |

With the fix the widget plots 1–7 authenticated reader opens per day (3, 5, 4, 7, 5, 1, 3, 3, 3, 1, 3, 1 across Jul 18–30).

## Change

- The pattern now derives from `QUEUE_PATH` — the constant the path itself is built from — so it cannot drift from the mount point again.
- The existing test asserted only that the query string *contained* `\/view$`, which is exactly why a never-matching pattern shipped. It now builds the emitted regex and runs it against a real permalink, plus two negative cases. Confirmed the new test fails against the old pattern.
- Drops the comment above the view-funnel widgets claiming "the pageview middleware cannot see /view". Production holds 1,863 `/view/*` article-path pageviews in the last 6 days, and that false belief is why the Jul 24 browser-coherence gate was never extended to `view_opened` until d4df6f75.

## Verification

- `pnpm check` — green (47 projects, 100% coverage).
- `pnpm check-infra` — the dashboard diff is exactly `~dashboardBody`; no replace or delete anywhere in the preview.

Split out from d4df6f75 per the "Unrelated Small Changes Ship as Their Own PR" rule: that commit is write-path analytics gating, this is read-path dashboard correctness, and only this half touches infra.