### PR TITLE
perf(hutch,inbox): serve the changelog banner stale instead of blocking renders

### DIFF
--- a/projects/hutch/src/runtime/app.ts
+++ b/projects/hutch/src/runtime/app.ts
@@ -764,7 +764,7 @@ export function createHutchApp(deps?: {
 	// Decorative, cached, fail-open source for the site-wide changelog banner.
 	// Points at blog-site's fragment endpoint via hutch's own API Gateway (set in
 	// infra); a slow or down source never blocks a page render.
-	const { getChangelogBanner } = initChangelogBannerSource({
+	const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 		fetch: globalThis.fetch,
 		sourceUrl: requireEnv("CHANGELOG_BANNER_URL"),
 		now: () => Date.now(),
@@ -772,6 +772,7 @@ export function createHutchApp(deps?: {
 		timeoutMs: 800,
 		logger: HutchLogger.from(consoleLogger),
 	});
+	void refreshChangelogBanner();
 
 	const app = createApp({
 		validateSaveableUrl: withUnwrapPreprocessing(

--- a/projects/hutch/src/runtime/server.ts
+++ b/projects/hutch/src/runtime/server.ts
@@ -477,6 +477,10 @@ export function createApp(dependencies: AppDependencies): Express {
 	app.use(express.urlencoded({ extended: true }));
 	app.use(cookieParser());
 	app.use(changelogDismissMiddleware);
+	app.use((_req: Request, _res: Response, next: NextFunction) => {
+		void deps.getChangelogBanner();
+		next();
+	});
 	app.use(createVisitorIdMiddleware({ generateVisitorId: randomUUID, secure: secureCookies }));
 	app.use(
 		createClickAttributionMiddleware({

--- a/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.test.ts
@@ -15,6 +15,14 @@ const BANNER: ChangelogBanner = {
 	version: VERSION,
 };
 
+const NEXT_VERSION = "b2c3d4e5";
+assert(isChangelogVersion(NEXT_VERSION));
+const NEXT_BANNER: ChangelogBanner = {
+	hook: "Now with highlights",
+	href: "/blog/highlights",
+	version: NEXT_VERSION,
+};
+
 type FetchResult = { status: number; ok: boolean; text: () => Promise<string> };
 
 function okFragment(banner: ChangelogBanner): FetchResult {
@@ -47,7 +55,7 @@ const FIXED = {
 };
 
 describe("initChangelogBannerSource", () => {
-	it("fetches on the first call and returns the parsed banner", async () => {
+	it("returns undefined immediately on a cold call and kicks exactly one background fetch", async () => {
 		let fetchCount = 0;
 		const { getChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
@@ -59,6 +67,24 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(fetchCount).toBe(1);
+	});
+
+	it("serves the fetched banner once refreshChangelogBanner settles, without refetching inside the TTL", async () => {
+		let fetchCount = 0;
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return okFragment(BANNER);
+			},
+		});
+
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
 		expect(await getChangelogBanner()).toEqual(BANNER);
 		expect(fetchCount).toBe(1);
 	});
@@ -66,7 +92,7 @@ describe("initChangelogBannerSource", () => {
 	it("serves from cache within the TTL and refetches once it expires", async () => {
 		let clock = 0;
 		let fetchCount = 0;
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => clock,
 			logger: noopLogger,
@@ -76,83 +102,128 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
-		await getChangelogBanner();
+		await refreshChangelogBanner();
 		expect(fetchCount).toBe(1);
 
 		clock = 999; // still inside the 1000ms TTL
-		await getChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
 		expect(fetchCount).toBe(1);
 
 		clock = 1000; // TTL elapsed
 		await getChangelogBanner();
+		await refreshChangelogBanner();
 		expect(fetchCount).toBe(2);
+	});
+
+	it("serves the stale banner past the TTL and swaps to the new value once the background refresh settles", async () => {
+		let clock = 0;
+		const responses = [okFragment(BANNER), okFragment(NEXT_BANNER)];
+		let index = 0;
+		let fetchCount = 0;
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return responses[index++];
+			},
+		});
+
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
+
+		clock = 2000; // past the TTL
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(2);
+
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(NEXT_BANNER);
+		expect(fetchCount).toBe(2);
+	});
+
+	it("keeps serving the old banner in the same request and only retracts once the 204 refresh settles", async () => {
+		let clock = 0;
+		const responses = [okFragment(BANNER), statusOnly(204)];
+		let index = 0;
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger,
+			fetch: async () => responses[index++],
+		});
+
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
+
+		clock = 2000; // past the TTL
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings).toEqual([]);
 	});
 
 	it("treats 204 as 'nothing to announce' without logging a failure", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: async () => statusOnly(204),
 		});
 
-		expect(await getChangelogBanner()).toBeUndefined();
-		expect(warnings).toEqual([]);
-	});
-
-	it("retracts a previously good banner when a later refetch returns 204", async () => {
-		let clock = 0;
-		const responses = [okFragment(BANNER), statusOnly(204)];
-		let index = 0;
-		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
-			...FIXED,
-			now: () => clock,
-			logger,
-			fetch: async () => responses[index++],
-		});
-
-		expect(await getChangelogBanner()).toEqual(BANNER);
-		clock = 2000; // force a refetch past the TTL
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings).toEqual([]);
 	});
 
 	it("returns undefined when the source has never succeeded", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: async () => statusOnly(503),
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings.some((w) => w.includes("503"))).toBe(true);
 	});
 
-	it("keeps serving the last good banner when a later refetch returns an error status", async () => {
+	it("serves stale and restamps the cache on a failed refetch, so a down source is retried at most once per TTL", async () => {
 		let clock = 0;
 		const responses = [okFragment(BANNER), statusOnly(500)];
 		let index = 0;
+		let fetchCount = 0;
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => clock,
 			logger,
-			fetch: async () => responses[index++],
+			fetch: async () => {
+				fetchCount++;
+				return responses[index++];
+			},
 		});
 
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+
+		clock = 2000; // past the TTL
 		expect(await getChangelogBanner()).toEqual(BANNER);
-		clock = 2000; // force a refetch
-		expect(await getChangelogBanner()).toEqual(BANNER);
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(2);
 		expect(warnings.some((w) => w.includes("500"))).toBe(true);
+
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(2);
 	});
 
 	it("fails open to the last good value when the fetch rejects (timeout abort)", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
@@ -161,31 +232,34 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings.some((w) => w.includes("timeout"))).toBe(true);
 	});
 
 	it("fails open when the fetch rejects with a non-Error value", async () => {
 		const { logger } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: () => Promise.reject("boom"),
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 	});
 
 	it("returns undefined and warns when the body is unparseable", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: async () => body200("<div>not a banner</div>"),
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings.some((w) => w.includes("unparseable"))).toBe(true);
 	});
