### PR TITLE
test(web-embed): pin CDN fonts in the embed visual suite

### DIFF
--- a/projects/web-embed/package.json
+++ b/projects/web-embed/package.json
@@ -9,6 +9,7 @@
     "test": "jest --testMatch='**/dist/**/*.test.js' --testTimeout=10000",
     "test-with-coverage": "c8 node scripts/run-tests-with-coverage.js && node enforce-coverage.config.js",
     "test:e2e": "pnpm compile && E2E_PORT=3700 playwright test --config playwright.config.local-dev.ts",
+    "update-visual-baselines": "node scripts/update-visual-baselines.js",
     "lint": "tsc --project tsconfig.lint.json && concurrently --kill-others-on-fail \"biome lint src\" \"knip\" \"editorconfig-checker\"",
     "check-infra": "PULUMI_CONFIG_PASSPHRASE='' pulumi preview --stack \"${PULUMI_STACK:?PULUMI_STACK is not set}\"",
     "check": "nx run web-embed:check"

--- a/projects/web-embed/project.json
+++ b/projects/web-embed/project.json
@@ -29,6 +29,10 @@
     "test-with-coverage": {
       "dependsOn": ["compile"]
     },
+    "update-visual-baselines": {
+      "dependsOn": ["compile"],
+      "cache": false
+    },
     "test": {}
   }
 }

--- a/projects/web-embed/scripts/update-visual-baselines.js
+++ b/projects/web-embed/scripts/update-visual-baselines.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const { globSync } = require('node:fs');
+const path = require('node:path');
+const { getFreePort } = require('@packages/test-phase-runner');
+const { HutchLogger, consoleLogger } = require('@packages/hutch-logger');
+const { devDependencies } = require('../package.json');
+
+const logger = HutchLogger.from(consoleLogger);
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const WORKSPACE_ROOT = path.resolve(PROJECT_ROOT, '..', '..');
+const PLAYWRIGHT_CONFIG = 'playwright.config.local-dev.ts';
+const VISUAL_SPEC_PATTERNS = ['src/e2e/**/*-visual.e2e-local.ts'];
+
+function playwrightImage() {
+  const pinnedVersion = devDependencies['@playwright/test'];
+  assert.match(
+    pinnedVersion,
+    /^\d+\.\d+\.\d+$/,
+    `@playwright/test must be pinned to an exact version so the container matches the host renderer, got "${pinnedVersion}"`,
+  );
+  return `mcr.microsoft.com/playwright:v${pinnedVersion}-noble`;
+}
+
+function visualSpecs() {
+  return VISUAL_SPEC_PATTERNS.flatMap((pattern) => {
+    const matches = globSync(pattern, { cwd: PROJECT_ROOT });
+    assert.ok(matches.length > 0, `no visual specs matched ${pattern}`);
+    return matches;
+  }).sort();
+}
+
+function run(command, args, options) {
+  execFileSync(command, args, { cwd: PROJECT_ROOT, stdio: 'inherit', ...options });
+}
+
+function pullPlaywrightImage(image) {
+  try {
+    run('docker', ['pull', '--platform', 'linux/amd64', image]);
+  } catch (cause) {
+    throw new Error(
+      `Cannot reach Docker to pull ${image}, which is the only place the -chromium-linux baselines can be captured. Refusing to refresh darwin alone and leave the two platforms out of step — start Docker (see devbox.json) and re-run.`,
+      { cause },
+    );
+  }
+}
+
+function playwrightCommand(specs) {
+  return [
+    'node_modules/.bin/playwright',
+    'test',
+    '--config',
+    PLAYWRIGHT_CONFIG,
+    '--update-snapshots=changed',
+    ...specs,
+  ];
+}
+
+async function captureDarwinBaselines(specs) {
+  process.env.E2E_PORT = String(await getFreePort());
+  process.env.HEADLESS = 'true';
+  run('node_modules/.bin/playwright', ['install', 'chromium']);
+  const [command, ...args] = playwrightCommand(specs);
+  run(command, args);
+}
+
+async function captureLinuxBaselines(specs, image) {
+  const port = await getFreePort();
+  const insideContainer = [
+    `cd "${WORKSPACE_ROOT}"`,
+    '. ./.envrc',
+    `cd "${PROJECT_ROOT}"`,
+    `exec ${playwrightCommand(specs).join(' ')}`,
+  ].join(' && ');
+  run('docker', [
+    'run',
+    '--rm',
+    '--ipc=host',
+    '--platform',
+    'linux/amd64',
+    '--volume',
+    `${WORKSPACE_ROOT}:${WORKSPACE_ROOT}`,
+    '--workdir',
+    PROJECT_ROOT,
+    '--env',
+    'HEADLESS=true',
+    '--env',
+    `E2E_PORT=${port}`,
+    image,
+    'bash',
+    '-c',
+    insideContainer,
+  ]);
+}
+
+function reportBaselines(specs) {
+  const status = execFileSync(
+    'git',
+    ['status', '--porcelain', '--', ...specs.map((spec) => `${spec}-snapshots`)],
+    { cwd: PROJECT_ROOT, encoding: 'utf8' },
+  ).trim();
+  if (status) {
+    logger.info(`\nBaselines changed — commit every platform together:\n${status}\n`);
+    return;
+  }
+  logger.info('\nBaselines are byte-identical to the committed ones.\n');
+}
+
+async function main() {
+  assert.equal(
+    process.platform,
+    'darwin',
+    'the -chromium-darwin baselines can only be captured on macOS; on any other host this run would refresh linux alone and leave darwin stale',
+  );
+
+  const specs = visualSpecs();
+  const image = playwrightImage();
+  logger.info(`\n=== Web Embed - Regenerating visual baselines for ${specs.join(', ')} ===\n`);
+
+  pullPlaywrightImage(image);
+
+  logger.info('\n=== Web Embed - Capturing chromium-darwin baselines ===\n');
+  await captureDarwinBaselines(specs);
+
+  logger.info(`\n=== Web Embed - Capturing chromium-linux baselines in ${image} ===\n`);
+  await captureLinuxBaselines(specs, image);
+
+  reportBaselines(specs);
+}
+
+main().catch((error) => {
+  logger.error('Visual baseline regeneration failed:', error);
+  process.exit(1);
+});

