### PR TITLE
feat: serve page CSS as hashed same-origin files instead of inlining it

### DIFF
--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -154,7 +154,8 @@ import {
 	initEmitSubscriptionEvent,
 	type SubscriptionLogEvent,
 } from "./observability/subscription-events";
-import { APPLE_TOUCH_ICON_PATH, CLIENT_DIST_MOUNT_PATH, isStaticAssetRequestPath } from "./web/static-asset-paths";
+import { APPLE_TOUCH_ICON_PATH, CLIENT_DIST_MOUNT_PATH, STYLES_MOUNT_PATH, isStaticAssetRequestPath } from "./web/static-asset-paths";
+import { findPageStylesheetByName } from "./web/page-stylesheets";
 import { canonicalizeViewLandingPath } from "./web/pages/view/view-path";
 import { initGoogleAuthRoutes } from "./web/auth/google-auth.page";
 import { initAppleAuthRoutes } from "./web/auth/apple-auth.page";
@@ -497,6 +498,18 @@ export function createApp(dependencies: AppDependencies): Express {
 			fallthrough: false,
 		}),
 	);
+
+	app.get(`${STYLES_MOUNT_PATH}/:file`, (req: Request, res: Response) => {
+		const match = /^([a-z0-9-]+)\.[a-f0-9]{12}\.css$/.exec(String(req.params.file));
+		const stylesheet = match ? findPageStylesheetByName(match[1]) : undefined;
+		if (!stylesheet) {
+			res.status(404).end();
+			return;
+		}
+		res.set("Content-Type", "text/css; charset=utf-8");
+		res.set("Cache-Control", "public, max-age=31536000, immutable");
+		res.send(stylesheet.css);
+	});
 
 	app.use(contentSignalMiddleware);
 	app.use(linkHeaderMiddleware);

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -500,14 +500,19 @@ export function createApp(dependencies: AppDependencies): Express {
 	);
 
 	app.get(`${STYLES_MOUNT_PATH}/:file`, (req: Request, res: Response) => {
-		const match = /^([a-z0-9-]+)\.[a-f0-9]{12}\.css$/.exec(String(req.params.file));
+		const file = String(req.params.file);
+		const match = /^([a-z0-9-]+)\.[a-f0-9]{12}\.css$/.exec(file);
 		const stylesheet = match ? findPageStylesheetByName(match[1]) : undefined;
 		if (!stylesheet) {
 			res.status(404).end();
 			return;
 		}
+		const requestedHrefIsCurrent = stylesheet.href === `${STYLES_MOUNT_PATH}/${file}`;
 		res.set("Content-Type", "text/css; charset=utf-8");
-		res.set("Cache-Control", "public, max-age=31536000, immutable");
+		res.set(
+			"Cache-Control",
+			requestedHrefIsCurrent ? "public, max-age=31536000, immutable" : "public, max-age=60",
+		);
 		res.send(stylesheet.css);
 	});
 

--- a/projects/hutch/src/runtime/web/page-stylesheets.test.ts
+++ b/projects/hutch/src/runtime/web/page-stylesheets.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { addPageStylesheet, findPageStylesheetByName } from "./page-stylesheets";
+
+describe("page stylesheets", () => {
+	it("derives a hashed, same-origin href from the name and css", () => {
+		const css = ".a { color: red; }";
+		const stylesheet = addPageStylesheet({ name: "alpha", css });
+		const expectedHash = createHash("sha256").update(css).digest("hex").slice(0, 12);
+
+		assert.equal(stylesheet.css, css);
+		assert.equal(stylesheet.href, `/styles/alpha.${expectedHash}.css`);
+		assert.match(stylesheet.href, /^\/styles\/alpha\.[a-f0-9]{12}\.css$/);
+	});
+
+	it("produces the same href for identical css and a different href when css changes", () => {
+		const first = addPageStylesheet({ name: "beta", css: ".b { color: red; }" });
+		const recomputed = createHash("sha256").update(".b { color: red; }").digest("hex").slice(0, 12);
+		assert.equal(first.href, `/styles/beta.${recomputed}.css`);
+
+		const differentCssHash = createHash("sha256").update(".b { color: blue; }").digest("hex").slice(0, 12);
+		assert.notEqual(recomputed, differentCssHash);
+	});
+
+	it("looks a registered stylesheet up by name", () => {
+		const stylesheet = addPageStylesheet({ name: "gamma", css: ".c {}" });
+		assert.deepEqual(findPageStylesheetByName("gamma"), stylesheet);
+	});
+
+	it("returns undefined for an unregistered name", () => {
+		assert.equal(findPageStylesheetByName("never-registered"), undefined);
+	});
+
+	it("rejects registering the same name twice", () => {
+		addPageStylesheet({ name: "delta", css: ".d {}" });
+		assert.throws(() => addPageStylesheet({ name: "delta", css: ".d-again {}" }));
+	});
+});

