### PR TITLE
fix(save-link): derive the tier snapshot's crawl status from the canonical enum

### DIFF
--- a/projects/save-link/src/runtime/domain/crawl-article-state/read-tier-snapshot.ts
+++ b/projects/save-link/src/runtime/domain/crawl-article-state/read-tier-snapshot.ts
@@ -1,7 +1,8 @@
 import type { TierName } from "@packages/hutch-infra-components";
+import type { CrawlStatus as PersistedCrawlStatus } from "@packages/article-state-types";
 
 export type PickedTier = TierName | "none";
-export type CrawlStatus = "ready" | "failed" | "pending" | "unsupported" | "absent";
+export type CrawlStatus = PersistedCrawlStatus | "absent";
 export type TierStatus = "success" | "failed" | "not_attempted";
 
 export type TierSnapshot = {
@@ -24,10 +25,16 @@ export type ReadArticleCrawlState = (params: { url: string }) => Promise<{
  * surfaces that distinction so the dashboard's `otherTierStatus` is accurate when one
  * tier reports a failure while the other has already failed. */
 function tier1StatusFromCrawlStatus(crawlStatus: CrawlStatus): TierStatus {
-	if (crawlStatus === "ready") return "success";
-	if (crawlStatus === "failed") return "failed";
-	return "not_attempted";
+	return TIER_1_STATUSES[crawlStatus];
 }
+
+const TIER_1_STATUSES = {
+	ready: "success",
+	failed: "failed",
+	pending: "not_attempted",
+	unsupported: "not_attempted",
+	absent: "not_attempted",
+} satisfies Record<CrawlStatus, TierStatus>;
 
 export function initReadTierSnapshot(deps: {
 	checkTier0SourceExists: CheckTier0SourceExists;

--- a/projects/save-link/src/runtime/providers/article-store/read-article-crawl-state-dynamodb.ts
+++ b/projects/save-link/src/runtime/providers/article-store/read-article-crawl-state-dynamodb.ts
@@ -5,10 +5,10 @@ import {
 	dynamoField,
 } from "@packages/hutch-storage-client";
 import { z } from "zod";
+import { CrawlStatusSchema } from "@packages/article-state-types";
 import { ArticleResourceUniqueId } from "../../domain/save-link/article-resource-unique-id";
 import type { ReadArticleCrawlState, CrawlStatus, PickedTier } from "../../domain/crawl-article-state/read-tier-snapshot";
 
-const CrawlStatusSchema = z.enum(["ready", "failed", "pending", "unsupported"]);
 const CanonicalSourceTierSchema = z.enum(["tier-0", "tier-1"]);
 
 const ArticleRow = z.object({


### PR DESCRIPTION
Follow-up to the stale-check crawl-status incident (`aa377484`), shipped separately because it is unrelated to that fix.

## Why

`read-article-crawl-state-dynamodb.ts` restated the crawl-status enum inline — the same shape whose drift dead-lettered `stale-check-requested-handler` when `unsupported` was added canonically and the copy was never widened.

This copy happens to be in sync today. It is still worth closing:

- it parses the same column of the same table through the same throwing `table.get`;
- it is a thin AWS wrapper wrapped in `/* c8 ignore */`, so no unit test would ever catch it drifting;
- `crawlStatus` was typed against a *local* `CrawlStatus` union, so a new canonical member produced no compile error here.

## What

- `read-article-crawl-state-dynamodb.ts` — import `CrawlStatusSchema` from `@packages/article-state-types` instead of redeclaring it.
- `read-tier-snapshot.ts` — derive `CrawlStatus` from the canonical type (`PersistedCrawlStatus | "absent"`), mirroring how `ReaderStatusSchema` composes `CrawlStatusSchema` with `"unavailable"`.

Importing the schema alone fixes the parse but not the hazard. `tier1StatusFromCrawlStatus` ended in a catch-all `return "not_attempted"`, so a new member would have been absorbed silently and the tier dashboard would have under-reported rather than failed. It is now a `TIER_1_STATUSES` map with `satisfies Record<CrawlStatus, TierStatus>`, matching `TERMINAL_ACTIONS` in `decide-terminal-action.ts`.

Behaviour is unchanged: `ready → success`, `failed → failed`, everything else → `not_attempted`.

## Verification

`pnpm check` passes across all 47 projects.

The guard was proved rather than assumed — adding a fifth member (`"blocked"`) to the canonical enum now fails the build here:

```
read-tier-snapshot.ts:37:3 - error TS1360: Type '{ ready: "success"; failed: "failed"; pending: "not_attempted"; unsupported: "not_attempted"; absent: "not_attempted"; }' does not satisfy the expected type 'Record<CrawlStatus, TierStatus>'.
read-tier-snapshot.ts:28:9 - error TS7053: Element implicitly has an 'any' type ...
```

Before this change the ladder compiled clean and silently mapped the new member to `not_attempted`.

Worth noting from the same probe: the addition already breaks `@packages/article-state-types:compile` and `@packages/crawl-article:compile` first, via their own exhaustive switches. This closes save-link's gap in that set.