@@ -196,7 +270,7 @@ describe("initChangelogBannerSource", () => {
 			resolveFetch = resolve;
 		});
 		let fetchCount = 0;
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger: noopLogger,
@@ -206,13 +280,68 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
-		const first = getChangelogBanner();
-		const second = getChangelogBanner();
-		resolveFetch(okFragment(BANNER));
-		const [a, b] = await Promise.all([first, second]);
-
+		await getChangelogBanner();
+		await getChangelogBanner();
 		expect(fetchCount).toBe(1);
-		expect(a).toEqual(BANNER);
-		expect(b).toEqual(BANNER);
+
+		resolveFetch(okFragment(BANNER));
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(1);
+	});
+
+	it("resolves refreshChangelogBanner without fetching when the cache is still fresh", async () => {
+		let fetchCount = 0;
+		const { refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return okFragment(BANNER);
+			},
+		});
+
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+	});
+
+	it("joins an in-flight refresh instead of starting a second fetch", async () => {
+		let resolveFetch: (result: FetchResult) => void = () => {};
+		const pending = new Promise<FetchResult>((resolve) => {
+			resolveFetch = resolve;
+		});
+		let fetchCount = 0;
+		const { refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return pending;
+			},
+		});
+
+		const first = refreshChangelogBanner();
+		const second = refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+
+		resolveFetch(okFragment(BANNER));
+		await Promise.all([first, second]);
+		expect(fetchCount).toBe(1);
+	});
+
+	it("never rejects from refreshChangelogBanner, even when the fetch throws", async () => {
+		const { logger } = capturingLogger();
+		const { refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: () => Promise.reject(new Error("boom")),
+		});
+
+		await expect(refreshChangelogBanner()).resolves.toBeUndefined();
 	});
 });