--- a/projects/hutch/src/runtime/web/page-stylesheets.ts
+++ b/projects/hutch/src/runtime/web/page-stylesheets.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert";
+import { createHash } from "node:crypto";
+
+export interface PageStylesheet {
+	href: string;
+	css: string;
+}
+
+const stylesheetsByName = new Map<string, PageStylesheet>();
+
+export function addPageStylesheet(entry: { name: string; css: string }): PageStylesheet {
+	assert(
+		!stylesheetsByName.has(entry.name),
+		`page stylesheet "${entry.name}" is already registered`,
+	);
+	const hash = createHash("sha256").update(entry.css).digest("hex").slice(0, 12);
+	const stylesheet: PageStylesheet = { href: `/styles/${entry.name}.${hash}.css`, css: entry.css };
+	stylesheetsByName.set(entry.name, stylesheet);
+	return stylesheet;
+}
+
+export function findPageStylesheetByName(name: string): PageStylesheet | undefined {
+	return stylesheetsByName.get(name);
+}

--- a/projects/hutch/src/runtime/web/pages/account/account.component.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.component.ts
@@ -6,9 +6,12 @@ import type { PageBody } from "@packages/web-shell";
 import { ACCOUNT_STYLES } from "./account.styles";
 import { ACCOUNT_EXPORT_URL } from "./account.url";
 import type { AccountViewModel, CardSectionViewModel } from "./account.view-model";
+import { addPageStylesheet } from "../../page-stylesheets";
 
 const ACCOUNT_TEMPLATE = readFileSync(join(__dirname, "account.template.html"), "utf-8");
 const ACCOUNT_CARD_TEMPLATE = readFileSync(join(__dirname, "account-card.template.html"), "utf-8");
