### PR TITLE
refactor: pre-existing cleanups — stale COUNT comment + zod .passthrough() → z.looseObject

### DIFF
--- a/projects/hutch/src/runtime/export-user-data/export-user-data-handler.test.ts
+++ b/projects/hutch/src/runtime/export-user-data/export-user-data-handler.test.ts
@@ -18,7 +18,7 @@ const stubAttributes: SQSRecordAttributes = {
 
 const ExportBodySchema = z.object({
 	articleCount: z.number(),
-	articles: z.array(z.object({ url: z.string(), title: z.string() }).passthrough()),
+	articles: z.array(z.looseObject({ url: z.string(), title: z.string() })),
 });
 
 function createSqsEvent(detail: {

--- a/projects/hutch/src/runtime/stripe-webhook-receiver/verify-stripe-signature.ts
+++ b/projects/hutch/src/runtime/stripe-webhook-receiver/verify-stripe-signature.ts
@@ -1,12 +1,10 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 
-const StripeEventSchema = z
-	.object({
-		type: z.string(),
-		data: z.object({ object: z.object({ id: z.string() }).passthrough() }).passthrough(),
-	})
-	.passthrough();
+const StripeEventSchema = z.looseObject({
+	type: z.string(),
+	data: z.looseObject({ object: z.looseObject({ id: z.string() }) }),
+});
 
 export type StripeEvent = z.infer<typeof StripeEventSchema>;
 

--- a/projects/hutch/src/runtime/web/auth/auth.page.ts
+++ b/projects/hutch/src/runtime/web/auth/auth.page.ts
@@ -82,9 +82,9 @@ import {
 import type { EmitSubscriptionEvent } from "../../observability/subscription-events";
 import { DISPOSABLE_EMAIL_MESSAGE } from "./disposable-email";
 
-const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
-const CheckoutSuccessQuerySchema = z.object({ session_id: z.string().min(1) }).passthrough();
-const SignupQuerySchema = z.object({ email: z.string().email() }).passthrough();
+const TokenQuerySchema = z.looseObject({ token: z.string().optional() });
+const CheckoutSuccessQuerySchema = z.looseObject({ session_id: z.string().min(1) });
+const SignupQuerySchema = z.looseObject({ email: z.string().email() });
 
 const EMAIL_FROM = "Fayner Brack <readplace@readplace.com>";
 

--- a/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
+++ b/projects/hutch/src/runtime/web/auth/forgot-password.page.ts
@@ -24,7 +24,7 @@ import { ForgotPasswordPage, ResetPasswordPage } from "./auth.component";
 import { buildPasswordResetEmailHtml } from "./password-reset-email";
 import { flattenZodErrors } from "./flatten-zod-errors";
 
-const TokenQuerySchema = z.object({ token: z.string().optional() }).passthrough();
+const TokenQuerySchema = z.looseObject({ token: z.string().optional() });
 
 const EMAIL_FROM = "Readplace Password Reset <readplace@readplace.com>";
 

--- a/projects/hutch/src/runtime/web/auth/parse-return-url.ts
+++ b/projects/hutch/src/runtime/web/auth/parse-return-url.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const ReturnQuerySchema = z.object({ return: z.string().optional() }).passthrough();
+const ReturnQuerySchema = z.looseObject({ return: z.string().optional() });
 
 function validatedReturnUrl(query: unknown): string | undefined {
 	const parsed = ReturnQuerySchema.safeParse(query);

--- a/projects/hutch/src/runtime/web/pages/import/import.url.ts
+++ b/projects/hutch/src/runtime/web/pages/import/import.url.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
-const ImportPageQuerySchema = z
-	.object({
-		page: z.coerce.number().int().min(1).optional().catch(undefined),
-	})
-	.passthrough();
+const ImportPageQuerySchema = z.looseObject({
+	page: z.coerce.number().int().min(1).optional().catch(undefined),
+});
 
 export function parseImportPage(query: Record<string, unknown>): number {
 	const parsed = ImportPageQuerySchema.parse(query);

--- a/projects/hutch/src/runtime/web/pages/queue/my-readplace/my-readplace.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/my-readplace/my-readplace.url.ts
@@ -7,10 +7,10 @@ export const MY_READPLACE_TAB_ID = "my";
 
 export const MY_READPLACE_SAVE_PATH = `${QUEUE_PATH}/my-readplace`;
 
-const MyReadplaceQuerySchema = z.object({
+const MyReadplaceQuerySchema = z.looseObject({
 	edit: z.string().optional().catch(undefined),
 	invalid: z.string().optional().catch(undefined),
-}).passthrough();
+});
 
 export function parseMyReadplaceState(query: Record<string, unknown>): {
 	edit: boolean;

--- a/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
+++ b/projects/hutch/src/runtime/web/pages/queue/queue.url.ts
@@ -15,13 +15,13 @@ export interface QueueUrlState {
 	feature?: string;
 }
 
-const QueueQuerySchema = z.object({
+const QueueQuerySchema = z.looseObject({
 	tab: z.enum(TAB_IDS).optional().catch(undefined),
 	status: z.enum(["unread", "read"]).optional().catch(undefined),
 	order: z.enum(["asc", "desc"]).optional().catch(undefined),
 	page: z.coerce.number().int().min(1).optional().catch(undefined),
 	feature: z.string().optional().catch(undefined),
-}).passthrough();
+});
 
 export function parseQueueUrl(query: Record<string, unknown>): QueueUrlState {
 	const parsed = QueueQuerySchema.parse(query);

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-articles-more.url.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-articles-more.url.ts
@@ -6,8 +6,7 @@ export const ARTICLES_PAGE_SIZE = 20;
 // strings: a POST that carries no body at all leaves `req.body` undefined, and
 // an absent page size is the default page, not a request to reject.
 const ArticlesShownSchema = z
-	.object({ shown: z.coerce.number().int().min(1).optional().catch(undefined) })
-	.passthrough()
+	.looseObject({ shown: z.coerce.number().int().min(1).optional().catch(undefined) })
 	.catch({});
 
 export function parseArticlesShown(source: unknown): number {

--- a/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.url.ts
+++ b/projects/inbox/src/runtime/web/pages/inbox/inbox-emails.url.ts
@@ -12,9 +12,10 @@ const CursorValueSchema = z
 	.optional()
 	.catch(undefined);
 
-const InboxEmailsQuerySchema = z
-	.object({ older: CursorValueSchema, newer: CursorValueSchema })
-	.passthrough();
+const InboxEmailsQuerySchema = z.looseObject({
+	older: CursorValueSchema,
+	newer: CursorValueSchema,
+});
 
 export function parseInboxEmailsUrl(query: Record<string, unknown>): {
 	cursor: InboxEmailsCursor | undefined;

--- a/src/packages/provider-contracts/src/article-store.ts
+++ b/src/packages/provider-contracts/src/article-store.ts
@@ -100,11 +100,6 @@ export type FindArticlesByUser = (
 	query: FindArticlesQuery,
 ) => Promise<FindArticlesResult>;
 
-/** Count a user's articles (optionally by status) with a single COUNT round
- * trip and no row fetch. Use instead of `findArticlesByUser` when only the
- * number is needed: the list path's page fetch is a `Limit:pageSize` filtered
- * walk that DynamoDB evaluates one row per round trip, which is pathological
- * for sparse matches such as an unread-count badge. */
 export type CountArticlesByUser = (
 	query: CountArticlesQuery,
 ) => Promise<number>;


### PR DESCRIPTION
## Summary

Two small, pre-existing cleanups, landed as separate commits (one per item):

1. **`docs(@packages/provider-contracts)`: drop stale COUNT round-trip claim** — the `CountArticlesByUser` doc comment claimed the count happens "with a single COUNT round trip", but the implementation pages `Select: "COUNT"` queries over `LastEvaluatedKey` with a `countLimit` early exit. The clause had been loose since the `bfe0b2aa` extraction (not the recent perf work). Comment-only deletion; the guidance it carried now lives in the commit body.

2. **`refactor(hutch,inbox)`: migrate zod `.passthrough()` → `z.looseObject()`** — `.passthrough()` is deprecated in the pinned zod `4.4.3`; both deprecation hints in its typings terminate at `z.looseObject`, which produces the same `$loose` config. Runtime behaviour and `z.infer` output are identical, so no test expectations change. All 12 remaining occurrences across 8 files migrated in one commit so the repo never carries two loose-object idioms; nested schemas convert at each level (`verify-stripe-signature.ts`).

## Note on the dropped third item

The original cleanup set included replacing `as` casts in the article-store test with zod helpers. That item is now **obsolete**: `main` has since renamed and rewritten that test (`dynamodb-saved-article-store.test.ts` → `dynamodb-article-store.test.ts`) and independently adopted the same idiom this item proposed — a `CapturedCommand` zod schema over captured command input plus a single documented fake-client cast (the allowed "test fake bound to an existing signature" exception). Nothing left to change, so it is not part of this PR.

## Verification

- Full `pnpm check` (all 42 projects) passes: compile, lint, tests, 100% coverage.
- No behaviour change: `z.looseObject` and `.passthrough()` share the `$loose` config, and item 1 is comment-only.
- No infrastructure inputs touched, so `pnpm check-infra` is not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CTQPwobNdf8DGv6TgHH2E

---
_Generated by [Claude Code](https://claude.ai/code/session_019CTQPwobNdf8DGv6TgHH2E)_