--- a/projects/hutch/src/runtime/web/changelog-banner-source.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner-source.ts
@@ -24,12 +24,9 @@ type ChangelogFetch = (
  *     good value (undefined only until the first success).
  *
  * Results are cached for `ttlMs` so most renders pay nothing, and concurrent
- * misses share one in-flight fetch. The first render after the TTL lapses awaits
- * the refetch (bounded by `timeoutMs`), so the source adds latency at most once
- * per TTL per instance — it blocks-to-revalidate rather than serving stale, which
- * keeps a 204 retraction immediate; it never errors a render. Failures log at
- * warn (no alarm — a missing promo banner is not an incident). Caching is added
- * because every page consults it. */
+ * misses share one in-flight fetch. Failures log at warn (no alarm — a missing
+ * promo banner is not an incident). Caching is added because every page consults
+ * it. */
 export function initChangelogBannerSource(deps: {
 	fetch: ChangelogFetch;
 	sourceUrl: string;
@@ -37,13 +34,16 @@ export function initChangelogBannerSource(deps: {
 	ttlMs: number;
 	timeoutMs: number;
 	logger: HutchLogger;
-}): { getChangelogBanner: GetChangelogBanner } {
+}): {
+	getChangelogBanner: GetChangelogBanner;
+	refreshChangelogBanner: () => Promise<void>;
+} {
 	const { fetch, sourceUrl, now, ttlMs, timeoutMs, logger } = deps;
 
 	let lastGood: ChangelogBanner | undefined;
 	let cachedAt: number | undefined;
 	let cachedValue: ChangelogBanner | undefined;
-	let inFlight: Promise<ChangelogBanner | undefined> | undefined;
+	let inFlight: Promise<void> | undefined;
 
 	async function fetchFresh(): Promise<ChangelogBanner | undefined> {
 		try {
@@ -71,15 +71,15 @@ export function initChangelogBannerSource(deps: {
 		}
 	}
 
-	async function getChangelogBanner(): Promise<ChangelogBanner | undefined> {
-		const nowMs = now();
-		if (cachedAt !== undefined && nowMs - cachedAt < ttlMs) return cachedValue;
-		if (inFlight) return inFlight;
+	function isFresh(): boolean {
+		return cachedAt !== undefined && now() - cachedAt < ttlMs;
+	}
+
+	function startRefresh(): Promise<void> {
 		inFlight = fetchFresh()
 			.then((value) => {
 				cachedValue = value;
-				cachedAt = nowMs;
-				return value;
+				cachedAt = now();
 			})
 			.finally(() => {
 				inFlight = undefined;
@@ -87,5 +87,15 @@ export function initChangelogBannerSource(deps: {
 		return inFlight;
 	}
 
-	return { getChangelogBanner };
+	async function getChangelogBanner(): Promise<ChangelogBanner | undefined> {
+		if (!isFresh() && !inFlight) void startRefresh();
+		return cachedValue;
+	}
+
+	function refreshChangelogBanner(): Promise<void> {
+		if (isFresh()) return Promise.resolve();
+		return inFlight ?? startRefresh();
+	}
+
+	return { getChangelogBanner, refreshChangelogBanner };
 }

--- a/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
+++ b/projects/hutch/src/runtime/web/changelog-banner.route.test.ts
@@ -72,4 +72,20 @@ describe("changelog banner on hutch pages", () => {
 		expect(banner.getAttribute("data-changelog-version")).toBe(VERSION);
 		expect(banner.querySelector("script")?.textContent).toBe(CHANGELOG_SEEN_SCRIPT);
 	});
+
+	it("consults the changelog source once via the pre-auth kick on a redirect that never renders the shell", async () => {
+		let consultations = 0;
+		const { app } = createTestApp(createDefaultTestAppFixture(TEST_APP_ORIGIN), {
+			getChangelogBanner: async () => {
+				consultations++;
+				return undefined;
+			},
+		});
+
+		const response = await request(app).get("/queue/counts");
+
+		expect(response.status).toBe(303);
+		expect(response.headers.location).toBe("/login");
+		expect(consultations).toBe(1);
+	});
 });

--- a/projects/inbox/src/runtime/app.route.test.ts
+++ b/projects/inbox/src/runtime/app.route.test.ts
@@ -91,4 +91,26 @@ describe("Inbox app composition", () => {
 			await harness.close();
 		}
 	});
+
+	it("consults the changelog source once via the pre-auth kick on a redirect that never renders the shell", async () => {
+		let consultations = 0;
+		const fixture = createDefaultTestAppFixture(TEST_APP_ORIGIN);
+		const harness: RunningServer & ReturnType<typeof createInboxTestApp> = buildHarness(
+			createInboxTestApp(fixture, {
+				getChangelogBanner: async () => {
+					consultations++;
+					return undefined;
+				},
+			}),
+		);
+		try {
+			const response = await request(harness.server).get("/inbox");
+
+			expect(response.status).toBe(303);
+			expect(response.headers.location).toBe("/login");
+			expect(consultations).toBe(1);
+		} finally {
+			await harness.close();
+		}
+	});
 });

--- a/projects/inbox/src/runtime/app.ts
+++ b/projects/inbox/src/runtime/app.ts
@@ -61,6 +61,10 @@ export function createInboxApp(
 	app.use(express.urlencoded({ extended: true }));
 	app.use(cookieParser());
 	app.use(changelogDismissMiddleware);
+	app.use((_req: Request, _res: Response, next: NextFunction) => {
+		void deps.getChangelogBanner();
+		next();
+	});
 
 	app.use("/client-dist", express.static(resolve(__dirname, "web", "client-dist")));
 

--- a/projects/inbox/src/runtime/lambda.main.ts
+++ b/projects/inbox/src/runtime/lambda.main.ts
@@ -58,7 +58,7 @@ const readEmailContent = initS3ReadContent({
 	bucketName: requireEnv("CONTENT_BUCKET_NAME"),
 });
 
-const { getChangelogBanner } = initChangelogBannerSource({
+const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 	fetch: globalThis.fetch,
 	sourceUrl: requireEnv("CHANGELOG_BANNER_URL"),
 	now: () => Date.now(),
@@ -66,6 +66,7 @@ const { getChangelogBanner } = initChangelogBannerSource({
 	timeoutMs: 800,
 	logger,
 });
+void refreshChangelogBanner();
 
 const application = express()
 	.disable("x-powered-by")

--- a/projects/inbox/src/runtime/web/changelog-banner-source.test.ts
+++ b/projects/inbox/src/runtime/web/changelog-banner-source.test.ts
@@ -15,6 +15,14 @@ const BANNER: ChangelogBanner = {
 	version: VERSION,
 };
 
+const NEXT_VERSION = "b2c3d4e5";
+assert(isChangelogVersion(NEXT_VERSION));
+const NEXT_BANNER: ChangelogBanner = {
+	hook: "Now with highlights",
+	href: "/blog/highlights",
+	version: NEXT_VERSION,
+};
+
 type FetchResult = { status: number; ok: boolean; text: () => Promise<string> };
 
 function okFragment(banner: ChangelogBanner): FetchResult {
@@ -47,7 +55,7 @@ const FIXED = {
 };
 
 describe("initChangelogBannerSource", () => {
-	it("fetches on the first call and returns the parsed banner", async () => {
+	it("returns undefined immediately on a cold call and kicks exactly one background fetch", async () => {
 		let fetchCount = 0;
 		const { getChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
@@ -59,6 +67,24 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(fetchCount).toBe(1);
+	});
+
+	it("serves the fetched banner once refreshChangelogBanner settles, without refetching inside the TTL", async () => {
+		let fetchCount = 0;
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return okFragment(BANNER);
+			},
+		});
+
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
 		expect(await getChangelogBanner()).toEqual(BANNER);
 		expect(fetchCount).toBe(1);
 	});
@@ -66,7 +92,7 @@ describe("initChangelogBannerSource", () => {
 	it("serves from cache within the TTL and refetches once it expires", async () => {
 		let clock = 0;
 		let fetchCount = 0;
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => clock,
 			logger: noopLogger,
@@ -76,83 +102,128 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
-		await getChangelogBanner();
+		await refreshChangelogBanner();
 		expect(fetchCount).toBe(1);
 
 		clock = 999; // still inside the 1000ms TTL
-		await getChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
 		expect(fetchCount).toBe(1);
 
 		clock = 1000; // TTL elapsed
 		await getChangelogBanner();
+		await refreshChangelogBanner();
 		expect(fetchCount).toBe(2);
+	});
+
+	it("serves the stale banner past the TTL and swaps to the new value once the background refresh settles", async () => {
+		let clock = 0;
+		const responses = [okFragment(BANNER), okFragment(NEXT_BANNER)];
+		let index = 0;
+		let fetchCount = 0;
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return responses[index++];
+			},
+		});
+
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
+
+		clock = 2000; // past the TTL
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(2);
+
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(NEXT_BANNER);
+		expect(fetchCount).toBe(2);
+	});
+
+	it("keeps serving the old banner in the same request and only retracts once the 204 refresh settles", async () => {
+		let clock = 0;
+		const responses = [okFragment(BANNER), statusOnly(204)];
+		let index = 0;
+		const { logger, warnings } = capturingLogger();
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => clock,
+			logger,
+			fetch: async () => responses[index++],
+		});
+
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
+
+		clock = 2000; // past the TTL
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toBeUndefined();
+		expect(warnings).toEqual([]);
 	});
 
 	it("treats 204 as 'nothing to announce' without logging a failure", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: async () => statusOnly(204),
 		});
 
-		expect(await getChangelogBanner()).toBeUndefined();
-		expect(warnings).toEqual([]);
-	});
-
-	it("retracts a previously good banner when a later refetch returns 204", async () => {
-		let clock = 0;
-		const responses = [okFragment(BANNER), statusOnly(204)];
-		let index = 0;
-		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
-			...FIXED,
-			now: () => clock,
-			logger,
-			fetch: async () => responses[index++],
-		});
-
-		expect(await getChangelogBanner()).toEqual(BANNER);
-		clock = 2000; // force a refetch past the TTL
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings).toEqual([]);
 	});
 
 	it("returns undefined when the source has never succeeded", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: async () => statusOnly(503),
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings.some((w) => w.includes("503"))).toBe(true);
 	});
 