+
+const ACCOUNT_STYLESHEET = addPageStylesheet({ name: "account", css: ACCOUNT_STYLES });
 
 /** Same-origin glue bundle (Stripe.js itself loads from js.stripe.com inside it).
  * Loaded on every /account render; it no-ops unless the Elements container is
@@ -47,7 +50,7 @@ export function AccountPage(
 			canonicalUrl: "/account",
 			robots: "noindex, nofollow",
 		},
-		styles: ACCOUNT_STYLES,
+		styles: { href: ACCOUNT_STYLESHEET.href },
 		bodyClass: surface ? "page-account page-account--chromeless" : "page-account",
 		content: {
 			html: render(ACCOUNT_TEMPLATE, {

--- a/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/account/account.route.test.ts
@@ -426,9 +426,10 @@ describe("GET /account?platform=ios&shell=app (the app's in-app web sheet)", () 
 
 		const doc = new JSDOM((await agent.get("/account?platform=ios&shell=app")).text).window.document;
 
-		const style = doc.querySelector("main.account style");
-		assert(style, "the page styles must be injected into <main>");
-		expect(style.textContent).toContain(".account__back");
+		const link = doc.querySelector('main.account link[rel="stylesheet"]');
+		assert(link, "the page styles must be linked from inside <main>");
+		expect(link.getAttribute("href")).toMatch(/^\/styles\/account\.[a-f0-9]{12}\.css$/);
+		expect(doc.querySelector("main.account style")).toBeNull();
 	});
 
 	it("serves local-time (the trial cutoff would otherwise freeze at the server's UTC baseline) but neither WebMCP nor the Stripe card glue", async () => {

--- a/projects/hutch/src/runtime/web/pages/home/home.component.ts
+++ b/projects/hutch/src/runtime/web/pages/home/home.component.ts
@@ -25,8 +25,11 @@ import { renderFoundingProgress } from "../../shared/founding-progress/founding-
 import type { FoundingAllocation } from "../../shared/founding-progress/founding-allocation";
 import { buildHomeSeo } from "./home.seo";
 import { HOME_PAGE_STYLES } from "./home.styles";
+import { addPageStylesheet } from "../../page-stylesheets";
 
 const HOME_TEMPLATE = readFileSync(join(__dirname, "home.template.html"), "utf-8");
+
+const HOME_STYLESHEET = addPageStylesheet({ name: "home", css: HOME_PAGE_STYLES });
 
 /** The install CTA label for the visitor's browser. Keyed by InstallBrowser, so
  * a new browser extension is a compile error here until it earns its own label —
@@ -179,7 +182,7 @@ export function HomePage(params: HomePageParams): PageBody {
 			foundingMemberLimit,
 			foundingAllocationAvailable,
 		}),
-		styles: HOME_PAGE_STYLES,
+		styles: { href: HOME_STYLESHEET.href },
 		scripts: HOME_CLIENT_SCRIPT,
 		bodyClass: `page-home variant-${variant}`,
 		content: { html: render(HOME_TEMPLATE, {

--- a/projects/hutch/src/runtime/web/pages/import/import.component.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.component.ts
@@ -4,6 +4,7 @@ import { render } from "@packages/web-shell";
 import type { PageBody } from "@packages/web-shell";
 
 import { IMPORT_STYLES } from "./import.styles";
+import { addPageStylesheet } from "../../page-stylesheets";
 import type {
 	ImportAcquireViewModel,
 	ImportMode,
@@ -38,6 +39,8 @@ const IMPORT_FROM_URL_PANEL_TEMPLATE = readFileSync(
 	"utf-8",
 );
 const IMPORT_CLIENT_SCRIPT = `<script src="/client-dist/import.client.js" defer></script>`;
+
+const IMPORT_STYLESHEET = addPageStylesheet({ name: "import", css: IMPORT_STYLES });
 
 interface PanelConfig {
 	readonly template: string;
@@ -129,7 +132,7 @@ export function ImportPage(vm: ImportViewModel): PageBody {
 			canonicalUrl: `/import/${vm.sessionId}`,
 			robots: "noindex, nofollow",
 		},
-		styles: IMPORT_STYLES,
+		styles: { href: IMPORT_STYLESHEET.href },
 		bodyClass: "page-import",
 		content: { html: content },
 		scripts: IMPORT_CLIENT_SCRIPT,
@@ -216,7 +219,7 @@ export function ImportAcquirePage(vm: ImportAcquireViewModel): PageBody {
 				},
 			],
 		},
-		styles: IMPORT_STYLES,
+		styles: { href: IMPORT_STYLESHEET.href },
 		bodyClass: "page-import",
 		content: { html: content },
 		scripts: panel.scripts,

--- a/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.component.ts
@@ -25,8 +25,11 @@ import { SAVE_SURFACES_SHORT_PHRASE } from "../../shared/client-surface-phrases"
 import type { QueueViewModel, SubscriptionBannerState } from "./queue.viewmodel";
 import { buildQueueUrl } from "./queue.url";
 import { tabQuery, type TabId } from "./queue.tabs";
+import { addPageStylesheet } from "../../page-stylesheets";
 
 const QUEUE_TEMPLATE = readFileSync(join(__dirname, "queue.template.html"), "utf-8");
+
+const QUEUE_STYLESHEET = addPageStylesheet({ name: "queue", css: `${QUEUE_STYLES}\n${ONBOARDING_STYLES}` });
 
 /** Long enough to read the message and reach for Undo, short enough not to
  * linger; the global toast.client script removes it after this delay. */
@@ -217,7 +220,7 @@ export function QueuePage(vm: QueueViewModel, options: { deviceClass: DeviceClas
 			canonicalUrl: "/queue",
 			robots: "noindex, nofollow",
 		},
-		styles: `${QUEUE_STYLES}\n${ONBOARDING_STYLES}`,
+		styles: { href: QUEUE_STYLESHEET.href },
 		bodyClass: "page-queue",
 		content: { html: content },
 		scripts: scriptParts.join("\n"),

--- a/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.listing.route.test.ts
@@ -47,6 +47,19 @@ describe("Queue routes", () => {
 				'<script src="/client-dist/reader-nav.client.js" defer></script>',
 			);
 		});
