### PR TITLE
chore(hutch): remove concierge email notice from the homepage

### DIFF
--- a/projects/hutch/src/runtime/web/pages/home/home.template.html
+++ b/projects/hutch/src/runtime/web/pages/home/home.template.html
@@ -52,7 +52,7 @@
           </li>
           {{/each}}
         </ul>
-        <p class="home-ways__note">A PDF link works anywhere an article link does &mdash; <a href="{{track '/pdf-ocr' source='home-ways' content='pdf'}}">Tesseract reads it off the pixels, up to 300 pages</a>. If an export is too big for the importer, email the file to <a href="mailto:readplace+migrate@readplace.com">readplace+migrate@readplace.com</a> and I import it by hand within 24 to 48 hours.</p>
+        <p class="home-ways__note">A PDF link works anywhere an article link does &mdash; <a href="{{track '/pdf-ocr' source='home-ways' content='pdf'}}">Tesseract reads it off the pixels, up to 300 pages</a>.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## What

Removes the concierge email fallback sentence from the "Every way to save" note on the homepage:

> If an export is too big for the importer, email the file to readplace+migrate@readplace.com and I import it by hand within 24 to 48 hours.

The first sentence of the same note — the PDF / Tesseract line — is left untouched.

## Why

The homepage no longer surfaces this concierge notice. The concierge import path itself is **not** being removed: it stays the documented over-cap fallback in the Pocket migration blog post, so product behaviour is unchanged — only the homepage copy is trimmed.

## Testing

- Type-check (`tsc`), the homepage test suites (107 tests across 3 suites), `biome lint`, and `check-unused-css` all pass locally. The `.home-ways__note` selectors remain in use — the PDF link stays inside the note.
- The full `pnpm check` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGyHY454KURAToHVRdwcnN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGyHY454KURAToHVRdwcnN)_