-	it("keeps serving the last good banner when a later refetch returns an error status", async () => {
+	it("serves stale and restamps the cache on a failed refetch, so a down source is retried at most once per TTL", async () => {
 		let clock = 0;
 		const responses = [okFragment(BANNER), statusOnly(500)];
 		let index = 0;
+		let fetchCount = 0;
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => clock,
 			logger,
-			fetch: async () => responses[index++],
+			fetch: async () => {
+				fetchCount++;
+				return responses[index++];
+			},
 		});
 
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+
+		clock = 2000; // past the TTL
 		expect(await getChangelogBanner()).toEqual(BANNER);
-		clock = 2000; // force a refetch
-		expect(await getChangelogBanner()).toEqual(BANNER);
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(2);
 		expect(warnings.some((w) => w.includes("500"))).toBe(true);
+
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(2);
 	});
 
 	it("fails open to the last good value when the fetch rejects (timeout abort)", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
@@ -161,31 +232,34 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings.some((w) => w.includes("timeout"))).toBe(true);
 	});
 
 	it("fails open when the fetch rejects with a non-Error value", async () => {
 		const { logger } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: () => Promise.reject("boom"),
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 	});
 
 	it("returns undefined and warns when the body is unparseable", async () => {
 		const { logger, warnings } = capturingLogger();
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger,
 			fetch: async () => body200("<div>not a banner</div>"),
 		});
 