+
+		it("links page CSS from inside <main> instead of inlining a <style>", async () => {
+			const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+			const { auth } = harness;
+			const agent = await loginAgent(harness.server, auth);
+
+			const response = await agent.get("/queue");
+
+			const doc = new JSDOM(response.text).window.document;
+			const link = doc.querySelector('main link[rel="stylesheet"]');
+			expect(link?.getAttribute("href")).toMatch(/^\/styles\/queue\.[a-f0-9]{12}\.css$/);
+			expect(doc.querySelector("main style")).toBeNull();
+		});
 	});
 
 	describe("GET /queue — degraded batched summary/crawl reads", () => {

--- a/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
+++ b/projects/hutch/src/runtime/web/pages/reader/reader.component.ts
@@ -23,8 +23,11 @@ import {
 import { shareUserIdPrefix } from "../../shared/share-balloon/share-user-id-prefix";
 import { viewPathFor } from "../view/view-path";
 import { READER_STYLES } from "./reader.styles";
+import { addPageStylesheet } from "../../page-stylesheets";
 
 const READER_TEMPLATE = readFileSync(join(__dirname, "reader.template.html"), "utf-8");
+
+const READER_STYLESHEET = addPageStylesheet({ name: "reader", css: READER_STYLES });
 const PROGRESS_BAR_SCRIPT = `<script src="/client-dist/progress-bar.client.js" defer></script>`;
 const READER_IFRAME_SCRIPT = `<script src="/client-dist/reader-iframe.client.js" defer></script>`;
 const SUMMARY_TOGGLE_SCRIPT = `<script src="/client-dist/summary-toggle.client.js" defer></script>`;
@@ -123,7 +126,7 @@ export function ReaderPage(
 			canonicalUrl: `/queue/${articleId}/view`,
 			robots: "noindex, nofollow",
 		},
-		styles: READER_STYLES,
+		styles: { href: READER_STYLESHEET.href },
 		bodyClass: actions.bodyClass,
 		content: { html: content },
 		scripts: readerScripts({

--- a/projects/hutch/src/runtime/web/static-asset-paths.test.ts
+++ b/projects/hutch/src/runtime/web/static-asset-paths.test.ts
@@ -5,6 +5,8 @@ describe("isStaticAssetRequestPath", () => {
 		"/client-dist",
 		"/client-dist/toast.client.js",
 		"/client-dist/view-paywall.client.js.map",
+		"/styles",
+		"/styles/queue.abc123def456.css",
 		"/toast.client.js",
 		"/extension-suggestion-banner.client.js",
 		"/progress-bar.client.js.map",

--- a/projects/hutch/src/runtime/web/static-asset-paths.ts
+++ b/projects/hutch/src/runtime/web/static-asset-paths.ts
@@ -1,5 +1,7 @@
 export const CLIENT_DIST_MOUNT_PATH = "/client-dist";
 
+export const STYLES_MOUNT_PATH = "/styles";
+
 export const APPLE_TOUCH_ICON_PATH = /^\/apple-touch-icon(?:-\d+x\d+)?(?:-precomposed)?\.png$/;
 
 /** express.static responds terminally, so a client-dist asset's finish-time
@@ -11,6 +13,7 @@ const TRIMMED_BUNDLE_PATH = /^\/[a-z0-9-]+\.client\.js(\.map)?$/;
  * source URLs and may end `.png`/`.html`. */
 export function isStaticAssetRequestPath(path: string): boolean {
 	if (path === CLIENT_DIST_MOUNT_PATH || path.startsWith(`${CLIENT_DIST_MOUNT_PATH}/`)) return true;
+	if (path === STYLES_MOUNT_PATH || path.startsWith(`${STYLES_MOUNT_PATH}/`)) return true;
 	if (APPLE_TOUCH_ICON_PATH.test(path)) return true;
 	return TRIMMED_BUNDLE_PATH.test(path);
 }

--- a/projects/hutch/src/runtime/web/styles.route.test.ts
+++ b/projects/hutch/src/runtime/web/styles.route.test.ts
@@ -26,7 +26,7 @@ describe("GET /styles/:file", () => {
 		expect(response.text).toBe(stylesheet.css);
 	});
 
-	it("serves the current css even when the hash in the url is stale", async () => {
+	it("serves the current css with a short, self-healing cache when the hash in the url is stale", async () => {
 		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
 		const stylesheet = queueStylesheet();
 
@@ -36,6 +36,7 @@ describe("GET /styles/:file", () => {
 
 		expect(response.status).toBe(200);
 		expect(response.text).toBe(stylesheet.css);
+		expect(response.headers["cache-control"]).toBe("public, max-age=60");
 	});
 
 	it("404s an unknown stylesheet name", async () => {

--- a/projects/hutch/src/runtime/web/styles.route.test.ts
+++ b/projects/hutch/src/runtime/web/styles.route.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import request from "supertest";
+import { useTestServer, loginAgent } from "../test-app";
+import { TEST_APP_ORIGIN, createDefaultTestAppFixture } from "@packages/test-fixtures";
+import { findPageStylesheetByName } from "./page-stylesheets";
+
+const useApp = useTestServer();
+
+function queueStylesheet() {
+	const stylesheet = findPageStylesheetByName("queue");
+	assert(stylesheet, "the queue page must register its stylesheet at import time");
+	return stylesheet;
+}
+
+describe("GET /styles/:file", () => {
+	it("serves the registered stylesheet as immutable, long-lived text/css", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const stylesheet = queueStylesheet();
+
+		const response = await request(harness.server).get(stylesheet.href);
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("text/css; charset=utf-8");
+		expect(response.headers["cache-control"]).toBe("public, max-age=31536000, immutable");
+		expect(response.text).toBe(stylesheet.css);
+	});
+
+	it("serves the current css even when the hash in the url is stale", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const stylesheet = queueStylesheet();
+
+		const staleUrl = "/styles/queue.000000000000.css";
+		assert.notEqual(staleUrl, stylesheet.href);
+		const response = await request(harness.server).get(staleUrl);
+
+		expect(response.status).toBe(200);
+		expect(response.text).toBe(stylesheet.css);
+	});
+
+	it("404s an unknown stylesheet name", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/styles/nonexistent.abc123def456.css");
+		expect(response.status).toBe(404);
+	});
+
+	it("404s a filename that is not a hashed stylesheet", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const response = await request(harness.server).get("/styles/queue.css");
+		expect(response.status).toBe(404);
+	});
+
+	it("references the exact served href from the queue page's <main>", async () => {
+		const harness = useApp(createDefaultTestAppFixture(TEST_APP_ORIGIN));
+		const { auth } = harness;
+		const stylesheet = queueStylesheet();
+		const agent = await loginAgent(harness.server, auth);
+
+		const response = await agent.get("/queue");
+
+		expect(response.status).toBe(200);
+		const doc = new JSDOM(response.text).window.document;
+		const link = doc.querySelector('main link[rel="stylesheet"]');
+		expect(link?.getAttribute("href")).toBe(stylesheet.href);
+		expect(doc.querySelector("main style")).toBeNull();
+	});
+});

--- a/src/packages/web-shell/src/base.component.test.ts
+++ b/src/packages/web-shell/src/base.component.test.ts
@@ -132,6 +132,26 @@ describe("Base component", () => {
 		expect(main?.querySelector("style")?.textContent).toBe(".lead { color: rebeccapurple; }");
 	});
 
+	it("injects page styles as a <link> in <main> and preloads it from <head> for the href variant", () => {
+		const href = "/styles/queue.abc123def456.css";
+		const page = createTestPageBody({
+			styles: { href },
+			content: { html: "<main><p>Test content</p></main>" },
+		});
+		const result = Base(page, GUEST_STATE).to("text/html");
+		const doc = new JSDOM(result.body).window.document;
+
+		const main = doc.querySelector("main");
+		const injected = main?.firstElementChild;
+		expect(injected?.tagName).toBe("LINK");
+		expect(injected?.getAttribute("rel")).toBe("stylesheet");
+		expect(injected?.getAttribute("href")).toBe(href);
+		expect(main?.querySelector("style")).toBeNull();
+
+		const preload = doc.head.querySelector('link[rel="preload"][as="style"]');
+		expect(preload?.getAttribute("href")).toBe(href);
+	});
+
 	it("preserves the reader iframe's double-escaped srcdoc when injecting page styles, so code samples stay text", () => {
 		const srcdoc =
 			"&lt;!doctype html&gt;&lt;body&gt;&lt;code&gt;&amp;lt;input&amp;gt;&lt;/code&gt;&lt;/body&gt;";

--- a/src/packages/web-shell/src/base.component.ts
+++ b/src/packages/web-shell/src/base.component.ts
@@ -20,7 +20,7 @@ import { renderChangelogBannerShell } from "./changelog-banner";
 import type { Component, ParsedComponent } from "./component.types";
 import { HtmlPage } from "./html-page";
 import { HTMX_SCRIPTS } from "./htmx-script";
-import { injectPageStylesIntoMain } from "./inject-page-styles";
+import { injectPageStylesIntoMain, pageStylesheetPreload } from "./inject-page-styles";
 import { htmlToMarkdown } from "./html-to-markdown";
 import { MarkdownPage } from "./markdown-page";
 import { buildMarkdownFrontmatter } from "./markdown-frontmatter";
@@ -269,6 +269,7 @@ export function initBase(config: BaseConfig): RenderBase {
 				accessIsReadOnly: state.accessIsReadOnly ?? false,
 				trialCounter: state.trial,
 			}),
+			pageStylesheetPreload: pageStylesheetPreload(body.styles),
 			content: injectPageStylesIntoMain(body.content.html, body.styles),
 			footer: renderFooter(),
 			navScript: NAV_SCRIPT,

--- a/src/packages/web-shell/src/base.template.ts
+++ b/src/packages/web-shell/src/base.template.ts
@@ -32,6 +32,7 @@ export const BASE_TEMPLATE = `<!DOCTYPE html>
 	{{#if twitterSite}}<meta name="twitter:site" content="{{twitterSite}}">{{/if}}
 	<meta name="twitter:creator" content="@fagnerbrack">
 
+	{{{pageStylesheetPreload}}}
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/src/packages/web-shell/src/chromeless-page.template.ts
+++ b/src/packages/web-shell/src/chromeless-page.template.ts
@@ -7,6 +7,7 @@ export const CHROMELESS_TEMPLATE = `<!DOCTYPE html>
 	<meta name="description" content="{{description}}">
 	<meta name="robots" content="{{robots}}">
 
+	{{{pageStylesheetPreload}}}
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/src/packages/web-shell/src/chromeless-page.test.ts
+++ b/src/packages/web-shell/src/chromeless-page.test.ts
@@ -61,6 +61,23 @@ describe("ChromelessPage", () => {
 		expect(doc.querySelector(".footer")).toBeNull();
 	});
 
+	it("injects page styles as a <link> in <main> and preloads it from <head> for the href variant", () => {
+		const href = "/styles/reader.0123456789ab.css";
+		const doc = new JSDOM(
+			ChromelessPage(createTestPageBody({ styles: { href } }), NO_BANNER).to("text/html").body,
+		).window.document;
+
+		const main = doc.querySelector("main.reader");
+		const injected = main?.firstElementChild;
+		expect(injected?.tagName).toBe("LINK");
+		expect(injected?.getAttribute("rel")).toBe("stylesheet");
+		expect(injected?.getAttribute("href")).toBe(href);
+		expect(main?.querySelector("style")).toBeNull();
+
+		const preload = doc.head.querySelector('link[rel="preload"][as="style"]');
+		expect(preload?.getAttribute("href")).toBe(href);
+	});
+
 	it("carries the page's seo title, description, and robots into <head>", () => {
 		const doc = new JSDOM(ChromelessPage(createTestPageBody(), NO_BANNER).to("text/html").body).window.document;
 		expect(doc.title).toBe("Reader");

--- a/src/packages/web-shell/src/chromeless-page.ts
+++ b/src/packages/web-shell/src/chromeless-page.ts
@@ -12,7 +12,7 @@ import { CHROMELESS_TEMPLATE } from "./chromeless-page.template";
 import type { Component } from "./component.types";
 import { HtmlPage } from "./html-page";
 import { HTMX_SCRIPTS } from "./htmx-script";
-import { injectPageStylesIntoMain } from "./inject-page-styles";
+import { injectPageStylesIntoMain, pageStylesheetPreload } from "./inject-page-styles";
 import type { PageBody, SeoMetadata } from "./page-body.types";
 import { render } from "./render";
 
@@ -64,6 +64,7 @@ export function initChromelessPage(config: ChromelessPageConfig): RenderChromele
 			bannerAreaStyles: CHROMELESS_BANNER_AREA_STYLES,
 			changelogBannerStyles: CHANGELOG_BANNER_STYLES,
 			changelogBanner: renderChangelogBannerShell(state.changelogBanner, state.currentPath),
+			pageStylesheetPreload: pageStylesheetPreload(body.styles),
 			content: injectPageStylesIntoMain(body.content.html, body.styles),
 			scripts: HTMX_SCRIPTS + (body.scripts ?? "") + siteScripts + liveReloadScript,
 		});

--- a/src/packages/web-shell/src/inject-page-styles.test.ts
+++ b/src/packages/web-shell/src/inject-page-styles.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { injectPageStylesIntoMain, pageStylesheetPreload } from "./inject-page-styles";
+
+describe("injectPageStylesIntoMain", () => {
+	it("inserts inline CSS as a <style> first child of <main> for the string variant", () => {
+		const html = injectPageStylesIntoMain(
+			"<main><p>Body</p></main>",
+			".lead { color: rebeccapurple; }",
+		);
+		const main = new JSDOM(html).window.document.querySelector("main");
+		assert(main, "output must contain <main>");
+		assert.equal(main.firstElementChild?.tagName, "STYLE");
+		assert.equal(main.querySelector("style")?.textContent, ".lead { color: rebeccapurple; }");
+	});
+
+	it("inserts a stylesheet <link> first child of <main> for the href variant", () => {
+		const html = injectPageStylesIntoMain("<main><p>Body</p></main>", {
+			href: "/styles/queue.abc123def456.css",
+		});
+		const main = new JSDOM(html).window.document.querySelector("main");
+		assert(main, "output must contain <main>");
+		const link = main.firstElementChild;
+		assert.equal(link?.tagName, "LINK");
+		assert.equal(link?.getAttribute("rel"), "stylesheet");
+		assert.equal(link?.getAttribute("href"), "/styles/queue.abc123def456.css");
+	});
+
+	it("preserves the <main>'s attributes when injecting either variant", () => {
+		const styleHtml = injectPageStylesIntoMain('<main class="reader"><p>x</p></main>', ".a{}");
+		const linkHtml = injectPageStylesIntoMain('<main class="reader"><p>x</p></main>', {
+			href: "/styles/reader.0123456789ab.css",
+		});
+		assert.equal(new JSDOM(styleHtml).window.document.querySelector("main")?.className, "reader");
+		assert.equal(new JSDOM(linkHtml).window.document.querySelector("main")?.className, "reader");
+	});
+
+	it("returns the content untouched when the inline string is empty", () => {
+		const content = "<main><p>No styles</p></main>";
+		assert.equal(injectPageStylesIntoMain(content, ""), content);
+	});
+
+	it("throws when styles are provided but there is no <main> to host them", () => {
+		assert.throws(() => injectPageStylesIntoMain("<section><p>x</p></section>", ".a{}"));
+		assert.throws(() =>
+			injectPageStylesIntoMain("<section><p>x</p></section>", { href: "/styles/x.0123456789ab.css" }),
+		);
+	});
+
+	it("keeps the reader iframe's double-escaped srcdoc intact under the href variant", () => {
+		const srcdoc = "&lt;code&gt;&amp;lt;input&amp;gt;&lt;/code&gt;";
+		const html = injectPageStylesIntoMain(
+			`<main><iframe data-reader-iframe srcdoc="${srcdoc}"></iframe></main>`,
+			{ href: "/styles/reader.0123456789ab.css" },
+		);
+		assert.ok(html.includes("&amp;lt;input&amp;gt;"));
+	});
+});
+
+describe("pageStylesheetPreload", () => {
+	it("emits nothing for the inline string variant", () => {
+		assert.equal(pageStylesheetPreload(".a{}"), "");
+		assert.equal(pageStylesheetPreload(""), "");
+	});
+
+	it("emits a style preload <link> for the href variant", () => {
+		const link = new JSDOM(
+			`<head>${pageStylesheetPreload({ href: "/styles/queue.abc123def456.css" })}</head>`,
+		).window.document.querySelector("link");
+		assert.equal(link?.getAttribute("rel"), "preload");
+		assert.equal(link?.getAttribute("as"), "style");
+		assert.equal(link?.getAttribute("href"), "/styles/queue.abc123def456.css");
+	});
+});

--- a/src/packages/web-shell/src/inject-page-styles.ts
+++ b/src/packages/web-shell/src/inject-page-styles.ts
@@ -1,11 +1,6 @@
 import assert from "node:assert";
 
 /**
- * Inject page-specific CSS as a <style> element inside <main>, so that htmx
- * navigation (hx-target="main" hx-select="main" hx-swap="outerHTML") swaps the
- * page's CSS atomically with its content. Without this, htmx leaves the
- * previous page's <style> stranded in <head>, defacing the new page's layout.
- *
  * String insert, NOT linkedom's parseHTML. A DOM parse-then-serialize round-trip
  * decodes one level of HTML escaping, and the reader iframe's `srcdoc` is
  * intentionally double-escaped, so a code sample like `&amp;lt;input&amp;gt;`
@@ -13,10 +8,18 @@ import assert from "node:assert";
  * tool only for untrusted markup crossing a network boundary; this is trusted
  * server markup whose escaping must survive byte-for-byte. Do not restore parseHTML.
  */
-export function injectPageStylesIntoMain(content: string, styles: string): string {
-	if (!styles) return content;
-	const styleTag = `<style>${styles}</style>`;
+export function injectPageStylesIntoMain(content: string, styles: string | { href: string }): string {
+	if (typeof styles === "string" && !styles) return content;
+	const styleTag =
+		typeof styles === "string"
+			? `<style>${styles}</style>`
+			: `<link rel="stylesheet" href="${styles.href}">`;
 	const updated = content.replace(/<main(?=[\s/>])[^>]*>/i, (mainTag) => mainTag + styleTag);
 	assert(updated !== content, "PageBody.content must contain a <main> element when styles are provided");
 	return updated;
+}
+
+export function pageStylesheetPreload(styles: string | { href: string }): string {
+	if (typeof styles === "string") return "";
+	return `<link rel="preload" as="style" href="${styles.href}">`;
 }

--- a/src/packages/web-shell/src/page-body.types.ts
+++ b/src/packages/web-shell/src/page-body.types.ts
@@ -32,7 +32,7 @@ export interface SeoMetadata {
 
 export interface PageBody {
 	seo: SeoMetadata;
-	styles: string;
+	styles: string | { href: string };
 	headerVariant?: "default" | "transparent";
 	bodyClass?: string;
 	content: { html: string; markdown?: string };


### PR DESCRIPTION
## Summary

Stops re-sending ~15–19 KB of inline page CSS on every hutch HTML response **and on every boosted `<main>` swap** for the measured CTA surfaces. Page CSS is now delivered as a content-hashed, same-origin, immutable-cached stylesheet linked from inside `<main>`, instead of an inline `<style>` block.

This is **Phase A, wave 1** (queue, reader, account, import, home). It is deliberately low-risk and complementary to the server-side latency work — it does **not** itself fix the CTA latencies (those are DynamoDB/banner-fetch, server-side, and belong to other plans).

## What changed

**`@packages/web-shell`**
- `PageBody.styles` becomes a union `string | { href: string }` — a union (not an extra optional field) so "both inline and href" is unrepresentable. Every existing consumer (blog-site, extensions, …) keeps passing strings and compiles unchanged.
- `injectPageStylesIntoMain` emits a `<link rel="stylesheet">` as the first child of `<main>` for the href variant (a `<style>` for the string variant, unchanged). The string-insert mechanism (not `parseHTML`) is preserved so the reader `srcdoc`'s intentional double-escaping survives byte-for-byte.
- `pageStylesheetPreload` feeds a matching `<link rel="preload" as="style">` into `<head>` via a new slot in both the base and chromeless shells, placed **before** the third-party font preloads so the preload scanner queues the render-critical same-origin CSS first.

**`hutch`**
- New `page-stylesheets.ts`: `addPageStylesheet({ name, css })` content-hashes the CSS into `/styles/<name>.<sha256-12>.css` at module load; `findPageStylesheetByName` looks it up.
- New `GET /styles/:file` route mounted **before** session/auth, serving `text/css` with `Cache-Control: public, max-age=31536000, immutable`. Lookup is **by name, ignoring the hash**, so a mixed-fleet deploy window serves current CSS rather than a 404/unstyled page. Unknown name or malformed filename → terminal 404.
- `/styles` is exempted from click attribution alongside `/client-dist`.
- Wave-1 pages register their composed CSS and pass `{ href }` instead of inlining.

## Why these design choices

- **Page CSS stays inside `<main>`** so boosted swaps replace styles atomically with content; a `<head>` link would break cross-page swaps (reader → queue mark-read).
- **Lookup by name, hash ignored** — a mixed-fleet deploy window serves current CSS instead of a 404/unstyled page.
- **Runtime hashing, no build step** — the composition lives in runtime TS (reader concatenates 3 sources, queue appends onboarding), so a build step would replicate it and drift.
- **Same-origin, not CDN** — per-commit assets must ship with the server that renders the HTML referencing them.

## Test plan

- Unit: `injectPageStylesIntoMain` / `pageStylesheetPreload` (both variants, escaping intact), `page-stylesheets` (href determinism, name lookup, collision), base + chromeless shells (link in `<main>` + head preload).
- Integration `styles.route.test.ts`: 200 + `text/css` + immutable header; stale hash still serves current CSS; unknown name / non-hashed filename → 404; `/queue` references the exact served href.
- Extended `static-asset-paths`, `queue.listing.route`, and `account.route` tests.
- `pnpm check` passes across all 47 projects (compile, lint, tests, 100% coverage, knip, unused-css).

## Scope / expected impact

Wave-1 pages only. Expected: decoded payload per CTA ~131 KB → ~87 KB, gzip transfer ~21 KB → ~12–13 KB, and elimination of a ~19 KB CSS parse + style-recalc on every boosted swap (single-digit-to-tens ms). Does **not** address the 900–2400 ms server-side CTA latencies. Wave 2 (the remaining ~22 producer sites, mechanical) is a separate follow-up once wave 1 is verified in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111DWvSaQrpKSpGMZ5X4cEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111DWvSaQrpKSpGMZ5X4cEQ)_