--- a/projects/web-embed/src/e2e/embed-visual.e2e-local.ts
+++ b/projects/web-embed/src/e2e/embed-visual.e2e-local.ts
@@ -1,17 +1,17 @@
 import assert from "node:assert/strict";
-import { expect, test, type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { expect, test, waitForBrandFonts } from "@packages/e2e-harness";
 
 const E2E_PORT = process.env.E2E_PORT;
 assert(E2E_PORT, "E2E_PORT must be set by the Playwright webServer config");
 const BASE_URL = `http://localhost:${E2E_PORT}`;
 
-const FONTS_READY = "document.fonts.ready.then(() => undefined)";
 const IMAGES_READY =
 	"Array.from(document.images).every(img => img.complete && img.naturalWidth > 0)";
 
 async function waitForPageReady(page: Page, pageMarker: string): Promise<void> {
 	await page.waitForSelector(pageMarker);
-	await page.evaluate(FONTS_READY);
+	await waitForBrandFonts(page, ["Inter"]);
 	await page.waitForFunction(IMAGES_READY, undefined, { timeout: 5000 });
 }
 


### PR DESCRIPTION
## Mechanism

`projects/web-embed/src/e2e/embed-visual.e2e-local.ts` was the **only** local E2E suite in the repo importing `test` from `@playwright/test` instead of `@packages/e2e-harness` (every other spec imports only `type { Page }` from Playwright). So `pinCdnFixtures` never installed, and the embed pages fetched Inter live from `fonts.googleapis.com` / `fonts.gstatic.com` — injected by the shared shell's deferred preload-to-stylesheet swap.

The suite's own readiness wait was `page.evaluate("document.fonts.ready…")`, run at `domcontentloaded`, i.e. *before* the swap applies. It therefore resolved against an empty `FontFaceSet` — a false green. The `white` capture then succeeded against fallback rendering (under `maxDiffPixelRatio: 0.1`), the stylesheet registered `@font-face`, and the stalled live woff2 fetch left `surface` and `dark` burning their full 5000 ms expect budget inside `toHaveScreenshot`'s internal font wait.

**Observed failure:** CI run `30791342451` attempt 1 — `surface` and `dark` timed out in `waiting for fonts to load...`, `white` passed, suite took 17.8 s against its normal 3.1–4.8 s envelope.

The `e2e-testing` skill already forbids every element of this; the convention came out of the root-caused 45 %-rate font-race investigation (`b52ccd37`). This brings the one non-compliant suite into line.

## The fix

Three hunks in one file: import `expect` / `test` / `waitForBrandFonts` from `@packages/e2e-harness`, drop the `FONTS_READY` constant, and wait via `waitForBrandFonts(page, ["Inter"])` — which polls until a `FontFace` for the family actually reaches `status === "loaded"`, and so cannot false-green the way `document.fonts.ready` did.

`retries` stays **0** and no timeout was bumped.

## Repro (3/3 deterministic, patch never committed)

The plan's original recipe — delay the Google Fonts CSS by 2000 ms — does **not** reproduce: the whole test finishes in ~1.4 s, so the stylesheet never lands mid-test and the run passes. Instrumenting the timeline showed all three captures completing within ~180 ms of each other, so no wall-clock delay reliably lands in the ~50 ms gap between `white` and `surface`.

Gating the stylesheet on the `white` capture instead pins the same ordering with no timing race:

```diff
+let releaseFontCss: () => void = () => {};
+const fontCssGate = new Promise<void>((resolve) => {
+	releaseFontCss = resolve;
+});
+const FONT_LOADING =
+	"(() => { let loading = false; document.fonts.forEach(f => { if (f.status === 'loading') loading = true }); return loading })()";
+
 test.describe("Embed preview visual regression", () => {
+	test.beforeEach(async ({ context }) => {
+		await context.route(
+			(url) => url.hostname === "fonts.googleapis.com",
+			async (route) => {
+				await fontCssGate;
+				await route.fulfill({ path: "<repo>/src/packages/e2e-harness/e2e-cdn-fixtures/inter.css", contentType: "text/css" });
+			},
+		);
+		await context.route(
+			(url) => url.hostname === "fonts.gstatic.com",
+			() => new Promise(() => {}),
+		);
+	});
 		for (const bg of ["white", "surface", "dark"] as const) {
 			await expect.soft(stage).toHaveScreenshot(`preview-${bg}-stage.png`);
+			if (bg === "white") {
+				releaseFontCss();
+				await page.waitForFunction(FONT_LOADING);
+			}
 		}
```

Run directly against Playwright (bypassing the phase-runner's one-shot e2e retry), the pre-fix suite fails identically 3/3:

```
Error: expect(locator).toHaveScreenshot(expected) failed
Locator: locator('[data-test-bg="surface"] .embed-preview__stage')
  - taking element screenshot
    - disabled all CSS animations
  - waiting for fonts to load...
  - Timeout 5000ms exceeded.

Error: expect(locator).toHaveScreenshot(expected) failed
Locator: locator('[data-test-bg="dark"] .embed-preview__stage')
  - waiting for fonts to load...
  - Timeout 5000ms exceeded.
```

| run | font-wait timeouts | surface | dark | white |
|---|---|---|---|---|
| 1 | 2 | fail | fail | never hits the font wait |
| 2 | 2 | fail | fail | never hits the font wait |
| 3 | 2 | fail | fail | never hits the font wait |

On darwin `white` passes cleanly rather than soft-failing on pixels.

## Hermeticity proof — DNS blackhole

With `--host-resolver-rules=MAP fonts.googleapis.com ^NOTFOUND,MAP fonts.gstatic.com ^NOTFOUND,MAP cdn.jsdelivr.net ^NOTFOUND` (temporary config patch, reverted), the full suite passes 3/3.

That green is **not** discriminating on its own — the pre-fix suite also passes with dead DNS, because a fast `NXDOMAIN` leaves the same empty font set as before. Probing what each variant actually renders with makes it decisive:

| variant, all 3 CDN hosts DNS-dead | `document.fonts` contents | result |
|---|---|---|
| pre-fix | `[]` — zero faces | "passes" vacuously, pure fallback rendering |
| fixed | 28 Inter faces, 3 `loaded` | passes with real Inter, served from the pinned fixtures |

## Baseline provenance

`projects/web-embed/scripts/update-visual-baselines.js` is ported from `projects/hutch/scripts/update-visual-baselines.js`, differing only in `VISUAL_SPEC_PATTERNS` (`src/e2e/**/*-visual.e2e-local.ts`) and the project-name log prefix. Every guardrail is intact: darwin-host assert, Docker-pull-or-refuse (never a single-platform refresh), container tag derived from the exact pinned `@playwright/test` devDependency (`1.60.0` → `mcr.microsoft.com/playwright:v1.60.0-noble`), `HEADLESS=true`, `getFreePort`, `--update-snapshots=changed`, and the final `git status` report.

Regeneration ran on both platforms — darwin locally, then chromium-linux in the container — and reported:

```
Baselines are byte-identical to the committed ones.

$ git status --porcelain -- projects/web-embed/src/e2e/embed-visual.e2e-local.ts-snapshots
(empty)
```

So **no PNGs change in this PR**. That is itself the point: at `maxDiffPixelRatio: 0.1` the committed images already tolerated both the pinned and the fallback rendering, which is exactly how the live-font race stayed invisible behind a green suite. A clean no-update verification pass is green on darwin and in the container.

The port also carries hutch's nx target (`dependsOn: ["compile"]`, `cache: false`). Without it the script — which never compiles on its own, and whose Playwright `webServer` boots `dist/runtime/server.main.js` — would capture baselines from a stale `dist/` and report a reassuring "byte-identical", or fail outright on a fresh clone. Verified end-to-end: `nx run web-embed:update-visual-baselines` compiles 23 dependency tasks first, then captures both platforms.

## Verification

- **20/20** uncached soak of `web-embed:test-with-coverage` (`CLAUDE_CODE_REMOTE` unset; the E2E phase ran in all 20, 0 skip markers)
- `pnpm nx run web-embed:check --skip-nx-cache` green, 100 % coverage
- Full pre-commit `pnpm check` green across 47 projects
- No comments added; `retries: 0` and all timeouts untouched