+		await refreshChangelogBanner();
 		expect(await getChangelogBanner()).toBeUndefined();
 		expect(warnings.some((w) => w.includes("unparseable"))).toBe(true);
 	});
@@ -196,7 +270,7 @@ describe("initChangelogBannerSource", () => {
 			resolveFetch = resolve;
 		});
 		let fetchCount = 0;
-		const { getChangelogBanner } = initChangelogBannerSource({
+		const { getChangelogBanner, refreshChangelogBanner } = initChangelogBannerSource({
 			...FIXED,
 			now: () => 0,
 			logger: noopLogger,
@@ -206,13 +280,68 @@ describe("initChangelogBannerSource", () => {
 			},
 		});
 
-		const first = getChangelogBanner();
-		const second = getChangelogBanner();
-		resolveFetch(okFragment(BANNER));
-		const [a, b] = await Promise.all([first, second]);
-
+		await getChangelogBanner();
+		await getChangelogBanner();
 		expect(fetchCount).toBe(1);
-		expect(a).toEqual(BANNER);
-		expect(b).toEqual(BANNER);
+
+		resolveFetch(okFragment(BANNER));
+		await refreshChangelogBanner();
+		expect(await getChangelogBanner()).toEqual(BANNER);
+		expect(fetchCount).toBe(1);
+	});
+
+	it("resolves refreshChangelogBanner without fetching when the cache is still fresh", async () => {
+		let fetchCount = 0;
+		const { refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return okFragment(BANNER);
+			},
+		});
+
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+		await refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+	});
+
+	it("joins an in-flight refresh instead of starting a second fetch", async () => {
+		let resolveFetch: (result: FetchResult) => void = () => {};
+		const pending = new Promise<FetchResult>((resolve) => {
+			resolveFetch = resolve;
+		});
+		let fetchCount = 0;
+		const { refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger: noopLogger,
+			fetch: async () => {
+				fetchCount++;
+				return pending;
+			},
+		});
+
+		const first = refreshChangelogBanner();
+		const second = refreshChangelogBanner();
+		expect(fetchCount).toBe(1);
+
+		resolveFetch(okFragment(BANNER));
+		await Promise.all([first, second]);
+		expect(fetchCount).toBe(1);
+	});
+
+	it("never rejects from refreshChangelogBanner, even when the fetch throws", async () => {
+		const { logger } = capturingLogger();
+		const { refreshChangelogBanner } = initChangelogBannerSource({
+			...FIXED,
+			now: () => 0,
+			logger,
+			fetch: () => Promise.reject(new Error("boom")),
+		});
+
+		await expect(refreshChangelogBanner()).resolves.toBeUndefined();
 	});
 });

--- a/projects/inbox/src/runtime/web/changelog-banner-source.ts
+++ b/projects/inbox/src/runtime/web/changelog-banner-source.ts
@@ -24,12 +24,9 @@ type ChangelogFetch = (
  *     good value (undefined only until the first success).
  *
  * Results are cached for `ttlMs` so most renders pay nothing, and concurrent
- * misses share one in-flight fetch. The first render after the TTL lapses awaits
- * the refetch (bounded by `timeoutMs`), so the source adds latency at most once
- * per TTL per instance — it blocks-to-revalidate rather than serving stale, which
- * keeps a 204 retraction immediate; it never errors a render. Failures log at
- * warn (no alarm — a missing promo banner is not an incident). Caching is added
- * because every page consults it. */
+ * misses share one in-flight fetch. Failures log at warn (no alarm — a missing
+ * promo banner is not an incident). Caching is added because every page consults
+ * it. */
 export function initChangelogBannerSource(deps: {
 	fetch: ChangelogFetch;
 	sourceUrl: string;
@@ -37,13 +34,16 @@ export function initChangelogBannerSource(deps: {
 	ttlMs: number;
 	timeoutMs: number;
 	logger: HutchLogger;
-}): { getChangelogBanner: GetChangelogBanner } {
+}): {
+	getChangelogBanner: GetChangelogBanner;
+	refreshChangelogBanner: () => Promise<void>;
+} {
 	const { fetch, sourceUrl, now, ttlMs, timeoutMs, logger } = deps;
 
 	let lastGood: ChangelogBanner | undefined;
 	let cachedAt: number | undefined;
 	let cachedValue: ChangelogBanner | undefined;
-	let inFlight: Promise<ChangelogBanner | undefined> | undefined;
+	let inFlight: Promise<void> | undefined;
 
 	async function fetchFresh(): Promise<ChangelogBanner | undefined> {
 		try {
@@ -71,15 +71,15 @@ export function initChangelogBannerSource(deps: {
 		}
 	}
 
-	async function getChangelogBanner(): Promise<ChangelogBanner | undefined> {
-		const nowMs = now();
-		if (cachedAt !== undefined && nowMs - cachedAt < ttlMs) return cachedValue;
-		if (inFlight) return inFlight;
+	function isFresh(): boolean {
+		return cachedAt !== undefined && now() - cachedAt < ttlMs;
+	}
+
+	function startRefresh(): Promise<void> {
 		inFlight = fetchFresh()
 			.then((value) => {
 				cachedValue = value;
-				cachedAt = nowMs;
-				return value;
+				cachedAt = now();
 			})
 			.finally(() => {
 				inFlight = undefined;
@@ -87,5 +87,15 @@ export function initChangelogBannerSource(deps: {
 		return inFlight;
 	}
 
-	return { getChangelogBanner };
+	async function getChangelogBanner(): Promise<ChangelogBanner | undefined> {
+		if (!isFresh() && !inFlight) void startRefresh();
+		return cachedValue;
+	}
+
+	function refreshChangelogBanner(): Promise<void> {
+		if (isFresh()) return Promise.resolve();
+		return inFlight ?? startRefresh();
+	}
+
+	return { getChangelogBanner, refreshChangelogBanner };
 }


### PR DESCRIPTION
## What & why

Every full-page render and boosted `<main>` swap awaited `getChangelogBanner` before responding. That getter fetches blog-site's fragment over hutch's own API Gateway (800 ms timeout, cached 300 s in-process), so **every cache miss blocked the response up to 800 ms, and every cold start always paid it** — for a purely decorative changelog announcement. This takes that external fetch off the render path, removing the periodic +800 ms TTFB tail spikes and the unconditional cold-start add-on.

## How

The source now **serves stale while revalidating** in the background:

- A cold call returns `undefined` immediately; the hidden banner shell is valid HTML (already pinned by a route test).
- Past the TTL it returns the last-good value now and kicks **one** background refresh; concurrent misses still share one in-flight fetch.
- `cachedAt` is stamped at **settle time**, so a refresh that thaws late on a frozen Lambda is not born expired — a down source is retried at most once per TTL.
- `refreshChangelogBanner` never rejects (the fetch path swallows everything), so `void`-ing it cannot raise `unhandledRejection`.

Two kick points keep the cache warm off the render path:

1. **INIT-time warm** in each composition root (hutch `app.ts`, inbox `lambda.main.ts`).
2. A **two-line pre-auth middleware** that fires at request start (not `sendComponent` time), so the refresh gets the whole handler window to settle in the same invoke — and POST/redirect/Siren traffic that never renders `Base` keeps it warm too.

The `changelog-banner-source.ts` change is mirrored byte-identically into the inbox deployable (no cross-project relative imports), and both `*.test.ts` copies stay identical.

## Trade-off (maintainer-approved)

A 204 retraction or new post now propagates in **≤ TTL + one settle cycle** per instance, versus ≤ TTL before. The banner is decorative editorial content and per-instance cache skew already exists; the removed +800 ms TTFB tail was measured, user-visible harm. This regression was explicitly signed off before implementation, so the falsified "retraction is immediate" sentence in the source header was removed and the rationale lives in the commit body.

## Testing

- `pnpm check` green across all 47 projects — lint, type-check, tests, **100 % coverage on `changelog-banner-source.ts` in both projects**, knip, editorconfig, unused-css.
- Reshaped `changelog-banner-source.test.ts` (both copies) for the serve-stale semantics: cold-returns-`undefined`, serve-after-refresh, stale-past-TTL swap, 204 retraction bounded, failed-refetch restamp (one attempt per TTL), concurrent dedup, and `refreshChangelogBanner` fresh / join-in-flight / never-rejects.
- New route tests (hutch + inbox) assert the pre-auth middleware consults the source exactly once on an unauthenticated redirect that never renders `Base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaKYhtbydGSN32kKuRZpXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaKYhtbydGSN32kKuRZpXR)_